### PR TITLE
refactor(schema): #3852 Phase B-2 checklist/challenge-set/rule-preset の domain Zod → 単一 Valibot schema 統合 (選択肢B完成)

### DIFF
--- a/src/lib/domain/validation/challenge-set.ts
+++ b/src/lib/domain/validation/challenge-set.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 // #3151 slice4 (ADR-0066): icon の値域は「grapheme 数」で判定する。grapheme 計数は activity /
 // reward / checklist と同一実装 (countIconGraphemes) を共有し、値でなく述語を SSOT 化する
 // (ADR-0066 原則 2)。
@@ -7,7 +7,7 @@ import { countIconGraphemes } from './activity';
 // ============================================================
 // challenge-set item 値域 SSOT (#3151 slice4 / ADR-0066)
 // ============================================================
-// domain Zod schema (本ファイル challengeSetItemSchema) と wire Valibot schema
+// domain Valibot schema (本ファイル challengeSetItemSchema) と wire Valibot schema
 // (src/lib/marketplace/schemas/challenge-set-schema.ts の ChallengeSetItemSchema) の両方が
 // 本定数を参照する。値域 literal の二重定義は #3132 class (値域ドリフト blocker) の root class の
 // ため禁止。domain⊆wire 包含は tests/unit/architecture/schema-range-ssot.test.ts が boundary
