### PR TITLE
fix(security): #3824 market_benchmarks 書込を ops 限定に厳格化 (parent-admin 403、cross-tenant 統計汚染 CWE-639 隣接を遮断)

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -471,6 +471,19 @@ client 供給の opaque id（Cookie / POST form-field / URL param）は、uuid �
 - **fitness function（挙動）**: `tests/unit/routes/child-cookie-guard.test.ts`（checklist toggle の cookie 経路 + form-field `templateId` guard）+ `tests/unit/routes/home-cookie-guard.test.ts`（home stampCard / loginStamp）+ `tests/unit/routes/home-form-field-guard.test.ts`（home の record / cancelRecord / togglePin / claimChallengeReward / sendCheer / markCheersShown の form-field id guard）が DSQL で非 uuid → 拒否（redirect or `fail(400)`）/ 有効 uuid → service 到達 / 非 DSQL で通過を機械検証する。`tests/unit/db/dsql-child-repo.test.ts` / `dsql-checklist-repo.test.ts` / `dsql-stamp-mission-repos.test.ts` が repo 入口の not-found 正規化を、`dsql-reward-message-repos.test.ts`（[SR2b]/[SR2c]/[MSG2b]/[MSG2c]）が beacon の childId / rewardId / messageId 正規化を、`dsql-pg-uuid-guard.test.ts` が warn の rate-limit を固定する。
 - **fitness function（構造、ADR-0061 same-class N→guard）**: `tests/unit/architecture/dsql-uuid-guard-ssot-fitness.test.ts` が本 trust 境界の 2 不変条件を CI hard-fail 化し、22P02 → 500 の同一クラスを **人の注意ではなく機械**で再発防止する。[SSOT-1] uuid 形式判定の hand-rolled regex は `pg-uuid.ts` の 1 箇所のみ（別実装で `warnInvalidUuidId` observability と not-found 正規化契約を迂回させない、ADR-0063 単一強制点）。[OBS-2] guard module（dsql repos + `child-cookie-guard` + `child-form-field-guard`）で `isUuidFormat` guard を使う各 module は `warnInvalidUuidId` を同数以上呼ぶ（silent guard = 観測点ゼロの guard 追加を禁止）。
 
+#### 5.2.8 グローバル master（market_benchmarks）書込の ops 限定（全テナント波及書込の権限昇格防止、CWE-639、#3824 / #3593）
+
+`market_benchmarks`（age/category 別の統計基準値）は **tenant 非依存のグローバル master** であり、全テナントで共有される（`findBenchmark` / `findAllBenchmarks` は tenant 非依存で全テナント共通行を返す）。したがって upsert は「1 テナントの書込が全テナントに波及する」書込であり、通常の保護者（parent-admin）操作から到達させると **1 家庭の保護者が全テナント共有の統計基準値を書き換え得る**（CWE-639 隣接の権限昇格。書込値は平均値で PII 非該当だが統計の汚染に至る）。書込到達点（`/admin/status` の `updateBenchmark` action）で **ops/admin 相当の authz を強制**し、parent-admin は 403 にする（#3593 ④ の interface 明文化を実厳格化）。
+
+| 操作 | 到達点 | 許可 | 拒否（`error(403)`） |
+|---|---|---|---|
+| 書込（`upsertBenchmark`） | `/admin/status` `?/updateBenchmark` action | `local`（NUC セルフホスト = 単一テナントの唯一運用者 = ops/admin 相当）/ cognito ops group member | cognito parent-admin（非 ops）/ anonymous（demo）/ 未認証（fail-closed） |
+| 読取（`findAllBenchmarks` / `getBenchmarkValues`） | `/admin/status` load ほか | 全 admin（自テナント統計比較のため）— 現状維持 | —（書込 gate は読取に波及しない） |
+
+- **単一強制点（ADR-0063 整合）**: 認可判定を散在させず `src/lib/server/auth/ops-authz.ts` の `requireGlobalMasterWriteAccess(locals)` に集約する。ops 判定 SSOT は同 module の `isOpsMember` / `OPS_GROUPS`（`/ops` route protection と共有）。`local` を許可するのは NUC が信頼ベース（`capabilities.ts` `canWriteDb` と同原則、ADR-0051）で全テナント波及の概念を持たないため。
+- **admin bypass 禁止との整合（ADR-0022）**: グローバル master 書込を ops group の認可境界に載せ、parent-admin ロールでの書込を構造的に排除する。
+- **fitness function**: `tests/unit/routes/admin-status-benchmark-authz.test.ts` が guard 単体（local / ops 許可、parent-admin / anonymous / 未認証 → 403）+ `updateBenchmark` action（parent-admin → 403 かつ `upsertBenchmark` 未到達 / ops・local → upsertBenchmark 到達）+ 読取 load（parent-admin・ops いずれも benchmarks 取得可）を機械検証する。
+
 ### 5.3 ライセンス状態による制限
 
 | ライセンス状態 | アクセス制限 |

