### PR TITLE
test(fitness): #3682 AC1 ADR-0065 DPU 規約 原則 1/2 の機械強制 (原則 2 ループ内逐次 write fitness 新設 + 原則 1 カバー済判定)

### DIFF
--- a/docs/decisions/0065-dsql-dpu-query-rules.md
+++ b/docs/decisions/0065-dsql-dpu-query-rules.md
@@ -41,6 +41,16 @@ DSQL の課金は DPU (処理バイト + CPU 秒) で、行数課金ではない
 
 **EXPLAIN 運用**: `EXPLAIN ANALYZE VERBOSE` の Statement DPU Estimate は **相対比較 (変更前後の回帰確認) 用**とし、絶対閾値の CI gate にはしない (Estimate は billing-grade でない + データ量依存)。重い新規クエリ (集計 / cross-tenant cron) を追加する PR は、PR body に代表データでの DPU Estimate を記録する (レビュー判断材料。機械 gate 化は実運用の回帰実績が出てから再判断)
 
+## 機械強制の適用状況 (原則 1 / 2、#3682 AC1)
+
+- **原則 1 (PK prefix 必須) = 既存 fitness 2 本の合成でカバー済 (新規 fitness 不要)**。
+  (a) `tests/unit/db/pk-freeze-manifest.test.ts` [2b] が全テナント表の PK 先頭 = `family_id` を強制し、
+  (b) `tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts` (ADR-0063) が dsql module の全 SQL 文に `family_id` 述語を強制する (例外は閉じた allowlist)。
+  ∴ family_id 述語 = 複合 PK 先頭列アクセス = PK prefix であり、原則 1 は tenant 分離と同一強制点で機械強制済。allowlist 例外 (global-UNIQUE capability lookup = UNIQUE index 経由 / cross-tenant cron §11.2) は原則 1 の明示例外と同一集合
+- **原則 2 (ループ内逐次 txn 禁止) = `tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts` (#3682) で機械強制**。
+  TS AST でループ body 内の awaited write call (`await repo.insertX(...)` 等) を検出し、既存分は baseline に file × method × count で pin (ratchet、増加 = CI fail / 減少 = baseline 更新)。正当な例外 (cross-tenant cron の per-tenant txn 分離 / 非 DB write) は `// dpu2-allow: <理由>` で明示除外
+- **静的検出の限界 (残余はレビュー基準で担保)**: helper 関数経由の transitive write (`await processChild(...)` 等) と `Promise.all(map(...))` 並行形状は静的追跡不能。原則 3〜5 も定量判断 / 実測依存のため機械 gate 化しない (per-query DPU 予算 gate は #3682 AC2 = cutover 後 1 ヶ月の CloudWatch 実測で要否判断)
+
 ## 結果
 
 - コスト事故 (full scan 常態化 / N+1) がコードレビューの明文基準になる。監視側は CloudWatch TotalDPU 日次 alarm (#3431) が defense-in-depth

--- a/tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts
+++ b/tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts
@@ -1,0 +1,361 @@
+// tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts
+// Issue #3682 AC1 / ADR-0065 原則 2 (N+1 禁止・write は束ねる) の機械強制
+//
+// **ADR-0065 原則 2**: DSQL は write txn ごとに Transaction minimum 0.05 WriteDPU が課金される
+// (#3425 staging 実測)。ループ内で `await repo.insertX(...)` を逐次実行すると、内容に関わらず
+// 0.05 × N WriteDPU が課金されるため、同一操作の複数 write は単一 txn / bulk repo call に束ねる
+// (模範 = recordActivityCore #3541 / bulk-import 3,000 行チャンク §6.4)。
+//
+// **検出器 (fitness#7 dsql-txn-work-allowlist.test.ts と同型の TS AST 走査)**:
+//   ループ (for / for-of / for-in / for-await-of / while / do) の body 内にある
+//   AwaitExpression のうち、callee 末尾 method 名が write 系 prefix (WRITE_METHOD_RE) に
+//   一致するものを「ループ内逐次 write」として計数する。
+//   - `runInTransaction(async (tx) => { for (...) await tx.insert(...) })` は単一 txn に
+//     束ねられた正当形のため、work param binding への call は除外する
+//   - `// dpu2-allow: <理由>` を await 行 or 直上行に置けば明示除外 (fitness#7 gap 3 と同機構。
+//     cross-tenant cron の per-tenant txn 分離が正しいケース / 非 DB write 等に使う)
+//
+// **ratchet 方式 (base-token-routes-ratchet.test.ts と同型)**:
+//   既存違反は LOOP_WRITE_BASELINE に file × method × count で pin し、実測との完全一致を要求する。
+//   - 増加 → 新規のループ内逐次 write。bulk repo call / 単一 txn へ束ねるか、正当な例外なら
+//     dpu2-allow コメント (理由必須) を付ける
+//   - 減少 → 違反を解消したら baseline も下げる (ratchet down を記録する)
+//   baseline 残存分の解消は ADR-0065 原則 2 のレビュー基準 + 実測 (#3682 AC2) で個別判断する。
+//
+// **検出範囲の限界 (静的解析の制約、ADR-0065 §機械強制の適用状況)**:
+//   - helper 関数経由の transitive write (`for (...) await processChild(...)`) は method 名が
+//     write 系でない限り検出不能 (fitness#7 と同じ理由で静的追跡不能)。レビュー基準で担保
+//   - `await Promise.all(items.map((x) => repo.insert(x)))` の並行 N txn は await 直下が
+//     `Promise.all` のため検出対象外 (並行でも txn minimum × N は同じだが、別形状のため scope 外)
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const SERVICES_DIR = resolve(REPO_ROOT, 'src/lib/server/services');
+
+/** write 系 repo method の prefix。camelCase 継続 ([A-Z_0-9]) を要求し、Map#set / Set#add 等の
+ * 単語単体 method は対象外にする。read 系 (find/get/list/count) と送信系 (send*) は含めない。 */
+const WRITE_METHOD_RE =
+	/^(insert|create|upsert|update|delete|remove|record|save|persist|issue|archive|restore|copy|mark|import|set|add|increment|decrement)[A-Z_0-9]/;
+
+// ── baseline (既存違反の pin、2026-07-19 採取。減らしたら本表も下げる) ──
+// 値 = file 内の「ループ body 中の awaited write call」の method 名別出現数。
+// S3 / Cognito 等の非 DSQL write (saveFile / deleteFile / deleteCognitoUser 等) も
+// 検出上は含まれる (静的には区別不能)。新規追加が非 DB write なら dpu2-allow を付けること。
+const LOOP_WRITE_BASELINE: Record<string, Record<string, number>> = {
+	'account-deletion-service.ts': {
+		deleteCognitoUser: 1,
+		deleteInvite: 1,
+		deleteMembership: 1,
+		deleteUser: 1,
+		updateInviteStatus: 1,
+	},
+	'activity-import-service.ts': {
+		insertActivitiesBulk: 1,
+	},
+	'certificate-service.ts': {
+		issueCertificate: 2,
+	},
+	'challenge-set-import-service.ts': {
+		createChildChallengesBulk: 1,
+	},
+	'checklist-template-import-service.ts': {
+		addTemplateItem: 2,
+	},
+	'child-activity-copy-service.ts': {
+		copyActivitiesAcrossChildren: 1,
+	},
+	'child-challenge-service.ts': {
+		markCompleted: 1,
+		updateProgress: 1,
+	},
+	'child-reward-copy-service.ts': {
+		insertSpecialReward: 1,
+	},
+	'child-service.ts': {
+		deleteFile: 2,
+	},
+	'cloud-export-service.ts': {
+		saveFile: 1,
+		updateStatus: 3,
+	},
+	'consent-service.ts': {
+		recordConsent: 1,
+	},
+	'daily-mission-service.ts': {
+		insertDailyMission: 1,
+	},
+	'evaluation-service.ts': {
+		updateStatus: 2,
+	},
+	'grace-period-service.ts': {
+		deleteOwnerFullDelete: 1,
+		deleteOwnerOnlyAccount: 1,
+	},
+	'import-service.ts': {
+		importOneChecklistTemplate: 1,
+		importOneSpecialReward: 1,
+		insertActivity: 1,
+		insertChild: 1,
+		insertEvaluation: 1,
+		insertForRestore: 6,
+		insertOverrideForRestore: 1,
+		insertPointLedger: 1,
+		insertRedemptionForRestore: 1,
+		insertRestDayForRestore: 1,
+		insertTemplateItem: 1,
+		saveFile: 1,
+		setSetting: 1,
+		upsertLog: 1,
+		upsertStatus: 1,
+	},
+	'notification-service.ts': {
+		deleteByEndpoint: 2,
+	},
+	'pmf-survey-service.ts': {
+		incrementMarketingEmailCount: 1,
+		setSetting: 1,
+	},
+	'questionnaire-service.ts': {
+		addTemplateItem: 1,
+		createTemplate: 1,
+	},
+	'resource-archive-service.ts': {
+		archiveChecklistTemplates: 1,
+	},
+	'retention-cleanup-service.ts': {
+		deleteActivityLogsBeforeDate: 1,
+		deleteLoginBonusesBeforeDate: 1,
+		deletePointLedgerBeforeDate: 1,
+		deleteStatusHistoryBeforeDate: 1,
+	},
+	'reward-set-import-service.ts': {
+		importRewardSet: 1,
+		insertSpecialReward: 1,
+	},
+	'tenant-cleanup-service.ts': {
+		deleteActivity: 1,
+		deleteByChild: 1,
+		deleteByEndpoint: 1,
+		deleteById: 2,
+		deleteByPrefix: 1,
+		deleteChild: 1,
+		deleteChildFiles: 1,
+	},
+	'voice-service.ts': {
+		setActive: 1,
+	},
+};
+
+// ── 検出器 ──
+
+const isLoop = (n: ts.Node): boolean =>
+	ts.isForOfStatement(n) ||
+	ts.isForInStatement(n) ||
+	ts.isForStatement(n) ||
+	ts.isWhileStatement(n) ||
+	ts.isDoStatement(n);
+
+function calleeMethodName(expr: ts.CallExpression): string | null {
+	const c = expr.expression;
+	if (ts.isPropertyAccessExpression(c)) return c.name.text;
+	if (ts.isIdentifier(c)) return c.text;
+	return null;
+}
+
+/** callee チェーンを根の識別子まで unwrap する (fitness#7 の isTxBoundCall と同手法)。 */
+function rootIdentifier(expr: ts.CallExpression): string | null {
+	let c: ts.Expression = expr.expression;
+	for (;;) {
+		if (ts.isPropertyAccessExpression(c) || ts.isElementAccessExpression(c)) c = c.expression;
+		else if (ts.isCallExpression(c)) c = c.expression;
+		else break;
+	}
+	return ts.isIdentifier(c) ? c.text : null;
+}
+
+interface LoopWriteHit {
+	file: string;
+	line: number;
+	method: string;
+}
+
+/** node が `runInTransaction(inline work)` の callsite なら work param 名を返す (それ以外 null)。 */
+function txWorkParamName(node: ts.Node): string | null {
+	if (!ts.isCallExpression(node)) return null;
+	const callee = node.expression;
+	const isRunInTx =
+		(ts.isPropertyAccessExpression(callee) && callee.name.text === 'runInTransaction') ||
+		(ts.isIdentifier(callee) && callee.text === 'runInTransaction');
+	const work = node.arguments[0];
+	if (!isRunInTx || !work || !(ts.isArrowFunction(work) || ts.isFunctionExpression(work))) {
+		return null;
+	}
+	const p = work.parameters[0]?.name;
+	return p && ts.isIdentifier(p) ? p.text : null;
+}
+
+/** ループ内 awaited call が「逐次 write 違反」か判定する (tx-bound は単一 txn のため除外)。 */
+function isLoopWriteViolation(call: ts.CallExpression, txRoots: ReadonlySet<string>): boolean {
+	const method = calleeMethodName(call);
+	if (!method || !WRITE_METHOD_RE.test(method)) return false;
+	const root = rootIdentifier(call);
+	return !(root !== null && txRoots.has(root));
+}
+
+function findLoopSequentialWrites(sourceText: string, fileName: string): LoopWriteHit[] {
+	const sf = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true);
+	const lines = sourceText.split('\n');
+	const hits: LoopWriteHit[] = [];
+
+	const isExempted = (node: ts.Node): boolean => {
+		const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+		const current = lines[line] ?? '';
+		const prev = line > 0 ? (lines[line - 1] ?? '') : '';
+		return /dpu2-allow:/.test(current) || /dpu2-allow:/.test(prev);
+	};
+
+	const visit = (node: ts.Node, loopDepth: number, txRoots: ReadonlySet<string>) => {
+		const workParam = txWorkParamName(node);
+		const nextTx = workParam ? new Set([...txRoots, workParam]) : txRoots;
+		if (loopDepth > 0 && ts.isAwaitExpression(node) && ts.isCallExpression(node.expression)) {
+			const call = node.expression;
+			if (isLoopWriteViolation(call, nextTx) && !isExempted(node)) {
+				const { line } = sf.getLineAndCharacterOfPosition(node.getStart(sf));
+				hits.push({ file: fileName, line: line + 1, method: calleeMethodName(call) ?? '' });
+			}
+		}
+		const nd = isLoop(node) ? loopDepth + 1 : loopDepth;
+		ts.forEachChild(node, (ch) => visit(ch, nd, nextTx));
+	};
+	visit(sf, 0, new Set());
+	return hits;
+}
+
+function walkTsFiles(dir: string, acc: string[]): string[] {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) walkTsFiles(full, acc);
+		else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) acc.push(full);
+	}
+	return acc;
+}
+
+function measureServices(): Record<string, Record<string, number>> {
+	const measured: Record<string, Record<string, number>> = {};
+	for (const file of walkTsFiles(SERVICES_DIR, [])) {
+		const rel = relative(SERVICES_DIR, file).replace(/\\/g, '/');
+		const hits = findLoopSequentialWrites(readFileSync(file, 'utf-8'), rel);
+		for (const hit of hits) {
+			measured[rel] ??= {};
+			measured[rel][hit.method] = (measured[rel][hit.method] ?? 0) + 1;
+		}
+	}
+	return measured;
+}
+
+describe('ADR-0065 原則 2 fitness: ループ内逐次 write の ratchet (#3682 AC1)', () => {
+	it('[armed] services が実在し検出対象が空でない (armed-before-use)', () => {
+		const files = walkTsFiles(SERVICES_DIR, []);
+		expect(files.length).toBeGreaterThan(30);
+	});
+
+	it('[main] services のループ内 awaited write が baseline と完全一致する (増減とも本表を更新)', () => {
+		const measured = measureServices();
+		expect(
+			measured,
+			[
+				'ループ内逐次 write の実測が LOOP_WRITE_BASELINE と一致しません (ADR-0065 原則 2)。',
+				'- 増加した場合: 逐次 `await repo.write()` は txn minimum 0.05 WriteDPU × N を課金する。',
+				'  bulk repo call / runInTransaction 単一 txn へ束ねるか、正当な例外 (cross-tenant cron の',
+				'  per-tenant txn 分離 / 非 DB write) なら `// dpu2-allow: <理由>` を await 行に付ける。',
+				'- 減少した場合: 解消を記録するため baseline の該当 count を下げる (ratchet down)。',
+			].join('\n'),
+		).toEqual(LOOP_WRITE_BASELINE);
+	});
+
+	// ── 非トートロジー証明 (検出器が本当に検出することの fixture 検証) ──
+
+	it('ループ内の awaited repo write を検出する (for-of / while / for-await-of)', () => {
+		const cases: string[] = [
+			'async function f() { for (const r of rows) { await repo.insertActivity(r); } }',
+			'async function f() { while (queue.length) { await repo.deleteById(queue.pop()); } }',
+			'async function f() { for await (const r of stream) { await repo.upsertStatus(r); } }',
+		];
+		for (const src of cases) {
+			expect(findLoopSequentialWrites(src, 'fixture.ts').length, src).toBeGreaterThan(0);
+		}
+	});
+
+	it('read 系 / 送信系 / 単語単体 method / ループ外 write は検出しない', () => {
+		const ok: string[] = [
+			'async function f() { for (const r of rows) { await repo.findActivitiesByChild(r); } }',
+			'async function f() { for (const r of rows) { await sendTrialEndingEmail(r); } }',
+			'async function f() { for (const r of rows) { seen.add(r); map.set(r.id, r); } }',
+			'async function f() { await repo.insertActivitiesBulk(rows); }',
+		];
+		for (const src of ok) {
+			expect(findLoopSequentialWrites(src, 'fixture.ts'), src).toEqual([]);
+		}
+	});
+
+	it('runInTransaction work 内の tx-bound write ループは単一 txn のため検出しない', () => {
+		const ok = `async function f() {
+			await runner.runInTransaction(async (tx) => {
+				for (const r of rows) { await tx.insert(children).values(r); }
+			});
+		}`;
+		expect(findLoopSequentialWrites(ok, 'fixture.ts')).toEqual([]);
+		// tx binding 以外の write は runInTransaction 内のループでも検出する (別 txn / 別 db)
+		const ng = `async function f() {
+			await runner.runInTransaction(async (tx) => {
+				for (const r of rows) { await otherRepo.insertActivity(r); }
+			});
+		}`;
+		expect(findLoopSequentialWrites(ng, 'fixture.ts').length).toBeGreaterThan(0);
+	});
+
+	it('`// dpu2-allow:` コメント (直上行 / 同一行末尾) で明示除外できる', () => {
+		const above = `async function f() {
+			for (const t of tenants) {
+				// dpu2-allow: cross-tenant cron は per-tenant txn 分離が正しい (OCC 競合回避)
+				await repo.deleteActivityLogsBeforeDate(t.id, cutoff);
+			}
+		}`;
+		expect(findLoopSequentialWrites(above, 'fixture.ts')).toEqual([]);
+		const inline = `async function f() {
+			for (const t of tenants) {
+				await repo.deleteActivityLogsBeforeDate(t.id, cutoff); // dpu2-allow: per-tenant txn 分離
+			}
+		}`;
+		expect(findLoopSequentialWrites(inline, 'fixture.ts')).toEqual([]);
+		// dpu2-allow の無い 2 件目は依然検出する (除外は明示行のみ)
+		const partial = `async function f() {
+			for (const t of tenants) {
+				// dpu2-allow: 1 件目のみ除外
+				await repo.deleteActivityLogsBeforeDate(t.id, cutoff);
+				await repo.deletePointLedgerBeforeDate(t.id, cutoff);
+			}
+		}`;
+		expect(findLoopSequentialWrites(partial, 'fixture.ts').length).toBe(1);
+	});
+
+	it('[baseline-live] baseline の全 file が実在する (dead entry 検出)', () => {
+		const dead = Object.keys(LOOP_WRITE_BASELINE).filter((rel) => {
+			try {
+				readFileSync(resolve(SERVICES_DIR, rel), 'utf-8');
+				return false;
+			} catch {
+				return true;
+			}
+		});
+		expect(
+			dead,
+			`baseline に実在しない file があります (rename / 削除時は baseline も更新):\n${dead.join('\n')}`,
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（運用コスト → 顧客価格の持続性に波及）

**解決する課題**: ADR-0065（DSQL DPU コスト規約 5 原則）はレビュー明文基準のみで機械強制がなく、full scan / N+1 逐次 txn の混入が CI を素通りして DPU コスト事故（write txn minimum 0.05 WriteDPU × N の常態化）に至るリスクが残っていた（QM residual #3662）。

**期待される効果**: 原則 1（PK prefix 必須）は既存 fitness 2 本の合成でカバー済であることを機械根拠つきで確定し、原則 2（ループ内逐次 txn 禁止）は新設 fitness の ratchet で「新規のループ内逐次 write」を CI が即検出する。コスト事故の構造的防止がレビュー依存から機械強制に昇格する。

## 関連 Issue

#3682 （AC1 を本 PR で完遂。AC2 = DPU 相対回帰の CI 化要否は 2026-08 の CloudWatch 実測 gate で判断するため、issue は open のまま維持し close しない）

<!-- no-issue-close: AC2 (cutover 後 1 ヶ月の CloudWatch 実測による CI 化要否判断) が実測 gate で残るため、AC1 のみ本 PR で消化し issue は open 維持 -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 原則 1/2 の機械強制の実現性評価（可能なら fitness 実装、不可能なら根拠を ADR-0065 に追記） | `npx vitest run tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts tests/unit/db/pk-freeze-manifest.test.ts` | HEAD `cf4be103` / 3 files 15 passed。原則 1 = カバー済判定（`pk-freeze-manifest.test.ts` [2b] L100-103「全テナント表 PK 先頭 = family_id」× `dsql-tenant-predicate-fitness.test.ts` の family_id 述語必須の合成 = PK prefix 強制）を `docs/decisions/0065-dsql-dpu-query-rules.md` §機械強制の適用状況（L44-56）に追記。原則 2 = `tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts` を新設（services/ ループ内 awaited write 検出、既存 69 件 / 24 file を baseline pin、fixture 6 件で非トートロジー証明、failing-test-first: baseline 意図的乖離で `[main]` RED → 正値で GREEN を確認済） |
| AC2 | DPU 相対回帰の CI 化要否を cutover 後 1 ヶ月の CloudWatch 実測で判断 | `gh issue view 3682` | 本 PR scope 外（実測 gate）。issue #3682 を open のまま維持し、2026-08 の CloudWatch 実測で判断する。判断 gate の存在は ADR-0065 §機械強制の適用状況 末尾（`docs/decisions/0065-dsql-dpu-query-rules.md` L56）に明記済 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`tests/unit/architecture/` fitness 新設 + `docs/decisions/` ADR 追記)

**影響を受ける画面・機能**:
なし（CI fitness function + ADR 追記のみ。production コード変更 0 行）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts`（新設、7 test）: `[armed]` armed-before-use / `[main]` baseline 完全一致 ratchet / fixture 4 群（for-of・while・for-await-of 検出、read 系・送信系・単語単体 method 非検出、runInTransaction tx-bound 除外、`dpu2-allow:` コメント明示除外）/ `[baseline-live]` dead entry 検出
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — priority:low の test Issue

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — UI 変更なし。変更は `tests/unit/architecture/` の fitness function 新設と `docs/decisions/0065-dsql-dpu-query-rules.md` の追記のみで、視覚差分ゼロ。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検出器を `txWorkParamName` / `isLoopWriteViolation` / `findLoopSequentialWrites` に単一責任分割（biome cognitive complexity ≤ 20 準拠、suppression なし）
- [x] **DRY**: 既存 fitness（`dsql-txn-work-allowlist.test.ts` の TS AST 走査 + callee unwrap / `base-token-routes-ratchet.test.ts` の baseline ratchet / `dsql-tenant-predicate-fitness.test.ts` の閉じた allowlist + dead entry 検出）と同型 pattern を踏襲。`grep -rn "runInTransaction" tests/unit/architecture/` で近縁 fitness を確認済
- [x] **YAGNI**: 検出は「ループ内 awaited write の直接呼出」に限定し、helper transitive / Promise.all 並行形状の追跡は実装しない（静的追跡不能、ADR に限界として明記）
- [x] **Security（OSS 公開前提）**: N/A — dev-only test + docs。秘密情報なし
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: 検出器は services/ 63 file の AST 走査で vitest 実行 +1.2s 程度（`[main]` 1219ms 実測）。CI 負荷影響は軽微

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [x] **設計書同期** (ADR-0001): ADR-0065（`docs/decisions/0065-dsql-dpu-query-rules.md`）に §機械強制の適用状況 を追記（58 行 / 5 セクション、ボリューム上限 150 行 / 7 セクション内）。DSQL fitness 番号体系（`dsql-data-model.md` §13.1 の fitness#1-9）とは独立した ADR-0065 起点の gate のため ADR 側を SSOT とした
- [x] N/A — 上記以外の並行実装ペア（本番/デモ・LP・年齢モード・ナビ・seed・labels）は影響範囲外（test + docs のみ、production コード変更なし）

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- baseline 69 件（24 file）は「既存のループ内逐次 write」の pin であり、本 PR では解消しない（ratchet 導入が scope）。残存分の束ね化は ADR-0065 原則 2 のレビュー基準 + #3682 AC2 の実測で個別判断する設計
- `WRITE_METHOD_RE` は S3 / Cognito 等の非 DSQL write（`saveFile` / `deleteCognitoUser` 等）も静的には区別できず baseline に含む。新規追加時は `// dpu2-allow: <理由>` で明示除外できる（fixture で検証済）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope の AC1 を完遂。AC2 は issue 側の実測 gate として open 維持し、PR には未完遂項目を残さない）
- [x] Phase 分割した場合: N/A — Phase 分割なし（AC2 の実測 gate 分離は issue #3682 本文で起票時に定義済）
- [x] UI 変更時: N/A — UI 変更なし
- [x] 認証画面変更時: N/A — 認証画面変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
