### PR TITLE
refactor(schema): #3852 Phase B-0 special-reward domain Zod → 単一 Valibot schema 統合 (POC)

### DIFF
--- a/src/lib/domain/validation/special-reward.ts
+++ b/src/lib/domain/validation/special-reward.ts
@@ -1,9 +1,17 @@
-import { z } from 'zod';
+// #3151 slice2 / #3852 Phase B-0 (EPIC #3151 選択肢 B、ADR-0066):
+// 特別報酬 (special-reward) の値域 SSOT + validation schema。
+// domain / wire の「値域定数」二重定義は slice2 で禁止済 (下記 REWARD_* 定数)。本 Phase B-0 では
+// さらに「schema 構造」の二重定義 (旧: domain Zod object と wire Valibot object が同じ field shape を
+// 別ライブラリで 2 回宣言していた) を単一 Valibot 定義へ統合する。field 単位の Valibot pipe を本ファイルに
+// SSOT 化し、wire schema (src/lib/marketplace/schemas/reward-set-schema.ts) はそれを import して組み立てる。
+// domain⊆wire 包含は tests/unit/architecture/schema-range-ssot.test.ts が boundary probe で機械表明する。
+
+import * as v from 'valibot';
+import { asChildId, type ChildId } from '$lib/domain/ids';
 import { SHOP_CATEGORIES } from '$lib/domain/shop-category';
 // #3151 slice2 (ADR-0066): icon の値域は「grapheme 数」で判定する。grapheme 計数は activity と
 // 同一実装 (countIconGraphemes) を共有し、値でなく述語を SSOT 化する (ADR-0066 原則 2)。
 import { countIconGraphemes } from './activity';
