### PR TITLE
fix(privacy): #3868 退会時に cloudExports の S3 実体を削除 (孤児化した backup ZIP の PII 即時消去)

### DIFF
--- a/docs/design/account-deletion-flow.md
+++ b/docs/design/account-deletion-flow.md
@@ -62,7 +62,8 @@ else                              pattern = 'member';
 | 対象 | 1. owner-only | 2a. transfer | 2b. full-delete | 3. child | 4. member |
 |------|---|---|---|---|---|
 | Stripe Subscription（#741 必須） | ✔ | ✘ | ✔ | ✘ | ✘ |
-| S3 / ストレージ（`tenants/{tenantId}/`） | ✔ | ✘ | ✔ | ✘ | ✘ |
+| S3 / ストレージ（`tenants/{tenantId}/` prefix） | ✔ | ✘ | ✔ | ✘ | ✘ |
+| S3 / クラウドバックアップ実体（`exports/{tenantId}/` prefix、#3868） | ✔ | ✘ | ✔ | ✘ | ✘ |
 | `deleteTenantScopedData` (activities, viewerTokens, cloudExports, pushSubscriptions, voice) | ✔ | ✘ | ✔ | ✘ | ✘ |
 | 子供データ全件 (`deleteAllChildrenData`) | ✔ | ✘ | ✔ | ✘ | ✘ |
 | 全メンバーシップ (`deleteAllMemberships`) | ✔ | ✘ | ✔ | ✘ | ✘ |
@@ -77,6 +78,8 @@ else                              pattern = 'member';
 | Discord 通知（`notifyDeletionComplete`） | ✔ | — | ✔ | — | — |
 
 > **重要**: パターン 3 (`deleteChildAccount`) は子供レコード自体を削除しない（活動履歴・実績は残す）。代わりに `child.userId` を `null` にしてアカウントだけ切り離す。これは「子供がスマホを返した」「再ログインのため UID を作り直したい」等のケースを想定したもの。
+
+> **S3 実体削除は 2 prefix に及ぶ（#3868）**: 「テナントスコープのデータ削除」は DB 行だけでなく S3 上の payload まで含む。① `fullTenantDeletion` / `deleteOwnerFullDelete` が `deleteByPrefix('tenants/{tenantId}/')` でアバター・音声・画像を削除する（§3 シーケンスの「S3 削除」）のに加え、② クラウドバックアップ ZIP は `exports/{tenantId}/{pinCode}/...` という**別 prefix**に置かれるため `tenants/{tenantId}/` の一括削除では消えない。これを `deleteTenantScopedData` の cloudExports 削除ループ内で、DB 行削除の**前**に `storage.deleteByPrefix(exp.s3Key)` を呼んで削除する（個別削除 `cloud-export-service.deleteCloudExport` と同一手段を再利用）。S3 削除失敗は best-effort（`logger.warn` で記録し DB 行削除・account 削除は継続）。これを怠ると退会後も子供の完全 PII を含むバックアップが S3 lifecycle（30 日）失効まで孤児として滞留する。
 
 ---
 

--- a/src/lib/server/services/tenant-cleanup-service.ts
+++ b/src/lib/server/services/tenant-cleanup-service.ts
@@ -149,9 +149,23 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 	}
 
 	// Cloud exports（findByTenant + deleteById 可能）
