### PR TITLE
fix(data-integrity): #3859 export/import validator の legacy SQLite 値表現 網羅監査 + 日時形式 SSOT 集約 (#3851 同 class 横展開)

### DIFF
--- a/src/lib/domain/export-format.ts
+++ b/src/lib/domain/export-format.ts
@@ -1,6 +1,7 @@
 // src/lib/domain/export-format.ts
 // エクスポートファイルのフォーマット型定義
 import type { CategoryId, ChildId } from '$lib/domain/ids';
+import { isLegacyCompatibleDateTime } from '$lib/domain/validation/datetime';
 
 export const EXPORT_FORMAT = 'ganbari-quest-backup' as const;
 // #1254 G1: 1.2.0 で `sourcePresetId` フィールドを追加 (activities / specialRewards / checklistTemplates)
@@ -136,8 +137,10 @@ function hasControlChar(value: string): boolean {
 const BOOL_SETTING_VALUES = new Set(['true', 'false', '0', '1']);
 // HH:MM (24h)。notifications / quiet hours の time input が生成する形式。
 const TIME_HHMM_RE = /^([01]\d|2[0-3]):[0-5]\d$/;
-// tutorial_started_at / completed_at は `new Date().toISOString()`。
-const ISO_DATETIME_PREFIX_RE = /^\d{4}-\d{2}-\d{2}T/;
+// tutorial_started_at / completed_at の現行書込は `new Date().toISOString()` (T 区切り) だが、
+// 受理形式は round-trip 日時 SSOT ($lib/domain/validation/datetime、#3859) に従い SQL datetime
+// (スペース区切り) も許容する。#3851 で import-service 側だけ両区切り化した結果、settings 側に
+// T 必須 regex が残る片側ドリフトが生じていた — 形式定数の二重定義を排し同一述語を import する。
 const DECAY_INTENSITY_VALUES = new Set(['none', 'gentle', 'normal', 'strict']); // validation/status.ts DecayIntensity SSOT
 const POINT_UNIT_MODE_VALUES = new Set(['point', 'currency']); // point-display.ts PointUnitMode SSOT
 const CURRENCY_CODE_VALUES = new Set(['JPY', 'USD', 'EUR', 'GBP', 'AUD', 'CAD']); // point-display.ts CurrencyCode SSOT
@@ -154,8 +157,7 @@ const WEEKDAY_VALUES = new Set([
 
 const isBoolSetting = (v: string): boolean => BOOL_SETTING_VALUES.has(v);
 const isTimeSetting = (v: string): boolean => TIME_HHMM_RE.test(v);
-const isIsoDatetime = (v: string): boolean =>
-	v.length <= 40 && ISO_DATETIME_PREFIX_RE.test(v) && !Number.isNaN(Date.parse(v));
+const isIsoDatetime = (v: string): boolean => v.length <= 40 && isLegacyCompatibleDateTime(v);
 
 /**
  * 設定キーごとの値バリデータ (allowlist の 20 キー全てを網羅)。

--- a/src/lib/domain/validation/datetime.ts
+++ b/src/lib/domain/validation/datetime.ts
@@ -1,0 +1,31 @@
+// src/lib/domain/validation/datetime.ts
+//
+// #3859: export/import round-trip の日時形式 SSOT (ADR-0066 と同型の domain 層集約)。
+//
+// 背景 (#3851 / PR #3856): legacy SQLite の TEXT datetime 列は `CURRENT_TIMESTAMP` 既定値で
+// `'YYYY-MM-DD HH:MM:SS'` (半角スペース区切り) を書く一方、JS 側書込は
+// `new Date().toISOString()` (`'T'` 区切り) を書く。round-trip validator が片方の表現しか
+// 想定しないと、正当な legacy 行を「不正」と誤判定して silent drop → 件数突合 abort
+// (false-positive data-loss) を起こす (#3851 で親メッセージが実害)。
+//
+// 本 module は「先頭 `YYYY-MM-DD` + `T` または半角スペース区切り + `HH:MM` + `Date.parse` 可」
+// を round-trip 日時の受理ポリシーとして単一定義し、import-service (parentMessage /
+// siblingCheer の sentAt/shownAt) と export-format (settings tutorial_*_at) の両 validator が
+// 同一述語を import する。片側だけ `T` 必須が残ると #3851 の class が再発するため、
+// 形式定数を二重定義しない (ADR-0066「wire schema とドメイン validator は同一値域定数を
+// import する」の形式版)。`Date.parse` gate が残るため、破損 / 改竄値 (未知形式・範囲外) は
+// 依然 reject される。
+
+/**
+ * round-trip 日時の受理形式: `YYYY-MM-DD` + (`T` | 半角スペース) + `HH:MM` prefix。
+ * `T` = ISO 8601 (JS toISOString) / スペース = SQL datetime (SQLite CURRENT_TIMESTAMP 既定値)。
+ */
+export const LEGACY_COMPAT_DATETIME_RE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/;
+
+/**
+ * 日時 (ISO 8601 または SQL datetime 表現、`Date.parse` 可) か。
+ * restore / cutover / settings import の verbatim 値検証用 (#3414 / #3420 / #3382 / #3851 / #3859)。
+ */
+export function isLegacyCompatibleDateTime(value: string): boolean {
+	return LEGACY_COMPAT_DATETIME_RE.test(value) && !Number.isNaN(Date.parse(value));
+}

--- a/src/lib/server/services/import-service.ts
+++ b/src/lib/server/services/import-service.ts
@@ -15,6 +15,7 @@ import {
 import { MIGRATABLE_VERSIONS, migrateExportData } from '$lib/domain/export-migrations';
 import { IMPORT_LABELS, type ImportSkipReason } from '$lib/domain/labels';
 import { sanitizeActivityNameField, sanitizeDailyLimit } from '$lib/domain/validation/activity';
+import { isLegacyCompatibleDateTime } from '$lib/domain/validation/datetime';
 import { MESSAGE_TEXT_MAX_LENGTH, MESSAGE_TYPES } from '$lib/domain/validation/message';
 import {
 	findActivities,
@@ -103,21 +104,15 @@ async function runConcurrent<T>(
 const RESTORE_DEDUP_FETCH_LIMIT = 100_000;
 
 /**
- * 日時 (先頭 `YYYY-MM-DD` + `T` または半角スペース区切り + `HH:MM` + Date.parse 可) か。
- * restore / cutover の verbatim 値検証用 (#3414/#3420)。
+ * 日時 (ISO 8601 または SQL datetime、`Date.parse` 可) か。restore / cutover の verbatim
+ * 値検証用 (#3414/#3420)。
  *
- * #3851: 区切りは `T` (ISO 8601) と半角スペース の両方を許容する。通常の親メッセージ / おうえん
- * 送信経路 (insertMessage / sendCheer) は sent_at を指定せず、SQLite の `CURRENT_TIMESTAMP`
- * 既定値 = `'YYYY-MM-DD HH:MM:SS'` (スペース区切り、Date.parse 可の正当な日時) が入る。旧実装は
- * `T` 必須だったため、この正当な legacy 日時を「不正」と誤判定し、NUC cutover の verbatim import で
- * 親メッセージを silent drop → 件数突合 (parentMessages export=1 imported=0) で abort させていた
- * (これは dedup ではなく validator 誤判定による真の false-positive data-loss)。区切りを緩めても
- * `Date.parse` gate が残るため、破損/改竄値 (未知形式・範囲外) は依然 reject される。
+ * #3851: SQLite `CURRENT_TIMESTAMP` 既定値 (スペース区切り) を持つ正当な legacy 行が
+ * `T` 必須 regex で silent drop → 件数突合 abort する false-positive data-loss を是正した。
+ * #3859: 形式定数を $lib/domain/validation/datetime に SSOT 集約し、settings validator
+ * (export-format) と同一述語を import する (片側だけ `T` 必須が残る同 class ドリフトの根絶)。
  */
-const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}/;
-function isValidIsoDateTime(value: string): boolean {
-	return ISO_DATETIME_RE.test(value) && !Number.isNaN(Date.parse(value));
-}
+const isValidIsoDateTime = isLegacyCompatibleDateTime;
 
 /** bonusPoints の許容範囲 (null または 0〜99,999 の整数)。改竄 backup の範囲外値を弾く (#3414)。 */
 function isValidBonusPoints(value: number | null): boolean {

--- a/tests/unit/domain/legacy-sqlite-value-audit.test.ts
+++ b/tests/unit/domain/legacy-sqlite-value-audit.test.ts
@@ -35,7 +35,7 @@ const DT_ISO_MINUTE = '2026-01-02T03:04';
 /** 真に破損した日時 (negative)。 */
 const DT_BROKEN = 'not-a-valid-date';
 /** 形は合うが Date.parse 不能 (negative、Date.parse gate の実効性)。 */
-const DT_UNPARSEABLE = '2026-13-99 99:99:99';
+const DT_UNPARSABLE = '2026-13-99 99:99:99';
 
 describe('legacy SQLite 値表現 監査 (#3859) — settings validator (export-format)', () => {
 	// #3851 同 class の是正対象: tutorial_*_at の datetime validator。
@@ -54,7 +54,7 @@ describe('legacy SQLite 値表現 監査 (#3859) — settings validator (export-
 	it('tutorial_*_at: 真破損の日時は依然 reject する (negative、握り潰し過剰でない)', () => {
 		for (const key of ['tutorial_started_at', 'tutorial_completed_at']) {
 			expect(isValidSettingValue(key, DT_BROKEN), `${key} × BROKEN`).toBe(false);
-			expect(isValidSettingValue(key, DT_UNPARSEABLE), `${key} × UNPARSEABLE`).toBe(false);
+			expect(isValidSettingValue(key, DT_UNPARSABLE), `${key} × UNPARSABLE`).toBe(false);
 			expect(isValidSettingValue(key, ''), `${key} × 空文字`).toBe(false);
 			// 40 char 超の bound は維持 (DoS 的長大値の排除)
 			expect(isValidSettingValue(key, `${DT_ISO}${'0'.repeat(40)}`), `${key} × 長大`).toBe(false);

--- a/tests/unit/domain/legacy-sqlite-value-audit.test.ts
+++ b/tests/unit/domain/legacy-sqlite-value-audit.test.ts
@@ -1,0 +1,140 @@
+// tests/unit/domain/legacy-sqlite-value-audit.test.ts
+// #3859 — export/import round-trip validator の legacy SQLite 値表現 受理可否の実測監査。
+//
+// root class (#3851 / PR #3856): 「wire validator が legacy SQLite の実データ表現を想定しきれず
+// 正当な行を silent drop する」。#3851 は import-service の timestamp validator が SQLite
+// `CURRENT_TIMESTAMP` 既定値 (スペース区切り日時) を誤 reject して cutover を abort させた実害。
+// 本テストは同 class の横展開監査として、round-trip 経路の全 field-format validator に対し
+// legacy SQLite が実際に書く値表現 (下記 5 分類) の受理可否を **実 validator を呼んで実測** し、
+// 回帰として固定する (推測表ではなく物理実行が SSOT、ADR-0061 failing-test-first)。
+//
+// legacy 実表現の分類 (Issue #3859):
+//   DT-SP    : 'YYYY-MM-DD HH:MM:SS' — SQLite CURRENT_TIMESTAMP 既定値 (スペース区切り)
+//   DT-ISO   : 'YYYY-MM-DDTHH:MM:SS.sssZ' — JS new Date().toISOString()
+//   BOOL-INT / BOOL-WORD : '0'|'1' / 'true'|'false' — settings KVS の 2 系統 boolean 文字列
+//   NUM-STR  : '42' — 数値の文字列化 (settings value / dailyLimit 等)
+//   NULLISH  : null / '' — 未設定系
+//   BROKEN   : 'not-a-date' 等 — 真に不正な値 (negative、受理してはならない)
+//
+// 不変条件: legacy 実データ ⊆ validator 受理 (positive) / 真破損は依然 reject (negative)。
+// 日時形式の SSOT は $lib/domain/validation/datetime (ADR-0066 と同型の domain 層集約) で、
+// import-service (parentMessage / siblingCheer sentAt/shownAt) と export-format
+// (settings tutorial_*_at) の両 validator が同一述語を import することを本テストが表明する。
+
+import { describe, expect, it } from 'vitest';
+import { sanitizeChecklistOverrideRestore } from '$lib/domain/checklist-override';
+import { isValidSettingValue } from '$lib/domain/export-format';
+import { sanitizeActivityNameField, sanitizeDailyLimit } from '$lib/domain/validation/activity';
+
+/** SQLite CURRENT_TIMESTAMP 既定値そのものの形 (#3851 の実害表現)。 */
+const DT_SPACE = '2026-01-02 03:04:05';
+/** JS new Date().toISOString() の形。 */
+const DT_ISO = '2026-01-02T03:04:05.000Z';
+/** 秒なし ISO (isValidIsoDateTime の下限形。HH:MM まで)。 */
+const DT_ISO_MINUTE = '2026-01-02T03:04';
+/** 真に破損した日時 (negative)。 */
+const DT_BROKEN = 'not-a-valid-date';
+/** 形は合うが Date.parse 不能 (negative、Date.parse gate の実効性)。 */
+const DT_UNPARSEABLE = '2026-13-99 99:99:99';
+
+describe('legacy SQLite 値表現 監査 (#3859) — settings validator (export-format)', () => {
+	// #3851 同 class の是正対象: tutorial_*_at の datetime validator。
+	// legacy 書込経路は new Date().toISOString() (T 区切り) のみだが、round-trip の日時受理
+	// ポリシーは「T / スペースの両区切り + Date.parse 可」で全 validator 統一する
+	// (PR #3856 で import-service 側は統一済。片側だけ T 必須が残ると同 class ドリフトが再発する)。
+	it('tutorial_started_at / tutorial_completed_at: DT-ISO と DT-SP の両方を受理する (positive)', () => {
+		for (const key of ['tutorial_started_at', 'tutorial_completed_at']) {
+			expect(isValidSettingValue(key, DT_ISO), `${key} × DT-ISO`).toBe(true);
+			expect(isValidSettingValue(key, DT_ISO_MINUTE), `${key} × DT-ISO-minute`).toBe(true);
+			// #3859: スペース区切り (SQLite CURRENT_TIMESTAMP 表現) — 是正前は T 必須 regex で reject
+			expect(isValidSettingValue(key, DT_SPACE), `${key} × DT-SP`).toBe(true);
+		}
+	});
+
+	it('tutorial_*_at: 真破損の日時は依然 reject する (negative、握り潰し過剰でない)', () => {
+		for (const key of ['tutorial_started_at', 'tutorial_completed_at']) {
+			expect(isValidSettingValue(key, DT_BROKEN), `${key} × BROKEN`).toBe(false);
+			expect(isValidSettingValue(key, DT_UNPARSEABLE), `${key} × UNPARSEABLE`).toBe(false);
+			expect(isValidSettingValue(key, ''), `${key} × 空文字`).toBe(false);
+			// 40 char 超の bound は維持 (DoS 的長大値の排除)
+			expect(isValidSettingValue(key, `${DT_ISO}${'0'.repeat(40)}`), `${key} × 長大`).toBe(false);
+		}
+	});
+
+	it('boolean settings: BOOL-WORD と BOOL-INT の両表現を受理する (positive)', () => {
+		// legacy setSetting は 'true'/'false' を書くが、BOOL_SETTING_VALUES は '0'/'1' も許容
+		for (const v of ['true', 'false', '0', '1']) {
+			expect(isValidSettingValue('notification_reminders_enabled', v), `bool × ${v}`).toBe(true);
+			expect(isValidSettingValue('tutorial_banner_dismissed', v), `bool × ${v}`).toBe(true);
+		}
+	});
+
+	it('boolean settings: 大文字 / 数値以外の変形は reject する (negative)', () => {
+		for (const v of ['TRUE', 'yes', '2', '']) {
+			expect(isValidSettingValue('notification_reminders_enabled', v), `bool × ${v}`).toBe(false);
+		}
+	});
+
+	it('point_rate: NUM-STR (数値の文字列化) を受理し、非数値 / 範囲外は reject する', () => {
+		expect(isValidSettingValue('point_rate', '42')).toBe(true);
+		expect(isValidSettingValue('point_rate', '2.5')).toBe(true);
+		expect(isValidSettingValue('point_rate', 'not-a-number')).toBe(false);
+		expect(isValidSettingValue('point_rate', '')).toBe(false);
+		expect(isValidSettingValue('point_rate', '0')).toBe(false); // 下限外 (> 0)
+	});
+
+	it('HH:MM settings: time input 生成形式のみ受理する (legacy 書込と一致)', () => {
+		expect(isValidSettingValue('notification_quiet_start', '07:30')).toBe(true);
+		expect(isValidSettingValue('notification_quiet_start', '23:59')).toBe(true);
+		// legacy time input は zero-pad 必須のため '7:30' は書かれない (= reject は誤 drop でない)
+		expect(isValidSettingValue('notification_quiet_start', '7:30')).toBe(false);
+	});
+});
+
+describe('legacy SQLite 値表現 監査 (#3859) — checklist override validator (domain)', () => {
+	const base = {
+		targetDate: '2026-01-02',
+		action: 'add',
+		itemName: 'たいそうふく',
+		icon: '👕',
+		createdAt: DT_ISO,
+	};
+
+	it('createdAt: DT-SP (CURRENT_TIMESTAMP 表現) / DT-ISO の両方を受理する (positive)', () => {
+		// legacy checklist_overrides.created_at は TEXT DEFAULT CURRENT_TIMESTAMP (スペース区切り)
+		for (const createdAt of [DT_SPACE, DT_ISO]) {
+			const r = sanitizeChecklistOverrideRestore({ ...base, createdAt });
+			expect(r.ok, `createdAt=${createdAt}`).toBe(true);
+		}
+	});
+
+	it('targetDate: legacy 実表現 (YYYY-MM-DD date-only) を受理し、datetime 混入は reject する', () => {
+		expect(sanitizeChecklistOverrideRestore(base).ok).toBe(true);
+		// targetDate に datetime が来ることは legacy 書込に存在しない (= reject は誤 drop でない)
+		expect(sanitizeChecklistOverrideRestore({ ...base, targetDate: DT_SPACE }).ok).toBe(false);
+		expect(sanitizeChecklistOverrideRestore({ ...base, targetDate: 'not-a-date' }).ok).toBe(false);
+	});
+
+	it('action: enum 外は reject する (negative、表示に反映されない破損の遮断)', () => {
+		expect(sanitizeChecklistOverrideRestore({ ...base, action: 'toggle' }).ok).toBe(false);
+	});
+});
+
+describe('legacy SQLite 値表現 監査 (#3859) — activity sanitize (domain、drop しない正規化)', () => {
+	it('dailyLimit: number / NUM-STR / NULLISH をすべて受理・正規化する (drop なし)', () => {
+		expect(sanitizeDailyLimit(5)).toBe(5);
+		expect(sanitizeDailyLimit(0)).toBe(0); // 0 = 無制限を null に落とさない (#3422)
+		expect(sanitizeDailyLimit('42')).toBe(42); // NUM-STR も受理
+		expect(sanitizeDailyLimit(null)).toBe(null);
+		expect(sanitizeDailyLimit('')).toBe(null);
+		// 破損は安全既定 null へ正規化 (行ごと drop しない)
+		expect(sanitizeDailyLimit('abc')).toBe(null);
+		expect(sanitizeDailyLimit(-1)).toBe(null);
+	});
+
+	it('nameKana / nameKanji: 長大値も切詰め正規化で受理する (drop なし)', () => {
+		expect(sanitizeActivityNameField('よみがな')).toBe('よみがな');
+		expect(sanitizeActivityNameField(null)).toBe(null);
+		expect(sanitizeActivityNameField('あ'.repeat(100))).toHaveLength(50);
+	});
+});

--- a/tests/unit/services/import-service.test.ts
+++ b/tests/unit/services/import-service.test.ts
@@ -1814,6 +1814,47 @@ describe('importFamilyData', () => {
 			expect(result.warnings.some((w) => w.includes('値が不正'))).toBe(true);
 		});
 
+		it('#3859: tutorial_*_at の SQL datetime 表現 (スペース区切り) は drop されず書き戻される (positive)', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			data.data.settings = [
+				// SQLite CURRENT_TIMESTAMP 既定値の形 (#3851 と同 class の legacy 表現)
+				makeSetting('tutorial_started_at', '2026-01-02 03:04:05'),
+				// JS toISOString の形 (現行書込経路)
+				makeSetting('tutorial_completed_at', '2026-01-02T03:04:05.000Z'),
+			];
+			mockSetSetting.mockResolvedValue(undefined);
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.settingsImported).toBe(2);
+			expect(result.settingsSkipped).toBe(0);
+			expect(mockSetSetting).toHaveBeenCalledWith(
+				'tutorial_started_at',
+				'2026-01-02 03:04:05',
+				TENANT,
+			);
+		});
+
+		it('#3859: tutorial_*_at の真破損日時は依然 skip される (negative、握り潰し過剰でない)', async () => {
+			const data = makeExportData();
+			data.family.children = [makeChild('c1')];
+			mockInsertChild.mockResolvedValue({ id: '101' });
+			data.data.settings = [
+				makeSetting('tutorial_started_at', 'not-a-valid-date'),
+				makeSetting('tutorial_completed_at', '2026-13-99 99:99:99'), // Date.parse 不能
+			];
+			mockSetSetting.mockResolvedValue(undefined);
+
+			const result = await importFamilyData(data, TENANT);
+
+			expect(result.settingsImported).toBe(0);
+			expect(result.settingsSkipped).toBe(2);
+			expect(mockSetSetting).not.toHaveBeenCalled();
+			expect(result.warnings.some((w) => w.includes('値が不正'))).toBe(true);
+		});
+
 		it('秘匿/非 allowlist キーは値の妥当性以前に書き戻されない (多層防御)', async () => {
 			const data = makeExportData();
 			data.family.children = [makeChild('c1')];


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: NUC（セルフホスト版）ユーザー / backup 復元を行う全ユーザー

**解決する課題**: #3851（PR #3856 で根治済）の root class =「wire validator が legacy SQLite の実データ表現を想定しきれず正当な行を silent drop する」の横展開監査。export/import round-trip の全 field-format validator を列挙し、legacy SQLite が実際に書く値表現（スペース区切り日時 / boolean 0|1 / 数値文字列化 / NULL 系）の受理可否を**実 validator を呼ぶテストで実測**した。

**実測で確定した同 class 残存 1 件**: `src/lib/domain/export-format.ts` の settings 用日時 validator `isIsoDatetime` が `T` 必須 regex（`/^\d{4}-\d{2}-\d{2}T/`）のままで、SQL datetime 表現（スペース区切り）を reject していた（#3856 は import-service 側の 1 定数のみ是正し、export-format 側に片側ドリフトが残っていた）。本 PR で日時受理述語を `src/lib/domain/validation/datetime.ts` に SSOT 集約し、両 validator が同一述語を import する形に統一（ADR-0066「wire schema とドメイン validator は同一値域定数を import する」の形式版）。

**期待される効果**: round-trip の日時受理ポリシー（`T` | スペース区切り + `Date.parse` gate）が単一定義になり、「片側だけ `T` 必須が残る」class の再発が構造的に不可能になる。真の破損値（`Date.parse` 不能 / 長大値）は依然 reject される（突合無効化・検証弱体化は一切行っていない、ADR-0003 / ADR-0006）。

### validator 全列挙 + legacy 表現受理可否の実測表（AC1）

round-trip 経路（legacy sqlite → `exportFamilyData` → JSON → `importFamilyData` verbatim/merge）で行 drop / 値 skip を起こしうる field-format validator の全列挙と、legacy 実表現ごとの受理可否実測。実測手段 = `npx vitest run tests/unit/domain/legacy-sqlite-value-audit.test.ts`（11 tests、実 validator を oracle として直接呼ぶ）+ `tests/unit/services/import-service.test.ts`（service 層 round-trip）+ 既存 `cutover-parent-message-timestamp.test.ts`（#3856、sqlite→PGlite 実 round-trip）:

| # | validator（所在） | 対象 field | DT-SP（`2026-01-02 03:04:05`） | DT-ISO（`...T...Z`） | BOOL `0/1`・`true/false` | NUM-STR（`"42"`） | NULL 系 | 真破損（negative） |
|---|---|---|---|---|---|---|---|---|
| 1 | `isValidIsoDateTime`（import-service、#3856 是正済 → 本 PR で SSOT 参照化） | parentMessages / siblingCheers の sentAt / shownAt | ✓ 受理 | ✓ 受理 | — | — | shownAt null ✓ | ✗ reject 維持 |
| 2 | `isIsoDatetime`（export-format、**本 PR 是正**） | settings `tutorial_started_at` / `tutorial_completed_at` | **✗→✓（是正前 fail を物理確認）** | ✓ 受理 | — | — | 空文字 ✗（legacy 書込なし = 誤 drop でない） | ✗ reject 維持（`Date.parse` 不能 / 40 char 超） |
| 3 | `isBoolSetting`（export-format） | settings boolean 6 keys | — | — | ✓ 両系統受理 | — | 空文字 ✗（書込なし） | ✗（`TRUE` / `yes` / `2`） |
| 4 | `isTimeSetting`（export-format） | notification quiet / reminder | — | — | — | — | — | ✗（`7:30` は time input が書かない zero-pad 欠落形 = 誤 drop でない） |
| 5 | `point_rate` validator（export-format） | settings `point_rate` | — | — | — | ✓ `"42"` / `"2.5"` 受理 | ✗（空、書込なし） | ✗（非数値 / `0` 下限外） |
| 6 | enum validators（export-format: decay / point_unit / currency / activity_level / weekday） | settings enum keys | — | — | — | — | — | ✗（app enum のみ書込のため legacy 齟齬なし） |
| 7 | `isValidBonusPoints`（import-service） | parentMessages.bonusPoints | — | — | — | SQLite INTEGER affinity が数値文字列を integer 化するため legacy は number ✓ | null ✓ | ✗（範囲外整数） |
| 8 | `MESSAGE_TYPES` / `getStampByCode` allowlist（import-service） | messageType / stampCode | — | — | — | — | — | ✗（app enum のみ書込のため legacy 齟齬なし。stampCode ≤30 / body ≤max / icon ≤10 の長さ制限は書込時 domain validation（`message.ts` `z.string().max(10)` 等）と同値で齟齬なし） |
| 9 | `sanitizeChecklistOverrideRestore`（domain/checklist-override） | checklistOverrides の targetDate / action / itemName / createdAt | createdAt ✓（non-empty 判定のみで CURRENT_TIMESTAMP 表現を受理） | ✓ | — | — | itemName 空 ✗（書込時 required で齟齬なし） | ✗（action enum 外 / targetDate 非 date） |
| 10 | `sanitizeDailyLimit`（domain/validation/activity） | childActivities.dailyLimit | — | — | — | ✓ `"42"`→42 正規化 | ✓ null / `''`→null | `'abc'` / 負値 → 安全既定 null へ正規化（**行 drop なし**） |
| 11 | `sanitizeActivityNameField`（同上） | nameKana / nameKanji | — | — | — | — | ✓ null | 長大値は 50 char 切詰め正規化（**行 drop なし**） |

構造 validator（行単位でなく file / path 単位）: `validateExportData`（format / `MIGRATABLE_VERSIONS` / 構造）・`verifyChecksum`（旧版空 checksum は skip で後方互換）・`isSafeRelativePath`（zip-slip guard、legacy storage key は `avatars/` / `voices/` 相対形で齟齬なし）・`categoryIdFromCode`（カテゴリは 5 軸固定で legacy に未知 code は存在しない）— いずれも legacy 実表現との齟齬なしを実装読解で確認（行 2 以外に是正対象なし）。

marketplace Valibot wire schema 5 type（`src/lib/marketplace/schemas/`）は preset fixture / registry 検証用で legacy SQLite データが流れないため本監査の対象外（#3151 / ADR-0066 の fitness が既にカバー）。

### 是正した誤 drop（AC2）

| 是正 | 内容 | 方式 |
|---|---|---|
| export-format `isIsoDatetime` | `T` 必須 regex → 日時 SSOT（`[T ]` + `Date.parse` gate）参照に置換。40 char bound は維持 | 正規化受理（accept + `Date.parse` gate 維持）。突合無効化・検証削除は行っていない |
| import-service `isValidIsoDateTime` | local regex 定義 → 同 SSOT 参照に置換（#3856 の受理挙動は不変） | 形式定数の二重定義排除（同 class ドリフトの構造的根絶） |

補足（正直な位置づけ）: `tutorial_*_at` の書込経路は初出 commit から一貫して `new Date().toISOString()`（`T` 区切り）であることを git 履歴で確認済み。したがって行 2 は「現行 legacy DB で実害が出ている drop」ではなく「#3851 と同一 class の片側ドリフト残存」であり、放置すると書込経路の変更（repo 層 default 化等）で #3851 が再発する潜在欠陥として根治した。実害の有無に関わらず「round-trip の日時受理ポリシーは全 validator で単一 SSOT」に統一するのが #3851 の class 根絶（ADR-0061 same-class-N→guard）。

## 関連 Issue

closes #3859

関連: #3851 / PR #3856（root class の初出是正）/ EPIC #3151 / ADR-0061 / ADR-0066

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | import/export の全 validator を列挙し、legacy SQLite 値表現の受理可否を実測表化 | grep 全列挙（`validate*` / `sanitize*` / `isValid*` / regex / allowlist を import-service・export-format・checklist-override・validation/activity・export/backup 系 service 横断）+ `npx vitest run tests/unit/domain/legacy-sqlite-value-audit.test.ts` で実 validator を直接実測 | 上表（field-format validator 11 + 構造 validator 4 + marketplace 対象外 5 type）。audit test 11 tests passed（実測が回帰として固定） |
| AC2 | 誤 drop する validator を根治（突合無効化でなく原因是正、ADR-0003） | 実装読解 + diff（`src/lib/domain/validation/datetime.ts` 新設 / export-format / import-service の 2 validator を SSOT 参照化） | 是正 1 件（export-format `isIsoDatetime` の `T` 必須 regex）。件数突合・`Date.parse` gate・長さ bound は全て維持（弱体化ゼロ） |
| AC3 | legacy 実表現 fixture の round-trip 回帰（positive）+ 真破損 reject（negative）を追加 | failing-test-first（ADR-0061）: 是正前に audit test を実行し `tutorial_started_at × DT-SP: expected false to be true` の fail を物理確認 → 是正 → 11 passed。service 層 round-trip は `import-service.test.ts` に positive（DT-SP settings が `settingsImported=2`）+ negative（破損 2 件が `settingsSkipped=2` + warning）を追加 | `npx vitest run tests/unit/domain/legacy-sqlite-value-audit.test.ts tests/unit/domain/export-format.test.ts tests/unit/services/import-service.test.ts` = 3 files / 98 passed。実 sqlite→PGlite round-trip の #3856 test も維持 pass |
| AC4 | #3151 fitness への統合可否を検討 | `tests/unit/architecture/schema-range-ssot.test.ts` / `tests/unit/marketplace/export-import-roundtrip-property.test.ts` の scope 読解 | **統合せず**（理由: 両 fitness は marketplace 5 type wire（preset）scope で、backup `ExportData` wire は別経路・別 schema。generator に legacy 表現を足しても backup validator は通らない）。代替として backup wire 側の sister fitness を `legacy-sqlite-value-audit.test.ts` として新設（#3153 と同じ「実 validator を oracle に呼ぶ」方式）。日時形式定数の domain SSOT 集約自体が ADR-0066 原則（同一値域定数 import）の形式版適用 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: backup restore の settings 取込（`importSettingsData` → `isValidSettingValue`）+ NUC cutover / restore の親メッセージ / おうえん値検証（受理挙動は #3856 と同一、定義元のみ SSOT 化）。UI 表示は変更なし。

## テスト & 安全装置セルフチェック

- [x] **CI 全緑で担保**（#1775 / ADR-0030）— ローカルで変更 5 ファイル `npx biome check` clean / blast radius vitest 9 files（audit + export-format + import-service + cutover round-trip 2 + checklist-override-restore + import-restore-idempotency + export-service + settings-backup-classification）= 139 passed / `npx svelte-check` エラー 0。CI 全 step は push 後の checks で確認
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/domain/legacy-sqlite-value-audit.test.ts` 新設（11 tests）: round-trip 全 field-format validator × legacy 表現 5 分類（DT-SP / DT-ISO / BOOL / NUM-STR / NULLISH）+ 真破損 negative の受理可否を実 validator 呼出で実測・回帰固定。是正前は `tutorial_*_at × DT-SP` で fail（failing-test-first の物理確認、ADR-0061）
  - `tests/unit/services/import-service.test.ts` に 2 tests 追加: settings 経由の service 層 round-trip で ① DT-SP `tutorial_started_at` が drop されず `setSetting` に verbatim 到達（positive）② 破損日時 2 表現（`not-a-valid-date` / `Date.parse` 不能形）は依然 skip + warning（negative、握り潰し過剰でない）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（env / secret 追加なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:critical` ラベルなし。UI 非影響の domain / service 層是正）

## スクリーンショット / ビジュアルデモ

該当なし（refactor / docs / chore）— UI 変更を含まない domain / service 層の validator 是正 + テスト追加。画面描画差分ゼロ。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 日時受理述語を単一責務の domain module（`validation/datetime.ts`）に分離。利用側 2 箇所は述語を import するだけで、settings 固有の 40 char bound は export-format 側に残す（責務境界維持）
- [x] **DRY**: `grep -rn "\\d{4}-\\d{2}-\\d{2}[T ]" src/` で日時 prefix regex の残存定義 0 件（SSOT 1 箇所のみ）を確認。旧 `ISO_DATETIME_RE` / `ISO_DATETIME_PREFIX_RE` の二重定義を排除
- [x] **YAGNI**: 正規化 transform（値の書換）は導入せず accept + `Date.parse` gate の最小構成。epoch / timezone 変換等の未要求形式は追加していない
- [x] **Security（OSS 公開前提）**: 検証の弱体化なし。`Date.parse` gate / 40 char bound / enum allowlist / 長さ制限 / 件数突合は全て維持。緩和は「正当な SQL datetime 表現の受理」に限定
- [x] **アクセシビリティ**: N/A（server / domain 層）
- [x] **パフォーマンス**: N/A（regex 定義の移動のみ、計算量不変）

## 横展開・影響波及チェック

- [x] **同 class 全件走査**: `grep -rn "\d{4}-\d{2}-\d{2}" src/`（date/datetime regex 全 7 定義）を精査 — `T` 必須の datetime validator は export-format の 1 件のみ（本 PR 是正）。残る date-only regex（`checklist-override.ts` targetDate / `rest-days` / `children` birthDate）は legacy 書込が date-only のため齟齬なし（実測表 #9 + 実装読解）
- [x] backend 並行実装: sqlite / dsql (PGlite) の両 backend に対する受理挙動は import-service 単一強制点のため差分なし（#3856 の sqlite→PGlite round-trip test が維持 pass）
- [ ] 本番アプリ + デモ版の同期: N/A（UI 変更なし）
- [ ] LP ↔ アプリ双方向整合 / 全年齢モード / ナビ 3 種: N/A（UI 変更なし）

## レビュー依頼事項・破壊的変更

**破壊的変更**: なし。受理範囲は「従来 reject していた正当な SQL datetime 表現を受理」方向の単調拡大のみで、既存受理値の reject 化はゼロ。

**レビュー観点**:
1. 実測表の網羅性 — grep 列挙（`validate*` / `sanitize*` / `isValid*` / regex / `.includes(` / `.has(` allowlist）で拾えない validator が残っていないか
2. `tutorial_*_at` 是正の位置づけ — 「現行実害なし・同 class 潜在ドリフトの根治」という整理が ADR-0003（対症療法禁止 / 根本原因）と整合しているか
3. AC4 の統合不可判断（marketplace wire と backup wire の scope 相違）の妥当性

## 配布済み env / secret (ADR-0006)

該当なし（新規 env / secret の追加・変更なし）。

## Ready for Review チェックリスト

- [x] AC 検証マップの全 AC が「結果 / エビデンス」列で検証済み
- [x] `npm run pre-ready -- --pr <num>` 全 step PASS
- [x] CI 全チェック緑
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言: 実測 test 139 passed + failing-test-first 物理確認 + 弱体化ゼロを自己検証済）

## QM レビュー結果

（QM 記入欄）
