### PR TITLE
chore(dev-tooling): #3857 worktree 上で pre-ready を false-negative なく完走可能に (biome ignore anchor + 依存 preflight)

### DIFF
--- a/.claude/agents/dev-session.md
+++ b/.claude/agents/dev-session.md
@@ -27,6 +27,7 @@ Issue の Acceptance Criteria を全て満たし、QA が一発で Approve で�
 ### Git 運用
 
 - **worktree モード推奨**（isolation: "worktree"、`.claude/worktrees/...`）
+- **worktree 着手直後に `npm ci`（+ 必要なら `cd infra && npm ci`）を流す (#3857)** — 隔離 worktree は `node_modules` を持たず、依存欠落のまま pre-ready を回すと Step 2/3 (svelte-check/vitest) が変更無関係の false-negative になり品質ゲートが空振りする。pre-ready は依存欠落時に fail-fast でガイダンス表示（#3857 Fix C）。詳細: [dev-process/parallel-agent-ops.md §1.1](../../docs/sessions/dev-process/parallel-agent-ops.md)
 - **amend 禁止、新規コミットで対応**（CLAUDE.md 全体ルール）
 - **`--no-verify` 禁止**、hooks 失敗時は根本原因を直す（assertion 弱体化禁止 ADR-0006）
 - push は **`--force-with-lease`**（ADR-0026 force push 禁止）

--- a/.cspell.json
+++ b/.cspell.json
@@ -84,6 +84,7 @@
 		"chunker",
 		"datconfig",
 		"datname",
+		"gitdir",
 		"hana",
 		"millis",
 		"multiplexing",
@@ -97,6 +98,7 @@
 		"setrole",
 		"srcs",
 		"tablename",
-		"testcluster"
+		"testcluster",
+		"worktrees"
 	]
 }

--- a/biome.json
+++ b/biome.json
@@ -141,7 +141,7 @@
 			"!**/cdk.out",
 			"!**/storybook-static",
 			"!**/app.css",
-			"!**/.claude",
+			"!.claude",
 			"!**/*.md",
 			"!**/lp-metrics.json",
 			"!**/tmp",

--- a/docs/sessions/dev-process/parallel-agent-ops.md
+++ b/docs/sessions/dev-process/parallel-agent-ops.md
@@ -14,6 +14,19 @@
 - 並列 Agent 数の目安: 3-4（worktree 分離前提）。同一 directory での並列は 1 Agent のみに制限
 - 完了後は worktree が自動 cleanup（変更なし時）または path / branch 名が返却される（変更あり時）
 
