### PR TITLE
infra(ci): #3874 cfn-lint synth 静的 lint gate 導入 (Class ① property 制約違反を deploy 前に hard-fail)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       cognito: ${{ steps.filter.outputs.cognito }}
       docker: ${{ steps.filter.outputs.docker }}
       docs: ${{ steps.filter.outputs.docs }}
+      infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v7
 
@@ -146,6 +147,13 @@ jobs:
               - 'scripts/check-doc-code-references.mjs'
               - 'scripts/doc-code-references-baseline.json'
               - 'scripts/__tests__/**'
+              - '.github/workflows/ci.yml'
+            # #3874 Layer 1: CDK synth 静的 lint (cfn-lint) gate の起動条件。
+            # infra/ (stack / lambda) 変更・cfn-lint gate 本体・ci.yml 変更で発火。
+            infra:
+              - 'infra/**'
+              - 'scripts/check-cdk-cfn-lint.mjs'
+              - 'scripts/__tests__/check-cdk-cfn-lint.test.mjs'
               - '.github/workflows/ci.yml'
 
   lint-and-test:
@@ -382,6 +390,54 @@ jobs:
 
       - name: Dependency boundaries — infra CDK stacks (循環/stack 間直 import, #3871 AC3)
         run: npm run depcruise:infra
+
+  # #3874 Layer 1: CDK synth 静的 lint (cfn-lint) gate。
+  # `cdk synth --all` 出力 (cdk.out/*.template.json) を cfn-lint で検査し、AWS::* リソースの
+  # property 制約違反 (charset / allowed-value / type) を deploy 前 (synth 時点) に hard-fail する。
+  # #3870 (IAM Role Description 非-ASCII → 本番 deploy rollback) 級の「synth 成功・unit test 通過・
+  # staging すり抜けで本番 deploy 初露見」する回帰を、カスタムコードなしで根絶する (E3031 等)。
+  # develop 向け PR でも発火させることで ADR-0019 replacement gate の「develop で効かない」gap を補完。
+  # 役割分担: cfn-lint = AWS schema 由来の網羅的 property 制約 (汎用) /
+  #           assertion = project 固有の意図 (tests/unit/infra/*.test.ts)。
+  # infra/ 変更時のみ実行 (軽量。node ci + infra ci + synth + cfn-lint で ~1-2 分)。
+  cdk-cfn-lint:
+    needs: changes
+    if: needs.changes.outputs.infra == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      # tsx (cdk.json app) と aws-cdk / aws-cdk-lib は infra/package.json SSOT (root は持たない)。
+      - name: Install infra dependencies
+        run: cd infra && npm ci
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # cfn-lint は Python dev tool (本番 bundle 0、外部送信なし、offline、AWS 認証不要)。
+      # 版を pin して synth template 検査の決定性を担保する (#3874 実機実証版)。
+      - name: Install cfn-lint (pinned)
+        run: pip install "cfn-lint==1.53.0"
+
+      # synth → cfn-lint。E ルール (property 制約違反) のみ hard-fail。CDK ノイズ (W3005 等) は
+      # infra/.cfnlintrc の ignore_checks で抑制済 (false-positive ゼロ)。
+      - name: cfn-lint synth gate (property 制約違反 hard-fail、#3874 Layer 1)
+        run: node scripts/check-cdk-cfn-lint.mjs
+
+      # #3870 相当の非-ASCII IAM Description を gate が E3031 で捕捉することを再現実証 (#3874 AC1)。
+      # cfn-lint (Python) を要するため本 job (install 済) で実行する。
+      - name: cfn-lint regression test (#3870 相当を再現、#3874 AC1)
+        run: node --test scripts/__tests__/check-cdk-cfn-lint.test.mjs
 
   # #1006 Phase 2: vitest を 2 shard に分割して並列化 (1m 23s → ~40s 目標)
   # 各 shard は coverage を出力し、unit-test-merge で合算してラチェットチェック。
@@ -1123,6 +1179,8 @@ jobs:
         lint-and-test,
         marketplace-registry-integrity-check,
         deps-supply-chain-check,
+        dependency-cruiser,
+        cdk-cfn-lint,
         unit-test,
         unit-test-merge,
         storybook-test,
@@ -1171,6 +1229,8 @@ jobs:
         lint-and-test,
         marketplace-registry-integrity-check,
         deps-supply-chain-check,
+        dependency-cruiser,
+        cdk-cfn-lint,
         unit-test,
         unit-test-merge,
         storybook-test,

--- a/infra/.cfnlintrc
+++ b/infra/.cfnlintrc
@@ -1,0 +1,21 @@
+# cfn-lint 設定 (#3874 Layer 1 — synth 静的 lint gate)
+#
+# `scripts/check-cdk-cfn-lint.mjs` が `cdk synth --all` 出力 (infra/cdk.out/*.template.json) を
+# 本設定で検査する。目的は AWS::* リソースの property 制約違反 (charset / allowed-value / type)
+# を deploy 前 (synth 時点) に hard-fail させ、#3870 (IAM Role Description 非-ASCII → deploy
+# rollback) 級の "unit test も staging もすり抜け本番 deploy で初露見" する回帰を根絶すること。
+#
+# gate semantics: error (E ルール) のみ hard-fail。warning / informational は advisory
+#   (`--non-zero-exit-code error` を script が付与)。E3031 (IAM Description charset) 等が
+#   該当する。役割分担 = cfn-lint は AWS schema 由来の網羅的 property 制約 (汎用・自動) /
+#   カスタム assertion (tests/unit/infra/*.test.ts) は project 固有の意図 (logical ID 固定等)。
+#
+# ignore_checks: CDK 生成テンプレ由来のノイズ (実害なし) を抑制し false-positive ゼロにする。
+#   - W3005: CDK が GetAtt 参照に加えて明示 DependsOn を出すため "dependency already enforced" 警告
+#            (14 件、実際に synth 出力に現れる CDK 固有ノイズ)
+#   - W2001: CDK が未使用 Parameter を出すことがある (Fn::If gate 等)
+#   - I1022: Fn::Sub over Fn::Join の style 情報 (機能影響なし)
+ignore_checks:
+  - W3005
+  - W2001
+  - I1022

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -30,6 +30,28 @@ SSOT: `docs/CLAUDE.md` §「サブディレクトリ別局所テストコマン�
 
 CloudFront はグローバル（geoRestriction `JP`）。新規 region 言及は本ファイルを SSOT として `us-east-1`。`tests/unit/e2e-helpers/*` の `ap-northeast-1` 言及はテスト fixture（変更不要）。
 
+## CDK deploy 失敗の層別 未然防止（#3874、どの層で最初に落ちるか SSOT）
+
+「synth 成功・unit test 通過・staging すり抜けで**本番 deploy の実 AWS で初めて失敗**する」CDK トラブル（第16回リリースで 2 class 連続発生）を、人の注意ではなく CI で未然に捕捉する層別防御。AWS 推奨の shift-left（synth 静的検査）→ fitness function → rehearsal（staging 実 deploy）の重ねに整合。**新しい deploy 失敗に遭遇したら、まず「どの層が最初に捕捉すべきか」を本表で判定してから対策を実装する**。
+
+| 層 | 検証 | 実体 | 何を最初に捕捉するか |
+|---|---|---|---|
+| **Layer 1: synth 静的 lint** | `cdk synth --all` 出力 template を **cfn-lint** で検査し AWS schema 由来の property 制約違反（charset / allowed-value / type）を synth 時点で hard-fail | `scripts/check-cdk-cfn-lint.mjs` + `infra/.cfnlintrc` + ci.yml `cdk-cfn-lint` job（`infra/**` 変更時、develop 向け PR でも発火） | **Class ①（静的プロパティ制約違反）**。例: IAM Role/ManagedPolicy `Description` の非-ASCII（cfn-lint **E3031**、#3870）を含む全リソースの pattern / allowed-value / type 違反を**カスタムコードなしで**網羅捕捉 |
+| **Layer 2: project 固有 fitness** | 「本 project が壊してはいけない不変条件」を `Template.fromStack` synth 後に assert（AWS schema には無い project 固有の意図） | `tests/unit/infra/iam-role-description-ascii.test.ts`（IAM description ASCII、#3870）/ `tests/unit/infra/cross-stack-export-ratchet.test.ts`（自動 export/import allowlist ratchet、#3858） | **Class ②（stateful なデプロイ順序制約）の一部**。cross-stack export の新規混入を PR 時点で検出（deployed-state 依存の in-use 削除ロックの残りは Layer 3 が担う）。Layer 1 と冗長化する IAM ASCII assertion は上位互換の fallback として保持 |
+| **Layer 3: rehearsal（staging 実 deploy）** | prod 経路（CDK synth → ECR push → Lambda update → health）を統合 PR で実 AWS 貫通。ADR-0019 replacement gate（`scripts/check-cdk-replacement.mjs`）も staging diff に適用 | `.github/workflows/deploy-aws-staging.yml`（AWS staging 3 stack）/ `.github/workflows/deploy-nuc-staging.yml`（NUC staging） | **Class ②（export-in-use ロック等 deployed-state 依存の失敗）**。静的では原理的に catch 不能なため実 deploy でのみ露見する class を統合監査で捕捉 |
+
+**役割分担の要点**: cfn-lint（Layer 1）は「AWS が受け付けない template」を汎用・自動で、assertion（Layer 2）は「本 project の不変条件」を、rehearsal（Layer 3）は「deployed-state 依存の失敗」を守る。3 層は補完関係で、上位ほど安価・高速・shift-left。
+
+**ローカル実行**:
+
+```bash
+npm run check:cfn-lint                 # cdk synth --all → cfn-lint（要 pip install cfn-lint）
+node scripts/check-cdk-cfn-lint.mjs --skip-synth   # 既存 cdk.out を再 synth せず lint のみ
+CFN_LINT_BIN=<path> npm run check:cfn-lint          # Windows で Scripts が PATH 外の場合
+```
+
+cfn-lint は Python dev tool（`pip install "cfn-lint==1.53.0"`）。本番 bundle には含まれず、AWS 認証・ネット不要で offline 動作する。CI の `cdk-cfn-lint` job が pin 版を install する。`.cfnlintrc` の `ignore_checks`（W3005 等）は CDK 生成テンプレのノイズ抑制で false-positive をゼロにする（error = E ルールのみ hard-fail）。
+
 ## production env 必須配布 4 経路（#911 / #806）
 
 新規 env 追加時は以下 4 経路すべてに配布。欠けると本番デプロイで起動失敗（#911 で 25 連続失敗の原因）:

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"optimize:lp-images:check": "node scripts/optimize-lp-images.mjs --check",
 		"check:no-demo-route-dup": "node scripts/check-no-demo-route-duplication.mjs",
 		"check:cron-observability": "node scripts/check-cron-observability.mjs",
+		"check:cfn-lint": "node scripts/check-cdk-cfn-lint.mjs",
 		"ops:reconcile-stripe": "npx tsx scripts/reconcile-stripe-subscriptions.ts",
 		"setup:stripe-portal": "npx tsx scripts/stripe-setup-portal.ts",
 		"verify:pack-coverage": "node scripts/verify-pack-coverage.mjs"

--- a/scripts/__tests__/check-cdk-cfn-lint.test.mjs
+++ b/scripts/__tests__/check-cdk-cfn-lint.test.mjs
@@ -1,0 +1,113 @@
+// scripts/__tests__/check-cdk-cfn-lint.test.mjs — Issue #3874 Layer 1 AC1 回帰実証
+//
+// #3870 (AWS::IAM::Role.Description に日本語 → deploy rollback) 相当の property 制約違反を、
+// **本 PR が同梱する gate (cfn-lint + infra/.cfnlintrc)** が synth 時点で捕捉することを実証する。
+// cdk synth を経由せず handcraft した最小 template を cfn-lint に掛けることで、gate の検出力を
+// 決定的に (AWS 認証 / ネット不要で) 検証する。
+//
+// 実行: node --test scripts/__tests__/check-cdk-cfn-lint.test.mjs
+//   cfn-lint (Python) を要するため CI の `cdk-cfn-lint` job (pin 版 install 済) で走らせる。
+//   cfn-lint 不在環境 (通常の unit-test job / cfn-lint 未 install の local) では skip する
+//   (本テストは gate の検出力の検証であって、gate 本体ではない。gate 本体は fail-closed)。
+//
+// 参照: scripts/check-cdk-cfn-lint.mjs / infra/.cfnlintrc / infra/CLAUDE.md §IAM description ASCII
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+const cfnlintrc = join(repoRoot, 'infra', '.cfnlintrc');
+const cfnLint = process.env.CFN_LINT_BIN || 'cfn-lint';
+
+/** cfn-lint が実行可能か (不在なら本テスト群を skip)。 */
+function cfnLintAvailable() {
+	const probe = spawnSync(cfnLint, ['--version'], { encoding: 'utf8' });
+	return !probe.error && probe.status === 0;
+}
+
+/** 与えた IAM Role Description を持つ最小 CloudFormation template を返す。 */
+function iamRoleTemplate(description) {
+	return JSON.stringify({
+		Resources: {
+			MyRole: {
+				Type: 'AWS::IAM::Role',
+				Properties: {
+					Description: description,
+					AssumeRolePolicyDocument: {
+						Version: '2012-10-17',
+						Statement: [
+							{
+								Effect: 'Allow',
+								Principal: { Service: 'backup.amazonaws.com' },
+								Action: 'sts:AssumeRole',
+							},
+						],
+					},
+				},
+			},
+		},
+	});
+}
+
+/** shipped の gate と同一設定 (config-file + fail-on-error) で cfn-lint を回す。 */
+function runCfnLint(templatePath) {
+	return spawnSync(
+		cfnLint,
+		['--config-file', cfnlintrc, '--non-zero-exit-code', 'error', templatePath],
+		{ encoding: 'utf8' },
+	);
+}
+
+const available = cfnLintAvailable();
+
+test('[AC1] 非-ASCII (日本語) IAM Role Description を E3031 で hard-fail (#3870 相当を再現)', (t) => {
+	if (!available) {
+		t.skip('cfn-lint が未 install (CI cdk-cfn-lint job で実行される)');
+		return;
+	}
+	const dir = mkdtempSync(join(tmpdir(), 'cfn-lint-regress-'));
+	try {
+		const bad = join(dir, 'bad.template.json');
+		// #3870 の DsqlBackupRole が持っていた日本語 description に相当する非-ASCII 値。
+		writeFileSync(bad, iamRoleTemplate('DSQL バックアップ用ロール'));
+		const res = runCfnLint(bad);
+		assert.notEqual(
+			res.status,
+			0,
+			`非-ASCII description は hard-fail すべき (exit ${res.status})。gate が #3870 を見逃す`,
+		);
+		assert.match(
+			`${res.stdout}${res.stderr}`,
+			/E3031/,
+			'IAM Description charset 違反は cfn-lint E3031 で検出されるべき',
+		);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+test('[AC2] ASCII の IAM Role Description は false-positive なく PASS する', (t) => {
+	if (!available) {
+		t.skip('cfn-lint が未 install (CI cdk-cfn-lint job で実行される)');
+		return;
+	}
+	const dir = mkdtempSync(join(tmpdir(), 'cfn-lint-regress-'));
+	try {
+		const good = join(dir, 'good.template.json');
+		writeFileSync(good, iamRoleTemplate('Role for DSQL backup'));
+		const res = runCfnLint(good);
+		assert.equal(
+			res.status,
+			0,
+			`ASCII description は PASS すべき (exit ${res.status})\n${res.stdout}${res.stderr}`,
+		);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});

--- a/scripts/check-cdk-cfn-lint.mjs
+++ b/scripts/check-cdk-cfn-lint.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-cdk-cfn-lint.mjs — Issue #3874 Layer 1 (synth 静的 lint gate)
+ *
+ * CDK が synth する CloudFormation template (`infra/cdk.out/*.template.json`) を cfn-lint で
+ * 静的検査し、AWS::* リソースの property 制約違反 (charset / allowed-value / type) を
+ * **deploy 前 (synth 時点)** に hard-fail させる shift-left gate。
+ *
+ * 背景 (#3870 / 第16回リリース):
+ *   `AWS::IAM::Role.Description` に日本語 (非-ASCII) を入れたことで IAM の ASCII/Latin-1 制約
+ *   (U+00FF 上限) に違反 → 本番 deploy で `InvalidRequest` → CREATE_FAILED → stack rollback。
+ *   この class は synth 成功・unit test 通過・staging すり抜けで「本番 deploy で初露見」する。
+ *   cfn-lint rule **E3031** が `AWS::IAM::Role.Description` の schema pattern
+ *   (許容 = U+0009 / U+000A / U+000D / U+0020-U+007E / U+00A1-U+00FF) を synth 時点で検査し捕捉する。
+ *
+ * 役割分担 (#3874 Layer 1 / Layer 2):
+ *   - cfn-lint (本 gate)      = AWS schema 由来の**網羅的** property 制約 (汎用・自動・全リソース)
+ *   - assertion fitness       = project 固有の意図 (`tests/unit/infra/*.test.ts`、logical ID 固定 /
+ *                               IAM description ASCII / cross-stack export ratchet 等)
+ *   両者は補完関係。cfn-lint は「AWS が受け付けない template」を、assertion は「本 project が
+ *   壊してはいけない不変条件」を守る。
+ *
+ * gate semantics:
+ *   error (E ルール) のみ hard-fail。warning / informational は advisory
+ *   (`--non-zero-exit-code error`)。CDK 生成テンプレのノイズ (W3005 等) は `infra/.cfnlintrc`
+ *   の ignore_checks で抑制し false-positive ゼロにする。
+ *
+ * Usage:
+ *   node scripts/check-cdk-cfn-lint.mjs              # synth → cfn-lint (CI / local 共通)
+ *   node scripts/check-cdk-cfn-lint.mjs --skip-synth # 既存 cdk.out を再 synth せず lint のみ
+ *   CFN_LINT_BIN=/path/to/cfn-lint node scripts/check-cdk-cfn-lint.mjs  # cfn-lint 実体を明示
+ *
+ * 依存: cfn-lint (Python、`pip install cfn-lint`)。CI は `cdk-cfn-lint` job が pin 版を install する。
+ *       本番 bundle には一切含まれない (Python dev tool、外部送信なし、AWS 認証不要、offline)。
+ *
+ * exit:
+ *   0 = OK (E ルール違反なし)
+ *   1 = 準備エラー (cfn-lint 不在 / synth 失敗)
+ *   2 = cfn-lint が property 制約違反 (E ルール) を検出
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const infraDir = join(repoRoot, 'infra');
+const cdkOutDir = join(infraDir, 'cdk.out');
+const cfnlintrc = join(infraDir, '.cfnlintrc');
+
+/**
+ * `cdk synth --all` に渡す context。addError guard (parentGateCookieSecret / opsSecretKey /
+ * dsqlEndpoint / dsqlClusterArn 非空要求) を満たす**非秘密のダミー値**と、全 stack を synth 対象に
+ * するための context gate (dsqlEnabled / dsqlStagingEnabled / stagingEnabled) で構成する。
+ * これにより #3870 の DsqlBackupRole を含む全 stack (prod 6 + Dsql + DsqlStaging + staging 3 = 11)
+ * を cfn-lint の検査対象にする (`tests/unit/infra/iam-role-description-ascii.test.ts` と同じ網羅性)。
+ */
+const SYNTH_CONTEXT = [
+	['parentGateCookieSecret', 'cfnlint-dummy-parent-gate-secret-0000000000'],
+	['opsSecretKey', 'cfnlint-dummy-ops-secret-key'],
+	['dsqlEndpoint', 'cfnlintdummy1234.dsql.us-east-1.on.aws'],
+	['dsqlClusterArn', 'arn:aws:dsql:us-east-1:000000000000:cluster/cfnlintdummy1234'],
+	['dsqlEnabled', 'true'],
+	['dsqlStagingEnabled', 'true'],
+	['stagingEnabled', 'true'],
+];
+
+/** cfn-lint 実体を解決する。CFN_LINT_BIN で明示可 (Windows で Scripts が PATH 外の場合等)。 */
+function resolveCfnLintBin() {
+	return process.env.CFN_LINT_BIN || 'cfn-lint';
+}
+
+function fail(message, code = 1) {
+	console.error(`[check-cdk-cfn-lint] ✗ ${message}`);
+	process.exit(code);
+}
+
+function main() {
+	const skipSynth = process.argv.includes('--skip-synth');
+	const cfnLint = resolveCfnLintBin();
+
+	// --- 1. cfn-lint 実体の存在確認 (fail-closed。ADR-0006: silent skip 禁止) ---
+	const versionProbe = spawnSync(cfnLint, ['--version'], { encoding: 'utf8' });
+	if (versionProbe.error || versionProbe.status !== 0) {
+		fail(
+			`cfn-lint が見つかりません (${cfnLint})。\n` +
+				'  導入: pip install "cfn-lint==1.53.0"\n' +
+				'  Windows で Scripts が PATH 外の場合は CFN_LINT_BIN で実体を指定:\n' +
+				'    CFN_LINT_BIN="$LOCALAPPDATA/Programs/Python/Python3xx/Scripts/cfn-lint.exe" node scripts/check-cdk-cfn-lint.mjs\n' +
+				'  本 gate は fail-closed です (cfn-lint 不在で PASS しません)。',
+			1,
+		);
+	}
+	console.log(`[check-cdk-cfn-lint] cfn-lint: ${versionProbe.stdout.trim()}`);
+
+	// --- 2. cdk synth --all (全 stack の template を cdk.out に生成) ---
+	if (!skipSynth) {
+		// npx は Windows で npx.cmd。Node の .cmd spawn 制約 (要 shell) を跨ぐため
+		// shell:true + コマンド文字列で起動する (context 値は controlled constant、注入リスクなし)。
+		const ctxFlags = SYNTH_CONTEXT.map(([k, v]) => `-c "${k}=${v}"`).join(' ');
+		const synthCmd = `npx cdk synth --all --quiet ${ctxFlags}`;
+		console.log('[check-cdk-cfn-lint] cdk synth --all (dummy context、全 11 stack)...');
+		const synth = spawnSync(synthCmd, {
+			cwd: infraDir,
+			stdio: 'inherit',
+			shell: true,
+			// synth の addError guard を満たすダミー account (env-agnostic stack 合成)。
+			env: {
+				...process.env,
+				CDK_DEFAULT_ACCOUNT: process.env.CDK_DEFAULT_ACCOUNT || '000000000000',
+			},
+		});
+		if (synth.error) {
+			fail(`cdk synth の起動に失敗しました: ${synth.error.message}`, 1);
+		}
+		if (synth.status !== 0) {
+			fail(`cdk synth が失敗しました (exit ${synth.status})。infra/ の依存 (npm ci) を確認。`, 1);
+		}
+	}
+
+	// --- 3. cdk.out の template ファイルを列挙 (glob をシェルに委ねず自前展開) ---
+	if (!existsSync(cdkOutDir)) {
+		fail(`${cdkOutDir} が存在しません。--skip-synth 指定時は事前に cdk synth が必要です。`, 1);
+	}
+	const templates = readdirSync(cdkOutDir)
+		.filter((f) => f.endsWith('.template.json'))
+		.map((f) => join(cdkOutDir, f))
+		.sort();
+	if (templates.length === 0) {
+		fail(`${cdkOutDir} に *.template.json がありません (synth 空振り)。`, 1);
+	}
+	console.log(`[check-cdk-cfn-lint] 検査対象 ${templates.length} template:`);
+	for (const t of templates) console.log(`  - ${t.replace(repoRoot, '.').replace(/\\/g, '/')}`);
+
+	// --- 4. cfn-lint 実行 (error のみ hard-fail、CDK ノイズは .cfnlintrc で抑制) ---
+	const lintArgs = ['--config-file', cfnlintrc, '--non-zero-exit-code', 'error', ...templates];
+	const lint = spawnSync(cfnLint, lintArgs, { stdio: 'inherit' });
+	if (lint.error) {
+		fail(`cfn-lint の起動に失敗しました: ${lint.error.message}`, 1);
+	}
+	if (lint.status !== 0) {
+		fail(
+			'cfn-lint が property 制約違反 (E ルール) を検出しました。\n' +
+				'  上記 E##### を修正してください (例: E3031 = IAM Role/ManagedPolicy Description の非-ASCII、#3870)。\n' +
+				'  IAM description は英語 ASCII で書き、日本語の背景はコード直上のコメントに記載します。',
+			2,
+		);
+	}
+
+	console.log('[check-cdk-cfn-lint] ✓ PASS — property 制約違反 (E ルール) なし');
+}
+
+main();

--- a/scripts/check-cdk-cfn-lint.mjs
+++ b/scripts/check-cdk-cfn-lint.mjs
@@ -40,7 +40,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -49,23 +49,39 @@ const repoRoot = resolve(__dirname, '..');
 const infraDir = join(repoRoot, 'infra');
 const cdkOutDir = join(infraDir, 'cdk.out');
 const cfnlintrc = join(infraDir, '.cfnlintrc');
+const cdkContextFile = join(infraDir, 'cdk.context.json');
+
+// synth を決定的にするため account を固定する (CI の CDK_DEFAULT_ACCOUNT 有無に依存しない)。
+// これにより hosted-zone lookup key の account 部が常に一致し、下記 context cache が確実に効く。
+const SYNTH_ACCOUNT = '000000000000';
 
 /**
- * `cdk synth --all` に渡す context。addError guard (parentGateCookieSecret / opsSecretKey /
- * dsqlEndpoint / dsqlClusterArn 非空要求) を満たす**非秘密のダミー値**と、全 stack を synth 対象に
- * するための context gate (dsqlEnabled / dsqlStagingEnabled / stagingEnabled) で構成する。
- * これにより #3870 の DsqlBackupRole を含む全 stack (prod 6 + Dsql + DsqlStaging + staging 3 = 11)
- * を cfn-lint の検査対象にする (`tests/unit/infra/iam-role-description-ascii.test.ts` と同じ網羅性)。
+ * `cdk synth --all` を **AWS 認証・ネット不要**で全 stack 合成するための context。
+ * 一時 `cdk.context.json` に書き込んで synth 後に元へ戻す (gitignored な build artifact、
+ * CLI の JSON quoting を跨がず cross-platform で決定的)。
+ *
+ * - addError guard (parentGateCookieSecret / opsSecretKey / dsqlEndpoint / dsqlClusterArn の
+ *   非空要求) を満たす**非秘密のダミー値**
+ * - 全 stack を synth 対象にする context gate (dsqlEnabled / dsqlStagingEnabled / stagingEnabled)。
+ *   #3870 の DsqlBackupRole を含む全 11 stack (prod 6 + Dsql + DsqlStaging + staging 3) を検査対象化
+ *   (`tests/unit/infra/iam-role-description-ascii.test.ts` と同じ網羅性)
+ * - **hosted-zone lookup の cache**: `ses-stack.ts` の `HostedZone.fromLookup` は無条件に
+ *   `ganbari-quest.com` を引くため、cache が無いと CI (creds 無し) で AWS 呼び出しに落ちる。
+ *   `tests/unit/infra/iam-role-description-ascii.test.ts` の `makeApp()` と同じダミー値を与える。
  */
-const SYNTH_CONTEXT = [
-	['parentGateCookieSecret', 'cfnlint-dummy-parent-gate-secret-0000000000'],
-	['opsSecretKey', 'cfnlint-dummy-ops-secret-key'],
-	['dsqlEndpoint', 'cfnlintdummy1234.dsql.us-east-1.on.aws'],
-	['dsqlClusterArn', 'arn:aws:dsql:us-east-1:000000000000:cluster/cfnlintdummy1234'],
-	['dsqlEnabled', 'true'],
-	['dsqlStagingEnabled', 'true'],
-	['stagingEnabled', 'true'],
-];
+const SYNTH_CONTEXT = {
+	parentGateCookieSecret: 'cfnlint-dummy-parent-gate-secret-0000000000',
+	opsSecretKey: 'cfnlint-dummy-ops-secret-key',
+	dsqlEndpoint: 'cfnlintdummy1234.dsql.us-east-1.on.aws',
+	dsqlClusterArn: `arn:aws:dsql:us-east-1:${SYNTH_ACCOUNT}:cluster/cfnlintdummy1234`,
+	dsqlEnabled: true,
+	dsqlStagingEnabled: true,
+	stagingEnabled: true,
+	[`hosted-zone:account=${SYNTH_ACCOUNT}:domainName=ganbari-quest.com:region=us-east-1`]: {
+		Id: '/hostedzone/Z00000000000000000000',
+		Name: 'ganbari-quest.com.',
+	},
+};
 
 /** cfn-lint 実体を解決する。CFN_LINT_BIN で明示可 (Windows で Scripts が PATH 外の場合等)。 */
 function resolveCfnLintBin() {
@@ -75,6 +91,45 @@ function resolveCfnLintBin() {
 function fail(message, code = 1) {
 	console.error(`[check-cdk-cfn-lint] ✗ ${message}`);
 	process.exit(code);
+}
+
+/**
+ * SYNTH_CONTEXT を一時 `cdk.context.json` にマージ書き込みしてから `cdk synth --all` を実行し、
+ * 完了後に元の cdk.context.json を復元する (存在しなければ削除)。context を CLI の `-c` で渡すと
+ * hosted-zone の JSON 値の shell quoting が cross-platform で壊れるため、file 経由にして決定的にする。
+ * cdk.context.json は gitignored な build artifact なので commit されない。
+ */
+function runSynth() {
+	const hadContextFile = existsSync(cdkContextFile);
+	const originalContent = hadContextFile ? readFileSync(cdkContextFile, 'utf8') : null;
+	const base = originalContent ? JSON.parse(originalContent) : {};
+	writeFileSync(cdkContextFile, JSON.stringify({ ...base, ...SYNTH_CONTEXT }, null, 2));
+
+	try {
+		// npx は Windows で npx.cmd。Node の .cmd spawn 制約 (要 shell) を跨ぐため shell:true。
+		// 引数は固定 (context は cdk.context.json 経由) なので注入リスクなし。
+		console.log('[check-cdk-cfn-lint] cdk synth --all (dummy context、全 11 stack)...');
+		const synth = spawnSync('npx cdk synth --all --quiet', {
+			cwd: infraDir,
+			stdio: 'inherit',
+			shell: true,
+			// account を固定して synth を決定的にする (hosted-zone lookup key の一致 + 実 AWS 呼び出し回避)。
+			env: { ...process.env, CDK_DEFAULT_ACCOUNT: SYNTH_ACCOUNT },
+		});
+		if (synth.error) {
+			fail(`cdk synth の起動に失敗しました: ${synth.error.message}`, 1);
+		}
+		if (synth.status !== 0) {
+			fail(`cdk synth が失敗しました (exit ${synth.status})。infra/ の依存 (npm ci) を確認。`, 1);
+		}
+	} finally {
+		// 元の cdk.context.json を復元 (無ければ削除)。synth が cache を追記していても元に戻す。
+		if (originalContent !== null) {
+			writeFileSync(cdkContextFile, originalContent);
+		} else {
+			rmSync(cdkContextFile, { force: true });
+		}
+	}
 }
 
 function main() {
@@ -97,27 +152,7 @@ function main() {
 
 	// --- 2. cdk synth --all (全 stack の template を cdk.out に生成) ---
 	if (!skipSynth) {
-		// npx は Windows で npx.cmd。Node の .cmd spawn 制約 (要 shell) を跨ぐため
-		// shell:true + コマンド文字列で起動する (context 値は controlled constant、注入リスクなし)。
-		const ctxFlags = SYNTH_CONTEXT.map(([k, v]) => `-c "${k}=${v}"`).join(' ');
-		const synthCmd = `npx cdk synth --all --quiet ${ctxFlags}`;
-		console.log('[check-cdk-cfn-lint] cdk synth --all (dummy context、全 11 stack)...');
-		const synth = spawnSync(synthCmd, {
-			cwd: infraDir,
-			stdio: 'inherit',
-			shell: true,
-			// synth の addError guard を満たすダミー account (env-agnostic stack 合成)。
-			env: {
-				...process.env,
-				CDK_DEFAULT_ACCOUNT: process.env.CDK_DEFAULT_ACCOUNT || '000000000000',
-			},
-		});
-		if (synth.error) {
-			fail(`cdk synth の起動に失敗しました: ${synth.error.message}`, 1);
-		}
-		if (synth.status !== 0) {
-			fail(`cdk synth が失敗しました (exit ${synth.status})。infra/ の依存 (npm ci) を確認。`, 1);
-		}
+		runSynth();
 	}
 
 	// --- 3. cdk.out の template ファイルを列挙 (glob をシェルに委ねず自前展開) ---


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発・運用チーム、間接的に全ユーザーのサービス可用性）

**解決する課題**: 第16回リリースで「synth 成功・unit test 通過・staging すり抜けで **本番 deploy の実 AWS で初めて失敗**」する CDK トラブルが 2 class 連続発生した。うち Class ①（静的プロパティ制約違反）は #3870 の `AWS::IAM::Role.Description` に日本語（非-ASCII）を入れ IAM の ASCII/Latin-1 制約に違反 → `InvalidRequest` → CREATE_FAILED → stack rollback。CI のどの層も捕捉できず本番 deploy が止まった。

**期待される効果**: `cdk synth` 出力 template を cfn-lint で静的検査する CI gate（Layer 1 shift-left）を追加し、Class ① 相当の property 制約違反を **deploy 前（synth 時点）に hard-fail** する。IAM 非-ASCII に限らず全リソースの pattern / allowed-value / type 違反をカスタムコードなしで網羅捕捉し、本番 deploy 断による可用性毀損を未然に防ぐ。

## 関連 Issue

#3874 の Phase 1（Layer 1 = cfn-lint synth 静的 lint gate）+ AC5（層別防御 SSOT 化）を実装。
Phase 2（Layer 2 Class② = cross-stack export ratchet）は #3858 が担当し develop 反映済。
Phase 3（Layer 3 = staging env-parity）は stack 定義変更を含むため #3874 Phase 3 区分として本 PR scope 外。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | cfn-lint が CI で cdk.out を検査し IAM Description 非-ASCII 等の property 制約違反を hard-fail（#3870 相当を再現テストで実証） | `node scripts/check-cdk-cfn-lint.mjs` + `node --test scripts/__tests__/check-cdk-cfn-lint.test.mjs` | HEAD `cfe5dce1` / gate ローカル実測 = synth 11 stack → cfn-lint PASS exit 0。回帰テスト 2 pass 0 fail（非-ASCII IAM Desc → E3031 exit≠0 / ASCII → exit0）。負テスト = cdk.out に非-ASCII template 注入で gate exit 2。CI job `cdk-cfn-lint`（.github/workflows/ci.yml） |
| AC2 | CDK 生成テンプレのノイズ（W2001/I1022 等）が .cfnlintrc で抑制され false-positive ゼロ | `node scripts/check-cdk-cfn-lint.mjs`（実 template 11 本で noise ゼロ確認） | HEAD `cfe5dce1` / infra/.cfnlintrc `ignore_checks: [W3005, W2001, I1022]` + `--non-zero-exit-code error`（E ルールのみ hard-fail）。実 synth 出力に現れるのは W3005×14 のみ→抑制後 exit 0 で clean |
| AC3 | #3858 export ratchet が Class ② を develop lane 早期検出 | `tests/unit/infra/cross-stack-export-ratchet.test.ts`（#3858、develop 反映済 commit 3d39c02e） | 本 PR は Layer 1 として #3858 と **非重複**（cfn-lint = AWS schema 由来の property 制約 / #3858 = 自動 export/import allowlist ratchet）。list-imports 精緻化は #3858 の設計精緻化領域として同 Issue が担当 |
| AC4 | staging env-parity で prod-only resource が staging deploy で exercise される | Layer 3（`.github/workflows/deploy-aws-staging.yml`）。本 PR scope 外 | #3874 Phase 3 区分。staging の backup role 生成は env-config.ts の stack 定義変更 + cost 判断を要し、#3850/#3854 DSQL cutover 稼働セッションとの衝突回避のため本 PR では未実装 |
| AC5 | 各層の役割と「どの層で最初に落ちるか」を SSOT 化 | infra/CLAUDE.md §「CDK deploy 失敗の層別 未然防止」 | HEAD `cfe5dce1` / infra/CLAUDE.md に 3 層（Layer 1 cfn-lint / Layer 2 fitness / Layer 3 rehearsal）+ どの Class をどの層が最初に捕捉するか + ローカル実行手順を追記 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [x] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（CI gate の追加のみ）。CDK **stack 定義（dsql/compute/storage-stack.ts 等）は一切変更していない**。追加は `scripts/check-cdk-cfn-lint.mjs` / `infra/.cfnlintrc` / `.github/workflows/ci.yml`（`cdk-cfn-lint` job + `infra` paths filter）/ `infra/CLAUDE.md` / `package.json`。cfn-lint は synth 出力を read-only で検査するのみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / doc-code-references / check-pr-body 等をローカル検証（下記「追加テスト」欄参照）
- [x] 追加・変更したテストの概要を以下に記載: `scripts/__tests__/check-cdk-cfn-lint.test.mjs` を新規追加。非-ASCII IAM Role Description が cfn-lint E3031 で hard-fail する（#3870 相当）+ ASCII は false-positive なく PASS することを、shipped の `infra/.cfnlintrc` 経由で決定的に実証（cfn-lint 不在環境は skip、CI `cdk-cfn-lint` job で実行）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（`CFN_LINT_BIN` は optional な実体 override read のみ、必須 env 追加なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（新規 CI gate 追加、bug 修正ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: CI/CD gate + スクリプト + ドキュメントの変更のみで UI 変更を含まない。cfn-lint gate の動作証跡は AC 検証マップの実測ログ（synth 11 stack → PASS / 非-ASCII 注入 → exit 2 / 回帰テスト 2 pass）で代替する。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: gate script は「synth → template 列挙 → cfn-lint 実行」の単一責任。property 制約検査（cfn-lint）と project 固有不変条件（既存 assertion fitness）を責務分離
- [x] **DRY**: 既存資産と非重複。IAM ASCII は `tests/unit/infra/iam-role-description-ascii.test.ts`（Layer 2 fallback）と役割分担、export ratchet は #3858、synth 網羅性は同 test の 11 stack と同一 context を踏襲。新規に synth ロジックを重複実装しない方針を SSOT 化
- [x] **YAGNI**: cdk-nag v3 / cfn-guard / Checkov / LocalStack は Issue の比較で不採用（property 書式は対象外 or 過剰導入）。cfn-lint 1 個のみ、error クラスのみ hard-fail の最小構成
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし（synth context はすべて非秘密のダミー値）。cfn-lint は offline・外部送信なし・AWS 認証不要。synth context 値は controlled constant で shell 注入リスクなし
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: infra/** 変更時のみ発火。node ci + infra ci + synth + cfn-lint で ~1-2 分、他 job と並列。本番 bundle 影響ゼロ（Python dev tool）

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期 — N/A
- [ ] LP ↔ アプリ双方向整合 — N/A
- [ ] 全年齢モード 5 種 — N/A
- [ ] ナビゲーション 3 種 — N/A
- [ ] E2E / ユニットシード + チュートリアル — N/A
- [ ] labels SSOT — N/A
- [x] **設計書同期** (ADR-0001): インフラ変更のため `infra/CLAUDE.md` に層別防御 SSOT を追記。CDK stack 定義は不変更のため 13-AWS 設計書の resource 記述に差分なし
- [x] **並行 PR overlap** (#1200): 稼働中 infra セッション（#3850/#3854 DSQL cutover、#3858 export ratchet）と **file overlap なし**。本 PR は CI/lint 追加のみで stack 定義（dsql/compute/storage-stack.ts）に触れていない
- [ ] N/A — 並行実装の影響範囲外

該当なし: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:
- Layer 1 の scope 判断: 本 PR は #3874 Phase 1（cfn-lint gate）+ AC5（SSOT）に限定。AC3 は #3858（develop 反映済）、AC4（Layer 3 staging env-parity）は stack 定義変更 + cost 判断を要すため #3874 Phase 3 区分とした点をご確認ください。
- cfn-lint の gate semantics: E（error）ルールのみ hard-fail、W/I は advisory。CDK ノイズ（W3005 等）は `infra/.cfnlintrc` で ignore し false-positive ゼロにしています。
- cfn-lint 版は Issue の実機実証版 `1.53.0` を pin。E3031 が AWS IAM Description の charset 制約（`^[\t\n\r\x20-\x7E\xA1-\xFF]*$`）を検査することをローカル実機で確認済。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`CFN_LINT_BIN` は optional な cfn-lint 実体 override の read のみ）。cfn-lint は CI の `cdk-cfn-lint` job が `pip install "cfn-lint==1.53.0"` で導入する Python dev tool（本番 bundle 0）

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = Phase 1 の AC1/AC2/AC5、未消化マーカーの残置なし。AC3=#3858 / AC4=#3874 Phase 3 は AC マップに status 明記）
- [x] Phase 分割した場合: #3874 の段階導入計画（Phase 1/2/3）に沿って Phase 1 を実装、Phase 3 は #3874 に status 記録
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言: gate 3 経路をローカル実機実測 = synth PASS / 非-ASCII 注入 exit2 / 回帰 2 pass）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


