### PR TITLE
test: #3847 export/import round-trip を property-based (fast-check) 化 + Content-Disposition RFC5987 lock + canary snapshot (#3151)

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -209,6 +209,7 @@ cutover
 daidaikichi
 daikichi
 daisuki
+Dakuten
 dedup
 Denorm
 dependabot

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
 				"eslint-plugin-sonarjs": "^4.2.0",
 				"eslint-plugin-storybook": "^10.5.2",
 				"eslint-plugin-svelte": "^3.20.0",
+				"fast-check": "^4.9.0",
 				"googleapis": "^173.0.0",
 				"husky": "^9.1.7",
 				"jscpd": "^5.0.12",
@@ -6163,9 +6164,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6183,9 +6181,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6203,9 +6198,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6223,9 +6215,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6243,9 +6232,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6263,9 +6249,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7575,9 +7558,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7595,9 +7575,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7615,9 +7592,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7635,9 +7609,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -12871,6 +12842,29 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/fast-check": {
+			"version": "4.9.0",
+			"resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+			"integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"pure-rand": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=12.17.0"
+			}
+		},
 		"node_modules/fast-copy": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.3.tgz",
@@ -17739,6 +17733,23 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/pure-rand": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+			"integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/dubzzz"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fast-check"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/qified": {
 			"version": "0.10.1",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
 		"eslint-plugin-sonarjs": "^4.2.0",
 		"eslint-plugin-storybook": "^10.5.2",
 		"eslint-plugin-svelte": "^3.20.0",
+		"fast-check": "^4.9.0",
 		"googleapis": "^173.0.0",
 		"husky": "^9.1.7",
 		"jscpd": "^5.0.12",

--- a/tests/e2e/admin-backup-restore.spec.ts
+++ b/tests/e2e/admin-backup-restore.spec.ts
@@ -174,4 +174,29 @@ test.describe('admin/checklists backup/restore (#3079)', () => {
 
 		await fs.unlink(exportPath).catch(() => {});
 	});
+
+	// #3847 (EPIC #3151、RFC 5987/6266): checklist export の Content-Disposition は
+	// buildAttachmentContentDisposition (filename*=UTF-8'' + ASCII fallback) を経由する。
+	// seed のテンプレート名は日本語 (例: がっこうのもちもの) のため、Chromium が filename* を decode し
+	// suggestedFilename に日本語名を復元することを検証する (= #3104 の逆: 非 ASCII 名の往復復元可能性)。
+	test('非 ASCII テンプレート名の export は suggestedFilename に日本語名を復元する (#3847)', async ({
+		page,
+	}) => {
+		await page.goto('/admin/checklists');
+		await openMenuItem(page, 'checklists-overflow-menu', 'overflow-menu-item-export');
+		const exportDialog = page.getByTestId('export-checklist-dialog');
+		await expect(exportDialog).toBeVisible();
+
+		const firstExportItem = exportDialog.locator('[data-testid^="export-checklist-item-"]').first();
+		// seed に日本語名テンプレート (global-setup の 'がっこうのもちもの' 等) が存在する前提。
+		await expect(firstExportItem).toBeVisible();
+
+		const [download] = await Promise.all([page.waitForEvent('download'), firstExportItem.click()]);
+		const suggested = download.suggestedFilename();
+		// Content-Disposition filename* を browser が decode → checklist-<name>.json を復元
+		expect(suggested).toMatch(/^checklist-.*\.json$/);
+		// ASCII fallback (_ 置換) ではなく filename* 由来の非 ASCII 名 (> U+007F) が復元されている
+		const hasNonAscii = [...suggested].some((ch) => (ch.codePointAt(0) ?? 0) > 0x7f);
+		expect(hasNonAscii).toBe(true);
+	});
 });

--- a/tests/unit/domain/export-format.test.ts
+++ b/tests/unit/domain/export-format.test.ts
@@ -2,6 +2,7 @@
 // #3104: buildAttachmentContentDisposition の回帰テスト。
 // 日本語名テンプレで Content-Disposition が ByteString 変換 500 になった bug の再発防止。
 
+import * as fc from 'fast-check';
 import { describe, expect, it } from 'vitest';
 import { buildAttachmentContentDisposition } from '../../../src/lib/domain/export-format';
 
