### PR TITLE
fix: #3850 MainTable cross-stack export を Deploy-1 で保持し本番 deploy 停止を解消 (#3438 の 2-deploy 分割)

### DIFF
--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -42,13 +42,27 @@
 
 ### 3.1 StorageStack
 
-DB backend は Aurora DSQL（`DsqlStack`）が唯一の SSOT（EPIC #3424）。StorageStack は
-DB リソースを持たず、S3（アセット / バックアップ）と ECR（Lambda コンテナイメージ）のみを
-提供する。DSQL のリレーショナルスキーマは [dsql-data-model.md](dsql-data-model.md) を参照。
+DB backend は Aurora DSQL（`DsqlStack`）が唯一の SSOT（EPIC #3424）。runtime で DynamoDB
+table を参照する経路は無い（health は probePg、analytics は on-demand 化済）。DSQL の
+リレーショナルスキーマは [dsql-data-model.md](dsql-data-model.md) を参照。
 
-> DynamoDB シングルテーブル + その AWS Backup（daily plan）は #3438 で撤去した。prod は
-> removalPolicy=RETAIN だったため、既存 table は CloudFormation の管理から外れる（orphan）
-> だけで物理 table + データは AWS 上に保全される（物理削除は別 ops 手順 / PO 承認）。
+> **DynamoDB `MainTable` の撤去は cross-stack export の 2-deploy 制約により 2 段で行う（#3438 → #3850）。**
+> CloudFormation は「利用中（in-use）の export は削除も値変更もできない」ため、producer（StorageStack）が
+> `MainTable` ARN の cross-stack export を消せるのは、consumer（ComputeStack）の import 消失が本番へ
+> 反映された後に限られる。deploy pipeline は Storage → Auth → Compute の producer-first 固定順（かつ
+> Storage は ECR repo を先に作る必要があり Storage-first は必須制約）で、1 リリース内で consumer を先に
+> 更新できないため、同一 PR での table + export 同時撤去は StorageStack rollback を招く。よって:
+>
+> - **Deploy-1（#3850、本リリース）**: consumer（ComputeStack）は `grantReadWriteData` + `DYNAMODB_TABLE`
+>   env を落とす（#3438 で実施済）。producer（StorageStack）は `MainTable`（removalPolicy=RETAIN）+
+>   その AWS Backup（daily plan）+ `exportValue(table.tableArn)` による cross-stack export を保持する。
+> - **Deploy-2（follow-up、次リリース）**: Deploy-1 が本番反映され consumer の import が消失した後、
+>   StorageStack から `MainTable` + `exportValue` を撤去する（この時点で export は in-use ではないため
+>   削除成功）。prod は removalPolicy=RETAIN のため、この撤去でも table は CloudFormation の管理から
+>   外れる（orphan）だけで物理 table + データは AWS 上に保全される（物理削除は別 ops 手順 / PO 承認）。
+>
+> prod 不変条件（table + Backup + export の Deploy-1 保持 / consumer の table 非参照）は
+> `tests/unit/infra/staging-cdk.test.ts`（P-1 / B-3850a / B-3850b）が fitness function として固定する。
 
 **S3バケット:**
 - アバター画像: `avatars/{tenantId}/{childId}/`
