### PR TITLE
fix(security): #3829 #3828 アプリ側 CSP unsafe-inline hardening (script-src=hash 撤廃 / style-src=案C 維持+ADR)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -179,6 +179,7 @@ chukichi
 CKLOG
 CKOVER
 CKTPL
+clickjacking
 clientside
 Cloudflare
 CloudWatch

--- a/docs/decisions/0067-app-csp-script-src-hash.md
+++ b/docs/decisions/0067-app-csp-script-src-hash.md
@@ -1,11 +1,11 @@
-# 0067. アプリ側 CSP script-src の hash 化 (SvelteKit kit.csp、`'unsafe-inline'` 撤廃)
+# 0067. アプリ側 CSP の `'unsafe-inline'` hardening (script-src = hash 撤廃 / style-src = 維持 + 構造的根拠)
 
 | 項目 | 内容 |
 |------|------|
 | ステータス | accepted |
 | 日付 | 2026-07-17 |
 | 起票者 | Dev (audit team) |
-| 関連 Issue | #3829 (EPIC #3408 slice C) / #3112 |
+| 関連 Issue | #3829 (EPIC #3408 slice C, script-src) / #3828 (slice B, style-src) / #3112 |
 | 関連 ADR | ADR-0029 (LP 側 CSP、**併存**) / ADR-0025 (LP SSOT 注入 XSS) / ADR-0010 (Pre-PMF スコープ) / ADR-0062 (統一エラー通知) |
 
 ## コンテキスト
@@ -38,7 +38,19 @@ impact-analysis の実測で、アプリの inline `<script>` は **SvelteKit hy
 
 **選択肢 A を採用**。`svelte.config.js` `kit.csp` (hash mode) に directive を一本化し、`script-src` から `'unsafe-inline'` を撤廃する (`['self']` のみ → SvelteKit が sha256 を自動付与)。旧 `hooks.server.ts` の `buildCspHeader()` / `CSP_HEADER` / `response.headers.set('Content-Security-Policy', ...)` は二重付与 (clobber) を避けるため撤去する。directive 値は旧 builder を SSOT として 1:1 写経し (img/media/font/connect 等を漏らさない)、`connect-src 'self'` 固定による「外部送信ゼロ」も引き継ぐ。
 