+	// #3868: DB 行削除の前に S3 実体 (backup ZIP = 子供名・アバター・音声を含む完全 PII) を削除する。
+	// cloudExport の s3Key は `exports/${tenantId}/...` で fullTenantDeletion の
+	// `tenants/${tenantId}/` prefix 一括削除の外側にあるため、ここで明示削除しないと退会後も
+	// S3 lifecycle (30 日) の失効まで孤児として滞留する。個別削除
+	// (cloud-export-service.deleteCloudExport) と同一手段 storage.deleteByPrefix を再利用する。
 	try {
 		const exports = await r.cloudExport.findByTenant(tenantId);
 		for (const exp of exports) {
+			// S3 削除は best-effort: 失敗しても DB 行削除 + account 削除を継続する。
+			// ただし削除漏れを silent にせず warn で記録する (ADR-0006)。
+			try {
+				await r.storage.deleteByPrefix(exp.s3Key);
+			} catch (err) {
+				logger.warn(
+					`[tenant-cleanup] cloudExport S3 実体削除失敗 (DB 行削除は継続) id=${exp.id} s3Key=${exp.s3Key}: ${String(err)}`,
+				);
+			}
 			await r.cloudExport.deleteById(exp.id, tenantId);
 			deleted++;
 		}

--- a/tests/unit/services/tenant-cleanup-service.test.ts
+++ b/tests/unit/services/tenant-cleanup-service.test.ts
@@ -40,6 +40,12 @@ const mockCloudExportRepo = {
 	deleteById: vi.fn().mockResolvedValue(undefined),
 };
 
+// #3868: cloudExport の S3 実体 (backup ZIP = 完全 PII) 削除に使う storage repo mock。
+// 個別削除 (cloud-export-service.deleteCloudExport) と同一の deleteByPrefix を再利用する。
+const mockStorageRepo = {
+	deleteByPrefix: vi.fn().mockResolvedValue(0),
+};
+
 const mockPushSubscriptionRepo = {
 	findByTenant: vi.fn().mockResolvedValue([]),
 	deleteByEndpoint: vi.fn().mockResolvedValue(undefined),
@@ -78,6 +84,7 @@ vi.mock('$lib/server/db/factory', () => ({
 		childActivity: mockChildActivityRepo,
 		viewerToken: mockViewerTokenRepo,
 		cloudExport: mockCloudExportRepo,
+		storage: mockStorageRepo,
 		pushSubscription: mockPushSubscriptionRepo,
 		voice: mockVoiceRepo,
 		settings: mockSettingsRepo,
@@ -119,6 +126,7 @@ vi.mock('./child-service', () => ({
 
 // --- Imports (after mocks) ---
 
+import { logger } from '$lib/server/logger';
 import {
 	deleteAllChildrenData,
 	deleteTenantScopedData,
@@ -294,7 +302,9 @@ describe('deleteTenantScopedData', () => {
 			.mockResolvedValueOnce([{ id: '1001' }, { id: '1002' }])
 			.mockResolvedValueOnce([{ id: '2001' }]);
 		mockViewerTokenRepo.findByTenant.mockResolvedValue([{ id: 'tk1' }]);
-		mockCloudExportRepo.findByTenant.mockResolvedValue([{ id: 'ex1' }]);
+		mockCloudExportRepo.findByTenant.mockResolvedValue([
+			{ id: 'ex1', s3Key: 'exports/test-tenant-739/pin1/backup.zip' },
+		]);
 		mockPushSubscriptionRepo.findByTenant.mockResolvedValue([{ endpoint: 'https://push1' }]);
 
 		await deleteTenantScopedData(TENANT);
@@ -316,6 +326,83 @@ describe('deleteTenantScopedData', () => {
 		expect(mockViewerTokenRepo.deleteById).toHaveBeenCalledWith('tk1', TENANT);
 		expect(mockCloudExportRepo.deleteById).toHaveBeenCalledWith('ex1', TENANT);
 		expect(mockPushSubscriptionRepo.deleteByEndpoint).toHaveBeenCalledWith('https://push1', TENANT);
+	});
+
+	// =========================================================
+	// #3868: cloudExports の S3 実体 (backup ZIP = 完全 PII) を退会時に削除する
+	// =========================================================
+
+	describe('#3868 cloudExports S3 実体削除', () => {
+		it('account 削除後、各 cloudExport の S3 実体を deleteByPrefix で削除し DB 行も 0 にする', async () => {
+			mockCloudExportRepo.findByTenant.mockResolvedValue([
+				{ id: 'ex1', s3Key: `exports/${TENANT}/pin1/backup.zip` },
+				{ id: 'ex2', s3Key: `exports/${TENANT}/pin2/backup.zip` },
+			]);
+
+			await deleteTenantScopedData(TENANT);
+
+			// AC1: S3 実体を各 record の s3Key で削除 (個別削除と同一手段 deleteByPrefix を再利用)
+			expect(mockStorageRepo.deleteByPrefix).toHaveBeenCalledTimes(2);
+			expect(mockStorageRepo.deleteByPrefix).toHaveBeenCalledWith(
+				`exports/${TENANT}/pin1/backup.zip`,
+			);
+			expect(mockStorageRepo.deleteByPrefix).toHaveBeenCalledWith(
+				`exports/${TENANT}/pin2/backup.zip`,
+			);
+			// AC3: DB 行も 0 件になる (退会後 cloudExports の DB 行 0 + 対応 S3 object 0)
+			expect(mockCloudExportRepo.deleteById).toHaveBeenCalledTimes(2);
+			expect(mockCloudExportRepo.deleteById).toHaveBeenCalledWith('ex1', TENANT);
+			expect(mockCloudExportRepo.deleteById).toHaveBeenCalledWith('ex2', TENANT);
+		});
+
+		it('AC1: S3 削除は DB 行削除より先に実行される (孤児化を防ぐ順序)', async () => {
+			const callOrder: string[] = [];
+			mockCloudExportRepo.findByTenant.mockResolvedValue([
+				{ id: 'ex1', s3Key: `exports/${TENANT}/pin1/backup.zip` },
+			]);
+			mockStorageRepo.deleteByPrefix.mockImplementationOnce(async () => {
+				callOrder.push('s3');
+				return 1;
+			});
+			mockCloudExportRepo.deleteById.mockImplementationOnce(async () => {
+				callOrder.push('db');
+			});
+
+			await deleteTenantScopedData(TENANT);
+
+			expect(callOrder).toEqual(['s3', 'db']);
+		});
+
+		it('AC2: S3 削除が失敗しても DB 行削除は継続する (best-effort)', async () => {
+			mockCloudExportRepo.findByTenant.mockResolvedValue([
+				{ id: 'ex1', s3Key: `exports/${TENANT}/pin1/backup.zip` },
+				{ id: 'ex2', s3Key: `exports/${TENANT}/pin2/backup.zip` },
+			]);
+			// 1 件目の S3 削除を失敗させる
+			mockStorageRepo.deleteByPrefix
+				.mockRejectedValueOnce(new Error('s3 err'))
+				.mockResolvedValueOnce(1);
+
+			await deleteTenantScopedData(TENANT);
+
+			// S3 削除失敗しても両 record の DB 行削除は実行される
+			expect(mockCloudExportRepo.deleteById).toHaveBeenCalledTimes(2);
+			expect(mockCloudExportRepo.deleteById).toHaveBeenCalledWith('ex1', TENANT);
+			expect(mockCloudExportRepo.deleteById).toHaveBeenCalledWith('ex2', TENANT);
+		});
+
+		it('AC2: S3 削除失敗を silent にせず logger.warn で記録する (ADR-0006)', async () => {
+			mockCloudExportRepo.findByTenant.mockResolvedValue([
+				{ id: 'ex1', s3Key: `exports/${TENANT}/pin1/backup.zip` },
+			]);
+			mockStorageRepo.deleteByPrefix.mockRejectedValueOnce(new Error('s3 err'));
+
+			await deleteTenantScopedData(TENANT);
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('cloudExport S3 実体削除失敗'),
+			);
+		});
 	});
 
 	it('1 つの repo の削除失敗は他の削除をブロックしない', async () => {


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / システム全体（privacy / data retention）

**解決する課題**: 退会（アカウント削除）時に、クラウドバックアップ（cloud export）の DB 行は削除されるものの、S3 上のバックアップ ZIP 実体（`s3Key`）が明示削除されず孤児化していた。バックアップ ZIP は子供の名前・アバター画像・音声を含む完全 PII のため、退会後も S3 lifecycle（30 日）失効まで S3 に滞留する privacy gap があった。

**期待される効果**: 退会時に cloudExports の S3 実体を即時削除し、「削除したはずのユーザの PII が最大 30 日 S3 に残る」状態を根絶する。GDPR 等の「アカウント削除時は速やかに個人データを消去」原則に整合し、account-deletion の不変条件（テナントスコープのデータ削除）を payload（S3）まで及ばせる。

## 関連 Issue

closes #3868

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | cloudExports 削除ループで DB 行削除の前に S3 実体を削除（`storage.deleteByPrefix(exp.s3Key)`）、既存手段を再利用 | `grep -n "storage.deleteByPrefix" src/lib/server/services/tenant-cleanup-service.ts` + 順序 assert test | HEAD `2364a940` / tenant-cleanup-service.ts:159 に `await r.storage.deleteByPrefix(exp.s3Key)` を deleteById の前に配置 / `AC1: S3 削除は DB 行削除より先に実行される` test で `callOrder` = `['s3','db']` を assert（tenant-cleanup-service.test.ts:344-361）|
| AC2 | S3 削除失敗でも DB 行削除 + account 削除は継続（best-effort）、失敗を silent にせず logger.warn で記録 | `npx vitest run tests/unit/services/tenant-cleanup-service.test.ts` | HEAD `2364a940` / 18 passed / `AC2: S3 削除が失敗しても DB 行削除は継続する` + `AC2: S3 削除失敗を silent にせず logger.warn で記録する` の 2 test PASS（内側 try/catch + `logger.warn('...cloudExport S3 実体削除失敗...')`、tenant-cleanup-service.ts:161-165）|
| AC3 | account 削除後に cloudExports DB 行 0 + 対応 S3 object 0 を検証する test を追加（deleteByPrefix 呼出 assert、failing-test-first） | `npx vitest run tests/unit/services/tenant-cleanup-service.test.ts` | HEAD `2364a940` / 修正前: 3 test fail（S3 削除未呼出）→ 修正後: 18 passed。`#3868 cloudExports S3 実体削除` describe に 4 test 追加（deleteByPrefix 2 回 + deleteById 2 回 assert、tenant-cleanup-service.test.ts:306-399）|
| AC4 | `account-deletion-flow.md` に cloudExports の S3 実体削除を追記、テナントスコープ削除が payload まで含むことを明文化 | `grep -n "#3868" docs/design/account-deletion-flow.md` | HEAD `2364a940` / §2 マトリクスに「S3 / クラウドバックアップ実体（`exports/{tenantId}/` prefix、#3868）」行追加 + 「S3 実体削除は 2 prefix に及ぶ（#3868）」note 追加（account-deletion-flow.md:66, 82）|

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 退会（アカウント削除）フロー全経路（pattern 1 owner-only / 2b full-delete、および admin データ全削除）。`deleteTenantScopedData` は `fullTenantDeletion` / `deleteOwnerFullDelete` / grace-period cron / admin データ全削除の全経路から呼ばれるため、cloud export を持つ全退会経路で S3 実体が削除される。ユーザー可視の画面変化はなし（サーバー側クリーンアップ）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / check-pr-body をローカル一括検証（本 PR 番号で実行済）
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/services/tenant-cleanup-service.test.ts` に `#3868 cloudExports S3 実体削除` describe（4 test）を追加。① account 削除後に各 s3Key で `deleteByPrefix` + `deleteById` を呼び DB 行 0 にする ② S3 削除は DB 行削除より先（`callOrder` = `['s3','db']`）③ S3 削除失敗でも DB 行削除継続（best-effort）④ S3 削除失敗を logger.warn で記録（silent fail 防止）。既存の combined test にも s3Key + deleteByPrefix assert を追加。failing-test-first（ADR-0061）で修正前 3 fail → 修正後 18 passed を物理確認。
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:medium）

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — サーバー側のデータ削除ロジック（`$lib/server/services/`）+ 設計書 + テストのみの変更で、UI（`.svelte` / `.css` / `site/`）変更を含まない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: S — cloudExports クリーンアップの責務内に S3 実体削除を追加。D — `storage` repo は interface（`IStorageRepo`）経由で注入され `getRepos()` から解決。既存の cloud-export-service と同一の抽象に依存。
- [x] **DRY**: S3 削除手段は既存 `storage.deleteByPrefix`（`cloud-export-service.ts:416` の個別削除で使用）を再利用し、使い捨て実装を追加していない。`grep -rn "storage.deleteByPrefix" src/lib/server/services/` で 2 箇所（個別削除 + 退会クリーンアップ）に集約。
- [x] **YAGNI**: cron による orphan S3 走査等の追加抽象は入れず、account 削除時の同期削除（issue AC1）に限定。
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし。退会時 PII 消去の強化そのものが目的。s3Key は tenant 束縛された `findByTenant` 経由で取得し cross-tenant 削除は発生しない。
- [x] **アクセシビリティ**: N/A（サーバー側）
- [x] **パフォーマンス**: 退会は低頻度操作。cloudExport 件数分の逐次 `deleteByPrefix` 呼出で N+1 懸念はない（退会時 1 回のみ、件数は少数）。

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードと チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): 退会フロー SSOT `docs/design/account-deletion-flow.md` を同 PR で更新（§2 データクリア範囲マトリクスに S3 exports prefix 行追加 + §「S3 実体削除は 2 prefix に及ぶ」note）
- [x] **並行 PR overlap** (#1200): 本 PR が変更する `tenant-cleanup-service.ts` / 同 test / `account-deletion-flow.md` を同時変更する open PR なし
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**: S3 実体削除は `deleteById`（DB 行削除）の**前**に配置し、DB に該当行が残っている間に S3 を消すことで「DB 行だけ消えて S3 が孤児化」を防いでいる。S3 削除失敗は best-effort（内側 try/catch で warn し、外側の DB 行削除・account 削除は継続）で、既存の `viewerTokens` / `pushSubscriptions` 等と同じ「個別失敗が全体をブロックしない」方針に整合。`s3Key` フォーマットが `exports/{tenantId}/...` で、`fullTenantDeletion` の `tenants/{tenantId}/` prefix 一括削除の外側にある点が本 issue の根本原因（別 prefix のため既存の tenant-wide S3 削除ではカバーされない）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装のまま残っている AC がない）
- [x] Phase 分割した場合: 該当なし（単一 PR で完結）
- [x] UI 変更時: 該当なし（サーバー側 + docs + test のみ）
- [x] 認証画面変更時: 該当なし
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — vitest 18 passed / biome clean / svelte-check 0 error をローカル確認済、QM が re-verify）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