--- a/src/lib/server/auth/ops-authz.ts
+++ b/src/lib/server/auth/ops-authz.ts
@@ -4,6 +4,7 @@
 // 現状（PR-A）: 定数と判定ヘルパを追加するのみ。実際の /ops 認可切替は PR-C で行う。
 // 将来の階層化（`ops-cs` / `ops-eng` など）に備え、名前は enum 化して 1 箇所で管理する。
 
+import { error } from '@sveltejs/kit';
 import type { Identity } from './types';
 
 /**
@@ -30,4 +31,32 @@ export function isOpsMember(identity: Identity | null): boolean {
 	const groups = identity.groups;
 	if (!groups || groups.length === 0) return false;
 	return OPS_GROUPS.some((g) => groups.includes(g));
+}
+
+/**
+ * グローバル master (全テナント共有の統計基準値 = `market_benchmarks` 等) への書込を
+ * ops/admin 相当に限定する単一強制点 (#3824、CWE-639 隣接 / #3593 ④ の実厳格化)。
+ *
+ * `market_benchmarks` は tenant 非依存のグローバル master であり、1 テナントの書込が
+ * 全テナントに波及する。したがって「通常の保護者 (parent-admin) 操作」から到達させず、
+ * ops/admin 相当の権限に限定する (ADR-0063 単一強制点 / ADR-0022 admin bypass 禁止と整合)。
+ *
+ * 書込許可:
+ * - `local` identity (NUC セルフホスト): 単一テナントの唯一運用者 = ops/admin 相当。
+ *   全テナント波及の概念がなく、`capabilities.ts` の `canWriteDb` と同じ信頼ベース (ADR-0051)。
+ * - `cognito` ops group member: SaaS 運営スタッフ。
+ *
+ * 書込拒否 (`error(403)` を throw):
+ * - `cognito` parent-admin (非 ops、通常の保護者顧客): 1 家庭の保護者が全テナント共有の
+ *   統計基準値を書換える権限昇格を防ぐ。
+ * - `anonymous` (demo) / 未認証: そもそも hooks で write no-op だが fail-closed で 403。
+ *
+ * 読取 (`findBenchmark` / `findAllBenchmarks`) は本 guard の対象外 (全 admin が自テナント
+ * 統計比較のため読める)。書込 (`upsertBenchmark`) 到達点でのみ呼ぶこと。
+ */
+export function requireGlobalMasterWriteAccess(locals: App.Locals): void {
+	const identity = locals.identity;
+	if (identity?.type === 'local') return;
+	if (isOpsMember(identity)) return;
+	error(403, 'Forbidden: global master write requires ops access');
 }