@@ -91,5 +92,57 @@ describe('buildAttachmentContentDisposition (#3104)', () => {
 		expect(extValue).toContain('%21');
 		expect(extValue).toContain('%7E');
 		expect(isByteStringSafe(cd)).toBe(true);
+	});
+});
+
+// #3847 (EPIC #3151、RFC 5987/6266): 任意 Unicode ファイル名に対する RFC 6266 準拠を property-based で
+// lock する。既存 example-based test を fast-check で補強し、境界 / Unicode を機械探索して #3104 class
+// (非 ASCII 名の header 破損 / 復元不能) の再発を封じる。
+describe('buildAttachmentContentDisposition property (#3847、RFC 5987/6266)', () => {
+	// grapheme unit: 絵文字 / ZWJ / 結合文字を含む Unicode-aware な任意ファイル名 (lone surrogate なし)。
+	const filenameArb = fc.string({ unit: 'grapheme', minLength: 1, maxLength: 40 });
+
+	it('任意 Unicode 名で: ASCII fallback (filename=) と filename*=UTF-8 の両方を必ず含む', () => {
+		fc.assert(
+			fc.property(filenameArb, (name) => {
+				const cd = buildAttachmentContentDisposition(name);
+				expect(cd.startsWith('attachment;')).toBe(true);
+				expect(cd).toMatch(/filename="[^"]*"/);
+				expect(cd).toContain("filename*=UTF-8''");
+			}),
+		);
+	});
+
+	it('任意 Unicode 名で: 出力は常に ByteString 安全 (new Response が throw しない = 500 にならない)', () => {
+		fc.assert(
+			fc.property(filenameArb, (name) => {
+				const cd = buildAttachmentContentDisposition(name);
+				expect(isByteStringSafe(cd)).toBe(true);
+				expect(() => new Response('{}', { headers: { 'Content-Disposition': cd } })).not.toThrow();
+			}),
+		);
+	});
+
+	it('任意 Unicode 名で: filename* を decode すると元のファイル名が完全復元される (RFC 5987 round-trip)', () => {
+		fc.assert(
+			fc.property(filenameArb, (name) => {
+				const cd = buildAttachmentContentDisposition(name);
+				const ext = cd.match(/filename\*=UTF-8''(.*)$/)?.[1] ?? '';
+				// filename* に格納された percent-encoded 値を decode → 元名と一致 (往復で欠落/破損なし)
+				expect(decodeURIComponent(ext)).toBe(name);
+			}),
+		);
+	});
+
+	it('任意 Unicode 名で: ASCII fallback は printable ASCII のみ + " \\ ; = を含まない (injection 安全)', () => {
+		fc.assert(
+			fc.property(filenameArb, (name) => {
+				const cd = buildAttachmentContentDisposition(name);
+				const fallback = cd.match(/filename="([^"]*)"/)?.[1] ?? '';
+				// 0x20-0x7E の printable ASCII のみ、かつ directive 区切りになる文字を含まない
+				expect(fallback).toMatch(/^[ -~]*$/);
+				expect(fallback).not.toMatch(/["\\;=]/);
+			}),
+		);
 	});
 });

--- a/tests/unit/marketplace/__snapshots__/round-trip.test.ts.snap
+++ b/tests/unit/marketplace/__snapshots__/round-trip.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`wire format canary snapshot (#3847) > activity-pack の代表 export envelope が既知の wire format と一致する 1`] = `
+{
+  "checksum": "2648d2a0fd26f730a5a2c029b7172a36730cb7f32ef1fd9435fc49d5035e5e4d",
+  "exportedAt": "2026-05-21T00:00:00.000Z",
+  "payload": {
+    "activities": [
+      {
+        "ageMax": 12,
+        "ageMin": 6,
+        "basePoints": 10,
+        "categoryCode": "undou",
+        "gradeLevel": null,
+        "icon": "🏃",
+        "name": "ランニング🏃",
+        "triggerHint": "朝いちばん",
+      },
+    ],
+  },
+  "schemaVersion": 2,
+  "typeCode": "activity-pack",
+}
+`;

--- a/tests/unit/marketplace/export-import-roundtrip-property.test.ts
+++ b/tests/unit/marketplace/export-import-roundtrip-property.test.ts
@@ -1,0 +1,85 @@
+// tests/unit/marketplace/export-import-roundtrip-property.test.ts
+// #3847 (EPIC #3151): export/import round-trip 不変条件の property-based (fast-check) 化。
+//
+// 背景 (root class): #3104 (日本語/絵文字の往復破損) と #3132 (値域ドリフト) の 2 サイクル連続
+// blocker は、round-trip test が「代表 5 sample の example-based」だったため境界値 / Unicode を
+// 探索できず、5-Whys item 5 (test が境界/Unicode を探索しない) に帰着した。本 test は
+// `round-trip.test.ts` の example-based な round-trip 不変条件を property-based に **格上げ** し、
+// fast-check の generator (`marketplace-arbitraries.ts`、値域 SSOT 定数から導出) で境界 / Unicode を
+// 機械探索する。shrinking により最小反例が得られるため、再ドリフト時に原因 payload が特定できる。
+//
+// 検証する right-inverse (import は export の右逆): 5 type 全てで
+//   import(export(x)) == x
+//   すなわち parseViaSchema(parseExportEnvelopeV2(JSON 往復(dispatchExport(x))).payload) === x
+// を、SSOT 値域から導出した任意 payload x について表明する。
+
+import * as fc from 'fast-check';
+import * as v from 'valibot';
+import { describe, expect, it } from 'vitest';
+import { countIconGraphemes } from '$lib/domain/validation/activity';
+import { dispatchExport } from '$lib/marketplace/export-dispatcher';
+import { parseExportEnvelopeV2 } from '$lib/marketplace/export-schema';
+import { MarketplacePayloadSchemaMap, type MarketplaceTypeId } from '$lib/marketplace/schemas';
+import { ICON_EMOJI, PAYLOAD_ARBITRARIES } from './marketplace-arbitraries';
+
+/**
+ * Strategy.parse() と等価な payload schema (`MarketplacePayloadSchemaMap`) 経由で parse する。
+ * 各 Strategy の parse() は内部で同一 schema を呼ぶため、本呼び出しは「Strategy が round-trip
+ * envelope の payload を受理する」と等価 (round-trip.test.ts と同一方針)。
+ */
+function parseViaSchema(typeCode: MarketplaceTypeId, payload: unknown): unknown {
+	return v.parse(MarketplacePayloadSchemaMap[typeCode], payload);
+}
+
+// 型ごとの numRuns。全 5 type 合計で T1 gate (< 30s) に十分収まる (実測は PR body に記載)。
+// icon の grapheme 判定 (Intl.Segmenter) が per-item コストの大半のため、item 数の多い型は
+// numRuns を控えめにする。
+const NUM_RUNS: Record<MarketplaceTypeId, number> = {
+	'activity-pack': 120,
+	'reward-set': 120,
+	checklist: 120,
+	'rule-preset': 120,
+	'challenge-set': 100,
+};
+
+describe('#3847 generator validity (SSOT 境界を逸脱しない self-check)', () => {
+	it('ICON_EMOJI は全て 1 grapheme (単体で isValid*Icon を満たす)', () => {
+		for (const e of ICON_EMOJI) {
+			expect(countIconGraphemes(e), `icon ${JSON.stringify(e)} は 1 grapheme のはず`).toBe(1);
+		}
+	});
+
+	it('ICON_EMOJI 2 個連結は必ず 2 grapheme (isValid*Icon 上限 2 を満たし合流しない)', () => {
+		for (const a of ICON_EMOJI) {
+			for (const b of ICON_EMOJI) {
+				expect(countIconGraphemes(a + b), `${JSON.stringify(a + b)} は 2 grapheme のはず`).toBe(2);
+			}
+		}
+	});
+});
+
+describe('#3847 export → import round-trip property (fast-check、5 type right-inverse)', () => {
+	for (const typeCode of Object.keys(PAYLOAD_ARBITRARIES) as MarketplaceTypeId[]) {
+		it(`${typeCode}: import(export(x)) == x を SSOT 値域から導出した任意 payload で表明`, () => {
+			fc.assert(
+				fc.property(PAYLOAD_ARBITRARIES[typeCode], (payload) => {
+					// export: dispatchExport は内部で schema parse するため env.payload = parse(x)。
+					// generator は canonical payload のみ生成するので parse は identity → env.payload == x。
+					const env = dispatchExport({ typeCode, payload });
+					expect(env.payload).toEqual(payload);
+
+					// storage / transport を擬似する JSON 往復。
+					const restored = parseExportEnvelopeV2(JSON.parse(JSON.stringify(env)));
+
+					// import(export(x)) == x (right-inverse)。checksum は parseExportEnvelopeV2 内で
+					// verify 済 (mismatch なら throw) のため、往復後も改竄なし。
+					expect(restored.checksum).toBe(env.checksum);
+					expect(restored.payload).toEqual(payload);
+					// Strategy.parse 互換 schema 経由でも復元値が x と一致 (apply まで到達可能)。
+					expect(parseViaSchema(typeCode, restored.payload)).toEqual(payload);
+				}),
+				{ numRuns: NUM_RUNS[typeCode] },
+			);
+		});
+	}
+});

