### PR TITLE
feat(dx): #3880 pre-push に eslint fast check を追加 (biome と対で shift-left、CI 挙動を忠実 mirror)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -14,9 +14,11 @@
 #   3. PR body 13 セクション + AC 4 列 + 禁止語 + mojibake verify
 #      (#2576 / #2586 / #2633 第 5 弾、PR が既に存在する場合のみ)
 #   4. biome check (軽量 lint、重い vitest / playwright は CI 委ね)
+#   5. eslint fast check (#3880、変更 file 絞り込み。tests/**/*.ts は hard-block =
+#      CI 唯一の eslint merge blocker、src/**/*.{ts,svelte} は warn-only = CI continue-on-error 同格)
 #
 # # 設計境界 (Pre-PMF / ADR-0010 整合)
-# 重い検査 (vitest / playwright / svelte-check) は本 hook に **追加しない**。
+# 重い検査 (vitest / playwright / svelte-check / type-aware eslint #3877) は本 hook に **追加しない**。
 # 理由: push 速度を保ち、BLOCK 早期検出と push hook cost のバランスを取る。
 # 全 step は CI / `npm run pre-ready` が二重で実行する設計 (defense in depth)。
 #
@@ -31,6 +33,7 @@
 #   - ADR-0030 (pre-ready CLI と本 hook の defense in depth 関係)
 #   - #2598 (本実装、QA self-implement 第 8 弾、本日 7+ 連続 BLOCK 構造的予防)
 #   - #2633 (第 5 弾 pre-ready Step 9 強化 — 本 hook と相補的に Dev / push 経路を 2 層化)
+#   - #3880 (Step 2.5 eslint fast check、biome と対で shift-left。CI eslint 挙動を忠実 mirror)
 #
 # # bypass
 # `git push --no-verify` で skip 可能だが、ADR-0026 で discouraged。
@@ -171,5 +174,55 @@ if command -v npx >/dev/null 2>&1; then
 	fi
 else
 	echo "[pre-push] WARN: npx 未インストール、biome check skip"
+fi
+
+# --- Step 2.5: eslint fast check (変更 file 絞り込み、#3880) ---
+# biome (Step 2.4) と対で eslint も push レイヤで実行し、CI で初めて eslint 違反に気づく
+# 往復を減らす (shift-left)。CI (.github/workflows/ci.yml) の eslint 挙動を忠実に mirror し、
+# 「hook が CI merge policy より strict」= --no-verify 常態化を招く事故を避けるため 2 段構成:
+#
+#   (A) hard-block: tests/**/*.ts (Playwright rules)。CI は `npx eslint "tests/**/*.ts"` を
+#       continue-on-error 無しで走らせる唯一の eslint merge blocker (baseline 0 error)。
+#       変更 file の部分集合を push 前に block して shift-left する。
+#   (B) warn-only: src/**/*.{ts,svelte}。CI は SonarJS / local design rules を
+#       continue-on-error で走らせる (svelte は #3450 の 36 error baseline が green 化不能
+#       のため warn 導入)。hook でも block せず違反表示のみ = CI merge policy と同格。
+#
+# 設計境界 (ADR-0030 / ADR-0010 / ADR-0007): 型情報ロードを要する type-aware rules
+# (#3877 で導入する parserOptions.project 系) は現 eslint.config.js に不在で、本 hook は fast rules
+# のみ走らせる (変更 file 数件で ~8s、type-aware は CI 限定側 #3877 に置き hook を遅くしない)。
+# 重い svelte-check / vitest / playwright は従来どおり CI / npm run pre-ready 委ね (defense in depth)。
+# 抽出は既存 biome step と同じ three-dot (origin/<base>...HEAD)。base は Step 2.0 で解決済み。
+echo "[pre-push] eslint fast check (変更 file 絞り込み、#3880)"
+if command -v npx >/dev/null 2>&1; then
+	CHANGED_ESLINT_FILES=$(git diff --name-only --diff-filter=AM "origin/$BASE_BRANCH...HEAD" 2>/dev/null || true)
+	# (A) hard-block: tests/**/*.ts (CI 唯一の eslint merge blocker、green baseline)
+	CHANGED_TEST_TS=$(echo "$CHANGED_ESLINT_FILES" | grep -E '^tests/.*\.ts$' || true)
+	if [ -n "$CHANGED_TEST_TS" ]; then
+		echo "$CHANGED_TEST_TS" | head -5
+		if ! echo "$CHANGED_TEST_TS" | xargs npx eslint; then
+			echo "[pre-push] FAIL: eslint (tests/**/*.ts, Playwright rules) 違反"
+			echo "          対処: npx eslint --fix <file> (no-wait-for-timeout / no-networkidle 等は手修正)"
+			echo "          理由: CI の tests eslint は continue-on-error 無し = merge blocker。"
+			echo "          skip (非推奨): git push --no-verify (ADR-0026 で discouraged)"
+			exit 1
+		fi
+		echo "[pre-push]     OK: eslint (tests/**/*.ts)"
+	fi
+	# (B) warn-only: src/**/*.{ts,svelte} (CI continue-on-error 同格、block しない)
+	CHANGED_SRC_LINT=$(echo "$CHANGED_ESLINT_FILES" | grep -E '^src/.*\.(ts|svelte)$' || true)
+	if [ -n "$CHANGED_SRC_LINT" ]; then
+		if echo "$CHANGED_SRC_LINT" | xargs npx eslint; then
+			echo "[pre-push]     OK: eslint (src 変更 file、違反なし)"
+		else
+			echo "[pre-push]     WARN: src eslint 違反あり (上記)。CI continue-on-error 同格で block しない。"
+			echo "                 push 前に npx eslint --fix <file> での修正を推奨 (design rules / SonarJS)。"
+		fi
+	fi
+	if [ -z "$CHANGED_TEST_TS" ] && [ -z "$CHANGED_SRC_LINT" ]; then
+		echo "[pre-push]     OK: eslint 対象 file 変更なし、skip"
+	fi
+else
+	echo "[pre-push] WARN: npx 未インストール、eslint check skip"
 fi
 echo "[pre-push] OK: QA self-implement 第 8 弾 verify chain 全 PASS (#2598)"


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者 DX / CI 効率）

