### PR TITLE
feat(infra): #3412 staging 用 PII-free 合成ダミーデータ seed (demo-data 再利用 + PGlite 流し込み検証 + NUC staging opt-in 配線)

### DIFF
--- a/.github/workflows/deploy-nuc-staging.yml
+++ b/.github/workflows/deploy-nuc-staging.yml
@@ -47,6 +47,14 @@ on:
         description: 'PGlite backend で staging を deploy (EPIC #3620 cutover リハーサル、手動検証用)'
         type: boolean
         default: false
+      # #3412: PII-free 合成ダミー seed (opt-in)。true で本番 DB snapshot (Step 4) を skip し、
+      # scripts/seed-staging.ts (demo-data.ts 再利用の合成 5 tenant) で data/pglite を構築して
+      # 起動する = staging に本番 PII を複製しない (#2999 根本解決)。pgliteEnabled=true が前提
+      # (合成 seed は pg-core backend 専用)。false (既定) は従来どおり snapshot 経路で不変。
+      syntheticSeed:
+        description: 'PII-free 合成ダミー seed で staging を deploy (#3412、pgliteEnabled=true が前提)'
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-nuc-staging
@@ -62,6 +70,10 @@ env:
   # では **常時 pglite lane** を回して「本番構成 = staging 構成」を恒常一致させる。dispatch は手動
   # opt-in (pgliteEnabled=true) のときのみ。
   PGLITE_LANE: ${{ (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.pgliteEnabled == true)) && 'true' || 'false' }}
+  # 合成 seed lane 判定 (#3412)。workflow_dispatch で syntheticSeed=true かつ pglite lane のときのみ。
+  # 統合 PR (pull_request) は従来どおり snapshot + cutover rehearsal 経路 (既存検証フロー不変)。
+  # snapshot 経路の完全置換 (統合 PR でも合成 seed 化) は staging 実機での合成 seed 検証後に判断する。
+  SYNTHETIC_SEED: ${{ (github.event_name == 'workflow_dispatch' && inputs.syntheticSeed == true && inputs.pgliteEnabled == true) && 'true' || 'false' }}
 
 jobs:
   deploy-nuc-staging:
@@ -167,7 +179,9 @@ jobs:
       # 本番 container 不在/停止時 (初回 provision 等) は従来同様 fixture fallback で継続し、staging は
       # fresh DB で起動する (lazy migration が初期 schema を構築)。container 稼働中でも本番 DB file
       # 不在なら script 自身が exit 0 + fixture fallback する (tmp file 非生成 → move skip)。
+      # #3412: 合成 seed lane では本番 snapshot を実行しない (staging に本番 PII を複製しない)。
       - name: Snapshot prod DB to staging DB (in prod app container)
