### PR TITLE
infra: #3846 変更タイプ checkbox 未選択の shift-left 機械検出 + AC map inline-code false-positive 根治

### DIFF
--- a/.claude/skills/dev-open-pr/SKILL.md
+++ b/.claude/skills/dev-open-pr/SKILL.md
@@ -106,6 +106,7 @@ Agent が実装完了後、Skill 出力の雛形に対して以下を埋める:
 | スクリーンショット | UI 変更時 4 スロット必須、それ以外は「該当なし（理由）」 |
 | 横展開 | 並行実装ペア確認、N/A 可 |
 | 配布済み env / secret | ADR-0006 該当時のみ、それ以外 N/A |
+| **変更タイプ** | **`- [x]` 1 つ以上必須 (#3846)**。Issue に `type:*` label があれば雛形展開時に自動 `[x]` 化されるが、label 無し Issue では全て `- [ ]` のまま出力されるため**必ず手動で主変更タイプを選択**する（未選択は CI 必須 gate hard-fail、ステップ 3 の `--body-file` 検証で PR 作成前に検出される） |
 
 雛形の `<!-- ... -->` Markdown コメントは説明用ヒント。書き換える必要なし（コメントのまま残してよい）。
 
@@ -143,6 +144,7 @@ npm run pre-ready -- --pr <PR番号後で発番>
 - 禁止語混入（`予定` / `follow-up` / `PENDING` / `DEFERRED` / `別途` / `個別起票` / `TODO`）
 - AC 検証マップの 4 列空セル / コメントのみセル
 - Ready チェックリスト未チェック残置
+- **変更タイプ checkbox 未選択（`- [x]` 1 つ以上必須、#3846）** — CI 必須 gate「変更タイプの選択」(`pr-template-gate.yml`) と同一 SSOT (`scripts/pr-template-gate-checks.mjs` `checkChangeType`) を PR 作成前に実行。未選択のまま提出して CI hard-fail → QM body-only remediation が 3 PR 連続再発 (#3835 / #3837 / #3844) した same-class defect (ADR-0061) の shift-left 対策。**`gh pr create` 前に必ず本 `--body-file` 検証を PASS させる**
 
 検証 PASS まで雛形を更新する。Skill 雛形は **PR template SSOT (`.github/PR_TEMPLATE_SECTIONS.json` 経由) に完全準拠** した状態で提供されるが、雛形時点では「AC 検証マップの検証手段 / 結果列」「Ready for Review チェックリスト」が空のため `check-pr-body.mjs` は fail する。**Agent がステップ 2 の穴埋めを完了してから検証 PASS する**設計。穴埋め完了の signal として、本検証 CLI の PASS を使用する。
 

--- a/.claude/skills/dev-open-pr/templates/pr-body-default.md
+++ b/.claude/skills/dev-open-pr/templates/pr-body-default.md
@@ -23,6 +23,9 @@ closes #{{ISSUE_NUMBER}}
 
 ## 変更タイプ
 
+<!-- ⚠️ 1 つ以上 [x] 必須 (CI 必須 gate「変更タイプの選択」hard-fail、#3846)。
+     Issue に type:* label が無い場合は自動 [x] されないため、必ず手動で主変更タイプを選択する -->
+
 {{TYPE_CHECKBOXES}}
 
 ## 影響範囲・変更コンポーネント

--- a/.claude/skills/dev-open-pr/templates/pr-body-lp.md
+++ b/.claude/skills/dev-open-pr/templates/pr-body-lp.md
@@ -18,6 +18,9 @@ closes #{{ISSUE_NUMBER}}
 
 ## 変更タイプ
 
+<!-- ⚠️ 1 つ以上 [x] 必須 (CI 必須 gate「変更タイプの選択」hard-fail、#3846)。
+     Issue に type:* label が無い場合は自動 [x] されないため、必ず手動で主変更タイプを選択する -->
+
 {{TYPE_CHECKBOXES}}
 
 ## 影響範囲・変更コンポーネント

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,6 +34,9 @@ closes #
 
 ## 変更タイプ
 
+<!-- ⚠️ 1 つ以上 [x] を必ず選択 — 未選択のままだと CI 必須 gate「変更タイプの選択」が hard-fail する (#3846、3 PR 連続再発 #3835/#3837/#3844)。
+     PR 作成前に `node scripts/check-pr-body.mjs --body-file <path> --skip-mergeable` で機械検証できる -->
+
 - [ ] feat: 新機能
 - [ ] fix: バグ修正
 - [ ] refactor: リファクタリング

--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -56,8 +56,27 @@ export const INTEGRATION_EVIDENCE_SECTION = 'マージ判定エビデンス表';
  * 区切り 1 文字必須にすれば slug `followup` を除外しつつ「別途 follow-up で対応」等は検出し続ける。
  * 拡張子 whitelist による strip 前処理は脆く（bypass + 非収録拡張子の FP）、撤去して生 cell に
  * 本パターンを直接適用する方針に戻した（#3488）。
+ *
+ * **inline-code strip（#3846 / #3844 BLOCK fix）**: 拡張子 whitelist strip（#3488 で撤去）とは別に、
+ * evidence cell の **inline-code (`...`) 内トークンのみ** は判定前に strip する。inline-code は
+ * 定数名 / コマンド / ファイル参照などの機械トークンであり（例: 定数名 `RANGE_SSOT_TODO` が
+ * #3844 で `todo` に部分一致し false-positive gate fail）、未完了宣言の prose ではない。
+ * 未完了マーカーを backtick で囲んで逃避する pattern は QM レビュー + PR body 禁止語 gate
+ * (`check-pr-body.mjs`) の別層で扱う。prose（コード外）の未完了表記検出は従来どおり生 cell。
  */
 const TODO_PATTERN = /todo|予定|追加予定|別途|follow[\s-]up|後で/i;
+
+/**
+ * evidence cell 内の inline-code span（`...`）を除去する（#3846）。
+ * table cell は `|` split 済のため改行を含まず、backtick 対を単純除去すれば十分。
+ * 対にならない孤立 backtick は残す（除去しすぎによる検出漏れ防止）。
+ *
+ * @param {string} cell
+ * @returns {string}
+ */
+function stripInlineCode(cell) {
+	return cell.replace(/`[^`]*`/g, '');
+}
 
 /** integration lane の「残 NG 0 件」明示を検出するパターン（audit-team.md §3.5 #5）。 */
 const NG_ZERO_PATTERN = /残\s*NG\s*(?:合計\s*)?0\s*件|残\s*NG[^\n|]*[:：]?\s*0\b|NG\s*0\s*件/;
@@ -192,7 +211,8 @@ export function checkPerPrAcMap(body, lane) {
 				.slice(1, -1)
 				.map((c) => c.trim());
 			const evidenceCell = cells[3] ?? '';
-			if (TODO_PATTERN.test(evidenceCell)) {
+			// #3846: inline-code 内の機械トークン（定数名 / コマンド / ファイル参照）は判定対象外
+			if (TODO_PATTERN.test(stripInlineCode(evidenceCell))) {
 				const acId = cells[0] || `行 ${idx + 1}`;
 				return { acId, evidenceCell };
 			}

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -11,6 +11,8 @@
  *   3. AC 検証マップの 4 列フォーマット欠落 / 空行
  *   4. Ready for Review チェックリストの未チェック残置
  *   5. `mergeable: CONFLICTING` 事前検知（GitHub API 経由）
+ *   6. 変更タイプ checkbox 未選択（#3846、CI gate「変更タイプの選択」の shift-left。
+ *      判定は scripts/pr-template-gate-checks.mjs の checkChangeType を SSOT として再利用）
  *
  * 必須セクション SSOT:
  *   `.github/PULL_REQUEST_TEMPLATE.md` を runtime parse し、
@@ -32,6 +34,7 @@ import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { checkChangeType } from './pr-template-gate-checks.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -427,6 +430,48 @@ export function detectMojibake(body) {
 }
 
 // ---------------------------------------------------------------------------
+// 変更タイプ checkbox 未選択検出 (#3846、shift-left)
+// ---------------------------------------------------------------------------
+
+/**
+ * `## 変更タイプ` セクションで `- [x]` が 1 つも選択されていない場合に violation を返す (#3846)。
+ *
+ * 背景: PR body の変更タイプ checkbox 未選択のまま提出 → CI 必須 gate「変更タイプの選択」
+ * (`pr-template-gate.yml`) hard-fail が 3 PR 連続再発 (#3835 / #3837 / #3844)。いずれも実装は
+ * 健全で body checkbox のみが原因 = ADR-0061 same-class-N→guard 対象。本検出により
+ * `--body-file` mode (PR 作成前) / `--pr` mode (pre-ready Step 9 / pre-push hook) の両方で
+ * CI より手前 (shift-left) で機械検出する。
+ *
+ * 検証ロジックは CI gate と同一 SSOT (`scripts/pr-template-gate-checks.mjs` の `checkChangeType`)
+ * を再利用する (二重実装なし)。lane は本 CLI の対象 (feature / hotfix per-PR self-check) で
+ * 判定が同一のため 'feature' 固定。section 欠落時は missing-required-sections gate に委譲
+ * (checkChangeType 側が skipped=true を返す)。
+ *
+ * @param {string} body
+ * @param {string} template `.github/PULL_REQUEST_TEMPLATE.md` の内容
+ * @param {string[]} labels PR ラベル (dependencies label skip は SSOT 側で処理)
+ * @returns {{ id: string; message: string } | null}
+ */
+export function checkChangeTypeSelection(body, template, labels = []) {
+	const result = checkChangeType({
+		body,
+		labels,
+		template,
+		ssotSections: null,
+		lane: 'feature',
+	});
+	if (result.ok) return null;
+	return {
+		id: 'change-type-unselected',
+		message:
+			`${result.message}\n` +
+			'背景: 未選択のまま提出 → CI 必須 gate「変更タイプの選択」hard-fail が 3 PR 連続再発 (#3835 / #3837 / #3844)。\n' +
+			'対応: PR 作成前に `node scripts/check-pr-body.mjs --body-file <path> --skip-mergeable` で本検証を PASS させる。\n' +
+			'      `npm run dev:open-pr -- --issue <num>` 経由なら Issue の type:* label から自動 [x] 化される (init-pr-body.mjs)。',
+	};
+}
+
+// ---------------------------------------------------------------------------
 // Self-Review 証跡検出 (#2475 Phase 2 / #2815 D-1、PO 判断 2026-06-04: 導入必須)
 // ---------------------------------------------------------------------------
 
@@ -648,6 +693,7 @@ Detected violations:
   5. PR が CONFLICTING (--pr 指定時)
   6. hotfix label PR (${HOTFIX_LABELS.join(' / ')}) で ADR-0006 配布証跡欄が空 (#2343)
   7. PR body の文字化け (BOM / \`??\` 5 件以上) — heredoc 由来 cp932 mojibake (#2562 / #2576)
+  8. 変更タイプ checkbox 未選択 (\`- [x]\` 1 つ以上必須、CI gate「変更タイプの選択」と同一 SSOT、#3846)
 
 Exit codes:
   0 = OK
@@ -691,10 +737,11 @@ function loadPrBody(args) {
  * PR body と template から全違反リストを計算する。
  * @param {string} body
  * @param {string[]} requiredSections
+ * @param {string} template `.github/PULL_REQUEST_TEMPLATE.md` の内容 (#3846 変更タイプ検証で使用)
  * @param {{ pr: string | null; skipMergeable: boolean; labels?: string[] }} args
  * @returns {{ id: string; issue: string; message: string }[]}
  */
-function collectViolations(body, requiredSections, args) {
+function collectViolations(body, requiredSections, template, args) {
 	const violations = [];
 	const labels = args.labels ?? [];
 
@@ -764,6 +811,12 @@ function collectViolations(body, requiredSections, args) {
 		violations.push({ ...selfReviewEvidence, issue: '#2475/#2815 D-1' });
 	}
 
+	// #3846: 変更タイプ checkbox 未選択の shift-left 検出 (CI gate と同一 SSOT を再利用)
+	const changeType = checkChangeTypeSelection(body, template, labels);
+	if (changeType) {
+		violations.push({ ...changeType, issue: '#3835/#3837/#3844/#3846' });
+	}
+
 	return violations;
 }
 
@@ -792,7 +845,7 @@ export async function main(argv = process.argv.slice(2)) {
 				.filter(Boolean)
 		: fetchPrLabels(args.pr);
 
-	const violations = collectViolations(body, requiredSections, { ...args, labels });
+	const violations = collectViolations(body, requiredSections, template, { ...args, labels });
 
 	if (violations.length === 0) {
 		console.log('[check-pr-body] OK — 違反なし');

--- a/tests/unit/scripts/check-ac-verification-map.test.ts
+++ b/tests/unit/scripts/check-ac-verification-map.test.ts
@@ -73,7 +73,8 @@ const FEATURE_AC_MAP_SLUG_FOLLOWUP_VARIANTS = `
 `;
 
 // #3488: 未完了マーカーは区切り 1 文字（空白 or ハイフン）を必ず持つため検出継続する。
-// strip を全廃したので code span / `/` 隣接 / 日本語連続トークンに置いても生 cell に当たる。
+// prose（inline-code 外）の `/` 隣接 / 日本語連続トークンは生 cell に当たる
+// （#3846 で inline-code 内のみ strip 対象になったが、prose 検出は不変）。
 const FEATURE_AC_MAP_TODO_FOLLOWUP_SPACE = `
 ## AC 検証マップ
 
@@ -101,6 +102,35 @@ const FEATURE_AC_MAP_TODO_JP_TOKEN = `
 const FEATURE_AC_MAP_MISSING_SECTION = `
 ## 概要
 AC マップ section が無い PR
+`;
+
+// #3846 / #3844 BLOCK fix: inline-code (`...`) 内の定数名 \`RANGE_SSOT_TODO\` が
+// TODO_PATTERN の \`todo\` に部分一致して false-positive gate fail していた。
+// inline-code は機械トークン（定数名 / コマンド / ファイル参照）であり未完了宣言の prose ではない。
+const FEATURE_AC_MAP_INLINE_CODE_CONSTANT = `
+## AC 検証マップ
+
+| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
+|---|---|---|---|
+| AC2 | 値域定数 SSOT 化 | grep | HEAD \`abc1234\` / \`RANGE_SSOT_TODO\` を domain 層へ集約 (src/lib/domain/range.ts:12) |
+`;
+
+// #3846: inline-code 内にコマンド由来の "todo" / "予定" 相当トークンがあっても PASS する。
+const FEATURE_AC_MAP_INLINE_CODE_COMMAND = `
+## AC 検証マップ
+
+| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
+|---|---|---|---|
+| AC1 | todo list 機能の unit 検証 | vitest | \`npx vitest run tests/unit/todo-list.test.ts\` 12 passed |
+`;
+
+// #3846: inline-code strip 後も prose 側の未完了表記は従来どおり検出する（strip し過ぎ防止）。
+const FEATURE_AC_MAP_INLINE_CODE_PLUS_PROSE_TODO = `
+## AC 検証マップ
+
+| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
+|---|---|---|---|
+| AC1 | ログイン | vitest | \`RANGE_SSOT_TODO\` は集約済、残りは後で対応 |
 `;
 
 const INTEGRATION_EVIDENCE_PASS = `
@@ -214,6 +244,24 @@ describe('checkPerPrAcMap (feature/hotfix lane、AC4)', () => {
 		const r = checkPerPrAcMap(FEATURE_AC_MAP_PASS, 'hotfix');
 		expect(r.ok).toBe(true);
 		expect(r.lane).toBe('hotfix');
+	});
+
+	// --- #3846 / #3844: evidence cell の inline-code strip (定数名 false-positive 解消) ---
+
+	it('PASS: inline-code 内の定数名 `RANGE_SSOT_TODO` を未完了表記と誤検出しない (#3846 / #3844)', () => {
+		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_CONSTANT, 'feature');
+		expect(r.ok).toBe(true);
+	});
+
+	it('PASS: inline-code 内のコマンド (`npx vitest run tests/unit/todo-list.test.ts`) を誤検出しない (#3846)', () => {
+		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_COMMAND, 'feature');
+		expect(r.ok).toBe(true);
+	});
+
+	it('FAIL: inline-code strip 後も prose 側の未完了表記 (「後で対応」) は検出継続 (#3846 strip し過ぎ防止)', () => {
+		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_PLUS_PROSE_TODO, 'feature');
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain('未完了表記');
 	});
 });
 

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
 	checkAcMap,
+	checkChangeTypeSelection,
 	checkEnvDistributionForHotfix,
 	checkSelfReviewEvidence,
 	detectMojibake,
@@ -635,5 +636,79 @@ describe('checkSelfReviewEvidence (#2475 Phase 2 / #2815 D-1)', () => {
 			'- [ ] **SOLID**: 未確認',
 		].join('\n');
 		expect(checkSelfReviewEvidence(body)).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #3846: 変更タイプ checkbox 未選択の shift-left 検出
+// CI 必須 gate「変更タイプの選択」hard-fail が 3 PR 連続再発 (#3835 / #3837 / #3844) した
+// same-class defect (ADR-0061) を、PR 作成前 (--body-file) / pre-ready Step 9 (--pr) で機械検出する。
+// 判定 SSOT は scripts/pr-template-gate-checks.mjs の checkChangeType (二重実装なし)。
+// ---------------------------------------------------------------------------
+
+describe('checkChangeTypeSelection (#3846)', () => {
+	// detectChangeTypeHeading は「`- [ ]` を 3 行以上持つ ## セクション」を変更タイプと判定する。
+	// 実 template (.github/PULL_REQUEST_TEMPLATE.md) と同構造の最小 fixture。
+	const TEMPLATE = [
+		'## 顧客価値・目的',
+		'',
+		'本文',
+		'',
+		'## 変更タイプ',
+		'',
+		'- [ ] feat: 新機能',
+		'- [ ] fix: バグ修正',
+		'- [ ] refactor: リファクタリング',
+		'- [ ] infra: インフラ・CI/CD',
+		'',
+		'## 関連 Issue',
+	].join('\n');
+
+	it('FAIL: checkbox 未選択 (- [ ] のみ) → change-type-unselected (#3835/#3837/#3844 再発 pattern)', () => {
+		const body = [
+			'## 変更タイプ',
+			'',
+			'- [ ] feat: 新機能',
+			'- [ ] fix: バグ修正',
+			'- [ ] refactor: リファクタリング',
+			'- [ ] infra: インフラ・CI/CD',
+			'',
+			'## 関連 Issue',
+		].join('\n');
+		const result = checkChangeTypeSelection(body, TEMPLATE);
+		expect(result).not.toBeNull();
+		expect(result?.id).toBe('change-type-unselected');
+		// self-serve 修正を高速化する guidance を含む (issue #3846 提案 2)
+		expect(result?.message).toMatch(/- \[x\]/);
+		expect(result?.message).toMatch(/--body-file/);
+		expect(result?.message).toMatch(/#3835/);
+	});
+
+	it('PASS: 1 つ以上 [x] 選択済み → null', () => {
+		const body = [
+			'## 変更タイプ',
+			'',
+			'- [ ] feat: 新機能',
+			'- [ ] fix: バグ修正',
+			'- [x] infra: インフラ・CI/CD',
+			'',
+			'## 関連 Issue',
+		].join('\n');
+		expect(checkChangeTypeSelection(body, TEMPLATE)).toBeNull();
+	});
+
+	it('PASS: 大文字 [X] も選択として認める (CI gate checkChangeType と同一判定)', () => {
+		const body = ['## 変更タイプ', '', '- [X] fix: バグ修正', '', '## 関連 Issue'].join('\n');
+		expect(checkChangeTypeSelection(body, TEMPLATE)).toBeNull();
+	});
+
+	it('セクション欠落は missing-required-sections gate に委譲 (null)', () => {
+		const body = '## 顧客価値・目的\n本文\n';
+		expect(checkChangeTypeSelection(body, TEMPLATE)).toBeNull();
+	});
+
+	it('dependencies label PR は skip (Dependabot exempt、#1808 整合)', () => {
+		const body = ['## 変更タイプ', '', '- [ ] feat: 新機能', '', '## 関連 Issue'].join('\n');
+		expect(checkChangeTypeSelection(body, TEMPLATE, ['dependencies'])).toBeNull();
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発プロセス（Dev / QM チーム。間接的に全ユーザー — レビュー時間が本質判定に使われることで品質向上）

**解決する課題**: PR body `## 変更タイプ` の `- [x]` 未選択のまま提出 → CI 必須 gate「変更タイプの選択」hard-fail が 3 PR 連続再発（#3835 / #3837 / #3844）。いずれも実装は健全で body checkbox のみが原因なのに、QM が body-only Fix Agent で人手 remediation を繰り返していた（ADR-0061 same-class-N→guard 対象）。

**期待される効果**: PR 作成前（`--body-file`）/ pre-ready Step 9 / pre-push hook の 3 層で機械検出され、CI red → QM remediation のサイクル自体が発生しなくなる（shift-left）。併せて `Verify AC map` gate の定数名 false-positive（#3844 で `RANGE_SSOT_TODO` が `todo` に誤マッチ）も根治し、健全な PR が誤 BLOCK されなくなる。

## 関連 Issue

closes #3846

関連: #3835 / #3837 / #3844（再発 3 PR、QM 検出元）/ ADR-0061（same-class-N→guard）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dev-open-pr skill の checkbox 初期化 or gate self-serve メッセージ改善のいずれかを実装 | `node scripts/check-pr-body.mjs --body-file <path> --skip-mergeable` を未選択 body / 選択済 body で実行 | HEAD `f6523b5a` / 未選択 = exit 1（`change-type-unselected`、`- [x]` 例 + `--body-file` 再検証手順 + 再発 3 PR 番号を明示する self-serve message）/ 選択済 = exit 0 を物理確認。検証 SSOT は CI gate と同一（`scripts/pr-template-gate-checks.mjs` `checkChangeType` を import 再利用、`scripts/check-pr-body.mjs:478-517`）。checkbox 初期化は `init-pr-body.mjs` `buildTypeCheckboxes` が既存実装済のため、label 無し Issue で全て未選択出力になる残 gap を template inline 注意 + SKILL.md 手動選択ルールで封鎖 |
| AC2 | `check-ac-verification-map.mjs` の inline-code strip で定数名 false-positive を解消 | `npx vitest run tests/unit/scripts/check-ac-verification-map.test.ts` | HEAD `f6523b5a` / 25 passed（`stripInlineCode` を `TODO_PATTERN` 判定前に適用、`scripts/check-ac-verification-map.mjs:71-90`。evidence cell の `` `RANGE_SSOT_TODO` `` / `` `npx vitest run tests/unit/todo-list.test.ts` `` は PASS、prose 側の未完了表記検出は不変） |
| AC3 | 回帰テスト追加（未選択 body で fail / 選択済 body で pass / 定数名 `X_TODO` を含む evidence セルで pass） | `npx vitest run tests/unit/scripts/check-pr-body.test.ts tests/unit/scripts/check-ac-verification-map.test.ts` | HEAD `f6523b5a` / 2 files 99 passed（`checkChangeTypeSelection` 5 件: 未選択 fail / `[x]` pass / `[X]` pass / section 欠落委譲 / dependencies skip + inline-code strip 3 件: 定数名 pass / コマンド pass / prose fail 継続） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（開発プロセス gate script / PR template / dev-open-pr skill のみ。アプリ本体・UI 変更なし）

- `scripts/check-pr-body.mjs`: 検出項目 8 に「変更タイプ checkbox 未選択」を追加（`--pr` / `--body-file` 両 mode で有効 = pre-ready Step 9・pre-push hook・PR 作成前 self-check の 3 層に自動波及）
- `scripts/check-ac-verification-map.mjs`: evidence cell の inline-code strip（CI `Verify AC map` gate の判定に反映）
- `.github/PULL_REQUEST_TEMPLATE.md` / dev-open-pr templates: inline 注意コメントのみ（見出し不変、`check-pr-template-sections-sync` OK 確認済）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 結果はレビュー依頼事項欄に記載
- [x] 追加・変更したテストの概要を以下に記載: `tests/unit/scripts/check-pr-body.test.ts` に `checkChangeTypeSelection` describe 5 件、`tests/unit/scripts/check-ac-verification-map.test.ts` に inline-code strip fixture 3 種 + 3 件を追加（合計 8 件、failing-test-first で fail → 実装 → pass を確認）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — priority:critical ではない

## スクリーンショット / ビジュアルデモ

**該当なし（CI gate script / PR template / skill ドキュメントのみの変更で UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 判定ロジックは CI gate SSOT（`pr-template-gate-checks.mjs` `checkChangeType`）を import 再利用し、`check-pr-body.mjs` 側は violation 形式への変換 + guidance 付与のみ（単一責任 / 二重実装なし）。`grep -n "checkChangeType" scripts/check-pr-body.mjs scripts/pr-template-gate-checks.mjs` で SSOT 1 箇所を確認
- [x] **DRY**: 変更タイプ判定の regex / heading 検出を再実装していない（`detectChangeTypeHeading` も SSOT 側のまま）
- [x] **YAGNI**: lane は本 CLI の対象（feature / hotfix per-PR self-check、判定同一）で 'feature' 固定。lane 引数化は統合 PR 用 CLI が別 SSOT（`pr-template-gate-checks.mjs` CLI）のため不採用
- [x] **Security（OSS 公開前提）**: N/A — 秘密情報なし、ローカル CLI の検証ロジックのみ
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: N/A — 文字列判定 1 回追加のみ

## 横展開・影響波及チェック

- [x] N/A — 並行実装（本番/デモ・年齢モード・ナビ・DB seed）の影響範囲外。同 class の gate script 横展開として、`pr-template-gate-checks.mjs`（CI 側）はロジック変更なしで挙動不変（947 passed で回帰なし確認）。inline-code strip は `checkPerPrAcMap`（feature / hotfix lane）のみが対象で、integration lane のエビデンス表判定は `TODO_PATTERN` を使用しないため波及なし

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- `pre-ready -- --pr <N>` 全 step PASS（Step 1 biome / 1b cspell / 2 svelte-check / 3 vitest / 9 Readiness gate 含む）。物理確認ログ: 未選択 body → `[check-pr-body] FAIL — 1 件の違反: change-type-unselected` exit 1 / `[x]` あり完全 body → `OK — 違反なし` exit 0
- inline-code strip の設計判断: #3488 で撤去された「拡張子 whitelist strip」とは別物で、strip 対象を inline-code（機械トークン: 定数名 / コマンド / ファイル参照）に限定。backtick で未完了宣言を囲む逃避 pattern は QM レビュー + `check-pr-body.mjs` 禁止語 gate の別層で扱う（`scripts/check-ac-verification-map.mjs:56-70` コメントに trade-off を明記）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完遂のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — N/A（分割なし、単一 PR で完遂）
- [x] UI 変更時: SS 添付 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` SS — N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