--- a/src/lib/server/db/interfaces/status-repo.interface.ts
+++ b/src/lib/server/db/interfaces/status-repo.interface.ts
@@ -47,13 +47,15 @@ export interface IStatusRepo {
 	/**
 	 * market_benchmarks (世代別平均値) を upsert する。
 	 *
-	 * ⚠️ 書込 authz (#3593 ④、明文化): market_benchmarks は **グローバル master** (tenant 非依存、
-	 * 全テナントで共有される統計基準値) である。したがって本 upsert は「1 テナントの書込が全テナントに
-	 * 波及する」書込であり、**ops/admin 相当の権限に限定**されるべき (通常の保護者操作から到達させない)。
-	 * `tenantId` 引数は audit/observability 用であり分離キーではない (findBenchmark も tenant 非依存で
-	 * 全テナント共通行を返す)。呼出は現状 `/admin/status` (parent-admin ルート、hooks.server.ts の
-	 * admin 認可下) のみ。将来グローバル書込を ops group 限定に厳格化する場合は上位ルート層で行う
-	 * (repo は primitive、権限判断を持たない)。
+	 * ⚠️ 書込 authz (#3593 ④ 明文化 → #3824 実厳格化): market_benchmarks は **グローバル master**
+	 * (tenant 非依存、全テナントで共有される統計基準値) である。したがって本 upsert は「1 テナントの
+	 * 書込が全テナントに波及する」書込であり、**ops/admin 相当の権限に限定**される (通常の保護者操作
+	 * から到達させない、CWE-639 隣接の権限昇格防止)。`tenantId` 引数は audit/observability 用であり
+	 * 分離キーではない (findBenchmark も tenant 非依存で全テナント共通行を返す)。書込到達点は現状
+	 * `/admin/status` の `updateBenchmark` action のみで、そこで `requireGlobalMasterWriteAccess`
+	 * (`src/lib/server/auth/ops-authz.ts`、ops group or NUC local に限定) を強制する。repo は primitive
+	 * のまま権限判断を持たず、認可は上位ルート層の単一強制点に集約する (ADR-0063)。詳細は
+	 * `docs/design/14-セキュリティ設計書.md` §5.2.8。
 	 */
 	upsertBenchmark(
 		age: number,

--- a/src/routes/(parent)/admin/status/+page.server.ts
+++ b/src/routes/(parent)/admin/status/+page.server.ts
@@ -3,7 +3,7 @@ import { formIdString } from '$lib/domain/form-value';
 import { asCategoryId, asChildId } from '$lib/domain/ids';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
-import { requireGlobalMasterWriteAccess } from '$lib/server/auth/ops-authz';
+import { isOpsMember, requireGlobalMasterWriteAccess } from '$lib/server/auth/ops-authz';
 import { findAllBenchmarks, upsertBenchmark } from '$lib/server/db/status-repo';
 import { getAllChildren } from '$lib/server/services/child-service';
 import {
@@ -19,6 +19,15 @@ import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals, url }) => {
 	const tenantId = requireTenantId(locals);
+	// #3824 (QM Tier2 H1): benchmark (market_benchmarks = 全テナント共有グローバル master) の
+	// 編集 UI は書込 authz (requireGlobalMasterWriteAccess) と同一境界で出し分ける。
+	//   parent-admin に編集フォームを描画すると、保存時 server が 403 を返し「見えるが必ず失敗する
+	//   dead-form」+ 内部概念 (global master / ops) の英語露出になる (NN/G #1 visibility 違反)。
+	//   UI hide (本フラグ) + server enforce (updateBenchmark action) の防御多層で、parent-admin は
+	//   read-only 比較 (成長レポート RadarChart) のみを見る。判定基準は書込 guard の許可条件と一致:
+	//   local identity (NUC 単一運用者) or cognito ops group member。
+	const canEditBenchmark =
+		locals.identity?.type === 'local' || isOpsMember(locals.identity ?? null);
 	const [children, benchmarks, levelTitles] = await Promise.all([
 		getAllChildren(tenantId),
 		findAllBenchmarks(tenantId),
@@ -56,7 +65,13 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 				]
 			: childrenWithStatus;
 
-	return { children: sortedChildren, categoryDefs: CATEGORY_DEFS, benchmarks, levelTitles };
+	return {
+		children: sortedChildren,
+		categoryDefs: CATEGORY_DEFS,
+		benchmarks,
+		levelTitles,
+		canEditBenchmark,
+	};
 };
 
 export const actions = {

--- a/src/routes/(parent)/admin/status/+page.server.ts
+++ b/src/routes/(parent)/admin/status/+page.server.ts
@@ -3,6 +3,7 @@ import { formIdString } from '$lib/domain/form-value';
 import { asCategoryId, asChildId } from '$lib/domain/ids';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
+import { requireGlobalMasterWriteAccess } from '$lib/server/auth/ops-authz';
 import { findAllBenchmarks, upsertBenchmark } from '$lib/server/db/status-repo';
 import { getAllChildren } from '$lib/server/services/child-service';
 import {
@@ -96,6 +97,10 @@ export const actions = {
 	},
 
 	updateBenchmark: async ({ request, locals }) => {
+		// #3824 (CWE-639 隣接): market_benchmarks は全テナント共有のグローバル master のため、
+		// 書込は ops/admin 相当 (ops group or NUC local) に限定する。parent-admin は 403。
+		// tenantId 取得より前に評価し、認可判定を単一強制点 (ops-authz) に集約する (ADR-0063)。
+		requireGlobalMasterWriteAccess(locals);
 		const tenantId = requireTenantId(locals);
 		const form = await request.formData();
 		const age = Number(form.get('age'));

--- a/src/routes/(parent)/admin/status/+page.svelte
+++ b/src/routes/(parent)/admin/status/+page.svelte
@@ -302,6 +302,12 @@ let levelTitleInputs: Record<number, string> = $state({});
 		{/if}
 	</Card>
 
+	<!-- #3824 (QM Tier2 H1): benchmark (全テナント共有グローバル master) 編集 UI は書込 authz と
+		同一境界でゲートする。parent-admin (非 ops) には描画せず「見えるが必ず 403 で失敗する dead-form」+
+		内部概念の英語露出 (NN/G #1 visibility 違反) を防ぐ。read-only 比較は上の成長レポート
+		(RadarChart + comparisonValues) が担う。書込は updateBenchmark action が server で再強制する
+		(UI hide + server enforce の防御多層)。 -->
+	{#if data.canEditBenchmark}
 	<div>
 		<!-- 機能説明 -->
 		<div class="bg-[var(--color-feedback-info-bg)] border border-[var(--color-feedback-info-border)] rounded-lg p-3 mb-4 text-sm text-[var(--color-feedback-info-text)]">
@@ -444,4 +450,5 @@ let levelTitleInputs: Record<number, string> = $state({});
 			{/each}
 		</div>
 	</div>
+	{/if}
 </div>

--- a/tests/unit/routes/admin-status-benchmark-authz.test.ts
+++ b/tests/unit/routes/admin-status-benchmark-authz.test.ts
@@ -1,0 +1,183 @@
+// tests/unit/routes/admin-status-benchmark-authz.test.ts
+// #3824 (CWE-639 隣接 / #3593 ④ の実厳格化): market_benchmarks (グローバル master =
+// 全テナント共有の age/category 統計基準値) への書込を ops/admin 相当に限定する回帰テスト。
+//
+// テスト観点 (3 象限 + fail-closed):
+// - guard 単体 (requireGlobalMasterWriteAccess): local / ops 許可、parent-admin / anonymous / 未認証 拒否 (403)
+// - 書込 (updateBenchmark action): parent-admin 拒否 (403 + upsertBenchmark 未到達) / ops 許可 / local 許可
+// - 読取 (load): parent-admin / ops いずれも benchmarks を取得できる (書込 gate は読取に波及しない、#3824 読取現状維持)
+//
+// failing-test-first (ADR-0061): 実装前は updateBenchmark が parent-admin でも upsertBenchmark に
+// 到達する (脆弱性) ため、下記 "parent-admin は 403" が red。guard を action に配線して green。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Identity } from '../../../src/lib/server/auth/types';
+
+// ---------- mocks ----------
+
+const mockUpsertBenchmark = vi.fn();
+const mockFindAllBenchmarks = vi.fn();
+vi.mock('$lib/server/db/status-repo', () => ({
+	upsertBenchmark: (...args: unknown[]) => mockUpsertBenchmark(...args),
+	findAllBenchmarks: (...args: unknown[]) => mockFindAllBenchmarks(...args),
+}));
+
+const mockGetAllChildren = vi.fn();
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: (...args: unknown[]) => mockGetAllChildren(...args),
+}));
+
+const mockGetLevelTitleList = vi.fn();
+vi.mock('$lib/server/services/status-service', () => ({
+	getBenchmarkValues: vi.fn(),
+	getChildStatus: vi.fn(),
+	getLevelTitleList: (...args: unknown[]) => mockGetLevelTitleList(...args),
+	getMonthlyComparison: vi.fn(),
+	resetAllLevelTitles: vi.fn(),
+	resetLevelTitle: vi.fn(),
+	saveLevelTitle: vi.fn(),
+}));
+
+const { requireGlobalMasterWriteAccess } = await import('../../../src/lib/server/auth/ops-authz');
+const { actions, load } = await import('../../../src/routes/(parent)/admin/status/+page.server');
+
+// ---------- helpers ----------
+
+const PARENT_ADMIN: Identity = {
+	type: 'cognito',
+	userId: 'u-parent',
+	email: 'parent@example.com',
+	groups: [],
+};
+const OPS_MEMBER: Identity = {
+	type: 'cognito',
+	userId: 'u-ops',
+	email: 'ops@example.com',
+	groups: ['ops'],
+};
+const LOCAL: Identity = { type: 'local' };
+const ANONYMOUS: Identity = { type: 'anonymous', userId: 'anon-1', email: 'anon@example.com' };
+
+function makeLocals(identity: Identity | null): App.Locals {
+	return {
+		requestId: 'req-test',
+		authenticated: identity !== null,
+		identity,
+		context: { tenantId: 't-test', role: 'owner', licenseStatus: 'active' },
+		isDemo: false,
+		runtimeMode: 'nuc-prod',
+	} as unknown as App.Locals;
+}
+
+function makeBenchmarkForm(): Request {
+	const fd = new FormData();
+	fd.set('age', '4');
+	fd.set('categoryId', '1'); // undou (legacyNumericId=1)
+	fd.set('mean', '10');
+	fd.set('stdDev', '3');
+	return new Request('http://localhost/admin/status?/updateBenchmark', {
+		method: 'POST',
+		body: fd,
+	});
+}
+
+function makeActionEvent(identity: Identity | null) {
+	return {
+		request: makeBenchmarkForm(),
+		locals: makeLocals(identity),
+	} as unknown as Parameters<(typeof actions)['updateBenchmark']>[0];
+}
+
+function makeLoadEvent(identity: Identity | null) {
+	return {
+		locals: makeLocals(identity),
+		url: new URL('http://localhost/admin/status'),
+	} as unknown as Parameters<typeof load>[0];
+}
+
+// ---------- tests ----------
+
+describe('requireGlobalMasterWriteAccess guard (#3824)', () => {
+	it('local identity (NUC セルフホスト) は許可 (throw しない)', () => {
+		expect(() => requireGlobalMasterWriteAccess(makeLocals(LOCAL))).not.toThrow();
+	});
+
+	it('cognito ops group member は許可 (throw しない)', () => {
+		expect(() => requireGlobalMasterWriteAccess(makeLocals(OPS_MEMBER))).not.toThrow();
+	});
+
+	it('cognito parent-admin (非 ops) は 403 で拒否', () => {
+		expect(() => requireGlobalMasterWriteAccess(makeLocals(PARENT_ADMIN))).toThrowError(
+			expect.objectContaining({ status: 403 }),
+		);
+	});
+
+	it('anonymous (demo) は 403 で拒否', () => {
+		expect(() => requireGlobalMasterWriteAccess(makeLocals(ANONYMOUS))).toThrowError(
+			expect.objectContaining({ status: 403 }),
+		);
+	});
+
+	it('未認証 (identity=null) は 403 で拒否 (fail-closed)', () => {
+		expect(() => requireGlobalMasterWriteAccess(makeLocals(null))).toThrowError(
+			expect.objectContaining({ status: 403 }),
+		);
+	});
+});
+
+describe('updateBenchmark action の ops 限定 authz (#3824 書込)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockUpsertBenchmark.mockResolvedValue({});
+	});
+
+	it('parent-admin は 403 で拒否され upsertBenchmark に到達しない (red → green)', async () => {
+		await expect(actions.updateBenchmark(makeActionEvent(PARENT_ADMIN))).rejects.toMatchObject({
+			status: 403,
+		});
+		expect(mockUpsertBenchmark).not.toHaveBeenCalled();
+	});
+
+	it('anonymous (demo) は 403 で拒否され upsertBenchmark に到達しない', async () => {
+		await expect(actions.updateBenchmark(makeActionEvent(ANONYMOUS))).rejects.toMatchObject({
+			status: 403,
+		});
+		expect(mockUpsertBenchmark).not.toHaveBeenCalled();
+	});
+
+	it('cognito ops member は成功経路に入り upsertBenchmark を呼ぶ (positive)', async () => {
+		const res = await actions.updateBenchmark(makeActionEvent(OPS_MEMBER));
+		expect(res).toMatchObject({ success: true, benchmarkUpdated: true });
+		expect(mockUpsertBenchmark).toHaveBeenCalledTimes(1);
+		// upsertBenchmark(age, categoryId, mean, stdDev, source, tenantId)
+		expect(mockUpsertBenchmark).toHaveBeenCalledWith(4, '1', 10, 3, '管理画面', 't-test');
+	});
+
+	it('local (NUC セルフホスト) は成功経路に入り upsertBenchmark を呼ぶ (positive)', async () => {
+		const res = await actions.updateBenchmark(makeActionEvent(LOCAL));
+		expect(res).toMatchObject({ success: true, benchmarkUpdated: true });
+		expect(mockUpsertBenchmark).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('benchmark 読取 (load) は書込 gate に波及しない (#3824 読取現状維持)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetAllChildren.mockResolvedValue([]); // 0 children → per-child service 呼び出しを回避
+		mockGetLevelTitleList.mockResolvedValue([]);
+		mockFindAllBenchmarks.mockResolvedValue([
+			{ age: 4, categoryId: '1', mean: 10, stdDev: 3, source: 'seed' },
+		]);
+	});
+
+	it('parent-admin は benchmarks を取得できる (読取許可)', async () => {
+		const data = (await load(makeLoadEvent(PARENT_ADMIN))) as { benchmarks: unknown[] };
+		expect(data.benchmarks).toHaveLength(1);
+		expect(mockFindAllBenchmarks).toHaveBeenCalledWith('t-test');
+	});
+
+	it('cognito ops member も benchmarks を取得できる (読取許可)', async () => {
+		const data = (await load(makeLoadEvent(OPS_MEMBER))) as { benchmarks: unknown[] };
+		expect(data.benchmarks).toHaveLength(1);
+	});
+});

--- a/tests/unit/routes/admin-status-benchmark-authz.test.ts
+++ b/tests/unit/routes/admin-status-benchmark-authz.test.ts
@@ -181,3 +181,41 @@ describe('benchmark 読取 (load) は書込 gate に波及しない (#3824 読�
 		expect(data.benchmarks).toHaveLength(1);
 	});
 });
