### PR TITLE
fix: #3851 NUC cutover が legacy SQL-datetime の親メッセージを誤 drop して件数突合 abort する回帰を修正

### DIFF
--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -102,8 +102,19 @@ async function runConcurrent<T>(
  */
 const RESTORE_DEDUP_FETCH_LIMIT = 100_000;
 
-/** ISO 8601 日時 (先頭 `YYYY-MM-DDTHH:MM` + Date.parse 可) か。restore の verbatim 値検証用 (#3414/#3420)。 */
-const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/;
+/**
+ * 日時 (先頭 `YYYY-MM-DD` + `T` または半角スペース区切り + `HH:MM` + Date.parse 可) か。
+ * restore / cutover の verbatim 値検証用 (#3414/#3420)。
+ *
+ * #3851: 区切りは `T` (ISO 8601) と半角スペース の両方を許容する。通常の親メッセージ / おうえん
+ * 送信経路 (insertMessage / sendCheer) は sent_at を指定せず、SQLite の `CURRENT_TIMESTAMP`
+ * 既定値 = `'YYYY-MM-DD HH:MM:SS'` (スペース区切り、Date.parse 可の正当な日時) が入る。旧実装は
+ * `T` 必須だったため、この正当な legacy 日時を「不正」と誤判定し、NUC cutover の verbatim import で
+ * 親メッセージを silent drop → 件数突合 (parentMessages export=1 imported=0) で abort させていた
+ * (これは dedup ではなく validator 誤判定による真の false-positive data-loss)。区切りを緩めても
+ * `Date.parse` gate が残るため、破損/改竄値 (未知形式・範囲外) は依然 reject される。
+ */
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/;
 function isValidIsoDateTime(value: string): boolean {
 	return ISO_DATETIME_RE.test(value) && !Number.isNaN(Date.parse(value));
 }

--- a/tests/unit/services/cutover-parent-message-timestamp.test.ts
+++ b/tests/unit/services/cutover-parent-message-timestamp.test.ts
@@ -1,0 +1,143 @@
+// tests/unit/services/cutover-parent-message-timestamp.test.ts
+// #3851 — NUC cutover (旧 sqlite → PGlite) で、SQLite `CURRENT_TIMESTAMP` 既定値由来の
+// スペース区切り日時 (`YYYY-MM-DD HH:MM:SS`) を持つ親メッセージが verbatim import で
+// silent drop され、件数突合 (parentMessages export=1 imported=0) で cutover が abort する
+// 回帰を固定する。
+//
+// 真因: `validateParentMessageRow` の `isValidIsoDateTime` が 'T' 区切り必須の regex
+// (`/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/`) で、通常送信経路 (sendCheer) が使う SQLite
+// `CURRENT_TIMESTAMP` 既定値 (スペース区切り) を「不正」と誤判定していた。#3284 の
+// point_ledger dedup は無関係 (dedup 後も件数は export=import で一致する) — 実 CI 失敗軸は
+// parentMessages。
+//
+// 構成は pglite-cutover-roundtrip.test.ts と同型 (1 it 内で 2 phase 直列):
+//   Phase A: DATA_SOURCE=sqlite + test-db → child seed + 親メッセージ (既定 sent_at) → export
+//   Phase B: DATA_SOURCE=pglite → verbatim import → nuc-cutover-verify で件数突合
+// 併せて「握り潰し過剰でない」= 真の欠落 (validator が正当に reject する破損値) は依然
+// count-verify が検知する、というネガティブ不変条件も同 it 内で確認する (ADR-0061)。
+
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+let testDb: unknown;
+let testSqlite: import('better-sqlite3').Database | null = null;
+
+vi.mock('$lib/server/db', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		return testDb;
+	},
+	getOrInitDb() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
+const TENANT = '00000000-0000-4000-8000-00000000cc51';
+const originalDataSource = process.env.DATA_SOURCE;
+
+afterAll(async () => {
+	if (originalDataSource === undefined) delete process.env.DATA_SOURCE;
+	else process.env.DATA_SOURCE = originalDataSource;
+	testSqlite?.close();
+});
+
+describe('NUC cutover — legacy SQL-datetime 親メッセージ timestamp (#3851)', () => {
+	it('スペース区切り sent_at (valid) は import・破損 sent_at は reject し、件数突合が data-loss を隠さない', async () => {
+		// ═══ Phase A: 旧 sqlite backend で seed → export ═══
+		process.env.DATA_SOURCE = 'sqlite';
+		const { createTestDb } = await import('../helpers/test-db');
+		const t = createTestDb();
+		testDb = t.db;
+		testSqlite = t.sqlite;
+
+		const { getRepos } = await import('../../../src/lib/server/db/factory');
+		const repos = getRepos();
+
+		const taro = await repos.child.insertChild(
+			{ nickname: '移行太郎', age: 8, birthDate: '2018-02-10' },
+			TENANT,
+		);
+
+		// (1) 通常の送信経路 (insertMessage / sendCheer) は sent_at を指定せず、SQLite の
+		//     `CURRENT_TIMESTAMP` 既定値 (= 'YYYY-MM-DD HH:MM:SS'、スペース区切り) が入る。
+		//     実 legacy NUC DB の親メッセージはこの形式で保存されている (= 修正前は誤 reject)。
+		t.sqlite
+			.prepare(
+				`INSERT INTO parent_messages (child_id, message_type, body, icon) VALUES (?, 'text', 'よくがんばったね', '💌')`,
+			)
+			.run(Number(taro.id));
+
+		const stored = t.sqlite.prepare('SELECT sent_at FROM parent_messages').get() as {
+			sent_at: string;
+		};
+		// legacy 格納形式 = スペース区切り (回帰の前提を固定)
+		expect(stored.sent_at).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+
+		// (2) 破損した sent_at を持つ行も 1 件混ぜる。validator が正当に reject すべき値であり、
+		//     修正 (区切り緩和) 後も依然 skip されること = 握り潰し過剰でないことを担保する。
+		t.sqlite
+			.prepare(
+				`INSERT INTO parent_messages (child_id, message_type, body, icon, sent_at) VALUES (?, 'text', 'こわれた日時', '💌', 'not-a-valid-date')`,
+			)
+			.run(Number(taro.id));
+
+		const { exportFamilyData } = await import('../../../src/lib/server/services/export-service');
+		const exportData = await exportFamilyData({ tenantId: TENANT });
+
+		// export は verbatim: 2 件とも JSON に載る (1 件 valid スペース区切り + 1 件破損)
+		expect(exportData.data.parentMessages).toHaveLength(2);
+		expect(exportData.data.parentMessages.some((m) => /^\d{4}-\d{2}-\d{2} /.test(m.sentAt))).toBe(
+			true,
+		);
+
+		// ═══ Phase B: PGlite backend へ verbatim import → 件数突合 ═══
+		vi.resetModules();
+		process.env.DATA_SOURCE = 'pglite';
+		delete process.env.PGLITE_DATA_DIR; // in-memory
+
+		const pgliteConn = await import('../../../src/lib/server/db/pglite/connection');
+		const verify = await import('../../../scripts/lib/runtime/nuc-cutover-verify');
+		const { importFamilyData } = await import('../../../src/lib/server/services/import-service');
+
+		await pgliteConn.resetPgliteConnectionForTesting();
+		await pgliteConn.initPgliteConnection();
+
+		try {
+			const result = await importFamilyData(exportData, TENANT, undefined, { mode: 'verbatim' });
+			// 破損行の skip は warnings に可視化される。hard error (insert 失敗) は無いこと。
+			expect(result.errors, `import errors: ${JSON.stringify(result.errors)}`).toEqual([]);
+
+			const actual = await verify.collectImportedCounts(pgliteConn.getPgliteDbSync(), TENANT);
+
+			// positive: スペース区切り legacy 日時の行は drop されず import される (修正前は 0 件)。
+			// negative: 破損 sent_at の行は依然 reject され import されない (握り潰し過剰でない)。
+			// → tenant の parent_messages 実件数はちょうど 1。
+			expect(actual.parentMessages).toBe(1);
+			expect(result.parentMessagesImported).toBe(1);
+			expect(result.parentMessagesSkipped).toBe(1);
+
+			// count-verify は「export emit 件数 (=2) vs import insert 件数 (=1)」の差を依然検知する。
+			// = 正当な行数変化を許容しつつ、真の data-loss (破損行の欠落) を隠さない不変条件。
+			const expected = verify.summarizeExportCounts(exportData); // parentMessages = 2
+			const mismatches = verify.diffCutoverCounts(expected, actual);
+			expect(mismatches.some((m) => m.startsWith('parentMessages'))).toBe(true);
+
+			// 一方、破損行を含まない (valid のみの) export では突合が完全一致する = 誤検知しない。
+			const cleanExport = structuredClone(exportData);
+			cleanExport.data.parentMessages = cleanExport.data.parentMessages.filter((m) =>
+				/^\d{4}-\d{2}-\d{2}[T ]/.test(m.sentAt),
+			);
+			// clean 側で破損行を除いた期待値は import 実測 (1 件) と完全一致する
+			const cleanExpected = verify.summarizeExportCounts(cleanExport);
+			expect(verify.diffCutoverCounts(cleanExpected, actual)).toEqual([]);
+		} finally {
+			await pgliteConn.resetPgliteConnectionForTesting();
+		}
+	}, 120_000);
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: NUC（セルフホスト版）ユーザー / システム全体

**解決する課題**: NUC の legacy sqlite → PGlite cutover rehearsal（`deploy-nuc-staging` の「PGlite cutover rehearsal」step）が件数突合不一致で abort し、親メッセージ（おうえん）を持つ実 NUC ユーザーの移行が常に失敗していた。第16回リリース統合監査（PR #3848）の blocker。

**期待される効果**: legacy DB で通常送信された親メッセージ（`sent_at` が SQLite `CURRENT_TIMESTAMP` 既定値 = スペース区切り日時）が cutover verbatim import で drop されなくなり、NUC の PGlite 移行が正当なデータで貫通する。真の data-loss（破損値・解決不能行）は依然 count-verify が検知する。

**真因（Issue の dedup 仮説は誤り、実装読解 + 実 CI ログ + 再現で確定）**:
`#3284` の point_ledger dedup（16 行減）は cutover 失敗の原因ではない（dedup 後も point_ledger は export=import で 750 件一致、`deploy-nuc-staging` run 29582721985 の実失敗軸は `parentMessages export=1 imported=0`）。実際の原因は、親メッセージ / おうえんの通常送信経路（`insertMessage` / `sendCheer`）が `sent_at` を指定せず SQLite の `CURRENT_TIMESTAMP` 既定値（`'YYYY-MM-DD HH:MM:SS'`、半角スペース区切りの正当な日時）を書き込むところにある。verbatim import の値検証 `validateParentMessageRow` が使う `isValidIsoDateTime` は `'T'` 区切り必須の regex（`/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/`）だったため、この正当な legacy 日時を「不正」と誤判定して silent drop → 件数突合で abort させていた（validator 誤判定による false-positive data-loss）。

## 関連 Issue

closes #3851

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | count-verification の基準を「post-migration の export emit 件数 vs import insert 件数」に是正し、migration による正当な行数変化を許容する。真因を確定してから修正する | 実装読解（`scripts/nuc-pglite-cutover.ts` L147-153 / `scripts/lib/runtime/nuc-cutover-verify.ts`）+ 実 CI ログ `gh run view 29582721985 --log` + fixture 再現 | HEAD `9dd1cb9b` / 突合は既に export JSON(post-migration) vs import で正しく、真の欠陥は import 側 validator の誤 reject と確定。実失敗軸 = `parentMessages (parent_messages): export=1 imported=0`（point_ledger は 750 一致）。修正 = `src/lib/server/services/import-service.ts:117` `ISO_DATETIME_RE` を `[T ]` 区切りに緩和 |
| AC2 | 真の data-loss（migration で説明できない欠損）は依然検知できる（握り潰し過剰でない） | `npx vitest run tests/unit/services/cutover-parent-message-timestamp.test.ts` | HEAD `9dd1cb9b` / 1 passed / negative ケースで破損 `sent_at='not-a-valid-date'` は依然 skip され `diffCutoverCounts` が parentMessages mismatch を検知（test:125-129）。`Date.parse` gate 維持で破損値は reject |
| AC3 | failing-test-first（ADR-0061）: 重複 point_ledger を含む状態でも cutover が通ることを回帰固定。修正前 fail・修正後 pass | `npx vitest run tests/unit/services/cutover-parent-message-timestamp.test.ts`（T-only 版で fail → `[T ]` 版で pass） | HEAD `9dd1cb9b` / 修正前（T-only regex）: `expected +0 to be 1`（tests:121、space+破損とも drop）。修正後（`[T ]`）: 1 passed。実 CLI 再現も export→import が exit 0 に転換（下記 QA 欄） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: NUC cutover（`scripts/nuc-pglite-cutover.ts` の verbatim import 経路）+ backup restore の親メッセージ / おうえん値検証（`validateParentMessageRow` / `validateSiblingCheerRow` が共有する `isValidIsoDateTime`）。UI 表示は変更なし。

## テスト & 安全装置セルフチェック

- [x] **CI 全緑で担保**（#1775 / ADR-0030）— PR #3856 の非 skip check（lint-and-test / marketplace-registry / schema-checks / new-env-distribution / orphan detection 等 18 件）が SUCCESS。変更 2 ファイルはローカルで `npx biome check <files>` clean + `svelte-check` エラー 0 + blast radius vitest 5 files/23 tests green + 実 CLI 再現（export→import exit 0）。**注**: 本 worktree は dev 依存（tsx / fast-check / aws-cdk-lib）未 install のため `pre-ready` の biome `.`=0 files / svelte-check(infra) / vitest(tsx-CLI) が env 制約で未完走（baseline でも同一挙動、変更起因でない）。CI（full `npm ci`）で全 step 実行済み
- [x] 追加・変更したテストの概要を以下に記載:
  `tests/unit/services/cutover-parent-message-timestamp.test.ts` を新設。`pglite-cutover-roundtrip.test.ts` と同型の 2 phase（sqlite export → PGlite verbatim import）で、① スペース区切り legacy `sent_at` の親メッセージが drop されず件数一致（`actual.parentMessages === 1`、修正前は 0）、② 破損 `sent_at` は依然 reject され `diffCutoverCounts` が mismatch を検知（握り潰し過剰でない）、③ 破損行除外の clean export は完全一致（誤検知なし）を固定。検証コマンド `npx vitest run tests/unit/services/cutover-parent-message-timestamp.test.ts` = 1 passed。
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（env / secret 追加なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:critical` ラベル無し。NUC cutover の実 defect だが本番アプリの 5 年齢モード UI に影響しない script / service 層修正）

## スクリーンショット / ビジュアルデモ

該当なし（refactor / docs / chore）— UI 変更を含まない script / service 層のバグ修正（`src/lib/server/services/import-service.ts` の日時検証 regex 緩和 + unit test 追加）。NUC cutover CLI 経路であり画面描画差分ゼロ。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任を保持。値検証ヘルパー `isValidIsoDateTime` の 1 点修正で、それを共有する `validateParentMessageRow` / `validateSiblingCheerRow` の両方に一貫して波及（重複修正なし）
- [x] **DRY**: `grep -rn "isValidIsoDateTime" src/` で使用箇所 4 件（parentMessage sentAt/shownAt + siblingCheer sentAt/shownAt）を全件確認。単一定数の緩和で class 全体をカバー
- [x] **YAGNI**: regex の区切り文字を 1 文字クラス化する最小差分。export 側 normalize 等の追加抽象は入れない
- [x] **Security（OSS 公開前提）**: `Date.parse` gate を維持するため破損 / 改竄値（未知形式・範囲外）は依然 reject。緩和は「正当な SQL datetime 形式の受理」に限定し、検証の意図（描画 / ソート破壊値の排除）を保持
- [x] **アクセシビリティ**: N/A（server 層）
- [x] **パフォーマンス**: N/A（regex 1 文字追加のみ、計算量不変）

## 横展開・影響波及チェック

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシードと チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [ ] **設計書同期** (ADR-0001): 対象なし。本修正は validator の誤 reject 是正（spec 変更ではなく defect 修正）。「`sent_at` は `'T'` 区切り必須」を仕様として記載した設計書は存在せず、stale 化する記述なし（`grep -n "isValidIsoDateTime" docs/` 確認済、runbook `nuc-pglite-cutover.md` は原因を narrative 記載しておらず docs SSOT 原則で追記不要）
- [ ] **並行 PR overlap** (#1200)
- [x] N/A — 並行実装の影響範囲外（NUC cutover verbatim import の値検証。`validateParentMessageRow` / `validateSiblingCheerRow` が共有する単一ヘルパーの修正で class 全体をカバー済み）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
Issue #3851 の root cause 仮説（#3284 point_ledger dedup が突合を狂わせる）は誤りで、実際は parentMessage の `sent_at` 検証誤判定でした。実 CI ログ（run 29582721985: `parentMessages export=1 imported=0`）と fixture 再現で確定しています。突合基準の変更（Issue の対応方針 1/2）は行わず、既に正しい「export emit 件数 vs import 件数」の突合を維持したまま、import 側で正当な legacy 行を drop していた validator を是正しました（対症療法回避 / ADR-0003）。実 CLI 再現ログ: 修正前 `npx tsx scripts/nuc-pglite-cutover.ts import` が `parentMessages export=1 imported=0` で exit 1、修正後は `parentMessages:1` で exit 0。ローカル環境（worktree）で `nuc-pglite-cutover-cli.test.ts` の 4 test が `node_modules/tsx/dist/cli.mjs` 不在（worktree の tsx 子プロセス解決の既知制約、develop 基点でも同様に fail）で落ちますが、本変更とは無関係で CI（full node_modules）では実行されます。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **検証を確認した** — CI 全緑（PR #3856 非 skip 18 check SUCCESS）で担保。ローカルは変更 2 ファイルの biome/svelte-check clean + blast radius vitest 23 tests green + 実 CLI 再現で確認（worktree は dev 依存未 install のため `pre-ready` full 完走は CI に委譲、上記テスト & 安全装置セクション注記参照）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（N/A — 単一 PR 完結）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認（N/A — UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付（N/A — 認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

