### PR TITLE
fix(db-migration): #3925 login_bonuses fold migration を fresh-DB-safe 化 (fresh provision 回帰 [PV6] 同梱、第17回リリース blocker 根治)

### DIFF
--- a/drizzle/pglite/0004_drop_login_bonuses.sql
+++ b/drizzle/pglite/0004_drop_login_bonuses.sql
@@ -2,6 +2,20 @@
 -- fold 論理 = domain deriveStreakCounter (最新ログイン日を終端に連続 run を数える) と同一。
 -- gaps-and-islands: 降順 row_number に対し login_date = max_d - (rn-1) を満たす行だけが最新連続 run。
 -- updated_at は run 内の最新 created_at を保全する (lastClaimedAt 表示の連続性)。
+--
+-- fresh-DB-safe guard (#3925): 現 schema は login_bonuses を作らないため、fresh provision
+-- (staging / 新規 NUC / DR 再構築) では fold の SELECT が未作成 table を参照して失敗する。
+-- pure SQL で guard するため空 shell を IF NOT EXISTS で先置きする (既存 DB では no-op、
+-- fresh DB では 0 行 fold の no-op → 末尾 DROP IF EXISTS で shell ごと撤去)。DO ブロックは
+-- DSQL 互換が未確証のため不採用。列は fold クエリが参照する 4 列のみ (旧 0000 定義と同型)。
+CREATE TABLE IF NOT EXISTS "login_bonuses" (
+	"family_id" uuid NOT NULL,
+	"child_id" uuid NOT NULL,
+	"login_date" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "login_bonuses_family_id_child_id_login_date_pk" PRIMARY KEY("family_id","child_id","login_date")
+);
+--> statement-breakpoint
 INSERT INTO "login_streaks" ("family_id", "child_id", "last_login_date", "current_streak", "updated_at")
 SELECT s.family_id, s.child_id, max(s.login_date), count(*)::int, max(s.created_at)
 FROM (
@@ -14,4 +28,4 @@ WHERE s.login_date::date = s.max_d - (s.rn - 1)::int
 GROUP BY s.family_id, s.child_id
 ON CONFLICT (family_id, child_id) DO NOTHING;
 --> statement-breakpoint
-DROP TABLE "login_bonuses" CASCADE;
+DROP TABLE IF EXISTS "login_bonuses" CASCADE;

--- a/tests/unit/db/dsql-migration-provision.test.ts
+++ b/tests/unit/db/dsql-migration-provision.test.ts
@@ -123,4 +123,32 @@ describe('DSQL schema provisioning (#3424 M5 DoD2、provision.ts)', () => {
 			expect(plan.ddl.length, `${file.tag} の ddl が空`).toBeGreaterThan(0);
 		}
 	});
+
+	it('[PV6] fresh provision 回帰 (#3925): 実 migration 全 tag が空 PGlite に journal 順で適用できる (prior state 仮定の混入を検出)', async () => {
+		// fresh staging DSQL / 新規 NUC / DR 再構築の「空 DB に全 migration」path を実 SQL で貫通する。
+		// 0004 の login_bonuses fold が fresh DB で 'table does not exist' となった class
+		// (migration が既存 state を仮定する) を、以後どの migration についても機械検出する。
+		const { PGlite } = await import('@electric-sql/pglite');
+		const client = new PGlite();
+		try {
+			const realDir = resolve(process.cwd(), 'drizzle', 'pglite');
+			for (const file of loadMigrationFiles(realDir)) {
+				const statements = file.sqlText
+					.split('--> statement-breakpoint')
+					.map((s) => s.trim())
+					.filter((s) => s.length > 0);
+				for (const stmt of statements) {
+					await expect(client.exec(stmt), `${file.tag} が fresh DB で失敗`).resolves.toBeDefined();
+				}
+			}
+			// 終端 state: 縮約後 schema (login_streaks あり / login_bonuses なし)
+			const tables = await client.query(
+				`SELECT table_name FROM information_schema.tables
+				 WHERE table_name IN ('login_streaks', 'login_bonuses')`,
+			);
+			expect(tables.rows).toEqual([{ table_name: 'login_streaks' }]);
+		} finally {
+			await client.close();
+		}
+	}, 120_000);
 });