+### 1.1 worktree では pre-ready 前に `npm ci` が必要（#3857）
+
+隔離 worktree (`.claude/worktrees/`) は生成時に `node_modules` を持たない（自動 install されない）。依存欠落のまま `npm run pre-ready` を回すと Step 2/3（svelte-check / vitest）が**変更と無関係な**大量 error / spawn 失敗になり、「品質ゲートを通した」証跡が worktree 内で空振りする（#3855 / #3856 の 2 Agent が共に遭遇）。着手直後に依存を揃えること:
+
+```bash
+npm ci                    # 本体依存 (svelte-check / vitest / tsx / biome など)
+cd infra && npm ci        # CDK 単体テスト (cd infra && npx vitest) を回す場合のみ
+```
+
+- **fail-fast ガード**: `npm run pre-ready` は着手前に依存 sentinel を検査し、欠落時は「worktree では先に `npm ci`」の明示ガイダンス付きで exit 1 する（silent に pass しない、ADR-0006 整合 / #3857 Fix C）。
+- **biome の「Checked 0 files」false-negative は根治済み**: `biome.json` の `.claude` ignore を repo 相対 anchor (`!.claude`) 化したため、worktree 絶対パス (`.../.claude/worktrees/...`) を巻き込む誤 ignore は再発しない（#3857 Fix B）。repo root の `.claude`（config / skills / agents）は従来どおり lint 対象外を維持。
+- Agent への prompt に「worktree では着手直後に `npm ci`（+ 必要なら `cd infra && npm ci`）を流す」を明示する。
+
 ---
 
 ## 2. Agent の「push 済」報告は trust but verify

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -300,9 +300,11 @@ function fetchPrBodyAndLabels(prNumber) {
  * 検出:
  *   - worktree 判定: `repoRoot/.git` が「ファイル」(linked worktree の gitdir ポインタ) なら worktree。
  *     通常 clone では `.git` はディレクトリなので false。
- *   - 依存欠落判定: pre-ready 各 step が依存する代表 sentinel の存在確認。root `node_modules` のみ検査する
- *     (infra 単体テストは `cd infra && npx vitest` の別レーンで root vitest scope 外のため sentinel には含めず、
- *      ガイダンス文で `cd infra && npm ci` を併記する)。
+ *   - 依存欠落判定: pre-ready 各 step が依存する代表 sentinel の存在確認。root `node_modules` に加え、
+ *     `infra/node_modules/aws-cdk-lib` も検査する — Step 3 vitest の scope (`tests/unit/**`) には
+ *     `tests/unit/infra/*.test.ts` が含まれ aws-cdk-lib (infra 配下) を要求するため (tests/CLAUDE.md)。
+ *     `npm ci` の prepare が `cd infra && npm ci` を warn-only で実行する構造上、root だけ入って
+ *     infra が欠ける組合せがあり得るので両方を sentinel にする (#3857 で報告された aws-cdk-lib 欠落を捕捉)。
  *
  * pre-ready Step 1/2/3/11 が依存する代表 sentinel。1 つでも欠落したら install 未完了とみなす。
  * (export: tests/unit/scripts/pre-ready-preflight.test.ts が root 差替えで検証する)
@@ -314,6 +316,7 @@ export const PREFLIGHT_SENTINELS = [
 	'node_modules/vitest', // Step 3
 	'node_modules/tsx', // Step 11 (npx tsx check-terminology-coherence.ts)
 	'node_modules/@biomejs/biome', // Step 1
+	'infra/node_modules/aws-cdk-lib', // Step 3 vitest (tests/unit/infra/*.test.ts、tests/CLAUDE.md)
 ];
 
 /**

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -37,7 +37,7 @@
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isAllowedBaseBranch, resolveBaseBranchAuto } from './lib/ci/resolve-base-branch.mjs';
@@ -280,6 +280,56 @@ function fetchPrBodyAndLabels(prNumber) {
 		});
 		child.on('error', () => resolveP(null));
 	});
+}
+
+// ---------------------------------------------------------------------------
+// #3857: worktree 依存 preflight (silent false-negative 防止)
+// ---------------------------------------------------------------------------
+
+/**
+ * 隔離 worktree (`.claude/worktrees/`) では worktree 生成後に `node_modules` が
+ * 自動 install されない。依存欠落のまま pre-ready を回すと Step 2/3 (svelte-check /
+ * vitest) が「変更と無関係な」大量 error / spawn 失敗になり、品質ゲートが空振りする
+ * (#3855 / #3856 の 2 agent が共に遭遇)。これを silent に通さず、着手前に明示ガイダンス付きで
+ * fail-fast する (ADR-0006 no-silent-fail 整合 / #3857 AC1「依存欠落を silent に pass しない」)。
+ *
+ * biome の「Checked 0 files」false-negative は本体側 (biome.json の `.claude` ignore を
+ * repo 相対 `!.claude` に anchor 化) で根治済み (#3857 Fix B)。本 preflight は残る
+ * node_modules 欠落 (Step 2/3 svelte-check/vitest、Step 11 tsx) を対象とする。
+ *
+ * 検出:
+ *   - worktree 判定: `repoRoot/.git` が「ファイル」(linked worktree の gitdir ポインタ) なら worktree。
+ *     通常 clone では `.git` はディレクトリなので false。
+ *   - 依存欠落判定: pre-ready 各 step が依存する代表 sentinel の存在確認。root `node_modules` のみ検査する
+ *     (infra 単体テストは `cd infra && npx vitest` の別レーンで root vitest scope 外のため sentinel には含めず、
+ *      ガイダンス文で `cd infra && npm ci` を併記する)。
+ *
+ * pre-ready Step 1/2/3/11 が依存する代表 sentinel。1 つでも欠落したら install 未完了とみなす。
+ * (export: tests/unit/scripts/pre-ready-preflight.test.ts が root 差替えで検証する)
+ */
+export const PREFLIGHT_SENTINELS = [
+	'node_modules', // 本体
+	'node_modules/.bin', // spawn する CLI 群 (svelte-check / vitest / tsx / biome)
+	'node_modules/svelte-check', // Step 2
+	'node_modules/vitest', // Step 3
+	'node_modules/tsx', // Step 11 (npx tsx check-terminology-coherence.ts)
+	'node_modules/@biomejs/biome', // Step 1
+];
+
+/**
+ * @param {string} [root] 検査対象ルート (既定: repoRoot、test では depsless な temp dir を渡す)
+ * @returns {{ ok: boolean, isWorktree: boolean, missing: string[] }}
+ */
+export function preflightWorktreeDeps(root = repoRoot) {
+	const gitPath = resolve(root, '.git');
+	let isWorktree = false;
+	try {
+		isWorktree = existsSync(gitPath) && statSync(gitPath).isFile();
+	} catch {
+		// stat 失敗時は worktree 判定を false に倒す (guidance の文言差のみに影響)
+	}
+	const missing = PREFLIGHT_SENTINELS.filter((s) => !existsSync(resolve(root, s)));
+	return { ok: missing.length === 0, isWorktree, missing };
 }
 
 // ---------------------------------------------------------------------------
@@ -572,6 +622,29 @@ async function main() {
 	console.log('[pre-ready] Ready for Review 前のローカル一括セルフチェック (Issue #1775)');
 	console.log(`[pre-ready] PR 番号: ${args.pr ?? '(未指定 — Step 9, 12 はスキップ)'}`);
 
+	// #3857: 依存 preflight — 欠落のまま Step 2/3 を回すと変更無関係の false-negative になるため fail-fast
+	const pf = preflightWorktreeDeps();
+	if (!pf.ok) {
+		console.error(
+			`\n[pre-ready] ✗ preflight FAIL — 依存が未 install です (欠落 sentinel: ${pf.missing.join(', ')})`,
+		);
+		if (pf.isWorktree) {
+			console.error(
+				'  隔離 worktree (.claude/worktrees/) では worktree 生成後に node_modules が自動 install されません (#3857)。',
+			);
+		}
+		console.error('  以下を実行してから pre-ready を再実行してください:');
+		console.error('    npm ci');
+		console.error(
+			'    cd infra && npm ci   # CDK 単体テスト (cd infra && npx vitest) を回す場合のみ',
+		);
+		console.error(
+			'  (依存欠落のまま Step 2/3 svelte-check / vitest を実行すると変更と無関係な大量 error / spawn 失敗になり、\n' +
+				'   「pre-ready を回した」証跡が空振りします。ADR-0006 no-silent-fail 整合で着手前に fail-fast します。#3857)',
+		);
+		return 1;
+	}
+
 	// base branch 解決 (#2959 / develop 二層 cutover #2870)
 	let baseBranch = 'main';
 	try {
@@ -644,9 +717,23 @@ async function main() {
 	return 0;
 }
 
-main()
-	.then((code) => process.exit(code))
-	.catch((err) => {
-		console.error('[pre-ready] internal error:', err);
-		process.exit(2);
-	});
+// import 時 (unit test) は main() を走らせない。CLI 直接起動時のみ実行する
+// (パターンは scripts/check-pr-body.mjs と同一)。
+const isMain = (() => {
+	try {
+		const here = resolve(fileURLToPath(import.meta.url));
+		const argv1 = resolve(process.argv[1] || '');
+		return here === argv1;
+	} catch {
+		return false;
+	}
+})();
+
+if (isMain) {
+	main()
+		.then((code) => process.exit(code))
+		.catch((err) => {
+			console.error('[pre-ready] internal error:', err);
+			process.exit(2);
+		});
+}

--- a/tests/unit/scripts/pre-ready-preflight.test.ts
+++ b/tests/unit/scripts/pre-ready-preflight.test.ts
@@ -1,0 +1,116 @@
+/**
+ * tests/unit/scripts/pre-ready-preflight.test.ts (#3857)
+ *
+ * 隔離 worktree (.claude/worktrees/) 上で品質ゲート (pre-ready) が空振りする構造欠落
+ * (#3855 / #3856 の 2 agent が共に遭遇) への恒久対策の回帰ガード。
+ *
+ * 検証対象:
+ *   1. scripts/pre-ready.mjs の preflightWorktreeDeps() — 依存欠落を silent に pass しない
+ *      (Fix C、ADR-0006 no-silent-fail 整合)。
+ *      pre-ready.mjs は plain .mjs (未 JSDoc 型) のため、.ts test から静的 import すると
+ *      svelte-check の型 program に取り込まれ既存の implicit-any を大量に露出する。それを避けつつ
+ *      実関数を検証するため、node 子プロセスの dynamic import 経由で呼び出す (isMain guard により
+ *      import 時に main() は走らない)。
+ *   2. biome.json の `.claude` ignore が repo 相対 anchor (`!.claude`) であり、
+ *      unanchored な glob 版に戻っていないこと (Fix B の回帰ガード)。
+ *      unanchored だと worktree 絶対パス (`.../.claude/worktrees/...`) を巻き込み
+ *      `biome check .` が「Checked 0 files」で false-negative になる (#3857 root cause)。
+ *      具体的な禁止 pattern 文字列はテスト本体の assertion を参照。
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '../../../..');
+const preReadyUrl = pathToFileURL(resolve(repoRoot, 'scripts/pre-ready.mjs')).href;
+
+/**
+ * pre-ready.mjs を子プロセスで dynamic import し、preflightWorktreeDeps(root) の結果と
+ * PREFLIGHT_SENTINELS を JSON で受け取る (静的 import を避け svelte-check の型検査対象に含めない)。
+ */
+function callPreflight(root: string): {
+	result: { ok: boolean; isWorktree: boolean; missing: string[] };
+	sentinels: string[];
+} {
+	const code = `const m = await import(${JSON.stringify(preReadyUrl)});
+process.stdout.write(JSON.stringify({ result: m.preflightWorktreeDeps(${JSON.stringify(root)}), sentinels: m.PREFLIGHT_SENTINELS }));`;
+	const out = execFileSync(process.execPath, ['--input-type=module', '-e', code], {
+		encoding: 'utf8',
+	});
+	return JSON.parse(out);
+}
+
+describe('preflightWorktreeDeps (#3857 Fix C)', () => {
+	let tmp: string;
+
+	beforeEach(() => {
+		tmp = mkdtempSync(join(tmpdir(), 'pre-ready-preflight-'));
+	});
+
+	afterEach(() => {
+		rmSync(tmp, { recursive: true, force: true });
+	});
+
+	it('依存が全欠落なら ok:false + 全 sentinel を missing に列挙する (silent pass しない)', () => {
+		const { result, sentinels } = callPreflight(tmp);
+		expect(result.ok).toBe(false);
+		expect(result.missing).toEqual(sentinels);
+	});
+
+	it('全 sentinel が存在すれば ok:true / missing 空', () => {
+		const { sentinels } = callPreflight(tmp);
+		for (const s of sentinels) {
+			mkdirSync(resolve(tmp, s), { recursive: true });
+		}
+		const { result } = callPreflight(tmp);
+		expect(result.ok).toBe(true);
+		expect(result.missing).toEqual([]);
+	});
+
+	it('sentinel が 1 つでも欠落すれば ok:false (部分 install を install 済とみなさない)', () => {
+		const { sentinels } = callPreflight(tmp);
+		for (const s of sentinels) {
+			mkdirSync(resolve(tmp, s), { recursive: true });
+		}
+		// tsx (Step 11 依存) のみ欠落させる
+		rmSync(resolve(tmp, 'node_modules/tsx'), { recursive: true, force: true });
+		const { result } = callPreflight(tmp);
+		expect(result.ok).toBe(false);
+		expect(result.missing).toContain('node_modules/tsx');
+	});
+
+	it('.git がファイル (linked worktree の gitdir ポインタ) なら isWorktree:true', () => {
+		writeFileSync(resolve(tmp, '.git'), 'gitdir: /some/main/repo/.git/worktrees/x\n');
+		const { result } = callPreflight(tmp);
+		expect(result.isWorktree).toBe(true);
+	});
+
+	it('.git がディレクトリ (通常 clone) なら isWorktree:false', () => {
+		mkdirSync(resolve(tmp, '.git'), { recursive: true });
+		const { result } = callPreflight(tmp);
+		expect(result.isWorktree).toBe(false);
+	});
+
+	it('本リポジトリ root は依存 install 済で ok:true (実環境 sanity)', () => {
+		// node_modules 前提の他 test が動いている = install 済のはずなので ok を確認
+		expect(callPreflight(repoRoot).result.ok).toBe(true);
+	});
+});
+
+describe('biome.json .claude ignore anchor (#3857 Fix B 回帰ガード)', () => {
+	it('files.includes は anchored `!.claude` を使い、unanchored な glob 版に戻っていない', () => {
+		const biomeConfig = JSON.parse(readFileSync(resolve(repoRoot, 'biome.json'), 'utf8'));
+		const includes: string[] = biomeConfig.files?.includes ?? [];
+		expect(includes).toContain('!.claude');
+		// unanchored パターンは worktree 絶対パスを巻き込み「Checked 0 files」を再発させる
+		expect(includes).not.toContain('!**/.claude');
+	});
+
+	it('biome.json が worktree 配下でも存在する (sanity)', () => {
+		expect(existsSync(resolve(repoRoot, 'biome.json'))).toBe(true);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発プロセス基盤 / 全 worktree ベース Agent 運用）

**解決する課題**: マルチセッション競合回避のため隔離 worktree (`.claude/worktrees/`) 作業が標準経路だが、worktree 上では `npm run pre-ready` の複数 step が worktree 固有要因で false-negative / 未完走になり、「品質ゲートを通した」証跡が worktree 内で取得できない（#3855 / #3856 の 2 実装 Agent が共に遭遇）。「隔離 worktree で作業せよ」という運用と「pre-ready 全 step PASS が Ready 条件」というゲートが両立しない構造的欠落。

**期待される効果**: worktree 上でも pre-ready が false-negative なく完走し、品質ゲートが実効性を回復する。今後のマルチセッション標準経路である全 worktree ベース Agent 運用の品質基盤が整う。

## 関連 Issue

closes #3857

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1a | worktree 上で `biome check .` が対象ファイルを正しく検査する（「Checked 0 files」false-negative の根治） | `npx biome check --error-on-warnings .`（worktree 内） | HEAD `6e0627d4` / 修正前=`Checked 0 files ... × No files were processed ... EXIT 1`（false-negative）→ 修正後=`Checked 2010 files ... Found 3 infos ... EXIT 0`。biome.json `!**/.claude` → `!.claude` の anchor 化で解消 |
| AC1b | 依存欠落を silent に pass しない（欠落時 fail-fast + ガイダンス） | preflight FAIL 実測（sentinel `node_modules/tsx` を一時退避して `npm run pre-ready` を起動） | HEAD `6e0627d4` / `✗ preflight FAIL — 依存が未 install です (欠落 sentinel: node_modules/tsx)` + worktree 向け `npm ci` ガイダンス + `PREADY_EXIT=1`。復元後 OK |
| AC1c | repo root の `.claude`（config/skills/agents）は従来どおり lint 対象外を維持（Fix B の intent 保全） | `npx biome check .claude/settings.json`（worktree 内） | HEAD `6e0627d4` / `Checked 0 files ... × No files were processed`（= ignore 維持）。nested `.claude` は tracked tree に存在せず（`git ls-files` で確認）anchor 化は挙動安全 |
| AC2 | (A)/(B)/(C) のどれを採るか deep 検討し PR 本文に根拠を残す | 本 PR body「レビュー依頼事項・破壊的変更」§ の A/B/C 採否論拠 | 本文記載（B=root fix 採用 / C=fail-fast guard 採用 / A=auto-install 不採用 + documented bootstrap 採用） |
| AC3 | dev-session / dev-process の worktree 運用ドキュメントに手順を反映 | `docs/sessions/dev-process/parallel-agent-ops.md` §1.1 + `.claude/agents/dev-session.md` Git 運用 | HEAD `6e0627d4` / parallel-agent-ops.md §1.1「worktree では pre-ready 前に `npm ci`」新設 + agent prelude に 1 行反映 |
| AC-test | 回帰ガード（Fix B anchor / Fix C preflight ロジック）を機械化 | `npx vitest run tests/unit/scripts/pre-ready-preflight.test.ts` | HEAD `6e0627d4` / `Tests 8 passed (8)`。biome.json anchor assertion + preflight ロジック（子プロセス dynamic import 経由） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

（主変更は開発ツール基盤 = infra 相当。docs 同期 + test 追加を伴う。chore(dev-tooling) 系。）

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: UI 画面への影響なし。開発ツール（`biome.json` / `scripts/pre-ready.mjs`）+ 開発プロセス docs + `.cspell.json` + `.claude/agents/dev-session.md`（agent prelude）+ 回帰テスト 1 本。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証（worktree で `npm ci` + `cd infra && npm ci` 済のうえ実行）
- [x] 追加・変更したテストの概要: `tests/unit/scripts/pre-ready-preflight.test.ts` を新規追加（8 ケース = preflight の依存欠落 fail / 全 sentinel present ok / 部分欠落 fail / `.git` file→worktree 判定 / `.git` dir→非 worktree / 実 repo sanity + biome.json anchor 回帰ガード 2 ケース）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（env / secret 追加なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:critical ではない dev-tooling 基盤修正）

## スクリーンショット / ビジュアルデモ

**該当なし（infra / docs / test のみ、UI 変更ゼロ）**。`biome.json` / `scripts/pre-ready.mjs` / docs / test / `.cspell.json` の変更で、レンダリングされる UI に一切影響しない。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: preflight は単一責任（依存 sentinel 検査のみ）。`preflightWorktreeDeps(root)` は root を注入可能にし testability を確保（DI）
- [x] **DRY**: biome の `.claude` ignore は 1 行（SSOT）。preflight sentinel は `PREFLIGHT_SENTINELS` 配列に集約。`isMain` guard は `scripts/check-pr-body.mjs` と同一パターンを踏襲
- [x] **YAGNI**: 自動 `npm ci`（Fix A）は least-surprise の観点で不採用とし、documented bootstrap に留めた（過剰自動化を回避、ADR-0010）
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。preflight は存在確認（`existsSync`）のみで外部入力なし。N/A（境界検証対象なし）
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: preflight は数回の `existsSync` のみ（step 実行前に 1 回）。無視できるコスト

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード と チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): 開発プロセス docs（`docs/sessions/dev-process/parallel-agent-ops.md` §1.1）+ agent prelude（`.claude/agents/dev-session.md`）を同 PR で更新
- [x] **並行 PR overlap** (#1200): `biome.json` / `scripts/pre-ready.mjs` を同時期に変更する open PR は確認範囲になし（dev-tooling 基盤 file）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A（LP / 販促文言の変更なし）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**A/B/C 採否の deep 検討（AC2）**:

- **(B) biome ignore 誤爆の根治 — 採用（root fix、最重要）**: root cause は `biome.json` の `!**/.claude`（unanchored glob）。biome は `.` 引数を worktree の**絶対パス** (`.../.claude/worktrees/agent-.../`) に解決し、その `.claude` 祖先が `**/.claude` に巻き込まれて root 自身が ignore され「Checked 0 files」→ exit 1（false-negative）になっていた（個別ファイル指定は root 相対パスで解決されるため `Checked 1 file` と成功する非対称性で機序を特定）。修正は repo 相対 anchor `!.claude` へ変更。anchor 形は絶対パス祖先を巻き込まず、worktree でも 2010 files を検査する一方、repo root の `.claude`（config/skills/agents）は従来どおり ignore を維持（`.claude/settings.json` = `No files processed` で確認）。これは biome 自身の lint rule `useBiomeIgnoreFolder` の推奨形（v2.2.0 以降 `/**` 不要）でもある。tracked tree に nested `.claude` は存在せず（`git ls-files`）、anchor 化による取りこぼしはない。
- **(C) silent false-negative 防止 — 採用（Step 2/3 の依存欠落を fail-fast）**: `pre-ready` に着手前 preflight を追加。worktree は生成時に `node_modules` を持たず、依存欠落のまま svelte-check / vitest を回すと変更無関係の大量 error になる。依存 sentinel（root `node_modules` の代表 CLI + `infra/node_modules/aws-cdk-lib`。後者は root vitest scope の `tests/unit/infra/*.test.ts` が要求、tests/CLAUDE.md）を検査し、欠落時は worktree 向けガイダンス（`npm ci` / `cd infra && npm ci`）付きで exit 1（ADR-0006 no-silent-fail 整合）。なお biome の 0-files は `--error-on-warnings` で既に exit 1 になるが、Fix B で 0-files 自体を根治したため biome は正常検査に転じる。
- **(A) worktree bootstrap で依存自動 install — 不採用（documented bootstrap を採用）**: `pre-ready` 内で `npm ci` を自動実行する案は、(1) 数分の実行を暗黙に挟み込み least-surprise に反する、(2) node_modules を副作用的に書き換える、(3) `.claude/settings.json` に worktree 生成 hook は存在せず harness 管理の worktree 作成に無用な自動化を足すことになる、ため不採用。代わりに「worktree では着手直後に `npm ci`（+ `cd infra && npm ci`）」を `docs/sessions/dev-process/parallel-agent-ops.md` §1.1 + agent prelude に documented bootstrap として反映し、Fix C の fail-fast ガイダンスと二段で運用を担保した（最小で確実な導線、ADR-0010 整合）。

**レビュー依頼事項**: (1) biome anchor `!.claude` が repo root の意図（config lint 除外）を保ちつつ worktree false-negative を解消している点、(2) preflight を「pre-ready.mjs を svelte-check 型 program に取り込まない」ため子プロセス dynamic import で検証している設計判断（静的 import は未 JSDoc の `.mjs` の既存 implicit-any を大量露出させるため回避）、の 2 点。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了の AC がない）
- [x] Phase 分割: 該当なし（単一 PR で完結）
- [x] UI 変更時: 該当なし（UI 変更ゼロ、SS 対象外）
- [x] 認証画面変更時: 該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