+
+// #3824 (QM Tier2 H1): benchmark 編集 UI ゲートフラグ。書込 authz と同一境界で load が
+// canEditBenchmark を返し、+page.svelte が {#if data.canEditBenchmark} で編集フォームを出し分ける。
+// parent-admin に false を返すことで「見えるが必ず 403 で失敗する dead-form」を UI 層でも封じる
+// (server enforce = updateBenchmark action 403 と併せた防御多層)。読取 (benchmarks) は現状維持で全 admin 可。
+describe('canEditBenchmark UI ゲートフラグ (#3824 H1, load 出力)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockGetAllChildren.mockResolvedValue([]);
+		mockGetLevelTitleList.mockResolvedValue([]);
+		mockFindAllBenchmarks.mockResolvedValue([]);
+	});
+
+	it('parent-admin (非 ops) は canEditBenchmark=false (編集 UI 非表示)', async () => {
+		const data = (await load(makeLoadEvent(PARENT_ADMIN))) as { canEditBenchmark: boolean };
+		expect(data.canEditBenchmark).toBe(false);
+	});
+
+	it('cognito ops member は canEditBenchmark=true (編集 UI 表示)', async () => {
+		const data = (await load(makeLoadEvent(OPS_MEMBER))) as { canEditBenchmark: boolean };
+		expect(data.canEditBenchmark).toBe(true);
+	});
+
+	it('local identity (NUC セルフホスト) は canEditBenchmark=true (編集 UI 表示)', async () => {
+		const data = (await load(makeLoadEvent(LOCAL))) as { canEditBenchmark: boolean };
+		expect(data.canEditBenchmark).toBe(true);
+	});
+
+	it('anonymous (demo) は canEditBenchmark=false (編集 UI 非表示)', async () => {
+		const data = (await load(makeLoadEvent(ANONYMOUS))) as { canEditBenchmark: boolean };
+		expect(data.canEditBenchmark).toBe(false);
+	});
+
+	it('未認証 (identity=null) は canEditBenchmark=false (fail-closed)', async () => {
+		const data = (await load(makeLoadEvent(null))) as { canEditBenchmark: boolean };
+		expect(data.canEditBenchmark).toBe(false);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

`market_benchmarks`（age/category 別の統計基準値）は **全テナント共有のグローバル master**（`findBenchmark` / `findAllBenchmarks` は tenant 非依存で全テナント共通行を返す）だが、`/admin/status` の `updateBenchmark` action が `requireTenantId` のみで **parent-admin（通常の保護者管理者）から書込到達可能**だった。つまり 1 家庭の保護者が全テナント共有の統計基準値を書き換え得る（CWE-639 隣接の権限昇格。書込値は平均値で PII 非該当だが統計汚染に至る）。#3593 ④ は `upsertBenchmark` interface に「ops/admin 限定」を明文化しただけで実厳格化が残っていた。

本 PR は (1) グローバル master 書込を **ops/admin 相当に限定**（server enforce、SaaS の全テナント統計の完全性を守る）し、(2) **QM Tier2 指摘 H1 を受け benchmark 編集 UI を書込 authz と同一境界でゲート**（UI hide）する。従来 `/admin/status` の benchmark 編集フォームは全 admin に無条件描画されており、本 PR の server 403 化により parent-admin では「見えるが必ず 403 で失敗する dead-form」+ 内部概念（global master / ops）の英語露出（NN/G #1 visibility 違反）に陥る。UI hide + server enforce の防御多層で、parent-admin は read-only 比較（成長レポート RadarChart）のみを見る形に是正する。

## 関連 Issue

closes #3824

- #3593（検出元、point/status repo hardening ④ で authz を interface 明文化）/ #3822（#3593 実装 PR merged、QM Tier2 で本件 medium 検出）
- ADR-0063（tenant/認可 単一強制点）/ ADR-0022（admin bypass 禁止）/ ADR-0051（NUC 信頼境界）/ ADR-0061 / ADR-0001 / CWE-639

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | market_benchmarks 書込を ops/admin 相当に限定し parent-admin は 403 | `npx vitest run tests/unit/routes/admin-status-benchmark-authz.test.ts` | HEAD 00cf165218557f10495f07eb9b64761bd2a1df48 / PASS（parent-admin は 403 で upsertBenchmark 未到達）。red→green: 配線前は「promise resolved success instead of rejecting」→ guard 配線後 green |
| AC2 | ops group member / NUC local は書込許可（読取は両者許可で現状維持） | 同上 | HEAD 00cf1652 / PASS（cognito ops / local が upsertBenchmark 到達、読取 load は parent-admin・ops いずれも取得可） |
| AC3 | 認可判定を散在させず単一強制点に集約（ADR-0063） | `npx vitest run tests/unit/services/ops-authz.test.ts` | HEAD 00cf1652 / PASS（`requireGlobalMasterWriteAccess` を ops-authz.ts に集約、ops 判定は既存 `isOpsMember` / `OPS_GROUPS` SSOT 共有、書込到達点は updateBenchmark action 単一）9/9 |
| AC4 | fail-closed（anonymous / 未認証は 403） | `npx vitest run tests/unit/routes/admin-status-benchmark-authz.test.ts` | HEAD 00cf1652 / PASS（anonymous / identity=null は 403、action でも upsertBenchmark 未到達） |
| AC5 | 設計書同期（ADR-0001） | `docs/design/14-セキュリティ設計書.md §5.2.8` | HEAD 00cf1652 / §5.2.8 認可境界表追加 + upsertBenchmark interface コメントを実厳格化に更新 |
| AC6 | benchmark 編集 UI を書込 authz と同一境界でゲートし parent-admin dead-form を解消（QM Tier2 H1、防御多層） | `npx vitest run tests/unit/routes/admin-status-benchmark-authz.test.ts`（canEditBenchmark load 出力 5 件）+ parent SS before/after | HEAD 00cf1652 / PASS（load: parent-admin・anonymous・未認証 = false、ops・local = true）。実機 SS（後述）で parent-admin の編集フォーム消失（forms 5→0）+ ops は編集フォーム保持（forms 5）を実測 |

## 変更タイプ

- [x] fix: バグ修正（security hardening + parent-admin dead-form 解消の UI 是正）
- [x] docs: ドキュメント（設計書同期）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 認証 (`$lib/server/auth/`) — ops-authz.ts に `requireGlobalMasterWriteAccess` 単一強制点 + `isOpsMember` を load へ再利用
- [x] ページ / レイアウト (`src/routes/`) — admin/status/+page.server.ts の updateBenchmark action guard + load の `canEditBenchmark` フラグ / +page.svelte の benchmark 編集ブロックを `{#if data.canEditBenchmark}` でゲート
- [x] DB interface (`$lib/server/db/`) — status-repo.interface.ts の doc 更新
- [x] ドキュメント（14-セキュリティ設計書 §5.2.8）

**影響を受ける画面・機能**: `/admin/status` の benchmark 書込（parent-admin 403、ops/local 許可）。読取・成長レポート（RadarChart 比較）・称号カスタマイズ（tenant-scoped、parent 編集可）は不変。benchmark 編集 UI（年齢タブ + mean/SD 入力 + 保存ボタン + 未設定警告 + 機能説明）は parent-admin で非表示、ops/local で従来通り表示。

## テスト & 安全装置セルフチェック

- [x] targeted 検証コマンド（worktree tree で実行）:
- [x] `npx vitest run tests/unit/routes/admin-status-benchmark-authz.test.ts tests/unit/services/ops-authz.test.ts` → 25 passed（authz 16 = server guard/action/read 11 + canEditBenchmark UI ゲート load 5、ops-authz 回帰 9）
- [x] `npx svelte-check` → 変更 file 0 error（残 146 error は全て `infra/` 配下 aws-cdk-lib 未 install の環境要因、本 PR 変更 file と無関係）/ `npx biome check`（変更 5 file）→ clean
- [x] 追加・変更したテスト: server 側 = parent-admin 拒否（403 + upsert 未到達）/ ops・local 許可 / 読取両者許可 / fail-closed（anonymous・未認証 403）。UI ゲート = `canEditBenchmark` load 出力を parent-admin/anonymous/未認証 → false、ops/local → true で検証。既存 server authz assertion は非弱体化のまま維持（ADR-0006）
- [x] **新規 env / secret 追加時**: N/A（既存 Cognito ops group 判定を再利用）
- [x] **DynamoDB 実装変更時**: N/A（authz は上位ルート層で強制、backend の upsertBenchmark は無変更）
- [x] **Critical バグ修正の場合**: N/A（priority:medium、CWE-639 隣接）

## スクリーンショット / ビジュアルデモ

QM Tier2 H1 を受けた UI ゲートの実機検証（`npm run dev:cognito`、`DEV_USERS` の parent@example.com = cognito 非 ops）。**pre-fix では benchmark 編集フォームが parent-admin に無条件描画されていた（dead-form）ことを再現し、fix で read-only 化されることを実測**。

| 観点 | Before（pre-fix、parent-admin desktop） | After（fix 後、parent-admin desktop） | After（fix 後、parent-admin mobile） |
|---|---|---|---|
| benchmark 編集フォーム | 表示（`updateBenchmark` forms=5 / mean 入力=5） | **非表示**（forms=0 / 入力=0） | **非表示**（forms=0 / 入力=0） |
| SS | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3839/status-parent-before-desktop.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3839/status-parent-after-desktop.png) | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-3839/status-parent-after-mobile.png) |