-`style-src 'unsafe-inline'` は本 slice では **維持** (撤廃は #3408 AC2 = slice B で別途扱う)。`frame-ancestors 'none'` は SSR では header で有効、prerender では `X-Frame-Options: DENY` (hooks 継続付与) が backup。
+`frame-ancestors 'none'` は SSR では header で有効、prerender では `X-Frame-Options: DENY` (hooks 継続付与) が backup。
+
+### style-src は `'unsafe-inline'` を維持する (slice B = #3828、案C)
+
+`style-src` は `'unsafe-inline'` を **維持** する。撤廃 (script-src と同じ hash 化) は以下の構造的制約で不可能:
+
+- Svelte は SSR 時、`style:` binding (実測 102 箇所) と `style=` 属性を **inline style 属性 (`style="..."`) としてシリアライズ**する (hydration 後の更新のみ `element.style` = CSSOM 経由で非該当)。
+- **CSP の hash / nonce は `<style>` / `<script>` 要素にのみ適用でき、inline `style=` 属性には適用不可** (属性値ごとの hash + `'unsafe-hashes'` が必要で、`style="width:37%"` 等の動的値は非現実的)。SvelteKit `kit.csp` も自身が生成する inline のみ hash 化し、component の `style=` 属性は対象外。SvelteKit 自身の a11y ルーティング announcer も inline style 属性を持つ。
+- 完全撤廃には 102 箇所の `style:` を `$effect` + CSSOM 直接変更へ書き換える持続的負債が必要で、Pre-PMF (ADR-0010) には過剰。#3828 AC2 の「撤廃が過剰な場合は ADR で根拠 + scope 限定」に合致。
+
+**scope / 残余リスク**: style ベクタの残余リスクは stored-XSS 由来の style 属性ベース defacement / exfiltration に限定され、DOMPurify (ADR-0025) + nosniff + attachment 配信 (#3105/#3111) + user-content 配信不変条件 (#3827 fitness) が実防御を担う。XSS 最重要の script ベクタは script-src hash 撤廃で塞ぐ。
+
+**将来撤廃トリガ**: (a) フレームワークが `style:` の nonce/hash 化を提供、または (b) style 属性ベース攻撃の実害観測。いずれか成立時に slice B' として再評価する。
 
 ## 結果
 

--- a/docs/decisions/0067-app-csp-script-src-hash.md
+++ b/docs/decisions/0067-app-csp-script-src-hash.md
@@ -21,7 +21,7 @@ impact-analysis の実測で、アプリの inline `<script>` は **SvelteKit hy
 ### 選択肢 A: SvelteKit 標準 CSP `kit.csp` hash mode (採用)
 - 概要: `svelte.config.js` `kit.csp = { mode: 'hash', directives: {...} }`。SvelteKit が自身の inline bootstrap script の sha256 を計算し `script-src` に自動注入 (`@sveltejs/kit` `csp.js` 実装、v2.69.2)。SSR ページは HTTP header、prerender ページは `<meta>` で配信。
 - メリット: フレームワーク標準・追加依存ゼロ・bundle 影響ゼロ。custom inline script 0 のため親和性が高い。OWASP CSP Level 2+ 準拠。
-- デメリット: `<meta>` では `frame-ancestors` が効かない (SvelteKit が meta 生成時に自動除外) → prerender ページは `X-Frame-Options` backup が要る。
+- デメリット: `<meta>` では `frame-ancestors` が効かない (SvelteKit が meta 生成時に自動除外)。ただし本アプリで唯一の prerender endpoint は `/sitemap.xml` (非対話 XML) で clickjacking の実害が無く、対話 HTML は全て SSR で `X-Frame-Options` header を取得するため実質問題にならない。
 - Pre-PMF コスト: 低 (config 数行 + hooks の CSP set 撤去のみ、ADR-0010 Bucket A)。
 
 ### 選択肢 B: nonce + `strict-dynamic`
@@ -38,7 +38,7 @@ impact-analysis の実測で、アプリの inline `<script>` は **SvelteKit hy
 
 **選択肢 A を採用**。`svelte.config.js` `kit.csp` (hash mode) に directive を一本化し、`script-src` から `'unsafe-inline'` を撤廃する (`['self']` のみ → SvelteKit が sha256 を自動付与)。旧 `hooks.server.ts` の `buildCspHeader()` / `CSP_HEADER` / `response.headers.set('Content-Security-Policy', ...)` は二重付与 (clobber) を避けるため撤去する。directive 値は旧 builder を SSOT として 1:1 写経し (img/media/font/connect 等を漏らさない)、`connect-src 'self'` 固定による「外部送信ゼロ」も引き継ぐ。
 
-`frame-ancestors 'none'` は SSR では header で有効、prerender では `X-Frame-Options: DENY` (hooks 継続付与) が backup。
+`frame-ancestors 'none'` は SSR では header で有効。対話 HTML は全て SSR のため clickjacking 保護は確実に効く (SSR / 動的レスポンスに hooks が `X-Frame-Options: DENY` を付与)。prerender ページ (唯一 `/sitemap.xml`、非対話 XML) は build 時に静的化され hooks を経由しないため `X-Frame-Options` を持たないが、iframe 埋込による clickjacking の実害は無い (当初「hooks の X-Frame-Options が prerender ページの backup」とした記述は prerender ページ自身には成立しないため、QM runtime 検証 #3833 で実挙動へ是正)。
 
 ### style-src は `'unsafe-inline'` を維持する (slice B = #3828、案C)
 

--- a/docs/decisions/0067-app-csp-script-src-hash.md
+++ b/docs/decisions/0067-app-csp-script-src-hash.md
@@ -1,0 +1,48 @@
+# 0067. アプリ側 CSP script-src の hash 化 (SvelteKit kit.csp、`'unsafe-inline'` 撤廃)
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | accepted |
+| 日付 | 2026-07-17 |
+| 起票者 | Dev (audit team) |
+| 関連 Issue | #3829 (EPIC #3408 slice C) / #3112 |
+| 関連 ADR | ADR-0029 (LP 側 CSP、**併存**) / ADR-0025 (LP SSOT 注入 XSS) / ADR-0010 (Pre-PMF スコープ) / ADR-0062 (統一エラー通知) |
+
+## コンテキスト
+
+アプリ側 (SvelteKit、Lambda / NUC 配信) の CSP は `hooks.server.ts` の `buildCspHeader()` が全レスポンスに `script-src 'self' 'unsafe-inline'` を付与していた。`'unsafe-inline'` を許す限り、新たな stored-XSS 経路 (例: ZIP import SVG、#3105/#3111 で attachment + nosniff により実閉鎖済) が将来混入した際に **CSP が script ベクタの最終防壁にならない** (#3112 QM adversarial が指摘した構造リスク 1)。script は XSS 最重要ベクタで style より優先度が高い。
+
+impact-analysis の実測で、アプリの inline `<script>` は **SvelteKit hydration bootstrap 1 種のみ** (app.html の custom inline script 0 / `{@html}` 0 / inline handler 0) と確定した。`<script>` 要素は hash 化可能なため、`'unsafe-inline'` をクリーンに撤廃できる。
+
+本 ADR はアプリ側 script-src の hash 化方針を記録する。LP (`site/**`、GitHub Pages 静的配信) の CSP は別 origin・別配信経路・別脅威モデル (CDN DOMPurify/splidejs 依存) であり、ADR-0029 が引き続き SSOT。両者は **supersede でなく併存**する (下記 §結果)。
+
+## 検討した選択肢 (OSS / 確立パターン — #1350)
+
+### 選択肢 A: SvelteKit 標準 CSP `kit.csp` hash mode (採用)
+- 概要: `svelte.config.js` `kit.csp = { mode: 'hash', directives: {...} }`。SvelteKit が自身の inline bootstrap script の sha256 を計算し `script-src` に自動注入 (`@sveltejs/kit` `csp.js` 実装、v2.69.2)。SSR ページは HTTP header、prerender ページは `<meta>` で配信。
+- メリット: フレームワーク標準・追加依存ゼロ・bundle 影響ゼロ。custom inline script 0 のため親和性が高い。OWASP CSP Level 2+ 準拠。
+- デメリット: `<meta>` では `frame-ancestors` が効かない (SvelteKit が meta 生成時に自動除外) → prerender ページは `X-Frame-Options` backup が要る。
+- Pre-PMF コスト: 低 (config 数行 + hooks の CSP set 撤去のみ、ADR-0010 Bucket A)。
+
+### 選択肢 B: nonce + `strict-dynamic`
+- 概要: リクエストごとに nonce を発行し inline script に付与、`strict-dynamic` で伝播。
+- メリット: hash より厳格 (動的 script も統制)。
+- デメリット: SSR で nonce をリクエスト単位に配線する必要があり実装複雑。本アプリは custom inline script 0 で動的 script 統制の要求が無く、過剰 (ADR-0010)。
+- Pre-PMF コスト: 中〜高。
+
+### 選択肢 C: 独自 CSP builder 継続 + inline を許可し続ける (現状維持)
+- 概要: `buildCspHeader()` に `'unsafe-inline'` を残す。
+- デメリット: #3112 構造リスク 1 が残存。本 slice の撤廃目的そのものを満たさない。**却下**。
+
+## 決定
+
+**選択肢 A を採用**。`svelte.config.js` `kit.csp` (hash mode) に directive を一本化し、`script-src` から `'unsafe-inline'` を撤廃する (`['self']` のみ → SvelteKit が sha256 を自動付与)。旧 `hooks.server.ts` の `buildCspHeader()` / `CSP_HEADER` / `response.headers.set('Content-Security-Policy', ...)` は二重付与 (clobber) を避けるため撤去する。directive 値は旧 builder を SSOT として 1:1 写経し (img/media/font/connect 等を漏らさない)、`connect-src 'self'` 固定による「外部送信ゼロ」も引き継ぐ。
+
+`style-src 'unsafe-inline'` は本 slice では **維持** (撤廃は #3408 AC2 = slice B で別途扱う)。`frame-ancestors 'none'` は SSR では header で有効、prerender では `X-Frame-Options: DENY` (hooks 継続付与) が backup。
+
+## 結果
+
+- `script-src` から `'unsafe-inline'` が消え、hydration bootstrap のみ sha256 で許可 → stored-XSS の script ベクタが構造的に塞がれる (#3112 構造リスク 1 の根治)。
+- CSP header の付与主体が hooks → SvelteKit に移り、CSP は **ページレスポンス** にのみ付く。API / エンドポイント / 静的ファイルレスポンスは CSP を持たなくなるが、これらは script 実行文脈を持たず、user 由来 SVG は `Content-Disposition: attachment` (#3105、CSP 非依存の防御) で保護されるため security 中立。
+- **ADR-0029 との関係 (併存)**: 本 ADR = アプリ側 (SvelteKit `kit.csp`、`self` 完結、CDN 無し)。ADR-0029 = LP 側 (`site/**` 静的、`<meta>` CSP、`cdn.jsdelivr.net` allowlist + SRI/pin)。origin・配信経路・脅威モデルが異なるため一方が他方を supersede せず、役割分担して併存する。
+- 高回帰リスク (全画面 hydration) は `tests/e2e/app-csp.spec.ts` (SSR header hardened / CSP violation 0 / child home・admin Ark UI Menu・marketplace SPA nav の hydration 生存) + visual regression 3 層で担保する。設計仕様の SSOT は `docs/design/14-セキュリティ設計書.md §7.1`。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -189,7 +189,7 @@ ADR を現場の常時参照ルールとして機能させるため、以下の�
 | 0064 | [NUC 新 model repo 構築方式 — PGlite 一次採用 (dialect 税ゼロ) + raw SQLite fallback](0064-sqlite-core-repo-strategy.md) | accepted | 2026-07-09 |
 | 0065 | [DSQL DPU コスト規約 — service 層クエリの 5 原則 (実測裏付け)](0065-dsql-dpu-query-rules.md) | accepted | 2026-07-11 |
 | 0066 | [export/import 値域 SSOT — wire schema とドメイン validator は同一値域定数を import する](0066-export-import-schema-range-ssot.md) | accepted | 2026-07-12 |
-| 0067 | [アプリ側 CSP script-src の hash 化 (SvelteKit kit.csp、`'unsafe-inline'` 撤廃)](0067-app-csp-script-src-hash.md) | accepted | 2026-07-17 |
+| 0067 | [アプリ側 CSP の `'unsafe-inline'` hardening (script-src = hash 撤廃 / style-src = 維持 + 構造的根拠)](0067-app-csp-script-src-hash.md) | accepted | 2026-07-17 |
 
 > 注 (2026-06-04 #2440 PR-A5): 番号は欠番を許容する（削除済 ADR の番号は再利用しない、git 履歴で追跡可能）。新規 ADR は最大番号 +1 で採番する。renumber 規約は §renumber 規約 を参照。
 >
@@ -384,7 +384,7 @@ active 総数: 45 件 (棚卸後、ADR-0066 +1)。
 
 **完了項目**:
 
-1. **ADR-0067 新規追加**: アプリ側 CSP script-src の hash 化 (SvelteKit `kit.csp` hash mode、`'unsafe-inline'` 撤廃)。EPIC #3408 slice C (#3829) で、`hooks.server.ts buildCspHeader()` の `script-src 'self' 'unsafe-inline'` が残る限り将来の stored-XSS 経路混入時に CSP が script ベクタの最終防壁にならない構造リスク (#3112 リスク 1) を根治。impact-analysis で inline script が SvelteKit hydration bootstrap 1 種のみと実測し、選択肢 3 案比較 (A: kit.csp hash mode / B: nonce+strict-dynamic / C: 現状維持) を本文に記載し A 採用。ADR-0029 (LP 側 CSP、別 origin・別スコープ) は supersede せず併存 (役割分担を明記)。Pre-PMF Bucket A (ADR-0010 整合、config 数行 + 依存ゼロ)。
+1. **ADR-0067 新規追加**: アプリ側 CSP の `'unsafe-inline'` hardening。EPIC #3408 の slice C (#3829, script-src) + slice B (#3828, style-src) を 1 ADR に統合。script-src は `hooks.server.ts buildCspHeader()` の `'unsafe-inline'` が残る限り将来の stored-XSS 経路混入時に CSP が最終防壁にならない構造リスク (#3112 リスク 1) を、SvelteKit `kit.csp` hash mode で根治 (inline script が hydration bootstrap 1 種のみと impact-analysis で実測、3 案比較 A 採用)。style-src は Svelte SSR が `style:` binding (102) / `style=` を inline style 属性化し CSP hash が style 属性に効かない構造的制約により撤廃過剰のため案C (維持 + 根拠 + 将来撤廃トリガ、#3828 AC2 fallback 合致)。ADR-0029 (LP 側 CSP、別 origin) は supersede せず併存。Pre-PMF Bucket A (ADR-0010、config 数行 + 依存ゼロ)。
 
 **1-in-1-out 履行**: ADR-0064〜0066 起票時と同様、1-in-1-out は **2026-07 最終週の月 1 棚卸** で archive 候補 (ADR-0014 proposed 据置 / per-ADR ボリューム超過) と併せて消化する (本 PR scope 外)。
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -189,6 +189,7 @@ ADR を現場の常時参照ルールとして機能させるため、以下の�
 | 0064 | [NUC 新 model repo 構築方式 — PGlite 一次採用 (dialect 税ゼロ) + raw SQLite fallback](0064-sqlite-core-repo-strategy.md) | accepted | 2026-07-09 |
 | 0065 | [DSQL DPU コスト規約 — service 層クエリの 5 原則 (実測裏付け)](0065-dsql-dpu-query-rules.md) | accepted | 2026-07-11 |
 | 0066 | [export/import 値域 SSOT — wire schema とドメイン validator は同一値域定数を import する](0066-export-import-schema-range-ssot.md) | accepted | 2026-07-12 |
+| 0067 | [アプリ側 CSP script-src の hash 化 (SvelteKit kit.csp、`'unsafe-inline'` 撤廃)](0067-app-csp-script-src-hash.md) | accepted | 2026-07-17 |
 
 > 注 (2026-06-04 #2440 PR-A5): 番号は欠番を許容する（削除済 ADR の番号は再利用しない、git 履歴で追跡可能）。新規 ADR は最大番号 +1 で採番する。renumber 規約は §renumber 規約 を参照。
 >
@@ -378,3 +379,13 @@ active 総数: 44 件 (棚卸後、ADR-0065 +1)。
 **1-in-1-out 履行**: ADR-0064 / 0065 起票時と同様、1-in-1-out は **2026-07 最終週の月 1 棚卸** で archive 候補と併せて消化する (本 PR scope 外)。
 
 active 総数: 45 件 (棚卸後、ADR-0066 +1)。
+
+### 2026-07-17 棚卸 (ADR-0067 起票)
+
+**完了項目**:
+
+1. **ADR-0067 新規追加**: アプリ側 CSP script-src の hash 化 (SvelteKit `kit.csp` hash mode、`'unsafe-inline'` 撤廃)。EPIC #3408 slice C (#3829) で、`hooks.server.ts buildCspHeader()` の `script-src 'self' 'unsafe-inline'` が残る限り将来の stored-XSS 経路混入時に CSP が script ベクタの最終防壁にならない構造リスク (#3112 リスク 1) を根治。impact-analysis で inline script が SvelteKit hydration bootstrap 1 種のみと実測し、選択肢 3 案比較 (A: kit.csp hash mode / B: nonce+strict-dynamic / C: 現状維持) を本文に記載し A 採用。ADR-0029 (LP 側 CSP、別 origin・別スコープ) は supersede せず併存 (役割分担を明記)。Pre-PMF Bucket A (ADR-0010 整合、config 数行 + 依存ゼロ)。
+
+**1-in-1-out 履行**: ADR-0064〜0066 起票時と同様、1-in-1-out は **2026-07 最終週の月 1 棚卸** で archive 候補 (ADR-0014 proposed 据置 / per-ADR ボリューム超過) と併せて消化する (本 PR scope 外)。
+
+active 総数: 46 件 (棚卸後、ADR-0067 +1)。

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -590,7 +590,7 @@ Dockerfile.lambda        # Lambda Web Adapter用
 
 ### CSP との整合
 
-`hooks.server.ts` `buildCspHeader()` は外部送信先を一切ホワイトリストしない（`connect-src 'self'` 固定）。新たな外部 SaaS analytics を導入する場合は、本セクションと ADR-0023 §3.4 ホワイトリストの両方を更新する PR を先に通すこと（ADR-0006 安全弁削除禁止）。
+アプリ側 CSP (`svelte.config.js` `kit.csp`、#3829 / ADR-0067 で `hooks.server.ts buildCspHeader()` から移管) は外部送信先を一切ホワイトリストしない (`connect-src 'self'` 固定)。新たな外部 SaaS analytics を導入する場合は、本セクションと ADR-0023 §3.4 ホワイトリストの両方を更新する PR を先に通すこと (ADR-0006 安全弁削除禁止)。
 
 ### Pre-PMF (ADR-0010) スコープ
 

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -618,7 +618,7 @@ CSP 以外のヘッダは `hooks.server.ts` で全レスポンスに付与。**`
 - **directive SSOT**: `svelte.config.js` `kit.csp.directives` (旧 `hooks.server.ts buildCspHeader()` を 1:1 写経、`connect-src 'self'` 固定による「外部送信ゼロ」も継承)。
 - **付与範囲**: CSP は SvelteKit が **ページレスポンス** にのみ付与する。SSR ページは HTTP header、prerender ページ (`/sitemap.xml` 等) は `<meta http-equiv>`。API / エンドポイント / 静的ファイルレスポンスは CSP を持たない (script 実行文脈が無く、user 由来 SVG は §7.2 の `Content-Disposition: attachment` = CSP 非依存で保護されるため security 中立)。
 - **frame-ancestors backup**: `frame-ancestors 'none'` は SSR では header で有効だが、prerender ページの `<meta>` では無効 (SvelteKit が meta 生成時に自動除外)。この分は hooks が全レスポンスに付与する `X-Frame-Options: DENY` が backup。
-- **style-src は本 slice では `'unsafe-inline'` を維持** (撤廃は EPIC #3408 slice B で別途扱う)。
+- **style-src は `'unsafe-inline'` を維持** (#3828 slice B、案C)。Svelte が SSR で `style:` binding (102) / `style=` 属性を inline style 属性化し、CSP hash/nonce は style 属性に効かない構造的制約のため撤廃は Pre-PMF 過剰。style ベクタは DOMPurify (ADR-0025) + nosniff + attachment 配信 (#3105) が実防御を担う。根拠・将来撤廃トリガは ADR-0067 参照。
 - **LP (`site/**`) 側 CSP は別 origin・別スコープ** (GitHub Pages 静的配信、`<meta>` + `cdn.jsdelivr.net` allowlist)。§7.1.2 / ADR-0029 が SSOT で、本節 (アプリ側) とは supersede でなく併存。
 - **回帰検証**: `tests/e2e/app-csp.spec.ts` で SSR CSP header の `script-src 'unsafe-inline'` 非在 + sha256 付与 + CSP violation 0 件 + hydration 生存 (child home / admin Ark UI Menu / marketplace SPA nav) を担保。
 

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -599,17 +599,28 @@ IAM 分離は **CDK 単体テストで physical assertion** する。設計が�
 
 ### 7.1 セキュリティヘッダ
 
-`hooks.server.ts` で全レスポンスに付与:
+CSP 以外のヘッダは `hooks.server.ts` で全レスポンスに付与。**`Content-Security-Policy` は SvelteKit 標準 CSP (`svelte.config.js` `kit.csp`、hash mode) がページレスポンスに付与する** (#3829 / ADR-0067、下記):
 
-| ヘッダ | 値 | 目的 |
-|--------|-----|------|
-| `X-Frame-Options` | `DENY` | クリックジャッキング防止 |
-| `X-Content-Type-Options` | `nosniff` | MIME スニッフィング防止 |
-| `Referrer-Policy` | `strict-origin-when-cross-origin` | リファラー情報の制限 |
-| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 不要な API の無効化 |
-| `Content-Security-Policy` | `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'` | XSS/Polyglot 攻撃防止 |
-| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | HTTPS 強制（cognito のみ） |
-| `Cache-Control` | `no-cache, no-store, must-revalidate` | 認証ページのキャッシュ禁止 |
+| ヘッダ | 値 | 目的 | 付与主体 |
+|--------|-----|------|---------|
+| `X-Frame-Options` | `DENY` | クリックジャッキング防止 | hooks (全レスポンス) |
+| `X-Content-Type-Options` | `nosniff` | MIME スニッフィング防止 | hooks (全レスポンス) |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | リファラー情報の制限 | hooks (全レスポンス) |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 不要な API の無効化 | hooks (全レスポンス) |
+| `Content-Security-Policy` | `default-src 'self'; script-src 'self' 'sha256-<hydration bootstrap>'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'` | XSS/Polyglot 攻撃防止 | **SvelteKit kit.csp (ページレスポンス)** |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | HTTPS 強制（cognito のみ） | hooks (全レスポンス) |
+| `Cache-Control` | `no-cache, no-store, must-revalidate` | 認証ページのキャッシュ禁止 | hooks (認証ページ) |
+
+#### 7.1.1 アプリ側 CSP は kit.csp hash mode に一本化 (#3829 / ADR-0067)
+
+`script-src` から `'unsafe-inline'` を撤廃し、SvelteKit `kit.csp` (`mode: 'hash'`) が hydration bootstrap の inline `<script>` を sha256 hash 化して `script-src` に自動注入する。inline script が bootstrap 1 種のみ (impact-analysis 実測) のためクリーンに撤廃でき、stored-XSS の script ベクタが構造的に塞がれる (#3112 構造リスク 1 の根治)。
+
+- **directive SSOT**: `svelte.config.js` `kit.csp.directives` (旧 `hooks.server.ts buildCspHeader()` を 1:1 写経、`connect-src 'self'` 固定による「外部送信ゼロ」も継承)。
+- **付与範囲**: CSP は SvelteKit が **ページレスポンス** にのみ付与する。SSR ページは HTTP header、prerender ページ (`/sitemap.xml` 等) は `<meta http-equiv>`。API / エンドポイント / 静的ファイルレスポンスは CSP を持たない (script 実行文脈が無く、user 由来 SVG は §7.2 の `Content-Disposition: attachment` = CSP 非依存で保護されるため security 中立)。
+- **frame-ancestors backup**: `frame-ancestors 'none'` は SSR では header で有効だが、prerender ページの `<meta>` では無効 (SvelteKit が meta 生成時に自動除外)。この分は hooks が全レスポンスに付与する `X-Frame-Options: DENY` が backup。
+- **style-src は本 slice では `'unsafe-inline'` を維持** (撤廃は EPIC #3408 slice B で別途扱う)。
+- **LP (`site/**`) 側 CSP は別 origin・別スコープ** (GitHub Pages 静的配信、`<meta>` + `cdn.jsdelivr.net` allowlist)。§7.1.2 / ADR-0029 が SSOT で、本節 (アプリ側) とは supersede でなく併存。
+- **回帰検証**: `tests/e2e/app-csp.spec.ts` で SSR CSP header の `script-src 'unsafe-inline'` 非在 + sha256 付与 + CSP violation 0 件 + hydration 生存 (child home / admin Ark UI Menu / marketplace SPA nav) を担保。
 
 ### 7.1.2 LP（静的サイト）の CSP（ADR-0029 / #1719）
 

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -603,7 +603,7 @@ CSP 以外のヘッダは `hooks.server.ts` で全レスポンスに付与。**`
 
 | ヘッダ | 値 | 目的 | 付与主体 |
 |--------|-----|------|---------|
-| `X-Frame-Options` | `DENY` | クリックジャッキング防止 | hooks (全レスポンス) |
+| `X-Frame-Options` | `DENY` | クリックジャッキング防止 | hooks (SSR / 動的レスポンス。prerender 静的配信は非経由 — §7.1.1) |
 | `X-Content-Type-Options` | `nosniff` | MIME スニッフィング防止 | hooks (全レスポンス) |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` | リファラー情報の制限 | hooks (全レスポンス) |
 | `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` | 不要な API の無効化 | hooks (全レスポンス) |
@@ -617,7 +617,7 @@ CSP 以外のヘッダは `hooks.server.ts` で全レスポンスに付与。**`
 
 - **directive SSOT**: `svelte.config.js` `kit.csp.directives` (旧 `hooks.server.ts buildCspHeader()` を 1:1 写経、`connect-src 'self'` 固定による「外部送信ゼロ」も継承)。
 - **付与範囲**: CSP は SvelteKit が **ページレスポンス** にのみ付与する。SSR ページは HTTP header、prerender ページ (`/sitemap.xml` 等) は `<meta http-equiv>`。API / エンドポイント / 静的ファイルレスポンスは CSP を持たない (script 実行文脈が無く、user 由来 SVG は §7.2 の `Content-Disposition: attachment` = CSP 非依存で保護されるため security 中立)。
-- **frame-ancestors backup**: `frame-ancestors 'none'` は SSR では header で有効だが、prerender ページの `<meta>` では無効 (SvelteKit が meta 生成時に自動除外)。この分は hooks が全レスポンスに付与する `X-Frame-Options: DENY` が backup。
+- **clickjacking の適用境界**: `frame-ancestors 'none'` は SSR では header で有効。対話 HTML は全て SSR のため、hooks が SSR / 動的レスポンスに付与する `X-Frame-Options: DENY` で clickjacking 保護が確実に効く。prerender ページ (唯一 `/sitemap.xml`、非対話 XML) は build 時に静的化され hooks を経由しないため `frame-ancestors` (meta 自動除外) も `X-Frame-Options` (hooks 非経由) も持たないが、iframe 埋込による clickjacking の攻撃価値が無く実害は無い (当初「hooks の X-Frame-Options が prerender ページの backup」とした記述は prerender ページ自身には成立しないため、QM runtime 検証 #3833 で実挙動へ是正。回帰は `tests/e2e/app-csp.spec.ts` が SSR HTML の付与 + sitemap.xml の非付与を両方 assert)。
 - **style-src は `'unsafe-inline'` を維持** (#3828 slice B、案C)。Svelte が SSR で `style:` binding (102) / `style=` 属性を inline style 属性化し、CSP hash/nonce は style 属性に効かない構造的制約のため撤廃は Pre-PMF 過剰。style ベクタは DOMPurify (ADR-0025) + nosniff + attachment 配信 (#3105) が実防御を担う。根拠・将来撤廃トリガは ADR-0067 参照。
 - **LP (`site/**`) 側 CSP は別 origin・別スコープ** (GitHub Pages 静的配信、`<meta>` + `cdn.jsdelivr.net` allowlist)。§7.1.2 / ADR-0029 が SSOT で、本節 (アプリ側) とは supersede でなく併存。
 - **回帰検証**: `tests/e2e/app-csp.spec.ts` で SSR CSP header の `script-src 'unsafe-inline'` 非在 + sha256 付与 + CSP violation 0 件 + hydration 生存 (child home / admin Ark UI Menu / marketplace SPA nav) を担保。

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -103,31 +103,15 @@ function shouldReturnDemoNoop(method: string, path: string, mode: RuntimeMode): 
 	);
 }
 
-/**
- * Build CSP header.
- *
- * #1591 (ADR-0023 I2): umami / Sentry プロバイダ削除に伴い、provider 固有ドメインの
- * 追加は不要になった。analytics は AWS 内完結 (DynamoDB) のため connectSrc / scriptSrc
- * に外部ホストを足す必要がない — 'self' で完結する。これにより CSP は静的に決まり、
- * 「外部送信ゼロ」が CSP レイヤでも構造的に保証される。
- */
-function buildCspHeader(): string {
-	return [
-		`default-src 'self'`,
-		`script-src 'self' 'unsafe-inline'`,
-		`style-src 'self' 'unsafe-inline'`,
-		`img-src 'self' data: blob:`,
-		`media-src 'self' blob:`,
-		`font-src 'self'`,
-		`connect-src 'self'`,
-		`object-src 'none'`,
-		`base-uri 'self'`,
-		`frame-ancestors 'none'`,
-	].join('; ');
-}
-
-/** Cached CSP header (built once at startup) */
-const CSP_HEADER = buildCspHeader();
+// #3829 (EPIC #3408 slice C): アプリ側 CSP は SvelteKit 標準 CSP (svelte.config.js kit.csp、
+// hash mode) に一本化した。SvelteKit が hydration bootstrap の inline script を sha256 hash 化して
+// `script-src` に自動注入するため `script-src 'unsafe-inline'` を撤廃できる (stored-XSS の script
+// ベクタ最終防壁化、#3112 構造リスク 1)。旧 `buildCspHeader()` / `CSP_HEADER` / 下記
+// `response.headers.set('Content-Security-Policy', ...)` は clobber (二重付与) を避けるため撤去済。
+// directive 値の SSOT は svelte.config.js kit.csp。「外部送信ゼロ」の connect-src 'self' 固定も
+// 同 config に引き継いでいる (ADR-0067 / ADR-0023 §3.4)。
+// prerender ページ (sitemap 等) では frame-ancestors が meta で無効化されるため、下記
+// `X-Frame-Options: DENY` が clickjacking 防御の backup として引き続き必須。
 
 export const handle: Handle = ({ event, resolve }) =>
 	// #788: リクエスト境界でコンテキストを張る。resolveFullPlanTier / getTrialStatus が
@@ -497,11 +481,14 @@ export const handle: Handle = ({ event, resolve }) =>
 		const response = await resolve(event);
 
 		// 3) セキュリティヘッダ付与
+		// Content-Security-Policy は SvelteKit 標準 CSP (svelte.config.js kit.csp) が
+		// ページレスポンスに付与するため、ここでは set しない (#3829、clobber 除去)。
+		// X-Frame-Options は prerender ページで frame-ancestors が meta 無効化される分の
+		// clickjacking backup として引き続き全レスポンスに付与する。
 		response.headers.set('X-Frame-Options', 'DENY');
 		response.headers.set('X-Content-Type-Options', 'nosniff');
 		response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
 		response.headers.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
-		response.headers.set('Content-Security-Policy', CSP_HEADER);
 		if (authMode === 'cognito') {
 			response.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 		}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -110,8 +110,10 @@ function shouldReturnDemoNoop(method: string, path: string, mode: RuntimeMode): 
 // `response.headers.set('Content-Security-Policy', ...)` は clobber (二重付与) を避けるため撤去済。
 // directive 値の SSOT は svelte.config.js kit.csp。「外部送信ゼロ」の connect-src 'self' 固定も
 // 同 config に引き継いでいる (ADR-0067 / ADR-0023 §3.4)。
-// prerender ページ (sitemap 等) では frame-ancestors が meta で無効化されるため、下記
-// `X-Frame-Options: DENY` が clickjacking 防御の backup として引き続き必須。
+// clickjacking 防御 (下記 `X-Frame-Options: DENY`) は resolve(event) を通る SSR / 動的レスポンス
+// 全てに付与される。対話 HTML ページは全て SSR のため確実に効く。prerender ページ (唯一 sitemap.xml、
+// 非対話 XML) は build 時に静的化され hooks を経由しないため X-Frame-Options を持たないが、iframe 埋込
+// による clickjacking の実害は無い (QM runtime 検証 #3833 で実挙動を確認)。
 
 export const handle: Handle = ({ event, resolve }) =>
 	// #788: リクエスト境界でコンテキストを張る。resolveFullPlanTier / getTrialStatus が
@@ -483,8 +485,9 @@ export const handle: Handle = ({ event, resolve }) =>
 		// 3) セキュリティヘッダ付与
 		// Content-Security-Policy は SvelteKit 標準 CSP (svelte.config.js kit.csp) が
 		// ページレスポンスに付与するため、ここでは set しない (#3829、clobber 除去)。
-		// X-Frame-Options は prerender ページで frame-ancestors が meta 無効化される分の
-		// clickjacking backup として引き続き全レスポンスに付与する。
+		// X-Frame-Options は SSR / 動的レスポンス全てに付与し、対話 HTML の clickjacking を防ぐ。
+		// prerender ページ (sitemap.xml、非対話 XML) は静的化され本 hooks を経由しないため
+		// 本 header は乗らないが、非対話 XML で実害なし (#3833 で実挙動を確認)。
 		response.headers.set('X-Frame-Options', 'DENY');
 		response.headers.set('X-Content-Type-Options', 'nosniff');
 		response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -33,6 +33,32 @@ const config = {
 			// '*' はデフォルトの「/ から辿れるページを全部クロール」を維持。
 			entries: ['*', '/sitemap.xml'],
 		},
+		// #3829 (EPIC #3408 slice C): アプリ側 CSP を SvelteKit 標準 CSP (kit.csp hash mode) に一本化。
+		// SvelteKit が hydration bootstrap の inline `<script>` を sha256 hash 化して `script-src` に
+		// 自動注入するため、`script-src 'unsafe-inline'` を撤廃できる (stored-XSS 経路の script ベクタを
+		// 構造的に塞ぐ、#3112 構造リスク 1 の根治)。旧 `hooks.server.ts buildCspHeader()` の全 directive を
+		// SSOT として写経し 1:1 一致させている (img/media/font/connect 等を漏らさない)。CSP header の付与は
+		// SvelteKit が担うため hooks 側の `Content-Security-Policy` `.set()` は撤去済 (clobber 除去)。
+		// - SSR ページ: HTTP header で付与 / prerender ページ (sitemap 等): `<meta>` で付与。
+		// - `frame-ancestors` は meta では効かない (SvelteKit が meta 生成時に自動除外) ため、prerender
+		//   ページの clickjacking 防御は hooks の `X-Frame-Options: DENY` が backup として担保する。
+		// - `style-src 'unsafe-inline'` は本 PR では維持 (slice B = #3408 AC2 で別途扱う)。
+		// - ADR-0067 (アプリ側 script-src hash 化) / ADR-0029 (LP 側 CSP、別 origin・別スコープ、併存) 参照。
+		csp: {
+			mode: 'hash',
+			directives: {
+				'default-src': ['self'],
+				'script-src': ['self'],
+				'style-src': ['self', 'unsafe-inline'],
+				'img-src': ['self', 'data:', 'blob:'],
+				'media-src': ['self', 'blob:'],
+				'font-src': ['self'],
+				'connect-src': ['self'],
+				'object-src': ['none'],
+				'base-uri': ['self'],
+				'frame-ancestors': ['none'],
+			},
+		},
 	},
 };
 

--- a/tests/e2e/app-csp.spec.ts
+++ b/tests/e2e/app-csp.spec.ts
@@ -1,0 +1,185 @@
+// tests/e2e/app-csp.spec.ts
+// #3829 (EPIC #3408 slice C): アプリ側 CSP `script-src 'unsafe-inline'` 撤廃の回帰検証。
+//
+// アプリ側 (SvelteKit) の CSP は svelte.config.js `kit.csp` (hash mode) に一本化した。
+// SvelteKit が hydration bootstrap の inline `<script>` を sha256 hash 化して `script-src` に
+// 自動注入するため、`script-src 'unsafe-inline'` を撤廃できる (#3112 構造リスク 1 の根治)。
+//
+// 本 spec は「全画面 hydration」への高回帰リスクを厚く検証する:
+//   ① SSR ページのレスポンス CSP に `script-src 'unsafe-inline'` が **無い** + sha256 hash が付与されている
+//   ② X-Frame-Options: DENY が付与されている (prerender ページで frame-ancestors が meta 無効化される分の backup)
+//   ③ ページ読込時に CSP violation (Refused to execute inline script 等) の console error が **0 件**
+//   ④ hydration / interactivity が生存 (child home 遷移 / admin Ark UI Menu / marketplace SPA nav が client 動作する)
+//
+// CI は `npm run preview` (本番ビルド) で E2E 実行 = kit.csp hash mode が実効化する環境。
+// LP (site/**) 側 CSP は別 origin・別スコープ (GitHub Pages 静的配信、ADR-0029 + tests/e2e/lp-csp.spec.ts)。
+// 併存関係の整理は ADR-0067 / 設計書 14 §7.1 を参照。
+
+import { expect, type Page, test } from '@playwright/test';
+import { selectElementaryChildAndDismiss, selectJuniorChildAndDismiss } from './helpers';
+
+/** CSP violation (script/style/inline の Refused) を示す console error / pageerror を収集する */
+function collectCspViolations(page: Page): { consoleErrors: string[]; pageErrors: string[] } {
+	const consoleErrors: string[] = [];
+	const pageErrors: string[] = [];
+	page.on('console', (msg) => {
+		if (msg.type() !== 'error') return;
+		const text = msg.text();
+		if (
+			text.includes('Content Security Policy') ||
+			text.includes('Content-Security-Policy') ||
+			text.includes('Refused to execute') ||
+			text.includes('Refused to load') ||
+			text.includes('Refused to apply')
+		) {
+			consoleErrors.push(text);
+		}
+	});
+	page.on('pageerror', (err) => pageErrors.push(err.message));
+	return { consoleErrors, pageErrors };
+}
+
+/**
+ * SSR ページの CSP レスポンスヘッダが hash mode で hardened されていることを assert する。
+ * - `script-src` directive が存在し `'unsafe-inline'` を含まない (#3829 AC2 の核心)
+ * - hash mode により `sha256-` が付与されている (SvelteKit が bootstrap inline script を hash 化した証跡)
+ */
+function assertScriptSrcHardened(csp: string | undefined, label: string): void {
+	expect(csp, `${label}: CSP レスポンスヘッダが kit.csp により付与されている`).toBeTruthy();
+	const directives = (csp ?? '').split(';').map((d) => d.trim());
+	const scriptSrc = directives.find((d) => d.startsWith('script-src'));
+	expect(scriptSrc, `${label}: script-src directive が存在する`).toBeTruthy();
+	expect(
+		scriptSrc ?? '',
+		`${label}: script-src に 'unsafe-inline' が無い (#3829 撤廃)`,
+	).not.toContain("'unsafe-inline'");
+	expect(
+		scriptSrc ?? '',
+		`${label}: script-src に sha256- hash が付与 (kit.csp hash mode)`,
+	).toContain('sha256-');
+}
+
+/** hydration violation が無いことを assert する共通ヘルパ */
+function expectNoCspViolations(
+	violations: { consoleErrors: string[]; pageErrors: string[] },
+	label: string,
+): void {
+	expect(
+		violations.consoleErrors,
+		`${label}: CSP violation console error: ${violations.consoleErrors.join('\n')}`,
+	).toHaveLength(0);
+	expect(
+		violations.pageErrors,
+		`${label}: CSP 由来 pageerror: ${violations.pageErrors.join('\n')}`,
+	).toHaveLength(0);
+}
+
+test.describe('#3829 アプリ側 CSP script-src hash 化 (unsafe-inline 撤廃)', () => {
+	test('SSR ページの CSP header が script-src unsafe-inline 撤廃 + hash 付与 + X-Frame-Options backup', async ({
+		page,
+	}) => {
+		const violations = collectCspViolations(page);
+		const response = await page.goto('/switch', { waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('load');
+
+		const headers = response?.headers() ?? {};
+		assertScriptSrcHardened(headers['content-security-policy'], '/switch');
+
+		// style-src は本 PR では 'unsafe-inline' を維持 (slice B = #3408 AC2 で別途)
+		const styleSrc = (headers['content-security-policy'] ?? '')
+			.split(';')
+			.map((d) => d.trim())
+			.find((d) => d.startsWith('style-src'));
+		expect(styleSrc ?? '', "style-src は 'unsafe-inline' を維持 (slice B 未着手)").toContain(
+			"'unsafe-inline'",
+		);
+
+		// prerender ページで frame-ancestors が meta 無効化される分の clickjacking backup
+		expect(headers['x-frame-options'], 'X-Frame-Options: DENY が hooks で付与されている').toBe(
+			'DENY',
+		);
+
+		expectNoCspViolations(violations, '/switch');
+	});
+
+	test('prerender エンドポイント /sitemap.xml が CSP 一本化後も配信され X-Frame-Options を持つ', async ({
+		page,
+	}) => {
+		const response = await page.goto('/sitemap.xml', { waitUntil: 'domcontentloaded' });
+		expect(response?.status(), '/sitemap.xml が 200 で配信される').toBe(200);
+		expect(response?.headers()['x-frame-options'], 'X-Frame-Options: DENY backup').toBe('DENY');
+	});
+
+	// hydration 生存 = bootstrap inline script が CSP に blockされず実行された証跡。
+	// child home への遷移は /switch でのクライアント側 child 選択 (client-only) が成立して初めて成る。
+	for (const mode of [
+		{ name: 'elementary', select: selectElementaryChildAndDismiss, urlRe: /\/elementary\/home/ },
+		{ name: 'junior', select: selectJuniorChildAndDismiss, urlRe: /\/junior\/home/ },
+	] as const) {
+		test(`child home hydration 生存 (${mode.name}): client child 選択 → home 遷移 → 活動カード操作可能`, async ({
+			page,
+		}) => {
+			const violations = collectCspViolations(page);
+			await mode.select(page);
+			await expect(page, 'client child 選択が成立し home に遷移 (hydration 生存)').toHaveURL(
+				mode.urlRe,
+			);
+			await expect(
+				page.locator('[data-testid^="activity-card-"]').first(),
+				'活動カードが hydrate されている',
+			).toBeVisible();
+			expectNoCspViolations(violations, `child-home:${mode.name}`);
+		});
+	}
+
+	test('admin/activities hydration 生存: Ark UI + 追加メニューが client で開く + CSP header hardened', async ({
+		page,
+	}) => {
+		const violations = collectCspViolations(page);
+		const response = await page.goto('/admin/activities', { waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('load');
+		assertScriptSrcHardened(response?.headers()['content-security-policy'], '/admin/activities');
+
+		// Ark UI Menu は client-side hydration 完了後にのみ listener を attach する。
+		// menu が開く = bootstrap script が CSP block されず実行された動かぬ証跡。
+		// (#2260 Fix-6: hydration 直後は listener attach が間に合わず初回 click が空振りしうるため toPass retry)
+		const trigger = page.getByTestId('header-add-activity-btn');
+		await expect(trigger).toBeVisible();
+		await expect(async () => {
+			await trigger.click();
+			await expect(page.getByTestId('menu-item-manual')).toBeVisible({ timeout: 1_000 });
+		}, '+ 追加メニューが client で開く (hydration 生存)').toPass({ timeout: 10_000 });
+
+		expectNoCspViolations(violations, '/admin/activities');
+	});
+
+	test('marketplace hydration 生存: SPA ナビ (type filter) が client router で動く + CSP header hardened', async ({
+		page,
+	}) => {
+		const violations = collectCspViolations(page);
+		const response = await page.goto('/marketplace', { waitUntil: 'domcontentloaded' });
+		await page.waitForLoadState('load');
+		assertScriptSrcHardened(response?.headers()['content-security-policy'], '/marketplace');
+
+		// SvelteKit client router が hydrate されていれば <a> は full reload せず SPA 遷移する。
+		// window に probe を置き、type filter link click 後も残存 = full reload していない = hydration 生存。
+		await page.evaluate(() => {
+			(window as unknown as { __hydrationProbe?: string }).__hydrationProbe = 'alive';
+		});
+		const filterLink = page.locator('[data-testid^="filter-type-"]').first();
+		await expect(filterLink).toBeVisible();
+		const beforeUrl = page.url();
+		await filterLink.click();
+		await expect(page, 'type filter で URL が更新される (client router 動作)').not.toHaveURL(
+			beforeUrl,
+		);
+		const probe = await page.evaluate(
+			() => (window as unknown as { __hydrationProbe?: string }).__hydrationProbe,
+		);
+		expect(probe, 'SPA 遷移で window probe が残存 = full reload していない = hydration 生存').toBe(
+			'alive',
+		);
+
+		expectNoCspViolations(violations, '/marketplace');
+	});
+});

--- a/tests/e2e/app-csp.spec.ts
+++ b/tests/e2e/app-csp.spec.ts
@@ -106,9 +106,10 @@ test.describe('#3829 アプリ側 CSP script-src hash 化 (unsafe-inline 撤廃)
 
 		// /switch は SSR (動的) レスポンス = hooks が resolve(event) 経由で X-Frame-Options を付与する。
 		// 対話 HTML の clickjacking 防御はここで実測する。
-		expect(headers['x-frame-options'], 'SSR HTML に X-Frame-Options: DENY が hooks で付与されている').toBe(
-			'DENY',
-		);
+		expect(
+			headers['x-frame-options'],
+			'SSR HTML に X-Frame-Options: DENY が hooks で付与されている',
+		).toBe('DENY');
 
 		expectNoCspViolations(violations, '/switch');
 	});
@@ -117,9 +118,10 @@ test.describe('#3829 アプリ側 CSP script-src hash 化 (unsafe-inline 撤廃)
 		page,
 	}) => {
 		const response = await page.goto('/sitemap.xml', { waitUntil: 'domcontentloaded' });
-		expect(response?.status(), '/sitemap.xml が 200 で配信される (CSP 一本化後も prerender endpoint 生存)').toBe(
-			200,
-		);
+		expect(
+			response?.status(),
+			'/sitemap.xml が 200 で配信される (CSP 一本化後も prerender endpoint 生存)',
+		).toBe(200);
 
 		// prerender ページ (`export const prerender = true`) は build 時に静的化され request 時に
 		// server hooks (hooks.server.ts) を経由しない。従って hooks が付与する X-Frame-Options: DENY は

--- a/tests/e2e/app-csp.spec.ts
+++ b/tests/e2e/app-csp.spec.ts
@@ -7,9 +7,19 @@
 //
 // 本 spec は「全画面 hydration」への高回帰リスクを厚く検証する:
 //   ① SSR ページのレスポンス CSP に `script-src 'unsafe-inline'` が **無い** + sha256 hash が付与されている
-//   ② X-Frame-Options: DENY が付与されている (prerender ページで frame-ancestors が meta 無効化される分の backup)
+//   ② SSR (動的) レスポンスに X-Frame-Options: DENY が付与されている (対話 HTML の clickjacking 防御)
 //   ③ ページ読込時に CSP violation (Refused to execute inline script 等) の console error が **0 件**
 //   ④ hydration / interactivity が生存 (child home 遷移 / admin Ark UI Menu / marketplace SPA nav が client 動作する)
+//
+// clickjacking 防御の適用境界 (QM runtime 検証 #3833 で是正):
+//   X-Frame-Options: DENY は hooks.server.ts が resolve(event) を通る SSR / 動的レスポンス全てに付与する。
+//   対話 HTML ページは全て SSR のため clickjacking 保護は確実に効く (本 spec ② で実測)。
+//   一方 prerender ページ (`export const prerender = true`) は build 時に静的化され request 時に
+//   server hooks を経由しないため X-Frame-Options を持たない。本アプリで唯一の prerender endpoint は
+//   /sitemap.xml (非対話 XML) であり、iframe 埋め込みによる clickjacking の実害は事実上ない。
+//   従って「hooks の X-Frame-Options が prerender ページの backup になる」という当初の設計前提は
+//   prerender ページ自身には成立しない。本 spec は実挙動に整合させ、SSR HTML で X-Frame-Options を、
+//   sitemap.xml では「prerender は server-hook header を持たない」実挙動を assert する。
 //
 // CI は `npm run preview` (本番ビルド) で E2E 実行 = kit.csp hash mode が実効化する環境。
 // LP (site/**) 側 CSP は別 origin・別スコープ (GitHub Pages 静的配信、ADR-0029 + tests/e2e/lp-csp.spec.ts)。
@@ -75,7 +85,7 @@ function expectNoCspViolations(
 }
 
 test.describe('#3829 アプリ側 CSP script-src hash 化 (unsafe-inline 撤廃)', () => {
-	test('SSR ページの CSP header が script-src unsafe-inline 撤廃 + hash 付与 + X-Frame-Options backup', async ({
+	test('SSR ページの CSP header が script-src unsafe-inline 撤廃 + hash 付与 + X-Frame-Options (SSR clickjacking 防御)', async ({
 		page,
 	}) => {
 		const violations = collectCspViolations(page);
@@ -94,20 +104,33 @@ test.describe('#3829 アプリ側 CSP script-src hash 化 (unsafe-inline 撤廃)
 			"'unsafe-inline'",
 		);
 
-		// prerender ページで frame-ancestors が meta 無効化される分の clickjacking backup
-		expect(headers['x-frame-options'], 'X-Frame-Options: DENY が hooks で付与されている').toBe(
+		// /switch は SSR (動的) レスポンス = hooks が resolve(event) 経由で X-Frame-Options を付与する。
+		// 対話 HTML の clickjacking 防御はここで実測する。
+		expect(headers['x-frame-options'], 'SSR HTML に X-Frame-Options: DENY が hooks で付与されている').toBe(
 			'DENY',
 		);
 
 		expectNoCspViolations(violations, '/switch');
 	});
 
-	test('prerender エンドポイント /sitemap.xml が CSP 一本化後も配信され X-Frame-Options を持つ', async ({
+	test('prerender エンドポイント /sitemap.xml が CSP 一本化後も配信される (server-hook header は非経由)', async ({
 		page,
 	}) => {
 		const response = await page.goto('/sitemap.xml', { waitUntil: 'domcontentloaded' });
-		expect(response?.status(), '/sitemap.xml が 200 で配信される').toBe(200);
-		expect(response?.headers()['x-frame-options'], 'X-Frame-Options: DENY backup').toBe('DENY');
+		expect(response?.status(), '/sitemap.xml が 200 で配信される (CSP 一本化後も prerender endpoint 生存)').toBe(
+			200,
+		);
+
+		// prerender ページ (`export const prerender = true`) は build 時に静的化され request 時に
+		// server hooks (hooks.server.ts) を経由しない。従って hooks が付与する X-Frame-Options: DENY は
+		// sitemap.xml には乗らない (QM runtime 検証 #3833 で実測 = undefined)。当初 spec は
+		// `toBe('DENY')` を期待していたが実挙動と不整合だったため、実挙動に整合させる。
+		// clickjacking の実害は無い: sitemap.xml は非対話 XML で iframe 埋め込みの攻撃価値が無く、
+		// 対話 HTML ページは全て SSR で X-Frame-Options を確実に取得する (上の /switch test で担保)。
+		expect(
+			response?.headers()['x-frame-options'],
+			'prerender の静的レスポンスは server-hook 由来の X-Frame-Options を持たない (実挙動)',
+		).toBeUndefined();
 	});
 
 	// hydration 生存 = bootstrap inline script が CSP に blockされず実行された証跡。
@@ -160,6 +183,12 @@ test.describe('#3829 アプリ側 CSP script-src hash 化 (unsafe-inline 撤廃)
 		const response = await page.goto('/marketplace', { waitUntil: 'domcontentloaded' });
 		await page.waitForLoadState('load');
 		assertScriptSrcHardened(response?.headers()['content-security-policy'], '/marketplace');
+		// /marketplace は SSR HTML (対話ページ) = hooks が X-Frame-Options: DENY を付与する。
+		// clickjacking 保護が SSR HTML で効くことを 2 ページ目でも実測する (SSR-scoped 保証)。
+		expect(
+			response?.headers()['x-frame-options'],
+			'SSR HTML (/marketplace) に X-Frame-Options: DENY が付与されている',
+		).toBe('DENY');
 
 		// SvelteKit client router が hydrate されていれば <a> は full reload せず SPA 遷移する。
 		// window に probe を置き、type filter link click 後も残存 = full reload していない = hydration 生存。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（stored-XSS の最終防壁強化）

**解決する課題**: `hooks.server.ts` の CSP `script-src 'self' 'unsafe-inline'` が残る限り、新たな stored-XSS 経路が混入した際に CSP が **script ベクタの最終防壁にならない**（#3112 構造リスク 1）。script は XSS 最重要ベクタ。

**期待される効果**: アプリ側 CSP を SvelteKit 標準 CSP（`kit.csp` hash mode）に一本化し、`script-src 'unsafe-inline'` を撤廃。SvelteKit が hydration bootstrap の inline `<script>` を sha256 hash 化して自動注入するため、inline script は hash 許可のみで動作し、任意 inline script は CSP で拒否される。

## 関連 Issue

closes #3829
closes #3828

related: #3408 (EPIC) / #3112 / ADR-0067 (本 PR 新規、アプリ側 script-src hash 化) / ADR-0029 (LP 側 CSP、別 origin・別スコープ・併存)。style-src は #3828 (slice B) で 案C（unsafe-inline 維持 + ADR）扱いのため本 PR では維持。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | script-src hash 化方針の確定（案A、OSS 3案比較） | ADR-0067 目視 | HEAD 12feb99c8d57ad07cf0f99285c15fae62f2a12c8 / `docs/decisions/0067-app-csp-script-src-hash.md`（SvelteKit kit.csp hash vs nonce+strict-dynamic vs 独自の 3案比較、ADR-0029 併存明記） |
| AC2 | CSP から `script-src 'unsafe-inline'` 撤廃（hash 化）+ clobber 除去 | `npm run build` + preview で CSP header 実測 | HEAD 12feb99c8d57ad07cf0f99285c15fae62f2a12c8 / **build 通過 (37.55s)**。preview /setup の CSP = `script-src 'self' 'sha256-qlFHM4ix...'`（**unsafe-inline 撤廃 + hash 自動付与**）、`style-src 'self' 'unsafe-inline'`（案C 維持）、CSP header 単一（clobber 除去）、`X-Frame-Options: DENY` 残置 |
| AC3 | E2E / visual 回帰（hydration/interactivity） | `npx playwright test tests/e2e/app-csp.spec.ts` | spec 新規実装（6 test: SSR CSP hardened / hash 付与 / CSP violation 0 / X-Frame-Options=DENY を SSR HTML で assert + sitemap.xml は prerender で server-hook header 非経由の実挙動を assert / child home 遷移・admin Ark UI Menu・marketplace SPA nav の hydration 生存）。**CSP 実効環境（`npm run build` → preview）で 6/6 green 実測**（QM runtime 検証 #3833 で当初の sitemap X-Frame-Options 期待が prerender 実挙動と不整合だったため実挙動へ是正、assertion 非弱体化）。local は dev で kit.csp hash 非実効のため CSP 検証は preview で実施 |
| AC4 | 設計書反映（ADR-0001） | `docs/design/14-セキュリティ設計書.md §7.1` / `13-AWS設計書` | HEAD 12feb99c8d57ad07cf0f99285c15fae62f2a12c8 / §7.1 アプリ側 CSP を kit.csp hash 一本化 + script-src unsafe-inline 撤廃を反映、13-AWS の CSP 整合節も kit.csp 移管を反映 |
| AC5 (slice B) | style-src `'unsafe-inline'` は撤廃過剰のため案C=維持を ADR で根拠明文化 (#3828 AC2 fallback) | ADR-0067 + `docs/design/14-セキュリティ設計書.md §7.1.1` | Svelte SSR が `style:` binding(102)/`style=` を inline style 属性化し CSP hash が style 属性に非対応の構造的制約を ADR-0067 に記載。scope(style 属性ベース残余リスクは DOMPurify+nosniff+attachment が実防御) + 将来撤廃トリガも明記 |

## 変更タイプ

- [x] fix: バグ修正（stored-XSS script ベクタの CSP 最終防壁化）
- [x] infra: インフラ・CI/CD（svelte.config kit.csp + 新規 e2e）
- [x] docs: ドキュメント（ADR-0067 + 設計書同期）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI（`svelte.config.js` kit.csp / `src/hooks.server.ts` CSP 撤去 / `tests/e2e/app-csp.spec.ts`）
- [x] ドキュメント（ADR-0067 / README ADR 表 / 14-セキュリティ設計書 §7.1 / 13-AWS）

**影響を受ける画面・機能**: **全 SSR ページ**（CSP header 変更）。UI 描画は不変（script-src の厳格化のみ、inline script は SvelteKit bootstrap 1 種で hash 化済）。

## テスト & 安全装置セルフチェック

- [x] targeted 検証コマンド（main tree で実行）:
- [x] `npm run build` → 通過 (37.55s、kit.csp hash 生成 OK)
- [x] `npx svelte-check` → 0 error (8157 files) / `npx biome check` → clean / `npx cspell` → exit 0 / `node scripts/check-doc-code-references.mjs` → baseline 内
- [x] preview で CSP header 実測: `script-src` に `'unsafe-inline'` 無し + `sha256-` hash 付与を確認
- [x] 追加・変更したテスト: `tests/e2e/app-csp.spec.ts`（SSR CSP hardened / hash / CSP violation 0 / hydration 3面）。CI preview lane で実行
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A（priority:medium、defense-in-depth）

## スクリーンショット / ビジュアルデモ

**該当なし**: CSP header の厳格化のみで UI ピクセル不変（visual regression baseline 更新不要）。

## コード品質セルフレビュー (#1481)

- [x] **SOLID / DRY**: CSP directive の SSOT を svelte.config.js kit.csp に一本化（hooks の重複定義を撤去 = clobber 除去）
- [x] **YAGNI**: nonce+strict-dynamic の複雑化を避け SvelteKit 標準 hash mode を採用（ADR-0067）
- [x] **Security**: script-src unsafe-inline 撤廃で stored-XSS の script ベクタを CSP 最終防壁化。connect-src 'self' 固定（外部送信ゼロ）を kit.csp に引継ぎ
- [x] **アクセシビリティ**: N/A（CSP header、UI 不変）
- [x] **パフォーマンス**: hash は build 時決定的（CloudFront キャッシュ安全、nonce の per-request 非採用）

## 横展開・影響波及チェック

- [x] **clobber 除去**: hooks の `buildCspHeader()` / `CSP_HEADER` / `Content-Security-Policy` `.set()` を撤去。`X-Frame-Options: DENY` は SSR / 動的レスポンス全てに hooks が付与し、対話 HTML（全て SSR）の clickjacking を防御。prerender ページ（唯一 sitemap.xml、非対話 XML）は静的化され hooks 非経由のため本 header を持たないが実害なし（QM runtime #3833 で当初「prerender backup」記述を実挙動へ是正）
- [x] **LP 別スコープ**: LP (`site/**`) の CSP は GitHub Pages 別 origin・`<meta>` 自前管理（ADR-0029 / lp-csp.spec.ts）で本 PR 対象外。ADR-0067 で併存を明記
- [x] **設計書同期** (ADR-0001): 14-セキュリティ設計書 §7.1 / 13-AWS
- [x] N/A — labels/terms/年齢モード/navi/demo に波及なし

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（CSP の厳格化のみ、UI/API 契約不変。inline script は SvelteKit bootstrap 1 種で hash 化済のため hydration 影響なし）

**レビュー依頼事項・QA**:
- **prerender ページ（唯一 sitemap.xml、非対話 XML）**は kit.csp が `<meta>` 配信になり frame-ancestors が無効化される。加えて prerender は静的化され hooks を経由しないため `X-Frame-Options: DENY` も乗らない（QM runtime #3833 で実測）が、非対話 XML で clickjacking 実害なし。対話 HTML は全て SSR で `X-Frame-Options: DENY` を確実に取得（`app-csp.spec.ts` が SSR HTML の付与 + sitemap.xml の非付与を両方 assert）
- **CloudFront の CSP header pass**（EPIC AC5 = slice D）: header 名不変・値のみ変更のため現行 pass 設定維持前提
- **coordination**: 14-セキュリティ設計書 §7.2 の「script-src 'unsafe-inline' の本アプリでは…」の軽微な stale は slice A(#3827、§7.2 territory) で更新（#3105 attachment 防御は CSP 非依存で security 影響なし）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし

## Ready for Review チェックリスト

- [x] `npm run build` 通過 + preview CSP header 実測（script-src unsafe-inline 撤廃 + hash）/ svelte-check / biome / cspell / doc-code-references clean をローカル確認（main tree）
- [x] セルフレビュー済み（clobber 除去 + X-Frame-Options=DENY を SSR HTML で確認 + prerender 非経由の実挙動を spec へ是正）
- [x] 全 AC 実装済み（AC3 の browser hydration は CI preview lane の app-csp.spec で最終確認）
- [x] Phase 分割: EPIC #3408 の slice C（A=#3831 / B=#3828 案C / D=#3830 は別 slice）
- [x] UI ピクセル不変（visual regression baseline 更新不要）

## QM レビュー結果

<!-- QM 記入。app-csp.spec.ts は CI preview lane で実行（local dev では kit.csp hash 非実効）。 -->


