### PR TITLE
infra(quality): #3878 eslint-plugin-svelte recommended 活性化 (死蔵解消 + bulk suppressions ratchet)

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -25,6 +25,7 @@ description: Use when reviewing a pull request. Enforces the mandatory 9-point c
 - [ ] **failing-test-first（ADR-0061）**: バグ修正 PR は「再現テスト → 修正」順か。修正前に失敗し修正後に green になるテストで原因が pin されているか（修正だけで再現テストなしは差し戻し）
 - [ ] **push-down-the-pyramid（ADR-0061 / ADR-0007）**: 重量レーン（e2e / 統合監査）で露見した不具合は、同条件を unit / lint / fitness function で捕捉できないか検討し、可能なら下位層に降ろしてあるか
 - [ ] **same-class-N→guard（ADR-0061）**: 同一バグ class が 2 回以上再発している領域は、別 instance パッチでなく CI gate / lint / property test / fitness function で class 全体を lock しているか（instance パッチのみは Done にしない）
+- [ ] **Svelte Runes semantic（ADR-0007 §6 / #3878、lint 対象外の領域）**: `.svelte` 変更は `eslint-plugin-svelte` recommended（`lint:svelte`）が syntactic footgun を潰すが、**「この `$effect` は `$derived` にすべき」の意図判断は lint では原理的に不可能**（`prefer-writable-derived` は単一代入 trivial shape のみ検出）。effect で state を derive/同期していないか、新規 `eslint-suppressions.json` エントリ増（baseline 悪化）がないかを目視で確認する
 
 ### D. 横展開（parallel-implementations.md）
 - [ ] labels.ts の変更 → site/ + tutorial-chapters.ts も同期

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,13 +259,14 @@ jobs:
       - name: ESLint Playwright (no-networkidle / no-wait-for-timeout, #1259)
         run: npx eslint "tests/**/*.ts"
 
-      # #3450 item1: svelte/no-at-html-tags (XSS) の AST 検出を CI で二重化。
-      # XSS の hard merge-blocker は scripts/check-no-at-html.mjs (lint-parallel job) が担い、
-      # 本 step は AST 層の secondary 検出。既存違反 38 errors は全て local design rules
-      # (no-raw-button / max-style-lines 等、svelte/no-at-html-tags は 0 件) のため
-      # SonarJS step と同格の warn-only で導入 (green 化できない hard gate を足さない)。
-      - name: ESLint Svelte (svelte/no-at-html-tags AST XSS 二重化, #3450)
-        continue-on-error: true
+      # #3878: eslint-plugin-svelte recommended (Runes/reactivity correctness) を hard gate 化。
+      # 既存違反 483 errors (svelte recommended + local design rules) は ESLint 10 native bulk
+      # suppressions (eslint-suppressions.json) で baseline 凍結済のため green 化可能になり、
+      # #3450 時点の warn-only (green 化できない hard gate を足さない) 制約が解消した。
+      # 以後は新規違反のみ CI fail (ratchet)。svelte/no-at-html-tags (XSS) の hard merge-blocker は
+      # 引き続き scripts/check-no-at-html.mjs (lint-parallel job) が主で、本 step は AST 層の
+      # 二重化 + recommended 全ルールの gate を兼ねる。詳細 SSOT: ADR-0007 §6。
+      - name: ESLint Svelte (eslint-plugin-svelte recommended + XSS AST, #3878/#3450)
         run: npm run lint:svelte
 
       - name: Knip (unused exports/files/deps detection, #970)

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -185,8 +185,11 @@ fi
 #       continue-on-error 無しで走らせる唯一の eslint merge blocker (baseline 0 error)。
 #       変更 file の部分集合を push 前に block して shift-left する。
 #   (B) warn-only: src/**/*.{ts,svelte}。CI は SonarJS / local design rules を
-#       continue-on-error で走らせる (svelte は #3450 の 36 error baseline が green 化不能
-#       のため warn 導入)。hook でも block せず違反表示のみ = CI merge policy と同格。
+#       continue-on-error で走らせる。svelte recommended (svelte/*) は #3878 で bulk
+#       suppressions により hard gate 化したが、同 .svelte file に同居する local design
+#       rules (no-raw-button 等) は依然 continue-on-error のため、hook 側は「hook が CI
+#       より strict にならない」原則 (--no-verify 常態化回避) を優先し warn-only を維持する
+#       (新規 svelte/* 違反の hard block は CI lint:svelte が担う)。hook は違反表示のみ。
 #
 # 設計境界 (ADR-0030 / ADR-0010 / ADR-0007): 型情報ロードを要する type-aware rules
 # (#3877 で導入する parserOptions.project 系) は現 eslint.config.js に不在で、本 hook は fast rules

--- a/biome.json
+++ b/biome.json
@@ -148,7 +148,8 @@
 			"!**/.tmp-screenshots",
 			"!**/drizzle",
 			"!tests/fixtures/restore-real-scale-backup.json",
-			"!**/.dependency-cruiser-known-violations.json"
+			"!**/.dependency-cruiser-known-violations.json",
+			"!**/eslint-suppressions.json"
 		]
 	}
 }

--- a/docs/decisions/0007-static-analysis-tier-policy.md
+++ b/docs/decisions/0007-static-analysis-tier-policy.md
@@ -1,8 +1,8 @@
 # 0007. 静的解析 tier ポリシー (T1/T2/T3/T4 + EPIC-merge / customer-review tier)
 
-- **Status**: Accepted (2026-05-27 EPIC-merge tier 追加、#2544)
+- **Status**: Accepted (2026-05-27 EPIC-merge tier 追加、#2544 / 2026-07-18 §6 eslint-plugin-svelte 追記、#3878)
 - **Date**: 2026-04-20
-- **Related Issue**: #1262 / #1265 / #2544
+- **Related Issue**: #1262 / #1265 / #2544 / #3878
 
 ## コンテキスト
 
@@ -65,6 +65,7 @@ T1 合計が 3min を超えた時は、最も遅いツールを T3 へ降格す�
 | Playwright | T2 | ~2min |
 | `new-env-distribution-check`（ADR-0006） | T1 | — |
 | `schema-change-tests-check` | T1 | — |
+| ESLint Svelte (`lint:svelte`、recommended + suppressions) | T1 | < 30s、merge block、#3878（§6） |
 | jscpd 週次 | T3 | cron |
 | 脆弱性スキャン | T4 | 四半期 / 手動 |
 
@@ -80,6 +81,14 @@ T1-T4 は「実行頻度 × blast radius」で **静的解析・自動テスト*
 - **判定ルール**: 「interactive flow を触る test は per-PR でも act → outcome assert 必須 (render-only 禁止)。ただし CUJ 全網羅貫通 / Cognitive Walkthrough / visual baseline 全件は EPIC-merge / 顧客レビュー gate に置く」。
 - **失敗時の扱い**: EPIC-merge / customer-review gate は **merge を止めるのではなく「顧客に当てる前の必須チェックリスト」** (CX 版 DoR、#2459 C-1)。Pre-PMF では顧客レビュー = 貴重な「最初の 5 人」枠 (NN/G 5-user rule) なので、明白な 85% 級問題はこの gate で潰す。
 - **SSOT**: 横断 cadence ポリシーは本節を SSOT とし、`tests/CLAUDE.md` §interactive flow / §2 層 cadence はその tests/ 視点の抜粋とする。
+
+### 6. eslint-plugin-svelte recommended の活性化と Runes semantic の lint 対象外原則 (#3878 で追加)
+
+`eslint-plugin-svelte` は導入済みだったが `svelte/no-at-html-tags` の 1 本のみ有効で、公式 `svelte.configs.recommended` の十数ルール（Runes/reactivity correctness）が **死蔵**していた。#3878 で recommended を `.svelte` に適用し T1 gate 化した。
+
+- **層の責務分離（二重化しない）**: 型 = `svelte-check --threshold warning`（T1） / a11y = Svelte compiler warning を svelte-check が surface + `@axe-core/playwright` E2E / Runes・reactivity・SvelteKit correctness = `eslint-plugin-svelte` recommended（本節）。**`svelte/valid-compile` は追加しない**（compiler warning の ESLint 再実行 = svelte-check と二重）。**a11y ルールは eslint-plugin-svelte に存在しない**ため追加不能。自作 `local/*`（no-raw-button 等）と重複する opt-in ルール（no-inline-styles 等）も追加しない。
+- **既存違反の baseline 凍結（ratchet）**: recommended 有効化で既存コードに 483 error が出る（内訳: `no-navigation-without-resolve` 166 / `require-each-key` 133 / `no-useless-children-snippet` 113 / `prefer-svelte-reactivity` 15 / `prefer-writable-derived` 11 / `no-unused-svelte-ignore` 7 / `no-useless-mustaches` 2 + 既存 `local/*` 36）。ESLint 10 native bulk suppressions（`eslint --suppress-all` → `eslint-suppressions.json` を commit）で凍結し、**新規違反のみ CI fail**。段階返済後は `eslint --prune-suppressions` で baseline を ratchet down する（assertion 弱体化・ルール一括 disable は ADR-0006 禁止）。SSOT = `eslint.config.js`（recommended spread）+ `eslint-suppressions.json`（baseline）+ `.github/workflows/ci.yml`（`lint:svelte` hard gate）。
+- **Runes semantic 判断は lint 対象外＝PR review 領域**: Svelte 5 公式が最も警告する「`$effect` で state を derive/同期するな、`$derived` を使え」は、静的に捕まるのは `prefer-writable-derived` の単一代入 trivial shape のみ。effect 本体に分岐・複数文が入ると linter は沈黙する。「この effect は derived にすべき」の意図判断は ESLint では原理的に不可能なため、**lint は syntactic footgun を潰し、semantic 判断は PR review で補う**（`.claude/skills/pr-review/SKILL.md` の Svelte 観点で確認）。component 全体（script+template）の cognitive/cyclomatic 複雑度を測る既製 OSS は存在しない（SonarJS は `.svelte` 非サポート）ため深追いせず、自作 `local/max-svelte-lines`(500) を粗い proxy として維持する。
 
 ## 結果
 

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,0 +1,883 @@
+{
+  "src/lib/features/admin/components/ActivityCreateForm.svelte": {
+    "svelte/prefer-writable-derived": {
+      "count": 7
+    },
+    "svelte/require-each-key": {
+      "count": 5
+    }
+  },
+  "src/lib/features/admin/components/ActivityEditForm.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/lib/features/admin/components/ActivityLimitBanner.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/admin/components/ActivityListItem.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/admin/components/AdminHome.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 3
+    }
+  },
+  "src/lib/features/admin/components/AdminLayout.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 9
+    },
+    "svelte/require-each-key": {
+      "count": 4
+    }
+  },
+  "src/lib/features/admin/components/AiSuggestChecklistPanel.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/features/admin/components/AiSuggestCheerPanel.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/admin/components/AiSuggestPanel.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/admin/components/AiSuggestRewardPanel.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/admin/components/ChildListCard.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/admin/components/ChildProfileCard.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 4
+    }
+  },
+  "src/lib/features/admin/components/DemoCta.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/admin/components/DowngradeResourceSelector.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 9
+    },
+    "svelte/prefer-svelte-reactivity": {
+      "count": 3
+    }
+  },
+  "src/lib/features/admin/components/NotificationPermissionBanner.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    }
+  },
+  "src/lib/features/admin/components/NucLicensePanel.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/lib/features/admin/components/OnboardingChecklist.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 3
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/lib/features/admin/components/PlanStatusCard.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 4
+    }
+  },
+  "src/lib/features/admin/components/PremiumWelcome.svelte": {
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/lib/features/admin/components/RedemptionPendingBanner.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    }
+  },
+  "src/lib/features/admin/components/SaasLicensePanel.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 6
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/lib/features/admin/components/TrialBanner.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/birthday/BirthdayModal.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/features/certificate/CertificateCard.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    }
+  },
+  "src/lib/features/certificate/CertificateTemplate.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/features/certificate/ShareCard.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/features/character/CharacterTabs.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/features/child-home/BabyHomePage.stories.svelte": {
+    "svelte/prefer-svelte-reactivity": {
+      "count": 3
+    }
+  },
+  "src/lib/features/demo/DemoBanner.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    }
+  },
+  "src/lib/features/demo/DemoGuideBar.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 3
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/features/loyalty/ChurnPreventionModal.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/features/usage/WeeklyUsageChart.svelte": {
+    "svelte/require-each-key": {
+      "count": 4
+    }
+  },
+  "src/lib/features/value-preview/MilestoneBellButton.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/prefer-svelte-reactivity": {
+      "count": 1
+    }
+  },
+  "src/lib/features/value-preview/MonthlyValuePreview.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/marketplace/ui/UnifiedEmptyState.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/marketplace/ui/UnifiedImportHub.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/ActivityCard.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/ActivityEmptyState.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/AdventureStartOverlay.svelte": {
+    "svelte/require-each-key": {
+      "count": 3
+    }
+  },
+  "src/lib/ui/components/BottomNav.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/CategorySection.svelte": {
+    "svelte/prefer-writable-derived": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/CelebrationEffect.svelte": {
+    "svelte/require-each-key": {
+      "count": 4
+    }
+  },
+  "src/lib/ui/components/FeatureGate.stories.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 6
+    }
+  },
+  "src/lib/ui/components/FeatureGate.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/GoogleSignInButton.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/NumPad.svelte": {
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/lib/ui/components/ProgressFill.stories.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/RadarChart.svelte": {
+    "svelte/require-each-key": {
+      "count": 4
+    }
+  },
+  "src/lib/ui/components/SiblingCategoryChart.svelte": {
+    "svelte/require-each-key": {
+      "count": 4
+    }
+  },
+  "src/lib/ui/components/SiblingCheerOverlay.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/SiblingRanking.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/components/SiblingTrendChart.svelte": {
+    "svelte/require-each-key": {
+      "count": 5
+    }
+  },
+  "src/lib/ui/components/StampCard.svelte": {
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/lib/ui/components/StampPressOverlay.svelte": {
+    "svelte/require-each-key": {
+      "count": 3
+    }
+  },
+  "src/lib/ui/components/TutorialBubble.svelte": {
+    "svelte/no-unused-svelte-ignore": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/primitives/Alert.stories.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/primitives/Button.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/primitives/Dialog.stories.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 4
+    }
+  },
+  "src/lib/ui/primitives/PinInput.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/lib/ui/tutorial/PageGuideTabs.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/routes/(child)/+layout.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/routes/(child)/[uiMode=uiMode]/(character)/challenges/+page.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 2
+    }
+  },
+  "src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    },
+    "svelte/no-useless-mustaches": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/(child)/[uiMode=uiMode]/(character)/status/+page.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/routes/(child)/[uiMode=uiMode]/home/+page.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    }
+  },
+  "src/routes/(child)/checklist/+page.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/activities/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 3
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/routes/(parent)/admin/activities/[id]/edit/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/billing/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 3
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 7
+    }
+  },
+  "src/routes/(parent)/admin/billing/cancel/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/routes/(parent)/admin/billing/cancel/graduation/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 5
+    }
+  },
+  "src/routes/(parent)/admin/billing/cancel/thanks/+page.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 2
+    }
+  },
+  "src/routes/(parent)/admin/certificates/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/certificates/[id]/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/challenges/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    }
+  },
+  "src/routes/(parent)/admin/checklists/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 4
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 7
+    },
+    "svelte/require-each-key": {
+      "count": 4
+    }
+  },
+  "src/routes/(parent)/admin/cheer/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 4
+    }
+  },
+  "src/routes/(parent)/admin/children/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/growth-book/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 4
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/routes/(parent)/admin/members/+page.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 10
+    },
+    "svelte/require-each-key": {
+      "count": 3
+    }
+  },
+  "src/routes/(parent)/admin/packs/+page.svelte": {
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/routes/(parent)/admin/points/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 3
+    }
+  },
+  "src/routes/(parent)/admin/reports/+page.svelte": {
+    "local/no-raw-button": {
+      "count": 4
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 4
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 7
+    }
+  },
+  "src/routes/(parent)/admin/rewards/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 6
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/rewards/requests/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/settings/+layout.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/settings/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/settings/account/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/settings/activities/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/prefer-writable-derived": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/settings/data/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/settings/notifications/+page.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    }
+  },
+  "src/routes/(parent)/admin/settings/rules/+page.svelte": {
+    "local/no-style-attribute": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/routes/(parent)/admin/status/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/routes/(parent)/login/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/+error.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "local/no-raw-button": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 7
+    }
+  },
+  "src/routes/auth/forgot-password/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 2
+    }
+  },
+  "src/routes/auth/invite/[code]/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 3
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    }
+  },
+  "src/routes/auth/login/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/routes/auth/reset-pin/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    }
+  },
+  "src/routes/auth/signup/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 5
+    }
+  },
+  "src/routes/consent/+page.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/routes/marketplace/+page.svelte": {
+    "local/no-raw-button": {
+      "count": 2
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 13
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    },
+    "svelte/prefer-writable-derived": {
+      "count": 1
+    }
+  },
+  "src/routes/marketplace/[type]/[itemId]/+page.svelte": {
+    "local/no-raw-button": {
+      "count": 2
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 19
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 6
+    }
+  },
+  "src/routes/ops/+layout.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 8
+    }
+  },
+  "src/routes/ops/+page.svelte": {
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/ops/analytics/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 6
+    }
+  },
+  "src/routes/ops/business/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/routes/ops/cohort/+page.svelte": {
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/routes/ops/costs/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 1
+    }
+  },
+  "src/routes/ops/pmf-survey/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-unused-svelte-ignore": {
+      "count": 5
+    },
+    "svelte/prefer-writable-derived": {
+      "count": 1
+    }
+  },
+  "src/routes/ops/revenue/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 5
+    }
+  },
+  "src/routes/pricing/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/routes/setup/activities-defaults/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/routes/setup/challenges/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/prefer-svelte-reactivity": {
+      "count": 2
+    }
+  },
+  "src/routes/setup/children/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/routes/setup/complete/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    }
+  },
+  "src/routes/setup/first-adventure/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    }
+  },
+  "src/routes/setup/packs/+page.svelte": {
+    "local/no-raw-button": {
+      "count": 1
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/prefer-svelte-reactivity": {
+      "count": 2
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  },
+  "src/routes/setup/rewards/+page.svelte": {
+    "local/no-raw-button": {
+      "count": 2
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/prefer-svelte-reactivity": {
+      "count": 2
+    }
+  },
+  "src/routes/setup/rules/+page.svelte": {
+    "local/no-raw-button": {
+      "count": 3
+    },
+    "svelte/no-navigation-without-resolve": {
+      "count": 1
+    },
+    "svelte/prefer-svelte-reactivity": {
+      "count": 2
+    }
+  },
+  "src/routes/survey/sean-ellis/[token]/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    }
+  },
+  "src/routes/switch/+page.svelte": {
+    "svelte/no-navigation-without-resolve": {
+      "count": 2
+    }
+  },
+  "src/routes/view/[token]/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/require-each-key": {
+      "count": 2
+    }
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,19 @@ import noTailwindArbitraryHex from './eslint-plugin-local/no-tailwind-arbitrary-
 // - src/**/*.ts: SonarJS ルール（文字列重複・認知複雑度・関数重複等）#977
 // - JS/TS の基本 lint は Biome が担当
 export default [
+	// #3878: eslint-plugin-svelte の公式 recommended を .svelte に適用 (Runes/reactivity
+	// correctness の死蔵解消)。svelte-check (型 / a11y compiler warning) と非重複な高 ROV ルール
+	// (prefer-writable-derived / no-unnecessary-state-wrap / no-dom-manipulating / require-each-key /
+	// no-unused-props / no-dupe-* / SvelteKit no-navigation-without-resolve 等) を error で有効化する。
+	// - a11y ルールは eslint-plugin-svelte に存在せず (Svelte compiler warning を svelte-check が surface
+	//   + @axe-core/playwright E2E が担保) 二重化しない。
+	// - svelte/valid-compile は recommended 非収録のため未追加 (compiler warning の再実行 = svelte-check 二重化)。
+	// - 自作 local/* (no-raw-button / no-style-attribute 等) と重複する opt-in ルール (no-inline-styles 等)
+	//   は recommended 非収録のため未追加。
+	// 既存違反は eslint-suppressions.json (ESLint 10 native bulk suppressions, --suppress-all) で baseline
+	// 凍結し、新規違反のみ CI fail させる (ratchet)。この spread は既存 src/**/*.svelte ブロック (parser 設定) の
+	// より前に置き、後続ブロックの languageOptions を authoritative に保つ (#3877 type-aware 設定と非衝突)。
+	...svelte.configs.recommended,
 	// Svelte ファイル共通設定（パーサー）
 	{
 		files: ['src/**/*.svelte'],
@@ -38,6 +51,11 @@ export default [
 			// 正当な sanitize 済 HTML 注入 (ADR-0025 DOMPurify 等) が必要な場合は当該行のみ
 			// eslint-disable-next-line svelte/no-at-html-tags で明示 opt-out する。
 			'svelte/no-at-html-tags': 'error',
+			// #3878: recommended が warn 割当の 2 件 (残置 debug の掃除) を error へ昇格。
+			// bulk suppressions は error severity のみ凍結対象のため、gate 化するには error 必須。
+			// $inspect / {@debug} は本番コードに残さない前提 (Anti-engagement / デバッグ痕跡除去)。
+			'svelte/no-inspect': 'error',
+			'svelte/no-at-debug-tags': 'error',
 		},
 	},
 	// routes 配下: デザインシステム品質ルール


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発品質 = 顧客に届く実装の欠陥抑制）

**解決する課題**: `eslint-plugin-svelte ^3.20.0` は導入済みだが `svelte/no-at-html-tags` の 1 本のみ有効で、公式 `svelte.configs.recommended` の Runes/reactivity correctness ルール（十数本）が死蔵していた。`$effect`/`$state`/`$derived` の anti-pattern、keyed でない `{#each}`、重複 directive、SvelteKit `goto()` の resolve 漏れなどが CI をすり抜け、リアクティビティバグ・再描画バグとして顧客に到達し得る状態だった。

**期待される効果**: 死蔵ルールを T1 hard gate として活性化し、新規の Svelte footgun を PR 段階で機械的に阻止する。既存違反は bulk suppressions で凍結し段階返済する（ratchet）。

## 関連 Issue

closes #3878

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `.svelte` に `svelte.configs.recommended` を適用する config を追加（既存と非重複に絞る） | `eslint.config.js` の `...svelte.configs.recommended` spread | HEAD `6d3cc458` / `eslint.config.js:22` に spread 追加、`no-inline-styles`（local 重複 opt-in）は recommended 非収録で未混入 |
| AC2 | §A/§B の低ノイズ correctness/hygiene を error 有効化（既存 0 件を確認） | `npm run lint:svelte` の rule 別集計（Phase 0 計測） | HEAD `6d3cc458` / `no-unnecessary-state-wrap` `no-dom-manipulating` `no-dupe-*`(4) `no-not-function-handler` `no-object-in-text-mustaches` `no-unused-props` `no-inspect` `no-at-debug-tags` `infinite-reactive-loop` `valid-prop-names-in-kit-pages` = いずれも 0 件 error で即 gate |
| AC3 | `require-each-key` 等の件数が出るルールを error + bulk suppressions で凍結し新規違反のみ CI fail | `eslint --suppress-all` → `eslint-suppressions.json` commit + ratchet probe | HEAD `6d3cc458` / suppressions 483 件凍結（`no-navigation-without-resolve` 166 / `require-each-key` 133 / `no-useless-children-snippet` 113 / `prefer-svelte-reactivity` 15 / `prefer-writable-derived` 11 / `no-unused-svelte-ignore` 7 / `no-useless-mustaches` 2 / 既存 `local/*` 36）。probe（keyed でない `{#each}` を新規追加）で `lint:svelte` exit 1 を確認、削除後 exit 0 |
| AC4 | a11y / valid-compile を追加していないことを PR で明示 | `svelte.configs.recommended` の rule 集合 introspection | HEAD `6d3cc458` / recommended 内 a11y ルール = 0 本（plugin 自体に非存在、Svelte compiler warning を svelte-check が surface + `@axe-core/playwright` E2E が担保）/ `svelte/valid-compile` = 未収録（compiler warning の ESLint 再実行 = svelte-check 二重化のため off のまま）。ADR-0007 §6 に非重複判断を記載 |
| AC5 | Runes semantic 判断（$effect→$derived）は lint 対象外＝PR review で補う旨を docs に記載 | `docs/decisions/0007-static-analysis-tier-policy.md` §6 + pr-review SKILL | HEAD `6d3cc458` / ADR-0007 §6「Runes semantic 判断は lint 対象外＝PR review 領域」+ `.claude/skills/pr-review/SKILL.md` C 項に Svelte Runes semantic 目視レビュー項目を追加 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

<!-- 主眼は lint gate（infra/CI）活性化 + ratchet baseline（test 品質強化）。ADR/skill 更新は付随。 -->

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 実行時の画面挙動は不変（lint 設定 + CI gate のみ）。以後 `.svelte` を編集する全 PR に recommended ルールの gate が適用される。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要: テストコード追加なし。代わりに `eslint-suppressions.json`（ratchet baseline）+ `lint:svelte` hard gate 化で「新規 Svelte footgun のみ CI fail」を機械強制。ratchet 動作は probe（keyed でない `{#each}` 追加 → exit 1）で確認済み
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: lint 設定 + CI gate + ADR/skill 更新のみで、実行時 UI の描画・挙動は一切変更しない（`.svelte` ファイル本体は無変更、`eslint.config.js` / `eslint-suppressions.json` / `ci.yml` / `docs` / `skill` のみ）。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 公式 recommended config を spread し responsibility を plugin に委譲。独自 lint 実装を足していない
- [x] **DRY**: a11y / valid-compile / local 重複 opt-in を除外し、既存 gate（svelte-check / axe / local rules）と非重複に絞った
- [x] **YAGNI**: component 複雑度測定（OSS 空白地帯）は深追いせず既存 `max-svelte-lines` を proxy 維持。Pre-PMF Bucket A
- [x] **Security（OSS 公開前提）**: `svelte/no-at-html-tags`（XSS）は error を維持。suppressions は XSS ルールを凍結していない（該当 0 件）
- [x] **アクセシビリティ**: a11y は svelte-check（compiler warning）+ axe E2E が SSOT。本 PR で二重化しない判断を明示
- [x] **パフォーマンス**: `require-each-key` / `prefer-svelte-reactivity` の gate 化で再描画・reactivity 効率の footgun を新規流入から阻止

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] **設計書同期** (ADR-0001): 静的解析 tier の SSOT である ADR-0007 に §6 を追加、CI baseline 表に `lint:svelte` を登録
- [x] **並行 PR overlap** (#1200): `eslint.config.js` は #3877（tsconfig type-aware lint）も編集し得るため、recommended spread を独立ブロックとして surgical/additive に配置し parserOptions 領域と分離。develop 最新に rebase 済（`e2f0b564`）
- [ ] N/A

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- `lint:svelte` を warn-only（`continue-on-error: true`、#3450）から hard gate へ昇格した。これは既存 483 error を bulk suppressions で凍結して初めて green 化できたためで、副次的に既存の local design rules（`no-raw-button` 等、従来 warn-only）も新規違反が gate される（ratchet 強化、望ましい方向）。
- 迷った点: `--suppress-all` は svelte recommended だけでなく既存 `local/*` error（36 件）も凍結する。svelte ルールだけ `--suppress-rule` で個別凍結する案もあったが、それでは local error が残り `lint:svelte` を hard gate 化できず AC3「新規違反のみ CI fail」が実質満たせない。Issue 本文が明示的に `--suppress-all` を prescribe しているため全体凍結を採用した。
- **`eslint.config.js` touch のため #3877（tsconfig type-aware lint）と merge 順調整要**: 本 PR は recommended spread を独立ブロックとして additive 配置（parserOptions 領域と分離）済のため論理衝突はないが、同一ファイルのため #3877 が先に merge されると textual rebase conflict が起き得る。その際は両者の追加（svelte block + type-aware parserOptions）を保持して解決する。
- **develop 前進に伴う rebase 追随（`e2f0b564`）で 2 file を追加 touch**: (1) `biome.json` — #3891 の `.dependency-cruiser-known-violations.json` 除外と本 PR の `eslint-suppressions.json` 除外を両立（both-keep 解決）。(2) `.husky/pre-push` — #3888 で追加された eslint fast check (B) のコメントが「svelte は green 化不能のため warn」と本 PR で stale 化したため、comment のみ現状（svelte/* は CI hard gate、hook は local design rules 同居ゆえ warn-only 維持）に是正（hook behavior は不変）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了 AC なし）
- [x] Phase 分割: 単一 PR で完結（分割なし）
- [x] UI 変更時: N/A（UI 描画・挙動の変更なし）
- [x] 認証画面変更時: N/A
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — 上記 AC 検証マップ + pre-ready 全 Step PASS + ratchet probe を Dev が物理確認済。最終 approve は QM 責務）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