--- a/tests/unit/db/pglite-login-bonus-fold-3330.test.ts
+++ b/tests/unit/db/pglite-login-bonus-fold-3330.test.ts
@@ -118,3 +118,34 @@ describe('pg migration 0004: login_bonuses → login_streaks fold (#3330)', () =
 		expect(tables.rows).toHaveLength(0);
 	});
 });
+
+describe('pg migration 0004: fresh-DB-safe guard (#3925)', () => {
+	it('login_bonuses 未作成の fresh DB でも 0004 全 statement が成功する (staging run 30071244462 の再現封鎖)', async () => {
+		const client = new PGlite();
+		try {
+			// fresh provision 相当: 現 schema は login_bonuses を作らず、0003 で login_streaks のみ存在する
+			await client.exec(`
+				CREATE TABLE "login_streaks" (
+					"family_id" uuid NOT NULL,
+					"child_id" uuid NOT NULL,
+					"last_login_date" text NOT NULL,
+					"current_streak" integer DEFAULT 1 NOT NULL,
+					"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+					CONSTRAINT "login_streaks_family_id_child_id_pk" PRIMARY KEY("family_id","child_id")
+				);
+			`);
+			for (const stmt of loadMigration0004Statements()) {
+				await client.exec(stmt);
+			}
+			// fold は 0 行 no-op、shell も DROP 済で残らない
+			const streaks = await client.query('SELECT count(*)::int AS n FROM login_streaks');
+			expect(streaks.rows).toEqual([{ n: 0 }]);
+			const tables = await client.query(
+				`SELECT table_name FROM information_schema.tables WHERE table_name = 'login_bonuses'`,
+			);
+			expect(tables.rows).toHaveLength(0);
+		} finally {
+			await client.close();
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

第17回リリースの blocker #3 の根治。#3330 の login_bonuses→login_streaks fold migration (`drizzle/pglite/0004`) が **fresh DSQL では存在しない login_bonuses を参照して `table does not exist` で fail** し、deploy-aws-staging「Provision DSQL schema」step を赤化していた (staging run 30071244462)。本番は table 実在で動くが、fresh provision (staging / 新規 NUC / DR 再構築) で必ず壊れる class を封鎖する。

## 関連 Issue

Closes #3925

- fold migration 元: #3330 (counter 縮約、PR #3915) / staging DSQL lane: #3412 / 検出: 第17回 release #3924
- 同 release の兄弟 blocker: #3907 (vault RETAIN) / #3923 (obsolete backup step)

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証 | 状態 |
|---|---|---|---|
| fold を fresh-DB-safe に guard | fold 前に `CREATE TABLE IF NOT EXISTS "login_bonuses"` (4 列空 shell、旧 0000 定義と同型 + 同 PK)。既存 DB = no-op / fresh DB = 0 行 fold の no-op。**pure SQL 採用理由**: issue 提案の `to_regclass` 条件は DO ブロック (PL/pgSQL) が必要で DSQL 互換未確証 (既存 migration に前例ゼロ) のため、確実に動く方式を選択 | fresh path test + 既存 fold test (seed あり) が両方 green | ✅ |
| DROP も IF EXISTS 化 | `DROP TABLE IF EXISTS "login_bonuses" CASCADE` (shell / 旧表とも撤去) | 同上 (fresh path test が DROP 後の不在を assert) | ✅ |
| fitness/test: fresh provision で全 migration が通ることを回帰固定 | ① `pglite-login-bonus-fold-3330.test.ts` に fresh-DB case (login_streaks のみの空 DB で 0004 全 statement 成功 = staging fail の直接再現封鎖) ② `dsql-migration-provision.test.ts` [PV6] = **実 journal 全 tag を空 PGlite に順適用する full replay** (以後どの migration の prior-state 仮定も機械検出、監査所感の shift-left) | `npx vitest run` 対象 2 file **8 test 全 PASS** (41.8s) | ✅ |
| 本番 (適用済 DB) への安全性 | runner (`provision.ts`) は **tag 単位 applied 管理** (hash 照合なし) → 本番は 0004 skip で in-place 修正の再適用なし。仮に再適用されても IF NOT EXISTS + `ON CONFLICT DO NOTHING` + IF EXISTS で冪等 no-op | `dsql-migrate.ts` L12 運用制約コメント + PV3 冪等 test (既存) | ✅ |
| same-class 横展開 (sqlite 側) | `lazy-startup-migrations.ts` L1031 の sqlite fold は `tableExists` guard 済 → 欠落は pg migration のみと確認、追加修正不要 | grep 証跡 (PR 本文) | ✅ |

## 変更タイプ

- [x] fix（バグ修正 — リリース blocker / db-migration）

## 影響範囲・変更コンポーネント

- `drizzle/pglite/0004_drop_login_bonuses.sql`: shell CREATE 追加 + DROP IF EXISTS 化 + guard 理由コメント。fold の gaps-and-islands 論理・期待値は不変（既存 fold 導出 test が無変更で green）
- `tests/unit/db/pglite-login-bonus-fold-3330.test.ts`: fresh-DB describe 追加
- `tests/unit/db/dsql-migration-provision.test.ts`: [PV6] fresh full replay 追加 (timeout 120s、PGlite dynamic import)
- schema.ts / service 層 / 他 migration は不変

## テスト & 安全装置セルフチェック

- `npx vitest run tests/unit/db/pglite-login-bonus-fold-3330.test.ts tests/unit/db/dsql-migration-provision.test.ts` → **2 file / 8 test 全 PASS**（既存 fold 導出 3 family fixture 検証を含む = 既存 DB path の回帰なし）
- biome check 対象 file green
- ADR-0006 整合: guard は「fresh で fold 対象が無い」正当 skip であり assertion 弱体化ではない（既存 DB では従来どおり fold 実行、期待値 test で担保）

## スクリーンショット / ビジュアルデモ

N/A (migration SQL + unit test のみ)。

## コード品質セルフレビュー (#1481)

- guard 方式の選定理由 (DO ブロック不採用 = DSQL 互換未確証) を migration 内コメント + 本 PR に記録
- shell の列は fold クエリ参照 4 列に限定し、旧 0000 定義との同型性をコメントで紐付け

## 横展開・影響波及チェック

- **same-class sweep**: [PV6] が「migration が prior state を仮定する」class 全体を以後 CI で機械検出（0000〜0004 の全 tag で green 確認済）。sqlite lazy fold は guard 済
- **第17回 3 連続 blocker の共通 class** (本番は既存 state で動くが fresh provision で壊れる) に対する恒久検出網が本 PR の [PV6] で unit 層に押し下げられた (ADR-0061 push-down-pyramid)

## レビュー依頼事項・破壊的変更

- 破壊的変更なし（本番 = tag skip で無影響、fresh = fail していた path が通るようになるのみ）
- レビュー観点: ① shell 列型 (`login_date text` / `created_at timestamptz`) が fold クエリの cast (`login_date::date`) / INSERT 先 (`last_login_date text`) と整合するか ② [PV6] の journal 順 replay が provision の実順序と一致するか (`loadMigrationFiles` = journal idx 順、PV1 で担保)
- **リリース系統への申し送り**: 本 PR merge 後の release cut で staging「Provision DSQL schema」が貫通する見込み

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 5 点実装 + unit 8 test 全 PASS
- [x] 既存 DB path (fold 導出期待値) の無回帰確認
- [x] same-class 横展開 (sqlite guard 済) 確認
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — unit 層検証まで完遂、実 staging 発火は次 release lane で確認。最終承認は QM 責務、ADR-0022）

## QM レビュー結果

(QM 記入欄)