@@ -42,7 +42,7 @@ export const CHALLENGE_ICON_MAX_GRAPHEMES = 2;
 export const CHALLENGE_MONTH_DAY_REGEX = /^(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
 
 /**
- * challenge item icon 値域 (1〜2 grapheme) 判定。domain Zod refine と wire Valibot check の
+ * challenge item icon 値域 (1〜2 grapheme) 判定。domain / wire 両 Valibot check の
  * 共有 oracle (#3151 slice4)。旧 wire 側 `maxLength(20)` (UTF-16 units 基準) は ZWJ 連結絵文字
  * 2 個 (👨‍👩‍👧‍👦👨‍👩‍👧‍👦 = 22 units) を弾き (往復不能)、逆に絵文字 3 個以上 (🎁🎈🎀 = 6 units) を受理して
  * いた (単一〜少数の絵文字という意図に反する)。grapheme 判定への統一で「1〜2 個の絵文字」という
@@ -53,6 +53,90 @@ export function isValidChallengeIcon(val: string): boolean {
 	return count >= CHALLENGE_ICON_MIN_GRAPHEMES && count <= CHALLENGE_ICON_MAX_GRAPHEMES;
 }
 
+// ============================================================
+// field 単位の Valibot schema (domain / wire 共有 SSOT、#3852 Phase B-2 / EPIC #3151 選択肢 B)
+// ============================================================
+// 旧: 同じ title/description/monthDay/durationDays/baseTarget/rewardPoints/icon の shape を domain
+// Zod と wire Valibot (challenge-set-schema.ts) で 2 回宣言 (slice4 では値域「定数」だけを共有し、
+// field「schema 構造」は依然 2 重定義だった)。新: field pipe を本節に 1 回だけ定義し、domain object
+// (下記 challengeSetItemSchema) と wire object の双方が import して組み立てる。構造の二重定義を排し、
+// 境界値の再ドリフト (#3132 class) を構造的に不可能にする。activity / reward / checklist と同型。
+//
+// categoryId は「意味的カテゴリ enum」(picklist、$lib/domain/categories.ts SSOT) であり値域ではない
+// ため本 domain range validator の対象外。wire schema が picklist として検証する (SSOT はカテゴリ側に既存)。
+
+/** challenge title (1〜100 文字) */
+export const challengeTitleSchema = v.pipe(
+	v.string('title は文字列で指定してください'),
+	v.minLength(CHALLENGE_TITLE_MIN, 'title は必須です'),
+	v.maxLength(CHALLENGE_TITLE_MAX, `title は ${CHALLENGE_TITLE_MAX} 文字以内で指定してください`),
+);
+
+/** challenge description (1〜500 文字) */
+export const challengeDescriptionSchema = v.pipe(
+	v.string('description は文字列で指定してください'),
+	v.minLength(CHALLENGE_DESCRIPTION_MIN, 'description は必須です'),
+	v.maxLength(
+		CHALLENGE_DESCRIPTION_MAX,
+		`description は ${CHALLENGE_DESCRIPTION_MAX} 文字以内で指定してください`,
+	),
+);
+
+/** 'MM-DD' (例: '03-03' = ひな祭り)。毎年同月日に開催される年間行事の論理表現 */
+export const challengeMonthDaySchema = v.pipe(
+	v.string('monthDay は文字列で指定してください'),
+	v.regex(CHALLENGE_MONTH_DAY_REGEX, 'monthDay は MM-DD 形式 (01-01 〜 12-31) で指定してください'),
+);
+
+/** 期間 (日数、1〜90 の整数)。startDate = monthDay の (durationDays - 1) 日前。endDate = monthDay */
+export const challengeDurationDaysSchema = v.pipe(
+	v.number('durationDays は数値で指定してください'),
+	v.integer('durationDays は整数で指定してください'),
+	v.minValue(
+		CHALLENGE_DURATION_DAYS_MIN,
+		`durationDays は ${CHALLENGE_DURATION_DAYS_MIN} 以上で指定してください`,
+	),
+	v.maxValue(
+		CHALLENGE_DURATION_DAYS_MAX,
+		`durationDays は ${CHALLENGE_DURATION_DAYS_MAX} 以下で指定してください`,
+	),
+);
+
+/** 達成目標 (1〜1000 の整数、例: 累積 10 回) */
+export const challengeBaseTargetSchema = v.pipe(
+	v.number('baseTarget は数値で指定してください'),
+	v.integer('baseTarget は整数で指定してください'),
+	v.minValue(
+		CHALLENGE_BASE_TARGET_MIN,
+		`baseTarget は ${CHALLENGE_BASE_TARGET_MIN} 以上で指定してください`,
+	),
+	v.maxValue(
+		CHALLENGE_BASE_TARGET_MAX,
+		`baseTarget は ${CHALLENGE_BASE_TARGET_MAX} 以下で指定してください`,
+	),
+);
+
+/** 報酬ポイント (0〜10000 の整数) */
+export const challengeRewardPointsSchema = v.pipe(
+	v.number('rewardPoints は数値で指定してください'),
+	v.integer('rewardPoints は整数で指定してください'),
+	v.minValue(
+		CHALLENGE_REWARD_POINTS_MIN,
+		`rewardPoints は ${CHALLENGE_REWARD_POINTS_MIN} 以上で指定してください`,
+	),
+	v.maxValue(
+		CHALLENGE_REWARD_POINTS_MAX,
+		`rewardPoints は ${CHALLENGE_REWARD_POINTS_MAX} 以下で指定してください`,
+	),
+);
+
+/** challenge item icon (1〜2 grapheme の絵文字)。isValidChallengeIcon を共有 oracle に判定 (#3151) */
+export const challengeIconSchema = v.pipe(
+	v.string('icon は文字列で指定してください'),
+	v.minLength(1, 'icon は必須です'),
+	v.check(isValidChallengeIcon, 'icon は 1〜2 個の絵文字で指定してください'),
+);
+
 /**
  * challenge-set item の domain validator (SSOT)。
  *
@@ -62,17 +146,15 @@ export function isValidChallengeIcon(val: string): boolean {
  *
  * 注: categoryId は「意味的カテゴリ enum」(picklist、$lib/domain/categories.ts SSOT) であり値域
  * ではないため本 domain range validator の対象外。wire schema が picklist として検証する
- * (SSOT はカテゴリ側に既存)。
+ * (SSOT はカテゴリ側に既存)。domain object は categoryId を持たず、v.object は未知 entry を無視
+ * するため fitness probe が categoryId を含む base item を渡しても受理する (Zod object と同挙動)。
  */
-export const challengeSetItemSchema = z.object({
-	title: z.string().min(CHALLENGE_TITLE_MIN).max(CHALLENGE_TITLE_MAX),
-	description: z.string().min(CHALLENGE_DESCRIPTION_MIN).max(CHALLENGE_DESCRIPTION_MAX),
-	monthDay: z.string().regex(CHALLENGE_MONTH_DAY_REGEX),
-	durationDays: z.number().int().min(CHALLENGE_DURATION_DAYS_MIN).max(CHALLENGE_DURATION_DAYS_MAX),
-	baseTarget: z.number().int().min(CHALLENGE_BASE_TARGET_MIN).max(CHALLENGE_BASE_TARGET_MAX),
-	rewardPoints: z.number().int().min(CHALLENGE_REWARD_POINTS_MIN).max(CHALLENGE_REWARD_POINTS_MAX),
-	icon: z
-		.string()
-		.min(1)
-		.refine(isValidChallengeIcon, { message: 'アイコンは1〜2つの絵文字で指定してください' }),
+export const challengeSetItemSchema = v.object({
+	title: challengeTitleSchema,
+	description: challengeDescriptionSchema,
+	monthDay: challengeMonthDaySchema,
+	durationDays: challengeDurationDaysSchema,
+	baseTarget: challengeBaseTargetSchema,
+	rewardPoints: challengeRewardPointsSchema,
+	icon: challengeIconSchema,
 });

--- a/src/lib/domain/validation/checklist.ts
+++ b/src/lib/domain/validation/checklist.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 // #3151 slice3 (ADR-0066): icon の値域は「grapheme 数」で判定する。grapheme 計数は activity /
 // reward と同一実装 (countIconGraphemes) を共有し、値でなく述語を SSOT 化する (ADR-0066 原則 2)。
 import { countIconGraphemes } from './activity';
@@ -6,7 +6,7 @@ import { countIconGraphemes } from './activity';
 // ============================================================
 // チェックリスト item 値域 SSOT (#3151 slice3 / ADR-0066)
 // ============================================================
-// domain Zod schema (本ファイル checklistItemSchema) と wire Valibot schema
+// domain Valibot schema (本ファイル checklistItemSchema) と wire Valibot schema
 // (src/lib/marketplace/schemas/checklist-schema.ts の ChecklistItemSchema) の両方が本定数を参照する。
 // 値域 literal の二重定義は #3132 class (値域ドリフト blocker) の root class のため禁止。
 // domain⊆wire 包含は tests/unit/architecture/schema-range-ssot.test.ts が boundary probe で機械表明する。
@@ -26,7 +26,7 @@ export const CHECKLIST_ICON_MIN_GRAPHEMES = 1;
 export const CHECKLIST_ICON_MAX_GRAPHEMES = 2;
 
 /**
- * チェックリスト item icon 値域 (1〜2 grapheme) 判定。domain Zod refine と wire Valibot check の
+ * チェックリスト item icon 値域 (1〜2 grapheme) 判定。domain / wire 両 Valibot check の
  * 共有 oracle (#3151 slice3)。旧 wire 側 `maxLength(20)` (UTF-16 units 基準) は ZWJ 連結絵文字
  * 2 個 (👨‍👩‍👧‍👦👨‍👩‍👧‍👦 = 22 units) を弾き (往復不能)、逆に絵文字 3 個以上 (🎁🎈🎀 = 6 units) を
  * 受理していた (単一〜少数の絵文字という意図に反する)。grapheme 判定への統一で「1〜2 個の絵文字」
@@ -37,6 +37,36 @@ export function isValidChecklistIcon(val: string): boolean {
 	return count >= CHECKLIST_ICON_MIN_GRAPHEMES && count <= CHECKLIST_ICON_MAX_GRAPHEMES;
 }
 
+// ============================================================
+// field 単位の Valibot schema (domain / wire 共有 SSOT、#3852 Phase B-2 / EPIC #3151 選択肢 B)
+// ============================================================
+// 旧: 同じ label/icon/order の shape を domain Zod と wire Valibot (checklist-schema.ts) で 2 回宣言
+// (slice3 では値域「定数」だけを共有し、field「schema 構造」は依然 2 重定義だった)。新: field pipe を
+// 本節に 1 回だけ定義し、domain object (下記 checklistItemSchema) と wire object の双方が import して
+// 組み立てる。構造の二重定義を排し、境界値の再ドリフト (#3132 class) を構造的に不可能にする。
+// activity (Phase B-1 / #3860) / reward (Phase B-0 / #3853) と同型。
+
+/** チェックリスト項目名 (1〜100 文字) */
+export const checklistLabelSchema = v.pipe(
+	v.string('label は文字列で指定してください'),
+	v.minLength(CHECKLIST_LABEL_MIN, 'label は必須です'),
+	v.maxLength(CHECKLIST_LABEL_MAX, `label は ${CHECKLIST_LABEL_MAX} 文字以内で指定してください`),
+);
+
+/** チェックリスト項目 icon (1〜2 grapheme の絵文字)。isValidChecklistIcon を共有 oracle に判定 (#3151) */
+export const checklistIconSchema = v.pipe(
+	v.string(),
+	v.minLength(1, 'icon は必須です'),
+	v.check(isValidChecklistIcon, 'icon は 1〜2 個の絵文字で指定してください'),
+);
+
+/** チェックリスト項目の並び順 (0 以上の整数)。追加時に自動採番される */
+export const checklistOrderSchema = v.pipe(
+	v.number('order は数値で指定してください'),
+	v.integer('order は整数で指定してください'),
+	v.minValue(CHECKLIST_ORDER_MIN, `order は ${CHECKLIST_ORDER_MIN} 以上で指定してください`),
+);
+
 /**
  * チェックリスト item の domain validator (SSOT)。
  *
@@ -44,17 +74,14 @@ export function isValidChecklistIcon(val: string): boolean {
  * 上記 SSOT を参照し、wire schema (ChecklistItemSchema) と同一境界で受理/拒否する。
  *
  * 実利用箇所 (dead code ではない):
- *   - admin authoring 経路: `/admin/checklists` の addTemplateItem action が
- *     `checklistItemSchema.pick({ label: true, icon: true })` で label / icon を検証する
+ *   - admin authoring 経路: `/admin/checklists` の addItem action が
+ *     `v.pick(checklistItemSchema, ['label', 'icon'])` で label / icon を検証する
  *     (order は追加時に自動採番されるため authoring 対象外)。
  *   - fitness probe: tests/unit/architecture/schema-range-ssot.test.ts が本 schema を
  *     domain oracle として wire schema と cross-assert する。
  */
-export const checklistItemSchema = z.object({
-	label: z.string().min(CHECKLIST_LABEL_MIN).max(CHECKLIST_LABEL_MAX),
-	icon: z
-		.string()
-		.min(1)
-		.refine(isValidChecklistIcon, { message: 'アイコンは1〜2つの絵文字で指定してください' }),
-	order: z.number().int().min(CHECKLIST_ORDER_MIN),
+export const checklistItemSchema = v.object({
+	label: checklistLabelSchema,
+	icon: checklistIconSchema,
+	order: checklistOrderSchema,
 });

--- a/src/lib/domain/validation/rule-preset.ts
+++ b/src/lib/domain/validation/rule-preset.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as v from 'valibot';
 // #3151 slice4 (ADR-0066): icon の値域は「grapheme 数」で判定する。grapheme 計数は activity /
 // reward / checklist と同一実装 (countIconGraphemes) を共有し、値でなく述語を SSOT 化する
 // (ADR-0066 原則 2)。
@@ -7,7 +7,7 @@ import { countIconGraphemes } from './activity';
 // ============================================================
 // rule-preset item 値域 SSOT (#3151 slice4 / ADR-0066)
 // ============================================================
-// domain Zod schema (本ファイル rulePresetItemSchema) と wire Valibot schema
+// domain Valibot schema (本ファイル rulePresetItemSchema) と wire Valibot schema
 // (src/lib/marketplace/schemas/rule-preset-schema.ts の RulePresetItemSchema) の両方が本定数を
 // 参照する。値域 literal の二重定義は #3132 class (値域ドリフト blocker) の root class のため禁止。
 // domain⊆wire 包含は tests/unit/architecture/schema-range-ssot.test.ts が boundary probe で
@@ -33,7 +33,7 @@ export const RULE_ICON_MIN_GRAPHEMES = 1;
 export const RULE_ICON_MAX_GRAPHEMES = 2;
 
 /**
- * rule item icon 値域 (1〜2 grapheme) 判定。domain Zod refine と wire Valibot check の共有 oracle
+ * rule item icon 値域 (1〜2 grapheme) 判定。domain / wire 両 Valibot check の共有 oracle
  * (#3151 slice4)。旧 wire 側 `maxLength(20)` (UTF-16 units 基準) は ZWJ 連結絵文字 2 個 (22 units)
  * を弾き、逆に絵文字 3 個以上 (🎁🎈🎀 = 6 units) を受理していた。grapheme 判定への統一で
  * 「1〜2 個の絵文字」という意図を表現方式ごと SSOT 化し、activity / reward / checklist と同一
@@ -44,6 +44,51 @@ export function isValidRuleIcon(val: string): boolean {
 	return count >= RULE_ICON_MIN_GRAPHEMES && count <= RULE_ICON_MAX_GRAPHEMES;
 }
 
+// ============================================================
+// field 単位の Valibot schema (domain / wire 共有 SSOT、#3852 Phase B-2 / EPIC #3151 選択肢 B)
+// ============================================================
+// 旧: 同じ title/description/icon/pointCost/pointBonus の shape を domain Zod と wire Valibot
+// (rule-preset-schema.ts) で 2 回宣言 (slice4 では値域「定数」だけを共有し、field「schema 構造」は
+// 依然 2 重定義だった)。新: field pipe を本節に 1 回だけ定義し、domain object (下記
+// rulePresetItemSchema) と wire object の双方が import して組み立てる。構造の二重定義を排し、
+// 境界値の再ドリフト (#3132 class) を構造的に不可能にする。activity / reward / checklist と同型。
+
+/** rule title (1〜100 文字) */
+export const ruleTitleSchema = v.pipe(
+	v.string('title は文字列で指定してください'),
+	v.minLength(RULE_TITLE_MIN, 'title は必須です'),
+	v.maxLength(RULE_TITLE_MAX, `title は ${RULE_TITLE_MAX} 文字以内で指定してください`),
+);
+
+/** rule description (1〜500 文字) */
+export const ruleDescriptionSchema = v.pipe(
+	v.string('description は文字列で指定してください'),
+	v.minLength(RULE_DESCRIPTION_MIN, 'description は必須です'),
+	v.maxLength(
+		RULE_DESCRIPTION_MAX,
+		`description は ${RULE_DESCRIPTION_MAX} 文字以内で指定してください`,
+	),
+);
+
+/** rule item icon (1〜2 grapheme の絵文字)。isValidRuleIcon を共有 oracle に判定 (#3151) */
+export const ruleIconSchema = v.pipe(
+	v.string(),
+	v.minLength(1, 'icon は必須です'),
+	v.check(isValidRuleIcon, 'icon は 1〜2 個の絵文字で指定してください'),
+);
+
+/**
+ * pointCost / pointBonus 共通の値域 schema (0〜10000 の整数)。両 field は同一値域 (RULE_POINT_*) の
+ * ため単一 field schema を共有する (reward-set の rewardPointsSchema と同型の field 共有原則)。
+ * object 側で `v.optional(...)` により省略可を表現する。
+ */
+export const rulePointSchema = v.pipe(
+	v.number('ポイントは数値で指定してください'),
+	v.integer('ポイントは整数で指定してください'),
+	v.minValue(RULE_POINT_MIN, `ポイントは ${RULE_POINT_MIN} 以上で指定してください`),
+	v.maxValue(RULE_POINT_MAX, `ポイントは ${RULE_POINT_MAX} 以下で指定してください`),
+);
+
 /**
  * rule-preset item の domain validator (SSOT)。
  *
@@ -52,13 +97,10 @@ export function isValidRuleIcon(val: string): boolean {
  * 受理/拒否する。ruleType は item ではなく payload レベルの picklist (RULE_TYPES) のため本 item
  * validator の対象外。
  */
-export const rulePresetItemSchema = z.object({
-	title: z.string().min(RULE_TITLE_MIN).max(RULE_TITLE_MAX),
-	description: z.string().min(RULE_DESCRIPTION_MIN).max(RULE_DESCRIPTION_MAX),
-	icon: z
-		.string()
-		.min(1)
-		.refine(isValidRuleIcon, { message: 'アイコンは1〜2つの絵文字で指定してください' }),
-	pointCost: z.number().int().min(RULE_POINT_MIN).max(RULE_POINT_MAX).optional(),
-	pointBonus: z.number().int().min(RULE_POINT_MIN).max(RULE_POINT_MAX).optional(),
+export const rulePresetItemSchema = v.object({
+	title: ruleTitleSchema,
+	description: ruleDescriptionSchema,
+	icon: ruleIconSchema,
+	pointCost: v.optional(rulePointSchema),
+	pointBonus: v.optional(rulePointSchema),
 });

--- a/src/lib/marketplace/schemas/challenge-set-schema.ts
+++ b/src/lib/marketplace/schemas/challenge-set-schema.ts
@@ -9,9 +9,14 @@
  * `tests/fixtures/marketplace/challenge-sets/japan-annual-events.json` (15 件、年間行事 challenge セット)。
  *
  * **値域 SSOT (#3151 slice4 / ADR-0066)**: 値域 literal の直書きを禁止し、domain 層の値域 SSOT 定数
- * (`$lib/domain/validation/challenge-set.ts`) を参照する。domain Zod (challengeSetItemSchema) と本
- * wire schema の値域一致 (domain⊆wire) は tests/unit/architecture/schema-range-ssot.test.ts が
- * boundary probe で機械表明する。
+ * (`$lib/domain/validation/challenge-set.ts`) を参照する。
+ * **Issue #3852 Phase B-2 (EPIC #3151 選択肢 B)**: 値域「定数」だけでなく field「schema 構造」も domain
+ * 層の field pipe を import して組み立てる。これにより旧来 domain / wire で 2 回宣言していた
+ * title/description/monthDay/durationDays/baseTarget/rewardPoints/icon の shape が単一定義になり、境界値
+ * の再ドリフト (#3132 class) が構造的に不可能になる (activity Phase B-1 / #3860 と同型)。categoryId は
+ * wire 固有 (domain は値域でない意味的カテゴリ enum を対象外) のため本 schema に残す。domain Valibot
+ * (challengeSetItemSchema) と本 wire schema の値域一致 (domain⊆wire) は
+ * tests/unit/architecture/schema-range-ssot.test.ts が boundary probe で機械表明する。
  *
  * **協力タイプ固定**: EPIC #2294 ② で競争タイプ UI が削除されたため、本 schema でも competitive
  * variant を持たず cooperative 固定とする (interface 側コメントと整合)。期間は monthDay (MM-DD) +
@@ -21,18 +26,13 @@
 import * as v from 'valibot';
 import { CATEGORIES, CATEGORY_CODES, CATEGORY_NUMERIC_IDS } from '$lib/domain/categories.js';
 import {
-	CHALLENGE_BASE_TARGET_MAX,
-	CHALLENGE_BASE_TARGET_MIN,
-	CHALLENGE_DESCRIPTION_MAX,
-	CHALLENGE_DESCRIPTION_MIN,
-	CHALLENGE_DURATION_DAYS_MAX,
-	CHALLENGE_DURATION_DAYS_MIN,
-	CHALLENGE_MONTH_DAY_REGEX,
-	CHALLENGE_REWARD_POINTS_MAX,
-	CHALLENGE_REWARD_POINTS_MIN,
-	CHALLENGE_TITLE_MAX,
-	CHALLENGE_TITLE_MIN,
-	isValidChallengeIcon,
+	challengeBaseTargetSchema,
+	challengeDescriptionSchema,
+	challengeDurationDaysSchema,
+	challengeIconSchema,
+	challengeMonthDaySchema,
+	challengeRewardPointsSchema,
+	challengeTitleSchema,
 } from '$lib/domain/validation/challenge-set.js';
 
 /** picklist エラーメッセージ用の "1 (うんどう) / 2 (べんきょう) / ..." 列挙 (SSOT 派生、#3607) */
@@ -40,88 +40,36 @@ const CATEGORY_ID_CHOICES = CATEGORY_CODES.map(
 	(code) => `${CATEGORIES[code].legacyNumericId} (${CATEGORIES[code].name})`,
 ).join(' / ');
 
-/** challenge-set item: 単一のチャレンジ (#2297 ChallengeSetPayload interface 整合) */
+/** challenge-set item: 単一のチャレンジ (#2297 ChallengeSetPayload interface 整合)。
+ * title/description/monthDay/durationDays/baseTarget/rewardPoints/icon は domain 層 field schema の再利用。
+ * categoryId のみ wire 固有 (意味的カテゴリ enum、値域でないため domain range validator 対象外)。 */
 export const ChallengeSetItemSchema = v.object({
-	title: v.pipe(
-		v.string('title は文字列で指定してください'),
-		v.minLength(CHALLENGE_TITLE_MIN, 'title は必須です'),
-		v.maxLength(CHALLENGE_TITLE_MAX, `title は ${CHALLENGE_TITLE_MAX} 文字以内で指定してください`),
-	),
-	description: v.pipe(
-		v.string('description は文字列で指定してください'),
-		v.minLength(CHALLENGE_DESCRIPTION_MIN, 'description は必須です'),
-		v.maxLength(
-			CHALLENGE_DESCRIPTION_MAX,
-			`description は ${CHALLENGE_DESCRIPTION_MAX} 文字以内で指定してください`,
-		),
-	),
+	title: challengeTitleSchema,
+	description: challengeDescriptionSchema,
 	/** 'MM-DD' (例: '03-03' = ひな祭り)。毎年同月日に開催される年間行事の論理表現 */
-	monthDay: v.pipe(
-		v.string('monthDay は文字列で指定してください'),
-		v.regex(
-			CHALLENGE_MONTH_DAY_REGEX,
-			'monthDay は MM-DD 形式 (01-01 〜 12-31) で指定してください',
-		),
-	),
+	monthDay: challengeMonthDaySchema,
 	/** 期間 (日数)。startDate = monthDay の (durationDays - 1) 日前。endDate = monthDay */
-	durationDays: v.pipe(
-		v.number('durationDays は数値で指定してください'),
-		v.integer('durationDays は整数で指定してください'),
-		v.minValue(
-			CHALLENGE_DURATION_DAYS_MIN,
-			`durationDays は ${CHALLENGE_DURATION_DAYS_MIN} 以上で指定してください`,
-		),
-		v.maxValue(
-			CHALLENGE_DURATION_DAYS_MAX,
-			`durationDays は ${CHALLENGE_DURATION_DAYS_MAX} 以下で指定してください`,
-		),
-	),
+	durationDays: challengeDurationDaysSchema,
 	/**
 	 * legacy 数値カテゴリ id ($lib/domain/categories.ts SSOT の `legacyNumericId` 投影、#3607)。
 	 *
 	 * payload 内で自己完結する「意味的カテゴリ enum」であり、DB エンティティの
 	 * branded CategoryId (string、src/lib/domain/ids.ts) とは別物 (#3606 棚卸しで
 	 * runtime break なしを確認済)。値域はカテゴリ SSOT から派生し、カテゴリ追加時は
-	 * SSOT 1 エントリ追記で本 picklist にも自動伝播する。
+	 * SSOT 1 エントリ追記で本 picklist にも自動伝播する。値域でない enum のため domain range
+	 * validator (challenge-set.ts) の対象外で、wire 固有の field として本 schema に残す。
 	 */
 	categoryId: v.picklist(
 		CATEGORY_NUMERIC_IDS,
 		`categoryId は ${CATEGORY_ID_CHOICES} のいずれかで指定してください`,
 	),
 	/** 達成目標 (例: 累積 10 回) */
-	baseTarget: v.pipe(
-		v.number('baseTarget は数値で指定してください'),
-		v.integer('baseTarget は整数で指定してください'),
-		v.minValue(
-			CHALLENGE_BASE_TARGET_MIN,
-			`baseTarget は ${CHALLENGE_BASE_TARGET_MIN} 以上で指定してください`,
-		),
-		v.maxValue(
-			CHALLENGE_BASE_TARGET_MAX,
-			`baseTarget は ${CHALLENGE_BASE_TARGET_MAX} 以下で指定してください`,
-		),
-	),
+	baseTarget: challengeBaseTargetSchema,
 	/** 報酬ポイント */
-	rewardPoints: v.pipe(
-		v.number('rewardPoints は数値で指定してください'),
-		v.integer('rewardPoints は整数で指定してください'),
-		v.minValue(
-			CHALLENGE_REWARD_POINTS_MIN,
-			`rewardPoints は ${CHALLENGE_REWARD_POINTS_MIN} 以上で指定してください`,
-		),
-		v.maxValue(
-			CHALLENGE_REWARD_POINTS_MAX,
-			`rewardPoints は ${CHALLENGE_REWARD_POINTS_MAX} 以下で指定してください`,
-		),
-	),
+	rewardPoints: challengeRewardPointsSchema,
 	// icon は domain と同一 oracle (isValidChallengeIcon、1〜2 grapheme) で判定 (#3151 slice4)。
-	// 旧 maxLength(20) (UTF-16 units 基準) は domain 側 (無制限) と非対称で、ZWJ 連結絵文字 2 個
-	// (22 units) を弾き / 絵文字 3 個以上を受理していた。isValidChallengeIcon 共有で表現方式ごと統一。
-	icon: v.pipe(
-		v.string('icon は文字列で指定してください'),
-		v.minLength(1, 'icon は必須です'),
-		v.check(isValidChallengeIcon, 'icon は 1〜2 個の絵文字で指定してください'),
-	),
+	// 旧 maxLength(20) (UTF-16 units 基準) は ZWJ 連結絵文字 2 個 (22 units) を弾き domain⊆wire を破っていた。
+	icon: challengeIconSchema,
 });
 
 export const ChallengeSetPayloadSchema = v.object({

--- a/src/lib/marketplace/schemas/checklist-schema.ts
+++ b/src/lib/marketplace/schemas/checklist-schema.ts
@@ -3,45 +3,36 @@
  *
  * Issue #2364 (EPIC #2362 P1): MarketplacePayloadMap 5 type schema SSOT.
  * Issue #3151 slice3 (ADR-0066): 値域 literal の直書きを禁止し、domain 層の値域 SSOT 定数
- * (`$lib/domain/validation/checklist.ts`) を参照する。domain Zod (checklistItemSchema) と
- * 本 wire schema の値域一致 (domain⊆wire) は tests/unit/architecture/schema-range-ssot.test.ts
- * が boundary probe で機械表明する。
+ * (`$lib/domain/validation/checklist.ts`) を参照する。
+ * Issue #3852 Phase B-2 (EPIC #3151 選択肢 B): 値域「定数」だけでなく field「schema 構造」も domain 層
+ * (`$lib/domain/validation/checklist.ts`) の field pipe を import して組み立てる。これにより
+ * 旧来 domain / wire で 2 回宣言していた label/icon/order の shape が単一定義になり、境界値の再ドリフト
+ * (#3132 class) が構造的に不可能になる (activity Phase B-1 / #3860 と同型)。domain Valibot
+ * (checklistItemSchema) と本 wire schema の値域一致 (domain⊆wire) は
+ * tests/unit/architecture/schema-range-ssot.test.ts が boundary probe で機械表明する。
  *
  * 既存 SSOT: src/lib/domain/marketplace-item.ts `ChecklistPayload`
  */
 
 import * as v from 'valibot';
 import {
-	CHECKLIST_LABEL_MAX,
-	CHECKLIST_LABEL_MIN,
-	CHECKLIST_ORDER_MIN,
-	isValidChecklistIcon,
+	checklistIconSchema,
+	checklistLabelSchema,
+	checklistOrderSchema,
 } from '$lib/domain/validation/checklist.js';
 
 /** チェックリストの実施タイミング */
 export const CHECKLIST_TIMINGS = ['morning', 'evening', 'weekend', 'daily', 'weekly'] as const;
 export type ChecklistTiming = (typeof CHECKLIST_TIMINGS)[number];
 
-/** checklist item: 単一の確認項目 (`ChecklistPayload['items'][number]` の rebuild) */
+/** checklist item: 単一の確認項目 (`ChecklistPayload['items'][number]` の rebuild)。
+ * label/icon/order は domain 層 field schema (checklist.ts) の再利用。 */
 export const ChecklistItemSchema = v.object({
-	label: v.pipe(
-		v.string('label は文字列で指定してください'),
-		v.minLength(CHECKLIST_LABEL_MIN, 'label は必須です'),
-		v.maxLength(CHECKLIST_LABEL_MAX, `label は ${CHECKLIST_LABEL_MAX} 文字以内で指定してください`),
-	),
+	label: checklistLabelSchema,
 	// icon は domain と同一 oracle (isValidChecklistIcon、1〜2 grapheme) で判定 (#3151 slice3)。
-	// 旧 maxLength(20) (UTF-16 units 基準) は domain 側 (無制限) と非対称で、ZWJ 連結絵文字 2 個
-	// (22 units) を弾き / 絵文字 3 個以上を受理していた。isValidChecklistIcon 共有で表現方式ごと統一。
-	icon: v.pipe(
-		v.string(),
-		v.minLength(1, 'icon は必須です'),
-		v.check(isValidChecklistIcon, 'icon は 1〜2 個の絵文字で指定してください'),
-	),
-	order: v.pipe(
-		v.number('order は数値で指定してください'),
-		v.integer('order は整数で指定してください'),
-		v.minValue(CHECKLIST_ORDER_MIN, `order は ${CHECKLIST_ORDER_MIN} 以上で指定してください`),
-	),
+	// 旧 maxLength(20) (UTF-16 units 基準) は ZWJ 連結絵文字 2 個 (22 units) を弾き domain⊆wire を破っていた。
+	icon: checklistIconSchema,
+	order: checklistOrderSchema,
 });
 
 export const ChecklistPayloadSchema = v.object({

--- a/src/lib/marketplace/schemas/rule-preset-schema.ts
+++ b/src/lib/marketplace/schemas/rule-preset-schema.ts
@@ -3,67 +3,39 @@
  *
  * Issue #2364 (EPIC #2362 P1): MarketplacePayloadMap 5 type schema SSOT.
  * Issue #3151 slice4 (ADR-0066): 値域 literal の直書きを禁止し、domain 層の値域 SSOT 定数
- * (`$lib/domain/validation/rule-preset.ts`) を参照する。domain Zod (rulePresetItemSchema) と本
- * wire schema の値域一致 (domain⊆wire) は tests/unit/architecture/schema-range-ssot.test.ts が
- * boundary probe で機械表明する。
+ * (`$lib/domain/validation/rule-preset.ts`) を参照する。
+ * Issue #3852 Phase B-2 (EPIC #3151 選択肢 B): 値域「定数」だけでなく field「schema 構造」も domain 層
+ * の field pipe を import して組み立てる。これにより旧来 domain / wire で 2 回宣言していた
+ * title/description/icon/pointCost/pointBonus の shape が単一定義になり、境界値の再ドリフト
+ * (#3132 class) が構造的に不可能になる (activity Phase B-1 / #3860 と同型)。domain Valibot
+ * (rulePresetItemSchema) と本 wire schema の値域一致 (domain⊆wire) は
+ * tests/unit/architecture/schema-range-ssot.test.ts が boundary probe で機械表明する。
  *
  * 既存 SSOT: src/lib/domain/marketplace-item.ts `RulePresetPayload`
  */
 
 import * as v from 'valibot';
 import {
-	isValidRuleIcon,
-	RULE_DESCRIPTION_MAX,
-	RULE_DESCRIPTION_MIN,
-	RULE_POINT_MAX,
-	RULE_POINT_MIN,
-	RULE_TITLE_MAX,
-	RULE_TITLE_MIN,
+	ruleDescriptionSchema,
+	ruleIconSchema,
+	rulePointSchema,
+	ruleTitleSchema,
 } from '$lib/domain/validation/rule-preset.js';
 
 /** ルールタイプ */
 export const RULE_TYPES = ['exchange', 'bonus', 'penalty', 'special'] as const;
 export type RuleType = (typeof RULE_TYPES)[number];
 
-/** rule-preset item: 単一のルール (`RulePresetPayload['rules'][number]` の rebuild) */
+/** rule-preset item: 単一のルール (`RulePresetPayload['rules'][number]` の rebuild)。
+ * title/description/icon/pointCost/pointBonus は domain 層 field schema (rule-preset.ts) の再利用。 */
 export const RulePresetItemSchema = v.object({
-	title: v.pipe(
-		v.string('title は文字列で指定してください'),
-		v.minLength(RULE_TITLE_MIN, 'title は必須です'),
-		v.maxLength(RULE_TITLE_MAX, `title は ${RULE_TITLE_MAX} 文字以内で指定してください`),
-	),
-	description: v.pipe(
-		v.string('description は文字列で指定してください'),
-		v.minLength(RULE_DESCRIPTION_MIN, 'description は必須です'),
-		v.maxLength(
-			RULE_DESCRIPTION_MAX,
-			`description は ${RULE_DESCRIPTION_MAX} 文字以内で指定してください`,
-		),
-	),
+	title: ruleTitleSchema,
+	description: ruleDescriptionSchema,
 	// icon は domain と同一 oracle (isValidRuleIcon、1〜2 grapheme) で判定 (#3151 slice4)。
-	// 旧 maxLength(20) (UTF-16 units 基準) は domain 側 (無制限) と非対称で、ZWJ 連結絵文字 2 個
-	// (22 units) を弾き / 絵文字 3 個以上を受理していた。isValidRuleIcon 共有で表現方式ごと統一。
-	icon: v.pipe(
-		v.string(),
-		v.minLength(1, 'icon は必須です'),
-		v.check(isValidRuleIcon, 'icon は 1〜2 個の絵文字で指定してください'),
-	),
-	pointCost: v.optional(
-		v.pipe(
-			v.number(),
-			v.integer(),
-			v.minValue(RULE_POINT_MIN, `pointCost は ${RULE_POINT_MIN} 以上で指定してください`),
-			v.maxValue(RULE_POINT_MAX, `pointCost は ${RULE_POINT_MAX} 以下で指定してください`),
-		),
-	),
-	pointBonus: v.optional(
-		v.pipe(
-			v.number(),
-			v.integer(),
-			v.minValue(RULE_POINT_MIN, `pointBonus は ${RULE_POINT_MIN} 以上で指定してください`),
-			v.maxValue(RULE_POINT_MAX, `pointBonus は ${RULE_POINT_MAX} 以下で指定してください`),
-		),
-	),
+	// 旧 maxLength(20) (UTF-16 units 基準) は ZWJ 連結絵文字 2 個 (22 units) を弾き domain⊆wire を破っていた。
+	icon: ruleIconSchema,
+	pointCost: v.optional(rulePointSchema),
+	pointBonus: v.optional(rulePointSchema),
 });
 
 export const RulePresetPayloadSchema = v.object({

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import * as v from 'valibot';
 import { getMarketplaceItem } from '$lib/data/marketplace';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { todayDateJST } from '$lib/domain/date-utils';
@@ -9,6 +10,7 @@ import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import type { ChecklistPayload } from '$lib/domain/marketplace-item';
 // #3151 slice3 (ADR-0066): item label / icon の値域 SSOT。admin authoring 経路と wire schema が
 // 同一境界を共有し、authoring 可能な item ⊆ export/import 往復可能な item を成立させる。
+// #3852 Phase B-2: domain schema を Zod → Valibot 化。検証は `v.safeParse(v.pick(...), ...)`。
 import { checklistItemSchema } from '$lib/domain/validation/checklist';
 // #2367 (EPIC #2362 P3): checklist 経路は dispatchImport 経由 (Strangler Fig)
 // #2402 QM must-2: `marketplaceRegistry` 直接参照は dispatchImport API で代替済、import 撤去
@@ -369,11 +371,13 @@ export const actions: Actions = {
 		// #3151 slice3 (ADR-0066): label / icon を domain SSOT で検証し、export/import 往復不能な
 		// item (100 文字超 label / 3 個以上の絵文字 icon) の authoring を default-deny する。
 		// order は追加時に自動採番されるため authoring 検証対象外 (label / icon のみ pick)。
-		const itemCheck = checklistItemSchema
-			.pick({ label: true, icon: true })
-			.safeParse({ label: name, icon });
+		// #3852 Phase B-2: Valibot 化に伴い `.pick(...).safeParse(...)` → `v.safeParse(v.pick(...), ...)`。
+		const itemCheck = v.safeParse(v.pick(checklistItemSchema, ['label', 'icon']), {
+			label: name,
+			icon,
+		});
 		if (!itemCheck.success) {
-			return fail(400, { error: itemCheck.error.issues[0]?.message ?? 'アイテムが不正です' });
+			return fail(400, { error: itemCheck.issues[0]?.message ?? 'アイテムが不正です' });
 		}
 
 		await addTemplateItem({ templateId, name, icon, frequency, direction }, tenantId);

--- a/tests/unit/architecture/schema-range-ssot.test.ts
+++ b/tests/unit/architecture/schema-range-ssot.test.ts
@@ -1,10 +1,12 @@
 // tests/unit/architecture/schema-range-ssot.test.ts
-// #3151 slice1/slice2/slice3/slice4 (ADR-0066): export/import 値域ドリフト根絶の fitness function。
+// #3151 slice1/slice2/slice3/slice4 (ADR-0066) + #3852 Phase B (選択肢 B): export/import 値域
+// ドリフト根絶の fitness function。
 //
-// root class (#3104→#3132 の 2 サイクル連続 blocker): domain validation (Zod) と
-// wire schema (Valibot) が別ファイル・別ライブラリで値域を二重定義し、
-// 「アプリが許容する値域 ⊆ export/import が往復できる値域 (domain⊆wire)」という
-// 不変条件がどこにも機械表明されていなかった。
+// root class (#3104→#3132 の 2 サイクル連続 blocker): domain validation と wire schema が
+// 別ファイルで値域を二重定義し、「アプリが許容する値域 ⊆ export/import が往復できる値域
+// (domain⊆wire)」という不変条件がどこにも機械表明されていなかった。#3852 で domain / wire を
+// 単一 Valibot schema に統合し (5 type 全て domain の field pipe を wire が import)、構造の二重
+// 定義自体を排したうえで、本 fitness が値域境界の一致を behavior-level で表明し続ける。
 //
 // 本テストの表明:
 //   (1) no-silent-gap: marketplace 全 type が「値域 SSOT 適用済 (COVERED)」か
@@ -12,8 +14,9 @@
 //       新 type 追加時に本分類へ登録しなければ CI で fail する (silent skip 禁止、
 //       admin-resource-model-registry の NON_CANONICAL 方式と同型)。slice4 (#3151) で
 //       challenge-set / rule-preset を COVERED 化し RANGE_SSOT_TODO を空にした = 5 type 全 COVERED。
-//   (2) 全 5 type (COVERED): domain Zod (createActivitySchema / grantSpecialRewardSchema /
-//       checklistItemSchema / challengeSetItemSchema / rulePresetItemSchema) と wire Valibot
+//   (2) 全 5 type (COVERED): domain Valibot (createActivitySchema / grantSpecialRewardSchema /
+//       checklistItemSchema / challengeSetItemSchema / rulePresetItemSchema、#3852 で Zod→Valibot 統合済)
+//       と wire Valibot
 //       (ActivityPackItemSchema / RewardSetItemSchema / ChecklistItemSchema / ChallengeSetItemSchema /
 //       RulePresetItemSchema) が値域 SSOT 定数
 //       (`$lib/domain/validation/{activity,special-reward,checklist,challenge-set,rule-preset}.ts`)
@@ -179,7 +182,7 @@ const checklistItem = (over: Record<string, unknown> = {}) => ({
 	...over,
 });
 
-const checklistDomainOk = (data: unknown) => checklistItemSchema.safeParse(data).success;
+const checklistDomainOk = (data: unknown) => v.safeParse(checklistItemSchema, data).success;
 const checklistWireOk = (data: unknown) => v.safeParse(ChecklistItemSchema, data).success;
 
 /** checklist の domain / wire 両 schema が同一 field 値で受理/拒否一致することを表明する */
@@ -195,8 +198,9 @@ function expectBothChecklist(field: string, value: unknown, expected: boolean) {
 // ── (2d) challenge-set boundary probe 用の valid base item ──────────
 // domain (challengeSetItemSchema) と wire (ChallengeSetItemSchema) の共通 shape。base に categoryId
 // を含めるのは wire 側 picklist が必須のため。domain schema は categoryId (意味的カテゴリ enum、
-// 値域ではない) を対象外とし Zod default で無視する。SSOT 化前は domain 側 validator が存在せず、
-// wire icon が maxLength(20) (UTF-16 units) で domain の grapheme 意図と非対称だった。
+// 値域ではない) を対象外とし、v.object の未知 entry 無視で受理する (#3852 で Zod→Valibot 統合後も
+// 同挙動)。SSOT 化前は domain 側 validator が存在せず、wire icon が maxLength(20) (UTF-16 units) で
+// domain の grapheme 意図と非対称だった。
 
 const challengeItem = (over: Record<string, unknown> = {}) => ({
 	title: 'ひなまつりチャレンジ',
@@ -210,7 +214,7 @@ const challengeItem = (over: Record<string, unknown> = {}) => ({
 	...over,
 });
 
-const challengeDomainOk = (data: unknown) => challengeSetItemSchema.safeParse(data).success;
+const challengeDomainOk = (data: unknown) => v.safeParse(challengeSetItemSchema, data).success;
 const challengeWireOk = (data: unknown) => v.safeParse(ChallengeSetItemSchema, data).success;
 
 /** challenge の domain / wire 両 schema が同一 field 値で受理/拒否一致することを表明する */
@@ -236,7 +240,7 @@ const ruleItem = (over: Record<string, unknown> = {}) => ({
 	...over,
 });
 
-const ruleDomainOk = (data: unknown) => rulePresetItemSchema.safeParse(data).success;
+const ruleDomainOk = (data: unknown) => v.safeParse(rulePresetItemSchema, data).success;
 const ruleWireOk = (data: unknown) => v.safeParse(RulePresetItemSchema, data).success;
 
 /** rule の domain / wire 両 schema が同一 field 値で受理/拒否一致することを表明する */


### PR DESCRIPTION
## 顧客価値・目的

export/import (バックアップ / みんなのテンプレート取込) の「アプリが許容する値域 ⊆ 往復できる値域 (domain⊆wire)」不変条件を、marketplace 全 5 type で **構造レベル**まで機械保証する。#3104→#3132 の 2 サイクル連続 round-trip blocker の root class は「domain validation (Zod) と wire schema (Valibot) が別ファイル・別ライブラリで値域と shape を二重定義」していたこと。本 PR は残 3 type (checklist / challenge-set / rule-preset) の domain Zod を単一 Valibot schema に統合し、**marketplace 5 type 全ての domain validation から Zod を根絶 = EPIC #3151 選択肢 B の完成**。これにより値域ドリフト由来のデータ移管事故 (#3080 家族データ backup/restore) を構造的に不可能化する。

## 関連 Issue

- #3852 (Phase B-2、選択肢B完成) — 本 PR で `Closes`
- #3151 (tracking) — 本 PR は EPIC の schema-as-SSOT 統合 AC (選択肢 B) を全 5 type で完成させる。property / Content-Disposition filename* / canary snapshot AC は PR #3849 で code-merged 済 (issue #3847 は open のまま)、#3859 (legacy SQLite 値フォーマット網羅監査) も open。親 EPIC の close は sub-issue 解消後に owner が実施する判断とし、本 PR では `Closes` しない (工程 phase: 子 open 中の親 close 回避)
- 前段: #3853 (Phase B-0 special-reward、merged) / #3860 (Phase B-1 activity、merged)

## AC 検証マップ (ADR-0004)

本 PR の対象 = #3852 (Phase B-2) の AC。加えて EPIC #3151 の該当 AC 到達状況を明記する。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| #3852-1 | checklist / challenge-set / rule-preset の domain Zod を field 単位 Valibot pipe に統合 (値域定数 + 述語は維持) | `rg "from 'zod'"` on 3 domain files | 0 件 (marketplace 5 type validation 全 Zod 非依存) |
| #3852-2 | wire schema が domain の field schema を import して組み立てる (構造二重定義の排除) | 3 wire schema の import 差分 + biome | `import { checklist*Schema } / { challenge*Schema } / { rule*Schema }` に置換、inline pipe 撤去 |
| #3852-3 | active consumer (checklist admin authoring) の Valibot 移行 | `+page.server.ts` addItem 差分 + `admin-checklists-create-template.test.ts` | `v.safeParse(v.pick(...), x)` に移行、route test 3 件 green |
| #3852-4 | fitness probe の 3 type oracle を Valibot 化、5 type 全 COVERED + 残 type 分類リスト空維持 | `schema-range-ssot.test.ts` | `v.safeParse(schema, x)` 化、fitness suite green |
| #3852-5 | 既存 test (import/copy/round-trip/property #3847) 全 green | vitest 局所 + 広域 | 下記「テスト」参照、2893 tests green |
| #3151 (schema-as-SSOT 統合) | 5 type で domain / wire を単一 Valibot schema に統合、値域定数 1 箇所参照 | 本 PR (B-2) で完成 (B-0/B-1 と合流) | ✅ marketplace 5 type 全て domain field pipe を wire が import |
| #3151 (値域ドリフト lint / CI gate) | 新規ドリフト 1 件で fail する CI gate | ADR-0066 §決定 = fitness function 採用 (`schema-range-ssot.test.ts`、T1 gate) | ✅ 選択肢 C の fitness (behavior-level、literal lint より強) |
| #3151 (property / Content-Disposition / canary) | fast-check round-trip / RFC5987 filename* / snapshot canary | PR #3849 (#3847) merged | ✅ code-merged (issue #3847 open のまま = #3151 tracking 継続) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`) — checklist admin `+page.server.ts` addItem の validation 呼び出しのみ
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`) — validation 3 file の Zod→Valibot 統合
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

その他: `src/lib/marketplace/schemas/` 3 wire schema (domain field schema import 化) / `tests/unit/architecture/schema-range-ssot.test.ts` (fitness oracle)。churn = 8 files / +277 / -207 (≤25 file のため type 分割せず 1 PR)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready` 相当を個別実行**: biome (`--error-on-warnings src tests` exit 0) / svelte-check (`--threshold error` = 0 errors) / cspell (0 issues) / vitest 局所+広域 green
- [x] 追加・変更したテストの概要:
  - `schema-range-ssot.test.ts` fitness: 3 type domain oracle を `v.safeParse` に移行。5 type 全 COVERED boundary probe green (残 type 分類リスト空維持)
  - 既存 vitest 広域 (services + marketplace + architecture + routes): **193 files / 2893 tests 全 green** (exit 0)
  - 局所: fitness+marketplace 320 / round-trip+property #3847 64 / import service (challenge-set 21 + rule/checklist/challenge 50) / checklist route 3 = 全 green
  - 新規 test 追加なし (既存 test が oracle Valibot 化後も観測契約不変を lock、pure refactor)
- [x] **新規 env / secret 追加時**: N/A
- [x] **Critical バグ修正の場合**: N/A (refactor、priority:critical 非該当)

## スクリーンショット / ビジュアルデモ

N/A — schema / validation 層の内部リファクタで UI 描画・DOM に一切変更なし。値域境界 (accept/reject) は field pipe 構造を verbatim 移設したため観測不変、admin checklist の addItem エラー文言も日本語メッセージを維持 (どの test も message 文字列を assert していないことを確認済)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: field schema を domain 層 SSOT に単一定義し wire が import (依存方向 = wire→domain の単方向、DIP 整合)。責務 = domain が値域正準定義 / wire が type 固有 field (categoryId picklist 等) 合成
- [x] **DRY**: 本 PR の主目的が DRY 化そのもの。domain / wire の field shape 二重定義を排除 (`rg` で 3 type の inline pipe 撤去を確認)
- [x] **YAGNI**: B-0/B-1 で確立した field-schema 共有パターンを踏襲、新規抽象なし。rule の pointCost/pointBonus は同一値域のため単一 `rulePointSchema` 共有 (reward-set の rewardPointsSchema と同型)
- [x] **Security（OSS 公開前提）**: 値域 default-deny 境界を維持 (checklist authoring の往復不能データ拒否を保持)。秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A (UI 非変更)
- [x] **パフォーマンス**: N/A (schema 構造のみ、実行時コスト同等)

## 横展開・影響波及チェック

- [x] 本番アプリ + デモ版を同期 — demo は本番ルートを env 起動 (ADR-0048)、schema は共通のため自動同期
- [x] **LP ↔ アプリ双方向整合**: N/A (内部 schema、LP 文言非変更)
- [x] 全年齢モード 5 種に横展開 — N/A (age mode 非依存の schema 層)
- [x] ナビゲーション 3 種に反映 — N/A
- [x] E2E / ユニットシード と チュートリアル を同期 — N/A (seed data / 用語非変更)
- [x] **labels SSOT** (ADR-0009): N/A (validation エラーメッセージのみ、既存文言維持)
- [x] **設計書同期** (ADR-0001): ADR-0066 (値域 SSOT) は本統合が完成形。選択肢 B 方向の完成は ADR-0066 §結果 の残 AC 消化に相当し、追加の設計書更新は不要
- [x] **並行 PR overlap** (#1200): 対象 6 file (validation 3 / schemas 3) + fitness test + checklist page は同時期 open PR と非重複
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- 迷った点: rule-preset の pointCost/pointBonus は元 wire で field 名固有メッセージ (`pointCost は…` / `pointBonus は…`) だったが、同一値域 (RULE_POINT_*) のため単一 `rulePointSchema` を共有し「ポイントは…」の汎用メッセージに統一した (reward-set の `rewardPointsSchema` 共有と同型、accept/reject 境界は完全不変・message を assert する test は 0 件)。field 固有 message 復元が望ましいと判断されれば factory 化で対応可能。
- #3151 の Closes/tracking 判定: 全 8 AC は code-complete (本 PR で選択肢 B 完成 / property・CD・canary は #3849 merged / ADR-0066 accepted / activity drift 是正済 / lint は fitness function 採用) だが、sub-issue #3847 (open) / #3859 (open) が残るため親 EPIC は tracking とし owner の deliberate close に委ねる。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready` 相当 全 Step 相当をローカル確認した** (biome / svelte-check / cspell / vitest、上記「テスト」参照)
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（残課題なし、#3852 の全 AC 実装済）
- [x] Phase 分割した場合: EPIC #3151 の phased 計画 (POC→activity→残3type) に沿う最終 Phase、子 Issue #3852 起票済
- [x] UI 変更時: N/A (UI 非変更)
- [x] 認証画面変更時: N/A (認証画面非変更)
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言: fitness 5 type COVERED probe + round-trip/property #3847 + import service + 2893 tests 全 green、marketplace 5 type Zod 根絶を grep で物理確認済。最終承認は QM 責務、ADR-0022）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)



<!-- QM(V-2): refactor:internal-no-doc-impact 付与。src/routes/(parent)/admin/checklists/+page.server.ts は Zod→Valibot の safeParse/.error.issues→.issues 機械置換のみ (同 pick schema・fail(400)・fallback message アイテムが不正です・field 不変) で観測契約不変を Orchestrator diff 独立検証済。marketplace 5 type domain validator の from zod=0 (選択肢B完成) も確認。ADR-0003 §4 / #1985 exempt 妥当。 -->