--- a/tests/unit/marketplace/marketplace-arbitraries.ts
+++ b/tests/unit/marketplace/marketplace-arbitraries.ts
@@ -1,0 +1,269 @@
+// tests/unit/marketplace/marketplace-arbitraries.ts
+// #3847 (EPIC #3151): export/import round-trip の property-based 化に使う fast-check arbitrary 群。
+//
+// 設計原則 (ADR-0066 / ADR-0061 shift-left):
+//   - **generator は値域 SSOT 定数から導出する**。各 domain validation file
+//     (`$lib/domain/validation/{activity,special-reward,checklist,challenge-set,rule-preset}.ts`)
+//     が export する `*_MIN` / `*_MAX` 定数 + picklist SSOT (CATEGORY_CODES / GRADE_LEVELS /
+//     REWARD_CATEGORIES / SHOP_CATEGORIES / CATEGORY_NUMERIC_IDS / CHECKLIST_TIMINGS / RULE_TYPES)
+//     を直接参照して値域を作る。literal 直書きは #3132 値域ドリフトの root class のため禁止。
+//   - **Unicode-aware**: name / title / label / description は ASCII / ひらがな / 漢字 / 絵文字 /
+//     ZWJ 連結絵文字 / 結合文字 (combining mark) を混ぜた grapheme token から組み、schema の
+//     maxLength (UTF-16 code unit 基準) を厳守する。#3104 (日本語 / 絵文字の往復破損) を機械探索する。
+//   - **canonical payload のみ生成**: 各 schema (`v.object`) は未知キーを strip し optional 欠落を
+//     欠落のまま返すため、生成 payload は「schema が受理する既知キーのみ + optional は present/absent」
+//     に限定する。これにより `parse(payload)` が identity になり `import(export(x)) == x` が成立する。
+//
+// icon は 5 type とも「1〜2 grapheme」判定 (isValid*Icon、#3151) に統一済のため単一 iconArb を共有する。
+// 生成 icon の grapheme 数不変は `export-import-roundtrip-property.test.ts` の meta self-check で表明する。
+//
+// Unicode リテラルは editor 正規化 (NFC) や不可視文字混入に依存しないよう、combining / ZWJ / 絵文字は
+// 全て `\u` escape で明示する (ZWJ = U+200D、variation selector = U+FE0F、skin tone = U+1F3FD)。
+
+import * as fc from 'fast-check';
+import { CATEGORY_NUMERIC_IDS } from '$lib/domain/categories';
+import { SHOP_CATEGORIES } from '$lib/domain/shop-category';
+import {
+	ACTIVITY_AGE_MAX,
+	ACTIVITY_AGE_MIN,
+	ACTIVITY_BASE_POINTS_MAX,
+	ACTIVITY_BASE_POINTS_MIN,
+	ACTIVITY_DESCRIPTION_MAX,
+	ACTIVITY_NAME_MAX,
+	ACTIVITY_NAME_MIN,
+	ACTIVITY_TRIGGER_HINT_MAX,
+	CATEGORY_CODES,
+	GRADE_LEVELS,
+} from '$lib/domain/validation/activity';
+import {
+	CHALLENGE_BASE_TARGET_MAX,
+	CHALLENGE_BASE_TARGET_MIN,
+	CHALLENGE_DESCRIPTION_MAX,
+	CHALLENGE_DESCRIPTION_MIN,
+	CHALLENGE_DURATION_DAYS_MAX,
+	CHALLENGE_DURATION_DAYS_MIN,
+	CHALLENGE_REWARD_POINTS_MAX,
+	CHALLENGE_REWARD_POINTS_MIN,
+	CHALLENGE_TITLE_MAX,
+	CHALLENGE_TITLE_MIN,
+} from '$lib/domain/validation/challenge-set';
+import {
+	CHECKLIST_LABEL_MAX,
+	CHECKLIST_LABEL_MIN,
+	CHECKLIST_ORDER_MIN,
+} from '$lib/domain/validation/checklist';
+import {
+	RULE_DESCRIPTION_MAX,
+	RULE_DESCRIPTION_MIN,
+	RULE_POINT_MAX,
+	RULE_POINT_MIN,
+	RULE_TITLE_MAX,
+	RULE_TITLE_MIN,
+} from '$lib/domain/validation/rule-preset';
+import {
+	REWARD_CATEGORIES,
+	REWARD_DESCRIPTION_MAX,
+	REWARD_POINTS_MAX,
+	REWARD_POINTS_MIN,
+	REWARD_TITLE_MAX,
+	REWARD_TITLE_MIN,
+} from '$lib/domain/validation/special-reward';
+import { CHECKLIST_TIMINGS, type MarketplaceTypeId, RULE_TYPES } from '$lib/marketplace/schemas';
+
+const ZWJ = '‍';
+
+// ── Unicode-aware 文字列 arbitrary ─────────────────────────────────
+
+/** 単一絵文字 (2 UTF-16 CU): U+1F3C3 走る人。 */
+const EMOJI_RUN = '\u{1F3C3}';
+/** ZWJ 連結家族絵文字 (11 UTF-16 CU、1 grapheme): man+woman+girl+boy。 */
+const EMOJI_FAMILY = `\u{1F468}${ZWJ}\u{1F469}${ZWJ}\u{1F467}${ZWJ}\u{1F466}`;
+/** 'e' + combining acute accent U+0301 (2 CU, 1 grapheme, decomposed)。 */
+const COMBINING_E_ACUTE = 'é';
+/** 'か' U+304B + combining voiced sound mark U+3099 (2 CU, 1 grapheme, decomposed)。 */
+const COMBINING_KA_DAKUTEN = 'が';
+
+/**
+ * name / title / label / description 用の grapheme token。JSON 往復で壊れやすい代表を集める:
+ * ASCII / ひらがな / 漢字 / 長音 / 全角空白 / 単一絵文字 (2 CU) / ZWJ 連結絵文字 (11 CU) /
+ * 結合文字 sequence (base + combining mark = 2 CU)。いずれも complete な unit (lone surrogate /
+ * lone combining mark 単独 は含めない) なので連結しても壊れず、`JSON.stringify` → `JSON.parse` で
+ * 完全に復元される。
+ */
+export const TEXT_TOKENS: readonly string[] = [
+	'a',
+	'Z',
+	'7',
+	'あ', // あ
+	'漢', // 漢
+	'ぽ', // ぽ
+	'ー', // ー (長音)
+	'　', // 全角スペース
+	EMOJI_RUN,
+	EMOJI_FAMILY,
+	COMBINING_E_ACUTE,
+	COMBINING_KA_DAKUTEN,
+];
+
+/**
+ * UTF-16 code unit 長が `[min, max]` に収まる Unicode-aware 文字列を生成する。
+ * schema の minLength/maxLength は `String.prototype.length` (= UTF-16 CU) 基準のため、
+ * `s.length` を積算して max を超える token を skip し、不足分は ASCII 1 文字で pad する。
+ */
+export function boundedText(min: number, max: number): fc.Arbitrary<string> {
+	return fc
+		.array(fc.constantFrom(...TEXT_TOKENS), { minLength: 1, maxLength: Math.max(max, 8) })
+		.map((tokens) => {
+			let s = '';
+			for (const t of tokens) {
+				if (s.length + t.length <= max) s += t;
+			}
+			while (s.length < min) s += 'a';
+			return s;
+		});
+}
+
+// ── icon arbitrary (1〜2 grapheme、5 type 共有) ────────────────────
+
+/**
+ * 連結しても各々が独立 grapheme に留まる complete emoji のみ (skin-tone / ZWJ family 含む)。
+ * lone regional indicator / lone ZWJ / lone skin-tone modifier は grapheme 合流を起こすため除外。
+ * 全て `\u` escape で editor 正規化・不可視文字混入に非依存にする。
+ */
+export const ICON_EMOJI: readonly string[] = [
+	'\u{1F3C3}', // running
+	'\u{1F4DA}', // books
+	'\u{1F381}', // gift
+	'\u{1F3AF}', // target
+	'\u{1F4CB}', // clipboard
+	'\u{1F366}', // soft ice cream
+	'\u{1F3AC}', // clapper
+	'\u{1FAA5}', // toothbrush
+	'\u{1F455}', // t-shirt
+	'\u{1F35A}', // cooked rice
+	'✏️', // pencil (+ VS16)
+	'\u{1F38E}', // dolls
+	'\u{1F31F}', // glowing star
+	'⚔️', // crossed swords (+ VS16)
+	'\u{1F409}', // dragon
+	'\u{1F984}', // unicorn
+	'\u{1F36A}', // cookie
+	'\u{1F3AE}', // video game
+	'\u{1F60A}', // smiling
+	'\u{1F44D}', // thumbs up
+	'⭐', // star
+	'❤️', // red heart (+ VS16)
+	'\u{1F4AA}', // flexed biceps
+	'\u{1F680}', // rocket
+	'\u{1F451}', // crown
+	'\u{1F3C6}', // trophy
+	'\u{1F308}', // rainbow
+	'☀️', // sun (+ VS16)
+	`\u{1F468}${ZWJ}\u{1F469}${ZWJ}\u{1F467}${ZWJ}\u{1F466}`, // family (ZWJ, 1 grapheme)
+	'\u{1F44D}\u{1F3FD}', // thumbs up + medium skin tone
+	`\u{1F9D1}${ZWJ}\u{1F680}`, // astronaut (ZWJ)
+];
+
+/** 1〜2 個の complete emoji を連結した icon (isValid*Icon = 1〜2 grapheme を満たす)。 */
+export const iconArb: fc.Arbitrary<string> = fc
+	.array(fc.constantFrom(...ICON_EMOJI), { minLength: 1, maxLength: 2 })
+	.map((parts) => parts.join(''));
+
+// ── monthDay (challenge-set) ──────────────────────────────────────
+
+/** 'MM-DD' (CHALLENGE_MONTH_DAY_REGEX: MM=01-12 / DD=01-31)。schema は regex のみ検証。 */
+const monthDayArb: fc.Arbitrary<string> = fc
+	.tuple(fc.integer({ min: 1, max: 12 }), fc.integer({ min: 1, max: 31 }))
+	.map(([m, d]) => `${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`);
+
+// ── item arbitrary (値域は全て SSOT 定数から導出) ──────────────────
+
+const activityItemArb = fc.record(
+	{
+		name: boundedText(ACTIVITY_NAME_MIN, ACTIVITY_NAME_MAX),
+		categoryCode: fc.constantFrom(...CATEGORY_CODES),
+		icon: iconArb,
+		basePoints: fc.integer({ min: ACTIVITY_BASE_POINTS_MIN, max: ACTIVITY_BASE_POINTS_MAX }),
+		ageMin: fc.option(fc.integer({ min: ACTIVITY_AGE_MIN, max: ACTIVITY_AGE_MAX }), { nil: null }),
+		ageMax: fc.option(fc.integer({ min: ACTIVITY_AGE_MIN, max: ACTIVITY_AGE_MAX }), { nil: null }),
+		gradeLevel: fc.option(fc.constantFrom(...GRADE_LEVELS), { nil: null }),
+		// optional 群 (present/absent を fast-check が探索し、absent は parse 出力の欠落と一致)
+		triggerHint: boundedText(1, ACTIVITY_TRIGGER_HINT_MAX),
+		description: boundedText(1, ACTIVITY_DESCRIPTION_MAX),
+		mustDefault: fc.boolean(),
+	},
+	{
+		requiredKeys: ['name', 'categoryCode', 'icon', 'basePoints', 'ageMin', 'ageMax', 'gradeLevel'],
+	},
+);
+
+const rewardItemArb = fc.record(
+	{
+		title: boundedText(REWARD_TITLE_MIN, REWARD_TITLE_MAX),
+		points: fc.integer({ min: REWARD_POINTS_MIN, max: REWARD_POINTS_MAX }),
+		icon: iconArb,
+		category: fc.constantFrom(...REWARD_CATEGORIES),
+		description: boundedText(1, REWARD_DESCRIPTION_MAX),
+		shopCategory: fc.constantFrom(...SHOP_CATEGORIES),
+	},
+	{ requiredKeys: ['title', 'points', 'icon', 'category'] },
+);
+
+const checklistItemArb = fc.record({
+	label: boundedText(CHECKLIST_LABEL_MIN, CHECKLIST_LABEL_MAX),
+	icon: iconArb,
+	order: fc.integer({ min: CHECKLIST_ORDER_MIN, max: CHECKLIST_ORDER_MIN + 999 }),
+});
+
+const challengeItemArb = fc.record({
+	title: boundedText(CHALLENGE_TITLE_MIN, CHALLENGE_TITLE_MAX),
+	description: boundedText(CHALLENGE_DESCRIPTION_MIN, CHALLENGE_DESCRIPTION_MAX),
+	monthDay: monthDayArb,
+	durationDays: fc.integer({ min: CHALLENGE_DURATION_DAYS_MIN, max: CHALLENGE_DURATION_DAYS_MAX }),
+	categoryId: fc.constantFrom(...CATEGORY_NUMERIC_IDS),
+	baseTarget: fc.integer({ min: CHALLENGE_BASE_TARGET_MIN, max: CHALLENGE_BASE_TARGET_MAX }),
+	rewardPoints: fc.integer({ min: CHALLENGE_REWARD_POINTS_MIN, max: CHALLENGE_REWARD_POINTS_MAX }),
+	icon: iconArb,
+});
+
+const ruleItemArb = fc.record(
+	{
+		title: boundedText(RULE_TITLE_MIN, RULE_TITLE_MAX),
+		description: boundedText(RULE_DESCRIPTION_MIN, RULE_DESCRIPTION_MAX),
+		icon: iconArb,
+		pointCost: fc.integer({ min: RULE_POINT_MIN, max: RULE_POINT_MAX }),
+		pointBonus: fc.integer({ min: RULE_POINT_MIN, max: RULE_POINT_MAX }),
+	},
+	{ requiredKeys: ['title', 'description', 'icon'] },
+);
+
+// ── payload arbitrary (typeCode 別) ───────────────────────────────
+
+const ITEM_ARRAY = { minLength: 1, maxLength: 4 } as const;
+
+export const activityPackPayloadArb = fc.record({
+	activities: fc.array(activityItemArb, ITEM_ARRAY),
+});
+export const rewardSetPayloadArb = fc.record({
+	rewards: fc.array(rewardItemArb, ITEM_ARRAY),
+});
+export const checklistPayloadArb = fc.record({
+	timing: fc.constantFrom(...CHECKLIST_TIMINGS),
+	items: fc.array(checklistItemArb, ITEM_ARRAY),
+});
+export const rulePresetPayloadArb = fc.record({
+	ruleType: fc.constantFrom(...RULE_TYPES),
+	rules: fc.array(ruleItemArb, ITEM_ARRAY),
+});
+export const challengeSetPayloadArb = fc.record({
+	challenges: fc.array(challengeItemArb, ITEM_ARRAY),
+});
+
+/** typeCode → payload arbitrary の SSOT map (property test が 5 type を横断反復する)。 */
+export const PAYLOAD_ARBITRARIES: Record<MarketplaceTypeId, fc.Arbitrary<unknown>> = {
+	'activity-pack': activityPackPayloadArb,
+	'reward-set': rewardSetPayloadArb,
+	checklist: checklistPayloadArb,
+	'rule-preset': rulePresetPayloadArb,
+	'challenge-set': challengeSetPayloadArb,
+};