+        if: env.SYNTHETIC_SEED != 'true'
         run: |
           $prodCid = (& docker compose -p ganbari-quest ps -q app | Select-Object -First 1)
           if (-not $prodCid) {
@@ -212,7 +226,7 @@ jobs:
       # 旧 DB 不在 (fixture fallback) の場合は cutover を skip し fresh PGlite で起動する
       # (health/probePg は migration 適用済み schema を検証する)。
       - name: PGlite cutover rehearsal (pglite lane)
-        if: env.PGLITE_LANE == 'true'
+        if: env.PGLITE_LANE == 'true' && env.SYNTHETIC_SEED != 'true'
         run: |
           if (Test-Path ".\data\pglite") {
             Remove-Item -Recurse -Force ".\data\pglite"
@@ -228,6 +242,26 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "cutover import failed (exit $LASTEXITCODE; count-mismatch or errors>0 abort, legacy DB untouched)" }
           Remove-Item -Force ".\data\.cutover-export.json" -ErrorAction SilentlyContinue
           Write-Host "::notice::cutover rehearsal passed (export -> import -> count verification). Booting with PGlite backend"
+
+      # Step 5.6 (#3412、synthetic seed lane のみ): PII-free 合成ダミー seed。
+      # scripts/seed-staging.ts (generate=決定的 dataset 生成 / apply=fresh PGlite 構築 +
+      # importFamilyData verbatim + 件数突合) を image 同梱 CLI で実行する。generate と apply は
+      # factory singleton 制約 (nuc-pglite-cutover.ts と同じ) のため別プロセス (別 docker run)。
+      # anchor に当日を渡し、demo 由来の活動履歴が「直近 14 日」として描画されるようにする。
+      - name: Synthetic seed (PII-free, synthetic lane)
+        if: env.SYNTHETIC_SEED == 'true'
+        run: |
+          if (Test-Path ".\data\pglite") {
+            Remove-Item -Recurse -Force ".\data\pglite"
+            Write-Host "removed previous staging pglite dataDir (fresh synthetic seed)"
+          }
+          $anchor = (Get-Date -Format "yyyy-MM-dd")
+          docker compose -p ganbari-quest-staging run --rm --no-deps app npx tsx scripts/seed-staging.ts generate --out /app/data/.synthetic-seed.json --anchor $anchor
+          if ($LASTEXITCODE -ne 0) { throw "synthetic seed generate failed (exit $LASTEXITCODE)" }
+          docker compose -p ganbari-quest-staging run --rm --no-deps app npx tsx scripts/seed-staging.ts apply --in /app/data/.synthetic-seed.json --data-dir /app/data/pglite
+          if ($LASTEXITCODE -ne 0) { throw "synthetic seed apply failed (exit $LASTEXITCODE; count-mismatch or errors>0 abort)" }
+          Remove-Item -Force ".\data\.synthetic-seed.json" -ErrorAction SilentlyContinue
+          Write-Host "::notice::synthetic seed applied (no prod PII in staging, #3412). Booting with PGlite backend"
 
       - name: Start (staging)
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ COPY --from=build /app/drizzle.config.ts ./
 # docs/runbooks/nuc-pglite-cutover.md。
 COPY --from=build /app/src ./src
 COPY --from=build /app/scripts/nuc-pglite-cutover.ts ./scripts/nuc-pglite-cutover.ts
+# #3412: staging 用 PII-free 合成 seed CLI (deploy-nuc-staging.yml synthetic lane が
+# `docker compose run --rm app npx tsx scripts/seed-staging.ts <generate|apply>` で実行)。
+COPY --from=build /app/scripts/seed-staging.ts ./scripts/seed-staging.ts
 # CLI が import する scripts/lib/runtime/ (nuc-cutover-verify 等) を dir ごと同梱する — 単体ファイル
 # COPY だと lib module 追加のたびに漏れる (staging PGlite cycle 2 で ERR_MODULE_NOT_FOUND 実機露呈、#3620)。
 # CI/dev 専用 helper は scripts/lib/ci/ に分離し image に入れない (#3659、image 純度 / attack surface)。

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -21,6 +21,7 @@
 | LP sitemap.xml (#1908) | 自動生成: `scripts/generate-sitemap.mjs` (pages.yml main push 毎再生成、手動編集禁止) |
 | 6 type データモデル scope (ADR-0055) | `data-model-resource-scope.md` (per-child / family master 選択 SSOT、PR-3〜7 で参照) |
 | Marketplace 取込フロー (ADR-0055 §3.2) | `marketplace-import-flow.md` (child binding sequence + CWE-598 privacy SSOT) |
+| staging 合成 seed (#3412) | `staging-synthetic-seed.md` (PII-free 合成ダミーデータセット + seed CLI + staging 配線 SSOT) |
 
 **禁忌**: 会話で確定した仕様を反映せずに実装進行 / 「設計書は後で」と先送り / 設計書更新を別 Issue 切出しで本体 Done。アーキ図は drawio (`docs/design/diagrams/`)、ASCII 図禁止。
 

--- a/docs/design/staging-synthetic-seed.md
+++ b/docs/design/staging-synthetic-seed.md
@@ -1,0 +1,59 @@
+# staging 合成ダミーデータ seed 設計書 (#3412)
+
+**関連**: #2999 (本番 PII を staging で使わない) / #2872 (NUC staging) / #2873 (AWS staging) / ADR-0064 (PGlite) / ADR-0066 (export/import 値域 SSOT)
+**研究 SSOT**: [docs/research/2026-06-28-dummy-dataset-requirements.md](../research/2026-06-28-dummy-dataset-requirements.md) (網羅次元 D1-D21 / 既存資産評価 / 選択肢比較)
+
+---
+
+## §1 設計背景
+
+staging (NUC #2872) は本番 DB snapshot (`scripts/snapshot-prod-db.cjs`) から起動しており、実在の子供のニックネーム・生年月日・活動履歴 (= PII、CWE-359/200) が staging 環境に複製される。本設計がなかった場合:
+
+- 本番 PII が検証環境に恒常的に流出し続ける (privacy / 法務リスクの構造化)
+- AWS staging (#2873、cognito + DSQL) には本番 snapshot を流す経路自体がなく、「機能を一通り検証できる代表データ」が存在しない
+- 検証データが本番の偶然の状態に依存し、決定的な visual regression / E2E の基盤にならない
+
+PO 方針: 本番 PII の匿名化 mask ではなく、**最初から合成 (synthetic) データセット**で代替する。
+
+## §2 設計原則
+
+1. **既存資産の最大再利用** (research §5 決定 = 選択肢 A+B、#1442 使い捨て script 禁止):
+   demo-data.ts (PII-free がんばり家) を Tenant A の基盤に再利用し、プラン / トライアル軸の薄い tenant を専用 fixture で足す。流し込みは backup wire format (`ExportData`) + `importFamilyData` + `nuc-cutover-verify` 件数突合を再利用し、専用 insert 経路を新設しない (ADR-0066 wire SSOT 整合)。
+2. **決定性** (AC3): 乱数 / wall-clock 非使用 (faker 不採用、research §5 選択肢 C)。全日付は `anchorDate` の純関数で、同一 anchor に対し出力 byte 同一。
+3. **PII-free の機械保証** (AC1): 実在名 denylist はそれ自体が PII になるため置かず、「出現してよい合成名の完全列挙 (allowlist)」+ email / 電話番号 pattern の全走査 0 件を unit test で fail-closed 検証する。
+4. **非破壊 / fail-closed**: 空 dataDir にのみ seed し、import error / 件数突合不一致は部分構築を削除して abort する (`nuc-pglite-cutover.ts` と同型)。
+
+## §3 データセット仕様
+
+SSOT: `src/lib/server/demo/synthetic-staging-dataset.ts` (`buildSyntheticStagingDataset`)。5 tenant で research §2 の次元を網羅する:
+
+| tenant key | tenantUuid | plan / trial | 内容 | 担う次元 |
+|---|---|---|---|---|
+| `premium-family` | `LOCAL_TENANT_UUID` | family-monthly | がんばり家 5 人 (demo-data.ts 変換)。per-child 活動 + 14 日履歴 + marketplace 取込済 + checklist + スタンプ + 交換申請 3 status + 証明書 + メッセージ / きょうだい応援 | D1-D3 / D9-D17 / D20 |
+| `free` | `...00b1` | free (plan null) | 子供 1 人 + 最小データ。marketplace 未取込 = empty admin | D4 / D18 |
+| `trial-active` | `...00c1` | trial standard (anchor-2..+5 日) | 子供 1 人。トライアルバナー表示 | D6 |
+| `trial-expired` | `...00c2` | trial family (anchor-30..-23 日) | 子供 1 人 + archive 済 activity / checklist | D6 / D19 |
+| `empty` | `...00d1` | free | 子供 0 人 (行を一切 seed しない) | D18 |
+
+- **anchor shift**: `--anchor` (YYYY-MM-DD / today) で全日付 (birthDate 含む) が一律 shift される。birthDate も shift するため compute-on-read の age-tier 網羅 (5 mode) が anchor に依らず保たれる。trial は相対 offset (`startOffsetDays` / `endOffsetDays`) で保持し apply 時に絶対日付へ解決する。
+- **ロール軸 (D8、owner/parent/child/ops/federated)**: auth 層 (Cognito user) の関心で DB seed では表現しない。cognito staging のアカウント整備は `DEV_USERS` 同型で #2873 lane が担う。
+- **wire format 外の実体** (dailyBattles / enemyCollection 等、export-format 非対象): seed 対象外。バトル戦績は demo Lambda (DATA_SOURCE=demo) のみが持つ。
+
+## §4 seed 実行フロー
+
+```
+scripts/seed-staging.ts generate --out <json> [--anchor today]   # DB 不要・決定的
+scripts/seed-staging.ts apply --in <json> --data-dir <pglite>    # fresh PGlite 構築 + 件数突合
+```
+
+- generate / apply は別プロセス (factory singleton 制約、`nuc-pglite-cutover.ts` と同じ)。
+- apply core は `scripts/lib/runtime/seed-staging-apply.ts` (`applySyntheticDataset`)。drizzle pg db を注入できるため PGlite / DSQL (AWS staging) の両 pg-core backend で共通。tenant ごとに ①families 行 (plan 軸) ②trial_history 行 ③`importFamilyData` verbatim ④`nuc-cutover-verify` 件数突合 を実行する。
+- 機械検証: `tests/unit/demo/synthetic-staging-dataset.test.ts` (PII-free / 決定性 / 次元網羅) + `tests/unit/services/synthetic-staging-seed-pglite.test.ts` (実 PGlite への貫通 + 件数突合)。
+
+## §5 staging 配線
+
+| 環境 | 配線 | 状態 |
+|---|---|---|
+| NUC staging (#2872) | `deploy-nuc-staging.yml` の `workflow_dispatch` input `syntheticSeed` (opt-in、`pgliteEnabled=true` 前提)。true で本番 snapshot (Step 4) + cutover rehearsal (Step 5.5) を skip し、image 同梱 CLI で `generate --anchor <当日>` → `apply --data-dir /app/data/pglite` を実行して起動する | 配線済 (実機発火は統合 PR / dispatch lane で確認) |
+| NUC staging 統合 PR (pull_request) | 従来どおり snapshot + cutover rehearsal (既存検証フロー不変)。**合成 seed への完全切替 (snapshot 経路の置換) は staging 実機で合成 seed lane の緑を確認後に判断**し、切替時に `snapshot-prod-db.cjs` の staging 用途を撤去する | 未切替 (#2999 完遂条件) |
+| AWS staging (#2873) | apply core は DSQL でも動く構造 (drizzle db 注入 + factory 経由 repos)。DSQL staging cluster への seed 配線 (creds / dsql:migrate 後の実行 step) は #2873 lane で行う | 構造準備済 / 配線は #2873 |

--- a/scripts/lib/runtime/seed-staging-apply.ts
+++ b/scripts/lib/runtime/seed-staging-apply.ts
@@ -1,0 +1,127 @@
+// scripts/lib/runtime/seed-staging-apply.ts — 合成 staging dataset の pg-core backend 流し込み (#3412)
+//
+// buildSyntheticStagingDataset (src/lib/server/demo/synthetic-staging-dataset.ts) の出力を
+// PGlite / DSQL (pg-core 新 schema) へ seed する共通 core。呼び出し側 (CLI / vitest) が
+// DATA_SOURCE と接続 (initPgliteConnection 等) を確立してから呼ぶ。
+//
+// 既存資産の再利用 (#1442 / ADR-0066):
+//   - 家族データの流し込みは importFamilyData (backup wire format) を verbatim mode で再利用
+//     (nuc-pglite-cutover.ts import と同型。専用 insert 経路は作らない)
+//   - 件数突合は nuc-cutover-verify (summarizeExportCounts / collectImportedCounts) を再利用
+//   - trial 行は factory の trialHistory repo (ITrialHistoryRepo.insert) を再利用
+//
+// tenant メタ (families 行) のみ本 module が drizzle 直 insert する (auth repo の createTenant は
+// owner user 前提のため合成 seed には過剰。ownerUserId は nullable で families 単独 insert 可能)。
+
+import type { SqlExecutor } from '../../../src/lib/server/db/dsql/sql-executor';
+import type {
+	SyntheticStagingDataset,
+	SyntheticTenant,
+} from '../../../src/lib/server/demo/synthetic-staging-dataset';
+import {
+	collectImportedCounts,
+	diffCutoverCounts,
+	summarizeExportCounts,
+} from './nuc-cutover-verify';
+
+export interface SeedTenantResult {
+	key: string;
+	tenantUuid: string;
+	children: number;
+	importedCounts: Record<string, number> | null;
+	trial: { startDate: string; endDate: string; tier: string } | null;
+}
+
+export interface SeedApplyResult {
+	anchorDate: string;
+	tenants: SeedTenantResult[];
+}
+
+/**
+ * 合成 dataset を pg-core backend へ seed する。
+ * 前提: 呼び出し側で DATA_SOURCE (pglite/dsql) と接続が確立済み。fresh DB (空 tenant) を想定し
+ * verbatim import する (既存データがある DB への merge は本 seed の対象外)。
+ * import error / 件数突合不一致は throw する (部分成功の silent 継続はしない)。
+ *
+ * db は drizzle pg db (PGlite / DSQL 共通 schema)。公開型は件数突合が要求する SqlExecutor に
+ * 留め、families insert のみ内部で構造的 cast する (drizzle の insert builder generics を
+ * 公開 contract に持ち込むと backend 別 db 型 (PgliteDatabase 等) が variance で不適合になるため)。
+ */
+export async function applySyntheticDataset(
+	dataset: SyntheticStagingDataset,
+	db: SqlExecutor,
+): Promise<SeedApplyResult> {
+	const insertDb = db as unknown as {
+		insert(table: unknown): { values(v: Record<string, unknown>): PromiseLike<unknown> };
+	};
+	const { families } = await import('../../../src/lib/server/db/dsql/schema');
+	const { getRepos } = await import('../../../src/lib/server/db/factory');
+	const { importFamilyData } = await import('../../../src/lib/server/services/import-service');
+	const { resolveTrialWindow } = await import(
+		'../../../src/lib/server/demo/synthetic-staging-dataset'
+	);
+	const repos = getRepos();
+
+	const results: SeedTenantResult[] = [];
+	for (const tenant of dataset.tenants) {
+		const trialWindow = tenant.trial ? resolveTrialWindow(tenant.trial, dataset.anchorDate) : null;
+
+		// 1. tenant メタ (families 行)。plan / trialUsedAt が plan 軸 (D4) / trial 軸 (D6) の実データ
+		await insertDb.insert(families).values({
+			familyId: tenant.tenantUuid,
+			name: tenant.family.name,
+			ownerUserId: null,
+			status: tenant.family.status,
+			plan: tenant.family.plan,
+			trialUsedAt: trialWindow ? `${trialWindow.startDate}T00:00:00.000Z` : null,
+		});
+
+		// 2. trial 履歴 (D6: active / expired は start/end offset の解決値で表現)
+		if (tenant.trial && trialWindow) {
+			await repos.trialHistory.insert({
+				tenantId: tenant.tenantUuid,
+				startDate: trialWindow.startDate,
+				endDate: trialWindow.endDate,
+				tier: tenant.trial.tier,
+				source: 'synthetic-seed',
+				trialStartSource: 'synthetic-seed',
+			});
+		}
+
+		// 3. 家族データ (wire format → importFamilyData verbatim、cutover import と同型)
+		let importedCounts: Record<string, number> | null = null;
+		if (tenant.data && tenant.data.family.children.length > 0) {
+			const result = await importFamilyData(tenant.data, tenant.tenantUuid, undefined, {
+				mode: 'verbatim',
+			});
+			if (result.errors.length > 0) {
+				throw new Error(
+					`[seed-staging] tenant ${tenant.key} の import で hard error (${result.errors.length} 件): ${result.errors.join(' / ')}`,
+				);
+			}
+			// 4. 件数突合 (nuc-cutover-verify 再利用、1 件でも不一致なら abort)
+			const expected = summarizeExportCounts(tenant.data);
+			const actual = await collectImportedCounts(db, tenant.tenantUuid);
+			const mismatches = diffCutoverCounts(expected, actual);
+			if (mismatches.length > 0) {
+				throw new Error(
+					`[seed-staging] tenant ${tenant.key} の件数突合が不一致 (${mismatches.length} 軸): ${mismatches.join(' / ')}`,
+				);
+			}
+			importedCounts = actual;
+		}
+
+		results.push({
+			key: tenant.key,
+			tenantUuid: tenant.tenantUuid,
+			children: tenant.data?.family.children.length ?? 0,
+			importedCounts,
+			trial: trialWindow && tenant.trial ? { ...trialWindow, tier: tenant.trial.tier } : null,
+		});
+	}
+
+	return { anchorDate: dataset.anchorDate, tenants: results };
+}
+
+/** SyntheticTenant の再 export (CLI 側の型参照用)。 */
+export type { SyntheticTenant };

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -74,7 +74,12 @@ async function runApply(opts: Record<string, string>): Promise<void> {
 	}
 
 	const dataset = JSON.parse(readFileSync(inPath, 'utf-8'));
-	if (dataset?.format !== 'ganbari-quest-synthetic-staging-seed') {
+	// format 識別子は dataset module の SSOT 定数を参照する (リテラル二重化しない)。
+	// この import は fixture / pure module のみで DB 接続を伴わない (generate と同一 graph)。
+	const { SYNTHETIC_DATASET_FORMAT } = await import(
+		'../src/lib/server/demo/synthetic-staging-dataset'
+	);
+	if (dataset?.format !== SYNTHETIC_DATASET_FORMAT) {
 		fail(`dataset の format が不正です: ${String(dataset?.format)}`);
 	}
 

--- a/scripts/seed-staging.ts
+++ b/scripts/seed-staging.ts
@@ -1,0 +1,117 @@
+// scripts/seed-staging.ts — staging 用 PII-free 合成ダミーデータ seed CLI (#3412 / #2999 根本解決)
+//
+// staging (NUC #2872 / AWS #2873) を本番 DB snapshot (PII) から切り離すための generic seed ツール
+// (研究 SSOT: docs/research/2026-06-28-dummy-dataset-requirements.md §5 選択肢 A+B)。2 subcommand:
+//
+//   generate: 合成 dataset (5 tenant、demo-data.ts 再利用) を JSON に書き出す。DB 不要・決定的。
+//       npx tsx scripts/seed-staging.ts generate --out tmp/synthetic-seed.json
+//       npx tsx scripts/seed-staging.ts generate --out tmp/synthetic-seed.json --anchor today
+//     --anchor (YYYY-MM-DD | today、既定 = demo fixture 固定日 2026-03-27): 全日付を一律 shift し
+//     「直近 14 日の履歴」として描画させる。同一 anchor なら出力 byte 同一 (AC3 決定性)。
+//
+//   apply: dataset JSON を **空の** PGLITE_DATA_DIR に seed する (fresh PGlite 構築 + migration 適用
+//          + importFamilyData verbatim + 件数突合)。nuc-pglite-cutover.ts import と同型の非破壊設計:
+//          既存 (非空) dataDir を拒否し、失敗時は dataDir を削除して exit 1。
+//       npx tsx scripts/seed-staging.ts apply --in tmp/synthetic-seed.json --data-dir data/pglite
+//
+// factory singleton 制約 (nuc-pglite-cutover.ts と同じ) を避けるため generate は DB 非接続で
+// 完結し、apply のみ DATA_SOURCE=pglite で接続する (別 subcommand = 別プロセスで安全)。
+//
+// 本番 snapshot 経路 (scripts/snapshot-prod-db.cjs) の置換は deploy-nuc-staging.yml の
+// syntheticSeed input (opt-in) が担う。snapshot 経路は不変 (既存検証フローを壊さない)。
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+interface Args {
+	cmd: string;
+	opts: Record<string, string>;
+}
+
+function parseArgs(): Args {
+	const [cmd = ''] = process.argv.slice(2);
+	const opts: Record<string, string> = {};
+	for (let i = 3; i < process.argv.length; i += 2) {
+		const k = process.argv[i];
+		const v = process.argv[i + 1];
+		if (k?.startsWith('--') && v !== undefined) opts[k.slice(2)] = v;
+	}
+	return { cmd, opts };
+}
+
+function fail(msg: string): never {
+	console.error(`[seed-staging] ERROR: ${msg}`);
+	process.exit(1);
+}
+
+async function runGenerate(opts: Record<string, string>): Promise<void> {
+	const outPath = opts.out ?? fail('--out <出力 JSON path> が必要です');
+	const anchorOpt = opts.anchor;
+	const anchorDate = anchorOpt === 'today' ? new Date().toISOString().slice(0, 10) : anchorOpt;
+
+	const { buildSyntheticStagingDataset, SYNTHETIC_SEED_ANCHOR } = await import(
+		'../src/lib/server/demo/synthetic-staging-dataset'
+	);
+	const dataset = await buildSyntheticStagingDataset(anchorDate ?? SYNTHETIC_SEED_ANCHOR);
+
+	mkdirSync(dirname(resolve(outPath)), { recursive: true });
+	writeFileSync(outPath, JSON.stringify(dataset));
+	console.log(`[seed-staging] generate 完了: ${outPath} (anchor=${dataset.anchorDate})`);
+	for (const t of dataset.tenants) {
+		console.log(
+			`[seed-staging]   - ${t.key}: children=${t.data?.family.children.length ?? 0} trial=${t.trial ? `${t.trial.tier} (${t.trial.startOffsetDays}..${t.trial.endOffsetDays}d)` : 'none'}`,
+		);
+	}
+}
+
+async function runApply(opts: Record<string, string>): Promise<void> {
+	const inPath = opts.in ?? fail('--in <dataset JSON path> が必要です');
+	const dataDir = opts['data-dir'] ?? fail('--data-dir <PGlite dataDir> が必要です');
+	if (!existsSync(inPath)) fail(`dataset JSON が見つかりません: ${inPath}`);
+	// 非破壊保証 (nuc-pglite-cutover.ts import と同型): 既存 (非空) dataDir への seed を拒否
+	if (existsSync(dataDir) && readdirSync(dataDir).length > 0) {
+		fail(`--data-dir が空ではありません: ${dataDir} (fresh dir を指定してください)`);
+	}
+
+	const dataset = JSON.parse(readFileSync(inPath, 'utf-8'));
+	if (dataset?.format !== 'ganbari-quest-synthetic-staging-seed') {
+		fail(`dataset の format が不正です: ${String(dataset?.format)}`);
+	}
+
+	process.env.DATA_SOURCE = 'pglite';
+	process.env.PGLITE_DATA_DIR = resolve(dataDir);
+
+	const pglite = await import('../src/lib/server/db/pglite/connection');
+	await pglite.initPgliteConnection();
+
+	try {
+		const { applySyntheticDataset } = await import('./lib/runtime/seed-staging-apply');
+		const result = await applySyntheticDataset(dataset, pglite.getPgliteDbSync());
+		// close して FS flush を確定 (swap 前の完全永続化、cutover と同型)
+		await pglite.resetPgliteConnectionForTesting();
+		console.log(`[seed-staging] apply 完了 (anchor=${result.anchorDate}):`);
+		for (const t of result.tenants) {
+			console.log(
+				`[seed-staging]   - ${t.key} (${t.tenantUuid}): children=${t.children} trial=${t.trial ? `${t.trial.tier} ${t.trial.startDate}..${t.trial.endDate}` : 'none'} counts=${t.importedCounts ? JSON.stringify(t.importedCounts) : 'n/a'}`,
+			);
+		}
+	} catch (err) {
+		await pglite.resetPgliteConnectionForTesting().catch(() => {});
+		rmSync(dataDir, { recursive: true, force: true });
+		console.error('[seed-staging] 部分構築した dataDir を削除しました (再実行可能)');
+		throw err;
+	}
+}
+
+const { cmd, opts } = parseArgs();
+const main = cmd === 'generate' ? runGenerate : cmd === 'apply' ? runApply : null;
+if (!main) {
+	console.error(
+		'Usage: npx tsx scripts/seed-staging.ts <generate|apply> [--out|--anchor|--in|--data-dir ...]',
+	);
+	process.exit(1);
+}
+main(opts).catch((err) => {
+	console.error('[seed-staging] 失敗:', err);
+	process.exit(1);
+});

--- a/src/lib/server/demo/synthetic-staging-dataset.ts
+++ b/src/lib/server/demo/synthetic-staging-dataset.ts
@@ -1,0 +1,861 @@
+// src/lib/server/demo/synthetic-staging-dataset.ts — staging 用 PII-free 合成ダミーデータセット (#3412)
+//
+// staging (NUC #2872 / AWS #2873) を本番 DB snapshot (実在の子供名・活動履歴 = PII、#2999) から
+// 切り離すための合成 seed の SSOT。要件次元 (docs/research/2026-06-28-dummy-dataset-requirements.md §2)
+// を「demo-data.ts の PII-free がんばり家 (Tenant A) + 薄い専用 tenant B〜D」の 5 tenant で網羅する
+// (research §5 決定 = 選択肢 A+B)。
+//
+// 設計原則:
+//   - **決定的** (AC3): 乱数・wall-clock 非使用。同一 anchorDate に対し常に byte 同一の出力。
+//     既定 anchor は demo fixture の固定日 (SYNTHETIC_SEED_ANCHOR)。staging deploy 時は
+//     `--anchor` に当日を渡すと全日付が一律 shift され「直近 14 日の履歴」として描画される
+//     (offset は日数の純関数なので anchor を固定すれば出力も固定 = visual regression と両立)。
+//   - **PII-free** (AC1): 人物名は SYNTHETIC_NICKNAME_ALLOWLIST の合成名のみ。機械 assert は
+//     tests/unit/demo/synthetic-staging-dataset.test.ts (全走査 + email/電話 pattern 0 件)。
+//   - **wire format 再利用** (#1442 / ADR-0066): 出力は export-service の ExportData (backup wire
+//     format)。流し込みは既存 importFamilyData + nuc-cutover-verify 件数突合を再利用し、
+//     専用 insert 経路を新設しない。
+//
+// 各 tenant の役割 (research §4):
+//   A  premium-family : がんばり家 5 人 (5 age mode × 5 theme × M/F、demo-data.ts 変換)。フル機能表示
+//   B  free           : 子供 1 人 + 最小データ。free gate / empty admin (D18)
+//   C1 trial-active   : standard トライアル中 (バナー表示)
+//   C2 trial-expired  : トライアル期限切れ + archive 済データ (D19)
+//   D  empty          : 子供 0 人 (genuine-empty 全画面 + 初回オンボーディング)
+//
+// ロール軸 (owner/parent/child/ops/federated、research D8) は auth 層 (Cognito user) の関心で
+// DB seed では表現しない。cognito staging のアカウント整備は DEV_USERS 同型で #2873 lane が担う。
+
+import { CATEGORY_CODE_TO_ID, toCategoryCode } from '$lib/domain/categories';
+import {
+	EXPORT_FORMAT,
+	EXPORT_VERSION,
+	type ExportActivityLog,
+	type ExportChild,
+	type ExportChildActivity,
+	type ExportDailyMission,
+	type ExportData,
+	type ExportSpecialReward,
+	type ExportTransactionData,
+} from '$lib/domain/export-format';
+import { asChildId, type ChildId } from '$lib/domain/ids';
+import { LOCAL_TENANT_UUID } from '$lib/server/auth/local-tenant';
+import type { ChildActivity } from '$lib/server/db/types/index.js';
+import { finalizeExport } from '$lib/server/services/export-service';
+import {
+	DEMO_ACTIVITIES,
+	DEMO_ACTIVITY_LOGS,
+	DEMO_CERTIFICATES,
+	DEMO_CHECKLIST_ITEMS,
+	DEMO_CHECKLIST_TEMPLATES,
+	DEMO_CHILD_ACTIVITIES,
+	DEMO_CHILD_CHALLENGES,
+	DEMO_CHILDREN,
+	DEMO_DAILY_MISSIONS,
+	DEMO_EVALUATIONS,
+	DEMO_LOGIN_BONUSES,
+	DEMO_MARKETPLACE_SPECIAL_REWARDS,
+	DEMO_POINT_BALANCES,
+	DEMO_SIBLING_CHEERS,
+	DEMO_STAMP_CARDS,
+	DEMO_STAMP_ENTRIES,
+	DEMO_STATUSES,
+	getDemoMarketplaceActivitiesByChild,
+	getDemoMarketplaceChecklistItemsByTemplate,
+	getDemoMarketplaceChecklistTemplatesByChild,
+} from './demo-data';
+
+// ============================================================
+// Anchor (決定性の基準日)
+// ============================================================
+
+/** demo fixture の固定「今日」(demo-data.ts TODAY と同値)。既定 anchor = shift 0。 */
+export const SYNTHETIC_SEED_ANCHOR = '2026-03-27';
+
+/** anchor 間の日数差 (b - a、UTC 日割り)。 */
+export function daysBetween(a: string, b: string): number {
+	const ms = Date.parse(`${b}T00:00:00.000Z`) - Date.parse(`${a}T00:00:00.000Z`);
+	return Math.round(ms / 86_400_000);
+}
+
+function shiftDateOnly(date: string, offsetDays: number): string {
+	if (offsetDays === 0) return date;
+	const d = new Date(`${date}T00:00:00.000Z`);
+	d.setUTCDate(d.getUTCDate() + offsetDays);
+	return d.toISOString().slice(0, 10);
+}
+
+function shiftIso(iso: string, offsetDays: number): string {
+	if (offsetDays === 0) return iso;
+	const d = new Date(iso);
+	d.setUTCDate(d.getUTCDate() + offsetDays);
+	return d.toISOString();
+}
+
+// ============================================================
+// PII-free 保証 (機械 assert の SSOT)
+// ============================================================
+
+/**
+ * データセットに出現してよい人物ニックネームの完全列挙 (合成名のみ)。
+ * ここに無い nickname が 1 件でも出たら PII 混入疑いとして unit test が fail する。
+ * 実在家族名の再混入事故 (demo-data.ts 2026-05-16 リネーム経緯) の構造的再発防止。
+ */
+export const SYNTHETIC_NICKNAME_ALLOWLIST: readonly string[] = [
+	// Tenant A = demo-data.ts がんばり家 (PII-free 済)
+	'たろうくん',
+	'ひなちゃん',
+	'けんたくん',
+	'さくらちゃん',
+	'けいすけくん',
+	// Tenant B〜C2 (本 module 定義の合成 persona)
+	'まなぶくん',
+	'ももちゃん',
+	'そらくん',
+] as const;
+
+// ============================================================
+// Dataset envelope 型
+// ============================================================
+
+export const SYNTHETIC_DATASET_FORMAT = 'ganbari-quest-synthetic-staging-seed' as const;
+
+export interface SyntheticTrialSpec {
+	tier: 'standard' | 'family';
+	/** anchor からの相対日数 (負 = 過去)。決定性のため絶対日付を持たない。 */
+	startOffsetDays: number;
+	endOffsetDays: number;
+}
+
+export interface SyntheticFamilySpec {
+	name: string;
+	/** families.status (subscription-status.ts SSOT) */
+	status: 'active' | 'grace_period' | 'suspended' | 'terminated';
+	/** families.plan (subscription-plan.ts SSOT)。null = free (未課金) */
+	plan: string | null;
+}
+
+export interface SyntheticTenant {
+	key: 'premium-family' | 'free' | 'trial-active' | 'trial-expired' | 'empty';
+	tenantUuid: string;
+	description: string;
+	family: SyntheticFamilySpec;
+	trial: SyntheticTrialSpec | null;
+	/** backup wire format の家族データ。null = 空 tenant (行を一切 seed しない) */
+	data: ExportData | null;
+}
+
+export interface SyntheticStagingDataset {
+	format: typeof SYNTHETIC_DATASET_FORMAT;
+	version: 1;
+	anchorDate: string;
+	tenants: SyntheticTenant[];
+}
+
+/** trial 相対 offset を anchor 基準の絶対日付 (start/end) に解決する (apply 時に使用)。 */
+export function resolveTrialWindow(
+	trial: SyntheticTrialSpec,
+	anchorDate: string,
+): { startDate: string; endDate: string } {
+	return {
+		startDate: shiftDateOnly(anchorDate, trial.startOffsetDays),
+		endDate: shiftDateOnly(anchorDate, trial.endOffsetDays),
+	};
+}
+
+// ============================================================
+// Tenant A — がんばり家 (demo-data.ts → wire format 変換)
+// ============================================================
+
+function categoryCodeOf(categoryId: unknown): string {
+	return toCategoryCode(categoryId as Parameters<typeof toCategoryCode>[0]) ?? 'seikatsu';
+}
+
+/** demo 内部 sourcePresetId (`demo:<masterId>`) は marketplace 由来ではないため null に落とす。 */
+function normalizePresetId(sourcePresetId: string | null | undefined): string | null {
+	if (!sourcePresetId) return null;
+	return sourcePresetId.startsWith('demo:') ? null : sourcePresetId;
+}
+
+function emptyTransactionData(): ExportTransactionData {
+	return {
+		childActivities: [],
+		activityLogs: [],
+		pointLedger: [],
+		statuses: [],
+		statusHistory: [],
+		childAchievements: [],
+		childTitles: [],
+		loginBonuses: [],
+		evaluations: [],
+		specialRewards: [],
+		rewardRedemptions: [],
+		childChallenges: [],
+		stampCards: [],
+		certificates: [],
+		parentMessages: [],
+		siblingCheers: [],
+		activityPrefs: [],
+		checklistTemplates: [],
+		checklistLogs: [],
+		checklistOverrides: [],
+		restDays: [],
+		childVoices: [],
+		childAvatarItems: [],
+		dailyMissions: [],
+		settings: [],
+	};
+}
+
+type ExportBody = Omit<ExportData, 'checksum'>;
+
+function baseBody(
+	anchorDate: string,
+	children: ExportChild[],
+	data: ExportTransactionData,
+): ExportBody {
+	return {
+		format: EXPORT_FORMAT,
+		version: EXPORT_VERSION,
+		// 決定性: wall-clock を使わず anchor 由来の固定時刻にする
+		exportedAt: `${anchorDate}T09:00:00.000Z`,
+		master: { categories: [], activities: [], titles: [], achievements: [], avatarItems: [] },
+		family: { children },
+		data,
+	};
+}
+
+function toExportChildActivity(a: ChildActivity, childRef: string): ExportChildActivity {
+	return {
+		childRef,
+		name: a.name,
+		categoryCode: categoryCodeOf(a.categoryId),
+		icon: a.icon,
+		basePoints: a.basePoints,
+		triggerHint: a.triggerHint,
+		isMainQuest: a.isMainQuest,
+		priority: a.priority,
+		sourcePresetId: normalizePresetId(a.sourcePresetId),
+		isVisible: a.isVisible,
+		sortOrder: a.sortOrder,
+		isArchived: a.isArchived,
+		archivedReason: a.archivedReason,
+		dailyLimit: a.dailyLimit,
+		nameKana: a.nameKana,
+		nameKanji: a.nameKanji,
+	};
+}
+
+function buildTenantABody(anchorDate: string): ExportBody {
+	const offset = daysBetween(SYNTHETIC_SEED_ANCHOR, anchorDate);
+	const d = (v: string): string => shiftDateOnly(v, offset);
+	const ts = (v: string): string => shiftIso(v, offset);
+	const tsOrNull = (v: string | null): string | null => (v === null ? null : ts(v));
+
+	// children (5 age mode × 5 theme × M/F、D1-D3)。birthDate も同一 offset で shift し、
+	// compute-on-read (age = birth_date 起点) の age-tier 網羅が anchor に依らず保たれるようにする。
+	const childRefById = new Map<ChildId, string>();
+	const children: ExportChild[] = DEMO_CHILDREN.map((c, i) => {
+		const ref = `child-${i + 1}`;
+		childRefById.set(c.id, ref);
+		return {
+			exportId: ref,
+			nickname: c.nickname,
+			age: c.age,
+			birthDate: c.birthDate === null ? null : d(c.birthDate),
+			theme: c.theme,
+			uiMode: c.uiMode,
+			avatarUrl: c.avatarUrl,
+			activeTitle: null,
+			createdAt: ts(c.createdAt),
+			sourceChildId: c.id,
+		};
+	});
+	const refOf = (childId: ChildId): string | undefined => childRefById.get(childId);
+
+	// per-child 活動 (D10 per-child instance): 手作り fixture + marketplace 取込済 pack (D11)
+	const childActivities: ExportChildActivity[] = [];
+	const activityNamesByChild = new Map<string, Set<string>>();
+	const pushChildActivity = (entry: ExportChildActivity): void => {
+		const names = activityNamesByChild.get(entry.childRef) ?? new Set<string>();
+		if (names.has(entry.name)) return; // per-child 同名重複は import が dedup する前に除く (決定的)
+		names.add(entry.name);
+		activityNamesByChild.set(entry.childRef, names);
+		childActivities.push(entry);
+	};
+	for (const a of DEMO_CHILD_ACTIVITIES) {
+		const ref = refOf(a.childId);
+		if (!ref) continue;
+		pushChildActivity(toExportChildActivity(a, ref));
+	}
+	for (const c of DEMO_CHILDREN) {
+		const ref = refOf(c.id);
+		if (!ref) continue;
+		for (const a of getDemoMarketplaceActivitiesByChild(c.id)) {
+			pushChildActivity(
+				toExportChildActivity(
+					{ ...a, childId: c.id, dailyLimit: a.dailyLimit ?? null } as unknown as ChildActivity,
+					ref,
+				),
+			);
+		}
+	}
+
+	// activityId → 活動名の解決 (log / dailyMission 用)。
+	//   1. 同 child の per-child fixture の sourcePresetId `demo:<masterId>` に一致
+	//   2. master fixture (DEMO_ACTIVITIES) の同 id の name が同 child の活動名に存在
+	// 解決できない行は決定的に drop する (件数突合は本 dataset 自身を期待値にするため整合)。
+	const resolveActivityName = (childId: ChildId, activityId: unknown): string | null => {
+		const ref = refOf(childId);
+		if (!ref) return null;
+		const names = activityNamesByChild.get(ref);
+		if (!names) return null;
+		const fromPerChild = DEMO_CHILD_ACTIVITIES.find(
+			(a) => a.childId === childId && a.sourcePresetId === `demo:${activityId}`,
+		);
+		if (fromPerChild && names.has(fromPerChild.name)) return fromPerChild.name;
+		const master = DEMO_ACTIVITIES.find((a) => a.id === activityId);
+		if (master && names.has(master.name)) return master.name;
+		return null;
+	};
+
+	const activityLogs: ExportActivityLog[] = [];
+	for (const log of DEMO_ACTIVITY_LOGS) {
+		const ref = refOf(log.childId);
+		const name = resolveActivityName(log.childId, log.activityId);
+		if (!ref || !name) continue;
+		const activity = childActivities.find((a) => a.childRef === ref && a.name === name) ?? null;
+		activityLogs.push({
+			childRef: ref,
+			activityName: name,
+			activityCategory: activity?.categoryCode ?? 'seikatsu',
+			points: log.points,
+			streakDays: log.streakDays,
+			streakBonus: log.streakBonus,
+			recordedDate: d(log.recordedDate),
+			recordedAt: ts(log.recordedAt),
+			cancelled: log.cancelled !== 0,
+		});
+	}
+
+	const dailyMissions: ExportDailyMission[] = [];
+	for (const m of DEMO_DAILY_MISSIONS) {
+		const ref = refOf(m.childId);
+		const name = resolveActivityName(m.childId, m.activityId);
+		if (!ref || !name) continue;
+		dailyMissions.push({
+			childRef: ref,
+			missionDate: d(m.missionDate),
+			activityName: name,
+			completed: m.completed !== 0,
+			completedAt: tsOrNull(m.completedAt),
+		});
+	}
+
+	// ごほうび (D14): marketplace reward-set 由来 (sourcePresetId 付き = D11) + 交換申請 3 status
+	const specialRewards: ExportSpecialReward[] = DEMO_MARKETPLACE_SPECIAL_REWARDS.flatMap((r) => {
+		const ref = refOf(r.childId);
+		if (!ref) return [];
+		return [
+			{
+				childRef: ref,
+				title: r.title,
+				description: r.description,
+				points: r.points,
+				icon: r.icon,
+				category: r.category,
+				grantedAt: ts(r.grantedAt),
+				sourcePresetId: normalizePresetId(r.sourcePresetId),
+				exportId: `reward-${ref}-${r.id}`,
+			},
+		];
+	});
+	const rewardsOf903 = specialRewards.filter((r) => r.childRef === refOf(asChildId(903)));
+	// requestedAt 系は epoch **秒** (reward-redemption-repo の epochToIso 契約)
+	const redemptionAnchorSec = Math.floor(Date.parse(`${anchorDate}T09:00:00.000Z`) / 1000);
+	const rewardRedemptions = rewardsOf903.slice(0, 3).map((r, i) => ({
+		childRef: r.childRef,
+		rewardRef: r.title,
+		rewardExportId: r.exportId ?? null,
+		requestedAt: redemptionAnchorSec - (i + 1) * 86_400,
+		status: (['pending_parent_approval', 'approved', 'rejected'] as const)[i] as string,
+		parentNote: i === 2 ? 'ポイントがたりないので今回は見送り' : null,
+		resolvedAt: i === 0 ? null : redemptionAnchorSec - i * 43_200,
+		resolvedByParentId: null,
+		shownToChildAt: i === 1 ? redemptionAnchorSec - 21_600 : null,
+		rewardTitle: r.title,
+		rewardPoints: r.points,
+		rewardIcon: r.icon,
+	}));
+
+	// checklist (D10 family master + assignment): 手作り + marketplace 由来
+	const checklistTemplates = [
+		...DEMO_CHECKLIST_TEMPLATES.map((t) => ({ template: t, items: DEMO_CHECKLIST_ITEMS })),
+		...DEMO_CHILDREN.flatMap((c) =>
+			getDemoMarketplaceChecklistTemplatesByChild(c.id).map((t) => ({
+				template: t,
+				items: getDemoMarketplaceChecklistItemsByTemplate(t.id),
+			})),
+		),
+	].flatMap(({ template, items }) => {
+		const ref = refOf(template.childId);
+		if (!ref) return [];
+		return [
+			{
+				childRef: ref,
+				name: template.name,
+				icon: template.icon,
+				pointsPerItem: template.pointsPerItem,
+				completionBonus: template.completionBonus,
+				isActive: template.isActive !== 0,
+				isArchived: template.isArchived !== 0,
+				sourcePresetId: normalizePresetId(template.sourcePresetId),
+				exportId: `checklist-${ref}-${template.id}`,
+				items: items
+					.filter((it) => it.templateId === template.id)
+					.map((it) => ({
+						name: it.name,
+						icon: it.icon,
+						frequency: it.frequency,
+						direction: it.direction,
+						sortOrder: it.sortOrder,
+					})),
+			},
+		];
+	});
+
+	// スタンプカード (D15): card + entries を nested 化
+	const stampCards = DEMO_STAMP_CARDS.flatMap((card) => {
+		const ref = refOf(card.childId);
+		if (!ref) return [];
+		return [
+			{
+				childRef: ref,
+				weekStart: d(card.weekStart),
+				weekEnd: d(card.weekEnd),
+				status: card.status,
+				redeemedPoints: card.redeemedPoints,
+				redeemedAt: tsOrNull(card.redeemedAt),
+				createdAt: ts(card.createdAt),
+				updatedAt: ts(card.updatedAt),
+				entries: DEMO_STAMP_ENTRIES.filter((e) => e.cardId === card.id).map((e) => ({
+					stampMasterId: e.stampMasterId,
+					omikujiRank: e.omikujiRank,
+					slot: e.slot,
+					loginDate: d(e.loginDate),
+					earnedAt: ts(e.earnedAt),
+				})),
+			},
+		];
+	});
+
+	const body = baseBody(anchorDate, children, {
+		...emptyTransactionData(),
+		childActivities,
+		activityLogs,
+		// point 残高 (demo と同値): 残高 = ledger 合算になるよう 1 行の付与 entry に集約
+		pointLedger: DEMO_CHILDREN.flatMap((c) => {
+			const ref = refOf(c.id);
+			const balance = DEMO_POINT_BALANCES[String(c.id)] ?? 0;
+			if (!ref || balance <= 0) return [];
+			return [
+				{
+					childRef: ref,
+					amount: balance,
+					type: 'activity',
+					description: '合成 seed 初期残高',
+					createdAt: `${anchorDate}T00:00:00.000Z`,
+				},
+			];
+		}),
+		statuses: DEMO_STATUSES.flatMap((s) => {
+			const ref = refOf(s.childId);
+			if (!ref) return [];
+			return [
+				{
+					childRef: ref,
+					categoryCode: categoryCodeOf(s.categoryId),
+					totalXp: s.totalXp,
+					level: s.level,
+					peakXp: s.peakXp,
+					updatedAt: ts(s.updatedAt),
+				},
+			];
+		}),
+		loginBonuses: DEMO_LOGIN_BONUSES.flatMap((b) => {
+			const ref = refOf(b.childId);
+			if (!ref) return [];
+			return [
+				{
+					childRef: ref,
+					loginDate: d(b.loginDate),
+					rank: b.rank,
+					basePoints: b.basePoints,
+					multiplier: b.multiplier,
+					totalPoints: b.totalPoints,
+					consecutiveDays: b.consecutiveDays,
+					createdAt: ts(b.createdAt),
+				},
+			];
+		}),
+		evaluations: DEMO_EVALUATIONS.flatMap((e) => {
+			const ref = refOf(e.childId);
+			if (!ref) return [];
+			return [
+				{
+					childRef: ref,
+					weekStart: d(e.weekStart),
+					weekEnd: d(e.weekEnd),
+					scoresJson: e.scoresJson,
+					bonusPoints: e.bonusPoints,
+					createdAt: ts(e.createdAt),
+				},
+			];
+		}),
+		specialRewards,
+		rewardRedemptions,
+		childChallenges: DEMO_CHILD_CHALLENGES.flatMap((c) => {
+			const ref = refOf(c.childId);
+			if (!ref) return [];
+			return [
+				{
+					childRef: ref,
+					title: c.title,
+					description: c.description,
+					challengeType: c.challengeType,
+					periodType: c.periodType,
+					startDate: d(c.startDate),
+					endDate: d(c.endDate),
+					targetConfig: c.targetConfig,
+					rewardConfig: c.rewardConfig,
+					status: c.status,
+					isActive: c.isActive,
+					sourceTemplateId: c.sourceTemplateId,
+					currentValue: c.currentValue,
+					targetValue: c.targetValue,
+					completed: c.completed,
+					completedAt: tsOrNull(c.completedAt),
+					rewardClaimed: c.rewardClaimed,
+					rewardClaimedAt: tsOrNull(c.rewardClaimedAt),
+					createdAt: ts(c.createdAt),
+					updatedAt: ts(c.updatedAt),
+				},
+			];
+		}),
+		stampCards,
+		certificates: DEMO_CERTIFICATES.flatMap((c) => {
+			const ref = refOf(c.childId);
+			if (!ref) return [];
+			return [
+				{
+					childRef: ref,
+					certificateType: c.certificateType,
+					title: c.title,
+					description: c.description,
+					issuedAt: ts(c.issuedAt),
+					metadata: c.metadata,
+				},
+			];
+		}),
+		// 親→子おうえんメッセージ (D20)
+		parentMessages: [
+			{
+				childRef: 'child-2',
+				messageType: 'stamp',
+				stampCode: 'nikoniko',
+				body: null,
+				icon: '😊',
+				sentAt: ts('2026-03-26T18:00:00.000Z'),
+				shownAt: ts('2026-03-26T18:30:00.000Z'),
+				bonusPoints: null,
+				rewardCategory: null,
+			},
+			{
+				childRef: 'child-3',
+				messageType: 'text',
+				stampCode: null,
+				body: 'しゅくだい がんばってるね！',
+				icon: '💌',
+				sentAt: ts('2026-03-27T08:00:00.000Z'),
+				shownAt: null,
+				bonusPoints: null,
+				rewardCategory: null,
+			},
+		],
+		siblingCheers: DEMO_SIBLING_CHEERS.flatMap((c) => {
+			const fromRef = refOf(c.fromChildId);
+			const toRef = refOf(c.toChildId);
+			if (!fromRef || !toRef) return [];
+			return [
+				{
+					fromChildRef: fromRef,
+					toChildRef: toRef,
+					stampCode: c.stampCode,
+					sentAt: ts(c.sentAt),
+					shownAt: tsOrNull(c.shownAt),
+				},
+			];
+		}),
+		checklistTemplates,
+		dailyMissions,
+	});
+	// マスタ活動 (setup wizard 相当の活動候補一覧)
+	body.master.activities = DEMO_ACTIVITIES.map((a) => ({
+		name: a.name,
+		categoryCode: categoryCodeOf(a.categoryId),
+		icon: a.icon,
+		basePoints: a.basePoints,
+		gradeLevel: a.gradeLevel,
+		nameKana: a.nameKana,
+		nameKanji: a.nameKanji,
+		triggerHint: a.triggerHint,
+		sourcePresetId: normalizePresetId(a.sourcePresetId),
+	}));
+	return body;
+}
+
+// ============================================================
+// Tenant B / C1 / C2 (薄い専用 persona、research §4)
+// ============================================================
+
+interface SmallChildSpec {
+	nickname: string;
+	age: number;
+	birthOffsetDays: number; // anchor からの相対 (負)。age-tier が anchor に依らず一定になる
+	theme: string;
+	uiMode: string;
+}
+
+function buildSmallBody(
+	anchorDate: string,
+	child: SmallChildSpec,
+	options: { logDays: number[]; archived?: boolean },
+): ExportBody {
+	const d = (offset: number): string => shiftDateOnly(anchorDate, offset);
+	const iso = (offset: number): string => `${shiftDateOnly(anchorDate, offset)}T09:00:00.000Z`;
+	const children: ExportChild[] = [
+		{
+			exportId: 'child-1',
+			nickname: child.nickname,
+			age: child.age,
+			birthDate: d(child.birthOffsetDays),
+			theme: child.theme,
+			uiMode: child.uiMode,
+			avatarUrl: null,
+			activeTitle: null,
+			createdAt: iso(-30),
+		},
+	];
+	const activities: ExportChildActivity[] = [
+		{
+			childRef: 'child-1',
+			name: 'はみがき',
+			categoryCode: 'seikatsu',
+			icon: '🦷',
+			basePoints: 5,
+			triggerHint: null,
+			isMainQuest: 0,
+			priority: 'must',
+			sourcePresetId: null,
+			isVisible: 1,
+			sortOrder: 1,
+			isArchived: 0,
+			archivedReason: null,
+		},
+		{
+			childRef: 'child-1',
+			name: 'おてつだい',
+			categoryCode: 'seikatsu',
+			icon: '🧹',
+			basePoints: 10,
+			triggerHint: null,
+			isMainQuest: 0,
+			priority: 'optional',
+			sourcePresetId: null,
+			isVisible: 1,
+			sortOrder: 2,
+			isArchived: 0,
+			archivedReason: null,
+		},
+	];
+	if (options.archived) {
+		// D19: トライアル期限切れ由来の archive 済 instance (ARCHIVED_REASONS SSOT 準拠)
+		activities.push({
+			childRef: 'child-1',
+			name: 'ならいごとのれんしゅう',
+			categoryCode: 'souzou',
+			icon: '🎹',
+			basePoints: 15,
+			triggerHint: null,
+			isMainQuest: 0,
+			priority: 'optional',
+			sourcePresetId: null,
+			isVisible: 1,
+			sortOrder: 3,
+			isArchived: 1,
+			archivedReason: 'trial_expired',
+		});
+	}
+	const activityLogs: ExportActivityLog[] = options.logDays.map((offset, i) => ({
+		childRef: 'child-1',
+		activityName: i % 2 === 0 ? 'はみがき' : 'おてつだい',
+		activityCategory: 'seikatsu',
+		points: i % 2 === 0 ? 5 : 10,
+		streakDays: 1,
+		streakBonus: 0,
+		recordedDate: d(offset),
+		recordedAt: iso(offset),
+		cancelled: false,
+	}));
+	const body = baseBody(anchorDate, children, {
+		...emptyTransactionData(),
+		childActivities: activities,
+		activityLogs,
+		pointLedger:
+			activityLogs.length > 0
+				? [
+						{
+							childRef: 'child-1',
+							amount: activityLogs.reduce((sum, l) => sum + l.points, 0),
+							type: 'activity',
+							description: '合成 seed 初期残高',
+							createdAt: iso(0),
+						},
+					]
+				: [],
+	});
+	if (options.archived) {
+		body.data.checklistTemplates = [
+			{
+				childRef: 'child-1',
+				name: 'とこうじゅんび (きゅうし中)',
+				icon: '🎒',
+				pointsPerItem: 2,
+				completionBonus: 5,
+				isActive: false,
+				isArchived: true,
+				sourcePresetId: null,
+				exportId: 'checklist-child-1-archived',
+				items: [
+					{ name: 'ハンカチ', icon: '🧻', frequency: 'daily', direction: 'positive', sortOrder: 1 },
+				],
+			},
+		];
+	}
+	return body;
+}
+
+// ============================================================
+// Dataset builder (pure、決定的)
+// ============================================================
+
+/**
+ * 合成 staging データセットを構築する (AC1-AC3)。
+ * anchorDate 既定 = SYNTHETIC_SEED_ANCHOR (shift 0 = demo fixture 素値、byte 決定的)。
+ * staging deploy では当日を渡し「直近履歴」として描画させる (同一 anchor なら出力同一)。
+ */
+export async function buildSyntheticStagingDataset(
+	anchorDate: string = SYNTHETIC_SEED_ANCHOR,
+): Promise<SyntheticStagingDataset> {
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(anchorDate)) {
+		throw new Error(`anchorDate は YYYY-MM-DD 形式で指定してください: ${anchorDate}`);
+	}
+	const finalize = async (body: ExportBody): Promise<ExportData> =>
+		(await finalizeExport(body)).exportData;
+
+	const tenantA = await finalize(buildTenantABody(anchorDate));
+	const tenantB = await finalize(
+		buildSmallBody(
+			anchorDate,
+			// 小学生 1 人 (単独子構成、D9)。birthDate は anchor - 7歳ぶん
+			{
+				nickname: 'まなぶくん',
+				age: 7,
+				birthOffsetDays: -(365 * 7 + 40),
+				theme: 'blue',
+				uiMode: 'elementary',
+			},
+			{ logDays: [0, -1, -3] },
+		),
+	);
+	const tenantC1 = await finalize(
+		buildSmallBody(
+			anchorDate,
+			{
+				nickname: 'ももちゃん',
+				age: 4,
+				birthOffsetDays: -(365 * 4 + 100),
+				theme: 'pink',
+				uiMode: 'preschool',
+			},
+			{ logDays: [0, -1] },
+		),
+	);
+	const tenantC2 = await finalize(
+		buildSmallBody(
+			anchorDate,
+			{
+				nickname: 'そらくん',
+				age: 13,
+				birthOffsetDays: -(365 * 13 + 200),
+				theme: 'green',
+				uiMode: 'junior',
+			},
+			{ logDays: [-25, -27, -29], archived: true },
+		),
+	);
+
+	return {
+		format: SYNTHETIC_DATASET_FORMAT,
+		version: 1,
+		anchorDate,
+		tenants: [
+			{
+				key: 'premium-family',
+				tenantUuid: LOCAL_TENANT_UUID,
+				description:
+					'がんばり家 5 人 (demo-data.ts 再利用)。5 age mode × 5 theme × M/F、marketplace 取込済、フル機能表示。NUC local staging の単一 tenant として可視',
+				family: { name: 'がんばり家', status: 'active', plan: 'family-monthly' },
+				trial: null,
+				data: tenantA,
+			},
+			{
+				key: 'free',
+				tenantUuid: '00000000-0000-4000-8000-0000000000b1',
+				description: '無料プラン。子供 1 人 + 最小データ、marketplace 未取込 (empty admin、D18)',
+				family: { name: 'まなび家', status: 'active', plan: null },
+				trial: null,
+				data: tenantB,
+			},
+			{
+				key: 'trial-active',
+				tenantUuid: '00000000-0000-4000-8000-0000000000c1',
+				description: 'standard トライアル中 (anchor-2日 開始 / anchor+5日 終了、バナー表示)',
+				family: { name: 'もも家', status: 'active', plan: null },
+				trial: { tier: 'standard', startOffsetDays: -2, endOffsetDays: 5 },
+				data: tenantC1,
+			},
+			{
+				key: 'trial-expired',
+				tenantUuid: '00000000-0000-4000-8000-0000000000c2',
+				description:
+					'トライアル期限切れ (anchor-30日 開始 / anchor-23日 終了) + archive 済データ (D19)',
+				family: { name: 'そら家', status: 'active', plan: null },
+				trial: { tier: 'family', startOffsetDays: -30, endOffsetDays: -23 },
+				data: tenantC2,
+			},
+			{
+				key: 'empty',
+				tenantUuid: '00000000-0000-4000-8000-0000000000d1',
+				description: '空 tenant (子供 0 人)。genuine-empty 全画面 + 初回オンボーディング導線 (D18)',
+				family: { name: 'はじまり家', status: 'active', plan: null },
+				trial: null,
+				data: null,
+			},
+		],
+	};
+}
+
+// re-export (categories SSOT からの派生確認用。CATEGORY_CODE_TO_ID は builder の
+// fallback 'seikatsu' が実在 code であることを test が assert するために公開参照する)
+export { CATEGORY_CODE_TO_ID };

--- a/src/lib/server/demo/synthetic-staging-dataset.ts
+++ b/src/lib/server/demo/synthetic-staging-dataset.ts
@@ -562,9 +562,10 @@ function buildTenantABody(anchorDate: string): ExportBody {
 			{
 				childRef: 'child-2',
 				messageType: 'stamp',
-				stampCode: 'nikoniko',
+				// STAMP_PRESETS (message-service.ts) の実在 code を使う
+				stampCode: 'sugoi',
 				body: null,
-				icon: '😊',
+				icon: '🌟',
 				sentAt: ts('2026-03-26T18:00:00.000Z'),
 				shownAt: ts('2026-03-26T18:30:00.000Z'),
 				bonusPoints: null,

--- a/src/lib/server/demo/synthetic-staging-dataset.ts
+++ b/src/lib/server/demo/synthetic-staging-dataset.ts
@@ -27,6 +27,11 @@
 // DB seed では表現しない。cognito staging のアカウント整備は DEV_USERS 同型で #2873 lane が担う。
 
 import { CATEGORY_CODE_TO_ID, toCategoryCode } from '$lib/domain/categories';
+import { SUBSCRIPTION_PLAN } from '$lib/domain/constants/subscription-plan';
+import {
+	SUBSCRIPTION_STATUS,
+	type SubscriptionStatus,
+} from '$lib/domain/constants/subscription-status';
 import {
 	EXPORT_FORMAT,
 	EXPORT_VERSION,
@@ -39,6 +44,7 @@ import {
 	type ExportTransactionData,
 } from '$lib/domain/export-format';
 import { asChildId, type ChildId } from '$lib/domain/ids';
+import { PLAN_FULL_TERMS } from '$lib/domain/terms';
 import { LOCAL_TENANT_UUID } from '$lib/server/auth/local-tenant';
 import type { ChildActivity } from '$lib/server/db/types/index.js';
 import { finalizeExport } from '$lib/server/services/export-service';
@@ -130,7 +136,7 @@ export interface SyntheticTrialSpec {
 export interface SyntheticFamilySpec {
 	name: string;
 	/** families.status (subscription-status.ts SSOT) */
-	status: 'active' | 'grace_period' | 'suspended' | 'terminated';
+	status: SubscriptionStatus;
 	/** families.plan (subscription-plan.ts SSOT)。null = free (未課金) */
 	plan: string | null;
 }
@@ -816,15 +822,19 @@ export async function buildSyntheticStagingDataset(
 				tenantUuid: LOCAL_TENANT_UUID,
 				description:
 					'がんばり家 5 人 (demo-data.ts 再利用)。5 age mode × 5 theme × M/F、marketplace 取込済、フル機能表示。NUC local staging の単一 tenant として可視',
-				family: { name: 'がんばり家', status: 'active', plan: 'family-monthly' },
+				family: {
+					name: 'がんばり家',
+					status: SUBSCRIPTION_STATUS.ACTIVE,
+					plan: SUBSCRIPTION_PLAN.FAMILY_MONTHLY,
+				},
 				trial: null,
 				data: tenantA,
 			},
 			{
 				key: 'free',
 				tenantUuid: '00000000-0000-4000-8000-0000000000b1',
-				description: '無料プラン。子供 1 人 + 最小データ、marketplace 未取込 (empty admin、D18)',
-				family: { name: 'まなび家', status: 'active', plan: null },
+				description: `${PLAN_FULL_TERMS.free}。子供 1 人 + 最小データ、marketplace 未取込 (empty admin、D18)`,
+				family: { name: 'まなび家', status: SUBSCRIPTION_STATUS.ACTIVE, plan: null },
 				trial: null,
 				data: tenantB,
 			},
@@ -832,7 +842,7 @@ export async function buildSyntheticStagingDataset(
 				key: 'trial-active',
 				tenantUuid: '00000000-0000-4000-8000-0000000000c1',
 				description: 'standard トライアル中 (anchor-2日 開始 / anchor+5日 終了、バナー表示)',
-				family: { name: 'もも家', status: 'active', plan: null },
+				family: { name: 'もも家', status: SUBSCRIPTION_STATUS.ACTIVE, plan: null },
 				trial: { tier: 'standard', startOffsetDays: -2, endOffsetDays: 5 },
 				data: tenantC1,
 			},
@@ -841,7 +851,7 @@ export async function buildSyntheticStagingDataset(
 				tenantUuid: '00000000-0000-4000-8000-0000000000c2',
 				description:
 					'トライアル期限切れ (anchor-30日 開始 / anchor-23日 終了) + archive 済データ (D19)',
-				family: { name: 'そら家', status: 'active', plan: null },
+				family: { name: 'そら家', status: SUBSCRIPTION_STATUS.ACTIVE, plan: null },
 				trial: { tier: 'family', startOffsetDays: -30, endOffsetDays: -23 },
 				data: tenantC2,
 			},
@@ -849,7 +859,7 @@ export async function buildSyntheticStagingDataset(
 				key: 'empty',
 				tenantUuid: '00000000-0000-4000-8000-0000000000d1',
 				description: '空 tenant (子供 0 人)。genuine-empty 全画面 + 初回オンボーディング導線 (D18)',
-				family: { name: 'はじまり家', status: 'active', plan: null },
+				family: { name: 'はじまり家', status: SUBSCRIPTION_STATUS.ACTIVE, plan: null },
 				trial: null,
 				data: null,
 			},

--- a/src/lib/server/demo/synthetic-staging-dataset.ts
+++ b/src/lib/server/demo/synthetic-staging-dataset.ts
@@ -59,7 +59,7 @@ import {
 	DEMO_CHILDREN,
 	DEMO_DAILY_MISSIONS,
 	DEMO_EVALUATIONS,
-	DEMO_LOGIN_BONUSES,
+	DEMO_LOGIN_STREAKS,
 	DEMO_MARKETPLACE_SPECIAL_REWARDS,
 	DEMO_POINT_BALANCES,
 	DEMO_SIBLING_CHEERS,
@@ -192,7 +192,7 @@ function emptyTransactionData(): ExportTransactionData {
 		statusHistory: [],
 		childAchievements: [],
 		childTitles: [],
-		loginBonuses: [],
+		loginStreaks: [],
 		evaluations: [],
 		specialRewards: [],
 		rewardRedemptions: [],
@@ -488,19 +488,17 @@ function buildTenantABody(anchorDate: string): ExportBody {
 				},
 			];
 		}),
-		loginBonuses: DEMO_LOGIN_BONUSES.flatMap((b) => {
-			const ref = refOf(b.childId);
+		// #3330 counter 縮約 (wire 1.8.0): 子供ごと 1 行の streak counter。
+		// lastLoginDate は date のため anchor offset で shift し、「今日 claim 済」の意味を anchor 非依存で保つ
+		loginStreaks: DEMO_LOGIN_STREAKS.flatMap((s) => {
+			const ref = refOf(s.childId);
 			if (!ref) return [];
 			return [
 				{
 					childRef: ref,
-					loginDate: d(b.loginDate),
-					rank: b.rank,
-					basePoints: b.basePoints,
-					multiplier: b.multiplier,
-					totalPoints: b.totalPoints,
-					consecutiveDays: b.consecutiveDays,
-					createdAt: ts(b.createdAt),
+					lastLoginDate: d(s.lastLoginDate),
+					currentStreak: s.currentStreak,
+					updatedAt: ts(s.updatedAt),
 				},
 			];
 		}),

--- a/tests/unit/architecture/dockerfile-copy-import-fitness.test.ts
+++ b/tests/unit/architecture/dockerfile-copy-import-fitness.test.ts
@@ -164,7 +164,10 @@ function collectImportGraph(entryAbs: string): { files: string[]; unresolved: st
 
 /** 検証対象: Dockerfile → image 同梱 entry (CMD / cutover rehearsal が実行するもの)。 */
 const TARGETS: { dockerfile: string; entries: string[] }[] = [
-	{ dockerfile: 'Dockerfile', entries: ['scripts/nuc-pglite-cutover.ts'] },
+	{
+		dockerfile: 'Dockerfile',
+		entries: ['scripts/nuc-pglite-cutover.ts', 'scripts/seed-staging.ts'],
+	},
 	{ dockerfile: 'Dockerfile.scheduler', entries: ['scripts/scheduler.ts'] },
 ];
 

--- a/tests/unit/demo/synthetic-staging-dataset.test.ts
+++ b/tests/unit/demo/synthetic-staging-dataset.test.ts
@@ -1,0 +1,199 @@
+// tests/unit/demo/synthetic-staging-dataset.test.ts — 合成 staging dataset の機械保証 (#3412)
+//
+// AC1 (PII-free): dataset 全走査で「合成名 allowlist 外の nickname 0 件 / email 0 件 / 電話番号
+//   pattern 0 件」を機械 assert する。実在人名の denylist はそれ自体が PII になるため置けない —
+//   代わりに「出現してよい名前の完全列挙 (allowlist)」方式で混入を fail-closed 検出する。
+// AC2 (網羅次元): research §2 の各軸 (5 age mode / 5 theme / trial 3 状態 / 単独子・兄弟 /
+//   per-child・family master / marketplace 取込前後 / 空状態 / archive) が dataset に存在する。
+// AC3 (決定性): 同一 anchor で byte 同一。anchor shift は日付の純関数。
+
+import { describe, expect, it } from 'vitest';
+import {
+	buildSyntheticStagingDataset,
+	daysBetween,
+	resolveTrialWindow,
+	SYNTHETIC_NICKNAME_ALLOWLIST,
+	SYNTHETIC_SEED_ANCHOR,
+} from '../../../src/lib/server/demo/synthetic-staging-dataset';
+
+// 電話番号様 pattern (0 始まりハイフン区切り)。前後 lookaround で UUID
+// (`0000-4000-8000` のようなハイフン連結 hex run) と日付を誤検出しない。
+const PHONE_LIKE = /(?<![\d-])0\d{1,4}-\d{2,4}-\d{3,4}(?![\d-])/;
+
+describe('synthetic-staging-dataset (#3412)', () => {
+	it('AC1: PII-free — nickname は合成 allowlist のみ / email・電話番号 pattern 0 件 (全走査)', async () => {
+		const dataset = await buildSyntheticStagingDataset();
+
+		const nicknames = dataset.tenants.flatMap(
+			(t) => t.data?.family.children.map((c) => c.nickname) ?? [],
+		);
+		expect(nicknames.length).toBeGreaterThan(0);
+		for (const nickname of nicknames) {
+			expect(SYNTHETIC_NICKNAME_ALLOWLIST, `allowlist 外の nickname: ${nickname}`).toContain(
+				nickname,
+			);
+		}
+
+		// 全 field 走査 (serialize して素朴に scan する = field 追加漏れが構造的に起きない)
+		const serialized = JSON.stringify(dataset);
+		expect(serialized.includes('@'), 'email 様文字列 (@) が dataset に含まれる').toBe(false);
+		expect(PHONE_LIKE.test(serialized), '電話番号様 pattern が dataset に含まれる').toBe(false);
+	});
+
+	it('AC3: 決定性 — 同一 anchor で 2 回 build した出力が byte 同一', async () => {
+		const a = await buildSyntheticStagingDataset();
+		const b = await buildSyntheticStagingDataset();
+		expect(JSON.stringify(a)).toEqual(JSON.stringify(b));
+
+		const c = await buildSyntheticStagingDataset('2026-04-27');
+		const d = await buildSyntheticStagingDataset('2026-04-27');
+		expect(JSON.stringify(c)).toEqual(JSON.stringify(d));
+	});
+
+	it('AC3: anchor shift — 全日付が anchor 差分だけ一律 shift される (履歴の相対位置不変)', async () => {
+		const base = await buildSyntheticStagingDataset();
+		const shifted = await buildSyntheticStagingDataset('2026-04-27');
+		const offset = daysBetween(SYNTHETIC_SEED_ANCHOR, '2026-04-27');
+		expect(offset).toBe(31);
+
+		const baseA = base.tenants[0]?.data;
+		const shiftedA = shifted.tenants[0]?.data;
+		expect(baseA && shiftedA).toBeTruthy();
+		// 件数は不変 (drop 判定は anchor 非依存)
+		expect(shiftedA?.data.activityLogs.length).toBe(baseA?.data.activityLogs.length);
+		// 代表 field の日付が offset ぶん shift
+		const baseDate = baseA?.data.activityLogs[0]?.recordedDate;
+		const shiftedDate = shiftedA?.data.activityLogs[0]?.recordedDate;
+		expect(baseDate && shiftedDate && daysBetween(baseDate, shiftedDate)).toBe(offset);
+		// birthDate も shift = compute-on-read の age-tier 網羅が anchor に依らず保たれる
+		const baseBirth = baseA?.family.children[0]?.birthDate;
+		const shiftedBirth = shiftedA?.family.children[0]?.birthDate;
+		expect(baseBirth && shiftedBirth && daysBetween(baseBirth, shiftedBirth)).toBe(offset);
+	});
+
+	it('anchor の形式不正は throw する', async () => {
+		await expect(buildSyntheticStagingDataset('not-a-date')).rejects.toThrow('YYYY-MM-DD');
+	});
+
+	it('AC2: 5 age mode × 5 theme × 単独子/兄弟 両構成を網羅する (D1-D3 / D9)', async () => {
+		const dataset = await buildSyntheticStagingDataset();
+		const children = dataset.tenants.flatMap((t) => t.data?.family.children ?? []);
+
+		const uiModes = new Set(children.map((c) => c.uiMode));
+		for (const mode of ['baby', 'preschool', 'elementary', 'junior', 'senior']) {
+			expect(uiModes, `uiMode ${mode} が欠落`).toContain(mode);
+		}
+		const themes = new Set(children.map((c) => c.theme));
+		for (const theme of ['blue', 'pink', 'green', 'purple', 'orange']) {
+			expect(themes, `theme ${theme} が欠落`).toContain(theme);
+		}
+		// 兄弟あり (tenant A = 5 人) + 単独子 (tenant B/C = 1 人)
+		const childCounts = dataset.tenants.map((t) => t.data?.family.children.length ?? 0);
+		expect(Math.max(...childCounts)).toBeGreaterThanOrEqual(5);
+		expect(childCounts).toContain(1);
+		// 全 child に birthDate (compute-on-read の唯一の年齢ソース、#3584 cutover gate 整合)
+		for (const c of children) expect(c.birthDate, `${c.nickname} birthDate 欠落`).toBeTruthy();
+	});
+
+	it('AC2: plan / trial 軸 — premium + free + trial active/expired/not-started (D4 / D6)', async () => {
+		const dataset = await buildSyntheticStagingDataset();
+		const byKey = new Map(dataset.tenants.map((t) => [t.key, t]));
+
+		expect(byKey.get('premium-family')?.family.plan).toBe('family-monthly');
+		expect(byKey.get('free')?.family.plan).toBeNull();
+		expect(byKey.get('free')?.trial).toBeNull(); // not-started
+
+		const active = byKey.get('trial-active')?.trial;
+		expect(active?.tier).toBe('standard');
+		expect(active && active.startOffsetDays < 0 && active.endOffsetDays > 0).toBe(true);
+
+		const expired = byKey.get('trial-expired')?.trial;
+		expect(expired?.tier).toBe('family');
+		expect(expired && expired.endOffsetDays < 0).toBe(true);
+
+		// resolveTrialWindow は anchor 相対の純関数
+		expect(active && resolveTrialWindow(active, '2026-03-27')).toEqual({
+			startDate: '2026-03-25',
+			endDate: '2026-04-01',
+		});
+	});
+
+	it('AC2: per-child / family master / marketplace 取込前後 / 空状態 / archive (D10 / D11 / D18 / D19)', async () => {
+		const dataset = await buildSyntheticStagingDataset();
+		const byKey = new Map(dataset.tenants.map((t) => [t.key, t]));
+		const tenantA = byKey.get('premium-family')?.data;
+		expect(tenantA).toBeTruthy();
+
+		// D10: per-child instance + family master (checklist) 両モデル
+		expect(tenantA?.data.childActivities.length).toBeGreaterThan(0);
+		expect(tenantA?.data.checklistTemplates.length).toBeGreaterThan(0);
+
+		// D11: marketplace 取込済 (sourcePresetId 付き) が activity / reward / checklist に存在
+		expect(tenantA?.data.childActivities.some((a) => a.sourcePresetId)).toBe(true);
+		expect(tenantA?.data.specialRewards.some((r) => r.sourcePresetId)).toBe(true);
+		expect(tenantA?.data.checklistTemplates.some((t) => t.sourcePresetId)).toBe(true);
+		// demo 内部識別子 (`demo:<n>`) は marketplace 由来として持ち出さない
+		for (const a of tenantA?.data.childActivities ?? []) {
+			expect(a.sourcePresetId?.startsWith('demo:')).not.toBe(true);
+		}
+
+		// D11 (取込前): free tenant は marketplace 未取込 + checklist なし (empty admin)
+		const tenantB = byKey.get('free')?.data;
+		expect(tenantB?.data.childActivities.every((a) => !a.sourcePresetId)).toBe(true);
+		expect(tenantB?.data.checklistTemplates.length).toBe(0);
+
+		// D18: 空 tenant (子供 0 人)
+		expect(byKey.get('empty')?.data).toBeNull();
+
+		// D19: archive 済データ (trial-expired tenant)
+		const tenantC2 = byKey.get('trial-expired')?.data;
+		expect(tenantC2?.data.childActivities.some((a) => a.isArchived === 1)).toBe(true);
+		expect(tenantC2?.data.checklistTemplates.some((t) => t.isArchived)).toBe(true);
+	});
+
+	it('AC2: 活動属性 / ごほうび交換 3 status / スタンプ / 証明書 / 履歴深さ / コミュニケーション (D13-D17 / D20)', async () => {
+		const dataset = await buildSyntheticStagingDataset();
+		const tenantA = dataset.tenants.find((t) => t.key === 'premium-family')?.data;
+		expect(tenantA).toBeTruthy();
+		const tx = tenantA?.data;
+
+		// D13: must 属性 + main quest
+		expect(tx?.childActivities.some((a) => a.priority === 'must')).toBe(true);
+		expect(tx?.childActivities.some((a) => a.isMainQuest === 1)).toBe(true);
+
+		// D14: 交換申請 pending / approved / rejected の 3 status
+		const statuses = new Set(tx?.rewardRedemptions.map((r) => r.status));
+		expect(statuses).toContain('pending_parent_approval');
+		expect(statuses).toContain('approved');
+		expect(statuses).toContain('rejected');
+
+		// D15: スタンプカード + 押印 entry
+		expect(tx?.stampCards.length).toBeGreaterThan(0);
+		expect(tx?.stampCards.some((c) => c.entries.length > 0)).toBe(true);
+
+		// D16: status 5 軸 + 証明書
+		expect(new Set(tx?.statuses.map((s) => s.categoryCode)).size).toBeGreaterThanOrEqual(5);
+		expect(tx?.certificates.length).toBeGreaterThan(0);
+
+		// D17: 履歴の深さ (レーダー / MilestoneBanner / 月次レポートが空にならない件数)
+		expect(tx?.activityLogs.length).toBeGreaterThanOrEqual(50);
+
+		// D20: 親→子メッセージ + きょうだい応援
+		expect(tx?.parentMessages.length).toBeGreaterThan(0);
+		expect(tx?.siblingCheers.length).toBeGreaterThan(0);
+
+		// 活動ログの参照整合 (childRef × activityName が per-child 活動に解決できる)
+		const namesByRef = new Map<string, Set<string>>();
+		for (const a of tx?.childActivities ?? []) {
+			const set = namesByRef.get(a.childRef) ?? new Set<string>();
+			set.add(a.name);
+			namesByRef.set(a.childRef, set);
+		}
+		for (const log of tx?.activityLogs ?? []) {
+			expect(
+				namesByRef.get(log.childRef)?.has(log.activityName),
+				`log の activityName が未解決: ${log.childRef}/${log.activityName}`,
+			).toBe(true);
+		}
+	});
+});

--- a/tests/unit/services/synthetic-staging-seed-pglite.test.ts
+++ b/tests/unit/services/synthetic-staging-seed-pglite.test.ts
@@ -1,0 +1,106 @@
+// tests/unit/services/synthetic-staging-seed-pglite.test.ts — 合成 staging seed の PGlite 流し込み検証 (#3412)
+//
+// buildSyntheticStagingDataset → applySyntheticDataset (scripts/lib/runtime/seed-staging-apply.ts)
+// が実 PGlite (in-memory、実 migration 適用) に貫通することを機械検証する。CLI
+// (scripts/seed-staging.ts apply) と同一 core を呼ぶため、この test が緑 = staging workflow の
+// seed 経路が pg-core backend で成立することの実証になる (pglite-cutover-roundtrip.test.ts と同型)。
+//
+// staging 実機 (NUC #2872 / AWS #2873) での適用は deploy workflow の発火が必要なため本 test の
+// 対象外 (統合 PR lane / #2873 lane で確認する)。
+
+import { sql } from 'drizzle-orm';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const originalDataSource = process.env.DATA_SOURCE;
+
+afterAll(() => {
+	if (originalDataSource === undefined) delete process.env.DATA_SOURCE;
+	else process.env.DATA_SOURCE = originalDataSource;
+});
+
+describe('synthetic staging seed → PGlite apply (#3412)', () => {
+	it('5 tenant (premium/free/trial×2/empty) が families + trial + 家族データ込みで seed され件数突合が一致する', async () => {
+		process.env.DATA_SOURCE = 'pglite';
+		delete process.env.PGLITE_DATA_DIR; // in-memory (実 migration = drizzle/pglite/ を適用)
+
+		const { buildSyntheticStagingDataset } = await import(
+			'../../../src/lib/server/demo/synthetic-staging-dataset'
+		);
+		const dataset = await buildSyntheticStagingDataset();
+
+		const pgliteConn = await import('../../../src/lib/server/db/pglite/connection');
+		await pgliteConn.resetPgliteConnectionForTesting();
+		await pgliteConn.initPgliteConnection();
+
+		try {
+			const { applySyntheticDataset } = await import(
+				'../../../scripts/lib/runtime/seed-staging-apply'
+			);
+			const db = pgliteConn.getPgliteDbSync();
+			// applySyntheticDataset は import error / 件数突合不一致で throw する — 正常終了自体が検証
+			const result = await applySyntheticDataset(dataset, db);
+			expect(result.tenants.map((t) => t.key)).toEqual([
+				'premium-family',
+				'free',
+				'trial-active',
+				'trial-expired',
+				'empty',
+			]);
+
+			// families 行 (plan 軸 D4): 5 tenant 分 + plan 値
+			const famRows = await db.execute(
+				sql`SELECT family_id, plan, status FROM families ORDER BY name`,
+			);
+			expect(famRows.rows.length).toBe(5);
+			const planByUuid = new Map(
+				(famRows.rows as { family_id: string; plan: string | null }[]).map((r) => [
+					r.family_id,
+					r.plan,
+				]),
+			);
+			const byKey = new Map(dataset.tenants.map((t) => [t.key, t]));
+			expect(planByUuid.get(byKey.get('premium-family')?.tenantUuid ?? '')).toBe('family-monthly');
+			expect(planByUuid.get(byKey.get('free')?.tenantUuid ?? '')).toBeNull();
+
+			// trial 行 (D6): active / expired の 2 tenant に trial_history が入る
+			const trialRows = await db.execute(
+				sql`SELECT family_id, tier, start_date, end_date FROM trial_history`,
+			);
+			expect(trialRows.rows.length).toBe(2);
+			const trialByUuid = new Map(
+				(trialRows.rows as { family_id: string; tier: string; end_date: string }[]).map((r) => [
+					r.family_id,
+					r,
+				]),
+			);
+			expect(trialByUuid.get(byKey.get('trial-active')?.tenantUuid ?? '')?.tier).toBe('standard');
+			expect(trialByUuid.get(byKey.get('trial-expired')?.tenantUuid ?? '')?.tier).toBe('family');
+
+			// tenant A: がんばり家 5 人が repo 経由で読める (5 age mode 実データ)
+			const { getRepos } = await import('../../../src/lib/server/db/factory');
+			const repos = getRepos();
+			const tenantAUuid = byKey.get('premium-family')?.tenantUuid ?? '';
+			const childrenA = await repos.child.findAllChildren(tenantAUuid);
+			expect(childrenA.length).toBe(5);
+			expect(childrenA.map((c) => c.nickname).sort()).toEqual(
+				['たろうくん', 'ひなちゃん', 'けんたくん', 'さくらちゃん', 'けいすけくん'].sort(),
+			);
+
+			// 空 tenant (D18): 子供 0 人 / 家族データ行なし
+			const emptyUuid = byKey.get('empty')?.tenantUuid ?? '';
+			expect((await repos.child.findAllChildren(emptyUuid)).length).toBe(0);
+
+			// free tenant: 単独子 + 少量 log
+			const freeUuid = byKey.get('free')?.tenantUuid ?? '';
+			const childrenFree = await repos.child.findAllChildren(freeUuid);
+			expect(childrenFree.map((c) => c.nickname)).toEqual(['まなぶくん']);
+
+			// import counts が結果 summary に反映されている (件数突合済の値)
+			const tenantAResult = result.tenants.find((t) => t.key === 'premium-family');
+			expect(tenantAResult?.importedCounts?.children).toBe(5);
+			expect(tenantAResult?.importedCounts?.activityLogs).toBeGreaterThanOrEqual(50);
+		} finally {
+			await pgliteConn.resetPgliteConnectionForTesting();
+		}
+	}, 180_000);
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（間接的に全ユーザーの privacy 保護）

**解決する課題**: staging（NUC #2872）が本番 DB snapshot から起動しており、実在の子供のニックネーム・生年月日・活動履歴（= PII、CWE-359/200）が検証環境に複製され続けている（#2999）。また AWS staging（#2873、cognito + DSQL）には「機能を一通り検証できる代表データ」を流し込む手段自体が存在しない。

**期待される効果**: 本番 PII を一切含まない**合成（synthetic）ダミーデータセット**（demo-data.ts の PII-free がんばり家を基盤に 5 tenant 構成）と generic seed CLI により、staging を PII ゼロで起動できる。決定的（固定 anchor の純関数）なため visual regression / E2E の基盤としても安定する。

## 関連 Issue

#3412 (tracking)

<!-- no-issue-close: AC4 (staging deploy が本ダミー seed を使い snapshot 経路を置換) は staging 実機での合成 seed lane 発火 (deploy-nuc-staging workflow_dispatch / 統合 PR lane) と AWS staging 側配線 (#2873、blocked 関係) の確認が残るため、#3412 は close せず tracking で残す。本 PR は seed 生成 + PGlite 流し込み検証 + NUC workflow opt-in 配線までを完遂 -->

- related: #2999（本番 PII snapshot、本 seed が根本解決の実体）/ #2872（NUC staging）/ #2873（AWS staging、blocked by 本 seed）
- research SSOT: `docs/research/2026-06-28-dummy-dataset-requirements.md`（#3411）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 本番 PII を含まない合成 seed 実装（demo-data.ts の PII-free 5 人家族を基盤に再利用） | `npx vitest run tests/unit/demo/synthetic-staging-dataset.test.ts`（PII-free 機械 assert = nickname allowlist 全走査 + email/電話 pattern 0 件） | HEAD `69c19887` / 8 passed / `src/lib/server/demo/synthetic-staging-dataset.ts` が `DEMO_CHILDREN` 等を wire format 変換（L233-）、`SYNTHETIC_NICKNAME_ALLOWLIST` L104 |
| AC2 | research §2 網羅次元（5 age mode / 5 theme + M/F / trial 3 状態 × tier / ロール / 単独子・兄弟 / per-child・family master / marketplace 取込前後 / 空状態・archive） | 同上 vitest（AC2 系 4 test が各次元の存在を assert）+ 設計書 §3 の tenant × 次元表 | HEAD `69c19887` / uiMode 5 種・theme 5 種・trial active/expired/not-started・単独子+兄弟・childActivities+checklistTemplates・sourcePresetId 有無・empty tenant・isArchived を全 assert（tests/unit/demo/synthetic-staging-dataset.test.ts:87-186）。ロール軸は auth 層（Cognito user）の関心で DB seed 対象外 — DEV_USERS 同型整備は #2873 lane（`docs/design/staging-synthetic-seed.md` §3 に明記） |
| AC3 | 決定的（faker 等の非決定乱数を使わず固定 seed で visual regression / E2E と両立） | 同上 vitest（同一 anchor 2 回 build の byte 同一 + anchor shift の純関数性 assert） | HEAD `69c19887` / `JSON.stringify(a) === JSON.stringify(b)` PASS（test L43-52）。乱数 / wall-clock 非使用（`exportedAt` も anchor 固定値） |
| AC4 | staging deploy（NUC #2872 + AWS #2873）が本ダミー seed を使い本番 snapshot 経路を置換 | `.github/workflows/deploy-nuc-staging.yml` の `syntheticSeed` input（opt-in）+ `npx tsx scripts/seed-staging.ts generate/apply` の local 実機実行 | HEAD `69c19887` / NUC workflow に opt-in lane 配線済（snapshot Step 4 + cutover rehearsal を skip し image 同梱 CLI で seed、既定は snapshot 経路不変）。PGlite 流し込みは local 実行で 5 tenant 全件数突合 PASS（下記テスト概要）。**staging 実機発火と snapshot 経路の完全置換 + AWS 側配線は本 PR 対象外**のため #3412 は tracking（no-issue-close 宣言参照） |
| AC5 | research 結論を設計書（staging 構成 / 13-AWS or 専用 doc）に反映（ADR-0001） | `docs/design/staging-synthetic-seed.md`（3 部構成）+ `docs/CLAUDE.md` 設計書更新ルール表 | HEAD `69c19887` / 専用設計書新設（§1 背景 / §2 原則 / §3 データセット仕様 / §4 実行フロー / §5 staging 配線）+ docs/CLAUDE.md 表に 1 行追加 |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

その他: `src/lib/server/demo/`（合成 dataset module 新設、既存 demo-data.ts は無変更）/ `scripts/`（generic seed CLI + apply core）/ `Dockerfile`（seed CLI の image 同梱）/ `docs/`（専用設計書）

**影響を受ける画面・機能**:
staging deploy レーンのみ（本番アプリの画面・機能・bundle への影響なし。demo Lambda の挙動も不変 — demo-data.ts は読み取り再利用のみ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / check-pr-body をローカル一括検証
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/demo/synthetic-staging-dataset.test.ts`（8 tests）: PII-free 機械 assert（nickname allowlist / email・電話 pattern 全走査 0 件）/ 決定性（byte 同一）/ anchor shift 純関数性 / AC2 次元網羅（5 mode・5 theme・trial 3 状態・per-child + family master・marketplace 取込前後・empty・archive・交換 3 status・参照整合）
  - `tests/unit/services/synthetic-staging-seed-pglite.test.ts`（1 test）: 実 PGlite（in-memory + 実 migration）へ `applySyntheticDataset` を貫通させ、families 5 行 / trial_history 2 行 / がんばり家 5 人の repo 読出 / nuc-cutover-verify 件数突合を assert（CLI apply と同一 core）
  - `tests/unit/architecture/dockerfile-copy-import-fitness.test.ts`: entry に `scripts/seed-staging.ts` を追加（image 同梱 CLI の COPY ↔ import 整合を機械検証）
  - CLI 実機実行: `npx tsx scripts/seed-staging.ts generate --anchor today` → `apply --data-dir tmp/...` を local 実行し 5 tenant 全件数突合 PASS（tenant A: children=5 / childActivities=125 / activityLogs=199 / specialRewards=20 / stampCards=8 等）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（新規 env / secret なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（infra / scripts / test / docs のみで UI 変更なし。**本番アプリの画面・CSS・component に差分ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: dataset 生成（pure module）/ apply core（DB 注入）/ CLI（プロセス境界）を分離。apply core は `SqlExecutor` 注入で PGlite / DSQL 両 backend に対応（依存性逆転）
- [x] **DRY**: 流し込みは既存 `importFamilyData` + `nuc-cutover-verify` を再利用し専用 insert 経路を新設しない（#1442 / ADR-0066）。`grep` で類似 seed 機構（global-setup / plan-fixtures / cutover CLI）を調査済 — 転用可能なものは wire format / repos 経由で共有
- [x] **YAGNI**: faker 等の新規 OSS 不採用（research §5 選択肢 C 却下）。multi-backend 抽象も「db 注入 1 点」に留める
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし。合成データのみで実 PII を排除（PII-free は allowlist + pattern 走査で機械 assert）。apply は空 dataDir のみ受理（既存 DB 誤破壊防止）+ 失敗時 dataDir 削除の fail-closed
- [x] **アクセシビリティ**: N/A（UI なし）
- [x] **パフォーマンス**: seed は staging deploy 時のみ実行（本番 bundle / runtime 影響ゼロ）。dataset 生成は fixture 変換のみで軽量

## 横展開・影響波及チェック

**並行実装ペア**（`docs/design/parallel-implementations.md` 参照、該当するペアにチェック）:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版 (`src/routes/demo/`) を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）: LP 記載がアプリ実装と一致 / アプリの新規機能・用語が LP に未記載のままでない（Committed/Aspirational 確認）
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [x] E2E / ユニットシード（`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` / `src/lib/server/demo/demo-data.ts`）と チュートリアル (`tutorial-chapters.ts` / `demo-guide-state.svelte.ts`) を同期 — demo-data.ts を SSOT のまま**読み取り再利用**（fixture 自体は無変更のため既存 seed 群と非干渉。5 age mode 網羅は dataset test が担保）
- [ ] **labels SSOT** (ADR-0009): 新規ユーザー向け文言は `src/lib/domain/labels.ts` 経由 / LP 側は `data-label` 属性経由 / リテラル直書きなし
- [x] **設計書同期** (ADR-0001): `docs/design/staging-synthetic-seed.md` 新設 + `docs/CLAUDE.md` 設計書更新ルール表に追加
- [x] **並行 PR overlap** (#1200): `deploy-nuc-staging.yml` / `Dockerfile` / `demo/` を同時変更する open PR なしを確認済
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

（snapshot 経路は既定で不変。合成 seed は workflow_dispatch の opt-in input でのみ発火し、統合 PR lane / 本番 deploy には一切影響しない）

**レビュー依頼事項・QA**:
- AC4 の残タスク境界: 本 PR = seed 生成 + PGlite 流し込み検証 + NUC workflow opt-in 配線。**staging 実機での合成 seed lane 発火（workflow_dispatch: pgliteEnabled=true + syntheticSeed=true）と snapshot 経路の完全置換判断、AWS staging (#2873) への seed 配線は次の lane** で行うため #3412 は tracking（Issue の blocked_by/blocks 構造整合）
- 交換申請 `requestedAt` は epoch 秒（reward-redemption-repo の `epochToIso` 契約）— PGlite 統合 test で実証済だが、単位契約の妥当性を一応確認いただきたい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完のまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — N/A（AC4 実機検証の残タスクは Issue #3412 の blocked_by/blocks 構造（#2873）で既に管理されており、本 PR は Issue を close しない tracking 運用）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


