### PR TITLE
test(ci): #3683 DSQL staging lane に並行検証 test の自動実行 step を追加 (AC1 run summary + AC2 明示 skip)

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -410,6 +410,50 @@ jobs:
           fi
           echo "::notice::staging smoke test passed (/ and /switch reachable)"
 
+      # Step 15.5 (#3683、DSQL lane のみ): 実 DSQL staging cluster での並行検証 test を lane 内で自動実行。
+      # deploy → migrate → grant → health/smoke green の後、lane が整えた endpoint (GITHUB_ENV の
+      # DSQL_ENDPOINT) + OIDC creds (dsql:migrate と同一、DbConnectAdmin) をそのまま test に渡す。
+      # 実行コマンドは test ヘッダー SSOT (tests/integration/db/dsql-staging-concurrency.test.ts 冒頭) と同一。
+      # - AC2 (graceful skip): DSQL lane 非活性 / endpoint 未解決時は step 自体を if で明示 skip
+      #   (run UI に skipped と出る。silent fail ではない、ADR-0006)。
+      # - test fail 時は step fail = lane fail (本 workflow は advisory / required 未登録のため
+      #   merge は block しないが red が見える。既存 lane の advisory 位置付けは不変)。
+      # - 固定 FAMILY uuid の相互破壊 flake (issue #3683 コメント 2026-07-16) は、本 workflow の
+      #   concurrency group (deploy-aws-staging, cancel-in-progress) が同時 run を 1 本に制限する
+      #   ことで本 test に関しては顕在化しない (afterAll が family 全行を削除し原状復帰する)。
+      - name: DSQL staging concurrency test (dsql lane, #3683)
+        if: env.DSQL_LANE == 'true' && env.DSQL_ENDPOINT != ''
+        timeout-minutes: 20
+        env:
+          DSQL_ENDPOINT: ${{ env.DSQL_ENDPOINT }}
+        run: |
+          START=$(date +%s)
+          set +e
+          npx vitest run tests/integration/db/dsql-staging-concurrency.test.ts
+          STATUS=$?
+          set -e
+          DURATION=$(( $(date +%s) - START ))
+          if [ "$STATUS" = "0" ]; then
+            RESULT="PASS"
+          else
+            RESULT="FAIL (exit $STATUS)"
+          fi
+          {
+            echo "## DSQL staging 並行検証 test (#3683、AC1)"
+            echo ""
+            echo "| 項目 | 値 |"
+            echo "|---|---|"
+            echo "| test file | \`tests/integration/db/dsql-staging-concurrency.test.ts\` (V1-V4: OCC 実発生 / 冪等 guard / lost update なし / cancel 原子化) |"
+            echo "| 結果 | $RESULT |"
+            echo "| 所要 | ${DURATION}s |"
+            echo "| endpoint | $DSQL_ENDPOINT |"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$STATUS" != "0" ]; then
+            echo "::error::DSQL staging 並行検証 test が fail しました (exit $STATUS)。advisory lane のため merge は block しませんが、staging drift の可能性を確認してください (#3683)"
+            exit "$STATUS"
+          fi
+          echo "::notice::DSQL staging 並行検証 test passed (${DURATION}s、#3683)"
+
       # Step 16: Rollback on failure — staging ECR の previous digest に戻す
       # (deploy.yml Phase 5b 同型。staging repo は maxImageCount:3 のため直近 2 世代まで戻せる)。
       - name: Rollback on failure


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（運営 / 開発チーム）

**解決する課題**: `tests/integration/db/dsql-staging-concurrency.test.ts`（実 Aurora DSQL での OCC 40001 / 冪等 guard / lost update / cancel 原子化の並行検証、V1-V4）は `DSQL_ENDPOINT` + AWS creds が必要な手動 opt-in で、CI では常時 skip されていた。#3813 (#3685) で統合 PR の DSQL staging lane は常時実行化されたが、lane 内の検証は smoke curl のみで本 test を実行しておらず、実行されない期間が長引くと staging drift（実 DSQL 挙動と設計前提の乖離）を検出できない残余リスクが QM residual (#3651) として記録されていた。

**期待される効果**: DSQL lane が cluster deploy → migrate → grant → health/smoke green まで整えた直後（endpoint / OIDC creds が揃った状態）に本 test を自動実行し、統合 PR ごとに実 DSQL の並行アクセス保証（exactly-once 付与 / 二重返金防止 / lost update なし）を機械回帰できる。cutover 後の staging drift を人手に頼らず検出する。

## 関連 Issue

Closes #3683

補足: Issue コメント（2026-07-15/16）の `dsql-staging-import-restore.test.ts` / `dsql-staging-pin-bulk-latency.test.ts` の lane 組込は、両 file とも per-run tenant 分離（run id 由来 uuid への移行）が前提条件（solo-run 前提の固定 TENANT + pre-clean が並行 run で相互破壊 flake になる）であり、test file 本体の改修を伴うため本 PR（workflow YAML のみ変更）の対象外。本 PR の対象 test（concurrency）は afterAll で family 全行削除の原状復帰を持ち、workflow の `concurrency` group（`deploy-aws-staging`、cancel-in-progress）が同時 run を 1 本に制限するため固定 FAMILY uuid でも相互破壊は顕在化しない（YAML コメントに根拠明記）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dsql lane deploy 後に並行検証 test が自動実行され、結果が run summary に出る | `.github/workflows/deploy-aws-staging.yml` L413-455 の step 追加を js-yaml parse で構造検証（step index 24/26、prev=`Smoke test (staging)` / next=`Rollback on failure`）+ `$GITHUB_STEP_SUMMARY` へ結果 / 所要 / endpoint の表を出力 | HEAD `91f5da31` / YAML parse OK（`node -e "require('js-yaml').load(...)"` で step 配置・if・timeout-minutes・env を確認）/ summary 出力は L437-447。**実 staging での発火は本 workflow が advisory（required 未登録）である性質上、次の develop→main 統合 PR の lane run で実測確認される**（self-report ではなく実測は次 run） |
| AC2 | cluster 不在時（dsqlEnabled=false / cluster 削除済）は skip（fail させない） | step `if: env.DSQL_LANE == 'true' && env.DSQL_ENDPOINT != ''`（L425、run UI に skipped と明示表示 = silent fail ではない、ADR-0006）+ 防御 2 層目として test 側 `describe.skipIf(!ENDPOINT)` を local 実証: `npx vitest run tests/integration/db/dsql-staging-concurrency.test.ts`（DSQL_ENDPOINT 未設定） | HEAD `91f5da31` / local 実行で `Test Files 1 skipped / Tests 4 skipped / exit=0` を確認（endpoint 不在でも fail しない）。lane 非活性（workflow_dispatch で dsqlEnabled=false）は `DSQL_LANE='false'` で step skip、endpoint 未解決は既存 resolve step が exit 1 で先に停止するため本 step には到達しない |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（アプリ実行コード変更ゼロ。`deploy-aws-staging.yml` の DSQL lane に step 1 件追加のみ。test file 本体・CDK stack 定義は不変更）。既存 lane の advisory 位置付け（required check 未登録、merge 非 block）も不変 — test fail 時は step fail = lane 全体が red になり可視化されるが merge は block しない。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - test file の新規追加なし。既存 `tests/integration/db/dsql-staging-concurrency.test.ts` の CI 実行配線のみ（実行コマンドは test ヘッダー SSOT と同一の `npx vitest run tests/integration/db/dsql-staging-concurrency.test.ts`、env は `DSQL_ENDPOINT`（lane の GITHUB_ENV）+ ambient OIDC creds（`dsql:migrate` step と同一 role、DbConnectAdmin）+ `DSQL_MIGRATE_USER` 未指定 = 'admin' 既定）
  - skip 挙動の local 実証: endpoint 未設定で `1 skipped / exit 0`
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（新規 env / secret なし。既存 lane が解決済みの `DSQL_ENDPOINT` を参照するのみ）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（CI workflow YAML のみの変更で UI 変更ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 単一責任（step は「test 実行 + summary 記録」のみ。endpoint 解決 / creds は既存 step の責務を再利用し重複実装しない）
- [x] **DRY**: 実行コマンド・env 名は test ヘッダー SSOT / `scripts/dsql-migrate.ts` の既存規約（`DSQL_ENDPOINT` / `DSQL_MIGRATE_USER` 既定 'admin'）に一致させ、二重定義なし
- [x] **YAGNI**: reporter 加工・artifact upload 等は追加せず、summary 表 + exit code 伝播の最小構成
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし（endpoint は非 secret、既存 step が `::notice::` で出力済みの値）
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: `timeout-minutes: 20` で hang 上限を明示（test 内部 timeout 合計 最悪 ~11 分に余裕）。lane の追加所要は test PASS 時 数分程度

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード と チュートリアル を同期
- [ ] **labels SSOT** (ADR-0009)
- [ ] **設計書同期** (ADR-0001): 対象外 — `deploy-aws-staging.yml` の設計 SSOT は workflow 冒頭コメント + `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §4.3（責務分界）で、本変更は §4.3 の責務（本番 deploy 経路の貫通 + post-deploy 検証）の範囲内の step 追加であり設計書の記述変更を要しない
- [ ] **並行 PR overlap** (#1200): `gh pr list --state open` で `.github/workflows/deploy-aws-staging.yml` を変更する open PR が他に無いことを確認済み
- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- **実 staging 発火は次の develop→main 統合 PR の lane run で確認される advisory**（本 workflow は `pull_request: branches: [main]` トリガーのため、develop 向けの本 PR では発火しない。self-report ではなく実測検証は次 lane run で行われる）
- step 配置は smoke test（Step 15）の後 / Rollback（Step 16）の前。Rollback の `if: failure() && steps.healthcheck.outcome == 'failure'` は healthcheck fail のみに反応するため、本 test の fail が image rollback を誤発火させることはない
- `env: DSQL_ENDPOINT: ${{ env.DSQL_ENDPOINT }}` は GITHUB_ENV 伝播で技術的には冗長だが、既存 `Provision DSQL schema` step と同型の明示 pattern に揃えた

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3905` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし。diff は workflow YAML の +44 行のみ）
- [x] 全 AC が実装済み（未完遂のまま残っている AC がない）
- [x] Phase 分割した場合: N/A（Phase 分割なし、単一 PR で完結）
- [x] UI 変更時: N/A（UI 変更なし、CI workflow YAML のみ）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