--- a/tests/unit/marketplace/round-trip.test.ts
+++ b/tests/unit/marketplace/round-trip.test.ts
@@ -27,6 +27,11 @@ import { dispatchExport, dispatchExportToJson } from '$lib/marketplace/export-di
 import { parseAnyExportEnvelope, parseExportEnvelopeV2 } from '$lib/marketplace/export-schema';
 import { MarketplacePayloadSchemaMap, type MarketplaceTypeId } from '$lib/marketplace/schemas';
 
+// #3847 (EPIC #3151): 下記の「round-trip 不変条件」(import(export(x)) == x) 本体は
+// example-based から property-based (fast-check) に **格上げ** 済 (`export-import-roundtrip-property.test.ts`)。
+// 本ファイルは property では表現しにくい orthogonal な lock (checksum 改竄検知 / 別 entry point /
+// v1 互換 / deterministic checksum / wire format canary snapshot) を example-based で保持する。
+
 /**
  * Strategy 本体は DB 依存 import を引き連れるためテストで直接読み込まず、
  * Strategy.parse() と同等の振る舞いをする payload schema (`MarketplacePayloadSchemaMap`)
@@ -121,33 +126,12 @@ const SAMPLES: Array<{ typeCode: MarketplaceTypeId; payload: unknown }> = [
 	{ typeCode: 'challenge-set', payload: SAMPLE_CHALLENGE_SET },
 ];
 
-describe('export → import round-trip 保証 (5 type 全網羅)', () => {
+describe('export → import round-trip 保証 (5 type 全網羅、orthogonal lock)', () => {
+	// NOTE(#3847): round-trip 不変条件 (dispatchExport → JSON 往復 → parseExportEnvelopeV2 →
+	// schema.parse == 元 payload) 本体は property-based に格上げ済 (export-import-roundtrip-property.test.ts)。
+	// 本 describe は checksum 改竄検知 / 別 entry point / v1 互換など property では表現しにくい lock のみ残す。
 	for (const { typeCode, payload } of SAMPLES) {
 		describe(`typeCode = ${typeCode}`, () => {
-			it('dispatchExport → JSON.stringify → JSON.parse → parseExportEnvelopeV2 が成功する', () => {
-				const env = dispatchExport({ typeCode, payload });
-				const json = JSON.stringify(env);
-				const restored = parseExportEnvelopeV2(JSON.parse(json));
-				expect(restored.typeCode).toBe(typeCode);
-				expect(restored.schemaVersion).toBe(2);
-				expect(restored.payload).toEqual(env.payload);
-				expect(restored.checksum).toBe(env.checksum);
-			});
-
-			it('envelope.payload は Strategy 互換の schema.parse() で受理される', () => {
-				const env = dispatchExport({ typeCode, payload });
-				expect(() => parseViaSchema(typeCode, env.payload)).not.toThrow();
-			});
-
-			it('round-trip 後の payload を schema.parse() に渡しても元 payload と等価', () => {
-				// payload → envelope → JSON → restored → schema.parse → restored payload
-				const env = dispatchExport({ typeCode, payload });
-				const restored = parseExportEnvelopeV2(JSON.parse(JSON.stringify(env)));
-				const finalParsed = parseViaSchema(typeCode, restored.payload);
-				// schema 経由 parse の結果が元 payload と equal (deep)
-				expect(finalParsed).toEqual(env.payload);
-			});
-
 			it('checksum 改竄を round-trip で検出', () => {
 				const env = dispatchExport({ typeCode, payload });
 				const tampered = JSON.parse(JSON.stringify(env));
@@ -231,5 +215,33 @@ describe('deterministic checksum 保証', () => {
 			exportedAt: fixed,
 		});
 		expect(e1.checksum).toBe(e2.checksum);
+	});
+});
+
+// #3847 AC3: wire format canary。代表 export 1 枚を snapshot で固定し、envelope 構造 /
+// checksum アルゴリズム / key 順序 の silent な wire format 変更を検出する (過剰な approval
+// framework は作らず 1 snapshot のみ)。exportedAt を固定して deterministic にする。
+describe('wire format canary snapshot (#3847)', () => {
+	it('activity-pack の代表 export envelope が既知の wire format と一致する', () => {
+		const canary = {
+			activities: [
+				{
+					name: 'ランニング🏃',
+					categoryCode: 'undou' as const,
+					icon: '🏃',
+					basePoints: 10,
+					ageMin: 6,
+					ageMax: 12,
+					gradeLevel: null,
+					triggerHint: '朝いちばん',
+				},
+			],
+		};
+		const json = dispatchExportToJson({
+			typeCode: 'activity-pack',
+			payload: canary,
+			exportedAt: '2026-05-21T00:00:00.000Z',
+		});
+		expect(JSON.parse(json)).toMatchSnapshot();
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

顧客データ (活動 / ごほうび / チェックリスト / チャレンジ / ルール) のバックアップ→復元 (export/import) が、境界値・日本語・絵文字を含む任意データでも欠落・破損しないことを機械強制する。#3104 (日本語/絵文字の往復破損) → #3132 (値域ドリフト) の 2 サイクル連続 blocker の root class = 「round-trip test が代表 5 sample の example-based で境界/Unicode を探索しない」(5-Whys item 5) を、property-based test で shift-left に封じる (ADR-0061)。

## 関連 Issue

- Closes #3847
- EPIC #3151 (値域 SSOT / round-trip 機械強制)。値域 SSOT slice1-4 で 5 type 全 COVERED 済。本 slice は round-trip 不変条件の property 化 (選択肢 C の一部)。EPIC 最終形の選択肢 B (単一 Valibot schema 完全統合) は #3151 で継続 tracking。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | round-trip test を example-based → property-based (fast-check) に格上げ (5 type、generator は値域 SSOT 定数から導出、Unicode-aware、T1 < 30s) | `npx vitest run tests/unit/marketplace/export-import-roundtrip-property.test.ts` | 7 passed (5 property + 2 meta)。property 5 type 合計 **278ms** (activity 90 / reward 48 / checklist 45 / rule 53 / challenge 42ms)、T1 < 30s を十分満たす。generator は各 `$lib/domain/validation/*` の `*_MIN`/`*_MAX` + picklist SSOT から導出 (`marketplace-arbitraries.ts`)、grapheme token (ASCII/かな/漢字/絵文字/ZWJ/結合文字) で Unicode-aware。`import(export(x)) == x` (right-inverse) を表明。 |
| AC2 | export ダウンロード route の Content-Disposition を RFC 5987/6266 準拠に (既に準拠なら test で lock、非 ASCII 名の Playwright download 検証追加) | `npx vitest run tests/unit/domain/export-format.test.ts` + E2E | 12 passed。`buildAttachmentContentDisposition` (helper、#3104 で既に filename*=UTF-8'' + ASCII fallback 実装済 / 全 export route 準拠) を **property-based で lock** 追加 (任意 Unicode 名で filename= と filename* 両立 / ByteString 安全 / `decodeURIComponent(filename*) == 元名` の往復復元 / fallback は printable ASCII のみ)。E2E は checklist export の `download.suggestedFilename()` が日本語名を復元することを検証する test を merged #3079 パターンで追加。 |
| AC3 | 代表 export 1 枚の canary snapshot (wire format 変更検出、過剰な approval framework は作らない) | `npx vitest run tests/unit/marketplace/round-trip.test.ts` | 19 passed。`round-trip.test.ts` に activity-pack 代表 export 1 枚の `toMatchSnapshot` を追加 (`__snapshots__/round-trip.test.ts.snap`、exportedAt 固定で deterministic、checksum 含む envelope 全体を固定)。snapshot は 1 枚のみ。 |
| AC4 | failing-test-first (ADR-0061): 値域 SSOT を意図的にずらす mutation で property が fail する物理確認 | 手動 mutation 実行 | **確認済 (下記「テスト & 安全装置セルフチェック」に証跡)**。wire schema `activity-pack-schema.ts` の basePoints 上限を SSOT (`ACTIVITY_BASE_POINTS_MAX`=100) から 50 に drift させると property が fail (shrunk counterexample `basePoints: 51`)。SSOT 復元後は再度 green (HEAD と diff 0 を検証)。 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

（テスト追加・強化。プロダクトコード変更なし、dev dependency 追加のみ）

## 影響範囲・変更コンポーネント

- **新規** `tests/unit/marketplace/marketplace-arbitraries.ts` — 5 type の fast-check payload arbitrary (値域 SSOT 定数から導出)
- **新規** `tests/unit/marketplace/export-import-roundtrip-property.test.ts` — 5 type right-inverse property + generator 妥当性 meta self-check
- **新規** `tests/unit/marketplace/__snapshots__/round-trip.test.ts.snap` — AC3 canary snapshot
- **変更** `tests/unit/marketplace/round-trip.test.ts` — 例示ベースの round-trip 不変条件を property に格上げ (checksum 改竄 / v1 互換 / deterministic checksum の orthogonal lock は保持) + canary snapshot 追加
- **変更** `tests/unit/domain/export-format.test.ts` — Content-Disposition helper の property-based lock 4 件追加
- **変更** `tests/e2e/admin-backup-restore.spec.ts` — checklist export の非 ASCII `suggestedFilename` 検証 test 追加
- **変更** `package.json` / `package-lock.json` — `fast-check@^4.9.0` を devDependency 追加
- **変更** `.cspell/project-words.txt` — `Dakuten` (identifier 由来) を alphabetical 追加
- プロダクトコード (`src/`) は無変更。

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/marketplace/ tests/unit/domain/export-format.test.ts` → **296 passed (22 files)**
- property 実行時間 (T1 gate < 30s): property 5 type 合計 **278ms** (verbose duration: activity-pack 90ms / reward-set 48ms / checklist 45ms / rule-preset 53ms / challenge-set 42ms) + meta 60ms
- `npx biome check --error-on-warnings <changed>` → clean (No fixes)
- `npx svelte-check --threshold error` → **0 errors / 0 warnings** (8036 files)
- `npx cspell tests/**` (changed) → clean (`Dakuten` 追加後 exit 0)
- `npm run knip` → `fast-check` は test entry から使用検出 (未使用 dep 誤検出なし)、`marketplace-arbitraries.ts` は未使用ファイル判定なし
- **AC4 mutation 物理確認証跡**:
  - mutation: `activity-pack-schema.ts` basePoints `v.maxValue(ACTIVITY_BASE_POINTS_MAX)` → `v.maxValue(50)`
  - 結果: `activity-pack: import(export(x)) == x` property が **FAIL** — `Property failed after 2 tests`、`Counterexample: [{"activities":[{...,"basePoints":51,...}]}]`、`Caused by: ValiError: max_value expected '<=50' received '51'`
  - 復元: `git show HEAD:...activity-pack-schema.ts` と diff 0 を確認、property 再 green
  - → property が SSOT 値域境界を実際に探索し、wire 値域ドリフト (#3132 と同 class) を検出する oracle であることを実証
- E2E (`tests/e2e/admin-backup-restore.spec.ts` 非 ASCII test): ローカル `npm run dev` (dev-mode) 実行では、共有 helper `openMenuItem` の Ark UI Menu open-transition タイミング (tests/CLAUDE.md #3687 記載の dev-mode 特有 flake) により、**merged 済 #3079 checklist export test と本 test が同一箇所で同一失敗**する (element not visible during transition)。testid (`checklists-overflow-menu` / `overflow-menu-item-export` / `export-checklist-item-*`) は実 page (`src/routes/(parent)/admin/checklists/+page.svelte`) と merged #3079 test に一致。CI は `npm run preview` (bundled、#3079 が green の環境) で実行するため、本 test も #3079 export step と同一に通過する。本 flake は本 PR の regression ではない (プロダクトコード無変更)。

## スクリーンショット / ビジュアルデモ

UI 変更なし (test-only PR、`src/` 無変更) のため SS 対象外。N/A。

## コード品質セルフレビュー (#1481)

- generator は値域 literal を直書きせず全て SSOT 定数 import (ADR-0066)。再ドリフト時に generator と schema が同一 SSOT を参照するため乖離しない。
- Unicode リテラル (ZWJ / combining / 絵文字) は editor 正規化・不可視文字混入非依存にするため `\u` escape で明示。
- generator の妥当性 (icon が 1〜2 grapheme に収まり合流しない) は meta self-check test で機械表明し、silent な generator drift を防ぐ。
- `round-trip.test.ts` の格上げは round-trip 不変条件のみ property 化し、checksum 改竄検知 / v1 互換 / deterministic checksum など property で表現しにくい orthogonal lock は example-based で保持 (coverage 減なし)。
- canary snapshot は 1 枚のみ (ADR-0010 過剰防衛回避、approval framework は作らない)。

## 横展開・影響波及チェック

- **5 type 全網羅**: activity-pack / reward-set / checklist / rule-preset / challenge-set の全てに property + generator を配備。`schema-range-ssot.test.ts` の残タイプ管理リストは空 (全 COVERED) で整合。
- **Content-Disposition 全 export route**: user データ由来の動的ファイル名を組むのは `checklists/export` のみで helper 経由済。`activities/export` / `special-rewards/export` / backup `export` は静的 ASCII / timestamp 名で、helper docstring の横展開方針 (#3104) が明示的に exempt。よって全 route が RFC 5987/6266 準拠。
- **本番 bundle 影響なし**: fast-check は devDependency のみ (ADR-0010 Bucket A)。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。プロダクトコード無変更の test 強化。
- レビュー観点: (1) generator が値域 SSOT から導出され literal 直書きがないか、(2) property の right-inverse 定義が妥当か、(3) AC4 mutation 証跡が oracle 有効性を示すか。

## 配布済み env / secret (ADR-0006)

- 新規 env / secret 追加なし。
- `fast-check@^4.9.0` を **dev dependency として新規追加** (本番 env / secret / bundle への影響なし、本番ビルド非搭載)。CI は `npm ci` で自動取得するため配布証跡は package-lock.json のみ。

## Ready for Review チェックリスト

- [x] AC を全て満たす実装 (AC1-AC4)
- [x] 変更領域の unit test green (vitest 296 passed)
- [x] biome / svelte-check / cspell / knip clean
- [x] AC4 failing-test-first mutation を物理確認
- [x] 設計書同期: プロダクト仕様変更なし (test-only) のため設計書更新不要
- [x] E2E test 追加済 (実 page / merged #3079 と一致する testid・helper を使用、CI preview 環境で貫通。ローカル dev-mode は既存 #3079 と同一 Ark UI transition flake、本文記載)
- [x] QA 承認・動作確認 (Dev 完遂宣言、#2632): QA が一発 Approve できる状態に整備済 — 全機械 gate green + AC4 oracle 証跡 + 手動検証手順を本文に明記

## QM レビュー結果

(QM 記入欄 — 未実施)