**解決する課題**: eslint はこれまでどの git hook にも無く CI (`lint:svelte` / `eslint "tests/**/*.ts"`) でしか走らなかったため、eslint 由来の違反が push 後の CI で初めて発覚し、修正→再 push の往復が発生していた。biome は既に pre-push (Step 2.4) で変更ファイルに走るのに eslint だけ抜けていた。

**期待される効果**: 変更ファイル限定の eslint fast check を pre-push (Step 2.5) に追加し、CI の eslint merge blocker (tests Playwright rules) を push 前に検出（shift-left）。CI 往復を減らし開発サイクルを短縮する。

## 関連 Issue

Closes #3880

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `.husky/pre-push` に fast eslint（変更ファイル）step 追加 + fail 時 `eslint --fix` ガイダンス表示 | `.husky/pre-push` Step 2.5 実装 + `sh -n .husky/pre-push` 構文検証 + 統合テスト（violating test file で BLOCK） | HEAD `bcafe41c` / `.husky/pre-push:177-222` Step 2.5 / 統合テスト case1 = `RESULT=BLOCK (tests violation)` / FAIL メッセージに `npx eslint --fix <file>` を出力 (`.husky/pre-push:200`) |
| AC2 | eslint config を fast / type-checked に分離し type-aware rules が pre-push を遅くしないことを実測（push 時間許容範囲を記録） | `grep -n "project" eslint.config.js` で type-aware 不在を確認 + 変更ファイル数件での eslint 実測 | HEAD `bcafe41c` / `eslint.config.js` に `parserOptions.project` = 0 件（現 config は既に fast、type-aware は #3877 側）→ 本 hook は fast rules のみ走らせ config 分離は不要 / 変更ファイル 3-4 件で eslint ≈ 8s（startup 律速、型情報ロード無し）を実測。push 時間は既存 verify chain + ~8s（片 group）で許容範囲 |
| AC3 | worktree (`.claude/worktrees/`) でも hook が発火することを確認（#3857 と整合） | 本 PR の実 push 出力 + `git rev-parse --git-path hooks` の解決検証 | HEAD `bcafe41c` / 実 push が worktree から `[pre-push] eslint fast check (変更 file 絞り込み、#3880)` を出力（＝worktree 自身の hook body が実行）/ `git rev-parse --git-path hooks` = 相対 `.husky/_` → husky `h` が `s=.husky/pre-push` を CWD（worktree root）相対で解決 → 各 worktree は自身の committed hook を実行することを確認 |
| AC4 | `--no-verify` 禁止方針（ADR-0026）と defense-in-depth（CI 二重実行）を維持 | `.husky/pre-push` の bypass 文言 + CI `ci.yml` の full eslint 実行を確認 | HEAD `bcafe41c` / hook FAIL 時に `git push --no-verify (ADR-0026 で discouraged)` を出力 (`.husky/pre-push:201`) / `.github/workflows/ci.yml:254-266` が `eslint "src/**/*.ts"` / `eslint "tests/**/*.ts"` / `lint:svelte` を CI で二重実行（hook は変更ファイル限定 fast、全検査は CI 委ね） |
| AC5 | （任意採用時）lint-staged + pre-commit auto-fix の副作用（自動 git add）を評価し採否を明記 | 評価結果を本 PR に明記 | 不採用。理由: auto-fix + 自動 `git add` は明示的ユーザー意図不在の副作用を生む。#2086（pre-commit SSOT）が既に同理由で pre-commit の auto-add を見送っており整合。Pre-PMF (ADR-0010) で新規重量依存 (lint-staged) を足さず、pre-push の変更ファイル check で shift-left の目的は達成される |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 開発者の `git push` 時 pre-push hook のみ。アプリ実行時挙動・UI・API・DB への影響なし。`.husky/pre-push` 1 ファイルのみ変更（+54 / -1 行）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 変更は `.husky/pre-push`（shell script）1 ファイルのみで lint 対象拡張子を含まず、biome / svelte-check / vitest / eslint は対象ファイル 0（該当検証 skip）。`sh -n .husky/pre-push` = SYNTAX OK
- [x] 追加・変更したテストの概要: eslint 自動テストは追加しない（hook は shell script で vitest 対象外）。代わりに Step 2.5 の 3 分岐（tests violation=BLOCK / no eslint files=skip / red svelte=WARN-not-block）を実 eslint 実行で統合検証（本 PR 説明参照）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: UI 変更を含まない infra（dev-tooling / git hook）のみの PR。`.husky/pre-push` shell script 1 ファイルのみ変更で描画 surface が無い。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: Step 2.5 は既存 Step 2.4（biome）と同型の単一責任 step。base branch 解決 / 変更ファイル抽出は既存 Step 2.0 / 2.4 の SSOT を再利用
- [x] **DRY**: `git diff ... origin/$BASE_BRANCH...HEAD` three-dot 抽出パターンは既存 biome step と同一。eslint 呼び出しは CI (`ci.yml`) の invocation を mirror し二重ロジック定義を避けた
- [x] **YAGNI**: eslint.config.js は触らず（#3877 / #3878 の領域）hook 配線のみ。lint-staged 等の新規依存は足さない。現 config に type-aware rules 不在のため config 分離も現時点で不要
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。`xargs npx eslint` に渡すのは git 管理下の変更ファイルパスのみ
- [x] **アクセシビリティ**: N/A（UI 非該当）
- [x] **パフォーマンス**: 変更ファイル限定（three-dot 抽出）+ group 別 gate（変更が無い group は skip）で push 速度を保持。type-aware rules（型情報ロード）は hook に入れず CI 限定（#3877）

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [ ] **設計書同期** (ADR-0001): git hook（`.husky/`）は `docs/design/` の設計書対象外。ADR-0030（pre-ready CLI と hook の defense in depth）に整合し、hook 内コメント + 本 PR で設計判断を記録
- [x] **並行 PR overlap** (#1200): `.husky/pre-push` を同時変更する open PR が無いことを確認（#3875 = 直前 merge 済 base、#3877 / #3878 は eslint.config.js 側で本 PR とファイル非重複）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
設計判断で迷った 2 点を記録:
1. **block 範囲を CI merge policy に厳密整合**させた。CI で `eslint "tests/**/*.ts"` のみ continue-on-error 無し（唯一の eslint merge blocker、baseline 0 error）なので tests のみ hard-block。`src/**/*.{ts,svelte}` は CI が continue-on-error（svelte は #3450 の 36 error baseline が green 化不能）のため hook でも warn-only にした。全違反を hard-block すると既存 baseline に触れた push が常時 BLOCK → `--no-verify` 常態化を招くため、意図的に CI より strict にしていない。
2. **eslint.config.js の fast/slow 分離は本 PR では不要**と判断。現 config に type-aware rules（`parserOptions.project`）が不在で既に fast のため。type-aware 導入時（#3877）にその PR 側で CI 限定 config へ隔離する設計境界を hook コメントに明記した。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した（変更ファイルが lint 対象拡張子を含まず該当 step は対象 0、`sh -n` 構文検証 PASS）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了の AC なし）
- [x] Phase 分割: N/A（単一 PR で完結）
- [x] UI 変更時: N/A（UI 非該当）
- [x] 認証画面変更時: N/A
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — Step 2.5 の block / skip / warn 3 分岐を実 eslint 実行で検証、worktree hook 発火を実 push で確認済）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
