### PR TITLE
docs: #3895 dependency-cruiser required gate 昇格の ratify (ADR-0007 §7 + 昇格手続の正規化)

### DIFF
--- a/docs/decisions/0007-static-analysis-tier-policy.md
+++ b/docs/decisions/0007-static-analysis-tier-policy.md
@@ -1,8 +1,8 @@
 # 0007. 静的解析 tier ポリシー (T1/T2/T3/T4 + EPIC-merge / customer-review tier)
 
-- **Status**: Accepted (2026-05-27 EPIC-merge tier 追加、#2544 / 2026-07-18 §6 eslint-plugin-svelte 追記、#3878)
+- **Status**: Accepted (2026-05-27 EPIC-merge tier 追加、#2544 / 2026-07-18 §6 eslint-plugin-svelte 追記、#3878 / 2026-07-19 §7 dependency-cruiser required 昇格 ratify、#3895)
 - **Date**: 2026-04-20
-- **Related Issue**: #1262 / #1265 / #2544 / #3878
+- **Related Issue**: #1262 / #1265 / #2544 / #3878 / #3895
 
 ## コンテキスト
 
@@ -53,6 +53,7 @@ T1 合計が 3min を超えた時は、最も遅いツールを T3 へ降格す�
 - 昇格 / 降格は本 ADR に追記する（別 ADR 不要、文書同期のみ）
 - 新ツール導入 Issue には「想定階層」欄を必須化
 - T1 / T2 job の実行時間を定期モニタ
+- **required 化（merge block 化）の実装点は `ci.yml` の `ci-gate` job `needs:` 登録**（#3895）。branch ruleset (`PR_Mearge`) は `ci-gate` 単一 context を required とする集約設計のため、個別 job の required / advisory は needs 登録の有無で決まる（ruleset 変更は不要）。`ci-gate` の `needs:` に job を追加 / 削除する PR は、本 ADR の階層マッピング表を**同 PR で同期**する（silent な gating policy 変更の禁止）
 
 ### 既存 CI の階層マッピング（baseline）
 
@@ -66,6 +67,8 @@ T1 合計が 3min を超えた時は、最も遅いツールを T3 へ降格す�
 | `new-env-distribution-check`（ADR-0006） | T1 | — |
 | `schema-change-tests-check` | T1 | — |
 | ESLint Svelte (`lint:svelte`、recommended + suppressions) | T1 | < 30s、merge block、#3878（§6） |
+| `dependency-cruiser`（app + infra、#3871） | T2 | 並行 job、merge block（`ci-gate` needs 登録、#3895 ratify、§7）。baseline 12 件（循環 8 + orphan 4）は `--ignore-known` で pin、新規違反のみ block |
+| `cdk-cfn-lint`（#3874） | T2 | 並行 job、merge block（`ci-gate` needs 登録） |
 | jscpd 週次 | T3 | cron |
 | 脆弱性スキャン | T4 | 四半期 / 手動 |
 
@@ -89,6 +92,14 @@ T1-T4 は「実行頻度 × blast radius」で **静的解析・自動テスト*
 - **層の責務分離（二重化しない）**: 型 = `svelte-check --threshold warning`（T1） / a11y = Svelte compiler warning を svelte-check が surface + `@axe-core/playwright` E2E / Runes・reactivity・SvelteKit correctness = `eslint-plugin-svelte` recommended（本節）。**`svelte/valid-compile` は追加しない**（compiler warning の ESLint 再実行 = svelte-check と二重）。**a11y ルールは eslint-plugin-svelte に存在しない**ため追加不能。自作 `local/*`（no-raw-button 等）と重複する opt-in ルール（no-inline-styles 等）も追加しない。
 - **既存違反の baseline 凍結（ratchet）**: recommended 有効化で既存コードに 483 error が出る（内訳: `no-navigation-without-resolve` 166 / `require-each-key` 133 / `no-useless-children-snippet` 113 / `prefer-svelte-reactivity` 15 / `prefer-writable-derived` 11 / `no-unused-svelte-ignore` 7 / `no-useless-mustaches` 2 + 既存 `local/*` 36）。ESLint 10 native bulk suppressions（`eslint --suppress-all` → `eslint-suppressions.json` を commit）で凍結し、**新規違反のみ CI fail**。段階返済後は `eslint --prune-suppressions` で baseline を ratchet down する（assertion 弱体化・ルール一括 disable は ADR-0006 禁止）。SSOT = `eslint.config.js`（recommended spread）+ `eslint-suppressions.json`（baseline）+ `.github/workflows/ci.yml`（`lint:svelte` hard gate）。
 - **Runes semantic 判断は lint 対象外＝PR review 領域**: Svelte 5 公式が最も警告する「`$effect` で state を derive/同期するな、`$derived` を使え」は、静的に捕まるのは `prefer-writable-derived` の単一代入 trivial shape のみ。effect 本体に分岐・複数文が入ると linter は沈黙する。「この effect は derived にすべき」の意図判断は ESLint では原理的に不可能なため、**lint は syntactic footgun を潰し、semantic 判断は PR review で補う**（`.claude/skills/pr-review/SKILL.md` の Svelte 観点で確認）。component 全体（script+template）の cognitive/cyclomatic 複雑度を測る既製 OSS は存在しない（SonarJS は `.svelte` 非サポート）ため深追いせず、自作 `local/max-svelte-lines`(500) を粗い proxy として維持する。
+
+### 7. dependency-cruiser の required gate 昇格 ratify (#3895 で追加)
+
+`dependency-cruiser`（#3871 導入、ADR-0061 Phase 2）は導入 PR 時点で `ci-gate` の `needs:` 未登録＝advisory-only（job は走るが failure が merge を block しない）だった。#3890 の rebase 時に `ci-gate` + `integration-evidence` の `needs:` へ登録され required gate に昇格した。本 ADR で以下を正式決定として ratify する:
+
+- **dependency-cruiser は T2 required gate（merge block）が正**。「gate は block すべき」（ADR-0061 shift-left 機械強制）に整合し、advisory-only は導入 PR の gap であって設計意図ではない
+- **既存 PR を誤 block しない**: baseline 12 件（循環 8 + orphan 4）は `.dependency-cruiser-known-violations.json` に pin され、`npm run depcruise`（`--ignore-known` 内蔵）が新規違反のみ fail する（`depcruise:infra` は baseline 0 で全数 gate）
+- 今後の gating policy 変更（needs 追加 / 削除）は §4 の運用ルールに従い本 ADR へ同 PR で追記する
 
 ## 結果
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -156,7 +156,7 @@ ADR を現場の常時参照ルールとして機能させるため、以下の�
 | 0004 | [レビュー & AC 検証品質](0004-review-and-ac-verification.md) | accepted | 2026-04-20 |
 | 0005 | [テスト品質 ratchet](0005-test-quality-ratchet.md) | accepted | 2026-04-20 |
 | 0006 | [Safety Assertion Erosion Ban](0006-safety-assertion-erosion-ban.md) | accepted | 2026-04-20 |
-| 0007 | [静的解析 tier ポリシー (T1/T2/T3/T4)](0007-static-analysis-tier-policy.md) | accepted | 2026-04-20 |
+| 0007 | [静的解析 tier ポリシー (T1/T2/T3/T4)](0007-static-analysis-tier-policy.md) | accepted (2026-07-19 §7 dependency-cruiser required 昇格 ratify、#3895) | 2026-04-20 |
 | 0008 | [設計ポリシー先行確認フロー](0008-design-policy-pre-approval.md) | accepted | 2026-04-20 |
 | 0010 | [Pre-PMF スコープ判断（3 バケット + セキュリティ最小化 + 優先度）](0010-pre-pmf-scope-judgment.md) | accepted | 2026-04-20 |
 | 0011 | [0-2 歳 baby モードは「親の準備モード」](0011-baby-mode-as-parent-preparation.md) | accepted | 2026-04-21 |


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（開発プロセス品質）

**解決する課題**: #3891 で導入した dependency-cruiser CI job は当初 `ci-gate` の `needs:` 未登録＝advisory-only（failure が merge を block しない toothless gate）だった。#3890 の rebase 時に `needs:` へ登録され required gate に昇格したが、この gating policy 変更が cfn-lint PR の副作用として入ったため、意思決定記録がどこにも残っていない governance gap があった。

**期待される効果**: required 昇格の意思決定を ADR-0007（静的解析 tier ポリシー）§7 に正規記録し ratify 完了。あわせて「required 化の実装点 = `ci-gate` needs 登録（ruleset 変更不要）」「needs 追加 / 削除 PR は ADR-0007 の階層マッピング表を同 PR で同期」という手続を §4 運用ルールに明文化し、silent な gating policy 変更を構造的に禁止する。新規依存境界違反（循環 / orphan / layer 違反）は今後 merge を block する（ADR-0061 shift-left 機械強制に整合）。

## 関連 Issue

Closes #3895

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dependency-cruiser を required ci-gate にする方針が意図通りか PO/Dev で確認 | `grep -n "dependency-cruiser" .github/workflows/ci.yml`（needs 登録の現状確認）+ ADR-0007 §7 の Dev 判断記録 | HEAD `610feab3` / ci.yml L1197（ci-gate needs）+ L1247（integration-evidence needs）に登録済を確認。Dev 判断 = required が正（ADR-0061「gate は block すべき」整合、advisory-only は導入 PR の gap）を `docs/decisions/0007-static-analysis-tier-policy.md` §7 L96-102 に記録。PO 最終確認は本 PR の QM approve / merge をもって完結（revert 判断が出た場合は本 PR を close し needs から除去する） |
| AC2 | 意図通りなら本 Issue を close（ratify 完了）。#3871 の設計意図と整合させる | `Closes #3895`（本 PR body、統合 PR で main 到達時に auto-close）+ ADR-0007 §7 / 階層マッピング表 | HEAD `610feab3` / #3871 は ADR-0061 Phase 2 の具体化として dependency-cruiser を「宣言的 config + CI gate」と定義しており、required 昇格はその設計意図の完遂。ADR-0007 §4 に昇格手続（needs 登録 = 実装点、表の同 PR 同期義務）を追記 L56、階層マッピング表に dependency-cruiser (T2) / cdk-cfn-lint (T2) を追補 L70-71 |
| AC3 | baseline（8 循環 + 4 orphan）が required 化で既存 PR を誤 block しないこと（新規のみ block）を確認 | `node -e "const b=require('./.dependency-cruiser-known-violations.json');..."`（baseline 内訳）+ `npm run depcruise` + `npm run depcruise:infra` | HEAD `610feab3` / baseline 実測 = total 12（no-circular 8 + no-orphans 4、issue 記載と一致）。`npm run depcruise`（`--ignore-known` 内蔵）= exit 0 / `npm run depcruise:infra` = exit 0 を worktree でローカル実行し、既存コードが gate を PASS する（= 既存 PR を誤 block しない）ことを物理確認 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — ドキュメント上の CI policy 記録のみ（`docs/decisions/` 2 file、workflow 実ファイルの変更なし）

**影響を受ける画面・機能**: なし（ADR 文書のみ。CI の実挙動は #3890 merge 時点で既に required 化済みであり、本 PR はその意思決定記録・手続の正規化）

**ruleset（branch protection）変更の要否**: **不要**。branch ruleset `PR_Mearge`（id 14673945）は `ci-gate` 単一 context を required とする集約設計（ci.yml L1184-1186 コメント / branch-strategy.md §対応表）のため、dependency-cruiser の required 化は `needs:` 登録（#3890 で実施済）だけで完結しており、admin（QM / audit-manager）への ruleset 変更依頼は発生しない。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: N/A（docs のみ。gate 実挙動の検証は AC3 の `npm run depcruise` / `npm run depcruise:infra` ローカル実行で担保）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（docs のみ — ADR-0007 / decisions README の 2 file、UI 変更なし）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（docs のみ）。記録先の選定は ADR-0007 §4 既存ルール「昇格 / 降格は本 ADR に追記する（別 ADR 不要）」に準拠し、新規 ADR を起票しない（ADR README「新規 ADR 追加 gate」整合）
- [x] **DRY**: required check 一覧の SSOT 構造を `grep -rn "depcruise" docs/sessions/branch-strategy.md .github/CLAUDE.md` で確認 — branch-strategy.md §対応表は「workflow → required context」のマッピングで job 単位の一覧を持たないため二重管理は発生しない（ci.yml `needs:` が job 単位の SSOT、ADR-0007 は tier / 意思決定の記録）
- [x] **YAGNI**: 新規 script / CI job 追加なし。既存 ADR への追記のみ
- [x] **Security（OSS 公開前提）**: N/A（秘密情報なし）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] N/A — 並行実装の影響範囲外（docs のみ）
- [x] **設計書同期** (ADR-0001): `docs/decisions/README.md` の 0007 行 status を同 PR で同期（表 vs 実ファイル一致の維持）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 本 PR の approve / merge が AC1「PO/Dev で確認」の PO 側確認を兼ねる（issue #3895 は QM が #3890 で accept 済みの変更の透明化 ratify）。advisory へ戻すべきと判断する場合は本 PR を close し、`ci.yml` の `ci-gate` / `integration-evidence` needs から `dependency-cruiser` を除去する revert PR を起票する
- cdk-cfn-lint の階層マッピング表追補は同一 commit（#3890）で needs 登録された same-class の記録漏れ是正（cfn-lint 自体の gating は #3874 の設計意図どおりで、ratify 対象は dependency-cruiser のみ）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・保留のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — N/A（単一 PR で完結）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
