### PR TITLE
infra: #3808 DSQL backup の post-deploy smoke test 追加 (vault/plan/selection 実在 + recovery point 鮮度、ADR-0024 (c))

### DIFF
--- a/.claude/skills/deploy-verify/SKILL.md
+++ b/.claude/skills/deploy-verify/SKILL.md
@@ -64,6 +64,7 @@ rollback 経路を再利用するための SSOT。手動で再確認する場合
 
 - [ ] `/switch`（子供切替の入口）が到達する
 - [ ] AWS は `deploy.yml` の e2e-production（post-deploy smoke on Lambda URL）+ demo Lambda smoke（#2130）が緑
+- [ ] AWS は `deploy.yml` の DSQL backup smoke（#3808）が緑（vault / plan / selection 実在 + recovery point 鮮度 < 48h。初回 deploy 後の on-demand 実発火確認と alarm 実通知テストは [dsql-restore.md §post-deploy backup smoke](../../docs/runbooks/dsql-restore.md)）
 - [ ] 管理画面（`/admin`）が PIN gate を返す
 
 ### §3.8 step 9 = AWS + NUC 両 health を 1 run で確認（SSOT、4 系統形）

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -649,6 +649,78 @@ jobs:
         if: always()
         run: cat cdk-outputs.json 2>/dev/null || echo "No outputs file"
 
