### PR TITLE
feat(process): #3862 PO 決裁 triage + 決裁ブリーフ + サンプリング監査 (Phase 1-3 一括)

### DIFF
--- a/.claude/skills/dev-open-pr/SKILL.md
+++ b/.claude/skills/dev-open-pr/SKILL.md
@@ -52,6 +52,7 @@ Dev Agent が PR を `gh pr create --draft --body-file` で起票する際の **
 | **SKILL.md** (本ファイル) | PR 起票 4 ステップ (雛形展開 / 穴埋め / 検証 / Draft → Ready) |
 | [ready-gate-checklist.md](./ready-gate-checklist.md) | Ready 化前の 4 必須 CI gate 通過チェックリスト (Wave 1 知見) |
 | `templates/pr-body-{default,lp,critical-fix,refactor-ssot}.md` | kind 別 PR body 雛形 |
+| `templates/po-decision-brief.md` | **PO 決裁ブリーフ条件付きセクション雛形 (#3862、po-decision:required PR のみ append)** |
 | `scripts/init-pr-body.mjs` | Issue から `{{ISSUE_TITLE}}` `{{AC_TABLE}}` 等を自動穴埋め |
 
 各 PR 起票前に `node .claude/skills/dev-open-pr/scripts/init-pr-body.mjs --issue <num> --kind <type>` で `tmp/pr-bodies/<slug>.md` に雛形を展開してから穴埋めする。Ready 化直前に [ready-gate-checklist.md](./ready-gate-checklist.md) で 4 gate を順に確認する。
@@ -301,6 +302,25 @@ rm tmp/pr-bodies/<num>-<slug>.md
 | 設計書同期忘れで design-doc-check fail | Step 5 (pre-ready 4 種 check) |
 
 `--kind` を省略すると `default`。Issue label から推定する自動選択は導入しない（曖昧さによる事故回避、Agent が明示指定する）。
+
+## PO 決裁ブリーフ（po-decision:required 条件付きセクション、#3862）
+
+**PR が高リスク・不可逆変更に該当する場合**（`.github/labeler.yml` の `po-decision:required` glob 該当 = labeler 自動付与、または [pr-review SKILL.md](../pr-review/SKILL.md) §「Step 0-2」の判断層 checklist 該当 = 手動付与）、PR body 末尾（PR template 共通セクション + kind 別追加セクションの後ろ）に **`templates/po-decision-brief.md` を append** する。
+
+### 生成手順（6 項目）
+
+1. **triage 自己判定**: PR 起票前に変更 file 一覧を `.github/labeler.yml` の `po-decision:required` glob と突合 + Step 0-2 checklist（運用/保守コスト増・新規デザインアーキテクチャパターン採用・技術負債積み残し 等）を自問。該当なしなら本セクション不要（append しない）
+2. **雛形 append**: `templates/po-decision-brief.md` を PR body 末尾にコピー
+3. **項目 1〜3 記入**: リスク分類（可逆/不可逆 + 顧客面）/ ロールバック可否・データ破壊 / trade-off（ADR-0010 紐付け + PO 追加軸）
+4. **項目 4 記入**: `adversarial-reviewer` skill を dispatch し `tmp/adversarial-evidence/<pr>.json` の objections 3 件（business / UX / security）を表に転記 + 自身の推奨を 1 行
+5. **項目 5 記入**: 実機 SS（UI 変更時、screenshots branch）+ 顧客面の変化を具体的に。**PO がプロダクト実態を把握するための核**であり「テスト green」の羅列で代替しない
+6. **項目 6 記入**: PO への判断依頼を Yes/No 形式 1〜3 個に絞る
+
+### ルール
+
+- 本セクションは **必須 13 セクション（`PR_TEMPLATE_SECTIONS.json`）に含まれない条件付き append**（`--kind lp` の「LP メトリクス結果」と同じ慣行）。`check-pr-body.mjs` は追加セクションを許容する
+- `po-decision:required` label が付いた PR は **PO の Yes/No 判断を得てから merge**（QM / audit-manager 単独 merge 禁止）。判断待ちで Ready 化まで進めるのは可
+- label が synchronize（push）で後から自動付与された場合も、気づいた時点でブリーフを `gh pr edit <N> --body-file` で追補する
 
 ## SSOT alignment 原則
 

--- a/.claude/skills/dev-open-pr/templates/po-decision-brief.md
+++ b/.claude/skills/dev-open-pr/templates/po-decision-brief.md
@@ -1,0 +1,44 @@
+## PO 決裁ブリーフ (po-decision:required)
+
+<!-- #3862: pr-review skill「Step 0: PO 決裁 triage」該当 PR にのみ添付する条件付きセクション。
+     kind 別追加セクションと同じ慣行で、PR template 共通セクションの後ろに append する
+     (PR_TEMPLATE_SECTIONS.json の必須 13 セクションには含めない = 全 PR 強制ではない)。
+     ADR 型 1 ページ・5 分読了。AI は triage + ブリーフ生成のみ、判断は PO が行う。 -->
+
+### 1. リスク分類
+
+<!-- 可逆 / 不可逆の別 + 影響する顧客面 (子供画面 / 親画面 / 課金 / データ / 法務) を 1-2 行で -->
+
+### 2. ロールバック可否 / データ破壊の有無
+
+<!-- revert PR だけで戻るか。migration / 物理削除等でデータが破壊されるなら復旧手段を明記 -->
+
+### 3. trade-off (Pre-PMF スコープ判断、ADR-0010)
+
+<!-- 何を得て何を捨てるか。運用コスト / 保守コスト増・新規デザインアーキテクチャパターン採用・
+     技術負債の積み残しの有無 (PO 決裁 2026-07-19 追加軸) を明示 -->
+
+### 4. 推奨 + 反対理由 3 つ
+
+<!-- 推奨 (merge すべきか) を 1 行 + adversarial-reviewer skill の objections 3 件を転記。
+     tmp/adversarial-evidence/<pr>.json が未生成なら .claude/skills/adversarial-reviewer/SKILL.md の
+     手順で生成してから転記する (AI 要約への過信を構造的に打ち消す) -->
+
+**推奨**:
+
+| 軸 | 反対理由 (adversarial-reviewer 転記) |
+|---|---|
+| business | |
+| UX | |
+| security | |
+
+### 5. プロダクト実態 (実機 SS + 顧客面の変化)
+
+<!-- PO が「プロダクトで何が起きるか」を読む核。UI 変更なら実機 SS (screenshots branch 参照)、
+     非 UI なら顧客に届く挙動・データ・料金面の変化を具体的に。「変化なし」ならその根拠を書く -->
+
+### 6. PO への判断依頼事項 (1〜3 個)
+
+<!-- Yes/No で答えられる形に絞る。例: 「この migration を本番適用してよいか (Yes/No)」 -->
+
+1.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,9 +1,47 @@
 ---
 name: PR Review
-description: Use when reviewing a pull request. Enforces the mandatory 9-point checklist (file existence, dependencies, AC verification, E2E, lateral spread, CSS, design docs, documentation, recent-deploy deletion guard).
+description: Use when reviewing a pull request. Enforces Step 0 PO-decision triage (po-decision:required label for high-risk irreversible paths, #3862) plus the mandatory 9-point checklist (file existence, dependencies, AC verification, E2E, lateral spread, CSS, design docs, documentation, recent-deploy deletion guard).
 ---
 
 # PR レビューチェックリスト
+
+## Step 0: PO 決裁 triage（#3862、高リスク・不可逆変更の機械判定）
+
+A〜I のレビューに入る前に、本 PR が **PO 決裁対象か** を判定する。AI は triage + ブリーフ生成のみを担い、**判断と実態把握は PO が握る**（automation complacency / rubber-stamping への構造的対処）。
+
+### 0-1. パス判定マップ（機械層）
+
+**SSOT = `.github/labeler.yml` の `po-decision:required` エントリ**。`actions/labeler@v6`（`.github/workflows/labeler.yml`）が PR opened / synchronize で自動付与する。領域一覧（glob 実体は labeler.yml 参照）:
+
+| 領域 | 代表パス |
+|---|---|
+| DB スキーマ / migration | `src/lib/server/db/schema.ts` / `src/lib/server/db/dsql/schema.ts` / `drizzle/**` |
+| Stripe・billing | `src/lib/server/stripe/**` / `src/routes/api/stripe/**` |
+| auth・認可境界 | `src/hooks.server.ts` / `src/lib/policy/**` / `src/lib/server/auth/**` |
+| infra・deploy | `infra/**` / `.github/workflows/deploy*.yml` |
+| DSQL テナント分離（ADR-0063） | `src/lib/server/db/dsql/connection.ts` + tenant-predicate fitness test |
+| retention・PII（ADR-0049） | retention-cleanup / account-deletion / deletion-export service |
+| env（ADR-0006） | `.env.example` / `src/lib/runtime/env.ts` |
+| 価格・プラン文字列（ADR-0045） | `src/lib/domain/terms.ts` / `src/lib/domain/plan-features.ts` |
+| 法務・LP truth（ADR-0013） | `site/{terms,privacy,tokushoho,sla,pricing}.html` / プライシング戦略書 |
+
+回帰固定: `tests/unit/github/po-decision-labeler.test.ts`（高リスク代表パス → label 期待、false negative 0）。glob 追加・変更時は同テストの代表パスも同 PR で更新する。
+
+### 0-2. glob で表現できない triage シグナル（判断層 checklist、PO 決裁 2026-07-19 追加軸込み）
+
+パス非該当でも、以下に 1 つでも該当すれば `gh pr edit <N> --add-label "po-decision:required"` で手動付与する:
+
+- [ ] **運用コスト / 保守コストが増える変更**（定常運用手順の追加・監視対象の増加・手動運転の恒常化）
+- [ ] **新規デザインアーキテクチャパターンの採用**（既存 registry / Strategy / 3 層トークン等に無い新パターン導入）
+- [ ] **技術負債としての積み残しが発生する変更**（暫定実装のまま完了扱い・migration 半端・fallback の恒久化）
+- [ ] 変更ファイル数が大きい（50 file 超、レビュー shallow 化の実証リスク）
+- [ ] 5 年齢モード横断波及（`regression-check` / `impact-analysis` skill 該当）
+- [ ] `priority:critical`（ADR-0002）
+- [ ] ロールバック不能なデータ破壊 / 不可逆 migration を含む
+
+### 0-3. label 付与時の義務
+
+`po-decision:required` の PR は、PR body に **「## PO 決裁ブリーフ」条件付きセクション**（`dev-open-pr` skill の `templates/po-decision-brief.md`、6 項目）を必須添付し、**PO の Yes/No 判断を得てから merge する**（QM / audit-manager 単独で merge しない）。ブリーフ生成手順は [dev-open-pr SKILL.md](../dev-open-pr/SKILL.md) §「PO 決裁ブリーフ」を参照。非該当 PR は通常フロー（A〜I → QM 判定）で進み、抜き取り監査（`docs/sessions/audit-team.md` §3.9）の対象になる。
 
 ## 必須 9 項目（A〜I 全項目）
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -45,3 +45,48 @@
           - "tsconfig.json"
           - "svelte.config.js"
           - "vite.config.ts"
+
+# --- PO 決裁 triage (#3862) ---
+# 高リスク・不可逆パス touch で自動付与。付与された PR は PR body に
+# 「## PO 決裁ブリーフ」条件付きセクション (dev-open-pr skill templates/po-decision-brief.md) が必須。
+# パス判定マップの機械層 SSOT = 本エントリ / 判断層 (glob で表現できないシグナル) =
+# .claude/skills/pr-review/SKILL.md「Step 0: PO 決裁 triage」の checklist。
+# 回帰固定 (false negative 0): tests/unit/github/po-decision-labeler.test.ts
+"po-decision:required":
+  - changed-files:
+      - any-glob-to-any-file:
+          # DB スキーマ / migration (SQLite + DSQL 両系統)
+          - "src/lib/server/db/schema.ts"
+          - "src/lib/server/db/schema-validator.ts"
+          - "src/lib/server/db/dsql/schema.ts"
+          - "drizzle/**"
+          # Stripe・billing
+          - "src/lib/server/stripe/**"
+          - "src/routes/api/stripe/**"
+          # auth・認可境界
+          - "src/hooks.server.ts"
+          - "src/lib/policy/**"
+          - "src/lib/server/auth/**"
+          # infra・deploy
+          - "infra/**"
+          - ".github/workflows/deploy*.yml"
+          # DSQL テナント分離 (ADR-0063 単一強制点 + fitness function 弱体化検知)
+          - "src/lib/server/db/dsql/connection.ts"
+          - "tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts"
+          # retention・PII (ADR-0049)
+          - "src/lib/server/services/retention-cleanup-service.ts"
+          - "src/lib/server/services/account-deletion-service.ts"
+          - "src/lib/server/services/deletion-export-service.ts"
+          # env (必須 env 追加は配布証跡 4 経路が必要、ADR-0006)
+          - ".env.example"
+          - "src/lib/runtime/env.ts"
+          # 価格・プラン文字列 (atom SSOT、ADR-0045)
+          - "src/lib/domain/terms.ts"
+          - "src/lib/domain/plan-features.ts"
+          # 法務・LP truth (ADR-0013)
+          - "site/terms.html"
+          - "site/privacy.html"
+          - "site/tokushoho.html"
+          - "site/sla.html"
+          - "site/pricing.html"
+          - "docs/design/19-プライシング戦略書.md"

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -210,6 +210,17 @@ audit-manager が統合 PR の merge を判定する際に揃えるべき人間�
 - **冗長テスト回避（step 4）**: develop 取込時点で feature PR が追加済みのテストと突合し、同一観点の二重追加を避ける。監査チームが足すのは「統合状態でしか検出できない CUJ 横断テスト」に限る（§3.4 二重判定回避と同型）。
 - **健全性確認（step 9）**: AWS / NUC の health check は deploy-verify skill を再利用する。NUC 版は self-hosted runner（`local_nuc`）経由で実機起動を確認する（§3.7 #5 と対）。NUC 側 health の実体は **NUC staging の post-deploy health**（`deploy-nuc-staging.yml` の `localhost:3100/api/health` 200 + `schema.schemaValid=true` assert、#2872 AC8）、AWS 側 health の実体は **AWS staging の post-deploy health**（`deploy-aws-staging.yml` の `<StagingFunctionUrl>api/health` 200、#2873。DynamoDB backend で lazy migration を呼ばないため schema assert 無し）であり、統合 PR の 1 run で両系統を確認する。各 endpoint / schema 検証は [../../.claude/skills/deploy-verify/SKILL.md](../../.claude/skills/deploy-verify/SKILL.md) §「§3.8 step 9」が SSOT。
 
+### §3.9 非 critical PR サンプリング監査（complacency 対策、#3862）
+
+`po-decision:required` label（[pr-review SKILL.md](../../.claude/skills/pr-review/SKILL.md) §Step 0 の triage）が付かない非 critical PR は、PO 決裁ブリーフを経由せず QM / 監査チームの判定のみで merge される。この経路を放置すると **PO がプロダクトの実態を知る機会を失う** + **AI レビューへの追認（automation complacency / rubber-stamping）が検知不能になる**ため、抜き取り監査を運用に組み込む。
+
+**運用定義**:
+
+1. **抽出**: 統合 PR 監査 run（§3.8）ごとに、含有 feature/fix PR のうち `po-decision:required` 非該当のものから **無作為に 1〜2 件**を audit-manager が抽出する（run 内に非該当 PR が無ければ skip し evidence に明記）。
+2. **提示**: 抽出 PR について audit-manager が「変更概要 / 顧客面の変化（実機挙動）/ AI（QM・監査）の判定結果」を 5 分読了以内の人間可読サマリで PO に提示し、**PO が直接レビュー**する（ブリーフ 6 項目のうち 1 / 5 / 6 相当の縮約版で足りる）。
+3. **complacency 指標**: PO 判定と AI 判定の一致 / 不一致を run ごとに evidence へ記録する。**高一致の継続は good performance ではなく complacency の兆候**として扱う（LLM review 追認バイアスの実証研究、#3862 deep research）。不一致 0 が続く場合は「AI が正しい」と結論せず、(a) 抽出件数を増やす、(b) triage パス表（`.github/labeler.yml` `po-decision:required`）と Step 0-2 判断層 checklist を見直す、のいずれかを実施する。
+4. **不一致時**: PO 指摘は §3.6 の起票/棄却 flow に乗せる。triage の false negative（本来 `po-decision:required` であるべきだった）と判明した場合は、labeler glob + `tests/unit/github/po-decision-labeler.test.ts` の代表パスを同一 PR で追加し class を lock する（ADR-0061 原則 2）。
+
 ## §4 関連参照
 
 | 参照先 | 役割 |

--- a/tests/unit/github/po-decision-labeler.test.ts
+++ b/tests/unit/github/po-decision-labeler.test.ts
@@ -1,0 +1,133 @@
+/**
+ * po-decision:required labeler config 回帰固定 (#3862 Phase 1)
+ *
+ * `.github/labeler.yml` の `po-decision:required` エントリ (PO 決裁 triage の
+ * パス判定マップ機械層 SSOT) に対し、高リスク・不可逆パスの代表ファイルが
+ * 必ず label 付与対象になること (false negative 0) を回帰固定する。
+ *
+ * - matcher は actions/labeler@v6 と同じ minimatch (dot: true) を使用
+ *   (https://github.com/actions/labeler — any-glob-to-any-file の実装準拠)
+ * - 判断層 (glob で表現できない triage シグナル) は
+ *   .claude/skills/pr-review/SKILL.md「Step 0: PO 決裁 triage」の checklist が SSOT
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { minimatch } from 'minimatch';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const LABEL = 'po-decision:required';
+
+interface LabelerEntry {
+	'changed-files'?: Array<{ 'any-glob-to-any-file'?: string[] }>;
+}
+
+const labelerPath = resolve(__dirname, '../../../.github/labeler.yml');
+const config = parse(readFileSync(labelerPath, 'utf-8')) as Record<string, LabelerEntry[]>;
+
+function extractGlobs(label: string): string[] {
+	const entries = config[label];
+	if (!entries) return [];
+	return entries.flatMap((entry) =>
+		(entry['changed-files'] ?? []).flatMap((cf) => cf['any-glob-to-any-file'] ?? []),
+	);
+}
+
+/** actions/labeler v6 と同一挙動 (minimatch, dot: true) でいずれかの glob に一致するか */
+function matchesAnyGlob(filePath: string, globs: string[]): boolean {
+	return globs.some((glob) => minimatch(filePath, glob, { dot: true }));
+}
+
+/**
+ * 高リスク・不可逆パスの代表ファイル (各領域 1 件以上)。
+ * ここに列挙したパスが 1 件でも label 対象から外れたら triage の false negative =
+ * PO 決裁を経ずに不可逆変更が merge され得るため、テストで hard-fail させる。
+ */
+const HIGH_RISK_REPRESENTATIVES: Array<{ area: string; file: string }> = [
+	{ area: 'DB スキーマ (SQLite)', file: 'src/lib/server/db/schema.ts' },
+	{ area: 'DB スキーマ (DSQL)', file: 'src/lib/server/db/dsql/schema.ts' },
+	{ area: 'DB migration', file: 'drizzle/pglite/0000_pretty_wolfsbane.sql' },
+	{ area: 'Stripe・billing (server)', file: 'src/lib/server/stripe/client.ts' },
+	{ area: 'Stripe・billing (webhook route)', file: 'src/routes/api/stripe/webhook/+server.ts' },
+	{ area: 'auth 認可境界 (hooks)', file: 'src/hooks.server.ts' },
+	{ area: 'auth 認可境界 (policy)', file: 'src/lib/policy/capabilities.ts' },
+	{ area: 'auth 認可境界 (server/auth)', file: 'src/lib/server/auth/authorization.ts' },
+	{ area: 'infra (CDK)', file: 'infra/lib/compute-stack.ts' },
+	{ area: 'deploy workflow', file: '.github/workflows/deploy.yml' },
+	{ area: 'deploy workflow (NUC)', file: '.github/workflows/deploy-nuc.yml' },
+	{ area: 'DSQL テナント分離 (強制点)', file: 'src/lib/server/db/dsql/connection.ts' },
+	{
+		area: 'DSQL テナント分離 (fitness)',
+		file: 'tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts',
+	},
+	{ area: 'retention', file: 'src/lib/server/services/retention-cleanup-service.ts' },
+	{ area: 'PII (アカウント削除)', file: 'src/lib/server/services/account-deletion-service.ts' },
+	{ area: 'PII (削除エクスポート)', file: 'src/lib/server/services/deletion-export-service.ts' },
+	{ area: 'env', file: '.env.example' },
+	{ area: 'env (runtime)', file: 'src/lib/runtime/env.ts' },
+	{ area: '価格・プラン文字列 (atom)', file: 'src/lib/domain/terms.ts' },
+	{ area: '価格・プラン文字列 (plan)', file: 'src/lib/domain/plan-features.ts' },
+	{ area: '法務 (利用規約)', file: 'site/terms.html' },
+	{ area: '法務 (プライバシー)', file: 'site/privacy.html' },
+	{ area: '法務 (特商法)', file: 'site/tokushoho.html' },
+	{ area: '法務 (SLA)', file: 'site/sla.html' },
+	{ area: 'LP truth (価格ページ)', file: 'site/pricing.html' },
+	{ area: 'LP truth (プライシング戦略)', file: 'docs/design/19-プライシング戦略書.md' },
+];
+
+/**
+ * 低リスク代表 (label が付かないこと)。false positive を無制限に許すと
+ * PO の判断キューが飽和し triage 自体が形骸化するため、日常変更の代表点で sanity 固定する。
+ */
+const LOW_RISK_REPRESENTATIVES: string[] = [
+	'src/routes/(child)/[uiMode=uiMode]/home/+page.svelte',
+	'src/lib/ui/primitives/Button.svelte',
+	'src/lib/domain/labels.ts',
+	'tests/e2e/admin-add-path-isomorphism.spec.ts',
+	'docs/DESIGN.md',
+	'site/index.html',
+	'.github/workflows/ci.yml',
+];
+
+describe('po-decision:required labeler config (#3862)', () => {
+	const globs = extractGlobs(LABEL);
+
+	it(`labeler.yml に ${LABEL} エントリが存在し glob が 1 件以上定義されている`, () => {
+		expect(config[LABEL], `${LABEL} エントリが .github/labeler.yml に存在すること`).toBeDefined();
+		expect(globs.length).toBeGreaterThan(0);
+	});
+
+	describe('高リスク代表パスは必ず label 対象 (false negative 0)', () => {
+		for (const { area, file } of HIGH_RISK_REPRESENTATIVES) {
+			it(`${area}: ${file}`, () => {
+				expect(
+					matchesAnyGlob(file, globs),
+					`${file} が ${LABEL} の glob に一致しない (false negative)。` +
+						'.github/labeler.yml の該当領域 glob を修正すること',
+				).toBe(true);
+			});
+		}
+	});
+
+	describe('低リスク代表パスは label 対象外 (triage 形骸化防止 sanity)', () => {
+		for (const file of LOW_RISK_REPRESENTATIVES) {
+			it(file, () => {
+				expect(
+					matchesAnyGlob(file, globs),
+					`${file} が ${LABEL} に誤一致 (false positive)。glob が広すぎないか確認すること`,
+				).toBe(false);
+			});
+		}
+	});
+
+	it('高リスク代表パスは実ファイルとして存在する (glob と repo 実体の drift 防止)', () => {
+		for (const { file } of HIGH_RISK_REPRESENTATIVES) {
+			// drizzle migration はファイル名が生成順で変わるため directory 存在で代替
+			const target = file.startsWith('drizzle/') ? 'drizzle' : file;
+			expect(
+				existsSync(resolve(__dirname, '../../../', target)),
+				`${target} が repo に存在すること`,
+			).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 (PO) / システム全体 (品質プロセス)

**解決する課題**: PO 判断が必要な高リスク・不可逆変更 (DB スキーマ / 課金 / 認可境界 / 法務等) の検出が AI の ad-hoc 判断に依存し、(a) 体系性がなく抜け漏れる、(b) レビューを AI に委ねると PO がプロダクトの実態を知る機会を失う、という 2 つの構造課題があった。

**期待される効果**: 高リスクパス touch で `po-decision:required` label が機械付与され、該当 PR には ADR 型 1 ページの PO 決裁ブリーフ (実機 SS + 顧客面変化 + 反対理由 3 つ + Yes/No 判断依頼) が添付される。判断と実態把握は PO が握り、AI は triage + ブリーフ生成のみを担う。非 critical PR も抜き取り監査 + complacency 指標で rubber-stamping を検知する。顧客 (家族ユーザー) には、不可逆変更が PO 決裁なしで本番に届く事故の予防として間接的に効く。

## 関連 Issue

closes #3862

- PO 決裁: Issue #3862 コメント (2026-07-19、4 点回答 → 承認)
- 関連 ADR: ADR-0002 (critical fix gate) / ADR-0008 (設計ポリシー先行確認) / ADR-0010 (Pre-PMF) / ADR-0056 (adversarial-reviewer) / ADR-0061 (same-class→guard)
- PO 決裁事項 3 に基づき **ADR は起票しない** (SSOT = pr-review / dev-open-pr skill + labeler.yml + audit-team.md)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 高リスクパス touch で PR に `po-decision:required` が自動付与される（false negative ゼロを回帰固定） | `npx vitest run tests/unit/github/po-decision-labeler.test.ts` (高リスク代表 26 パス → label 一致 + 低リスク 7 パス非一致 + 実在 verify、actions/labeler@v6 と同一 minimatch dot:true) | HEAD `0eb3382d` / 35 passed / `.github/labeler.yml` po-decision:required エントリ + 既存 `.github/workflows/labeler.yml` (opened/synchronize) が付与実行。label 実体は `gh label create` 済 (`gh label list --search po-decision` で確認可) |
| AC2 | triage ルールが SSOT 化され、Claude の ad-hoc 判断でなく再現可能 | `.github/labeler.yml` (機械層 SSOT) + `.claude/skills/pr-review/SKILL.md` §Step 0 (判断層 checklist、PO 追加 4 軸込み) | HEAD `0eb3382d` / pr-review SKILL.md L9-L52 に Step 0-1 (パス判定マップ) / 0-2 (glob 非表現シグナル 7 項目) / 0-3 (label 付与時の義務) を SSOT 化 |
| AC3 | PO 決裁ブリーフが critical PR に条件付きで自動生成される（Phase 2） | `.claude/skills/dev-open-pr/templates/po-decision-brief.md` (雛形) + `dev-open-pr/SKILL.md` §「PO 決裁ブリーフ」(生成手順 6 step、triage 該当時のみ append する条件付きセクション) | HEAD `0eb3382d` / 本 PR body 末尾が適用第 1 号 (判断層「運用コスト増」該当で自己付与)。必須 13 セクション外 append のため `check-pr-body.mjs` PASS を維持 (`--kind lp` の LP メトリクス結果と同慣行) |
| AC4 | ブリーフに実機 SS + 顧客面変化 + 反対理由 3 つが必ず含まれる | `grep -n "プロダクト実態\|反対理由" .claude/skills/dev-open-pr/templates/po-decision-brief.md` | HEAD `0eb3382d` / 雛形項目 4 (推奨 + adversarial-reviewer objections 3 軸転記表) + 項目 5 (実機 SS + 顧客面の変化、「変化なし」時は根拠必須) が固定構造。本 PR 末尾ブリーフで実例提示 |
| AC5 | 非 critical PR のサンプリング抜き取り運用が定義される（Phase 3） | `docs/sessions/audit-team.md` §3.9 (抽出 1-2 件 / run + PO 直接レビュー + AI-PO 一致率記録 + 高一致 = complacency 兆候 + false negative 時の class-lock) | HEAD `0eb3382d` / §3.9 追加、`node scripts/check-doc-code-references.mjs` 新規違反なし |

## 変更タイプ

- [x] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: アプリ画面への影響なし。開発プロセスのみ — PR labeler 自動付与 (`actions/labeler@v6` 既存 workflow の config 拡張) / pr-review・dev-open-pr skill / audit-team 運用定義。

**再利用 vs 自作 (PO 決裁事項 1「自作最小化」)**:

| 区分 | 内容 |
|---|---|
| 再利用 (OSS / 既存資産) | `actions/labeler@v6` (label 自動付与、新規 script ゼロ) / `adversarial-reviewer` skill (反対理由 3 つの生成・schema は既存 ADR-0056 資産を転記参照) / `pr-review`・`dev-open-pr` skill (拡張のみ) / `audit-team.md` §3.6/§3.8 flow (§3.9 を接続) / minimatch + yaml (labeler 実装と同系 matcher、`scripts/check-dependabot-target-branch.mjs` の yaml parse 前例踏襲) |
| open skills 調査 | anthropics/skills (公開 Agent Skills カタログ) は document/creative/技術 skill 群で PR risk-triage / PO 決裁ブリーフ用途の skill は非存在。anthropics/defending-code-reference-harness はセキュリティ脅威モデリング・脆弱性 triage 特化で本課題 (プロダクト意思決定 triage) と不一致 → Issue 本文 deep research 2 回の「productized 資産は非存在に近い」結論を再確認 |
| 自作最小部分 | labeler.yml の 1 エントリ (glob 26 本) / brief 雛形 1 file / 回帰固定 unit test 1 file / skill・docs 追記 3 file |

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要を以下に記載:
  - `tests/unit/github/po-decision-labeler.test.ts` (新規): 高リスク代表 26 パス → `po-decision:required` glob 一致 (false negative 0) / 低リスク代表 7 パス → 非一致 (triage 形骸化防止) / 代表パスの repo 実在 verify (glob と実体の drift 防止)。35 tests passed
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（理由）**: 本 PR はアプリ UI を変更しない (labeler config / skill SSOT / docs 運用定義のみ)。実行画面を持たないため SS 4 スロットは対象外。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: triage の機械層 (labeler.yml) と判断層 (skill checklist) を責務分離。ブリーフ雛形は dev-open-pr 既存 template 機構に追加
- [x] **DRY**: 高リスクパス glob は labeler.yml の 1 箇所が SSOT、skill 側は領域名 + 代表パスのみ掲示 (glob 実体を複製しない)。`grep -rn "po-decision" .github/ .claude/ docs/ tests/` で二重定義なしを確認
- [x] **YAGNI**: 新規 script / workflow / 外部ツールゼロ。Issue 本文比較表 (crit.md / SaaS bot / merge-queue 不採用) + PO 決裁準拠
- [x] **Security（OSS 公開前提）**: 秘密情報 hardcode なし。外部コード送信ゼロ (privacy 要件、設計原則 2)
- [x] **アクセシビリティ**: N/A (UI なし)
- [x] **パフォーマンス**: N/A (labeler は既存 workflow の config 拡張、実行コスト増ほぼゼロ)

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外 (アプリ本体 / デモ / LP / 年齢モード / ナビ / DB に非接触)
- [x] 設計書同期 (ADR-0001): 運用定義は `docs/sessions/audit-team.md` §3.9 に同期済。docs/CLAUDE.md 更新ルール表の設計書種別 (API / DB / UI 等) には非該当

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- 高リスクパス glob (labeler.yml の 9 領域 26 本) の過不足。特に false positive 側 (`infra/**` / `src/lib/server/auth/**` は変更頻度が高く PO 判断キューを飽和させないか) は §3.9 サンプリング監査の一致率記録で運用調整する前提
- 本 PR 末尾の「PO 決裁ブリーフ」が適用第 1 号。様式の可読性 (5 分読了) を PO 視点で確認いただきたい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A (UI 変更なし)
- [x] 認証画面変更時: N/A (認証画面変更なし)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

## PO 決裁ブリーフ (po-decision:required)

本 PR は機械層 glob 非該当だが、判断層 checklist (pr-review skill §Step 0-2) の「運用コスト / 保守コストが増える変更」(PO 決裁ブリーフ + サンプリング監査という新運用の導入) に該当するため、**適用第 1 号**として本セクションを添付し label を自己付与した。

### 1. リスク分類

可逆 (プロセス定義のみ、データ / 顧客面のコード変更ゼロ)。影響面 = 開発運用 (PR triage / PO の判断キュー)。方向・様式・Phase 分割は Issue #3862 で PO 決裁済 (2026-07-19)。

### 2. ロールバック可否 / データ破壊の有無

revert PR 1 本で全戻し可能。データ破壊なし。label 実体 (`po-decision:required`) は revert 後も残るが無害 (未参照 label)。

### 3. trade-off (Pre-PMF スコープ判断、ADR-0010)

得るもの: triage の再現性 (ad-hoc 判断依存の解消) + PO のプロダクト実態把握機会の構造的確保。失うもの: 高リスク PR 1 件あたりブリーフ作成コスト (Dev Agent 側) + PO の読了 5 分。Bucket A (既存 skill / label 機構の拡張、外部送信ゼロ、新規重量ツールなし)。新規アーキテクチャパターン採用なし・技術負債積み残しなし (PO 追加軸で自己確認)。

### 4. 推奨 + 反対理由 3 つ

**推奨**: merge を推奨 (PO 決裁済みの設計を決裁条件通りに実装、検証 green)。

| 軸 | 反対理由 (adversarial-reviewer 3 軸様式で自己生成。merge 時は ADR-0056 hook により QM が evidence JSON を正規生成) |
|---|---|
| business | 高リスク glob が広め (`infra/**` / `src/lib/server/auth/**` 全体) のため、該当 PR が多発すると PO 判断キューが飽和し、本来止めるべき不可逆変更の判断が遅延・流し読みされる逆効果が起こり得る。§3.9 の一致率記録で glob 粒度を運用調整する必要がある |
| UX | ブリーフは Dev Agent が生成するため、項目 5「プロダクト実態」が「テスト green の羅列」に形骸化すると PO の実態把握という本来目的 ((b) 対策の核) が失われる。雛形コメントで抑止しているが、様式形骸化の検知は §3.9 サンプリングと PO 自身の差し戻しに依存する |
| security | 判断層 checklist (運用コスト増等) は機械強制されないため、Dev Agent が該当を自己申告しない false negative が残る。機械層 glob 非該当 × 判断層該当の変更 (本 PR がまさにその型) は unit test で回帰固定できず、§3.9 false negative 検出 → labeler glob + 代表パス追加の class-lock (ADR-0061) が唯一の是正経路になる |

### 5. プロダクト実態 (実機 SS + 顧客面の変化)

顧客に届く画面・挙動・料金の変化なし (アプリコード非接触、`src/` 差分ゼロ)。変化するのは開発プロセスのみ: 今後、高リスクパスを touch する PR には GitHub 上で `po-decision:required` label が自動付与され、PR body 末尾に本セクションと同型のブリーフが付く。PO は GitHub の label フィルタ (`label:po-decision:required`) で決裁待ち PR を一望できる。

### 6. PO への判断依頼事項 (1〜3 個)

1. 本 PR の内容 (glob 9 領域 / ブリーフ 6 項目様式 / §3.9 サンプリング運用) で triage 運用を開始してよいか (Yes/No)。glob 粒度の調整要望があれば labeler.yml の該当領域を指示ください