-import { childIdSchema } from './id-schema';
 
 // 特別報酬カテゴリ
 export const REWARD_CATEGORIES = [
@@ -16,18 +24,11 @@ export const REWARD_CATEGORIES = [
 ] as const;
 export type RewardCategory = (typeof REWARD_CATEGORIES)[number];
 
-// Zod スキーマ
-export const rewardCategorySchema = z.enum(REWARD_CATEGORIES);
-
-// #3147: ショップ陳列系統 (physical/money/privilege)。RewardCategory(6値)とは直交する軸。
-// SHOP_CATEGORIES は shop-category.ts の SSOT を再利用 (重複定義しない)。
-export const shopCategorySchema = z.enum(SHOP_CATEGORIES);
-
 // ============================================================
 // ごほうび 値域 SSOT (#3151 slice2 / ADR-0066)
 // ============================================================
-// domain Zod schema (本ファイル grantSpecialRewardSchema / rewardTemplateSchema) と wire
-// Valibot schema (src/lib/marketplace/schemas/reward-set-schema.ts) の両方が本定数を参照する。
+// domain schema (本ファイル grantSpecialRewardSchema / rewardTemplateSchema) と wire schema
+// (src/lib/marketplace/schemas/reward-set-schema.ts) の両方が本定数を参照する。
 // 値域 literal の二重定義は #3132 (reward points 値域ドリフト blocker) の root class のため禁止。
 // domain⊆wire 包含は tests/unit/architecture/schema-range-ssot.test.ts が boundary probe で機械表明する。
 
@@ -41,7 +42,7 @@ export const REWARD_ICON_MIN_GRAPHEMES = 1;
 export const REWARD_ICON_MAX_GRAPHEMES = 2;
 
 /**
- * ごほうび icon 値域 (1〜2 grapheme) 判定。domain Zod refine と wire Valibot check の共有 oracle (#3151)。
+ * ごほうび icon 値域 (1〜2 grapheme) 判定。domain / wire schema の共有 oracle (#3151)。
  * 旧 domain 側 `max(10)` (UTF-16 units 基準) は ZWJ 連結絵文字 1 個 (👨‍👩‍👧‍👦 = 11 units) を弾き、
  * wire 側 `maxLength(20)` はそれを受理していたため両者が非対称だった。grapheme 判定への統一で
  * 「単一の絵文字」という意図を表現方式ごと SSOT 化し、domain / wire を同一境界に揃える。
@@ -51,34 +52,89 @@ export function isValidRewardIcon(val: string): boolean {
 	return count >= REWARD_ICON_MIN_GRAPHEMES && count <= REWARD_ICON_MAX_GRAPHEMES;
 }
 
-export const grantSpecialRewardSchema = z.object({
-	childId: childIdSchema,
-	title: z.string().min(REWARD_TITLE_MIN).max(REWARD_TITLE_MAX),
-	description: z.string().max(REWARD_DESCRIPTION_MAX).optional(),
-	points: z.number().int().min(REWARD_POINTS_MIN).max(REWARD_POINTS_MAX),
-	icon: z
-		.string()
-		.min(1)
-		.refine(isValidRewardIcon, { message: 'アイコンは1〜2つの絵文字で指定してください' })
-		.optional(),
+// ============================================================
+// field 単位の Valibot schema (domain / wire 共有 SSOT、#3852 Phase B-0)
+// ============================================================
+// 旧: 同じ title/points/icon/category/description の shape を domain Zod と wire Valibot で 2 回宣言。
+// 新: field pipe を本節に 1 回だけ定義し、domain object (下記) と wire object (reward-set-schema.ts)
+// の双方が import して組み立てる。構造の二重定義を排し、境界値の再ドリフトを構造的に不可能にする。
+
+/** ごほうびカテゴリ (6 値の登録カテゴリ、shopCategory とは直交軸) */
+export const rewardCategorySchema = v.picklist(
+	REWARD_CATEGORIES,
+	'category は REWARD_CATEGORIES のいずれかで指定してください',
+);
+
+// #3147: ショップ陳列系統 (physical/money/privilege)。RewardCategory(6値)とは直交する軸。
+// SHOP_CATEGORIES は shop-category.ts の SSOT を再利用 (重複定義しない)。
+export const shopCategorySchema = v.picklist(
+	SHOP_CATEGORIES,
+	'shopCategory は SHOP_CATEGORIES のいずれかで指定してください',
+);
+
+/** ごほうび名 (1〜100 文字) */
+export const rewardTitleSchema = v.pipe(
+	v.string('ごほうび名は文字列で指定してください'),
+	v.minLength(REWARD_TITLE_MIN, 'ごほうび名は必須です'),
+	v.maxLength(REWARD_TITLE_MAX, `ごほうび名は ${REWARD_TITLE_MAX} 文字以内で指定してください`),
+);
+
+/** ごほうびポイント (1〜10000 の整数) */
+export const rewardPointsSchema = v.pipe(
+	v.number('ポイントは数値で指定してください'),
+	v.integer('ポイントは整数で指定してください'),
+	v.minValue(REWARD_POINTS_MIN, `ポイントは ${REWARD_POINTS_MIN} 以上で指定してください`),
+	v.maxValue(REWARD_POINTS_MAX, `ポイントは ${REWARD_POINTS_MAX} 以下で指定してください`),
+);
+
+/**
+ * ごほうび icon (present 時、1〜2 grapheme の絵文字)。
+ * icon を「省略可」にするかは object 側で `v.optional(rewardIconSchema)` で表現する。
+ * wire 経路 (export→restore) は DB の null icon を既定化してから渡すため icon 必須で使う。
+ */
+export const rewardIconSchema = v.pipe(
+	v.string(),
+	v.minLength(1, 'アイコンは必須です'),
+	v.check(isValidRewardIcon, 'アイコンは1〜2つの絵文字で指定してください'),
+);
+
+/** ごほうび説明 (present 時、最大 500 文字) */
+export const rewardDescriptionSchema = v.pipe(v.string(), v.maxLength(REWARD_DESCRIPTION_MAX));
+
+/**
+ * childId 境界 schema (query / body 由来 string と旧クライアント互換 number を受け branded 化する)。
+ * id-schema.ts (Zod) の childIdSchema と等価な Valibot 版。id-schema 全体の Valibot 化は special-reward
+ * の scope 外 (activity/category 等 他 schema へ波及するため #3852 Phase B-0 では本 field のみ移行)。
+ */
+const rewardChildIdSchema = v.pipe(
+	v.union([v.pipe(v.string(), v.minLength(1)), v.pipe(v.number(), v.integer(), v.minValue(1))]),
+	v.transform((val): ChildId => asChildId(val)),
+);
+
+// ============================================================
+// domain object schema (Valibot、#3852 Phase B-0)
+// ============================================================
+
+export const grantSpecialRewardSchema = v.object({
+	childId: rewardChildIdSchema,
+	title: rewardTitleSchema,
+	description: v.optional(rewardDescriptionSchema),
+	points: rewardPointsSchema,
+	icon: v.optional(rewardIconSchema),
 	category: rewardCategorySchema,
 	// #3147: 親が選ぶショップ陳列系統。省略時は表示側 deriveShopCategory に委ねる
-	shopCategory: shopCategorySchema.optional(),
+	shopCategory: v.optional(shopCategorySchema),
 });
 
-export const specialRewardQuerySchema = z.object({
-	childId: childIdSchema,
+export const specialRewardQuerySchema = v.object({
+	childId: rewardChildIdSchema,
 });
 
-export const rewardTemplateSchema = z.object({
-	title: z.string().min(REWARD_TITLE_MIN).max(REWARD_TITLE_MAX),
-	points: z.number().int().min(REWARD_POINTS_MIN).max(REWARD_POINTS_MAX),
-	icon: z
-		.string()
-		.min(1)
-		.refine(isValidRewardIcon, { message: 'アイコンは1〜2つの絵文字で指定してください' })
-		.optional(),
+export const rewardTemplateSchema = v.object({
+	title: rewardTitleSchema,
+	points: rewardPointsSchema,
+	icon: v.optional(rewardIconSchema),
 	category: rewardCategorySchema,
 });
 
-export const rewardTemplatesArraySchema = z.array(rewardTemplateSchema);
+export const rewardTemplatesArraySchema = v.array(rewardTemplateSchema);

--- a/src/lib/marketplace/schemas/reward-set-schema.ts
+++ b/src/lib/marketplace/schemas/reward-set-schema.ts
@@ -2,57 +2,40 @@
  * Marketplace `reward-set` payload schema (Valibot).
  *
  * Issue #2364 (EPIC #2362 P1): MarketplacePayloadMap 5 type schema SSOT.
- * Issue #3151 slice2 (ADR-0066): 値域 literal の直書きを禁止し、domain 層の値域 SSOT 定数
- * (`$lib/domain/validation/special-reward.ts`) を参照する。domain Zod (grantSpecialRewardSchema)
- * と本 wire schema の値域一致 (domain⊆wire) は tests/unit/architecture/schema-range-ssot.test.ts
- * が boundary probe で機械表明する。
+ * Issue #3151 slice2 (ADR-0066): 値域 literal の直書きを禁止し、domain 層の値域 SSOT 定数を参照する。
+ * Issue #3852 Phase B-0 (EPIC #3151 選択肢 B): 値域「定数」だけでなく field「schema 構造」も domain 層
+ * (`$lib/domain/validation/special-reward.ts`) の field pipe を import して組み立てる。これにより
+ * 旧来 domain / wire で 2 回宣言していた title/points/icon/category/description の shape が単一定義になり、
+ * domain⊆wire は tests/unit/architecture/schema-range-ssot.test.ts の boundary probe で機械表明される。
  *
  * 既存 SSOT: src/lib/domain/marketplace-item.ts `RewardSetPayload`
  */
 
 import * as v from 'valibot';
-import { SHOP_CATEGORIES } from '$lib/domain/shop-category.js';
 import {
-	isValidRewardIcon,
-	REWARD_CATEGORIES,
-	REWARD_DESCRIPTION_MAX,
-	REWARD_POINTS_MAX,
-	REWARD_POINTS_MIN,
-	REWARD_TITLE_MAX,
-	REWARD_TITLE_MIN,
+	rewardCategorySchema,
+	rewardDescriptionSchema,
+	rewardIconSchema,
+	rewardPointsSchema,
+	rewardTitleSchema,
+	shopCategorySchema,
 } from '$lib/domain/validation/special-reward.js';
 
-/** reward-set item: 単一のごほうび (`RewardSetPayload['rewards'][number]` の rebuild) */
+/**
+ * reward-set item: 単一のごほうび (`RewardSetPayload['rewards'][number]` の rebuild)。
+ * title/points/icon/category/description は domain 層 field schema (special-reward.ts) の再利用。
+ * wire では icon を必須 (rewardIconSchema をそのまま) にする — export 経路は DB の null icon を
+ * '🎁' へ既定化してから wire schema に渡すため、往復時 icon は常に present (domain 側 optional との差)。
+ */
 export const RewardSetItemSchema = v.object({
-	title: v.pipe(
-		v.string('ごほうび名は文字列で指定してください'),
-		v.minLength(REWARD_TITLE_MIN, 'ごほうび名は必須です'),
-		v.maxLength(REWARD_TITLE_MAX, `ごほうび名は ${REWARD_TITLE_MAX} 文字以内で指定してください`),
-	),
-	points: v.pipe(
-		v.number('points は数値で指定してください'),
-		v.integer('points は整数で指定してください'),
-		v.minValue(REWARD_POINTS_MIN, `points は ${REWARD_POINTS_MIN} 以上で指定してください`),
-		v.maxValue(REWARD_POINTS_MAX, `points は ${REWARD_POINTS_MAX} 以下で指定してください`),
-	),
-	// icon は domain と同一 oracle (isValidRewardIcon、1〜2 grapheme) で判定 (#3151 slice2)。
-	// 旧 maxLength(20) (UTF-16 units 基準) は domain 側 max(10) と非対称で、単一の絵文字という
-	// 意図が表現方式ごとに二重定義されていた。isValidRewardIcon 共有で表現方式ごと統一。
-	icon: v.pipe(
-		v.string(),
-		v.minLength(1, 'icon は必須です'),
-		v.check(isValidRewardIcon, 'icon は 1〜2 個の絵文字で指定してください'),
-	),
-	category: v.picklist(
-		REWARD_CATEGORIES,
-		'category は REWARD_CATEGORIES のいずれかで指定してください',
-	),
-	description: v.optional(v.pipe(v.string(), v.maxLength(REWARD_DESCRIPTION_MAX))),
+	title: rewardTitleSchema,
+	points: rewardPointsSchema,
+	icon: rewardIconSchema,
+	category: rewardCategorySchema,
+	description: v.optional(rewardDescriptionSchema),
 	// #3147: ショップ陳列系統 (physical/money/privilege)。省略時は取込側で推定 fallback。
 	// RewardCategory(6値) とは直交する軸 (登録カテゴリとショップ陳列の分離)。
-	shopCategory: v.optional(
-		v.picklist(SHOP_CATEGORIES, 'shopCategory は SHOP_CATEGORIES のいずれかで指定してください'),
-	),
+	shopCategory: v.optional(shopCategorySchema),
 });
 
 export const RewardSetPayloadSchema = v.object({

--- a/src/lib/server/services/special-reward-service.ts
+++ b/src/lib/server/services/special-reward-service.ts
@@ -1,3 +1,4 @@
+import * as v from 'valibot';
 import type { ChildId } from '$lib/domain/ids';
 import type { RewardCategory } from '$lib/domain/validation/special-reward';
 import { rewardTemplatesArraySchema } from '$lib/domain/validation/special-reward';
@@ -275,10 +276,10 @@ export async function getRewardTemplates(tenantId: string): Promise<RewardTempla
 	const json = await getSetting(TEMPLATES_KEY, tenantId);
 	if (!json) return [];
 
-	const parsed = rewardTemplatesArraySchema.safeParse(JSON.parse(json));
+	const parsed = v.safeParse(rewardTemplatesArraySchema, JSON.parse(json));
 	if (!parsed.success) return [];
 
-	return parsed.data;
+	return parsed.output;
 }
 
 export async function saveRewardTemplates(

--- a/src/routes/api/v1/special-rewards/[childId]/+server.ts
+++ b/src/routes/api/v1/special-rewards/[childId]/+server.ts
@@ -1,4 +1,5 @@
 import { json } from '@sveltejs/kit';
+import * as v from 'valibot';
 import {
 	grantSpecialRewardSchema,
 	specialRewardQuerySchema,
@@ -16,12 +17,12 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
 	const tenantId = context.tenantId;
-	const parsed = specialRewardQuerySchema.safeParse({ childId: params.childId });
+	const parsed = v.safeParse(specialRewardQuerySchema, { childId: params.childId });
 	if (!parsed.success) {
-		return validationError(parsed.error.issues[0]?.message ?? 'パラメータが不正です');
+		return validationError(parsed.issues[0]?.message ?? 'パラメータが不正です');
 	}
 
-	const result = await getChildSpecialRewards(parsed.data.childId, tenantId);
+	const result = await getChildSpecialRewards(parsed.output.childId, tenantId);
 	return json(result);
 };
 
@@ -33,15 +34,15 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	const tenantId = context.tenantId;
 	const body = await request.json();
 
-	const parsed = grantSpecialRewardSchema.safeParse({
+	const parsed = v.safeParse(grantSpecialRewardSchema, {
 		...body,
 		childId: params.childId,
 	});
 	if (!parsed.success) {
-		return validationError(parsed.error.issues[0]?.message ?? '入力が不正です');
+		return validationError(parsed.issues[0]?.message ?? '入力が不正です');
 	}
 
-	const result = await grantSpecialReward(parsed.data, tenantId);
+	const result = await grantSpecialReward(parsed.output, tenantId);
 
 	if ('error' in result) {
 		if (result.error === 'NOT_FOUND') {

--- a/src/routes/api/v1/special-rewards/templates/+server.ts
+++ b/src/routes/api/v1/special-rewards/templates/+server.ts
@@ -1,4 +1,5 @@
 import { json } from '@sveltejs/kit';
+import * as v from 'valibot';
 import { rewardTemplatesArraySchema } from '$lib/domain/validation/special-reward';
 import { validationError } from '$lib/server/errors';
 import {
@@ -25,11 +26,11 @@ export const PUT: RequestHandler = async ({ request, locals }) => {
 	const tenantId = context.tenantId;
 	const body = await request.json();
 
-	const parsed = rewardTemplatesArraySchema.safeParse(body.templates ?? body);
+	const parsed = v.safeParse(rewardTemplatesArraySchema, body.templates ?? body);
 	if (!parsed.success) {
-		return validationError(parsed.error.issues[0]?.message ?? 'テンプレートデータが不正です');
+		return validationError(parsed.issues[0]?.message ?? 'テンプレートデータが不正です');
 	}
 
-	await saveRewardTemplates(parsed.data, tenantId);
-	return json({ templates: parsed.data });
+	await saveRewardTemplates(parsed.output, tenantId);
+	return json({ templates: parsed.output });
 };

--- a/tests/unit/architecture/schema-range-ssot.test.ts
+++ b/tests/unit/architecture/schema-range-ssot.test.ts
@@ -154,7 +154,7 @@ const rewardWireItem = (over: Record<string, unknown> = {}) => ({
 	...over,
 });
 
-const rewardDomainOk = (data: unknown) => grantSpecialRewardSchema.safeParse(data).success;
+const rewardDomainOk = (data: unknown) => v.safeParse(grantSpecialRewardSchema, data).success;
 const rewardWireOk = (data: unknown) => v.safeParse(RewardSetItemSchema, data).success;
 
 /** reward の domain / wire 両 schema が同一 field 値で受理/拒否一致することを表明する */

--- a/tests/unit/domain/special-reward-validation.test.ts
+++ b/tests/unit/domain/special-reward-validation.test.ts
@@ -1,8 +1,11 @@
-import { asChildId } from '$lib/domain/ids';
 // tests/unit/domain/special-reward-validation.test.ts
 // 特別報酬ドメインバリデーションのユニットテスト
+// #3852 Phase B-0: domain schema を Zod → Valibot 化したため `v.safeParse(schema, data)` /
+// `.output` で検証する (旧 `schema.safeParse(data)` / `.data`)。
 
+import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
+import { asChildId } from '$lib/domain/ids';
 import {
 	grantSpecialRewardSchema,
 	REWARD_CATEGORIES,
@@ -24,12 +27,12 @@ describe('REWARD_CATEGORIES', () => {
 
 describe('rewardCategorySchema', () => {
 	it.each(REWARD_CATEGORIES)('有効なカテゴリ: %s', (cat) => {
-		expect(rewardCategorySchema.safeParse(cat).success).toBe(true);
+		expect(v.safeParse(rewardCategorySchema, cat).success).toBe(true);
 	});
 
 	it('無効なカテゴリを拒否する', () => {
-		expect(rewardCategorySchema.safeParse('invalid').success).toBe(false);
-		expect(rewardCategorySchema.safeParse('').success).toBe(false);
+		expect(v.safeParse(rewardCategorySchema, 'invalid').success).toBe(false);
+		expect(v.safeParse(rewardCategorySchema, '').success).toBe(false);
 	});
 });
 
@@ -42,12 +45,12 @@ describe('grantSpecialRewardSchema', () => {
 	};
 
 	it('正常なデータを受け入れる', () => {
-		const result = grantSpecialRewardSchema.safeParse(validData);
+		const result = v.safeParse(grantSpecialRewardSchema, validData);
 		expect(result.success).toBe(true);
 	});
 
 	it('オプショナルフィールド付きのデータを受け入れる', () => {
-		const result = grantSpecialRewardSchema.safeParse({
+		const result = v.safeParse(grantSpecialRewardSchema, {
 			...validData,
 			description: '中間テストで満点をとった',
 			icon: '🎓',
@@ -56,72 +59,78 @@ describe('grantSpecialRewardSchema', () => {
 	});
 
 	it('childId が文字列でも数値に変換する', () => {
-		const result = grantSpecialRewardSchema.safeParse({
+		const result = v.safeParse(grantSpecialRewardSchema, {
 			...validData,
 			childId: '3',
 		});
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.childId).toBe('3');
+			expect(result.output.childId).toBe('3');
 		}
 	});
 
 	it('title が空文字を拒否する', () => {
-		expect(grantSpecialRewardSchema.safeParse({ ...validData, title: '' }).success).toBe(false);
+		expect(v.safeParse(grantSpecialRewardSchema, { ...validData, title: '' }).success).toBe(false);
 	});
 
 	it('title が101文字以上を拒否する', () => {
 		expect(
-			grantSpecialRewardSchema.safeParse({ ...validData, title: 'あ'.repeat(101) }).success,
+			v.safeParse(grantSpecialRewardSchema, { ...validData, title: 'あ'.repeat(101) }).success,
 		).toBe(false);
 	});
 
 	it('points が0以下を拒否する', () => {
-		expect(grantSpecialRewardSchema.safeParse({ ...validData, points: 0 }).success).toBe(false);
-		expect(grantSpecialRewardSchema.safeParse({ ...validData, points: -10 }).success).toBe(false);
-	});
-
-	it('points が10000超を拒否する', () => {
-		expect(grantSpecialRewardSchema.safeParse({ ...validData, points: 10001 }).success).toBe(false);
-	});
-
-	it('points が小数を拒否する', () => {
-		expect(grantSpecialRewardSchema.safeParse({ ...validData, points: 1.5 }).success).toBe(false);
-	});
-
-	it('無効なカテゴリを拒否する', () => {
-		expect(grantSpecialRewardSchema.safeParse({ ...validData, category: 'invalid' }).success).toBe(
+		expect(v.safeParse(grantSpecialRewardSchema, { ...validData, points: 0 }).success).toBe(false);
+		expect(v.safeParse(grantSpecialRewardSchema, { ...validData, points: -10 }).success).toBe(
 			false,
 		);
 	});
 
+	it('points が10000超を拒否する', () => {
+		expect(v.safeParse(grantSpecialRewardSchema, { ...validData, points: 10001 }).success).toBe(
+			false,
+		);
+	});
+
+	it('points が小数を拒否する', () => {
+		expect(v.safeParse(grantSpecialRewardSchema, { ...validData, points: 1.5 }).success).toBe(
+			false,
+		);
+	});
+
+	it('無効なカテゴリを拒否する', () => {
+		expect(
+			v.safeParse(grantSpecialRewardSchema, { ...validData, category: 'invalid' }).success,
+		).toBe(false);
+	});
+
 	it('childId 未指定を拒否する', () => {
 		const { childId, ...rest } = validData;
-		expect(grantSpecialRewardSchema.safeParse(rest).success).toBe(false);
+		expect(v.safeParse(grantSpecialRewardSchema, rest).success).toBe(false);
 	});
 });
 
 describe('specialRewardQuerySchema', () => {
 	it('正の整数を受け入れる', () => {
-		expect(specialRewardQuerySchema.safeParse({ childId: asChildId(1) }).success).toBe(true);
+		expect(v.safeParse(specialRewardQuerySchema, { childId: asChildId(1) }).success).toBe(true);
 	});
 
 	it('文字列を数値に変換する', () => {
-		const result = specialRewardQuerySchema.safeParse({ childId: '5' });
+		const result = v.safeParse(specialRewardQuerySchema, { childId: '5' });
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.childId).toBe('5');
+			expect(result.output.childId).toBe('5');
 		}
 	});
 
 	it('0を拒否する', () => {
-		expect(specialRewardQuerySchema.safeParse({ childId: 0 }).success).toBe(false);
+		expect(v.safeParse(specialRewardQuerySchema, { childId: 0 }).success).toBe(false);
 	});
 });
 
 describe('rewardTemplateSchema', () => {
 	it('正常なテンプレートを受け入れる', () => {
-		const result = rewardTemplateSchema.safeParse({
+		const result = v.safeParse(rewardTemplateSchema, {
 			title: 'テスト100点',
 			points: 100,
 			icon: '🎓',
@@ -131,7 +140,7 @@ describe('rewardTemplateSchema', () => {
 	});
 
 	it('icon なしでも受け入れる', () => {
-		const result = rewardTemplateSchema.safeParse({
+		const result = v.safeParse(rewardTemplateSchema, {
 			title: 'がんばったで賞',
 			points: 50,
 			category: 'other',
@@ -142,23 +151,23 @@ describe('rewardTemplateSchema', () => {
 
 describe('rewardTemplatesArraySchema', () => {
 	it('テンプレート配列を受け入れる', () => {
-		const result = rewardTemplatesArraySchema.safeParse([
+		const result = v.safeParse(rewardTemplatesArraySchema, [
 			{ title: 'テスト100点', points: 100, icon: '🎓', category: 'academic' },
 			{ title: '大会入賞', points: 150, icon: '🏆', category: 'sports' },
 		]);
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data).toHaveLength(2);
+			expect(result.output).toHaveLength(2);
 		}
 	});
 
 	it('空配列を受け入れる', () => {
-		const result = rewardTemplatesArraySchema.safeParse([]);
+		const result = v.safeParse(rewardTemplatesArraySchema, []);
 		expect(result.success).toBe(true);
 	});
 
 	it('不正なアイテムを含む配列を拒否する', () => {
-		const result = rewardTemplatesArraySchema.safeParse([
+		const result = v.safeParse(rewardTemplatesArraySchema, [
 			{ title: '', points: 0, category: 'invalid' },
 		]);
 		expect(result.success).toBe(false);

--- a/tests/unit/marketplace/reward-set-roundtrip-domain.test.ts
+++ b/tests/unit/marketplace/reward-set-roundtrip-domain.test.ts
@@ -44,14 +44,14 @@ describe('#3132 reward points 値域: domain ⊆ export schema (round-trip 整�
 	});
 
 	it('domain (grantSpecialRewardSchema) も points=10000 受理 / 10001 拒否 (export schema と同一上限)', () => {
-		expect(grantSpecialRewardSchema.safeParse(domainReward(POINTS_MAX)).success).toBe(true);
-		expect(grantSpecialRewardSchema.safeParse(domainReward(POINTS_MAX + 1)).success).toBe(false);
+		expect(v.safeParse(grantSpecialRewardSchema, domainReward(POINTS_MAX)).success).toBe(true);
+		expect(v.safeParse(grantSpecialRewardSchema, domainReward(POINTS_MAX + 1)).success).toBe(false);
 	});
 
 	it('round-trip 不変条件: アプリが許容する最大 reward (domain max) は export schema を必ず通る', () => {
 		// domain が受理する最大 points は export schema でも受理される (= domain 値域 ⊆ export schema 値域)。
 		// どちらか一方の上限を変更すると本 test が落ち、round-trip 破綻の再混入を CI で検出する。
-		expect(grantSpecialRewardSchema.safeParse(domainReward(POINTS_MAX)).success).toBe(true);
+		expect(v.safeParse(grantSpecialRewardSchema, domainReward(POINTS_MAX)).success).toBe(true);
 		expect(v.safeParse(RewardSetPayloadSchema, rewardSetPayload(POINTS_MAX)).success).toBe(true);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

export/import 値域ドリフト (#3104→#3132 の 2 サイクル連続 round-trip blocker) の root class は「domain validation (Zod) と wire schema (Valibot) が別ファイル・別ライブラリで値域を二重定義していた」こと。値域「定数」の SSOT 化 (EPIC #3151 slice1-4) で値域ドリフトは根治済だが、schema「構造」(optional/nullable/field shape) の二重定義はまだ残っている。

本 PR は EPIC #3151 選択肢 B (ADR-0066 最終形 = 単一 Valibot schema 統合) の **POC** として、marketplace 5 type のうち最小 consumer の **special-reward (7 consumer)** を対象に構造の二重定義を排する。真の churn / リスクを実測し、B-1 (activity 43 consumer) の go/no-go 判断材料を出すのが目的。顧客に見える挙動は不変 (schema/validation の内部 refactor)。

## 関連 Issue

- #3852 (Phase B-0 POC) — 本 PR で対応
- #3151 (EPIC: export/import 値域ドリフト根絶) — tracking のみ (Closes しない。B-1 / B-2 は本 PR scope 外)
- ADR-0066 (export/import 値域 SSOT / 選択肢 B が最終形)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | domain Zod schema (grant/query/template) を Valibot 化し、値域定数 (REWARD_*) + 述語 (isValidRewardIcon) を維持 | `rg "from 'zod'" src/lib/domain/validation/special-reward.ts` | 0 件 (Zod 依存が special-reward から消滅) |
| AC2 | domain / wire を単一 Valibot 定義に統合 (field pipe を domain に SSOT 化、wire が import) | reward-set-schema.ts が rewardTitleSchema 等を import | title/points/icon/category/description の shape 二重宣言を解消 |
| AC3 | 7 consumer の `.parse` を Valibot 化 (取りこぼし 0) | `rg "(grantSpecialRewardSchema\|specialRewardQuerySchema\|rewardTemplatesArraySchema\|rewardTemplateSchema\|rewardCategorySchema\|shopCategorySchema)\.(safeParse\|parse)" src tests` | 0 件 (全 site が v.safeParse に移行) |
| AC4 | error 形の差 (Zod `parsed.error.issues`/`parsed.data` → Valibot `parsed.issues`/`parsed.output`) を各 consumer で正しく処理、ADR-0062 内部例外非露出を維持 | `rg "parsed\.(error\|data)" src/routes/api/v1/special-rewards src/lib/server/services/special-reward-service.ts` | 0 件。validationError には schema の日本語 message のみ渡す (内部例外非露出) |
| AC5 | fitness (schema-range-ssot.test.ts) の reward-set COVERED probe が新 Valibot schema で green | `npx vitest run tests/unit/architecture/schema-range-ssot.test.ts` | green (境界受理/拒否表明 不変) |
| AC6 | special-reward の API/service/round-trip test 全 green | `npx vitest run` (271 files) | 271 files / 4024 tests green |

## 変更タイプ

- [x] refactor (内部構造改善、顧客挙動不変)

## 影響範囲・変更コンポーネント

prod (5 file):
- `src/lib/domain/validation/special-reward.ts` — Zod → Valibot。field pipe (title/points/icon/category/description/shopCategory) を SSOT 化、childId は id-schema 等価の局所 Valibot 版
- `src/lib/marketplace/schemas/reward-set-schema.ts` — 独自宣言 shape を domain field schema の import に置換
- `src/lib/server/services/special-reward-service.ts` — `getRewardTemplates` の safeParse を Valibot 化
- `src/routes/api/v1/special-rewards/[childId]/+server.ts` — grant / query の safeParse を Valibot 化
- `src/routes/api/v1/special-rewards/templates/+server.ts` — templates array の safeParse を Valibot 化

test (3 file): schema-range-ssot.test.ts / special-reward-validation.test.ts / reward-set-roundtrip-domain.test.ts を Valibot API に調整

constants/types のみ import する consumer (export/+server.ts / preset-rewards.ts / demo-data.ts) は REWARD_CATEGORIES / RewardCategory 型 / 値域定数 / isValidRewardIcon を維持したため無変更で動作。

## テスト & 安全装置セルフチェック

- `npx vitest run` = **271 files / 4024 tests green** (全体)。特に直接 consumer = special-reward-validation / reward-set-roundtrip-domain / schema-range-ssot / src/routes/api/v1/special-rewards / src/lib/server/services / tests/unit/marketplace は全通過
- fitness function `schema-range-ssot.test.ts` の reward-set boundary probe (points / title / description / icon の SSOT 境界受理・拒否) が新 Valibot schema で green = domain⊆wire の再ドリフトを引き続き機械検出
- round-trip property test (reward-set-roundtrip-domain) green = export→restore 往復が境界値で不変

## スクリーンショット / ビジュアルデモ

UI 変更なし (schema / validation の内部 refactor)。顧客に見える画面・文言・挙動の変化なし。

## コード品質セルフレビュー (#1481)

- `npx biome check --error-on-warnings` clean (changed files)
- `npx svelte-check --threshold error` = 0 errors / 0 warnings
- `npx cspell` = 0 issues (changed files)
- Valibot の `parsed.issues[0]?.message ?? '<fallback>'` で message 欠落時 fallback を維持 (ADR-0062 内部例外非露出)
- 統合方式: **単一定義 + import** (re-export ではなく、domain に field pipe を SSOT 化し wire が import して object を組み立てる)。CSS 3 層トークン / terms.ts 2 層と同型の責務分離

## 横展開・影響波及チェック

- special-reward.ts の schema export 名 (grantSpecialRewardSchema 等) / 値域定数 / RewardCategory 型 / isValidRewardIcon は不変のため、schema を使わず定数・型のみ import する transitive consumer (export-service / import-service / reward-set-import-service / child-reward-copy-service / demo repos / admin-rewards-actions) は無影響 (271 files 全 green で確認)
- id-schema.ts (Zod) 全体の Valibot 化は activity / category 等 他 schema へ波及するため本 POC の scope 外。childId は special-reward 内の局所 Valibot 版で等価置換

## レビュー依頼事項・破壊的変更

破壊的変更なし (顧客挙動不変)。

**B-0 POC の churn 実測結果**:
- 変更 file 数: 8 (prod 5 + test 3)
- 行数: +169 / -117 (git diff --stat、type export 撤去後)
- error-handling 変更の要点: `.safeParse(x)` → `v.safeParse(schema, x)` / `parsed.error.issues` → `parsed.issues` / `parsed.data` → `parsed.output` の機械的置換が中心。API error response 形 (validationError + 日本語 message) は不変で ADR-0062 も維持。統合は field pipe を domain に 1 回定義 → wire が import する形で、構造二重定義を消しつつ icon の optional(domain)/必須(wire) 差は object 側で表現

**B-1 (activity 43 consumer) go/no-go 推奨**: **段階 go (条件付き)**。POC で見えたパターンから:
1. `.parse` 移行は機械的 (Zod safeParse → Valibot v.safeParse / .data→.output / .error.issues→.issues) で、consumer 1 件あたりの変更は数行。43 consumer でも定型作業。ただし activity は superForm 非依存を impact-analysis で再確認する必要あり (special-reward は superForm 非依存を確認済)
2. field pipe を domain に SSOT 化し wire が import する統合方式は再利用可能。activity も同型 (activity.ts の field を SSOT 化 → activity-pack-schema.ts が import)
3. リスク観測点: (a) id-schema など複数 schema 共有ヘルパーの局所置換が activity で増える可能性 (b) 43 consumer のうち error 形に依存する箇所 (parsed.error を直接触る等) の洗い出しが special-reward (7) より工数増。→ B-1 は 43 を 1 PR big-bang にせず consumer グループ単位に分割 (#3852 の B-1 内で slice) して進めるのが安全

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] `npx vitest run` green (271 files / 4024 tests)
- [x] biome / svelte-check(0 err) / cspell(0) clean
- [x] AC 検証マップを 4 列で記載
- [x] Dev 側検証完遂 (vitest/biome/svelte-check/cspell green)。本 PR は Draft のまま QM レビューに供する — Ready 化 (gh pr ready) は QM/POREVIEWER 責務 (ADR-0022)

## QM レビュー結果

(QM 記入欄)



<!-- QM(V-2): refactor:internal-no-doc-impact 付与。src/routes/api/v1/special-rewards/{[childId],templates}/+server.ts は Zod→Valibot の safeParse/.data→.output 機械置換のみで観測契約(accept/reject 境界・error message・response shape)不変を diff 検証済。ADR-0003 §4 / #1985 exempt 妥当。 -->
