### PR TITLE
infra: #3881 rollback-orphan named resource already-exists class の再発防止 (auto-naming 強制 fitness + orphan cleanup runbook)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -363,6 +363,35 @@ jobs:
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
 
+      # #3881: rollback-orphan による named resource "already exists" block の検知。
+      # CDK deploy (DSQL / all stacks) が失敗した場合、stack events / 失敗 change set から
+      # "already exists" を探し、該当時は掃除 runbook link を fail message に埋め込む
+      # (第16回リリースで orphan BackupVault が再 deploy を block し手動介入を要した実障害の再発対応)。
+      - name: Orphan-block detection (already exists -> runbook, #3881)
+        if: failure()
+        run: |
+          RUNBOOK="https://github.com/${{ github.repository }}/blob/main/docs/runbooks/rollback-orphan-cleanup.md"
+          found=0
+          for stack in GanbariQuestDsql GanbariQuestStorage GanbariQuestAuth GanbariQuestCompute GanbariQuestNetwork GanbariQuestSes GanbariQuestOps; do
+            events=$(aws cloudformation describe-stack-events --stack-name "$stack" --max-items 60 \
+              --query 'StackEvents[?ResourceStatus==`CREATE_FAILED` || ResourceStatus==`UPDATE_FAILED`].[LogicalResourceId,ResourceStatusReason]' \
+              --output text 2>/dev/null | grep -i "already exists" || true)
+            changesets=$(aws cloudformation list-change-sets --stack-name "$stack" \
+              --query 'Summaries[?Status==`FAILED`].[ChangeSetName,StatusReason]' \
+              --output text 2>/dev/null | grep -i "already exists" || true)
+            if [ -n "$events" ] || [ -n "$changesets" ]; then
+              found=1
+              echo "::error::[$stack] rollback-orphan による名前衝突 (already exists) を検出:"
+              [ -n "$events" ] && echo "$events"
+              [ -n "$changesets" ] && echo "$changesets"
+            fi
+          done
+          if [ "$found" -eq 1 ]; then
+            echo "::error::orphan named resource が再 deploy を block しています。掃除手順 (判断 gate 含む): $RUNBOOK"
+          else
+            echo "already exists 型の失敗イベントは検出されませんでした (別要因の deploy 失敗)"
+          fi
+
       # Phase 3.5 (#3646 本番 cutover): DSQL app role (app_user) provisioning。Lambda 実行 role は
       # dsql:DbConnect のみ持つ (最小権限) が DSQL 認可仕様では DbConnect は custom database role 専用の
       # ため、CREATE ROLE + AWS IAM GRANT (Lambda role ARN 紐付け) + 表 GRANT を冪等適用する。

--- a/docs/runbooks/rollback-orphan-cleanup.md
+++ b/docs/runbooks/rollback-orphan-cleanup.md
@@ -1,0 +1,137 @@
+# Runbook: rollback 後の orphan named resource 掃除 (already exists → redeploy block 解消)
+
+**関連**: #3881 (起票) / #3870 / #3872 (第16回リリース実障害) / #3874 (層別防御 epic) / ADR-0019 / ADR-0061
+**再発防止 SSOT**: `tests/unit/infra/physical-name-ratchet.test.ts` (明示物理名 allowlist ratchet) + `infra/CLAUDE.md` §「明示物理名は auto-naming が既定」
+
+---
+
+## 1. 対象 class と症状
+
+CDK deploy が CREATE 途中で失敗 → stack rollback した際、**明示物理名を持つリソース**が削除できず orphan 化 (stack 管理外で物理残存) することがある。次の deploy は同じ物理名で再作成しようとして **`already exists`** (名前衝突) で block される。
+
+代表的な fail message:
+
+```
+Resource of type 'AWS::Backup::BackupVault' with identifier 'ganbari-quest-dsql-vault' already exists.
+```
+
+`deploy.yml` の「Orphan-block detection」step (`if: failure()`) が stack events / 失敗 change set から `already exists` を自動検出し、本 runbook への link を `::error::` で出力する。
+
+**AWS 公式挙動 (一次情報)**:
+
+- rollback は作成物を削除するが、削除できないリソースは orphan 化する ("Resource removed from stack but not deleted"): <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html>
+- 物理名は "unique across all your active stacks" — 衝突すると deploy 失敗。回避の AWS 推奨 = 物理名を明示せず auto-naming: <https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-name.html>
+- BackupVault は recovery point があると削除自体が失敗し特に固着しやすい: <https://docs.aws.amazon.com/aws-backup/latest/devguide/deleting-backups.html> / <https://github.com/aws/aws-cdk/issues/33711>
+
+## 2. 検出手順
+
+deploy 失敗時、まず「どの物理名が衝突しているか」を特定する:
+
+```bash
+# (a) stack events から already exists を探す (直近 deploy の失敗理由)
+aws cloudformation describe-stack-events --stack-name <STACK> --region us-east-1 \
+  --query 'StackEvents[?ResourceStatus==`CREATE_FAILED`].[LogicalResourceId,ResourceStatusReason]' \
+  --output text | grep -i "already exists"
+
+# (b) change-set early validation で落ちた場合は失敗 change set 側に理由が残る
+aws cloudformation list-change-sets --stack-name <STACK> --region us-east-1 \
+  --query 'Summaries[?Status==`FAILED`].[ChangeSetName,StatusReason]' --output text
+
+# (c) 該当物理名のリソースが stack 管理外 (orphan) かを確認
+#     → どの active stack にも属していなければ orphan
+aws cloudformation describe-stack-resources --physical-resource-id <PHYSICAL_NAME> --region us-east-1
+```
+
+(c) が `Stack with id <PHYSICAL_NAME> does not exist` 等を返し、かつ実リソースが存在する (下記 §4 の各 list コマンドで見える) 場合、それが orphan である。
+
+## 3. 判断 gate (削除前に必ず確認)
+
+| gate | 判定 | 削除可否 |
+|---|---|---|
+| **G-1: orphan であること** | §2 (c) でどの active stack にも属さない | 属している場合は削除禁止 (稼働リソース)。stack 側の状態を先に確認 |
+| **G-2: 中身が空であること** | §4 の各「空確認」コマンドで recovery point / user / object / image が 0 | **空でない場合は削除禁止**。データ喪失になるため PO 承認 + backup 取得後にのみ実施 |
+| **G-3: RETAIN の意図確認** | RETAIN + 固定名リソース (vault / UserPool / S3 / ECR / backup-role) は「stack 削除でもデータを守る」意図の設計 | 中身があるならそれは守るべきデータの可能性が高い。削除ではなく「import して stack 管理へ戻す」(`cdk import`) を優先検討 |
+
+## 4. 資源別掃除手順 (空 orphan の削除 → redeploy)
+
+すべて `--region us-east-1` (region SSOT: `infra/CLAUDE.md`)。
+
+### 4.1 AWS Backup Vault (第16回で実際に orphan 化した type)
+
+```bash
+# 空確認 (G-2): recovery points が 0 であること
+aws backup list-recovery-points-by-backup-vault --backup-vault-name <VAULT_NAME> \
+  --query 'length(RecoveryPoints)' --region us-east-1
+
+# recovery point がある場合 (G-2 fail): PO 承認後にのみ全 purge
+#   aws backup delete-recovery-point --backup-vault-name <VAULT_NAME> \
+#     --recovery-point-arn <ARN> --region us-east-1   # (各 ARN について繰り返し)
+
+# 空 vault の削除
+aws backup delete-backup-vault --backup-vault-name <VAULT_NAME> --region us-east-1
+```
+
+### 4.2 Cognito User Pool
+
+```bash
+# 空確認 (G-2): user 0 であること。user がいる pool は削除禁止 (ADR-0022 系の実害履歴あり)
+aws cognito-idp list-users --user-pool-id <POOL_ID> --query 'length(Users)' --region us-east-1
+aws cognito-idp delete-user-pool --user-pool-id <POOL_ID> --region us-east-1
+```
+
+### 4.3 S3 Bucket
+
+```bash
+# 空確認 (G-2)
+aws s3api list-objects-v2 --bucket <BUCKET_NAME> --max-keys 1 --query 'KeyCount'
+aws s3 rb "s3://<BUCKET_NAME>"        # 空のみ成功する。--force は G-2 承認後のみ
+```
+
+### 4.4 ECR Repository
+
+```bash
+# 空確認 (G-2)
+aws ecr describe-images --repository-name <REPO_NAME> --query 'length(imageDetails)' --region us-east-1
+aws ecr delete-repository --repository-name <REPO_NAME> --region us-east-1   # 空のみ。--force は承認後のみ
+```
+
+### 4.5 IAM Role (第16回一次原因の DsqlBackupRole 等)
+
+```bash
+# attach 済み policy を外してから削除 (attach されたままだと DeleteConflict)
+aws iam list-attached-role-policies --role-name <ROLE_NAME> --query 'AttachedPolicies[].PolicyArn' --output text
+aws iam detach-role-policy --role-name <ROLE_NAME> --policy-arn <POLICY_ARN>   # (各 ARN)
+aws iam list-role-policies --role-name <ROLE_NAME> --output text               # inline policy 確認
+aws iam delete-role --role-name <ROLE_NAME>
+```
+
+### 4.6 その他 (SNS Topic / Log Group / Alarm / SSM Parameter / EventBridge Rule)
+
+データ喪失リスクが低い type。orphan 確認 (G-1) 後に削除してよい:
+
+```bash
+aws sns delete-topic --topic-arn <ARN> --region us-east-1
+aws logs delete-log-group --log-group-name <NAME> --region us-east-1
+aws cloudwatch delete-alarms --alarm-names <NAME> --region us-east-1
+aws ssm delete-parameter --name <NAME> --region us-east-1
+aws events remove-targets --rule <NAME> --ids $(aws events list-targets-by-rule --rule <NAME> --query 'Targets[].Id' --output text --region us-east-1) --region us-east-1
+aws events delete-rule --name <NAME> --region us-east-1
+```
+
+## 5. redeploy と事後確認
+
+1. orphan 削除後、`ROLLBACK_COMPLETE` の新規 stack が残っていれば削除する (`deploy.yml` Phase 2.5 「Cleanup failed stacks」が自動でも行う):
+
+   ```bash
+   aws cloudformation delete-stack --stack-name <STACK> --region us-east-1
+   aws cloudformation wait stack-delete-complete --stack-name <STACK> --region us-east-1
+   ```
+
+2. deploy を再実行する (main への push 再トリガ or `gh workflow run deploy.yml`)。
+3. deploy 後、`deploy.yml` の「Detect orphaned resources」step 出力で orphan が増えていないことを確認する。
+
+## 6. 再発防止 (この runbook を使わずに済ませるために)
+
+- **新規リソースに明示物理名を付けない** (CFN auto-naming が既定)。`tests/unit/infra/physical-name-ratchet.test.ts` が allowlist ratchet で機械強制する — allowlist 外の明示物理名は CI fail。
+- 既存 RETAIN stateful named (vault / pool / bucket / ECR / backup-role) は **rename しない** (rename = replacement = データ喪失。ADR-0019 gate が検知する)。
+- 原則の SSOT: `infra/CLAUDE.md` §「明示物理名は auto-naming が既定 (#3881)」。

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -41,7 +41,7 @@ CloudFront はグローバル（geoRestriction `JP`）。新規 region 言及は
 | 層 | 検証 | 実体 | 何を最初に捕捉するか |
 |---|---|---|---|
 | **Layer 1: synth 静的 lint** | `cdk synth --all` 出力 template を **cfn-lint** で検査し AWS schema 由来の property 制約違反（charset / allowed-value / type）を synth 時点で hard-fail | `scripts/check-cdk-cfn-lint.mjs` + `infra/.cfnlintrc` + ci.yml `cdk-cfn-lint` job（`infra/**` 変更時、develop 向け PR でも発火） | **Class ①（静的プロパティ制約違反）**。例: IAM Role/ManagedPolicy `Description` の非-ASCII（cfn-lint **E3031**、#3870）を含む全リソースの pattern / allowed-value / type 違反を**カスタムコードなしで**網羅捕捉 |
-| **Layer 2: project 固有 fitness** | 「本 project が壊してはいけない不変条件」を `Template.fromStack` synth 後に assert（AWS schema には無い project 固有の意図） | `tests/unit/infra/iam-role-description-ascii.test.ts`（IAM description ASCII、#3870）/ `tests/unit/infra/cross-stack-export-ratchet.test.ts`（自動 export/import allowlist ratchet、#3858） | **Class ②（stateful なデプロイ順序制約）の一部**。cross-stack export の新規混入を PR 時点で検出（deployed-state 依存の in-use 削除ロックの残りは Layer 3 が担う）。Layer 1 と冗長化する IAM ASCII assertion は上位互換の fallback として保持 |
+| **Layer 2: project 固有 fitness** | 「本 project が壊してはいけない不変条件」を `Template.fromStack` synth 後に assert（AWS schema には無い project 固有の意図） | `tests/unit/infra/iam-role-description-ascii.test.ts`（IAM description ASCII、#3870）/ `tests/unit/infra/cross-stack-export-ratchet.test.ts`（自動 export/import allowlist ratchet、#3858）/ `tests/unit/infra/physical-name-ratchet.test.ts`（明示物理名 allowlist ratchet、#3881） | **Class ②（stateful なデプロイ順序制約）の一部 + Class ③（rollback-orphan → named resource `already exists`）**。cross-stack export / 明示物理名の新規混入を PR 時点で検出（deployed-state 依存の in-use 削除ロックの残りは Layer 3 が担う）。Layer 1 と冗長化する IAM ASCII assertion は上位互換の fallback として保持 |
 | **Layer 3: rehearsal（staging 実 deploy）** | prod 経路（CDK synth → ECR push → Lambda update → health）を統合 PR で実 AWS 貫通。ADR-0019 replacement gate（`scripts/check-cdk-replacement.mjs`）も staging diff に適用 | `.github/workflows/deploy-aws-staging.yml`（AWS staging 3 stack）/ `.github/workflows/deploy-nuc-staging.yml`（NUC staging） | **Class ②（export-in-use ロック等 deployed-state 依存の失敗）**。静的では原理的に catch 不能なため実 deploy でのみ露見する class を統合監査で捕捉 |
 
 **役割分担の要点**: cfn-lint（Layer 1）は「AWS が受け付けない template」を汎用・自動で、assertion（Layer 2）は「本 project の不変条件」を、rehearsal（Layer 3）は「deployed-state 依存の失敗」を守る。3 層は補完関係で、上位ほど安価・高速・shift-left。
@@ -225,6 +225,23 @@ cron-dispatcher は **CRON_SECRET** または **OPS_SECRET_KEY** 最低 1 本必
 ## CDK Replacement gate の既知良性パターン (ADR-0019 運用)
 
 - `ErrorPagesDeploy/AwsCliLayer` の `may-cause-replacement` は aws-cdk-lib の version bump で BucketDeployment 補助 layer (deploy 時ツーリング) が再生成されるもの。**ユーザー向けリソースの置換ではなく良性** — 検出時は **branch の commit message (body) に** `replacement-approved: <ID>` を記載して承認する (squash message は commit message 由来 — PR body は乗らない) (初出: aws-cdk-lib 2.257→2.258、#2963)。
+
+## 明示物理名は auto-naming が既定 (rollback-orphan 予防、#3881)
+
+明示物理名 (`roleName` / `bucketName` / `functionName` / `backupVaultName` 等) を持つリソースは、create 失敗 → stack rollback の際に削除できず **orphan 化** し、次 deploy が **`already exists`** (名前衝突) で block される (第16回リリースで `DsqlBackupVault` = `ganbari-quest-dsql-vault` が実際に orphan 化し手動削除を要した、#3870 / #3872 / #3881)。これは AWS CloudFormation の設計上の既知挙動で、明示物理名を残す限り任意の create 失敗要因 (quota / IAM 結果整合性 / service エラー / dependency 失敗) で再発する。
+
+**AWS 公式一次情報 (SSOT)**:
+
+- rollback は作成物を削除するが、削除できないリソースは orphan 化する ("Resource removed from stack but not deleted"): <https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html>
+- 物理名は "unique across all your active stacks"。名前衝突は deploy 失敗。**AWS 推奨回避 = 物理名を明示せず CloudFormation auto-naming に委ねる** ("CloudFormation generates a unique physical ID"): <https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-name.html>
+- BackupVault は recovery point があると削除自体が失敗し特に固着する: <https://docs.aws.amazon.com/aws-backup/latest/devguide/deleting-backups.html> / <https://github.com/aws/aws-cdk/issues/33711>
+
+**運用ルール**:
+
+- **新規リソースは物理名 prop を省略する** (CFN auto-naming = ランダム suffix 付き生成名。rollback-orphan が残っても次 deploy と衝突しない)。
+- 明示名が本当に必要な場合 (外部から固定名で参照される契約 / SSM path 規約等) のみ、stack 側に justification コメントを書き、`tests/unit/infra/physical-name-ratchet.test.ts` の `NAMED_RESOURCE_ALLOWLIST` に reason 付き entry を追加する (allowlist 外の明示物理名は CI fail、#3874 Layer 2)。
+- **既存の RETAIN stateful named (vault / UserPool / S3 / ECR / backup-role) は rename しない** (rename = replacement = データ喪失。ADR-0019 gate 対象)。allowlist は一方通行で減らす (リソース撤去時に entry 削除)。
+- orphan 化して deploy が block された場合の掃除手順: [docs/runbooks/rollback-orphan-cleanup.md](../docs/runbooks/rollback-orphan-cleanup.md)。`deploy.yml` の「Orphan-block detection」step が `already exists` 検知時に本 runbook link を fail message に出力する。
 
 ## IAM Role description は ASCII/Latin-1 のみ (AWS 制約、#3870)
 

--- a/tests/unit/infra/physical-name-ratchet.test.ts
+++ b/tests/unit/infra/physical-name-ratchet.test.ts
@@ -238,7 +238,7 @@ function group(reason: string, keys: readonly string[]): NamedResourceEntry[] {
 	return keys.map((key) => ({ key, reason }));
 }
 
-// #3881 実測 baseline (2026-07-19、全 11 stack synth = 58 件)。既存の明示物理名はここに pin し、
+// #3881 実測 baseline (2026-07-19、全 11 stack synth = 58 件 + #3907 保全 vault 1 件 = 59 件)。既存の明示物理名はここに pin し、
 // **一方通行で減らす** (rename は replacement = データ喪失リスクのため既存は rename しない。
 // リソース撤去時に entry を削除する)。新規追加は「auto-naming で代替できない」justification が
 // ある場合のみ許容し、reason に根拠を書く。
@@ -343,6 +343,10 @@ const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
 			'GanbariQuestDsql/AWS::Backup::BackupPlan/ganbari-quest-dsql-daily',
 			'GanbariQuestDsql/AWS::IAM::Role/ganbari-quest-dsql-backup-role',
 		],
+	),
+	...group(
+		'#3907 RETAIN-orphan 保全 vault。既存物理 vault (recovery point 保持中、AWS Backup が削除拒否) と同一名の維持が in-place DeletionPolicy 更新の前提であり、rename = replacement CREATE (= #3881 class そのもの) を誘発するため明示名必須。物理 empty→delete は gated ops (storage-stack 設計書 §3.1)',
+		['GanbariQuestStorage/AWS::Backup::BackupVault/ganbari-quest-vault'],
 	),
 	...group('Budgets budgetName は console / cost 監視の識別子 (account 内 unique 制約)', [
 		'GanbariQuestDsql/AWS::Budgets::Budget/ganbari-quest-dsql-backup-guardrail',

--- a/tests/unit/infra/physical-name-ratchet.test.ts
+++ b/tests/unit/infra/physical-name-ratchet.test.ts
@@ -1,0 +1,425 @@
+// tests/unit/infra/physical-name-ratchet.test.ts
+// #3881 (ADR-0061 same-class→guard / fitness function): 明示物理名 (explicit physical name) の
+// allowlist ratchet gate。
+//
+// ## なぜ必要か (root class = rollback-orphan → "already exists" deploy block)
+// 第16回リリース (2026-07-18) で、DsqlBackupRole の IAM description 非 ASCII → CREATE_FAILED →
+// stack rollback の際に、明示物理名を持つ DsqlBackupVault (`ganbari-quest-dsql-vault`) が中途作成の
+// まま orphan 化し、次 deploy が `already exists` (名前衝突) で block された (#3870 / #3872 / #3881)。
+// これは AWS CloudFormation の設計上の既知挙動で、**明示物理名を持つ限り、任意の create 失敗要因
+// (quota / IAM 結果整合性 / service エラー / dependency 失敗) で同 class が再発する**:
+//   - rollback は作成物を削除するが、削除できないリソースは orphan 化する (physical 残存)
+//     https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html
+//   - 物理名は "unique across all your active stacks" — 衝突すると deploy 失敗
+//     https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-name.html
+//   - AWS 推奨回避 = 物理名を明示せず CloudFormation auto-naming に委ねる (同上)
+// #3874 の層別防御 (infra/CLAUDE.md §CDK deploy 失敗の層別) では Layer 2 (project 固有 fitness)。
+// Layer 1 (cfn-lint) は property 制約しか見ないため本 class を捕捉できない。
+//
+// ## 何をするか
+// 1. bin/app.ts が instantiate し得る全 11 stack (prod 6 + Dsql prod/staging + AWS staging 3) を
+//    synth し、CFN type ごとの物理名 property (RoleName / BucketName / FunctionName 等) を全抽出する。
+// 2. allowlist (既存 baseline、justification 付き) と**集合として過不足なく一致**することを assert:
+//    - allowlist 外の新規明示物理名 = fail (新規リソースは名前省略 = CFN auto-naming が既定)
+//    - allowlist の stale entry = fail (撤去したら entry も削除 = ratchet は一方通行で減らす)
+//
+// ## ratchet 運用
+// - **新規リソースに明示物理名を付けない** (CFN auto-naming はランダム suffix を生成するため
+//   rollback-orphan が残っても次 deploy と名前衝突しない)。
+// - どうしても明示名が必要な場合 (外部参照される固定名 / SSM path 契約等) のみ、stack 側に
+//   justification コメントを書いたうえで本 allowlist に entry (reason 付き) を追加する。
+// - 既存 RETAIN stateful named (vault / pool / bucket / ECR / backup-role) は **rename しない**
+//   (rename = replacement = データ喪失)。orphan 化した場合の掃除手順は
+//   docs/runbooks/rollback-orphan-cleanup.md を参照。
+//
+// ## 検出の注意 (required-name type)
+// AWS::CloudFront::Function の Name は CFN 必須 prop のため CDK が常に literal を emit する
+// (明示/自動を template から区別できない)。baseline に pin し、新規追加時は entry 追加を強制する
+// (CDK 生成名も construct path に安定依存するため rollback-orphan 衝突 class は同じ)。
+
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { describe, expect, it } from 'vitest';
+import { AuthStack } from '../../../infra/lib/auth-stack';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { DsqlStack } from '../../../infra/lib/dsql-stack';
+import { STAGING_ENV_CONFIG } from '../../../infra/lib/env-config';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { OpsStack } from '../../../infra/lib/ops-stack';
+import { SesStack } from '../../../infra/lib/ses-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+// cspell:ignore hostedzone TESTPOOL
+function makeApp(): cdk.App {
+	return new cdk.App({
+		context: {
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+		},
+	});
+}
+
+/**
+ * bin/app.ts が instantiate し得る全 stack (prod 6 + Dsql prod + Dsql staging + AWS staging 3)
+ * の Template を返す (iam-role-description-ascii.test.ts と同一 wire = 網羅性 SSOT)。
+ */
+function buildAllTemplates(): Array<[string, Template]> {
+	const templates: Array<[string, Template]> = [];
+
+	// --- prod 6 stack ---
+	const app = makeApp();
+	const storage = new StorageStack(app, 'GanbariQuestStorage', { env });
+	const auth = new AuthStack(app, 'GanbariQuestAuth', {
+		env,
+		appDomain: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+	});
+	const compute = new ComputeStack(app, 'GanbariQuestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'GanbariQuestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+	});
+	const ses = new SesStack(app, 'GanbariQuestSes', { env, domainName: 'ganbari-quest.com' });
+	const ops = new OpsStack(app, 'GanbariQuestOps', {
+		env,
+		lambdaFn: compute.fn,
+		distribution: network.distribution,
+		functionUrl: compute.functionUrl,
+		cronDispatcherFn: compute.cronDispatcherFn,
+		staticAssetsBucket: network.staticAssetsBucket,
+		opsEmail: 'ops@example.com',
+	});
+	for (const [name, stack] of [
+		['GanbariQuestStorage', storage],
+		['GanbariQuestAuth', auth],
+		['GanbariQuestCompute', compute],
+		['GanbariQuestNetwork', network],
+		['GanbariQuestSes', ses],
+		['GanbariQuestOps', ops],
+	] as const) {
+		templates.push([name, Template.fromStack(stack)]);
+	}
+
+	// --- DSQL prod (backup vault / role / rule / budget を含む) + DSQL staging ---
+	templates.push([
+		'GanbariQuestDsql',
+		Template.fromStack(
+			new DsqlStack(makeApp(), 'GanbariQuestDsql', { env, opsEmail: 'ops@example.com' }),
+		),
+	]);
+	templates.push([
+		'GanbariQuestDsqlStaging',
+		Template.fromStack(
+			new DsqlStack(makeApp(), 'GanbariQuestDsqlStaging', { env, deletionProtection: false }),
+		),
+	]);
+
+	// --- AWS staging 3 stack (#2873) ---
+	const stagingApp = makeApp();
+	const stStorage = new StorageStack(stagingApp, 'GanbariQuestStorageStaging', {
+		env,
+		envConfig: STAGING_ENV_CONFIG,
+	});
+	const stAuth = new AuthStack(stagingApp, 'GanbariQuestAuthStaging', {
+		env,
+		envConfig: STAGING_ENV_CONFIG,
+	});
+	const stCompute = new ComputeStack(stagingApp, 'GanbariQuestComputeStaging', {
+		env,
+		assetsBucket: stStorage.assetsBucket,
+		repository: stStorage.repository,
+		envConfig: STAGING_ENV_CONFIG,
+	});
+	for (const [name, stack] of [
+		['GanbariQuestStorageStaging', stStorage],
+		['GanbariQuestAuthStaging', stAuth],
+		['GanbariQuestComputeStaging', stCompute],
+	] as const) {
+		templates.push([name, Template.fromStack(stack)]);
+	}
+
+	return templates;
+}
+
+/**
+ * CFN resource type → 物理名 property の path。
+ * この repo に現存する type + 今後追加されやすい named type を網羅する。
+ * (AWS::Cognito::UserPoolDomain の Domain は DNS prefix で class が異なるため対象外)
+ */
+const PHYSICAL_NAME_PROPS: Record<string, readonly string[]> = {
+	'AWS::IAM::Role': ['RoleName'],
+	'AWS::IAM::ManagedPolicy': ['ManagedPolicyName'],
+	'AWS::S3::Bucket': ['BucketName'],
+	'AWS::ECR::Repository': ['RepositoryName'],
+	'AWS::Lambda::Function': ['FunctionName'],
+	'AWS::Backup::BackupVault': ['BackupVaultName'],
+	'AWS::Backup::BackupPlan': ['BackupPlan', 'BackupPlanName'],
+	'AWS::Budgets::Budget': ['Budget', 'BudgetName'],
+	'AWS::SNS::Topic': ['TopicName'],
+	'AWS::Logs::LogGroup': ['LogGroupName'],
+	'AWS::Events::Rule': ['Name'],
+	'AWS::CloudWatch::Alarm': ['AlarmName'],
+	'AWS::SSM::Parameter': ['Name'],
+	'AWS::Cognito::UserPool': ['UserPoolName'],
+	'AWS::DynamoDB::Table': ['TableName'],
+	'AWS::SQS::Queue': ['QueueName'],
+	'AWS::CloudFront::Function': ['Name'],
+	'AWS::Scheduler::Schedule': ['Name'],
+	'AWS::StepFunctions::StateMachine': ['StateMachineName'],
+};
+
+/** Properties から path を辿って値を取り出す。 */
+function dig(obj: unknown, path: readonly string[]): unknown {
+	let cur = obj;
+	for (const key of path) {
+		if (!cur || typeof cur !== 'object') return undefined;
+		cur = (cur as Record<string, unknown>)[key];
+	}
+	return cur;
+}
+
+/** 物理名値を安定 key 文字列化する (token 解決済 literal string が基本、object は JSON 化)。 */
+function nameToKey(v: unknown): string {
+	return typeof v === 'string' ? v : JSON.stringify(v);
+}
+
+/** 1 template から `${stack}/${type}/${name}` key の集合を抽出する。 */
+function collectNamedResources(stackName: string, template: Template): Set<string> {
+	const found = new Set<string>();
+	const json = template.toJSON() as {
+		Resources?: Record<string, { Type?: string; Properties?: unknown }>;
+	};
+	for (const res of Object.values(json.Resources ?? {})) {
+		const type = res.Type;
+		if (!type) continue;
+		const path = PHYSICAL_NAME_PROPS[type];
+		if (!path) continue;
+		const name = dig(res.Properties, path);
+		if (name === undefined) continue; // 名前省略 = CFN auto-naming (推奨既定)
+		found.add(`${stackName}/${type}/${nameToKey(name)}`);
+	}
+	return found;
+}
+
+/**
+ * allowlist entry。key = `${stack}/${CFN type}/${物理名}` (account は test env の 000000000000)。
+ * reason = 明示物理名を保持する justification (新規追加時は必須。「なんとなく」は不可)。
+ */
+interface NamedResourceEntry {
+	key: string;
+	reason: string;
+}
+
+/** 同一 justification の key 群を entry 化する builder。 */
+function group(reason: string, keys: readonly string[]): NamedResourceEntry[] {
+	return keys.map((key) => ({ key, reason }));
+}
+
+// #3881 実測 baseline (2026-07-19、全 11 stack synth = 58 件)。既存の明示物理名はここに pin し、
+// **一方通行で減らす** (rename は replacement = データ喪失リスクのため既存は rename しない。
+// リソース撤去時に entry を削除する)。新規追加は「auto-naming で代替できない」justification が
+// ある場合のみ許容し、reason に根拠を書く。
+const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
+	...group(
+		'RETAIN stateful。rename = replacement = 全 user / データ喪失 (auth-stack.ts / ADR-0017 系の orphan pool 実害履歴)。#3881 AC2 により rename せず pin',
+		[
+			'GanbariQuestAuth/AWS::Cognito::UserPool/ganbari-quest-users-v2',
+			'GanbariQuestAuthStaging/AWS::Cognito::UserPool/ganbari-quest-staging-users-v2',
+		],
+	),
+	...group(
+		'RETAIN stateful + deploy.yml / workflows が固定名参照 (ECR push / assets bucket / support-mail cleanup)。rename = replacement のため pin',
+		[
+			'GanbariQuestStorage/AWS::ECR::Repository/ganbari-quest',
+			'GanbariQuestStorage/AWS::S3::Bucket/ganbari-quest-assets-000000000000',
+			'GanbariQuestStorageStaging/AWS::ECR::Repository/ganbari-quest-staging',
+			'GanbariQuestStorageStaging/AWS::S3::Bucket/ganbari-quest-staging-assets-000000000000',
+			'GanbariQuestSes/AWS::S3::Bucket/ganbari-quest-support-mail-000000000000',
+			'GanbariQuestNetwork/AWS::S3::Bucket/ganbari-quest-error-pages-000000000000',
+		],
+	),
+	...group(
+		'SSM parameter path は app runtime / cross-stack 参照の固定契約 (path が API)。auto-naming 不可',
+		[
+			'GanbariQuestAuth/AWS::SSM::Parameter//ganbari-quest/cognito/client-id',
+			'GanbariQuestAuth/AWS::SSM::Parameter//ganbari-quest/cognito/user-pool-id',
+			'GanbariQuestAuthStaging/AWS::SSM::Parameter//ganbari-quest-staging/cognito/client-id',
+			'GanbariQuestAuthStaging/AWS::SSM::Parameter//ganbari-quest-staging/cognito/domain',
+			'GanbariQuestAuthStaging/AWS::SSM::Parameter//ganbari-quest-staging/cognito/user-pool-id',
+			'GanbariQuestOps/AWS::SSM::Parameter//ganbari-quest/health-check/last-notified-status',
+			'GanbariQuestOps/AWS::SSM::Parameter//ganbari-quest/health-check/weekly-stats',
+			'GanbariQuestSes/AWS::SSM::Parameter//ganbari-quest/ses/config-set-name',
+			'GanbariQuestSes/AWS::SSM::Parameter//ganbari-quest/ses/sender-email',
+		],
+	),
+	...group(
+		'deploy.yml / deploy-aws-staging.yml が update-function-code / logs tail / smoke test で functionName を固定名参照 (infra/CLAUDE.md §EventBridge Cron Rules の ops コマンド含む)',
+		[
+			'GanbariQuestAuth/AWS::Lambda::Function/ganbari-quest-cognito-custom-message',
+			'GanbariQuestAuthStaging/AWS::Lambda::Function/ganbari-quest-staging-cognito-custom-message',
+			'GanbariQuestCompute/AWS::Lambda::Function/ganbari-quest-app',
+			'GanbariQuestCompute/AWS::Lambda::Function/ganbari-quest-app-demo',
+			'GanbariQuestCompute/AWS::Lambda::Function/ganbari-quest-cron-dispatcher',
+			'GanbariQuestComputeStaging/AWS::Lambda::Function/ganbari-quest-staging-app',
+			'GanbariQuestOps/AWS::Lambda::Function/ganbari-quest-health-check',
+			'GanbariQuestSes/AWS::Lambda::Function/ganbari-quest-ses-receive',
+		],
+	),
+	...group(
+		'Lambda functionName 固定に対応する /aws/lambda/<fn> の固定 path (retention 管理を CDK 側で確定させるため事前 provision)',
+		[
+			'GanbariQuestCompute/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-app',
+			'GanbariQuestCompute/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-app-demo',
+			'GanbariQuestCompute/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-cron-dispatcher',
+			'GanbariQuestComputeStaging/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-staging-app',
+			'GanbariQuestOps/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-health-check',
+		],
+	),
+	...group(
+		'EventBridge Rule 固定名は ops 運用コマンド (`aws events list-rules --name-prefix ganbari-quest-cron`、infra/CLAUDE.md) の識別子契約',
+		[
+			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-export-build',
+			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-lifecycle-emails',
+			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-pmf-survey',
+			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-retention-cleanup',
+			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-trial-notifications',
+			'GanbariQuestOps/AWS::Events::Rule/ganbari-quest-aws-health',
+			'GanbariQuestOps/AWS::Events::Rule/ganbari-quest-health-check',
+			'GanbariQuestDsql/AWS::Events::Rule/ganbari-quest-dsql-backup-failed',
+		],
+	),
+	...group(
+		'CloudWatch Alarm 固定名は ops runbook / Discord 通知の識別子 (infra/CLAUDE.md §CloudWatch Alarm)',
+		[
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-cloudfront-5xx',
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-cron-dispatcher-errors',
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-concurrent',
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-duration-p99',
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-errors',
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-throttles',
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-url-4xx-spike',
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-url-5xx',
+		],
+	),
+	...group('SNS Topic 固定名は ops / SES notification 設定の識別子', [
+		'GanbariQuestOps/AWS::SNS::Topic/ganbari-quest-ops-alerts',
+		'GanbariQuestSes/AWS::SNS::Topic/ses-bounce-notifications',
+		'GanbariQuestSes/AWS::SNS::Topic/ses-complaint-notifications',
+	]),
+	...group(
+		'CloudFront::Function は Name が CFN 必須 prop で CDK が常に literal を emit する (明示/自動を template から区別不能)。現状名を pin',
+		[
+			'GanbariQuestNetwork/AWS::CloudFront::Function/ganbari-quest-demo-query-slash-encode',
+			'GanbariQuestNetwork/AWS::CloudFront::Function/ganbari-quest-query-slash-encode',
+		],
+	),
+	...group(
+		'AWS Backup 系 (#3437 で命名済)。vault は #3881 当該 orphan の実例だが RETAIN stateful のため rename = replacement 不可、現状名を pin (掃除は runbooks/rollback-orphan-cleanup.md)',
+		[
+			'GanbariQuestDsql/AWS::Backup::BackupVault/ganbari-quest-dsql-vault',
+			'GanbariQuestDsql/AWS::Backup::BackupPlan/ganbari-quest-dsql-daily',
+			'GanbariQuestDsql/AWS::IAM::Role/ganbari-quest-dsql-backup-role',
+		],
+	),
+	...group('Budgets budgetName は console / cost 監視の識別子 (account 内 unique 制約)', [
+		'GanbariQuestDsql/AWS::Budgets::Budget/ganbari-quest-dsql-backup-guardrail',
+		'GanbariQuestDsql/AWS::Budgets::Budget/ganbari-quest-dsql-guardrail',
+		'GanbariQuestOps/AWS::Budgets::Budget/ganbari-quest-monthly',
+	]),
+	...group('demo Lambda 実行 role (ADR-0048 IAM role 分離)。deploy 運用で固定名参照', [
+		'GanbariQuestCompute/AWS::IAM::Role/ganbari-quest-app-demo-role',
+	]),
+];
+
+const ALLOWLIST_KEYS: ReadonlySet<string> = new Set(NAMED_RESOURCE_ALLOWLIST.map((e) => e.key));
+
+describe('#3881 明示物理名 allowlist ratchet (rollback-orphan already-exists class の構造的予防)', () => {
+	const templates = buildAllTemplates();
+	const found = new Set<string>();
+	for (const [stackName, template] of templates) {
+		for (const key of collectNamedResources(stackName, template)) {
+			found.add(key);
+		}
+	}
+
+	it('[G1] instantiate 対象 11 stack を漏れなく synth できる (網羅性の担保)', () => {
+		// stack を追加したら本数を増やす。silent に synth 対象が減っていないことの guard。
+		expect(templates.length).toBe(11);
+	});
+
+	it('[G2] 明示物理名を持つ全リソースが allowlist 内である (新規明示名 = fail)', () => {
+		const unexpected = [...found].filter((k) => !ALLOWLIST_KEYS.has(k)).sort();
+		expect(
+			unexpected,
+			`allowlist 外の明示物理名を検出 (${unexpected.length} 件):\n${unexpected.join('\n')}\n\n` +
+				'新規リソースは物理名 prop (roleName / bucketName / functionName 等) を**省略**し、' +
+				'CloudFormation auto-naming に委ねるのが既定 (rollback-orphan の already-exists 衝突を' +
+				'構造回避、#3881 / AWS 公式推奨)。明示名が本当に必要な場合のみ、stack 側に justification ' +
+				'コメントを書き、本 test の NAMED_RESOURCE_ALLOWLIST に reason 付き entry を追加する。',
+		).toEqual([]);
+	});
+
+	it('[G3] allowlist に stale entry が無い (撤去済みリソース = entry 削除必須、ratchet 一方通行)', () => {
+		const stale = NAMED_RESOURCE_ALLOWLIST.map((e) => e.key)
+			.filter((k) => !found.has(k))
+			.sort();
+		expect(
+			stale,
+			`allowlist にあるが synth で生成されない明示物理名 (${stale.length} 件):\n${stale.join('\n')}\n\n` +
+				'リソースを撤去 / auto-naming 化したら、対応 entry を NAMED_RESOURCE_ALLOWLIST から削除する。',
+		).toEqual([]);
+	});
+
+	it('[G4] 実測集合と allowlist が過不足なく一致する (数の drift を 1 行で可視化)', () => {
+		expect(found.size).toBe(NAMED_RESOURCE_ALLOWLIST.length);
+		expect(new Set(found)).toEqual(ALLOWLIST_KEYS);
+	});
+});
+
+describe('#3881 ratchet が有効に機能する (negative test / failing-test-first、ADR-0061)', () => {
+	it('明示物理名を持つ新規リソースが現れたら検出される (物理確認)', () => {
+		// 故意に「明示 bucketName を持つ新規 bucket」を probe stack に作り、検出ロジックが
+		// allowlist 外 violation として返すことを実 synth で実証する (= #3881 と同 class の混入)。
+		const app = makeApp();
+		const probe = new cdk.Stack(app, 'GanbariQuestProbe', { env });
+		new cdk.aws_s3.Bucket(probe, 'ProbeNamedBucket', {
+			bucketName: 'ganbari-quest-probe-named-bucket',
+		});
+		const probeFound = collectNamedResources('GanbariQuestProbe', Template.fromStack(probe));
+		const unexpected = [...probeFound].filter((k) => !ALLOWLIST_KEYS.has(k));
+		expect(unexpected).toContain(
+			'GanbariQuestProbe/AWS::S3::Bucket/ganbari-quest-probe-named-bucket',
+		);
+	});
+
+	it('物理名を省略した (auto-naming) リソースは検出対象にならない (推奨経路が無摩擦であること)', () => {
+		const app = makeApp();
+		const probe = new cdk.Stack(app, 'GanbariQuestProbeAuto', { env });
+		new cdk.aws_s3.Bucket(probe, 'ProbeAutoNamedBucket'); // bucketName 省略 = CFN auto-naming
+		const probeFound = collectNamedResources('GanbariQuestProbeAuto', Template.fromStack(probe));
+		expect([...probeFound].filter((k) => k.includes('ProbeAutoNamedBucket'))).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体

**解決する課題**: 第16回リリース (2026-07-18) で、CDK stack rollback 時に明示物理名を持つ `DsqlBackupVault` (`ganbari-quest-dsql-vault`) が orphan 化し、次 deploy が `already exists` (名前衝突) で block され手動介入を要した。AWS CloudFormation の設計上の既知挙動 (rollback で削除できないリソースは orphan 化 + 物理名は active stack 横断 unique) により、明示物理名を残す限り任意の create 失敗要因で同 class が再発する (#3874 未カバーの Class 3)。

**期待される効果**: (1) 新規リソースの明示物理名を fitness function (allowlist ratchet) で機械抑制し、rollback-orphan → already-exists 衝突を構造回避 (CFN auto-naming を既定化)。(2) 既存 named resource が orphan 化した場合の掃除手順を runbook に SSOT 化し、deploy.yml が検知時に runbook link を fail message へ自動出力。deploy 完遂までの手動介入時間を最小化する。

## 関連 Issue

Closes #3881

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 新規リソースの明示物理名を fitness function で抑制 (auto-naming 既定、明示名は justification 必須、既存 baseline 許容の ratchet) | `npx vitest run tests/unit/infra/physical-name-ratchet.test.ts` | HEAD `41ad43e8` / 6 passed (G1-G4 + negative probe 2)。failing-test-first: 空 allowlist で G2/G4 が fail し実測 58 件を列挙することを先に物理確認 → baseline pin (reason 付き) 後 PASS。negative probe (明示 bucketName の新規 bucket) が allowlist 外 violation として検出されることも実 synth で assert |
| AC2 | 既存 RETAIN stateful named は rename しない + orphan cleanup runbook を docs/runbooks/ に SSOT 化 (BackupVault purge→delete→redeploy / UserPool・S3・ECR・IAM Role の空 orphan 削除→redeploy) | `ls docs/runbooks/rollback-orphan-cleanup.md` + `grep -n "rename" tests/unit/infra/physical-name-ratchet.test.ts` | HEAD `41ad43e8` / runbook 新設 (§3 判断 gate 3 種 = orphan 確認 / 空確認 / RETAIN 意図確認、§4.1 BackupVault recovery point purge→delete、§4.2-4.6 UserPool / S3 / ECR / IAM Role / その他)。既存 58 件は allowlist に「rename = replacement = データ喪失のため pin」の reason 付きで固定し rename を要求しない |
| AC3 | deploy.yml の orphan-block 検知時 fail message に runbook link を埋め込む | `grep -n "Orphan-block detection\|rollback-orphan-cleanup" .github/workflows/deploy.yml` + YAML parse 検証 | HEAD `41ad43e8` / .github/workflows/deploy.yml に `if: failure()` の検知 step を追加 (stack events の CREATE_FAILED/UPDATE_FAILED + 失敗 change set の StatusReason から already exists を grep → 該当時に runbook URL を error annotation 出力)。`node -e "require('js-yaml').load(...)"` で YAML parse OK |
| AC4 | AWS rollback/naming 挙動の一次情報 SSOT を infra/CLAUDE.md に明記 (#3874 層別アーキと整合) | `grep -n "auto-naming が既定\|troubleshooting.html\|aws-properties-name" infra/CLAUDE.md` | HEAD `41ad43e8` / infra/CLAUDE.md に §「明示物理名は auto-naming が既定 (rollback-orphan 予防、#3881)」を新設 (AWS 公式一次情報 4 URL + 運用ルール 4 点)。#3874 層別表 Layer 2 の実体列に本 fitness を追記し「Class ③」を層別マップへ位置づけ |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [x] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
アプリ UI への影響なし。影響対象は (1) CI unit test lane (`tests/unit/infra/` に fitness 1 file 追加、既存 CDK stack 定義は無変更)、(2) 本番 deploy workflow の失敗時診断出力 (deploy 成功経路は無変更、`if: failure()` step の追加のみ)、(3) docs (runbook 新設 + infra/CLAUDE.md 節追加)。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/infra/physical-name-ratchet.test.ts` 新設: 全 11 stack (prod 6 + Dsql prod/staging + AWS staging 3) を synth し、CFN type→物理名 prop map (19 type) で明示物理名を全抽出 → 実測 baseline 58 件の allowlist と集合一致を assert (G1 網羅性 / G2 新規明示名 fail / G3 stale entry fail / G4 集合一致)。negative probe 2 件 (明示名 bucket = 検出される / auto-naming bucket = 検出されない) で ratchet の有効性と推奨経路の無摩擦を実 synth で物理確認
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — 再発防止の infra/test 変更であり priority:critical fix ではない

補足 (既知 flake): `npx vitest run tests/unit/infra/` 一括実行時に既存 `static-assets-s3-offload.test.ts` の 1 test が 5s timeout で fail する場合があるが、単独実行では 17/17 passed (並列 synth 負荷起因、本 PR の変更対象外)。

## スクリーンショット / ビジュアルデモ

該当なし（docs / infra / test のみ、UI 変更なし）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: fitness test は既存 `iam-role-description-ascii.test.ts` の buildAllTemplates wire (網羅性 SSOT) を踏襲し、検出ロジックは type→prop map + 純関数 (`dig` / `nameToKey` / `collectNamedResources`) に分離
- [x] **DRY**: 検出 pattern は既存 ratchet 2 本 (`cross-stack-export-ratchet` #3858 / `base-token-routes-ratchet` #3152) と同一思想 (allowlist 一方通行)。`grep -rn "already exists" .github/workflows/deploy.yml` で同種検知 step の重複なしを確認
- [x] **YAGNI**: 検知 step は `if: failure()` 時のみ実行され正常経路のコスト 0。fitness の type map は現存 type + 頻出 named type に限定
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし (test env は dummy account 000000000000)。deploy.yml 追加 step は read-only API (describe-stack-events / list-change-sets) のみ
- [x] **アクセシビリティ**: N/A (UI 変更なし)
- [x] **パフォーマンス**: fitness test は synth 済み template の JSON 走査のみ (追加負荷は synth 1 回分 ~19s)。deploy.yml 追加 step は失敗時のみ

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシード（`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` / `src/lib/server/demo/demo-data.ts`）と チュートリアル同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): infra/CLAUDE.md に原則節 + #3874 層別表 Layer 2 追記、docs/runbooks/rollback-orphan-cleanup.md 新設 (AWS アーキ構成自体は不変のため 13-AWS 設計書は対象外)
- [x] **並行 PR overlap** (#1200): `gh pr list --state open` で deploy.yml / tests/unit/infra/ を変更中の open PR なしを確認
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314):

N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:
- fitness の allowlist は実測 58 件 (issue 記載の audit 54 件と差分があるのは、staging 系 stack + Budgets / BackupPlan 等の nested name prop も検出対象に含めた機械計測のため)。reason のグルーピング妥当性を確認いただきたい
- AWS::CloudFront::Function は Name が CFN 必須 prop で明示/自動を template から区別できないため baseline pin 方式 (test 冒頭コメントに明記)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み → N/A (単一 PR で完結)
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 → N/A (UI 変更なし)
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 → N/A (認証画面変更なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
