### PR TITLE
fix(devinfra): #3832 deploy-deletion gate に teardown trailer exemption を追加 (develop 二層 false-positive + --no-verify 常態化を根絶)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -118,6 +118,12 @@ if [ -n "$PR_NUM" ]; then
 	# #2959: 比較 base は解決済み base branch (develop 基点 branch で sibling PR の
 	# develop commit を自 PR の削除と誤算入しないため)。deploy file list 自体は
 	# script 内部で本日 deploy tag (main) から取得されるため意味は不変。
+	#
+	# #3832: intentional migration teardown exemption。develop 二層で main live な feature を
+	# 意図的に撤去する PR は、撤去 commit の message 末尾に `Deploy-Teardown: <path-regex> #<issue>`
+	# trailer を書けば、gate が宣言 path の削除を exempt する (引数不要、gate が commit trailer を
+	# 自動で読む)。宣言外の削除は BLOCK 維持。これにより full `--no-verify` (この account check
+	# 段階 1 まで飛ぶ) を使わずに正当な移管撤去を通せる。詳細は ADR-0056 §G / Issue #3832。
 	RECENT_DEPLOY_CHECK_BASE="origin/$BASE_BRANCH" node scripts/check-recent-deploy-deletion.mjs || {
 		EXIT_CODE=$?
 		echo "[pre-push] FAIL: 本日 deploy 全 file 削除検出 (exit $EXIT_CODE)"

--- a/docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md
+++ b/docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md
@@ -179,7 +179,8 @@ ADR-0056 §C (Persona Drift 対策 fallback) は Task subagent dispatch tool 不
 |---|---|
 | #2607 (deploy) | `scripts/check-recent-deploy-deletion.mjs` 初出 (#2603 で起票、QM Tier 2 Step 5 D 項目) |
 | #2618 (deploy、第 4 弾) | 機構運用層 bypass (worktree HEAD verify) 検出条文 §D 追加 + script self-defense exit 3 実装 |
-| **#2615 (本 PR、time-aware flag 拡張)** | gate に `--since <ISO>` / `--since-ref <SHA>` / `--since-recent <N>` flag 追加。Fix Agent push → Re-Review 間の main 進化による Time-of-Check vs Time-of-Use race 4 ラウンド連続観察 (PR #2607 Round 5) を構造解決。time window 指定で main 進化新規 file を比較対象外化、main 進化 (新規追加) を「削除」と誤検出しない |
+| **#2615 (time-aware flag 拡張)** | gate に `--since <ISO>` / `--since-ref <SHA>` / `--since-recent <N>` flag 追加。Fix Agent push → Re-Review 間の main 進化による Time-of-Check vs Time-of-Use race 4 ラウンド連続観察 (PR #2607 Round 5) を構造解決。time window 指定で main 進化新規 file を比較対象外化、main 進化 (新規追加) を「削除」と誤検出しない |
+| **#3832 (teardown marker exemption、本 §G)** | develop 二層で main live な feature を意図的に撤去する PR の誤 BLOCK (full `--no-verify` 強制) を解消。`Deploy-Teardown: <path-regex>` commit trailer で宣言 path のみ exempt (audit log 出力)、宣言外は BLOCK 維持。account check を温存したまま `--no-verify` 常態化を根絶 (#3821 で観察) |
 
 
 ## §F. push 時自己検証機構 (第 8 弾 deploy、#2598、2026-05-29 追記)
@@ -240,6 +241,39 @@ Step 2.2 (`check-recent-deploy-deletion.mjs`) は **引数なしで呼ぶ** = de
 由来: PR #2645 第 8 弾 deploy 直後の Fix Agent (#2644) 実観察、Issue #2647 で hot fix (第 9 弾 deploy)。
 unit test 検証: `tests/unit/scripts/check-recent-deploy-deletion.test.ts` §「#2647 hook context」 — 引数なし時の `prNumber === null` + worktree HEAD verify skip 仕様を pin。
 
+## §G. intentional migration teardown exemption (develop 二層 false-positive 是正、#3832、2026-07-17 追記)
+
+第 2 弾 gate (`scripts/check-recent-deploy-deletion.mjs`) は「直近 deploy した feature の削除 = 事故的消失」を data-loss として BLOCK する。しかし **develop 二層ブランチ戦略 (`docs/sessions/branch-strategy.md`) では「main に live な feature を develop 向け PR が migration で意図的に撤去する」のは正当**であり、gate はこれを区別できず正当な移管撤去 PR を誤 BLOCK する。
+
+**実害観察 (#3821 analytics Sub-B)**: DynamoDB → DSQL 移管の一環で always-on の analytics 収集 cron / service を撤去 (#3805 AC1 の文書化済み scope) した際、gate が「直近 merge file の削除」と誤検出。`.husky/pre-push` hook は gate が案内する `--ignore-pattern` を渡さないため実質使えず、ユーザ承認のもと **full `--no-verify`** で bypass した。`--no-verify` は全 hook を skip する = **account check (`check-gh-account-before-pr.mjs`) まで飛ぶ**副作用があり、常態化すると QA 機構を毀損する。
+
+### 対策 (commit trailer 宣言 + path scope)
+
+PR 自身の commit (`<base>..HEAD`) に **`Deploy-Teardown: <path-regex> #<issue> <理由>`** (別名 `Migration-Teardown:`) trailer を書けば、gate が宣言 path にマッチする削除を exempt する:
+
+- **path scope 必須 (無条件全通し防止)**: trailer の先頭 token は削除対象 path を絞る regex。宣言 path にマッチする削除のみ exempt し、**宣言外の削除は従来通り BLOCK** (genuine data-loss 保護維持)。path token 空は明示 Error。
+- **audit log 出力 (監査追跡可能)**: exempt した削除は `TEARDOWN-EXEMPT` として stdout に列挙 (file + 宣言 pattern + reason)。監査が後追いできる。
+- **QM-gated**: trailer は git 履歴 / PR body に残り QM / 監査が review する。self-exempt の濫用は path scope + log + QM review で構造的に抑止。
+- **`--no-verify` 常態化の根絶**: 本 exemption は deploy-deletion gate **単体**を対象化し、account check 等の他 hook は必ず走る。hook (`.husky/pre-push`) は trailer を自動で読むため引数不要で exemption が効く。
+- **両 lane 適用**: trailer は commit と共に develop → main へ流れるため、develop 向け PR で 1 度宣言すれば release/*→main 統合時も同一宣言が自動適用され、#3438 Phase 3 等の同種撤去での再エスカレーションを防ぐ。宣言外の削除は両 lane とも hard-block のまま。
+
+### 実装
+
+純関数 `parseTeardownTrailers` / `compileTeardownPattern` / `partitionDeletionsByTeardown` / `getTeardownPatternsFromCommits` を `scripts/check-recent-deploy-deletion.mjs` から export。`main()` は削除検出後に teardown trailer を読み、宣言 path マッチを exempt (log 出力) してから残りを `findViolations` に回す。regex compile は `compileIgnorePattern` (長さ上限 + fail-closed、#3766) を再利用。unit + 実 git fixture test (`tests/unit/scripts/check-recent-deploy-deletion.test.ts` §「#3832」) で「marker 無し BLOCK / marker 有り通過 / 宣言外は BLOCK 維持」の境界を failing-test-first (ADR-0061) で固定。
+
+### 運用 (migration teardown PR の宣言方法)
+
+意図的に main live な file を撤去する PR は、撤去 commit の message 末尾に trailer を付ける:
+
+```
+refactor(analytics): #3821 always-on analytics 収集を撤去
+
+Deploy-Teardown: ^src/lib/analytics/ #3821 analytics Sub-B teardown
+Deploy-Teardown: ^src/routes/api/cron/(analytics|challenge)-aggregate/ #3821
+```
+
+複数 path は trailer を複数行書く。ADR archive 移動等の非 teardown な既知除外は従来どおり `--ignore-pattern` も併用可。
+
 ## 関連
 
 - **Research SSOT**: [docs/research/qm-drift-prevention-2026-05-28.md](../research/qm-drift-prevention-2026-05-28.md)
@@ -250,4 +284,5 @@ unit test 検証: `tests/unit/scripts/check-recent-deploy-deletion.test.ts` §�
 - **#2632 (§E 起票元)**: pre-ready CLI Ready checklist gate 統合 + Persona Drift §C fallback 自動化 (QA self-implement 第 5 弾、2026-05-29 deploy)
 - **#2598 (§F 起票元)**: `.husky/pre-push` 軽量 verify chain (QA self-implement 第 8 弾、2026-05-29 deploy、本日 7+ 連続 BLOCK 構造的予防)
 - **#2647 (§F 補足 hotfix 起票元)**: Step 2.2 `--pr` 引数撤去 (QA self-implement 第 9 弾 hotfix deploy、2026-05-29 deploy、第 8 弾 deploy 直後の hook 設計バグ修正、Fix Agent `--no-verify` 強制利用解消)
+- **#3832 (§G 起票元)**: intentional migration teardown exemption (develop 二層 false-positive 是正、2026-07-17 追記、#3821 analytics Sub-B の full `--no-verify` bypass 実害への構造的対処)
 - **archive**: ADR-0031 (1-in-1-out 履行で本 PR で archive 移動)

--- a/scripts/check-recent-deploy-deletion.mjs
+++ b/scripts/check-recent-deploy-deletion.mjs
@@ -42,8 +42,13 @@
  * 1.5. `git merge-base --is-ancestor origin/main HEAD` が真 (rebase 済) かつ削除 0 件なら
  *    即 exit 0 (AC2 fast-path、recent merge 走査を省略)
  * 2. 直近 N 日 (default 7) に main に merge された commit (`--merges`) を `git log` で取得
+ * 2.7. **intentional teardown exemption (#3832)**: PR 自身の commit (`<base>..HEAD`) に
+ *    `Deploy-Teardown: <path-regex> <reason>` (or `Migration-Teardown:`) trailer があれば、
+ *    宣言 path にマッチする削除を exempt (BLOCK 対象外 + audit log 出力) にする。宣言外の削除は
+ *    従来通り gate 対象。develop 二層で main live な feature を意図的に撤去する PR が full
+ *    `--no-verify` (account check も飛ぶ) を強いられていた false-positive の構造的解消。
  * 3. 各 merge commit が touch した file (additions / modifications / deletions 不問) と
- *    PR の削除 file を path level で照合
+ *    PR の (teardown exempt 後の) 削除 file を path level で照合
  * 4. 重複 file が存在し、かつ `--ignore-pattern` regex にマッチしない場合 → exit 2
  *    + stderr に違反 listing (file:commit:date)
  * 5. 重複なし → exit 0
@@ -484,6 +489,120 @@ export function findViolations(deletedFiles, recentMerges, ignorePatterns) {
 	return violations;
 }
 
+/**
+ * intentional migration teardown を宣言する commit trailer の key 群 (#3832)。
+ *
+ * develop 二層ブランチ戦略 (docs/sessions/branch-strategy.md) では「main に live な feature を
+ * develop 向け PR が migration で意図的に撤去する」のは正当だが、deploy-deletion gate はそれを
+ * 「直近 deploy feature の削除 = 事故的消失」と区別できず誤 BLOCK し、full `--no-verify`
+ * (account check も飛ぶ) を強いていた (#3821 で観察)。PR 自身の commit に本 trailer で削除対象の
+ * path scope を宣言すれば、該当削除のみを gate が exempt する (無条件全通しにはしない)。
+ */
+export const TEARDOWN_TRAILER_KEYS = ['Deploy-Teardown', 'Migration-Teardown'];
+
+/**
+ * commit message blob 群から teardown trailer の raw value を抽出する純関数 (#3832)。
+ *
+ * `Deploy-Teardown: <value>` / `Migration-Teardown: <value>` の行を検出し value を返す。
+ * git trailer は case-insensitive 慣習のため key は大文字小文字を無視する。複数 commit を
+ * まとめた blob (record separator 混在) でも全 trailer を拾う。
+ *
+ * @param {string} text 1 つ以上の commit message を含む text
+ * @returns {string[]} trailer value (key: の後ろ、trim 済) の配列
+ */
+export function parseTeardownTrailers(text) {
+	if (!text) return [];
+	const keyAlt = TEARDOWN_TRAILER_KEYS.join('|');
+	const re = new RegExp(`^\\s*(?:${keyAlt}):\\s*(.+?)\\s*$`, 'i');
+	/** @type {string[]} */
+	const values = [];
+	for (const line of text.split(/\r?\n/)) {
+		const m = line.match(re);
+		if (m?.[1]) values.push(m[1].trim());
+	}
+	return values;
+}
+
+/**
+ * teardown trailer value を `{ pattern, patternSource, reason }` に compile する純関数 (#3832)。
+ *
+ * value の先頭 whitespace token を **削除対象 path を絞る regex** とみなし、残りを audit 用
+ * reason (通常 `#<issue> <説明>`) とする。path token が空なら明示 Error を throw して
+ * 「無条件全通し」を構造的に防ぐ (audit req 1)。regex compile は `compileIgnorePattern` に委ね、
+ * 長さ上限 + fail-closed (不正 regex で明示 Error) を再利用する (#3766)。
+ *
+ * @param {string} rawValue trailer value (例: `^src/lib/analytics/ #3821 teardown`)
+ * @returns {{ pattern: RegExp, patternSource: string, reason: string }}
+ */
+export function compileTeardownPattern(rawValue) {
+	const trimmed = rawValue.trim();
+	const spaceIdx = trimmed.search(/\s/);
+	const patternSource = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx);
+	const reason = spaceIdx === -1 ? '' : trimmed.slice(spaceIdx + 1).trim();
+	if (patternSource === '') {
+		throw new Error(
+			'Deploy-Teardown / Migration-Teardown trailer に path regex がありません (例: `Deploy-Teardown: ^src/lib/analytics/ #3821`)。無条件全通しを防ぐため path scope の宣言が必須です。',
+		);
+	}
+	const pattern = compileIgnorePattern(patternSource);
+	return { pattern, patternSource, reason };
+}
+
+/**
+ * PR 自身の commit (`<base>..HEAD`) から teardown trailer を読み、compile 済 pattern を返す (#3832)。
+ *
+ * two-dot (`<base>..HEAD`) は「HEAD 側にのみ存在する commit」= PR 自身の commit を列挙するため、
+ * base が進んでいても (behind) PR が積んだ commit の trailer だけを読む。trailer は commit と共に
+ * develop → main へ流れるため、develop 向け PR で宣言すれば release/*→main の統合時も同一宣言が
+ * 自動適用され再エスカレーションを防ぐ (#3438 Phase 3 の再発予防)。
+ *
+ * @param {string} base 比較 base (例: 'origin/main')
+ * @returns {{ patterns: Array<{pattern: RegExp, patternSource: string, reason: string}>, rawValues: string[] } | null}
+ *   git 失敗時 null
+ */
+export function getTeardownPatternsFromCommits(base) {
+	// %x1e = record separator。各 commit body を区切って parse する。
+	const output = runGit(['log', `${base}..HEAD`, '--no-merges', '--pretty=format:%B%x1e']);
+	if (output === null) return null;
+	/** @type {string[]} */
+	const rawValues = [];
+	for (const chunk of output.split('\x1e')) {
+		rawValues.push(...parseTeardownTrailers(chunk));
+	}
+	const patterns = rawValues.map((v) => compileTeardownPattern(v));
+	return { patterns, rawValues };
+}
+
+/**
+ * 削除 file を teardown 宣言で分類する純関数 (#3832)。
+ *
+ * 宣言 path (teardownPatterns) にマッチする削除は `exempted` (BLOCK されないが log 出力され
+ * 監査が後追いできる)、それ以外は `remaining` (通常 gate 対象 = 宣言外 = genuine data-loss として
+ * BLOCK 判定に回る)。teardownPatterns が空なら全削除が remaining となり従来挙動と完全一致する。
+ *
+ * @param {string[]} deletedFiles PR 側の削除 file
+ * @param {Array<{pattern: RegExp, patternSource: string, reason: string}>} teardownPatterns
+ * @returns {{ exempted: Array<{file: string, patternSource: string, reason: string}>, remaining: string[] }}
+ */
+export function partitionDeletionsByTeardown(deletedFiles, teardownPatterns) {
+	if (!teardownPatterns || teardownPatterns.length === 0) {
+		return { exempted: [], remaining: [...deletedFiles] };
+	}
+	/** @type {Array<{file: string, patternSource: string, reason: string}>} */
+	const exempted = [];
+	/** @type {string[]} */
+	const remaining = [];
+	for (const file of deletedFiles) {
+		const hit = teardownPatterns.find((t) => t.pattern.test(file));
+		if (hit) {
+			exempted.push({ file, patternSource: hit.patternSource, reason: hit.reason });
+		} else {
+			remaining.push(file);
+		}
+	}
+	return { exempted, remaining };
+}
+
 /** `--ignore-pattern` に許容する最大長 (ReDoS 表面積の上限、operator 誤用の早期検出)。 */
 export const MAX_IGNORE_PATTERN_LENGTH = 200;
 
@@ -590,7 +709,13 @@ export function helpText() {
 		'  検出する (main 進化の追加 file を誤算入しない)。<base> が ancestor (rebase 済) かつ',
 		'  削除 0 件なら early fast-path で即 exit 0 する。',
 		'',
-		'See docs/sessions/qa-session.md §Step 5 / Issue #2603 / #2615 (time-aware) / #2618 (worktree verify) / #2877 (three-dot) for context.',
+		'#3832: intentional migration teardown exemption。PR 自身の commit (`<base>..HEAD`) に',
+		'  `Deploy-Teardown: <path-regex> #<issue> <理由>` (or `Migration-Teardown:`) trailer が',
+		'  あれば、宣言 path にマッチする削除を exempt する (audit log 出力)。宣言外の削除は BLOCK 維持。',
+		'  develop 二層で main live な feature を撤去する PR が full `--no-verify` を強いられていた',
+		'  false-positive を、account check を温存したまま解消する (gate 本来の data-loss 保護は不変)。',
+		'',
+		'See docs/sessions/qa-session.md §Step 5 / Issue #2603 / #2615 (time-aware) / #2618 (worktree verify) / #2877 (three-dot) / #3832 (teardown marker) for context.',
 	].join('\n');
 }
 