- **Before**: 年齢タブ（3〜12歳）+ 平均/SD 入力 + 保存ボタン ×5 が parent-admin に露出。保存すると server 403（`Forbidden: global master write requires ops access`）が返る dead-form だった。
- **After**: 編集ブロックが消え、称号カスタマイズ（tenant-scoped、parent 編集可）のみ残存。成長レポート（RadarChart 比較）は子供データがある場合に read-only 表示（今回の parent テナントは子供 0 のため非表示）。
- **ops 対照（実測）**: ops@example.com（groups:['ops']）でログインすると `updateBenchmark` forms=5 で編集フォームが表示され、認可済ユーザーの編集 UI は不変であることを確認（ops のレンダリングは byte 単位で pre-fix の parent 画面と同一 = 認可済が見る編集 UI は変えず、parent-admin の到達のみ除去）。identical blob の二重埋め込みを避けるため ops SS は埋め込まず本文で記述する。

## コード品質セルフレビュー (#1481)

- [x] **SOLID / DRY**: 認可判定を ops-authz.ts の単一 guard に集約（ADR-0063）、ops 判定は既存 `isOpsMember` / `OPS_GROUPS` SSOT を再利用（二重定義なし）。UI ゲートフラグ `canEditBenchmark` は書込 guard と同一の許可条件（local or ops）で判定
- [x] **YAGNI**: 新規機構なし、既存 ops group 判定の再利用
- [x] **Security**: グローバル master 書込を ops 限定し cross-tenant 統計汚染（CWE-639 隣接）を遮断。UI hide + server enforce の防御多層（UI ゲートは UX 是正であり authz の主防壁は server 側 guard）。fail-closed（anonymous/未認証 403 かつ編集 UI 非表示）。repo は primitive のまま権限判断を持たせず認可を上位ルート層に配置
- [x] **アクセシビリティ / UX**: parent-admin の dead-form（NN/G #1 visibility 違反）+ 内部概念の英語露出を解消。read-only 比較のみを提示
- [x] **パフォーマンス**: guard は tenantId 取得より前に評価し最短経路で認可確定