+      # #3808 (#3437 F-3 / ADR-0024 (c)): DSQL AWS Backup 構成の post-deploy smoke test。
+      # CDK 単体テストは synth 段階 (template にリソースが存在すること) のみを検証し、AWS 上で
+      # backup plan / selection / vault が実在し日次 backup が回っている保証はゼロだった。
+      # #1586 (Cron dispatcher smoke test) と同型の「deploy 後に実 AWS 構成を assert する」パターン。
+      # - vault / plan の実在 + selection が本番 DSQL cluster ARN と確定 role (#3437 F-4) を指すことを assert
+      # - recovery point は日次 02:00 UTC 生成のため deploy 直後に無いのが正常 —
+      #   「存在すれば最新の age < 48h」の条件付き check とし、初回 deploy の false-fail を避ける。
+      #   存在するのに 48h 超 stale = 日次 backup の沈黙停止 → hard fail (ADR-0006 silent skip 禁止)。
+      # 失敗時は deploy job 全体が fail 扱い (health check 通過後のため app rollback は発火しない —
+      # backup 構成不備は app image の問題ではないため rollback 対象外が正しい)。
+      - name: DSQL backup smoke test (#3808)
+        run: |
+          set -euo pipefail
+          VAULT="ganbari-quest-dsql-vault"
+          PLAN_NAME="ganbari-quest-dsql-daily"
+          ROLE_NAME="ganbari-quest-dsql-backup-role"
+
+          # 1. backup vault 実在 (dsql-stack.ts DsqlBackupVault、RETAIN)
+          aws backup describe-backup-vault \
+            --backup-vault-name "$VAULT" --region "$AWS_REGION" > /dev/null
+          echo "::notice::backup vault OK: $VAULT"
+
+          # 2. backup plan 実在 (名前一致で解決、dsql-stack.ts DsqlBackupPlan)
+          PLAN_ID=$(aws backup list-backup-plans --region "$AWS_REGION" \
+            --query "BackupPlansList[?BackupPlanName=='$PLAN_NAME'] | [0].BackupPlanId" \
+            --output text)
+          if [ -z "$PLAN_ID" ] || [ "$PLAN_ID" = "None" ]; then
+            echo "::error::backup plan '$PLAN_NAME' が AWS 上に存在しません (#3808 / dsql-stack.ts DsqlBackupPlan)"
+            exit 1
+          fi
+          echo "::notice::backup plan OK: $PLAN_NAME ($PLAN_ID)"
+
+          # 3. selection が本番 DSQL cluster ARN + 確定 role (#3437 F-4) を指す
+          SELECTION_ID=$(aws backup list-backup-selections \
+            --backup-plan-id "$PLAN_ID" --region "$AWS_REGION" \
+            --query 'BackupSelectionsList[0].SelectionId' --output text)
+          if [ -z "$SELECTION_ID" ] || [ "$SELECTION_ID" = "None" ]; then
+            echo "::error::backup plan '$PLAN_NAME' に resource selection がありません (#3808)"
+            exit 1
+          fi
+          SEL_JSON=$(aws backup get-backup-selection \
+            --backup-plan-id "$PLAN_ID" --selection-id "$SELECTION_ID" --region "$AWS_REGION")
+          if ! echo "$SEL_JSON" | grep -qF "$DSQL_CLUSTER_ARN"; then
+            echo "::error::backup selection が本番 DSQL cluster ($DSQL_CLUSTER_ARN) を含みません (#3808)"
+            exit 1
+          fi
+          if ! echo "$SEL_JSON" | grep -qF "$ROLE_NAME"; then
+            echo "::error::backup selection の IAM role が $ROLE_NAME ではありません (#3437 F-4 / #3808)"
+            exit 1
+          fi
+          echo "::notice::backup selection OK: DSQL cluster + $ROLE_NAME"
+
+          # 4. recovery point (条件付き): 無し = 初回 deploy 直後の正常状態 (日次 02:00 UTC 生成)。
+          #    有るのに最新が 48h 超 stale = 日次 backup が 2 日以上生成されていない → hard fail。
+          LATEST=$(aws backup list-recovery-points-by-backup-vault \
+            --backup-vault-name "$VAULT" --region "$AWS_REGION" \
+            --query 'max_by(RecoveryPoints, &CreationDate).CreationDate' --output text)
+          if [ -z "$LATEST" ] || [ "$LATEST" = "None" ]; then
+            echo "::notice::recovery point は未生成 (日次 02:00 UTC 生成のため初回 deploy 直後は正常、#3808)"
+          else
+            # AWS CLI v2 既定は iso8601、v1 互換 (epoch float) にも fallback で対応
+            LATEST_SEC=$(date -u -d "$LATEST" +%s 2>/dev/null || printf '%.0f' "$LATEST")
+            NOW_SEC=$(date -u +%s)
+            AGE_H=$(( (NOW_SEC - LATEST_SEC) / 3600 ))
+            if [ "$AGE_H" -ge 48 ]; then
+              echo "::error::最新 recovery point が ${AGE_H}h 前 — 日次 backup が 2 日以上生成されていません (#3808 / runbook: docs/runbooks/dsql-restore.md)"
+              exit 1
+            fi
+            echo "::notice::recovery point OK: 最新は ${AGE_H}h 前 (< 48h)"
+          fi
+          echo "::notice::DSQL backup smoke test passed (#3808)"
+
   e2e-production:
     needs: deploy
     runs-on: ubuntu-latest

--- a/docs/runbooks/dsql-restore.md
+++ b/docs/runbooks/dsql-restore.md
@@ -25,6 +25,43 @@ backup は全 tenant 共有の 1 cluster 単位課金 (per-tenant ではない) 
 - **hard 監視**: `DsqlBackupBudget` ($0.07 ≈ ¥10、AWS Backup service filter) が 80% / 100% で通知する。
 - **¥10 接近時の対処**: budget 通知が来たら **retention_points を短縮** する (`dsql-stack.ts` の `deleteAfter` を 7→3 日等)。7→3 で月額 3/7 に、tenant 単位細粒度復元は論理 backup-archive が担保するため DR 実害は小。復元 RPO が要件を満たす範囲で最短化する。
 
+## post-deploy backup smoke (#3808 / ADR-0024 (c))
+
+CDK 単体テストは synth 段階のみの検証のため、AWS 上の backup 構成は `deploy.yml` の
+`DSQL backup smoke test (#3808)` step が deploy 毎に機械検証する (fail = deploy fail 扱い):
+
+| assert | 内容 | 失敗時の意味 |
+|---|---|---|
+| vault 実在 | `describe-backup-vault ganbari-quest-dsql-vault` | vault 消失 / stack drift |
+| plan 実在 | `list-backup-plans` に `ganbari-quest-dsql-daily` | plan 消失 / rename drift |
+| selection 整合 | selection が本番 DSQL cluster ARN + `ganbari-quest-dsql-backup-role` を指す | 対象外れ = backup が空回り |
+| recovery point 鮮度 (条件付き) | 未生成なら正常 (日次 02:00 UTC のため deploy 直後に無いのが通常)。存在するのに最新が 48h 超なら hard fail | 日次 backup の沈黙停止 (DR 空白) |
+
+### 初回 deploy 後の実発火確認 (one-time、on-demand backup)
+
+日次 backup を待たずに「recovery point が実際に生成できる」ことを初回 deploy 後に 1 回確認する
+(lifecycle 1 日で自動削除されるため恒常コストなし。CI には組み込まない — deploy 毎の full backup はコスト/時間の無駄):
+
+```bash
+ROLE_ARN=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsql --region us-east-1 \
+  --query "Stacks[0].Outputs[?OutputKey=='BackupRoleArn'].OutputValue" --output text)
+CLUSTER_ARN=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsql --region us-east-1 \
+  --query "Stacks[0].Outputs[?OutputKey=='ClusterArn'].OutputValue" --output text)
+JOB_ID=$(aws backup start-backup-job --region us-east-1 \
+  --backup-vault-name ganbari-quest-dsql-vault \
+  --resource-arn "$CLUSTER_ARN" --iam-role-arn "$ROLE_ARN" \
+  --lifecycle DeleteAfterDays=1 --query 'BackupJobId' --output text)
+aws backup describe-backup-job --backup-job-id "$JOB_ID" --region us-east-1 \
+  --query '{state:State,message:StatusMessage}'   # COMPLETED まで数分間隔で再実行
+```
+
+### alarm (SNS→opsEmail) 実通知テスト (one-time)
+
+`ganbari-quest-dsql-backup-failed` rule は実際の backup 失敗でしか発火しないため、経路を分けて確認する:
+
+1. **rule pattern**: `aws events test-event-pattern` に `{"source":["aws.backup"],"detail-type":["Backup Job State Change"],"detail":{"state":["FAILED"],"backupVaultName":["ganbari-quest-dsql-vault"]}}` 相当のテストイベントを渡し match を確認
+2. **SNS→email 疎通**: `aws sns publish --topic-arn <DsqlAlerts topic ARN> --subject "test" --message "DsqlAlerts 疎通テスト (#3808)"` を実行し opsEmail 受信を実確認 (subscription が PendingConfirmation のままだと届かない)
+
 ## 復元手順 (#3437 AC2)
 
 > **前提**: 同時 restore は最大 4。復元は新 cluster を作成し **source cluster を上書きしない** (= 常にロールバック可能)。full-cluster 単位のみ。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（全家族のデータ保全）

**解決する課題**: #3437 (PR #3801) で DSQL 日次 full backup を IaC 化したが、CDK 単体テストは synth 段階（template にリソースが存在すること）のみを検証し、**AWS 上で backup 構成が実在し日次 backup が回っている保証はゼロ**だった（QM Tier-2 F-3 指摘、ADR-0024 (c) post-deploy smoke test の gap）。DSQL の唯一の DR 手段が silent に空回りしても deploy は緑のままになる。

**期待される効果**: 本番 deploy 毎に backup vault / plan / selection の実在と「selection が本番 cluster + 確定 role を指すこと」を機械検証し、日次 backup が 2 日以上生成されない沈黙停止も hard fail で検知する。DR 空白の再発（EPIC #3424 が塞いだはずの空白）を deploy パイプラインで構造的に防ぐ。

## 関連 Issue

関連: #3808（tracking。close は次回 main deploy で本 smoke step の実発火緑 + runbook 記載の alarm SNS 実通知テスト完了を確認してから手動で行う — issue 対応方針が「初回 deploy 後の実通知テスト確認」を含むため、コード merge のみでは完遂と言えない）

<!-- no-issue-close: AC に実 deploy での発火確認（alarm SNS→opsEmail 実通知テスト）が含まれ、develop merge 時点では検証不能のため tracking とする -->

親: #3437 / 実装 PR: #3801 (merged) / SSOT: ADR-0024

## AC 検証マップ (ADR-0004)

<!-- ac-verification-skip は使わない。Issue #3808 は checklist 形式の AC を持たないため、対応方針 3 項目を AC として展開 -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | deploy 後に backup 構成（vault / plan / selection）の実在を実 AWS で assert する smoke を追加 | `node -e "require('yaml').parse(...)"` で YAML parse + step 列挙 / `grep -n "DSQL backup smoke test" .github/workflows/deploy.yml` | HEAD `77e44b6a` / parse OK・deploy job 33 steps・末尾 step = `DSQL backup smoke test (#3808)` / .github/workflows/deploy.yml:625-693。vault=`ganbari-quest-dsql-vault`・plan=`ganbari-quest-dsql-daily`・role=`ganbari-quest-dsql-backup-role` は infra/lib/dsql-stack.ts:213,218,241 の物理名と一致（grep で照合） |
| AC2 | recovery point 生成の検証（deploy 直後の false-fail を回避しつつ沈黙停止は fail） | `.github/workflows/deploy.yml` の smoke step 本文 review（条件分岐） | HEAD `77e44b6a` / 未生成 = notice で PASS（日次 02:00 UTC のため deploy 直後は正常）/ 存在するのに最新が 48h 超 = `::error` + exit 1（deploy fail 扱い、ADR-0006 silent skip 禁止）/ CLI v2 iso8601 と v1 epoch の両 timestamp 形式に fallback 対応 (.github/workflows/deploy.yml:676-689) |
| AC3 | deploy verify runbook に backup smoke 手順を組込 + alarm (SNS→opsEmail) 実通知テスト手順を明記 | `grep -n "post-deploy backup smoke" docs/runbooks/dsql-restore.md` / `grep -n "DSQL backup smoke" .claude/skills/deploy-verify/SKILL.md` | HEAD `77e44b6a` / docs/runbooks/dsql-restore.md:28-66 に §post-deploy backup smoke（CI assert 表 + 初回 one-time on-demand 実発火確認 + alarm rule pattern / SNS publish 疎通テスト手順）新設 / .claude/skills/deploy-verify/SKILL.md:68 にスモークテスト checklist 行追加 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [x] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 画面影響なし。`.github/workflows/deploy.yml` の deploy job 末尾に smoke step を **非破壊追加**（既存 step は 1 行も変更なし）。health check 通過後に実行されるため、smoke fail 時も app image の rollback は発火しない（backup 構成不備は app image の問題ではないため正しい挙動）。runbook (docs/runbooks/dsql-restore.md) と deploy-verify skill checklist を同期更新。

⚠️ **merge タイミングは QM / release 調整をお願いします**: `deploy.yml` はリリース系統の critical path のため、リリース進行中の統合 PR との干渉がないタイミングでの取込を推奨します（変更自体は末尾 step 追加のみで既存フローに影響しない設計）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  N/A — workflow YAML step の追加のみ（CDK / app code 変更なし）。YAML 構文は `node -e` での parse 検証済（deploy job 33 steps）。smoke の実発火検証は次回 main deploy（workflow は push to main でのみ trigger）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（既存 OIDC role の権限のみ使用、新規 env / secret なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（docs / infra workflow のみ、UI 変更なし）** — 変更ファイルは `.github/workflows/deploy.yml` / `docs/runbooks/dsql-restore.md` / `.claude/skills/deploy-verify/SKILL.md` の 3 件で `.svelte` / `.css` / `site/` を含まない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任 — smoke step は「backup 構成の実在検証」のみを担当し、既存 smoke（cron dispatcher #1586 / demo Lambda #2130）と同型パターンで並置。deploy フロー本体に条件分岐を混ぜない
- [x] **DRY**: 物理名（vault / plan / role）は `infra/lib/dsql-stack.ts` の命名（`grep -n "ganbari-quest-dsql" infra/lib/dsql-stack.ts`）と照合済。EventBridge 失敗 alarm（既存 #3437 F-2）とは検知軸が別（alarm = job 失敗イベント / smoke = 構成実在 + 鮮度）で重複なし
- [x] **YAGNI**: on-demand `start-backup-job` の CI 毎実行は不採用（deploy 毎の full backup はコスト / 時間の無駄 + lifecycle 未指定 recovery point の蓄積リスク）。one-time 実発火確認は runbook 手順に置いた
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし。AWS リソース物理名のみ（既に IaC で公開済の命名）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: smoke は read-only の AWS CLI 4 コール（describe / list × 4）で deploy 時間への影響は数秒

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] labels SSOT
- [x] **設計書同期** (ADR-0001): backup 運用の SSOT である `docs/runbooks/dsql-restore.md` に §post-deploy backup smoke を新設（設計書 13 は post-deploy smoke を総称記載済のため runbook 側が正しい同期先）。`deploy-verify` skill checklist にも 1 行追加
- [x] **並行 PR overlap** (#1200): open PR で `.github/workflows/deploy.yml` / `docs/runbooks/dsql-restore.md` を変更中のものなし（`gh pr list` で確認）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:

1. **Issue 対応方針からの設計判断**: Issue は「on-demand `start-backup-job` を起動し COMPLETED を待つ smoke」を一案として書いているが、CI 毎の on-demand full backup は (a) deploy 時間 + コスト増、(b) lifecycle 管理の複雑化を招くため、**CI では構成 assert + recovery point 鮮度（条件付き）**、**on-demand 実発火確認は初回 deploy 後の one-time runbook 手順**（`--lifecycle DeleteAfterDays=1` で恒常コストなし）に分離した。recovery point 鮮度 check（< 48h）により 2 回目以降の deploy では日次 backup の実生成が継続的に機械検証される
2. **false-fail 回避設計**: recovery point は日次 02:00 UTC 生成のため deploy 直後に無いのが正常 → 未生成は notice で PASS。存在するのに最新が 48h 超 stale の場合のみ hard fail（= 日次 backup の沈黙停止）。staging は backup ブロック自体を持たない（dsql-stack.ts の `isStaging` guard）ため本 smoke は `deploy.yml`（本番）にのみ追加
3. **配置**: deploy job 末尾（health check / rollback / audit の後）。smoke fail = deploy job fail（ADR-0006 silent skip 禁止）だが、health check 通過後のため app rollback は発火しない

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残っている AC がない）
- [x] Phase 分割した場合: 該当なし（単一 PR で完結）
- [x] UI 変更時: 該当なし（UI 変更なし）
- [x] 認証画面変更時: 該当なし（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
