### PR TITLE
fix: #3870 DsqlBackupRole の IAM description を ASCII 化 (本番 deploy rollback 解消 + 全 IAM Role description ASCII fitness)

### DIFF
--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -197,3 +197,11 @@ cron-dispatcher は **CRON_SECRET** または **OPS_SECRET_KEY** 最低 1 本必
 ## CDK Replacement gate の既知良性パターン (ADR-0019 運用)
 
 - `ErrorPagesDeploy/AwsCliLayer` の `may-cause-replacement` は aws-cdk-lib の version bump で BucketDeployment 補助 layer (deploy 時ツーリング) が再生成されるもの。**ユーザー向けリソースの置換ではなく良性** — 検出時は **branch の commit message (body) に** `replacement-approved: <ID>` を記載して承認する (squash message は commit message 由来 — PR body は乗らない) (初出: aws-cdk-lib 2.257→2.258、#2963)。
+
+## IAM Role description は ASCII/Latin-1 のみ (AWS 制約、#3870)
+
+`iam.Role` / `iam.ManagedPolicy` の `description` は AWS IAM 制約により **ASCII / Latin-1 (U+00FF 以下) のみ許容**。日本語 (U+3000 以上) を入れると deploy 時に `InvalidRequest` → `CREATE_FAILED` → **stack rollback** になる (第16回リリースで `DsqlBackupRole` の日本語 description が本番 deploy を rollback させた回帰、staging は backup role 非生成のためすり抜けた)。
+
+- **IAM Role / ManagedPolicy の `description` は英語 ASCII で書く**。日本語で説明したい背景はコード直上の `// コメント` に書く (コメントは synth 対象外なので日本語可)。
+- **`CfnOutput` / CloudWatch `Alarm` (AlarmDescription) / SSM Parameter の `description` は ASCII 制約が無い** ため日本語のままで良い (過剰に ASCII 化しない)。
+- **fitness guard**: `tests/unit/infra/iam-role-description-ascii.test.ts` が全 stack を synth し、全 `AWS::IAM::Role` / `AWS::IAM::ManagedPolicy` の `Description` が `^[\t\n\r\x20-\x7E\xA1-\xFF]*$` にマッチすることを CI で assert する。新 stack を追加したら同 test の対象本数を増やす。

--- a/infra/lib/dsql-stack.ts
+++ b/infra/lib/dsql-stack.ts
@@ -240,7 +240,9 @@ export class DsqlStack extends cdk.Stack {
 			const backupRole = new iam.Role(this, 'DsqlBackupRole', {
 				roleName: `ganbari-quest-dsql${nameSuffix}-backup-role`,
 				assumedBy: new iam.ServicePrincipal('backup.amazonaws.com'),
-				description: 'AWS Backup が DSQL cluster の backup / restore を実行する role (#3437)',
+				// NOTE: IAM Role description は AWS 制約により ASCII/Latin-1 (U+00FF 以下) のみ許容。
+				// 日本語を入れると deploy 時 InvalidRequest → CREATE_FAILED → stack rollback になる (#3870)。
+				description: 'AWS Backup role for DSQL cluster backup / restore (#3437)',
 				managedPolicies: [
 					iam.ManagedPolicy.fromAwsManagedPolicyName(
 						'service-role/AWSBackupServiceRolePolicyForBackup',

--- a/tests/unit/infra/iam-role-description-ascii.test.ts
+++ b/tests/unit/infra/iam-role-description-ascii.test.ts
@@ -1,0 +1,208 @@
+// tests/unit/infra/iam-role-description-ascii.test.ts
+// #3870 — 全 stack の AWS::IAM::Role の Description は AWS IAM 制約 (ASCII / Latin-1、U+00FF 以下)
+// のみ許容されるため、日本語等の U+0100 以上を含めると deploy 時に InvalidRequest → CREATE_FAILED
+// → stack rollback になる (第16回リリースで DsqlBackupRole の日本語 description が本番 deploy を
+// rollback させた回帰。CfnOutput / Alarm / SSM description には ASCII 制約が無く、IAM Role /
+// ManagedPolicy の description のみが対象)。
+//
+// AWS IAM description の許容文字集合 (AWS 公式 regex 相当):
+//   - tab (U+0009) / line feed (U+000A) / carriage return (U+000D)
+//   - printable ASCII (U+0020-U+007E)
+//   - Latin-1 Supplement の印字可能文字 (U+00A1-U+00FF)
+// 日本語 (U+3000 以上) はこの集合外なので必ず fail する。
+//
+// このテストは fitness function (Architecture Fitness Function、ADR-0061 same-class→guard) として、
+// DSQL に限らず**全 stack の全 IAM Role** を対象にし、将来どの stack で IAM Role/ManagedPolicy に
+// 日本語 description を書いても CI で落ちるようにする (本番 deploy 前の synth-time 捕捉)。
+//
+// 参考: infra/lib/dsql-stack.ts (DsqlBackupRole) / infra/CLAUDE.md §IAM description ASCII 制約 /
+//        docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { describe, expect, it } from 'vitest';
+import { AuthStack } from '../../../infra/lib/auth-stack';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { DsqlStack } from '../../../infra/lib/dsql-stack';
+import { STAGING_ENV_CONFIG } from '../../../infra/lib/env-config';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { OpsStack } from '../../../infra/lib/ops-stack';
+import { SesStack } from '../../../infra/lib/ses-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+// AWS IAM description 許容文字集合 (U+00FF 以下、AWS 公式制約相当)。
+const IAM_DESCRIPTION_ALLOWED = /^[\t\n\r\x20-\x7E\xA1-\xFF]*$/;
+
+// cspell:ignore hostedzone TESTPOOL
+function makeApp(): cdk.App {
+	return new cdk.App({
+		context: {
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+		},
+	});
+}
+
+/**
+ * bin/app.ts が instantiate し得る全 stack (prod 6 stack + Dsql + Dsql staging + AWS staging 3 stack)
+ * の Template を [stack 名, Template] のペアで返す。IAM Role の網羅性を最大化するため、context gate
+ * を要する stack も明示 instantiate する。
+ */
+function buildAllTemplates(): Array<[string, Template]> {
+	const templates: Array<[string, Template]> = [];
+
+	// --- prod 6 stack ---
+	const app = makeApp();
+	const storage = new StorageStack(app, 'GanbariQuestStorage', { env });
+	const auth = new AuthStack(app, 'GanbariQuestAuth', {
+		env,
+		appDomain: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+	});
+	const compute = new ComputeStack(app, 'GanbariQuestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'GanbariQuestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+	});
+	const ses = new SesStack(app, 'GanbariQuestSes', { env, domainName: 'ganbari-quest.com' });
+	const ops = new OpsStack(app, 'GanbariQuestOps', {
+		env,
+		lambdaFn: compute.fn,
+		distribution: network.distribution,
+		functionUrl: compute.functionUrl,
+		cronDispatcherFn: compute.cronDispatcherFn,
+		staticAssetsBucket: network.staticAssetsBucket,
+		opsEmail: 'ops@example.com',
+	});
+	for (const [name, stack] of [
+		['GanbariQuestStorage', storage],
+		['GanbariQuestAuth', auth],
+		['GanbariQuestCompute', compute],
+		['GanbariQuestNetwork', network],
+		['GanbariQuestSes', ses],
+		['GanbariQuestOps', ops],
+	] as const) {
+		templates.push([name, Template.fromStack(stack)]);
+	}
+
+	// --- DSQL prod (backup role を含む唯一の stack) + DSQL staging ---
+	// Template.fromStack は app 全体を synth するため、同一 app に synth 後 stack を足すと
+	// ConstructTreeModifiedAfterSynth になる。DSQL 2 stack は別 app に分離する。
+	templates.push([
+		'GanbariQuestDsql',
+		Template.fromStack(
+			new DsqlStack(makeApp(), 'GanbariQuestDsql', { env, opsEmail: 'ops@example.com' }),
+		),
+	]);
+	templates.push([
+		'GanbariQuestDsqlStaging',
+		Template.fromStack(
+			new DsqlStack(makeApp(), 'GanbariQuestDsqlStaging', { env, deletionProtection: false }),
+		),
+	]);
+
+	// --- AWS staging 3 stack (#2873) ---
+	const stagingApp = makeApp();
+	const stStorage = new StorageStack(stagingApp, 'GanbariQuestStorageStaging', {
+		env,
+		envConfig: STAGING_ENV_CONFIG,
+	});
+	const stAuth = new AuthStack(stagingApp, 'GanbariQuestAuthStaging', {
+		env,
+		envConfig: STAGING_ENV_CONFIG,
+	});
+	const stCompute = new ComputeStack(stagingApp, 'GanbariQuestComputeStaging', {
+		env,
+		assetsBucket: stStorage.assetsBucket,
+		repository: stStorage.repository,
+		envConfig: STAGING_ENV_CONFIG,
+	});
+	for (const [name, stack] of [
+		['GanbariQuestStorageStaging', stStorage],
+		['GanbariQuestAuthStaging', stAuth],
+		['GanbariQuestComputeStaging', stCompute],
+	] as const) {
+		templates.push([name, Template.fromStack(stack)]);
+	}
+
+	return templates;
+}
+
+describe('全 stack の IAM Role description は AWS IAM 制約 (ASCII/Latin-1) 準拠 (#3870)', () => {
+	const templates = buildAllTemplates();
+
+	it('[G1] instantiate 対象 stack を漏れなく synth できる (網羅性の担保)', () => {
+		// stack を追加したら本数を増やす。silent に synth 対象が減っていないことの guard。
+		expect(templates.length).toBe(11);
+	});
+
+	it('[G2] 全 stack の AWS::IAM::Role の Description が U+00FF 以下のみで構成される', () => {
+		const violations: string[] = [];
+		let inspectedRoleCount = 0;
+		let describedRoleCount = 0;
+
+		for (const [stackName, template] of templates) {
+			const roles = template.findResources('AWS::IAM::Role');
+			for (const [logicalId, role] of Object.entries(roles)) {
+				inspectedRoleCount += 1;
+				const description = role.Properties?.Description as string | undefined;
+				if (typeof description !== 'string') continue;
+				describedRoleCount += 1;
+				if (!IAM_DESCRIPTION_ALLOWED.test(description)) {
+					const offending = [...description].filter((ch) => !IAM_DESCRIPTION_ALLOWED.test(ch));
+					violations.push(
+						`${stackName}/${logicalId}: 非 ASCII/Latin-1 文字 [${offending.join('')}] を含む Description="${description}"`,
+					);
+				}
+			}
+		}
+
+		// synth 対象が空でないこと (テスト自体が空振りしていないことの sanity check)。
+		expect(inspectedRoleCount).toBeGreaterThan(0);
+		expect(describedRoleCount).toBeGreaterThan(0);
+		expect(violations, `IAM Role description に AWS 制約違反:\n${violations.join('\n')}`).toEqual(
+			[],
+		);
+	});
+
+	it('[G3] AWS::IAM::ManagedPolicy の Description も同制約を満たす', () => {
+		const violations: string[] = [];
+		for (const [stackName, template] of templates) {
+			const policies = template.findResources('AWS::IAM::ManagedPolicy');
+			for (const [logicalId, policy] of Object.entries(policies)) {
+				const description = policy.Properties?.Description as string | undefined;
+				if (typeof description !== 'string') continue;
+				if (!IAM_DESCRIPTION_ALLOWED.test(description)) {
+					violations.push(`${stackName}/${logicalId}: Description="${description}"`);
+				}
+			}
+		}
+		expect(
+			violations,
+			`ManagedPolicy description に AWS 制約違反:\n${violations.join('\n')}`,
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（間接的に全ユーザー）

**解決する課題**: 第16回リリース（#3866、main merge `d062222e`）を本番へ deploy した際、`deploy.yml` が DSQL スタックで CREATE_FAILED → rollback し、リリースが本番へ反映できないブロッカーが発生していた。真因は本リリースで新規追加された `infra/lib/dsql-stack.ts` の `DsqlBackupRole`（AWS Backup 用 IAM Role）の `description` に日本語が含まれていたこと。AWS IAM Role の description は ASCII/Latin-1（U+00FF まで）のみ許容のため `InvalidRequest` になる。staging DSQL は捨て構成で backup role を生成しないため `deploy-aws-staging` が緑ですり抜けた（staging coverage gap）。

**期待される効果**: description を英語 ASCII 化することで本番 DSQL スタックの deploy が成功し、第16回リリースが本番へ反映可能になる。加えて全 stack の IAM Role/ManagedPolicy description を synth-time に検査する fitness function を追加し、同種回帰を本番 deploy 前に機械捕捉する。

> 顧客影響ゼロ（本番は旧版 v1.20260716.1 で健全稼働、DSQL は clean な UPDATE_ROLLBACK_COMPLETE）。本 PR は blocker 解消の hotfix。

## 関連 Issue

Closes #3870

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | DsqlBackupRole の IAM description を ASCII 化（意味保存 + `(#3437)` 参照維持、IAM Role のみ対象） | `git diff` / `infra/lib/dsql-stack.ts:245` | HEAD `5b394249` / `description: 'AWS Backup role for DSQL cluster backup / restore (#3437)'`（英語 ASCII、日本語背景は synth 対象外の `// コメント` に退避） |
| AC2 | 同ファイル L269 付近の description の resource type を確認し IAM Role/ManagedPolicy なら ASCII 化・そうでなければ非変更 | `grep -n "new events.Rule\|new cdk.CfnOutput\|new iam" infra/lib/dsql-stack.ts` | HEAD `5b394249` / L269 は `new events.Rule('DsqlBackupJobFailed')`（EventBridge Rule、ASCII 制約なし）→ 非変更。ファイル内 IAM Role は L240 `DsqlBackupRole` の 1 個のみで対象は AC1 の 1 箇所に閉じる |
| AC3 | 全 stack の IAM Role description ASCII fitness test を追加（failing-test-first: 修正前 fail → 修正後 pass） | `npx vitest run tests/unit/infra/iam-role-description-ascii.test.ts` | HEAD `5b394249` / **修正前**（日本語 description）: G2 が `GanbariQuestDsql/DsqlBackupRole…: 非 ASCII/Latin-1 文字 [がのを実行する]` のみ検出して fail（G1/G3 pass）/ **修正後**: 3 passed。全 11 stack（prod 6 + Dsql + DsqlStaging + AWS staging 3）を synth し `AWS::IAM::Role` / `AWS::IAM::ManagedPolicy` の `Description` が `^[\t\n\r\x20-\x7E\xA1-\xFF]$` にマッチを assert |
| AC4 | synth で DsqlBackupRole の Description が ASCII になった証跡 | `cd infra && npx cdk synth GanbariQuestDsql -c dsqlEnabled=true …` | HEAD `5b394249` / synth 出力 L229 `Description: AWS Backup role for DSQL cluster backup / restore (#3437)`（`Type: AWS::IAM::Role` + `Principal: backup.amazonaws.com` ブロック内、ASCII のみ） |
| AC5 | 設計書同期（IAM description ASCII 制約 gotcha + fitness guard の存在を SSOT に追記） | `infra/CLAUDE.md` §「IAM Role description は ASCII/Latin-1 のみ (AWS 制約、#3870)」 | HEAD `5b394249` / infra/CLAUDE.md 末尾に gotcha 節追加（IAM Role/ManagedPolicy は ASCII / CfnOutput・Alarm・SSM は制約なし / fitness test パスを明記） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] インフラ (`infra/`)
- [x] 設定・CI (`package.json`, `.github/` 等) — 該当は `tests/unit/infra/` fitness test + `infra/CLAUDE.md`

**影響を受ける画面・機能**: なし（IAM Role の description 文言のみの変更。IAM Role の権限・assume policy・managed policy・role 名は不変。ユーザー向け画面・API・DB への影響なし）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 下記「Ready チェックリスト」参照
- [x] 追加・変更したテストの概要: `tests/unit/infra/iam-role-description-ascii.test.ts` を新規追加（全 11 stack synth → 全 IAM Role/ManagedPolicy description の U+00FF 以下 assert、failing-test-first 実測済）。`cd infra && npx vitest run tests/unit/infra/` は 9 files / 104 tests passed
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（env / secret 追加なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: 本 hotfix は infra IAM description 修正。E2E 回帰は該当なし（IAM 制約は synth-time fitness で捕捉、CDK は E2E 対象外）/ AC 全項目完了（上記マップ）/ 提案全実装 / **5 年齢モード検証 = N/A（子供 UI 非該当、infra のみ）** / 直近 30 日重複変更チェック = `dsql-stack.ts` は本リリースで新規追加された file であり本 PR が初 hotfix

## スクリーンショット / ビジュアルデモ

**該当なし（infra / CDK の IAM Role description 文言変更のみで UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: fitness test は単一責任（IAM description の ASCII 検査のみ）。stack build helper は既存 test（multi-lambda / staging-cdk）の context stub パターンを踏襲
- [x] **DRY**: 同種の日本語 IAM description が他 stack に無いことを fitness test G2 が全 11 stack 走査で確認済（違反 0 = DsqlBackupRole 修正後）。IAM description ASCII 制約の再発は本 fitness で一元検出
- [x] **YAGNI**: DSQL 1 stack のみでなく全 stack の IAM Role を対象にしたのは、将来どの stack で日本語 IAM description を書いても捕捉する最小限の横断ガード（過剰抽象なし）
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし（test の context 値は明示 dummy）。IAM Role の権限は不変
- [ ] **アクセシビリティ**: N/A（UI 非該当）
- [x] **パフォーマンス**: fitness test は suite 内で各 app を 1 回 synth（既存 infra test と同等コスト）

## 横展開・影響波及チェック

- [x] **設計書同期** (ADR-0001): `infra/CLAUDE.md` に IAM description ASCII 制約の gotcha + fitness guard を追記（インフラ = 13 系 SSOT だが本件は CDK 実装 gotcha のため infra ローカル SSOT に集約）
- [x] **並行 PR overlap** (#1200): `infra/lib/dsql-stack.ts` を同時期に変更する open PR は無し（本リリースで新規追加された file）
- [x] N/A — 子供 UI / LP / labels / 年齢モード / ナビ / デモ版 は影響範囲外

**LP / 販促文言変更時**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**（IAM Role の description 文言のみ。role 名 `ganbari-quest-dsql-backup-role` / assume policy / managed policy は不変のため、既存 backup selection / restore job への影響なし）

**レビュー依頼事項・QA**:
- 本番 deploy の動作確認は **main merge 後に `deploy.yml` が再発火して rerun** し、DSQL スタックの CREATE 成功 + health 再確認は audit / QM 側で担保する（Dev は実 AWS `cdk deploy` 権限を持たないため本 PR では synth-time 検証まで）。
- **staging coverage 深化は別 Issue 推奨**: staging DSQL で backup role を実 deploy 対象にする（今回すり抜けた staging coverage gap を塞ぐ、#3870 対応3）改修は scope 外。本 fitness test（全 stack synth）で当面の再発は機械捕捉できるため、staging 実 deploy 対象化は別 Issue で判断。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（worktree の biome/依存 false-negative #3857 は個別 `npx biome check <files>` + `cd infra && npx vitest run tests/unit/infra/` で担保）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未着手のまま残っている AC がない）
- [x] Phase 分割なし（単一 hotfix）
- [x] UI 変更なし（SS 該当なし）
- [x] 認証画面変更なし
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言: 上記 AC マップ・fitness・synth 証跡で検証完了。本番 deploy 実機 rerun + health は main merge 後の audit/QM 責務）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