@@ -540,7 +554,7 @@ export function resolveDemoActive(env: Pick<TypedEnv, 'AUTH_MODE' | 'DATA_SOURCE
 infra/
 ├── bin/app.ts           # CDKエントリポイント (demoDomainName / demoCertificateArn context 追加 #2097)
 ├── lib/
-│   ├── storage-stack.ts  # S3 + ECR (DB backend は dsql-stack.ts、#3438)
+│   ├── storage-stack.ts  # S3 + ECR + MainTable(#3438→#3850 の 2-deploy 撤去中、Deploy-1 は export 保持)
 │   ├── dsql-stack.ts     # Aurora DSQL cluster (EPIC #3424)
 │   ├── auth-stack.ts     # Cognito User Pool + SSM Parameters
 │   ├── compute-stack.ts  # Lambda (本番 + demo #2097) + Function URL + IAM Role 分離

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -24,7 +24,7 @@ SSOT: `docs/CLAUDE.md` §「サブディレクトリ別局所テストコマン�
 
 **全リソース `us-east-1` 固定**（Cognito custom domain ACM が us-east-1 必須のため統一）。CDK source `infra/bin/app.ts` L13-16 が `region: 'us-east-1'` で全 stack (`Storage` / `Auth` / `Compute` / `Network` / `Ops` / `Ses`) を deploy。
 
-主要リソース: Lambda (アプリ / cron-dispatcher / cognito custom message / SES) / ECR / Aurora DSQL (DsqlStack) / S3 / Cognito User Pool v2 (`auth.ganbari-quest.com`) / EventBridge cron rules / CloudWatch Logs / Route 53 (`ganbari-quest.com`) / SES (`noreply@ganbari-quest.com`) / SSM / Secrets Manager。DynamoDB table は #3438 で撤去 (DB backend は DSQL 一本化)。詳細は `infra/lib/*-stack.ts` 参照。
+主要リソース: Lambda (アプリ / cron-dispatcher / cognito custom message / SES) / ECR / Aurora DSQL (DsqlStack) / S3 / Cognito User Pool v2 (`auth.ganbari-quest.com`) / EventBridge cron rules / CloudWatch Logs / Route 53 (`ganbari-quest.com`) / SES (`noreply@ganbari-quest.com`) / SSM / Secrets Manager。DynamoDB `MainTable` は #3438 → #3850 の 2-deploy で撤去中 (DB backend は DSQL 一本化)。cross-stack export の in-use 削除制約により、Deploy-1 (#3850、本リリース) では StorageStack が table + `exportValue(table.tableArn)` を保持し、consumer(ComputeStack) 側だけ import を落とす。Deploy-2 (follow-up) で consumer の import 消失が本番反映された後に table + export を撤去する (詳細: `docs/design/13-AWSサーバレスアーキテクチャ設計書.md §3.1`)。詳細は `infra/lib/*-stack.ts` 参照。
 
 CloudFront はグローバル（geoRestriction `JP`）。新規 region 言及は本ファイルを SSOT として `us-east-1`。`tests/unit/e2e-helpers/*` の `ap-northeast-1` 言及はテスト fixture（変更不要）。
 

--- a/infra/lib/env-config.ts
+++ b/infra/lib/env-config.ts
@@ -19,6 +19,8 @@ export interface GqEnvConfig {
 	readonly resourcePrefix: string;
 	/** SSM パラメータ prefix (例: '/ganbari-quest' / '/ganbari-quest-staging') */
 	readonly ssmPrefix: string;
+	/** AWS Backup (daily plan) を構築するか。staging は空 table のため不要 */
+	readonly enableBackup: boolean;
 	/** demo Lambda (ADR-0048) を構築するか。staging は不要 */
 	readonly enableDemoLambda: boolean;
 	/** cron-dispatcher + EventBridge Rules (#1376) を構築するか。staging は不要 */
@@ -34,6 +36,7 @@ export const PROD_ENV_CONFIG: GqEnvConfig = {
 	envName: 'prod',
 	resourcePrefix: 'ganbari-quest',
 	ssmPrefix: '/ganbari-quest',
+	enableBackup: true,
 	enableDemoLambda: true,
 	enableCronDispatcher: true,
 	enableLogArchiving: true,
@@ -45,6 +48,7 @@ export const STAGING_ENV_CONFIG: GqEnvConfig = {
 	envName: 'staging',
 	resourcePrefix: 'ganbari-quest-staging',
 	ssmPrefix: '/ganbari-quest-staging',
+	enableBackup: false,
 	enableDemoLambda: false,
 	enableCronDispatcher: false,
 	enableLogArchiving: false,

--- a/infra/lib/storage-stack.ts
+++ b/infra/lib/storage-stack.ts
@@ -1,5 +1,8 @@
 import * as cdk from 'aws-cdk-lib';
+import * as backup from 'aws-cdk-lib/aws-backup';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as events from 'aws-cdk-lib/aws-events';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import type { Construct } from 'constructs';
 import { type GqEnvConfig, PROD_ENV_CONFIG } from './env-config';
@@ -7,21 +10,34 @@ import { type GqEnvConfig, PROD_ENV_CONFIG } from './env-config';
 export interface StorageStackProps extends cdk.StackProps {
 	/**
 	 * 環境設定 (#2873)。未指定時は PROD_ENV_CONFIG (現行 prod 値) — prod template 不変条件。
-	 * staging は STAGING_ENV_CONFIG を渡し、prefix 分離 + DESTROY + ECR maxImageCount:3 で構築する。
+	 * staging は STAGING_ENV_CONFIG を渡し、prefix 分離 + Backup 省略 + DESTROY +
+	 * ECR maxImageCount:3 で構築する。
 	 */
 	envConfig?: GqEnvConfig;
 }
 
 /**
- * S3 (assets) + ECR (Lambda container image) を提供する Storage stack。
+ * S3 (assets) + ECR (Lambda container image) + DynamoDB `MainTable` を提供する Storage stack。
  *
- * DynamoDB single-table (`MainTable` / GSI1 / GSI2) + その AWS Backup (daily plan) は
- * #3438 (EPIC #3424 DynamoDB → Aurora DSQL 移管の capstone) で撤去した。DB backend は DSQL
- * (`DsqlStack`) が唯一の SSOT であり、本 stack は DB リソースを持たない。
- * prod は removalPolicy=RETAIN だったため、CloudFormation は既存 MainTable を「管理から外す
- * (orphan)」だけで物理 table + データは AWS 上に保全される (物理削除は別 ops 手順 / PO 承認)。
+ * DynamoDB single-table (`MainTable` / GSI1 / GSI2) は EPIC #3424 (DynamoDB → Aurora DSQL 移管)
+ * の capstone #3438 で撤去予定だが、**cross-stack export の in-use 削除制約により 2-deploy に分割**
+ * する (#3850)。CloudFormation は「利用中の export は削除も値変更も不可」であり、producer(本 stack)
+ * が export を消す前に consumer(ComputeStack) が import を落とし終えている必要がある。1 回の synth で
+ * Storage template は固定 (Storage → Auth → Compute の producer-first 固定順) のため、同一リリース内で
+ * consumer を先に更新することはできない。よって CFN 標準の 2-deploy パターンを採る:
+ *   - Deploy-1 (本 stack の現状 / #3850): consumer は import を落とす (#3438 で `grantReadWriteData` +
+ *     `DYNAMODB_TABLE` env を撤去済) が、producer は table + export を保持する。
+ *   - Deploy-2 (次リリース / follow-up): consumer の import が本番反映され消失した後、producer が
+ *     table + `exportValue` を撤去する (この時点で export は in-use ではないため削除成功)。
+ *
+ * prod は removalPolicy=RETAIN のため、Deploy-2 での table 撤去時も CloudFormation は table を
+ * orphan 化するのみ (物理 table + データは AWS 上に保全、物理削除は別 ops 手順 / PO 承認)。
+ * DB backend の SSOT は既に DSQL (`DsqlStack`) 一本であり、本 table は runtime で参照されない
+ * (health は probePg、analytics は on-demand 化済)。本 stack が table を保持するのは Deploy-1 の
+ * export 保持のためだけであり、アプリケーションは DynamoDB を読み書きしない。
  */
 export class StorageStack extends cdk.Stack {
+	public readonly table: dynamodb.TableV2;
 	public readonly assetsBucket: s3.Bucket;
 	public readonly repository: ecr.Repository;
 
@@ -31,6 +47,71 @@ export class StorageStack extends cdk.Stack {
 		const cfg = props?.envConfig ?? PROD_ENV_CONFIG;
 		const prefix = cfg.resourcePrefix;
 		const isProd = cfg.envName === 'prod';
+
+		// --- DynamoDB: Single-table design ---
+		// timeToLiveAttribute='ttl': analytics event log (90 日 / DynamoAnalyticsProvider) と
+		// analytics 事前集計レコード (#1693, 365 日) の自動失効に使用。レコード側で `ttl` 属性に
+		// epoch seconds (UTC) を入れた行が DynamoDB バックグラウンドプロセスで自動削除される。
+		// TTL を持たないアプリケーションレコード (CHILD#... 等) は `ttl` 属性を持たないため影響なし。
+		this.table = new dynamodb.TableV2(this, 'MainTable', {
+			tableName: prefix,
+			partitionKey: { name: 'PK', type: dynamodb.AttributeType.STRING },
+			sortKey: { name: 'SK', type: dynamodb.AttributeType.STRING },
+			billing: dynamodb.Billing.onDemand(),
+			removalPolicy: cfg.removalPolicy,
+			pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: false },
+			timeToLiveAttribute: 'ttl',
+			globalSecondaryIndexes: [
+				{
+					indexName: 'GSI1',
+					partitionKey: { name: 'SK', type: dynamodb.AttributeType.STRING },
+					sortKey: { name: 'PK', type: dynamodb.AttributeType.STRING },
+				},
+				{
+					indexName: 'GSI2',
+					partitionKey: { name: 'GSI2PK', type: dynamodb.AttributeType.STRING },
+					sortKey: { name: 'GSI2SK', type: dynamodb.AttributeType.STRING },
+				},
+			],
+		});
+
+		// --- #3850: cross-stack export を明示保持 (2-deploy migration の肝) ---
+		// #3438 で ComputeStack は `grantReadWriteData` を撤去したため、MainTable ARN への
+		// auto cross-stack export (`${stackName}:ExportsOutputFnGetAttMainTable<hash>Arn`) を
+		// 生成する consumer 参照が消えた。CDK は参照ゼロの export を synth 時に自動削除するが、
+		// CloudFormation は「未だ本番反映されていない (= import 中の) consumer」があると in-use
+		// 判定で export 削除を拒否し、StorageStack rollback → 本番 deploy.yml 停止に至る (#3850)。
+		// `exportValue` は正にこの removal migration 用途の CDK 公式 API であり、consumer 参照が
+		// 消えた後も同一名の export を保持させる。明示 name は渡さない — CDK が prod / staging 各
+		// stack 名 (`GanbariQuest{,Staging}Storage`) で auto-export と同一名を自動再生成するため、
+		// staging との名前衝突を避けられる。Deploy-2 (follow-up) で consumer の import 消失が本番
+		// 反映された後、本行と table 構築を撤去すれば export は in-use でなくなり安全に削除できる。
+		this.exportValue(this.table.tableArn);
+
+		// --- AWS Backup: Daily backup with 3-day retention (cheaper than PITR) ---
+		// staging (#2873): 空 table 起点 + 使い捨て可能なため Backup 構成自体を省略する (idle≈¥0)。
+		if (cfg.enableBackup) {
+			const vault = new backup.BackupVault(this, 'BackupVault', {
+				backupVaultName: `${prefix}-vault`,
+				removalPolicy: cdk.RemovalPolicy.DESTROY,
+			});
+
+			const plan = new backup.BackupPlan(this, 'BackupPlan', {
+				backupPlanName: `${prefix}-daily`,
+				backupPlanRules: [
+					new backup.BackupPlanRule({
+						ruleName: 'daily-3day-retention',
+						scheduleExpression: events.Schedule.cron({ hour: '18', minute: '0' }),
+						deleteAfter: cdk.Duration.days(3),
+						backupVault: vault,
+					}),
+				],
+			});
+
+			plan.addSelection('DynamoDB', {
+				resources: [backup.BackupResource.fromDynamoDbTable(this.table)],
+			});
+		}
 
 		// --- S3: Avatar images & backups ---
 		this.assetsBucket = new s3.Bucket(this, 'AssetsBucket', {
@@ -83,6 +164,7 @@ export class StorageStack extends cdk.Stack {
 		});
 
 		// --- Outputs ---
+		new cdk.CfnOutput(this, 'TableName', { value: this.table.tableName! });
 		new cdk.CfnOutput(this, 'AssetsBucketName', { value: this.assetsBucket.bucketName });
 		new cdk.CfnOutput(this, 'EcrRepositoryUri', { value: this.repository.repositoryUri });
 	}

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -118,12 +118,19 @@ beforeAll(() => {
 describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)', () => {
 	describe('P: prod 不変 guard — envConfig 未指定 synth で従来 prod template を維持', () => {
 		it('P-1: Storage — DynamoDB table / AWS Backup を持たない (#3438 撤去 regression guard) / ECR=ganbari-quest (maxImageCount:10) / S3 prefix 不変', () => {
-			// #3438 (EPIC #3424): DB backend は DSQL に一本化。Storage stack は DynamoDB table も
-			// その AWS Backup (daily plan) も一切構築しない。再度 table を生やしたら CI で落ちる。
-			prodStorage.resourceCountIs('AWS::DynamoDB::GlobalTable', 0);
+			// #3850: #3438 の MainTable 撤去は CFN cross-stack export の in-use 削除制約により
+			// 2-deploy に分割する。Deploy-1 (本リリース) では ComputeStack が import を落とした状態で
+			// StorageStack は MainTable + その export を保持する (Deploy-2 = 次リリースで撤去)。
+			// producer(Storage) が export を消せるのは consumer(Compute) の import 消失が本番反映された
+			// 後のみ (CFN は in-use export の削除を拒否)。ここで table を消したら #3850 が再発するため落とす。
+			// TableV2 は AWS::DynamoDB::GlobalTable として synth される。
+			prodStorage.resourceCountIs('AWS::DynamoDB::GlobalTable', 1);
 			prodStorage.resourceCountIs('AWS::DynamoDB::Table', 0);
-			prodStorage.resourceCountIs('AWS::Backup::BackupVault', 0);
-			prodStorage.resourceCountIs('AWS::Backup::BackupPlan', 0);
+			// prod は removalPolicy=RETAIN 不変 (Deploy-2 の撤去でも物理 table + データは orphan 保全)。
+			prodStorage.hasResource('AWS::DynamoDB::GlobalTable', { DeletionPolicy: 'Retain' });
+			// enableBackup=true (prod)。DynamoDB daily backup plan (vault + plan) を保持する。
+			prodStorage.resourceCountIs('AWS::Backup::BackupVault', 1);
+			prodStorage.resourceCountIs('AWS::Backup::BackupPlan', 1);
 
 			const repos = prodStorage.findResources('AWS::ECR::Repository');
 			expect(Object.keys(repos).length).toBe(1);
@@ -211,13 +218,42 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 		});
 	});
 
-	describe('S-1: staging Storage — DynamoDB / Backup 不在 (#3438) + ECR maxImageCount:3 + DESTROY', () => {
-		it('DynamoDB table を構築しない (#3438 撤去、DB backend は DSQL)', () => {
-			stagingStorage.resourceCountIs('AWS::DynamoDB::GlobalTable', 0);
-			stagingStorage.resourceCountIs('AWS::DynamoDB::Table', 0);
+	describe('#3850: MainTable cross-stack export 2-deploy migration 不変条件 (Deploy-1)', () => {
+		it('B-3850a: prod StorageStack が MainTable ARN の cross-stack export を保持する (Deploy-1 の肝)', () => {
+			// #3850: ComputeStack が import を落とした Deploy-1 状態でも、StorageStack は exportValue で
+			// `<stackName>:ExportsOutputFnGetAttMainTable<hash>Arn` の export を明示保持する。これが無いと
+			// 未反映 consumer が旧 export を import 中に CFN が in-use 削除を拒否 → StorageStack rollback (#3850)。
+			// エラーログの export 名 `GanbariQuest{,Staging}Storage:ExportsOutputFnGetAttMainTable...Arn` と
+			// 同一 shape (test では stack 名 prefix が TestStorage、本番 synth は GanbariQuestStorage で実測一致済)。
+			const exportOutputs = prodStorage.findOutputs('*', {
+				Export: { Name: Match.stringLikeRegexp('ExportsOutputFnGetAttMainTable.*Arn') },
+			});
+			expect(Object.keys(exportOutputs).length).toBe(1);
 		});
 
-		it('AWS Backup (vault / plan) を構築しない', () => {
+		it('B-3850b: prod ComputeStack は MainTable を import / grant しない (Deploy-1 の consumer 状態)', () => {
+			// Deploy-1 の前提 = consumer(Compute) が既に MainTable への参照を落としていること:
+			//   (1) grantReadWriteData 由来の dynamodb: IAM policy が無い
+			//   (2) ExportsOutputFnGetAttMainTable...Arn を Fn::ImportValue する箇所が無い
+			// これらが残ると export が in-use のままで Deploy-2 (次リリース) の table+export 撤去が永遠にできない。
+			const computeJson = JSON.stringify(prodCompute.toJSON());
+			expect(computeJson).not.toContain('MainTable');
+			const policies = prodCompute.findResources('AWS::IAM::Policy');
+			expect(JSON.stringify(policies)).not.toContain('dynamodb:');
+		});
+	});
+
+	describe('S-1: staging Storage — DynamoDB MainTable(=1, DESTROY) + Backup 不在 (#3850 Deploy-1) + ECR maxImageCount:3', () => {
+		it('DynamoDB MainTable を Deploy-1 で保持 (#3850、staging も prod と同型 / removalPolicy=DESTROY)', () => {
+			// #3850: staging も prod と同型に MainTable + export を Deploy-1 で保持する (staging 側 export 名は
+			// GanbariQuestStorageStaging: 名前空間で prod と衝突しない)。staging は removalPolicy=DESTROY。
+			stagingStorage.resourceCountIs('AWS::DynamoDB::GlobalTable', 1);
+			stagingStorage.resourceCountIs('AWS::DynamoDB::Table', 0);
+			stagingStorage.hasResource('AWS::DynamoDB::GlobalTable', { DeletionPolicy: 'Delete' });
+		});
+
+		it('AWS Backup (vault / plan) を構築しない (enableBackup=false)', () => {
+			// staging は enableBackup=false (空 table 起点 + 使い捨て)。table は保持するが Backup plan は持たない。
 			stagingStorage.resourceCountIs('AWS::Backup::BackupVault', 0);
 			stagingStorage.resourceCountIs('AWS::Backup::BackupPlan', 0);
 		});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体

**解決する課題**: 第16回リリース統合監査（PR #3848）で `deploy-aws-staging`（required check）が本番同型で失敗し、本番 deploy pipeline が停止する hard blocker（#3850）。#3438 が StorageStack の DynamoDB `MainTable` cross-stack export と ComputeStack の import を同一 PR で同時撤去したため、CloudFormation の「利用中（in-use）の export は削除できない」制約に抵触し StorageStack が rollback していた。

**期待される効果**: CFN 標準の 2-deploy migration に分割し、本リリース（Deploy-1）では export を保持して deploy を貫通させる。本番 deploy pipeline の停止が解消され、第16回リリースを安全に反映できる（物理 table + データは removalPolicy=RETAIN で終始保全）。

## 関連 Issue

Closes #3850
Refs #3438 #3854 #3424

## AC 検証マップ (ADR-0004)

Issue #3850 は正式 AC ではなく「対応方針」3 案（1: 二段 deploy / 2: export 一時保持 / 3: failing-test-first）を提示。本 PR は **案 2（export 一時保持 = CFN migration の定石）+ 案 3（failing-test-first）** を実装する。各要件を検証項目に落として検証した。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | StorageStack が MainTable(TableV2/GSI1/GSI2/TTL) を Deploy-1 で保持し、#3438 直前版と verbatim 一致（RETAIN 設定を 1 文字も変えない） | `diff <(git show 9ebd59e1^:infra/lib/storage-stack.ts \| sed -n '/this.table = new dynamodb/,/^\t\t});/p') <(sed -n ...)` | HEAD `d44a28a3` / table ブロック `TABLE BLOCK: IDENTICAL` + backup ブロック `BACKUP BLOCK: IDENTICAL`（撤去コミット 9ebd59e1 の親版と一致） |
| AC2 | table 構築直後に `exportValue(table.tableArn)` を追加し cross-stack export を明示保持（案 2 の肝） | `infra/lib/storage-stack.ts` 目視 + synth | HEAD `d44a28a3` / `infra/lib/storage-stack.ts:96` `this.exportValue(this.table.tableArn);` |
| AC3 | prod export 名がエラーログ `GanbariQuestStorage:...MainTable...Arn` と一致 | `cd infra && npx cdk synth GanbariQuestStorage`（temp cdk.context.json で SSM stub、実施後削除） | HEAD `d44a28a3` / Outputs 内 `Export.Name: GanbariQuestStorage:ExportsOutputFnGetAttMainTable74195DABArnE0EC388B`（エラーログ pattern と一致） |
| AC4 | staging export 名が prod と衝突しない（`GanbariQuestStorageStaging:` 名前空間） | `cd infra && npx cdk synth GanbariQuestStorageStaging -c stagingEnabled=true` | HEAD `d44a28a3` / `Export.Name: GanbariQuestStorageStaging:ExportsOutputFnGetAttMainTable74195DABArnE0EC388B`（prod と別名前空間、衝突なし） |
| AC5 | ComputeStack / app.ts は table を参照しない（Deploy-1 の consumer 状態を維持） | `grep -n "storage.table\|grantReadWriteData\|MainTable" infra/lib/compute-stack.ts infra/bin/app.ts` | HEAD `d44a28a3` / 実参照 0（compute-stack.ts の hit はコメントのみ、app.ts は `assetsBucket`/`repository` のみ受領） |
| AC6 | failing-test-first（案 3 / ADR-0061）: export 保持 + consumer 非参照の不変条件を fitness function 化 | `npx vitest run tests/unit/infra/staging-cdk.test.ts` | HEAD `d44a28a3` / 18 passed。`tests/unit/infra/staging-cdk.test.ts` B-3850a（export 保持 assert）/ B-3850b（Compute が MainTable を import/grant しない assert）+ P-1/S-1 を Deploy-1 状態に反転 |
| AC7 | prod は removalPolicy=RETAIN 不変（Deploy-2 撤去でも orphan 保全）+ prod Backup / staging 非 Backup | `npx vitest run tests/unit/infra/staging-cdk.test.ts` | HEAD `d44a28a3` / P-1: prod GlobalTable=1 + DeletionPolicy=Retain + Backup vault/plan=1、S-1: staging GlobalTable=1 + DeletionPolicy=Delete + Backup=0（enableBackup=false）|
| AC8 | 既存 infra CDK テスト全 pass（回帰なし） | `npx vitest run tests/unit/infra/` | HEAD `d44a28a3` / 8 files 99 passed |
| AC9 | 設計書同期（ADR-0001）: 13-AWS §3.1 / infra/CLAUDE.md を 2-deploy 撤去中の記述へ | 目視 | HEAD `d44a28a3` / `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.1 + ファイル構成、`infra/CLAUDE.md` L27 更新済 |
| AC10 | Deploy-2（次リリースサイクルでの table + export 撤去）を Issue 起票し blocked-by を明記 | `gh issue view 3854` | HEAD `d44a28a3` / Issue #3854 起票済（Blocked by: 本 PR の本番 deploy 完了、EPIC #3424 明記） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [x] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（CDK synth 出力の StorageStack template のみ変更。runtime のアプリ挙動・UI は不変。DynamoDB は runtime で参照されない = health は probePg / analytics は on-demand）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: `tests/unit/infra/staging-cdk.test.ts` に #3850 describe（B-3850a: prod StorageStack が MainTable ARN の cross-stack export を保持 / B-3850b: prod ComputeStack が MainTable を import・grant しない）を新設。P-1（prod）/ S-1（staging）を「table 不在」assert から「Deploy-1 で table + export 保持」assert へ反転（fitness function = 以後 table/export を消したら CI で落ちる）。
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（env / secret 追加なし。`enableBackup` は CDK 内部 config フラグで env ではない）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（infra deploy blocker。5 年齢モード / E2E 回帰は UI 非該当。CDK fitness function 回帰は AC6 で追加済）

## スクリーンショット / ビジュアルデモ

**該当なし（infra / CDK のみ、UI 変更なし）**。変更は StorageStack の CDK 定義 + env-config フラグ + CDK 単体テスト + 設計書のみで、描画される画面は一切変わらない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: StorageStack の単一責務（storage リソース定義）を維持。exportValue は CDK 公式 API で自作抽象なし
- [x] **DRY**: `exportValue` は CDK の removal migration 公式 API を使用（独自実装ゼロ）。table / backup ブロックは #3438 直前版から verbatim 復元し二重定義なし
- [x] **YAGNI**: Deploy-1 に必要な最小変更（table + export 保持）のみ。明示 export name を渡さず CDK 自動生成に委ねることで staging 衝突回避も追加コードなしで達成
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし。物理 table は RETAIN で保全、cross-stack export は ARN のみで機密性なし
- [x] **アクセシビリティ**: N/A（UI 非該当）
- [x] **パフォーマンス**: N/A（deploy-time のみ。runtime 挙動不変）

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード と チュートリアル を同期
- [ ] labels SSOT (ADR-0009)
- [x] **設計書同期** (ADR-0001): インフラ変更のため `docs/design/13-AWSサーバレスアーキテクチャ設計書.md`（§3.1 StorageStack + ファイル構成）+ `infra/CLAUDE.md` を同 PR で更新
- [x] **並行 PR overlap** (#1200): `infra/lib/storage-stack.ts` / `env-config.ts` / `tests/unit/infra/staging-cdk.test.ts` を同時変更する open PR は他にない
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

Deploy-1 は「#3438 が撤去した table + export を保持へ戻す」変更であり、prod template は #3438 直前と同型（RETAIN table + Backup + export）に復帰する。既存 orphan 化された物理 table を CloudFormation の管理下に adopt し直す形で、データへの影響はない（RETAIN 終始）。

**レビュー依頼事項・QA**:
- CFN の 2-deploy 分割方針（本 PR = Deploy-1 で export 保持 → Deploy-2 = 次リリースサイクル Issue #3854 で撤去）の妥当性を確認いただきたい。1 synth で Storage template は固定 + producer-first 固定順のため、同一リリースでの同時撤去は構造的に不可能（#3850 の真因）。
- `exportValue(table.tableArn)` に明示 name を渡さない設計判断（prod / staging 各 stack 名で auto-export と同一名を自動再生成 → staging 衝突回避）。synth 実測で prod `GanbariQuestStorage:...` / staging `GanbariQuestStorageStaging:...` の別名前空間を確認済。
- **本番 / staging deploy 動作確認**: `deploy-aws-staging` lane（required check）での貫通検証は、PO 承認のうえ本 Draft をリリース系統に載せて実施する。本 PR scope での Dev 検証は CDK synth（prod / staging）+ diff 相当の template 確認 + `npx vitest run tests/unit/infra/`（99 passed）まで（実 AWS への `cdk deploy` は PO 権限のため未実行）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 全 Step PASS** を確認した（実体 step すべて PASS: cspell / svelte-check / vitest 8117 passed / check-hardcoded-strings / check-no-plan-literals / check-license-key-leak / check-doc-code-references。Step 1 biome は worktree が `.claude/worktrees/` 配下にあり biome.json `!**/.claude` が worktree 絶対パスを ignore する false negative のためローカル `.` 実行は skip されたが、変更 3 .ts ファイルへの直接 biome 実行は clean + CI biome check は SUCCESS。Step 9 Readiness gate は本チェックリスト自身の自己参照のため本 Ready 化で解消）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし。変更は infra CDK + env-config + CDK 単体テスト + 設計書の 5 file のみ）
- [x] 全 AC が実装済み（AC1〜AC10 すべて実装 + エビデンス付与済み。未実装・保留の AC なし）
- [x] Phase 分割: CFN 2-deploy 制約により Deploy-2 を子 Issue #3854 として起票済み（本 PR = Deploy-1）
- [x] UI 変更時 SS: **該当なし**（本 PR は infra / CDK のみで UI 変更ゼロ）
- [x] 認証画面変更時 `npm run dev:cognito`: **該当なし**（認証画面の変更なし）

**本番 / staging deploy 貫通検証について（Dev 完結不可・後続工程）**: 実 AWS への `cdk deploy` は PO 権限のため本 PR（Dev）scope では未実施。`deploy-aws-staging` lane（release integration の required check）での貫通検証は、PO 承認のうえリリース系統に載せて実施する。本 PR scope の Dev 検証は CDK synth（prod / staging の export 名一致・非衝突を実測確認）+ `npx vitest run tests/unit/infra/`（99 passed）+ CI 全緑（18 check SUCCESS）まで完了済み。この項目は Ready チェックリストの検証対象外（deploy は本番反映工程であり Dev の Ready 化条件に含まない）。

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