## 横展開・影響波及チェック

- [x] `upsertBenchmark` の書込到達点を全 src 走査し `/admin/status` の updateBenchmark action **単一**であることを確認（他 caller は repo 定義のみ）
- [x] 読取（findBenchmark / findAllBenchmarks / getBenchmarkValues）は本 guard 対象外で現状維持
- [x] UI ゲートは benchmark 編集ブロックのみに限定。成長レポート（read-only 比較）・称号カスタマイズ（tenant-scoped、`?/saveLevelTitle` は ops 非依存）は非ゲートで parent 操作を維持
- [x] backend parity: authz は上位ルート層で強制するため backend 非依存、各 backend の upsertBenchmark は無変更
- [x] **設計書同期** (ADR-0001): 14-セキュリティ設計書 §5.2.8
- [x] N/A — labels/年齢モード/navi/LP に波及なし

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（SaaS cognito parent-admin は元々このグローバル master を書き換えるべきでなく、403 + 編集 UI 非表示は意図された是正。NUC local admin・cognito ops は従来通り書込・編集可能）

**レビュー依頼事項・QA**: `local`（NUC セルフホスト）を許可対象に含めた判断（単一テナント = 全テナント波及の概念なし、信頼ベース ADR-0051）が妥当かをご確認願います。UI ゲート（`canEditBenchmark`）は書込 guard と同一許可条件で出し分けています。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし（既存 Cognito ops group 判定を再利用）

## Ready for Review チェックリスト

- [x] vitest 25 passed / svelte-check（変更 file 0 error）/ biome / cspell clean をローカル確認（worktree tree、origin/develop rebase 済）
- [x] failing-test-first の red→green を実証（ADR-0061、脆弱性 red 再現 → guard で green）
- [x] 設計書同期完了（14-セキュリティ設計書 §5.2.8 + interface コメント）
- [x] Phase 分割なし
- [x] UI 変更あり（benchmark 編集 UI を書込 authz と同一境界でゲート）— parent-admin 視点の before/after SS を dev:cognito で撮影・添付済（desktop + mobile）

## QM レビュー結果

<!-- QM 記入 -->