@@ -688,6 +813,34 @@ async function main() {
 		return 0;
 	}
 
+	// #3832: intentional migration teardown exemption (develop 二層 false-positive 是正)。
+	// PR 自身の commit (<base>..HEAD) に `Deploy-Teardown: <path-regex> <reason>` trailer があれば、
+	// 宣言 path にマッチする削除を exempt (BLOCK 対象外) にしつつ audit log を出力する。宣言外の
+	// 削除は remaining として従来通り gate 対象になり、genuine data-loss 保護は維持される。
+	// これにより意図的 migration 撤去 PR で full `--no-verify` (account check も飛ぶ) を回避できる。
+	const teardown = getTeardownPatternsFromCommits(opts.base);
+	const teardownPatterns = teardown?.patterns ?? [];
+	const { exempted, remaining } = partitionDeletionsByTeardown(deletedFiles, teardownPatterns);
+	if (exempted.length > 0) {
+		// audit trail (#3832 監査要件 1): exempt した削除を必ず log 出力し、監査が後追いできるようにする。
+		process.stdout.write(
+			`[check-recent-deploy-deletion] TEARDOWN-EXEMPT: ${exempted.length} file(s) exempted by intentional teardown trailer (audit trail #3832)${opts.prNumber ? ` (PR #${opts.prNumber})` : ''}.\n`,
+		);
+		for (const e of exempted) {
+			process.stdout.write(
+				`  - ${e.file}\n    └ declared teardown /${e.patternSource}/${e.reason ? ` — ${e.reason}` : ''}\n`,
+			);
+		}
+	}
+
+	// exempt 後に削除が 0 件なら、宣言外の削除が無い = 通常 gate 対象なしで即 OK。
+	if (remaining.length === 0) {
+		process.stdout.write(
+			`[check-recent-deploy-deletion] OK: ${deletedFiles.length} file(s) deleted, all covered by intentional teardown declarations${opts.prNumber ? ` (PR #${opts.prNumber})` : ''}.\n`,
+		);
+		return 0;
+	}
+
 	// #2615: resolve time-aware window (--since / --since-ref / --since-recent) or fallback to --days
 	const window = resolveSinceWindow(opts);
 	const recentMerges = getMergedFilesSince(opts.base, window.since);
@@ -698,11 +851,11 @@ async function main() {
 		return 3;
 	}
 
-	const violations = findViolations(deletedFiles, recentMerges, opts.ignorePatterns);
+	const violations = findViolations(remaining, recentMerges, opts.ignorePatterns);
 
 	if (violations.length === 0) {
 		process.stdout.write(
-			`[check-recent-deploy-deletion] OK: ${deletedFiles.length} file(s) deleted, none overlap with merges since ${window.note}${opts.prNumber ? ` (PR #${opts.prNumber})` : ''}.\n`,
+			`[check-recent-deploy-deletion] OK: ${remaining.length} file(s) deleted (after teardown exemption), none overlap with merges since ${window.note}${opts.prNumber ? ` (PR #${opts.prNumber})` : ''}.\n`,
 		);
 		return 0;
 	}
@@ -718,9 +871,27 @@ async function main() {
 		process.stderr.write(`  - ${v.file}\n    └ touched by ${v.commit} (${v.date})\n`);
 	}
 	process.stderr.write('\n');
-	process.stderr.write('If a deletion is intentional (e.g. ADR archive move, 1-in-1-out),\n');
 	process.stderr.write(
-		'  rerun with `--ignore-pattern <regex>` (e.g. `^docs/decisions/archive/`).\n',
+		'If a deletion is an intentional migration teardown (develop 二層で main live な\n',
+	);
+	process.stderr.write(
+		'  feature を撤去する等、#3832), declare its path scope in a commit trailer so the\n',
+	);
+	process.stderr.write(
+		'  gate exempts it WITHOUT needing `--no-verify` (which also skips the account check):\n',
+	);
+	process.stderr.write('    Deploy-Teardown: <path-regex> #<issue> <理由>\n');
+	process.stderr.write(
+		'    (例: `Deploy-Teardown: ^src/lib/analytics/ #3821 analytics 収集撤去`)\n',
+	);
+	process.stderr.write(
+		'  宣言 path にマッチする削除のみが exempt され (log 出力される), 宣言外の削除は\n',
+	);
+	process.stderr.write(
+		'  引き続き BLOCK されます (data-loss 保護維持)。ADR archive 移動等の非 teardown 除外は\n',
+	);
+	process.stderr.write(
+		'  従来どおり `--ignore-pattern <regex>` (例: `^docs/decisions/archive/`) も使えます。\n',
 	);
 	return 2;
 }

--- a/tests/unit/scripts/check-recent-deploy-deletion.test.ts
+++ b/tests/unit/scripts/check-recent-deploy-deletion.test.ts
@@ -41,16 +41,21 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from
 
 import {
 	compileIgnorePattern,
+	compileTeardownPattern,
 	DEFAULT_BASE,
 	DEFAULT_DAYS,
 	findViolations,
 	getDeletedFiles,
+	getTeardownPatternsFromCommits,
 	helpText,
 	isAncestor,
 	isIgnored,
 	MAX_IGNORE_PATTERN_LENGTH,
 	parseArgs,
+	parseTeardownTrailers,
+	partitionDeletionsByTeardown,
 	resolveSinceWindow,
+	TEARDOWN_TRAILER_KEYS,
 	verifyWorktreeHeadMatchesPrHead,
 } from '../../../scripts/check-recent-deploy-deletion.mjs';
 
@@ -787,5 +792,295 @@ describe('#2877 three-dot (merge-base) integration (実 git fixture)', () => {
 	it('isAncestor: 存在しない base ref → null (git エラーと非 ancestor を区別)', () => {
 		git('checkout', '-q', 'main');
 		expect(isAncestor('no-such-ref-xyz')).toBeNull();
+	});
+});
+
+/**
+ * Issue #3832: intentional migration teardown exemption (develop 二層 false-positive 是正)
+ *
+ * develop 二層ブランチ戦略では「main に live な feature を develop 向け PR が migration で
+ * 意図的に撤去する」のは正当だが、deploy-deletion gate はそれを「直近 deploy feature の削除 =
+ * 事故的消失」と区別できず誤 BLOCK する (#3821 analytics Sub-B で観察、full `--no-verify` を強いた)。
+ *
+ * 対策: PR 自身の commit (<base>..HEAD) に `Deploy-Teardown: <path-regex> <reason/#issue>`
+ * trailer があれば、宣言された path にマッチする削除のみを exempt する。宣言外の削除は従来通り
+ * BLOCK (data-loss 保護維持、audit req 3)。exempt は log 出力し監査が後追いできる (audit req 1)。
+ *
+ * 監査要件 (Issue #3832 comment):
+ *   1. exempt は path scope + log 出力 (無条件全通しにしない / 監査追跡可能)
+ *   2. 本 gate 単体を exempt する機構で、full `--no-verify` (account check も飛ぶ) を根絶
+ *   3. 宣言外の削除は genuine data-loss として BLOCK 維持
+ *   4. failing-test-first (ADR-0061): marker 無し BLOCK / marker 有り通過の境界を先に固定
+ */
+describe('parseTeardownTrailers (#3832 純関数)', () => {
+	it('TEARDOWN_TRAILER_KEYS は Deploy-Teardown / Migration-Teardown の 2 key を含む', () => {
+		expect(TEARDOWN_TRAILER_KEYS).toContain('Deploy-Teardown');
+		expect(TEARDOWN_TRAILER_KEYS).toContain('Migration-Teardown');
+	});
+
+	it('Deploy-Teardown trailer 行から value を抽出する', () => {
+		const msg = [
+			'feat(analytics): #3821 always-on 収集を撤去',
+			'',
+			'Deploy-Teardown: ^src/lib/analytics/ #3821 analytics Sub-B teardown',
+		].join('\n');
+		expect(parseTeardownTrailers(msg)).toEqual([
+			'^src/lib/analytics/ #3821 analytics Sub-B teardown',
+		]);
+	});
+
+	it('Migration-Teardown alias も抽出する', () => {
+		const msg = 'Migration-Teardown: ^src/routes/api/cron/analytics-aggregate/ #3821';
+		expect(parseTeardownTrailers(msg)).toEqual(['^src/routes/api/cron/analytics-aggregate/ #3821']);
+	});
+
+	it('複数 commit 分の blob から全 trailer を抽出する', () => {
+		const blob = [
+			'commit 1 body',
+			'Deploy-Teardown: ^src/lib/analytics/ #3821',
+			'\x1e',
+			'commit 2 body',
+			'Deploy-Teardown: ^src/routes/api/cron/challenge-aggregate/ #3821',
+		].join('\n');
+		expect(parseTeardownTrailers(blob)).toHaveLength(2);
+	});
+
+	it('key の大文字小文字は無視する (git trailer は case-insensitive 慣習)', () => {
+		expect(parseTeardownTrailers('deploy-teardown: ^src/x/')).toEqual(['^src/x/']);
+	});
+
+	it('trailer が無い commit message は空配列', () => {
+		expect(parseTeardownTrailers('fix: something\n\nCo-Authored-By: x <y>')).toEqual([]);
+	});
+
+	it('空文字 / null 相当 → 空配列 (防御)', () => {
+		expect(parseTeardownTrailers('')).toEqual([]);
+	});
+});
+
+describe('compileTeardownPattern (#3832 純関数)', () => {
+	it('先頭 token を path regex、残りを reason として分解する', () => {
+		const r = compileTeardownPattern('^src/lib/analytics/ #3821 analytics teardown');
+		expect(r.patternSource).toBe('^src/lib/analytics/');
+		expect(r.reason).toBe('#3821 analytics teardown');
+		expect(r.pattern.test('src/lib/analytics/index.ts')).toBe(true);
+		expect(r.pattern.test('src/lib/server/services/foo.ts')).toBe(false);
+	});
+
+	it('reason 無し (path のみ) でも compile できる', () => {
+		const r = compileTeardownPattern('^src/lib/analytics/');
+		expect(r.patternSource).toBe('^src/lib/analytics/');
+		expect(r.reason).toBe('');
+	});
+
+	it('path token が無い (空) → 明示 Error (無条件全通し防止)', () => {
+		expect(() => compileTeardownPattern('   ')).toThrow(/path regex/);
+	});
+
+	it('不正な regex → compileIgnorePattern 経由で fail-closed (Error)', () => {
+		expect(() => compileTeardownPattern('[ #reason')).toThrow(/不正な正規表現/);
+	});
+});
+
+describe('partitionDeletionsByTeardown (#3832 純関数、核心の境界)', () => {
+	// AC (marker 無し BLOCK): teardown 宣言 0 件 → 全削除が remaining (通常 gate 対象)
+	it('AC-marker無し: teardown patterns 空 → 全削除が remaining (従来 BLOCK 経路維持)', () => {
+		const deleted = [
+			'src/lib/analytics/index.ts',
+			'src/routes/api/cron/analytics-aggregate/+server.ts',
+		];
+		const { exempted, remaining } = partitionDeletionsByTeardown(deleted, []);
+		expect(exempted).toEqual([]);
+		expect(remaining).toEqual(deleted);
+	});
+
+	// AC (marker 有り通過): 宣言 path にマッチする削除 → exempted (BLOCK されない)
+	it('AC-marker有り: 宣言 path にマッチする削除 → exempted (BLOCK 回避)', () => {
+		const deleted = ['src/lib/analytics/index.ts', 'src/lib/analytics/providers/dynamo.ts'];
+		const teardown = [compileTeardownPattern('^src/lib/analytics/ #3821')];
+		const { exempted, remaining } = partitionDeletionsByTeardown(deleted, teardown);
+		expect(exempted).toHaveLength(2);
+		expect(exempted.map((e) => e.file)).toEqual(deleted);
+		expect(exempted[0]?.patternSource).toBe('^src/lib/analytics/');
+		expect(exempted[0]?.reason).toBe('#3821');
+		expect(remaining).toEqual([]);
+	});
+
+	// AC (scope 維持 = data-loss 保護): 宣言外の削除は remaining に残り BLOCK 対象
+	it('AC-scope: 宣言外の削除は remaining に残る (undeclared = genuine data-loss、BLOCK 維持)', () => {
+		const deleted = [
+			'src/lib/analytics/index.ts', // 宣言済 → exempt
+			'docs/decisions/0056-qm-drift-prevention.md', // 宣言外 → BLOCK 対象
+		];
+		const teardown = [compileTeardownPattern('^src/lib/analytics/ #3821')];
+		const { exempted, remaining } = partitionDeletionsByTeardown(deleted, teardown);
+		expect(exempted.map((e) => e.file)).toEqual(['src/lib/analytics/index.ts']);
+		expect(remaining).toEqual(['docs/decisions/0056-qm-drift-prevention.md']);
+	});
+
+	it('複数 teardown pattern のいずれかにマッチすれば exempt', () => {
+		const deleted = [
+			'src/lib/analytics/index.ts',
+			'src/routes/api/cron/challenge-aggregate/+server.ts',
+		];
+		const teardown = [
+			compileTeardownPattern('^src/lib/analytics/ #3821'),
+			compileTeardownPattern('^src/routes/api/cron/challenge-aggregate/ #3821'),
+		];
+		const { exempted, remaining } = partitionDeletionsByTeardown(deleted, teardown);
+		expect(exempted).toHaveLength(2);
+		expect(remaining).toEqual([]);
+	});
+
+	it('削除 0 件 → exempted / remaining ともに空', () => {
+		const { exempted, remaining } = partitionDeletionsByTeardown(
+			[],
+			[compileTeardownPattern('^src/lib/analytics/')],
+		);
+		expect(exempted).toEqual([]);
+		expect(remaining).toEqual([]);
+	});
+});
+
+/**
+ * #3832 integration: 実 git fixture で `getTeardownPatternsFromCommits` が PR 自身の commit
+ * (<base>..HEAD) から teardown trailer を読むことを検証する (git 挙動は mock 不能なため実 git)。
+ *
+ * marker 無し BLOCK / marker 有り通過の end-to-end 境界を実 commit で固定し、
+ * findViolations と組み合わせて「exempt された削除は violation にならない」を実証する。
+ */
+describe('#3832 getTeardownPatternsFromCommits (実 git fixture、end-to-end 境界)', () => {
+	let repoDir: string;
+	let originalCwd: string;
+	let baseSha: string;
+
+	function git(...args: string[]): string {
+		return execFileSync('git', args, { cwd: repoDir, encoding: 'utf8' });
+	}
+
+	function writeCommit(file: string, content: string, message: string): void {
+		// nested path (src/lib/analytics/index.ts 等) は親ディレクトリを先に作る
+		execFileSync(
+			'node',
+			[
+				'-e',
+				`const fs=require('fs'),p=require('path');fs.mkdirSync(p.dirname(process.argv[1]),{recursive:true});fs.writeFileSync(process.argv[1], process.argv[2])`,
+				file,
+				content,
+			],
+			{ cwd: repoDir },
+		);
+		git('add', file);
+		git('commit', '-m', message);
+	}
+
+	beforeAll(() => {
+		originalCwd = process.cwd();
+		repoDir = mkdtempSync(join(tmpdir(), 'rdd-3832-'));
+		git('init', '-q', '-b', 'main');
+		git('config', 'user.email', 'test@example.com');
+		git('config', 'user.name', 'Test');
+		git('config', 'commit.gpgsign', 'false');
+		// base: analytics feature を live させる (main に merge 済 = 直近 deploy 相当)
+		writeCommit('src/lib/analytics/index.ts', 'export const x = 1;\n', 'feat: add analytics');
+		writeCommit('docs/keep.md', 'keep\n', 'docs: add keep');
+		baseSha = git('rev-parse', 'HEAD').trim();
+	});
+
+	afterAll(() => {
+		process.chdir(originalCwd);
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	beforeEach(() => {
+		process.chdir(repoDir);
+		execFileSync('git', ['checkout', '-q', 'main'], { cwd: repoDir });
+		execFileSync('git', ['reset', '-q', '--hard', baseSha], { cwd: repoDir });
+		execFileSync('git', ['clean', '-fdq'], { cwd: repoDir });
+		try {
+			execFileSync('git', ['branch', '-D', 'feature'], { cwd: repoDir, stdio: 'ignore' });
+		} catch {
+			// 初回は feature branch 未作成
+		}
+	});
+
+	afterEach(() => {
+		process.chdir(originalCwd);
+	});
+
+	it('AC-marker無し (従来 BLOCK): teardown trailer 無しで analytics を削除 → patterns 0 件 → 削除が violation になる', () => {
+		git('checkout', '-q', '-b', 'feature');
+		git('rm', '-q', 'src/lib/analytics/index.ts');
+		git('commit', '-q', '-m', 'refactor: remove analytics (no teardown marker)');
+
+		const teardown = getTeardownPatternsFromCommits('main');
+		if (teardown === null) throw new Error('getTeardownPatternsFromCommits must not be null');
+		expect(teardown.patterns).toHaveLength(0);
+
+		// 削除は exempt されず remaining → 直近 merge と重複すれば violation (BLOCK)
+		const deleted = getDeletedFiles('main');
+		if (deleted === null) throw new Error('getDeletedFiles must not be null');
+		const { remaining } = partitionDeletionsByTeardown(deleted, teardown.patterns);
+		expect(remaining).toContain('src/lib/analytics/index.ts');
+		const merges = [
+			{
+				commit: 'deadbeef',
+				date: '2026-07-16 10:00:00 +0900',
+				files: ['src/lib/analytics/index.ts'],
+			},
+		];
+		expect(findViolations(remaining, merges, [])).toHaveLength(1);
+	});
+
+	it('AC-marker有り (通過): Deploy-Teardown trailer 付きで analytics を削除 → 該当削除が exempt され violation 0 件', () => {
+		git('checkout', '-q', '-b', 'feature');
+		git('rm', '-q', 'src/lib/analytics/index.ts');
+		git(
+			'commit',
+			'-q',
+			'-m',
+			'refactor(analytics): #3821 remove always-on analytics\n\nDeploy-Teardown: ^src/lib/analytics/ #3821 analytics Sub-B teardown',
+		);
+
+		const teardown = getTeardownPatternsFromCommits('main');
+		if (teardown === null) throw new Error('getTeardownPatternsFromCommits must not be null');
+		expect(teardown.patterns).toHaveLength(1);
+		expect(teardown.patterns[0]?.patternSource).toBe('^src/lib/analytics/');
+
+		const deleted = getDeletedFiles('main');
+		if (deleted === null) throw new Error('getDeletedFiles must not be null');
+		const { exempted, remaining } = partitionDeletionsByTeardown(deleted, teardown.patterns);
+		expect(exempted.map((e) => e.file)).toContain('src/lib/analytics/index.ts');
+		expect(remaining).toEqual([]);
+		// remaining が空なので、直近 merge と重複しても violation 0 件 = BLOCK されない
+		const merges = [
+			{
+				commit: 'deadbeef',
+				date: '2026-07-16 10:00:00 +0900',
+				files: ['src/lib/analytics/index.ts'],
+			},
+		];
+		expect(findViolations(remaining, merges, [])).toHaveLength(0);
+	});
+
+	it('AC-scope (宣言外は BLOCK 維持): teardown trailer で analytics のみ宣言、docs も削除 → docs は remaining に残る', () => {
+		git('checkout', '-q', '-b', 'feature');
+		git('rm', '-q', 'src/lib/analytics/index.ts');
+		git('rm', '-q', 'docs/keep.md');
+		git(
+			'commit',
+			'-q',
+			'-m',
+			'refactor: #3821 remove analytics + accidentally docs\n\nDeploy-Teardown: ^src/lib/analytics/ #3821',
+		);
+
+		const teardown = getTeardownPatternsFromCommits('main');
+		if (teardown === null) throw new Error('getTeardownPatternsFromCommits must not be null');
+		const deleted = getDeletedFiles('main');
+		if (deleted === null) throw new Error('getDeletedFiles must not be null');
+		const { exempted, remaining } = partitionDeletionsByTeardown(deleted, teardown.patterns);
+		expect(exempted.map((e) => e.file)).toEqual(['src/lib/analytics/index.ts']);
+		// docs/keep.md は宣言外 = genuine data-loss として remaining (BLOCK 対象) に残る
+		expect(remaining).toEqual(['docs/keep.md']);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

develop 二層ブランチ戦略では「main に live な feature を develop 向け PR が migration で意図的に撤去する」のは正当だが、`scripts/check-recent-deploy-deletion.mjs`（deploy-deletion gate、ADR-0056 §D/F）はそれを「直近 deploy feature の削除 = 事故的消失」と区別できず誤 BLOCK していた。#3821（analytics Sub-B）の push 時、意図的な analytics 収集撤去がこの gate で BLOCK され、full `--no-verify` で bypass した。`--no-verify` は全 hook を skip する = **account check (`check-gh-account-before-pr.mjs`) まで飛ぶ**副作用があり、常態化すると QA 機構を毀損する。本 PR は intentional migration teardown を gate が commit trailer で識別し、account check を温存したまま該当削除のみ exempt して false-positive と `--no-verify` 常態化を根絶する。

## 関連 Issue

closes #3832

Refs: #3821（発生元、analytics Sub-B 撤去で full `--no-verify` を強いた実害）/ #3438（DynamoDB → DSQL 移管、Phase 3 で同種撤去が続く）。根拠 ADR: ADR-0056 §G（本 PR 追記）/ ADR-0061 / ADR-0010（Pre-PMF Bucket A）/ ADR-0001。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 意図的 migration teardown を gate が識別し `--no-verify` なしで通す | `npx vitest run tests/unit/scripts/check-recent-deploy-deletion.test.ts` | HEAD 243e7b7ac4b525b5d6d66185457370b6bc7cf072 / 76 passed。commit trailer `Deploy-Teardown: <path-regex>` を `getTeardownPatternsFromCommits` が `<base>..HEAD` から読み exempt。marker 有り → 該当削除 exempt + remaining 空 |
| AC2 | 安全性維持（無条件全通しにしない = path scope に絞る） | `npx vitest run tests/unit/scripts/check-recent-deploy-deletion.test.ts` | HEAD 243e7b7ac4b525b5d6d66185457370b6bc7cf072 / `compileTeardownPattern` は path token 空で明示 Error / 宣言外削除は remaining に残る（「宣言外は BLOCK 維持」test green） |
| AC3 | genuine data-loss は従来通り BLOCK | `node scripts/check-recent-deploy-deletion.mjs`（temp git repo） | HEAD 243e7b7ac4b525b5d6d66185457370b6bc7cf072 / marker 無し → 全削除 remaining → violation（CLI 実測 exit 2）、marker 有り → exit 0 |
| AC4 | 全 hook bypass 常態化の根絶（account check 温存） | `.husky/pre-push` + ADR-0056 §G | HEAD 243e7b7ac4b525b5d6d66185457370b6bc7cf072 / exemption は deploy-deletion gate 単体を対象化、trailer は hook が自動で読むため引数不要で account check 段は必ず走る |
| AC5 | 監査追跡可能（exempt を log 出力） | CLI 実測 | HEAD 243e7b7ac4b525b5d6d66185457370b6bc7cf072 / `TEARDOWN-EXEMPT: N file(s) exempted ... audit trail #3832`（file + 宣言 pattern + reason）を stdout 列挙 |

## 変更タイプ

- [x] fix: バグ修正（gate の false-positive 是正）
- [x] infra: devinfra（CI/gate ツール）
- [x] docs: ドキュメント（ADR-0056 §G）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI（`scripts/check-recent-deploy-deletion.mjs` + `.husky/pre-push` コメント + test）
- [x] ドキュメント（ADR-0056 §G + 補強履歴表）

**影響を受ける画面・機能**: なし（gate ツールの内部ロジック）。

## テスト & 安全装置セルフチェック

- [x] targeted 検証コマンド（main tree で実行）:
- [x] `npx vitest run tests/unit/scripts/check-recent-deploy-deletion.test.ts` → 76 passed
- [x] `npx svelte-check` → 0 error / `npx biome check` → clean
- [x] 実 CLI 挙動: marker 無し `exit 2`（BLOCK）/ marker 有り `exit 0` + audit log を temp git repo で確認
- [x] 追加・変更したテスト: 純関数（`parseTeardownTrailers` / `compileTeardownPattern` / `getTeardownPatternsFromCommits` / `partitionDeletionsByTeardown`）+ 実 git fixture の end-to-end 境界（marker 無し BLOCK / 有り通過 / 宣言外 BLOCK）。failing-test-first で import error → RED (16 fail) → 実装後 76 pass
- [x] **新規 env / secret 追加時**: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**: N/A

## スクリーンショット / ビジュアルデモ

**該当なし**: CI/gate ツールの内部ロジック変更のみで UI 変更なし。

## コード品質セルフレビュー (#1481)

- [x] **SOLID / DRY**: 既存 `compileIgnorePattern`（長さ上限 + fail-closed、#3766）を teardown regex compile に再利用し二重実装回避
- [x] **YAGNI**: 新規依存ゼロ。commit trailer 方式で hook/CI 両経路とも引数変更不要
- [x] **Security**: path scope 必須（空 token → Error）で無条件全通しを防止。exemption を deploy-deletion gate 単体に閉じ account check を温存。宣言外削除は両 lane で hard-block 維持
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

- [x] gate を呼ぶのは `.husky/pre-push` + QM Tier2 Review + Fix Agent worktree のみ。trailer は commit と共に流れるため CI/hook いずれの経路でも引数変更不要で exemption が波及（release/*→main 統合時も同一宣言が自動適用）
- [x] `--ignore-pattern`（ADR archive 移動等の非 teardown 除外）は従来どおり併用可能で後方互換
- [x] **設計書同期** (ADR-0001): ADR-0056 §G + 補強履歴表に #3832 行
- [x] N/A — labels/年齢モード/navi/LP に波及なし

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（既存 gate 挙動は trailer 無し PR で完全一致）

**レビュー依頼事項・QA**: exempt が genuine data-loss を素通しさせないこと（path scope + audit log + 宣言外 BLOCK 維持）の独立検証を依頼。**marker 運用**: 意図的撤去 PR は撤去 commit message 末尾に `Deploy-Teardown: <path-regex> #<issue>`（先頭 token=削除対象 path regex、残り=audit reason、複数 path は複数行）を書く。gate が自動で読むため `--no-verify` 不要。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし

## Ready for Review チェックリスト

- [x] vitest 76 passed + CLI 実測（marker 無し exit2 / 有り exit0）+ svelte-check 0 / biome clean をローカル確認（main tree）
- [x] failing-test-first の red→green を実証（ADR-0061、import error RED → 76 pass）
- [x] 設計書同期完了（ADR-0056 §G）
- [x] Phase 分割なし
- [x] UI 変更なし / 認証画面変更なし

## QM レビュー結果

<!-- QM 記入。exempt が genuine data-loss を素通しさせないことの独立検証を依頼。 -->
