### PR TITLE
fix(devinfra): #3921 obsolete な #3702 pre-cutover DynamoDB backup step を撤去 (staging+本番、第17回リリース blocker 根治)

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -212,28 +212,9 @@ jobs:
       # DP=false (staging は捨てて作り直す前提)。cluster は scale-to-zero + 無料枠内 (¥0 圏)。
       # bin/app.ts は本番 stack 群を無条件 instantiate するため、DsqlStaging のみの deploy でも
       # synth には compute-stack の必須 context (opsSecretKey 等) が要る (cycle 1 の学び)。
-      # #3702 rehearsal: 本番 deploy.yml Phase 2.9 相当の cutover 前 DynamoDB backup を staging で検証。
-      # staging table (ganbari-quest-staging) は空でも create-backup の動作 (fail-closed 含む) を確認する。
-      - name: Pre-cutover DynamoDB backup (staging rehearsal, fail-closed #3702)
-        if: env.DSQL_LANE == 'true'
-        run: |
-          BACKUP_NAME="staging-pre-cutover-$(date -u +%Y%m%d-%H%M%S)"
-          ARN=$(aws dynamodb create-backup --table-name "$ECR_REPOSITORY" --backup-name "$BACKUP_NAME" \
-            --region "$AWS_REGION" --query 'BackupDetails.BackupArn' --output text)
-          echo "::notice::staging DynamoDB backup: $BACKUP_NAME ($ARN)"
-          ST=""
-          for i in $(seq 1 30); do
-            ST=$(aws dynamodb describe-backup --backup-arn "$ARN" --region "$AWS_REGION" \
-              --query 'BackupDescription.BackupDetails.BackupStatus' --output text)
-            echo "backup status: $ST"
-            [ "$ST" = "AVAILABLE" ] && break
-            sleep 5
-          done
-          if [ "$ST" != "AVAILABLE" ]; then
-            echo "::error::staging DynamoDB backup が AVAILABLE になりませんでした"
-            exit 1
-          fi
-
+      # 旧 #3702 の cutover 前 DynamoDB backup rehearsal step は、cutover 完遂 + DynamoDB
+      # 撤去 (#3438 Deploy-2) で対象 table が消滅し obsolete 化したため撤去 (#3921。
+      # TableNotFound で lane が赤化した第17回リリース blocker の根治)。
       - name: Deploy DSQL staging cluster (dsql lane)
         if: env.DSQL_LANE == 'true'
         working-directory: infra/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,28 +228,11 @@ jobs:
           fi
           # Note: Cost Anomaly Monitoring はデフォルトモニターを使用（CDK管理外）
 
-      # Phase 2.9 (EPIC #3424 M5 本番 cutover / #3702): cutover 前 DynamoDB backup + DSQL cluster/schema。
-      # deploy-aws-staging.yml の dsql lane を本番へ移植。backup fail-closed → cluster deploy → schema migrate。
+      # Phase 2.9 (EPIC #3424 M5 本番 cutover): DSQL cluster/schema の deploy + migrate。
       # 本番は cutover 恒久化のため常時 DSQL (staging の workflow_dispatch opt-in と異なり常時実行)。
-      # DynamoDB データは PO 合意でデータ移行不要 (zero users) だが、#2510 教訓で backup-first 厳守。
-      - name: Pre-cutover DynamoDB backup (fail-closed, #3702)
-        run: |
-          BACKUP_NAME="pre-dsql-cutover-$(date -u +%Y%m%d-%H%M%S)"
-          ARN=$(aws dynamodb create-backup --table-name "$ECR_REPOSITORY" --backup-name "$BACKUP_NAME" \
-            --region "$AWS_REGION" --query 'BackupDetails.BackupArn' --output text)
-          echo "::notice::DynamoDB backup 作成: $BACKUP_NAME ($ARN)"
-          ST=""
-          for i in $(seq 1 30); do
-            ST=$(aws dynamodb describe-backup --backup-arn "$ARN" --region "$AWS_REGION" \
-              --query 'BackupDescription.BackupDetails.BackupStatus' --output text)
-            echo "backup status: $ST"
-            [ "$ST" = "AVAILABLE" ] && break
-            sleep 5
-          done
-          if [ "$ST" != "AVAILABLE" ]; then
-            echo "::error::DynamoDB backup が AVAILABLE になりませんでした (cutover 中止)"
-            exit 1
-          fi
+      # 旧 #3702 の cutover 前 DynamoDB backup step (fail-closed) は、cutover 完遂 + DynamoDB
+      # 撤去 (#3438 Deploy-2) で対象 table が消滅し obsolete 化したため撤去 (#3921。撤去後の
+      # 初回 deploy で TableNotFound により本番 deploy が停止する class の根治)。
 
       # DSQL cluster を deploy (GanbariQuestDsql, DP=true)。bin/app.ts は本番 stack 群を無条件 synth
       # するため、cluster のみの deploy でも Phase 3 と同じ全 context が synth に要る。
@@ -585,7 +568,7 @@ jobs:
           aws lambda list-functions --query 'Functions[?starts_with(FunctionName,`ganbari`)].{Name:FunctionName,Memory:MemorySize,Timeout:Timeout}' --output table
 
           echo ""
-          echo "=== DynamoDB Tables (expected: 1) ==="
+          echo "=== DynamoDB Tables (#3438 で CDK 撤去済。RETAIN-orphan が物理削除まで残存し得るため expected: 0-1) ==="
           aws dynamodb list-tables --query 'TableNames[?contains(@,`ganbari`)]' --output text
 
           echo ""


### PR DESCRIPTION
## 顧客価値・目的

第17回リリースを止めた blocker の根治。cutover 完遂 + DynamoDB MainTable 撤去 (#3438 Deploy-2) により backup 対象 table が消滅したのに、#3702 の「cutover 前 DynamoDB backup」step が無条件実行され `TableNotFoundException` で deploy-aws-staging (required check) を赤化していた。obsolete step を staging + 本番の両 workflow から撤去し、リリースを通せる状態に復旧する。

## 関連 Issue

Closes #3921

- 検出元: 第17回 release (#3919、staging run 30059231641 の実 fail)
- 根本: #3438 Deploy-2 (#3893) の DynamoDB 撤去 / 旧 rehearsal: #3702
- 同系統の学び: #3881 (rollback-orphan)、第16回の DSQL backup 陳腐化

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証 | 状態 |
|---|---|---|---|
| staging の #3702 step 撤去 (TableNotFound 赤化の根治) | `deploy-aws-staging.yml` から `Pre-cutover DynamoDB backup (staging rehearsal)` step + 専用 comment を削除、撤去理由 comment に置換 | YAML parse OK + `rg create-backup` = 0 | ✅ |
| 本番 deploy.yml の同等 step も撤去 (本番 deploy 前の是正、issue 明記事項) | `deploy.yml` から `Pre-cutover DynamoDB backup (fail-closed, #3702)` step を削除、Phase 2.9 comment を DSQL のみに改稿 | 同上 | ✅ |
| 存在 guard でなく削除を採用 | rehearsal の目的自体が恒久消滅 (cutover 完遂 + table 撤去) のため guard 延命は dead code (ADR-0010 §0 はりぼて回避) | 撤去理由を workflow comment + 本 PR に記録 | ✅ |
| 残存 stale 表示の是正 | deploy 後インベントリの「DynamoDB Tables (expected: 1)」label を「#3438 撤去済、RETAIN-orphan 残存し得るため expected: 0-1」に是正 (読み取り専用表示、挙動不変) | 目視 + YAML parse | ✅ |

## 変更タイプ

- [x] fix（バグ修正 — リリース blocker の根治）
- [x] infra（CI/CD workflow）

## 影響範囲・変更コンポーネント

- `.github/workflows/deploy-aws-staging.yml`: #3702 rehearsal step (22 行) 削除のみ。lane の他 step (DSQL cluster deploy / migrate / health / 並行検証 test #3683) は不変。
- `.github/workflows/deploy.yml`: #3702 本番 step (23 行) 削除 + Phase 2.9 comment 改稿 + インベントリ label 1 行是正。DSQL cluster deploy 以降のフローは不変。
- 残存する `aws backup describe-backup-vault` (#3808 smoke) は **DSQL の AWS Backup** 用で正当 (対象別)。

## テスト & 安全装置セルフチェック

- js-yaml で両 workflow の YAML parse OK。
- `rg "create-backup|describe-backup" 両workflow` = DynamoDB 系 0 件 (残る describe-backup-vault は AWS Backup/DSQL 用で対象外)。
- 削除 step はどちらも「今後成功し得ない」(対象 table 恒久消滅) ため機能喪失なし。fail-closed の保護対象 (cutover 前の DynamoDB データ) 自体が存在しない。
- 実発火検証は次の release 統合 lane (advisory→required) で確認される (workflow は PR 上の static 検証のみ可能な性質)。

## スクリーンショット / ビジュアルデモ

N/A (CI workflow のみ)。

## コード品質セルフレビュー (#1481)

- 撤去理由を workflow 内 comment に 3 行で記録 (次の読者が「なぜ backup が無いのか」を追える。経緯 narrative は最小限、issue 番号 pointer)。
- guard 延命案を退けた判断 (issue の 2 案から削除を採用) を AC マップに明記。

## 横展開・影響波及チェック

- **同 class 総ざらい**: 両 workflow の `dynamodb` 残参照を grep → 残るのは deploy 後インベントリの読み取り専用 list-tables のみ (fail しない)。stale label を是正済み。
- **パターンの学び (#3921 記載)**: infra teardown release は「撤去対象 resource に依存する rehearsal/backup step」を陳腐化させる (第16回 DSQL backup / 今回 DynamoDB backup)。staging env-parity (#3412 merged) + 実 lane 発火が検出網。workflow lint での構造検出は #3921 のコメントに shift-left 案として記録済み。

## レビュー依頼事項・破壊的変更

- 破壊的変更なし (削除 step は現状必ず fail する dead path)。
- レビュー観点: ① 本番 deploy.yml 側の削除範囲が Phase 2.9 の DSQL 部分を壊していないか ② 撤去 comment の妥当性。
- **リリース系統への申し送り**: 本 PR merge 後に release/* を cut し直せば staging lane は #3702 step なしで貫通する見込み。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし (削除のみ)。

## Ready for Review チェックリスト

- [x] AC 4 点実装 + YAML parse 検証
- [x] 同 class 残参照の総ざらい (grep 証跡)
- [x] 撤去理由の workflow 内記録
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — workflow static 検証まで Dev 側で完遂、実 lane 発火は次 release 統合で確認。最終承認は QM 責務、ADR-0022）

## QM レビュー結果

(QM 記入欄)
