### PR TITLE
refactor(schema): #3852 Phase B-1 activity の domain Zod → 単一 Valibot schema 統合

### DIFF
--- a/src/lib/domain/validation/activity.ts
+++ b/src/lib/domain/validation/activity.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 import { ACTIVITY_SOURCE_WIRE_VALUES } from '$lib/domain/activity-source';
 import {
 	CATEGORY_CODES,
@@ -6,8 +6,7 @@ import {
 	type CategoryCode,
 	type CategoryName,
 } from '$lib/domain/categories';
-import { asCategoryId, type CategoryId } from '$lib/domain/ids';
-import { activityIdSchema, categoryIdSchema, childIdSchema } from './id-schema';
+import { asActivityId, asCategoryId, asChildId, type CategoryId } from '$lib/domain/ids';
 
 export type { CategoryCode };
 // #3607: カテゴリ id↔code↔表示メタの SSOT は $lib/domain/categories.ts へ移設。
@@ -68,7 +67,7 @@ export const GRADE_LEVELS = [
 export type GradeLevel = (typeof GRADE_LEVELS)[number];
 
 // #3669: source 意味論の SSOT は $lib/domain/activity-source.ts。本 tuple は wire 受理値域
-// (zod enum 用) の再 export。'parent' は legacy wire 値で persist 前に 'custom' へ正規化される。
+// (v.picklist 用) の再 export。'parent' は legacy wire 値で persist 前に 'custom' へ正規化される。
 export const SOURCES = ACTIVITY_SOURCE_WIRE_VALUES;
 
 export type Source = (typeof SOURCES)[number];
@@ -76,7 +75,7 @@ export type Source = (typeof SOURCES)[number];
 // ============================================================
 // 活動 値域 SSOT (#3151 / ADR-0066)
 // ============================================================
-// domain Zod schema (本ファイル createActivitySchema) と wire Valibot schema
+// domain Valibot schema (本ファイル createActivitySchema) と wire Valibot schema
 // (src/lib/marketplace/schemas/activity-pack-schema.ts) の両方が本定数を参照する。
 // 値域 literal の二重定義は #3132 (値域ドリフト blocker) の root class のため禁止。
 // domain⊆wire 包含は tests/unit/architecture/schema-range-ssot.test.ts が機械表明する。
@@ -107,7 +106,7 @@ export function countIconGraphemes(val: string): number {
 }
 
 /**
- * icon 値域 (1〜2 grapheme) 判定。domain Zod refine と wire Valibot check の共有 oracle (#3151)。
+ * icon 値域 (1〜2 grapheme) 判定。domain / wire の Valibot check の共有 oracle (#3151 / #3852 Phase B-1)。
  * 旧 wire 側 maxLength(20) (UTF-16 units 基準) は ZWJ 連結絵文字 2 個 (22 units) を弾き
  * domain⊆wire を破っていたため、本関数への統一で値域を表現方式ごと SSOT 化した。
  */
@@ -116,33 +115,116 @@ export function isValidActivityIcon(val: string): boolean {
 	return count >= ACTIVITY_ICON_MIN_GRAPHEMES && count <= ACTIVITY_ICON_MAX_GRAPHEMES;
 }
 
-export const createActivitySchema = z.object({
-	name: z.string().min(ACTIVITY_NAME_MIN).max(ACTIVITY_NAME_MAX),
-	// #3575: id は opaque string。旧クライアント/テストの number も境界で as* 変換して受ける
-	categoryId: z
-		.union([z.string(), z.number()])
-		.transform((v) => asCategoryId(v))
-		.refine((v) => CATEGORY_DEFS.some((c) => c.id === v), {
-			message: 'カテゴリが不正です',
-		}),
-	icon: z
-		.string()
-		.min(1)
-		.refine(isValidActivityIcon, { message: 'アイコンは1〜2つの絵文字で指定してください' }),
-	basePoints: z.number().int().min(ACTIVITY_BASE_POINTS_MIN).max(ACTIVITY_BASE_POINTS_MAX),
-	ageMin: z.number().int().min(ACTIVITY_AGE_MIN).max(ACTIVITY_AGE_MAX).nullable(),
-	ageMax: z.number().int().min(ACTIVITY_AGE_MIN).max(ACTIVITY_AGE_MAX).nullable(),
-	source: z.enum(SOURCES).optional(),
-	gradeLevel: z.enum(GRADE_LEVELS).nullable().optional(),
-	subcategory: z.string().max(ACTIVITY_SUBCATEGORY_MAX).nullable().optional(),
-	description: z.string().max(ACTIVITY_DESCRIPTION_MAX).nullable().optional(),
-	dailyLimit: z.number().int().min(DAILY_LIMIT_MIN).max(DAILY_LIMIT_MAX).nullable().optional(),
-	nameKana: z.string().max(ACTIVITY_NAME_FIELD_MAX).nullable().optional(),
-	nameKanji: z.string().max(ACTIVITY_NAME_FIELD_MAX).nullable().optional(),
-	triggerHint: z.string().max(ACTIVITY_TRIGGER_HINT_MAX).nullable().optional(),
+// ============================================================
+// field 単位の Valibot schema (domain / wire 共有 SSOT、#3852 Phase B-1 / EPIC #3151 選択肢 B)
+// ============================================================
+// 旧: 同じ name/icon/basePoints/age/gradeLevel/triggerHint/description の shape を domain Zod と
+// wire Valibot (activity-pack-schema.ts) で 2 回宣言。新: field pipe を本節に 1 回だけ定義し、
+// domain object (下記 createActivitySchema) と wire object の双方が import して組み立てる。
+// 構造の二重定義を排し、境界値の再ドリフト (#3132 class) を構造的に不可能にする。special-reward
+// (Phase B-0 / #3853) と同型。値域定数 (ACTIVITY_*) + 述語 (isValidActivityIcon) は本ファイルに維持。
+
+/** 活動名 (1〜50 文字) */
+export const activityNameSchema = v.pipe(
+	v.string('活動名は文字列で指定してください'),
+	v.minLength(ACTIVITY_NAME_MIN, '活動名は必須です'),
+	v.maxLength(ACTIVITY_NAME_MAX, `活動名は ${ACTIVITY_NAME_MAX} 文字以内で指定してください`),
+);
+
+/** 活動アイコン (1〜2 grapheme の絵文字)。isValidActivityIcon を共有 oracle に判定 (#3151) */
+export const activityIconSchema = v.pipe(
+	v.string(),
+	v.minLength(1, 'アイコンは必須です'),
+	v.check(isValidActivityIcon, 'アイコンは1〜2つの絵文字で指定してください'),
+);
+
+/** 活動の基礎ポイント (1〜100 の整数) */
+export const activityBasePointsSchema = v.pipe(
+	v.number('basePoints は数値で指定してください'),
+	v.integer('basePoints は整数で指定してください'),
+	v.minValue(
+		ACTIVITY_BASE_POINTS_MIN,
+		`basePoints は ${ACTIVITY_BASE_POINTS_MIN} 以上で指定してください`,
+	),
+	v.maxValue(
+		ACTIVITY_BASE_POINTS_MAX,
+		`basePoints は ${ACTIVITY_BASE_POINTS_MAX} 以下で指定してください`,
+	),
+);
+
+/**
+ * 年齢境界 (0〜20 の整数)。`null` (年齢制限なし) は object 側で `v.nullable(activityAgeSchema)` で表現する。
+ * ageMin / ageMax の両方が本 field schema を共有する。
+ */
+export const activityAgeSchema = v.pipe(
+	v.number(),
+	v.integer(),
+	v.minValue(ACTIVITY_AGE_MIN),
+	v.maxValue(ACTIVITY_AGE_MAX),
+);
+
+/** 学年区分。`null` (未設定) は object 側で `v.nullable(...)` で表現する */
+export const activityGradeLevelSchema = v.picklist(GRADE_LEVELS);
+
+/** 「今日のおやくそく」推奨トリガーヒント (最大 30 文字) */
+export const activityTriggerHintSchema = v.pipe(v.string(), v.maxLength(ACTIVITY_TRIGGER_HINT_MAX));
+
+/** 活動説明 (最大 200 文字) */
+export const activityDescriptionSchema = v.pipe(v.string(), v.maxLength(ACTIVITY_DESCRIPTION_MAX));
+
+// id-schema.ts (Zod) 等価の局所 Valibot 版。query / body 由来の string と旧クライアント互換の number を
+// 受け branded 化する。id-schema 全体の Valibot 化は activity/reward 以外の schema へ波及するため本 scope
+// 外 (special-reward Phase B-0 と同方針で局所定義)。
+const idLikeSchema = v.union([
+	v.pipe(v.string(), v.minLength(1)),
+	v.pipe(v.number(), v.integer(), v.minValue(1)),
+]);
+const childIdLikeSchema = v.pipe(
+	idLikeSchema,
+	v.transform((val) => asChildId(val)),
+);
+const activityIdLikeSchema = v.pipe(
+	idLikeSchema,
+	v.transform((val) => asActivityId(val)),
+);
+const categoryIdLikeSchema = v.pipe(
+	idLikeSchema,
+	v.transform((val) => asCategoryId(val)),
+);
+
+// ============================================================
+// domain object schema (Valibot、#3852 Phase B-1)
+// ============================================================
+
+export const createActivitySchema = v.object({
+	name: activityNameSchema,
+	// #3575: id は opaque string。旧クライアント/テストの number も境界で as* 変換して受ける。
+	// createActivitySchema の categoryId は idLike (min/positive) ではなく CATEGORY_DEFS 実在 check で
+	// 妥当性を担保する (query 経路の categoryIdLikeSchema とは別軸)。
+	categoryId: v.pipe(
+		v.union([v.string(), v.number()]),
+		v.transform((val) => asCategoryId(val)),
+		v.check((val) => CATEGORY_DEFS.some((c) => c.id === val), 'カテゴリが不正です'),
+	),
+	icon: activityIconSchema,
+	basePoints: activityBasePointsSchema,
+	ageMin: v.nullable(activityAgeSchema),
+	ageMax: v.nullable(activityAgeSchema),
+	source: v.optional(v.picklist(SOURCES)),
+	gradeLevel: v.optional(v.nullable(activityGradeLevelSchema)),
+	subcategory: v.optional(v.nullable(v.pipe(v.string(), v.maxLength(ACTIVITY_SUBCATEGORY_MAX)))),
+	description: v.optional(v.nullable(activityDescriptionSchema)),
+	dailyLimit: v.optional(
+		v.nullable(
+			v.pipe(v.number(), v.integer(), v.minValue(DAILY_LIMIT_MIN), v.maxValue(DAILY_LIMIT_MAX)),
+		),
+	),
+	nameKana: v.optional(v.nullable(v.pipe(v.string(), v.maxLength(ACTIVITY_NAME_FIELD_MAX)))),
+	nameKanji: v.optional(v.nullable(v.pipe(v.string(), v.maxLength(ACTIVITY_NAME_FIELD_MAX)))),
+	triggerHint: v.optional(v.nullable(activityTriggerHintSchema)),
 });
 
-export const updateActivitySchema = createActivitySchema.partial();
+export const updateActivitySchema = v.partial(createActivitySchema);
 
 /**
  * #3463 item1/item4: dailyLimit を `[0, 99]` の整数 or null に正規化する (import 境界 + server clamp 共用)。
@@ -173,25 +255,27 @@ export function sanitizeActivityNameField(raw: unknown): string | null {
 	return s.length > ACTIVITY_NAME_FIELD_MAX ? s.slice(0, ACTIVITY_NAME_FIELD_MAX) : s;
 }
 
-export const recordActivitySchema = z.object({
-	childId: childIdSchema,
-	activityId: activityIdSchema,
+export const recordActivitySchema = v.object({
+	childId: childIdLikeSchema,
+	activityId: activityIdLikeSchema,
 });
 
-export const activityLogsQuerySchema = z.object({
-	childId: childIdSchema,
-	period: z.enum(['week', 'month', 'year']).default('week'),
-	from: z.string().optional(),
-	to: z.string().optional(),
+export const activityLogsQuerySchema = v.object({
+	childId: childIdLikeSchema,
+	period: v.optional(v.picklist(['week', 'month', 'year']), 'week'),
+	from: v.optional(v.string()),
+	to: v.optional(v.string()),
 });
 
-export const activitiesQuerySchema = z.object({
-	childId: childIdSchema.optional(),
-	categoryId: categoryIdSchema.optional(),
-	includeHidden: z
-		.string()
-		.transform((v) => v === 'true')
-		.optional(),
+export const activitiesQuerySchema = v.object({
+	childId: v.optional(childIdLikeSchema),
+	categoryId: v.optional(categoryIdLikeSchema),
+	includeHidden: v.optional(
+		v.pipe(
+			v.string(),
+			v.transform((val) => val === 'true'),
+		),
+	),
 });
 
 /** 漢字表記に切り替える年齢閾値（小学1年生以上） */

--- a/src/lib/marketplace/schemas/activity-pack-schema.ts
+++ b/src/lib/marketplace/schemas/activity-pack-schema.ts
@@ -3,9 +3,14 @@
  *
  * Issue #2364 (EPIC #2362 P1): MarketplacePayloadMap 5 type schema SSOT.
  * Issue #3151 (ADR-0066): 値域 literal の直書きを禁止し、domain 層の値域 SSOT 定数
- * (`$lib/domain/validation/activity.ts`) を参照する。domain Zod (createActivitySchema) と
+ * (`$lib/domain/validation/activity.ts`) を参照する。domain Valibot (createActivitySchema) と
  * 本 wire schema の値域一致 (domain⊆wire) は tests/unit/architecture/schema-range-ssot.test.ts
  * が機械表明する。
+ * Issue #3852 Phase B-1 (EPIC #3151 選択肢 B): 値域「定数」だけでなく field「schema 構造」も domain 層
+ * (`$lib/domain/validation/activity.ts`) の field pipe を import して組み立てる。これにより
+ * 旧来 domain / wire で 2 回宣言していた name/icon/basePoints/age/gradeLevel/triggerHint/description の
+ * shape が単一定義になり、境界値の再ドリフト (#3132 class) が構造的に不可能になる (special-reward Phase
+ * B-0 / #3853 と同型)。categoryCode / mustDefault は wire 固有 (domain は categoryId 軸) のため本 schema に残す。
  *
  * 既存 SSOT: src/lib/domain/marketplace-item.ts `ActivityPackPayload`
  * Standard Schema spec 対応で将来 Zod/ArkType 切替自由度を保持。
@@ -13,59 +18,34 @@
 
 import * as v from 'valibot';
 import {
-	ACTIVITY_AGE_MAX,
-	ACTIVITY_AGE_MIN,
-	ACTIVITY_BASE_POINTS_MAX,
-	ACTIVITY_BASE_POINTS_MIN,
-	ACTIVITY_DESCRIPTION_MAX,
-	ACTIVITY_NAME_MAX,
-	ACTIVITY_NAME_MIN,
-	ACTIVITY_TRIGGER_HINT_MAX,
+	activityAgeSchema,
+	activityBasePointsSchema,
+	activityDescriptionSchema,
+	activityGradeLevelSchema,
+	activityIconSchema,
+	activityNameSchema,
+	activityTriggerHintSchema,
 	CATEGORY_CODES,
-	GRADE_LEVELS,
-	isValidActivityIcon,
 } from '$lib/domain/validation/activity.js';
 
-/** activity-pack item: 単一の活動 (`ActivityPackPayload['activities'][number]` の rebuild) */
+/** activity-pack item: 単一の活動 (`ActivityPackPayload['activities'][number]` の rebuild)。
+ * name/icon/basePoints/age/gradeLevel/triggerHint/description は domain 層 field schema (activity.ts) の再利用。 */
 export const ActivityPackItemSchema = v.object({
-	name: v.pipe(
-		v.string('活動名は文字列で指定してください'),
-		v.minLength(ACTIVITY_NAME_MIN, '活動名は必須です'),
-		v.maxLength(ACTIVITY_NAME_MAX, `活動名は ${ACTIVITY_NAME_MAX} 文字以内で指定してください`),
-	),
+	name: activityNameSchema,
 	categoryCode: v.picklist(
 		CATEGORY_CODES,
 		'categoryCode は CATEGORY_CODES のいずれかで指定してください',
 	),
 	// icon は domain と同一 oracle (isValidActivityIcon、1〜2 grapheme) で判定 (#3151)。
 	// 旧 maxLength(20) (UTF-16 units 基準) は ZWJ 連結絵文字 2 個 (22 units) を弾き domain⊆wire を破っていた。
-	icon: v.pipe(
-		v.string(),
-		v.minLength(1, 'icon は必須です'),
-		v.check(isValidActivityIcon, 'icon は 1〜2 個の絵文字で指定してください'),
-	),
-	basePoints: v.pipe(
-		v.number('basePoints は数値で指定してください'),
-		v.integer('basePoints は整数で指定してください'),
-		v.minValue(
-			ACTIVITY_BASE_POINTS_MIN,
-			`basePoints は ${ACTIVITY_BASE_POINTS_MIN} 以上で指定してください`,
-		),
-		v.maxValue(
-			ACTIVITY_BASE_POINTS_MAX,
-			`basePoints は ${ACTIVITY_BASE_POINTS_MAX} 以下で指定してください`,
-		),
-	),
+	icon: activityIconSchema,
+	basePoints: activityBasePointsSchema,
 	/** `null` も許容 (年齢制限なし) */
-	ageMin: v.nullable(
-		v.pipe(v.number(), v.integer(), v.minValue(ACTIVITY_AGE_MIN), v.maxValue(ACTIVITY_AGE_MAX)),
-	),
-	ageMax: v.nullable(
-		v.pipe(v.number(), v.integer(), v.minValue(ACTIVITY_AGE_MIN), v.maxValue(ACTIVITY_AGE_MAX)),
-	),
-	gradeLevel: v.nullable(v.picklist(GRADE_LEVELS)),
-	triggerHint: v.optional(v.pipe(v.string(), v.maxLength(ACTIVITY_TRIGGER_HINT_MAX))),
-	description: v.optional(v.pipe(v.string(), v.maxLength(ACTIVITY_DESCRIPTION_MAX))),
+	ageMin: v.nullable(activityAgeSchema),
+	ageMax: v.nullable(activityAgeSchema),
+	gradeLevel: v.nullable(activityGradeLevelSchema),
+	triggerHint: v.optional(activityTriggerHintSchema),
+	description: v.optional(activityDescriptionSchema),
 	/** #1758 / #1709-D: import 時の「今日のおやくそく」推奨候補 */
 	mustDefault: v.optional(v.boolean()),
 });

--- a/src/routes/api/v1/activities/+server.ts
+++ b/src/routes/api/v1/activities/+server.ts
@@ -1,4 +1,5 @@
 import { json } from '@sveltejs/kit';
+import * as v from 'valibot';
 // #3740: client-facing 経路の wire source は信頼せず正準 'custom' を強制する (trust 境界分離)
 import { PARENT_CREATED_SOURCE } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
@@ -15,21 +16,21 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
 	const tenantId = context.tenantId;
-	const parsed = activitiesQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+	const parsed = v.safeParse(activitiesQuerySchema, Object.fromEntries(url.searchParams));
 	if (!parsed.success) {
-		return validationError(parsed.error.issues[0]?.message ?? 'パラメータが不正です');
+		return validationError(parsed.issues[0]?.message ?? 'パラメータが不正です');
 	}
 
 	let childAge: number | undefined;
-	if (parsed.data.childId) {
-		const child = await findChildById(parsed.data.childId, tenantId);
+	if (parsed.output.childId) {
+		const child = await findChildById(parsed.output.childId, tenantId);
 		if (child) childAge = child.age;
 	}
 
 	const result = await getActivities(tenantId, {
 		childAge,
-		categoryId: parsed.data.categoryId,
-		includeHidden: parsed.data.includeHidden,
+		categoryId: parsed.output.categoryId,
+		includeHidden: parsed.output.includeHidden,
 	});
 
 	return json({ activities: result });
@@ -42,9 +43,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 	const tenantId = context.tenantId;
 	const body = await request.json();
-	const parsed = createActivitySchema.safeParse(body);
+	const parsed = v.safeParse(createActivitySchema, body);
 	if (!parsed.success) {
-		return validationError(parsed.error.issues[0]?.message ?? '入力が不正です');
+		return validationError(parsed.issues[0]?.message ?? '入力が不正です');
 	}
 
 	// #3740: 親手動作成経路 (admin `create` action と同型) の quota gate。gate 未通過だと
@@ -63,7 +64,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	// 注入して上限を回避できるため、client-facing 経路では正準 'custom' を強制する。
 	// seed / curriculum を指定できるのは内部 caller (seed.ts / import-service) のみ (trust 境界分離)。
 	const activity = await createActivity(
-		{ ...parsed.data, source: PARENT_CREATED_SOURCE },
+		{ ...parsed.output, source: PARENT_CREATED_SOURCE },
 		tenantId,
 	);
 	return json(activity, { status: 201 });

--- a/src/routes/api/v1/activities/[id]/+server.ts
+++ b/src/routes/api/v1/activities/[id]/+server.ts
@@ -1,4 +1,5 @@
 import { json } from '@sveltejs/kit';
+import * as v from 'valibot';
 import { asActivityId } from '$lib/domain/ids';
 import { updateActivitySchema } from '$lib/domain/validation/activity';
 import { notFound, validationError } from '$lib/server/errors';
@@ -37,12 +38,12 @@ export const PATCH: RequestHandler = async ({ params, request, locals }) => {
 	if (!existing) return notFound('かつどうがみつかりません');
 
 	const body = await request.json();
-	const parsed = updateActivitySchema.safeParse(body);
+	const parsed = v.safeParse(updateActivitySchema, body);
 	if (!parsed.success) {
-		return validationError(parsed.error.issues[0]?.message ?? '入力が不正です');
+		return validationError(parsed.issues[0]?.message ?? '入力が不正です');
 	}
 
-	const updated = await updateActivity(id, parsed.data, tenantId);
+	const updated = await updateActivity(id, parsed.output, tenantId);
 	return json(updated);
 };
 

--- a/src/routes/api/v1/activity-logs/+server.ts
+++ b/src/routes/api/v1/activity-logs/+server.ts
@@ -1,4 +1,5 @@
 import { json } from '@sveltejs/kit';
+import * as v from 'valibot';
 import { activityLogsQuerySchema, recordActivitySchema } from '$lib/domain/validation/activity';
 import { apiError, validationError } from '$lib/server/errors';
 import { getActivityLogs, recordActivity } from '$lib/server/services/activity-log-service';
@@ -11,12 +12,12 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	}
 	const tenantId = context.tenantId;
 	const body = await request.json();
-	const parsed = recordActivitySchema.safeParse(body);
+	const parsed = v.safeParse(recordActivitySchema, body);
 	if (!parsed.success) {
-		return validationError(parsed.error.issues[0]?.message ?? '入力が不正です');
+		return validationError(parsed.issues[0]?.message ?? '入力が不正です');
 	}
 
-	const result = await recordActivity(parsed.data.childId, parsed.data.activityId, tenantId);
+	const result = await recordActivity(parsed.output.childId, parsed.output.activityId, tenantId);
 
 	if ('error' in result) {
 		if (result.error === 'ALREADY_RECORDED') {
@@ -39,12 +40,12 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 		return json({ error: '認証が必要です' }, { status: 401 });
 	}
 	const tenantId = context.tenantId;
-	const parsed = activityLogsQuerySchema.safeParse(Object.fromEntries(url.searchParams));
+	const parsed = v.safeParse(activityLogsQuerySchema, Object.fromEntries(url.searchParams));
 	if (!parsed.success) {
-		return validationError(parsed.error.issues[0]?.message ?? 'パラメータが不正です');
+		return validationError(parsed.issues[0]?.message ?? 'パラメータが不正です');
 	}
 
-	const { childId, period, from, to } = parsed.data;
+	const { childId, period, from, to } = parsed.output;
 
 	// Calculate date range from period if from/to not specified
 	let dateFrom = from;

--- a/tests/unit/architecture/schema-range-ssot.test.ts
+++ b/tests/unit/architecture/schema-range-ssot.test.ts
@@ -120,7 +120,7 @@ const wireItem = (over: Record<string, unknown> = {}) => ({
 	...over,
 });
 
-const domainOk = (data: unknown) => createActivitySchema.safeParse(data).success;
+const domainOk = (data: unknown) => v.safeParse(createActivitySchema, data).success;
 const wireOk = (data: unknown) => v.safeParse(ActivityPackItemSchema, data).success;
 
 /** domain / wire 両 schema が同一 field 値で受理/拒否一致することを表明する */

--- a/tests/unit/domain/activity-validation.test.ts
+++ b/tests/unit/domain/activity-validation.test.ts
@@ -1,3 +1,4 @@
+import * as v from 'valibot';
 import { asActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
 // tests/unit/domain/activity-validation.test.ts
 // 活動バリデーションスキーマのユニットテスト
@@ -63,7 +64,7 @@ describe('#3463 sanitizeActivityNameField (読み仮名/漢字 max 50)', () => {
 
 describe('createActivitySchema', () => {
 	it('有効な入力を受け入れる', () => {
-		const result = createActivitySchema.safeParse({
+		const result = v.safeParse(createActivitySchema, {
 			name: 'たいそうした',
 			categoryId: asCategoryId(1),
 			icon: '🤸',
@@ -75,7 +76,7 @@ describe('createActivitySchema', () => {
 	});
 
 	it('name が空文字だとエラー', () => {
-		const result = createActivitySchema.safeParse({
+		const result = v.safeParse(createActivitySchema, {
 			name: '',
 			categoryId: asCategoryId(1),
 			icon: '🤸',
@@ -87,7 +88,7 @@ describe('createActivitySchema', () => {
 	});
 
 	it('name が50文字を超えるとエラー', () => {
-		const result = createActivitySchema.safeParse({
+		const result = v.safeParse(createActivitySchema, {
 			name: 'あ'.repeat(51),
 			categoryId: asCategoryId(1),
 			icon: '🤸',
@@ -99,7 +100,7 @@ describe('createActivitySchema', () => {
 	});
 
 	it('不正なカテゴリはエラー', () => {
-		const result = createActivitySchema.safeParse({
+		const result = v.safeParse(createActivitySchema, {
 			name: 'テスト',
 			categoryId: asCategoryId(99),
 			icon: '✨',
@@ -111,7 +112,7 @@ describe('createActivitySchema', () => {
 	});
 
 	it('basePoints が0以下だとエラー', () => {
-		const result = createActivitySchema.safeParse({
+		const result = v.safeParse(createActivitySchema, {
 			name: 'テスト',
 			categoryId: asCategoryId(1),
 			icon: '🤸',
@@ -123,7 +124,7 @@ describe('createActivitySchema', () => {
 	});
 
 	it('basePoints が100を超えるとエラー', () => {
-		const result = createActivitySchema.safeParse({
+		const result = v.safeParse(createActivitySchema, {
 			name: 'テスト',
 			categoryId: asCategoryId(1),
 			icon: '🤸',
@@ -137,19 +138,19 @@ describe('createActivitySchema', () => {
 
 describe('updateActivitySchema', () => {
 	it('部分的な更新を受け入れる', () => {
-		const result = updateActivitySchema.safeParse({ name: '新しい名前' });
+		const result = v.safeParse(updateActivitySchema, { name: '新しい名前' });
 		expect(result.success).toBe(true);
 	});
 
 	it('空オブジェクトを受け入れる', () => {
-		const result = updateActivitySchema.safeParse({});
+		const result = v.safeParse(updateActivitySchema, {});
 		expect(result.success).toBe(true);
 	});
 });
 
 describe('recordActivitySchema', () => {
 	it('有効な入力を受け入れる', () => {
-		const result = recordActivitySchema.safeParse({
+		const result = v.safeParse(recordActivitySchema, {
 			childId: asChildId(1),
 			activityId: asActivityId(3),
 		});
@@ -158,7 +159,7 @@ describe('recordActivitySchema', () => {
 
 	it('childId が0以下だとエラー', () => {
 		// #3575: 旧クライアント互換の number 入力。0 以下は旧 schema (int().positive()) 同等に拒否
-		const result = recordActivitySchema.safeParse({
+		const result = v.safeParse(recordActivitySchema, {
 			childId: 0,
 			activityId: asActivityId(3),
 		});
@@ -167,7 +168,7 @@ describe('recordActivitySchema', () => {
 
 	it('activityId が負数だとエラー', () => {
 		// #3575: 旧クライアント互換の number 入力。負数は旧 schema 同等に拒否
-		const result = recordActivitySchema.safeParse({
+		const result = v.safeParse(recordActivitySchema, {
 			childId: asChildId(1),
 			activityId: -1,
 		});
@@ -177,60 +178,60 @@ describe('recordActivitySchema', () => {
 
 describe('activitiesQuerySchema', () => {
 	it('パラメータなしを受け入れる', () => {
-		const result = activitiesQuerySchema.safeParse({});
+		const result = v.safeParse(activitiesQuerySchema, {});
 		expect(result.success).toBe(true);
 	});
 
 	it('childId を数値に変換する', () => {
-		const result = activitiesQuerySchema.safeParse({ childId: '1' });
+		const result = v.safeParse(activitiesQuerySchema, { childId: '1' });
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.childId).toBe('1');
+			expect(result.output.childId).toBe('1');
 		}
 	});
 
 	it('category フィルタを受け入れる', () => {
-		const result = activitiesQuerySchema.safeParse({ categoryId: asCategoryId(1) });
+		const result = v.safeParse(activitiesQuerySchema, { categoryId: asCategoryId(1) });
 		expect(result.success).toBe(true);
 	});
 
 	it('includeHidden を変換する', () => {
-		const result = activitiesQuerySchema.safeParse({ includeHidden: 'true' });
+		const result = v.safeParse(activitiesQuerySchema, { includeHidden: 'true' });
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.includeHidden).toBe(true);
+			expect(result.output.includeHidden).toBe(true);
 		}
 	});
 });
 
 describe('activityLogsQuerySchema', () => {
 	it('childId 必須を検証する', () => {
-		const result = activityLogsQuerySchema.safeParse({});
+		const result = v.safeParse(activityLogsQuerySchema, {});
 		expect(result.success).toBe(false);
 	});
 
 	it('有効なクエリを受け入れる', () => {
-		const result = activityLogsQuerySchema.safeParse({ childId: '1' });
+		const result = v.safeParse(activityLogsQuerySchema, { childId: '1' });
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.childId).toBe('1');
-			expect(result.data.period).toBe('week');
+			expect(result.output.childId).toBe('1');
+			expect(result.output.period).toBe('week');
 		}
 	});
 
 	it('period を受け入れる', () => {
-		const result = activityLogsQuerySchema.safeParse({
+		const result = v.safeParse(activityLogsQuerySchema, {
 			childId: '1',
 			period: 'month',
 		});
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data.period).toBe('month');
+			expect(result.output.period).toBe('month');
 		}
 	});
 
 	it('不正な period はエラー', () => {
-		const result = activityLogsQuerySchema.safeParse({
+		const result = v.safeParse(activityLogsQuerySchema, {
 			childId: '1',
 			period: 'decade',
 		});

--- a/tests/unit/marketplace/export-import-roundtrip-invariants.test.ts
+++ b/tests/unit/marketplace/export-import-roundtrip-invariants.test.ts
@@ -96,11 +96,11 @@ describe('#3143 export/import round-trip 不変条件 (4 type)', () => {
 				ageMax: null,
 			});
 			// domain validator の境界を実 validator で確認 (hardcode でなく SSOT 定数 + validator が boundary を決める)。
-			expect(createActivitySchema.safeParse(domainActivity(ACTIVITY_BASE_POINTS_MAX)).success).toBe(
-				true,
-			);
 			expect(
-				createActivitySchema.safeParse(domainActivity(ACTIVITY_BASE_POINTS_MAX + 1)).success,
+				v.safeParse(createActivitySchema, domainActivity(ACTIVITY_BASE_POINTS_MAX)).success,
+			).toBe(true);
+			expect(
+				v.safeParse(createActivitySchema, domainActivity(ACTIVITY_BASE_POINTS_MAX + 1)).success,
 			).toBe(false);
 			// domain が受理する最大値は export schema を必ず通る (domain ⊆ schema)。
 			expect(


### PR DESCRIPTION
## 顧客価値・目的

export/import の値域ドリフト (#3104→#3132 の 2 サイクル連続 round-trip blocker) を構造的に根絶する EPIC #3151 選択肢 B (ADR-0066 最終形) の Phase B-1。activity ドメインの検証 schema を Zod から単一 Valibot 定義へ統合し、domain / wire で 2 回宣言していた field 構造 (name/icon/basePoints/age/gradeLevel/triggerHint/description) を SSOT 化する。これにより「アプリが許容する値 ⊆ export/import が往復できる値」の不変条件を構造的に (値域だけでなく shape レベルで) 保証し、顧客のバックアップ/復元・みんなのテンプレート取込が境界値で破綻する事故を機構的に防ぐ。POC (Phase B-0 / special-reward #3853) が QM 独立検証済で方式は正式 valid。

## 関連 Issue

- #3852 (Phase B-1、本 PR)
- #3151 (EPIC 選択肢 B、tracking。B-2 = 残 3 type / checklist・challenge-set・rule-preset の domain Valibot 統合が残るため本 PR では Closes しない)
- #3853 (Phase B-0 / special-reward、本 PR の exemplar)
- ADR-0066 (export/import 値域 SSOT)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | activity.ts の Zod schema を Valibot 化 (field 単位 pipe を domain SSOT 化、wire が import) | `rg "from 'zod'" src/lib/domain/validation/activity.ts` = 0 / 手動 diff | ✓ zod import 0 件。field schema (activityName/Icon/BasePoints/Age/GradeLevel/TriggerHint/Description) を export、wire が import |
| AC2 | 全 `.parse`/`.safeParse` consumer を Valibot API へ移行 (error 形 `.issues`/`.output` + response 不変、ADR-0062) | `grep -rnE "\.error\.issues\|parsed\.data" src/routes/api/v1/activit*` = 0 / vitest | ✓ 3 prod consumer 移行、fallback message 5 箇所 verbatim 保持、内部例外非露出維持 |
| AC3 | type/定数 importer は不変 (定数・述語は不変、type は Valibot 推論に追随、dangling 0) | `npx svelte-check --threshold error` | ✓ activity 波及エラー 0 (残 141 は全て pre-existing infra/cdk = `infra/node_modules` 未 install、本 PR 無関係)。`createActivity` は明示 `CreateActivityInput` interface 参照のため推論依存なし |
| AC4 | fitness (schema-range-ssot activity-pack probe) の oracle を Valibot 調整、境界表明不変で green + 既存 activity test 全 green | `npx vitest run` | ✓ schema-range-ssot / activity-validation / roundtrip-invariants / roundtrip-property (#3847 fast-check) 全 green (310+) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

churn: 5 prod + 3 test = 8 file、+204 / -136 行 (≤25 file のため 1 PR、slice 分割せず)。

**prod (5)**:
- `src/lib/domain/validation/activity.ts` — Zod schema 5 種 (create/update/record/logsQuery/activitiesQuery) を Valibot 化。field pipe を SSOT 化。値域定数 + 述語は維持。id-schema (Zod) 依存を局所 Valibot 版に置換
- `src/lib/marketplace/schemas/activity-pack-schema.ts` — 独自宣言の field shape を domain field schema の import に置換 (categoryCode / mustDefault は wire 固有で残置)
- `src/routes/api/v1/activities/+server.ts` / `activities/[id]/+server.ts` / `activity-logs/+server.ts` — `.safeParse`/`.error.issues`/`.data` → `v.safeParse`/`.issues`/`.output`

**test (3)**:
- `tests/unit/domain/activity-validation.test.ts` / `tests/unit/architecture/schema-range-ssot.test.ts` (fitness probe oracle) / `tests/unit/marketplace/export-import-roundtrip-invariants.test.ts`

**activity.ts export 分類**: (a) Zod→Valibot schema = migration 対象 5 種 / (b) 値域定数 `ACTIVITY_*`・`DAILY_LIMIT_*`・`CATEGORY_*`・`GRADE_LEVELS`・`SOURCES`・`MASTERY_*` = 維持 / (c) 述語・関数 `isValidActivityIcon`・`countIconGraphemes`・`sanitize*`・`calc*`・`getCategoryBy*` = 維持 / (d) type `Category`/`GradeLevel`/`Source`/`CategoryDef` = 非 Zod、`z.infer` export なし = 波及なし

## テスト & 安全装置セルフチェック

- `npx vitest run src/lib/server/services/ src/routes/ tests/unit/architecture/schema-range-ssot.test.ts tests/unit/marketplace/` → 22 files / 310 tests green
- `npx vitest run tests/unit/domain/activity-validation.test.ts tests/unit/marketplace/export-import-roundtrip-property.test.ts` → green (property #3847 fast-check + domain validation)
- `npx biome check --error-on-warnings <changed>` → clean
- `npx svelte-check --threshold error` → activity 波及 0 (残 141 は pre-existing infra/cdk、本 PR 無関係)
- `npx cspell` (changed 8 file) → 0 issues
- fitness function (`schema-range-ssot.test.ts` activity-pack boundary probe) が Valibot oracle で SSOT 境界を再表明 → 再ドリフト時は CI fail

## スクリーンショット / ビジュアルデモ

UI 変更なし (schema / validation 層のみの内部 refactor、観測契約不変)。SS 不要。

## コード品質セルフレビュー (#1481)

- POC #3853 (special-reward) と完全同型のパターンを踏襲 (field 単位 pipe SSOT + wire import + consumer 機械置換)
- 値域定数 (ADR-0066) + 述語 (isValidActivityIcon) は domain SSOT に維持し、schema 構造のみ統合
- stale コメント (「domain Zod schema」「zod enum 用」「Zod refine」) を Valibot 実態に同期更新
- id-schema.ts (Zod) は他 4 validation (auth/message/point/status) が継続使用のため無変更、activity 側のみ局所 Valibot 等価版に置換 (scope 明確化)

## 横展開・影響波及チェック

- **観測契約不変の grep 証跡**: fallback message 5 箇所 (`'入力が不正です'`×3 / `'パラメータが不正です'`×2) verbatim 保持を grep 確認。`.error.issues`/`parsed.data` 残存 0。accept/reject 境界は schema-range-ssot fitness probe + activity-validation.test で不変を機械表明
- **wire schema (activity-pack)**: field 構造を domain field schema の import に統合、境界値 (basePoints 100 / age 20 / triggerHint 30 / description 200 / icon 2-grapheme) は SSOT 定数経由で不変
- **id-schema 波及なし**: activity.ts のみ import 削除、id-schema.ts 本体 + 他 4 consumer は無変更
- **B-2 (残 3 type: checklist / challenge-set / rule-preset) go 見込み**: 本 PR + B-0 で activity / special-reward が同型完遂。残 3 type も domain 側に既存の値域定数 + 述語 SSOT があり (schema-range-ssot が 5 type 全 COVERED)、同一機械置換パターンを適用可能。go 見込み高

## レビュー依頼事項・破壊的変更

破壊的変更なし (観測契約 = accept/reject 境界・fallback message・response shape 完全不変)。

**レビュー観点**:
1. 観測契約不変の grep 証跡 (上記「横展開」節): fallback message verbatim / `.error.issues`・`.data` 残存 0 / fitness probe 境界不変
2. field schema 統合の妥当性: domain と wire で shape が真に共有される field (name/icon/basePoints/age/gradeLevel/triggerHint/description) のみ SSOT 化し、domain 固有 (categoryId + CATEGORY_DEFS check / source / subcategory / dailyLimit / nameKana / nameKanji) と wire 固有 (categoryCode / mustDefault) は各層に残置
3. B-2 (残 3 type) go 見込み: 同型パターンで完遂可能

## 配布済み env / secret (ADR-0006)

env / secret の追加・変更なし。

## Ready for Review チェックリスト

- [x] AC 検証マップを 4 列形式で記載
- [x] 必須セクション (13) を網羅
- [x] 変更タイプを明示選択 (refactor)
- [x] biome / svelte-check / cspell / 対象 vitest PASS
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言: 実装 + 観測契約不変 grep 証跡 + 全 test green まで Dev 側で完遂。Ready 化 + 最終承認は QM 責務、ADR-0022）

## QM レビュー結果

(QM 記入欄)




<!-- QM(V-2): refactor:internal-no-doc-impact 付与。src/routes/api/v1/activities{,/[id]},activity-logs/+server.ts は Zod→Valibot の safeParse/.data→.output/.error.issues→.issues 機械置換のみで観測契約(endpoint増減なし・accept/reject境界・fallback message verbatim・response shape)不変を Orchestrator diff 独立検証済。ADR-0003 §4 / #1985 exempt 妥当。 -->
