### PR TITLE
test(infra): #3858 cross-stack 自動 export/ImportValue の allowlist ratchet fitness gate

### DIFF
--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -80,6 +80,14 @@ table を参照する経路は無い（health は probePg、analytics は on-dem
 > function として固定する。B-3850a は「Arn 1 本」ではなく「MainTable 由来 export = {Ref, Arn} が過不足なく
 > 存在」を断言し、Arn だけ見て Ref を見逃す #3855 の欠陥を構造的に再発不能化している。
 
+#### 3.1.1 cross-stack export allowlist ratchet（#3858、ADR-0061 shift-left）
+
+自動 cross-stack export（producer 側 `CfnOutput` + Export / consumer 側 `Fn::ImportValue`）は **synth 時に初めて生成されソースに存在しない**ため、撤去時の in-use 削除制約（#3438 → #3850）は develop 軽量レーンをすり抜け release 統合監査（deploy-aws-staging）で初めて露見していた。`tests/unit/infra/cross-stack-export-ratchet.test.ts` が全 stack（prod 6 + staging 3）を `bin/app.ts` と同一に wire して synth し、`findOutputs('*')` の Export 名 + `Fn::ImportValue` を **allowlist と集合一致**で照合する fitness gate を PR 時点（unit-test 層）に前倒し配備する（cdk-nag / ESLint-AST は自動 export を取りこぼすため、synth 後の template 検査層が唯一確実）。
+
+- **baseline（実測 17 = prod 11 + staging 6）**: prod StorageStack 6（MainTable Ref/Arn + AssetsBucket Ref/Arn + ECR AppRepo Ref/Arn）/ prod ComputeStack 4（main・demo Fn FunctionUrl + main・cron-dispatcher Fn Ref）/ prod NetworkStack 1（CloudFront Distribution Ref）/ staging StorageStack 6（prod Storage と同 hash、stack 名 prefix のみ差）。**属性ごとに別 entry**（#3855 = Ref を Arn と別本と認識する構造的再発防止）。
+- **ratchet 運用（一方通行で減らす）**: cross-stack 境界を SSM 疎結合化 / 撤去したら該当 export を allowlist から削除する（= 疎結合の進捗計測器）。**新規自動 export の追加（allowlist 外）は CI fail** で止める。cross-stack 完全禁止は AWS 公式（同一 App の層状参照は正規手段）に反するため意図的残存を allowlist で管理する（`base-token-routes-ratchet` / `check-cdk-replacement` の承認マーカーと同一思想）。
+- **#3854 との紐付け**: MainTable の Ref/Arn export（prod + staging = 4 本）は Deploy-1 の dangling export（どの consumer も import しない）として allowlist に載る。**Deploy-2（#3854）で table + 両 export を撤去したら allowlist の MainTable 4 entry も削除する**。削除し忘れると「stale allowlist 検出」assert が fail するため、撤去と allowlist 更新が構造的に紐づく。
+
 **S3バケット:**
 - アバター画像: `avatars/{tenantId}/{childId}/`
 - バックアップ: `backups/{date}/` （30日で自動削除）

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -26,6 +26,8 @@ SSOT: `docs/CLAUDE.md` §「サブディレクトリ別局所テストコマン�
 
 主要リソース: Lambda (アプリ / cron-dispatcher / cognito custom message / SES) / ECR / Aurora DSQL (DsqlStack) / S3 / Cognito User Pool v2 (`auth.ganbari-quest.com`) / EventBridge cron rules / CloudWatch Logs / Route 53 (`ganbari-quest.com`) / SES (`noreply@ganbari-quest.com`) / SSM / Secrets Manager。DynamoDB `MainTable` は #3438 → #3850 → #3854 の 2-deploy で撤去中 (DB backend は DSQL 一本化)。cross-stack export の in-use 削除制約により、Deploy-1 (#3850、本リリース) では StorageStack が table + **旧 consumer が import する全 export = `exportValue(table.tableName)` (Ref) + `exportValue(table.tableArn)` (Arn) の 2 本**を保持し、consumer(ComputeStack) 側だけ import を落とす (Arn だけの保持は #3855 で Ref 欠落による再 rollback を招いたため不十分)。Deploy-2 (#3854、follow-up) で consumer の import 消失が本番反映された後に table + 両 export を撤去する (詳細: `docs/design/13-AWSサーバレスアーキテクチャ設計書.md §3.1`)。詳細は `infra/lib/*-stack.ts` 参照。
 
+自動 cross-stack export/import の全集合 (実測 17 = prod 11 + staging 6) は `tests/unit/infra/cross-stack-export-ratchet.test.ts` が allowlist ratchet で PR 時点に機械検出する (#3858、ADR-0061 shift-left / §3.1.1)。新規自動 export の混入は CI fail、SSM 疎結合化 / #3854 撤去で allowlist から一方通行に減らす。
+
 CloudFront はグローバル（geoRestriction `JP`）。新規 region 言及は本ファイルを SSOT として `us-east-1`。`tests/unit/e2e-helpers/*` の `ap-northeast-1` 言及はテスト fixture（変更不要）。
 
 ## production env 必須配布 4 経路（#911 / #806）

--- a/tests/unit/infra/cross-stack-export-ratchet.test.ts
+++ b/tests/unit/infra/cross-stack-export-ratchet.test.ts
@@ -47,6 +47,7 @@ import { OpsStack } from '../../../infra/lib/ops-stack';
 import { SesStack } from '../../../infra/lib/ses-stack';
 import { StorageStack } from '../../../infra/lib/storage-stack';
 
+// cspell:ignore TESTPOOL ZTEST
 const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
 const APP_NAME = 'GanbariQuest';
 const DOMAIN = 'ganbari-quest.com';

--- a/tests/unit/infra/cross-stack-export-ratchet.test.ts
+++ b/tests/unit/infra/cross-stack-export-ratchet.test.ts
@@ -1,0 +1,369 @@
+// tests/unit/infra/cross-stack-export-ratchet.test.ts
+// #3858 (ADR-0061 shift-left / same-class→guard): CFN 自動 cross-stack export / ImportValue の
+// allowlist ratchet fitness gate。
+//
+// ## なぜ必要か (root class)
+// 自動 cross-stack export (producing 側 `CfnOutput` + Export + consuming 側 `Fn::ImportValue`) は
+// **synth 時に初めて生成されソースに存在しない**。#3438 で MainTable の自動 export を撤去した際、CFN の
+// 「in-use export は削除・値変更不可」制約に阻まれて本番 deploy が壊れた (第16回リリース blocker #3850)。
+// この class は develop 軽量レーン (unit/E2E) をすり抜け、release 統合監査 (deploy-aws-staging) で初めて
+// 露見した (deploy lane は個別 develop PR では走らない)。自動 export はソースに無いため CDK Aspects /
+// cdk-nag / ESLint-AST / dependency-cruiser では捕捉できず、**synth 後の template 検査層だけが確実に
+// 捕捉できる** (Issue #3858 deep research)。本 test は PR 時点 (unit-test 層) に前倒し検出する。
+//
+// ## 何をするか
+// 1. 全 stack (prod 6 + staging 3) を bin/app.ts と同一に wire して synth する。
+//    自動 export は「consumer stack が同一 App 内に存在して初めて」生成されるため、Storage/Auth/Compute
+//    だけの部分 synth (staging-cdk.test.ts) では Compute→Network / Compute→Ops の export を取りこぼす。
+//    したがって本 test は 6 prod stack を全て wire する (これが #3855 = 「Ref export を見落とす」class の
+//    構造的再発防止 = 全 consumer が import する export の全集合を基準にする、の実装)。
+// 2. 各 template の findOutputs('*') から Export 名を、toJSON() 再帰走査から Fn::ImportValue を全抽出。
+// 3. allowlist と **集合として過不足なく一致** することを assert する (新規 export = allowlist 外 = fail /
+//    allowlist の stale entry = 生成されない = fail)。加えて全 import が allowlist 内 export を指すことを
+//    検証する (dangling import guard)。
+//
+// ## ratchet 運用 (AC3)
+// allowlist は **一方通行で減らす**。cross-stack 境界を SSM 疎結合化 / 撤去したら該当 export を allowlist
+// から削除する (= 疎結合が進んだ進捗計測器)。**増やす方向 (新規自動 export) は CI fail** させて意図しない
+// 密結合の混入を止める。cross-stack 完全禁止は AWS 公式 (同一 App の層状参照は正規手段) に反し非現実的な
+// ため、意図的残存を allowlist で管理する (既存 base-token-routes-ratchet / check-cdk-replacement の
+// 承認マーカーと同一思想)。
+//
+// ## #3850 MainTable export と #3854 の紐付け (AC4)
+// MainTable の Ref/Arn export (prod + staging = 計 4 本) は #3850 Deploy-1 で「consumer(Compute) は
+// import を落としたが producer(Storage) は export を保持する」過渡状態のため allowlist に載る。これらは
+// どの consumer にも import されない **dangling export** (下記 assert で明示検証)。**Deploy-2 (#3854) で
+// StorageStack から table + 両 export を撤去したら、本 allowlist からも MainTable 4 entry を削除する**。
+// 削除し忘れると「stale allowlist 検出」assert が fail するため、撤去と allowlist 更新が構造的に紐づく。
+
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { AuthStack } from '../../../infra/lib/auth-stack';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { STAGING_ENV_CONFIG } from '../../../infra/lib/env-config';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { OpsStack } from '../../../infra/lib/ops-stack';
+import { SesStack } from '../../../infra/lib/ses-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+const APP_NAME = 'GanbariQuest';
+const DOMAIN = 'ganbari-quest.com';
+const CERT_ARN = 'arn:aws:acm:us-east-1:000000000000:certificate/test';
+
+// context stub (multi-lambda-cdk.test.ts / staging-cdk.test.ts 踏襲 + Network の HostedZone.fromLookup 用)
+const CTX: Record<string, unknown> = {
+	'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+		'us-east-1_TESTPOOL',
+	'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+		'test-client-id',
+	'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+		'auth.ganbari-quest.com',
+	'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+		'test-context-token-secret',
+	opsSecretKey: 'test-ops-secret-key',
+	parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+	// #3438 Phase 2A: DSQL 無条件 backend の fail-close 回避 (endpoint / clusterArn 必須)
+	dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+	dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+	'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+		Id: '/hostedzone/ZTEST',
+		Name: 'ganbari-quest.com.',
+	},
+};
+
+/**
+ * allowlist entry。export 名は construct token 由来の hash を含み stack 名で prefix される
+ * (staging-cdk.test.ts で本番 synth 実測一致を確認済)。attr ごとに別 entry (#3855 = Ref を Arn と
+ * 別本と認識する構造的再発防止)。`removeOnDeploy2` = #3854 で撤去する MainTable の dangling export。
+ */
+interface ExportEntry {
+	name: string;
+	producer: string;
+	descriptor: string;
+	removeOnDeploy2?: boolean;
+}
+
+// #3858 実測 baseline (2026-07-18、全 9 stack synth findOutputs 実測)。
+// prod 11 export (Storage 6 / Compute 4 / Network 1) + staging 6 export (StorageStaging 6) = 計 17。
+const AUTO_EXPORT_ALLOWLIST: readonly ExportEntry[] = [
+	// --- prod StorageStack (6) — Compute が assets/repo を import。MainTable Ref/Arn は #3850 dangling ---
+	{
+		name: 'GanbariQuestStorage:ExportsOutputRefMainTable74195DAB4503BD7E',
+		producer: 'GanbariQuestStorage',
+		descriptor: 'MainTable Ref (テーブル名) — #3850 Deploy-1 で保持する dangling export',
+		removeOnDeploy2: true,
+	},
+	{
+		name: 'GanbariQuestStorage:ExportsOutputFnGetAttMainTable74195DABArnE0EC388B',
+		producer: 'GanbariQuestStorage',
+		descriptor: 'MainTable Arn — #3850 Deploy-1 で保持する dangling export',
+		removeOnDeploy2: true,
+	},
+	{
+		name: 'GanbariQuestStorage:ExportsOutputRefAssetsBucket5CB761808BF2E271',
+		producer: 'GanbariQuestStorage',
+		descriptor: 'AssetsBucket Ref (bucket 名) → ComputeStack が import (ASSETS_BUCKET env)',
+	},
+	{
+		name: 'GanbariQuestStorage:ExportsOutputFnGetAttAssetsBucket5CB76180ArnBF60D959',
+		producer: 'GanbariQuestStorage',
+		descriptor: 'AssetsBucket Arn → ComputeStack が grantReadWrite の IAM policy で import',
+	},
+	{
+		name: 'GanbariQuestStorage:ExportsOutputRefAppRepoB478A890A63F2AF1',
+		producer: 'GanbariQuestStorage',
+		descriptor: 'ECR AppRepo Ref → ComputeStack が DockerImageFunction の image で import',
+	},
+	{
+		name: 'GanbariQuestStorage:ExportsOutputFnGetAttAppRepoB478A890ArnD4F6FFCA',
+		producer: 'GanbariQuestStorage',
+		descriptor: 'ECR AppRepo Arn → ComputeStack が pull grant の IAM policy で import',
+	},
+	// --- prod ComputeStack (4) — Network / Ops が Fn URL / Fn Ref を import ---
+	{
+		name: 'GanbariQuestCompute:ExportsOutputFnGetAttSvelteKitFnFunctionUrlB4DF7458FunctionUrl81A12F7D',
+		producer: 'GanbariQuestCompute',
+		descriptor:
+			'main Fn FunctionUrl → NetworkStack (CloudFront origin) + OpsStack (health check) が import',
+	},
+	{
+		name: 'GanbariQuestCompute:ExportsOutputFnGetAttSvelteKitDemoFnFunctionUrl2CF07107FunctionUrlCBC401AD',
+		producer: 'GanbariQuestCompute',
+		descriptor: 'demo Fn FunctionUrl → NetworkStack (demo CloudFront origin) が import',
+	},
+	{
+		name: 'GanbariQuestCompute:ExportsOutputRefSvelteKitFn878D73448615C011',
+		producer: 'GanbariQuestCompute',
+		descriptor: 'main Fn Ref → OpsStack が Errors alarm dimension で import',
+	},
+	{
+		name: 'GanbariQuestCompute:ExportsOutputRefCronDispatcherFn485916360A15CE7E',
+		producer: 'GanbariQuestCompute',
+		descriptor: 'cron-dispatcher Fn Ref → OpsStack が Errors alarm dimension で import',
+	},
+	// --- prod NetworkStack (1) — Ops が CloudFront distribution を import ---
+	{
+		name: 'GanbariQuestNetwork:ExportsOutputRefCDN2330F4C017228780',
+		producer: 'GanbariQuestNetwork',
+		descriptor: 'CloudFront Distribution Ref → OpsStack が 5xx alarm dimension で import',
+	},
+	// --- staging StorageStack (6) — 同 hash / stack 名 prefix のみ prod と異なる ---
+	{
+		name: 'GanbariQuestStorageStaging:ExportsOutputRefMainTable74195DAB4503BD7E',
+		producer: 'GanbariQuestStorageStaging',
+		descriptor: 'staging MainTable Ref — #3850 Deploy-1 dangling export',
+		removeOnDeploy2: true,
+	},
+	{
+		name: 'GanbariQuestStorageStaging:ExportsOutputFnGetAttMainTable74195DABArnE0EC388B',
+		producer: 'GanbariQuestStorageStaging',
+		descriptor: 'staging MainTable Arn — #3850 Deploy-1 dangling export',
+		removeOnDeploy2: true,
+	},
+	{
+		name: 'GanbariQuestStorageStaging:ExportsOutputRefAssetsBucket5CB761808BF2E271',
+		producer: 'GanbariQuestStorageStaging',
+		descriptor: 'staging AssetsBucket Ref → ComputeStaging が import',
+	},
+	{
+		name: 'GanbariQuestStorageStaging:ExportsOutputFnGetAttAssetsBucket5CB76180ArnBF60D959',
+		producer: 'GanbariQuestStorageStaging',
+		descriptor: 'staging AssetsBucket Arn → ComputeStaging が import',
+	},
+	{
+		name: 'GanbariQuestStorageStaging:ExportsOutputRefAppRepoB478A890A63F2AF1',
+		producer: 'GanbariQuestStorageStaging',
+		descriptor: 'staging ECR AppRepo Ref → ComputeStaging が import',
+	},
+	{
+		name: 'GanbariQuestStorageStaging:ExportsOutputFnGetAttAppRepoB478A890ArnD4F6FFCA',
+		producer: 'GanbariQuestStorageStaging',
+		descriptor: 'staging ECR AppRepo Arn → ComputeStaging が import',
+	},
+];
+
+const ALLOWLIST_NAMES: ReadonlySet<string> = new Set(AUTO_EXPORT_ALLOWLIST.map((e) => e.name));
+
+/** template JSON を再帰走査し全 Fn::ImportValue (string 形) を収集する。 */
+function collectImportValues(obj: unknown, acc: Set<string>): void {
+	if (Array.isArray(obj)) {
+		for (const v of obj) collectImportValues(v, acc);
+	} else if (obj && typeof obj === 'object') {
+		for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+			if (k === 'Fn::ImportValue' && typeof v === 'string') acc.add(v);
+			else collectImportValues(v, acc);
+		}
+	}
+}
+
+/** template の findOutputs から Export 名 (Export.Name が literal string のもの) を収集する。 */
+function collectExportNames(template: Template, acc: Set<string>): void {
+	for (const out of Object.values(template.findOutputs('*'))) {
+		const name = (out as { Export?: { Name?: unknown } }).Export?.Name;
+		if (typeof name === 'string') acc.add(name);
+	}
+}
+
+/**
+ * 全 stack を bin/app.ts と同一に wire して synth し、生成 Export 名 / Import 名を集合で返す。
+ * synth (Template.fromStack) は tree を lock するため、全 stack を build し終えてから Template 化する。
+ */
+function synthAllStacks(): { exports: Set<string>; imports: Set<string> } {
+	const app = new cdk.App({ context: CTX });
+
+	// --- prod 6 stack (bin/app.ts と同一 wire) ---
+	const storage = new StorageStack(app, `${APP_NAME}Storage`, { env });
+	new AuthStack(app, `${APP_NAME}Auth`, { env, appDomain: DOMAIN, certificateArn: CERT_ARN });
+	const compute = new ComputeStack(app, `${APP_NAME}Compute`, {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, `${APP_NAME}Network`, {
+		env,
+		functionUrl: compute.functionUrl,
+		domainName: DOMAIN,
+		certificateArn: CERT_ARN,
+		demoFunctionUrl: compute.demoFunctionUrl,
+		demoDomainName: `demo.${DOMAIN}`,
+		demoCertificateArn: CERT_ARN,
+	});
+	new SesStack(app, `${APP_NAME}Ses`, { env, domainName: DOMAIN });
+	new OpsStack(app, `${APP_NAME}Ops`, {
+		env,
+		lambdaFn: compute.fn,
+		distribution: network.distribution,
+		functionUrl: compute.functionUrl,
+		cronDispatcherFn: compute.cronDispatcherFn,
+		staticAssetsBucket: network.staticAssetsBucket,
+	});
+
+	// --- staging 3 stack (bin/app.ts stagingEnabled=true と同一 wire) ---
+	const sStorage = new StorageStack(app, `${APP_NAME}StorageStaging`, {
+		env,
+		envConfig: STAGING_ENV_CONFIG,
+	});
+	new AuthStack(app, `${APP_NAME}AuthStaging`, { env, envConfig: STAGING_ENV_CONFIG });
+	new ComputeStack(app, `${APP_NAME}ComputeStaging`, {
+		env,
+		assetsBucket: sStorage.assetsBucket,
+		repository: sStorage.repository,
+		envConfig: STAGING_ENV_CONFIG,
+	});
+
+	// 全 stack build 完了後に Template 化 (synth は tree を lock するため順序が重要)
+	const stackNames = [
+		`${APP_NAME}Storage`,
+		`${APP_NAME}Auth`,
+		`${APP_NAME}Compute`,
+		`${APP_NAME}Network`,
+		`${APP_NAME}Ses`,
+		`${APP_NAME}Ops`,
+		`${APP_NAME}StorageStaging`,
+		`${APP_NAME}AuthStaging`,
+		`${APP_NAME}ComputeStaging`,
+	];
+	const exports = new Set<string>();
+	const imports = new Set<string>();
+	for (const name of stackNames) {
+		const stack = app.node.tryFindChild(name) as cdk.Stack;
+		const template = Template.fromStack(stack);
+		collectExportNames(template, exports);
+		collectImportValues(template.toJSON(), imports);
+	}
+	return { exports, imports };
+}
+
+let synthResult: { exports: Set<string>; imports: Set<string> };
+
+beforeAll(() => {
+	synthResult = synthAllStacks();
+}, 120_000); // 9 stack synth は重い
+
+describe('#3858 cross-stack 自動 export/ImportValue allowlist ratchet (ADR-0061 shift-left)', () => {
+	it('生成される全 Export が allowlist 内である (新規自動 export = allowlist 外 = fail)', () => {
+		const unexpected = [...synthResult.exports].filter((n) => !ALLOWLIST_NAMES.has(n)).sort();
+		expect(
+			unexpected,
+			`allowlist 外の自動 cross-stack export を検出 (${unexpected.length} 件):\n` +
+				`${unexpected.join('\n')}\n\n` +
+				'これは新規 cross-stack 密結合の混入 (#3438 class = 撤去時に in-use 削除不可で本番 deploy 破壊) ' +
+				'の可能性がある。SSM 疎結合で回避できないか検討し、意図的なら本 test の AUTO_EXPORT_ALLOWLIST に ' +
+				'attr ごとに entry を追加する (hash は synth 実測値を貼る)。',
+		).toEqual([]);
+	});
+
+	it('allowlist に stale entry が無い (生成されない export = SSM 化/撤去済み = allowlist 削除必須)', () => {
+		// #3854 で MainTable export を撤去したら本 assert が fail し、allowlist からの削除を強制する (AC4)。
+		const stale = AUTO_EXPORT_ALLOWLIST.map((e) => e.name)
+			.filter((n) => !synthResult.exports.has(n))
+			.sort();
+		expect(
+			stale,
+			`allowlist にあるが synth で生成されない export (${stale.length} 件):\n${stale.join('\n')}\n\n` +
+				'cross-stack 境界を SSM 疎結合化 / 撤去したら、対応 entry を AUTO_EXPORT_ALLOWLIST から削除する ' +
+				'(ratchet は一方通行で減らす。特に MainTable export は #3854 撤去時に削除)。',
+		).toEqual([]);
+	});
+
+	it('生成 Export と allowlist が集合として過不足なく一致する (計 17 = prod 11 + staging 6)', () => {
+		// 上記 2 assert の統合表明 (数の drift を 1 行で可視化)。実測とズレたら人手承認 (本 test 更新) を要する。
+		expect(synthResult.exports.size).toBe(AUTO_EXPORT_ALLOWLIST.length);
+		expect(new Set(synthResult.exports)).toEqual(ALLOWLIST_NAMES);
+	});
+
+	it('全 Fn::ImportValue が allowlist 内 export を指す (dangling import guard)', () => {
+		// consumer が producer に無い export を import すると deploy が落ちる。手書き importValue の混入も検出。
+		const dangling = [...synthResult.imports].filter((n) => !ALLOWLIST_NAMES.has(n)).sort();
+		expect(
+			dangling,
+			`import 先が allowlist に無い Fn::ImportValue を検出 (${dangling.length} 件):\n${dangling.join('\n')}`,
+		).toEqual([]);
+	});
+
+	it('MainTable の Ref/Arn export は dangling である (#3850 Deploy-1 = どの consumer も import しない)', () => {
+		// #3850: consumer(Compute) は MainTable import を落とし、producer(Storage) だけ export を保持する
+		// 過渡状態。MainTable export がどれかに import されていたら Deploy-1 の前提 (consumer 参照除去) が
+		// 崩れており、#3854 の撤去が永久にできなくなる (in-use export 削除不可)。
+		const mainTableExports = AUTO_EXPORT_ALLOWLIST.filter((e) => e.removeOnDeploy2).map(
+			(e) => e.name,
+		);
+		expect(mainTableExports.length).toBe(4); // prod Ref/Arn + staging Ref/Arn
+		for (const name of mainTableExports) {
+			expect(
+				synthResult.imports.has(name),
+				`MainTable export ${name} が import されている (Deploy-1 前提違反 = #3850 再発リスク)`,
+			).toBe(false);
+		}
+	});
+});
+
+describe('#3858 ratchet が有効に機能する (negative test / failing-test-first、ADR-0061)', () => {
+	it('allowlist 外の新規自動 cross-stack export が現れたら検出される (物理確認)', () => {
+		// 故意に「新規 consumer が既存 producer の未参照属性を import する」= 新規自動 export を発生させ、
+		// ratchet の判定ロジック (exports ⊄ allowlist) が violation を返すことを実 synth で実証する。
+		const app = new cdk.App({ context: CTX });
+		const storage = new StorageStack(app, `${APP_NAME}Storage`, { env });
+		const compute = new ComputeStack(app, `${APP_NAME}Compute`, {
+			env,
+			assetsBucket: storage.assetsBucket,
+			repository: storage.repository,
+		});
+		// 新規 consumer stack が compute.fn.functionArn を参照 → Compute に新しい自動 export
+		// (ExportsOutputFnGetAttSvelteKitFn...Arn...) が生成される (= #3438 と同 class の新規 export)。
+		const probe = new SesStack(app, `${APP_NAME}Probe`, { env });
+		new cdk.CfnOutput(probe, 'ProbeRef', { value: compute.fn.functionArn });
+
+		const exports = new Set<string>();
+		for (const name of [`${APP_NAME}Storage`, `${APP_NAME}Compute`, `${APP_NAME}Probe`]) {
+			collectExportNames(Template.fromStack(app.node.tryFindChild(name) as cdk.Stack), exports);
+		}
+
+		const unexpected = [...exports].filter((n) => !ALLOWLIST_NAMES.has(n));
+		// probe が誘発した新規 export が少なくとも 1 本 allowlist 外として検出される = ratchet に歯がある。
+		expect(unexpected.length).toBeGreaterThan(0);
+		expect(unexpected.some((n) => n.includes('SvelteKitFn') && n.includes('Arn'))).toBe(true);
+	}, 120_000);
+});


### PR DESCRIPTION
## 顧客価値・目的

`#3438` は CFN 自動 cross-stack export を撤去する際「in-use export は削除・値変更不可」制約で本番 deploy を壊した（第16回リリース blocker #3850）。この class は develop 軽量レーン（unit/E2E）をすり抜け、release 統合監査（deploy-aws-staging）で初めて露見する（deploy lane は個別 develop PR では走らない）。本 PR は同 class を **PR 時点（unit-test 層）に機械検出する fitness gate** を導入し、リリースを壊す前に develop で fail させる（ADR-0061 shift-left / same-class→guard）。顧客への直接価値ではなく「リリースを壊さない」インフラ品質基盤の前倒し検出。

## 関連 Issue

Closes #3858

関連: #3850（MainTable export 2-deploy 保持）/ #3854（Deploy-2 撤去、本 gate と紐付く）/ #3855（Arn 単独欠陥で再 rollback した教訓）/ #3438（DynamoDB→DSQL 一本化）/ EPIC #3424。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
| --- | --- | --- | --- |
| AC1 | 全 stack synth の Export / ImportValue を allowlist と照合する fitness test 追加、現 baseline で green | `npx vitest run tests/unit/infra/cross-stack-export-ratchet.test.ts` | 6 tests passed。全 9 stack（prod 6 + staging 3）を bin/app.ts と同一 wire で synth、`findOutputs('*')` + `Fn::ImportValue` を集合照合 |
| AC2 | allowlist 外の新規自動 export を足す変更が CI fail することを実証（negative test） | negative test（probe stack が `compute.fn.functionArn` を参照 → 新規自動 export 誘発）+ 物理確認（allowlist から Network CDN entry を一時削除） | negative test green（新規 export を検出）。物理確認: entry 1 件削除で 3 assertion が fail（`allowlist 外を検出` / `17≠16` / dangling import）→ 復元で 6 tests green |
| AC3 | 「allowlist から要素削除＝SSM 化進捗」の ratchet 運用を doc 化（減る一方、増加は禁止） | 設計書 §3.1.1 + infra/CLAUDE.md 追記 | `docs/design/13-AWSサーバレスアーキテクチャ設計書.md §3.1.1` に一方通行 ratchet 運用を明記、infra/CLAUDE.md にポインタ追記 |
| AC4 | #3850 で保持した MainTable export を allowlist に明示登録し、Deploy-2（#3854）撤去で allowlist から外す旨を紐付け | test 内 `removeOnDeploy2` フラグ + stale-allowlist assert + dangling 検証 | MainTable Ref/Arn（prod+staging 4 本）を `removeOnDeploy2:true` で登録。stale assert が #3854 撤去時の allowlist 削除を構造的に強制、dangling 検証で「どの consumer も import しない」を明示 |

## 変更タイプ

- [ ] 機能追加 (feat)
- [ ] バグ修正 (fix)
- [x] テスト追加 (test)
- [x] インフラ / CI (infra) — 設計書同期のみ（インフラリソース定義は不変）
- [ ] リファクタ (refactor)
- [ ] ドキュメント (docs)

## 影響範囲・変更コンポーネント

- 新規: `tests/unit/infra/cross-stack-export-ratchet.test.ts`（fitness test、prod bundle 影響ゼロ）
- 更新: `docs/design/13-AWSサーバレスアーキテクチャ設計書.md`（§3.1.1 追加）/ `infra/CLAUDE.md`（ポインタ追記）
- **インフラリソース定義（`infra/lib/*-stack.ts`）は一切変更しない** — 本 PR は既存 synth 結果を検査するのみ。既存 `staging-cdk.test.ts`（107 tests）含む全 infra unit test に regression なし

## テスト & 安全装置セルフチェック

- [x] `npx vitest run tests/unit/infra/cross-stack-export-ratchet.test.ts` → 6 tests passed
- [x] `npx vitest run tests/unit/infra/`（regression）→ 9 files / 107 tests passed
- [x] `npx biome check --error-on-warnings <新規ファイル>` → clean
- [x] negative test + 物理確認で ratchet に歯があること実証（allowlist 1 件削除で 3 assertion fail）
- [x] MainTable export の dangling 検証（Deploy-1 前提 = consumer 非参照）を assert 化

## スクリーンショット / ビジュアルデモ

UI 変更なし（infra fitness test + 設計書のみ）。該当なし。

## コード品質セルフレビュー (#1481)

- [x] allowlist は実 synth 実測（17 = prod 11 + staging 6）で pin、属性ごとに別 entry（#3855 の Ref 見落とし class を構造的に再発不能化）
- [x] 判定ロジックは `collectExportNames` / `collectImportValues` の純関数に分離、negative test で再利用
- [x] 部分 synth の取りこぼし（Compute→Network / Compute→Ops）を避けるため 6 prod stack を全 wire、コメントで根拠明記
- [x] 既存 fitness function（`base-token-routes-ratchet` / `check-cdk-replacement`）と同一思想（承認 allowlist ratchet）

## 横展開・影響波及チェック

- [x] cross-stack topology 移行 EPIC（将来）の Phase 3 gate を先行独立実装。EPIC 本体着手前でも landable、以後の全 infra PR に即効
- [x] `staging-cdk.test.ts`（MainTable Ref/Arn 保持の fitness）と補完関係（本 gate = 全 export 集合の網羅照合 / staging-cdk = MainTable 個別断言）
- [x] allowlist が減る = SSM 疎結合が進む進捗計測器を兼ねる

## レビュー依頼事項・破壊的変更

- 破壊的変更なし（インフラリソース定義不変、prod bundle 影響ゼロ）
- レビュー観点: allowlist baseline（17 export）が実 synth と一致し、MainTable 4 本の `removeOnDeploy2` 紐付けが #3854 撤去フローと整合しているか
- aws-cdk-lib version bump で export 名 hash が変わった場合は本 test が fail し人手承認（allowlist 更新）を要する設計（ADR-0019 承認マーカーと同思想、意図的）

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。該当なし。

## Ready for Review チェックリスト

- [x] AC を全て満たし、AC 検証マップに検証手段・結果を記載した
- [x] `npx vitest run tests/unit/infra/` 全 green（107 tests）+ 新規 test green（6 tests）
- [x] biome clean（`--error-on-warnings`）
- [x] 設計書同期完了（§3.1.1 + infra/CLAUDE.md、ADR-0001）
- [x] 禁止語・必須セクション check-pr-body green
- [x] origin/develop に rebase 済み
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言: 全 AC を実測エビデンス付きで達成、negative test + 物理確認で ratchet 有効性を確認済。QM 最終承認・merge は QM 責務）

## QM レビュー結果

（QM が記入）
