### PR TITLE
fix(db-migration): #3928 DSQL migration を source 順適用に是正 (DDL-first 並び替え廃止 + pipeline 回帰、第17回リリース blocker #4 根治)

### DIFF
--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -15,7 +15,7 @@ description: Use when changing database schema (adding/modifying tables, columns
 - [ ] `tests/e2e/global-setup.ts` — E2E テスト用のシードデータ
 - [ ] `tests/unit/helpers/test-db.ts` — ユニットテスト用のヘルパー
 - [ ] `src/lib/server/demo/demo-data.ts` — デモモード用のサンプルデータ
-- [ ] `src/lib/server/db/types.ts` — 型定義（DynamoDB の場合）
+- [ ] `src/lib/server/db/dsql/schema.ts` — cloud (DSQL) / NUC (PGlite) 共用 pg schema
 - [ ] `docs/design/08-データベース設計書.md` — 設計書
 - [ ] マイグレーションファイル — `npx drizzle-kit generate`
 
@@ -25,11 +25,21 @@ description: Use when changing database schema (adding/modifying tables, columns
 - [ ] backfill UPDATE — 新カラム追加時は既存行のデフォルト値更新を同梱
 - [ ] NOT NULL 制約追加時は先に backfill してから制約追加
 
-### 3. DynamoDB 固有チェック
+### 3. fresh-DB 互換 + cross-backend 3 経路検証（#3925 / #3928、第17回リリース 4 連続 blocker の教訓）
 
-- [ ] PK/SK の設計は `src/lib/server/db/dynamodb/keys.ts` に準拠
-- [ ] GSI の追加は最小限（既存 GSI で対応できないか先に検討）
-- [ ] 新エンティティの ID 採番は `counter.ts` の `nextId()` を使用
+ADR-0031 (既存データ互換) と**対**で必須。migration は「既存 state を持つ本番」だけでなく
+「**空 DB からの全 migration 貫通**」(fresh staging provision / 新規 NUC / DR 再構築) でも成立させる:
+
+- [ ] **fresh-DB 貫通**: 空 DB に全 migration を journal 順で通して成功するか。既存 table / 行の
+      存在を仮定する文 (`SELECT FROM <旧表>` 等) は IF (NOT) EXISTS guard で fresh-safe 化する
+      (`tests/unit/db/dsql-migration-provision.test.ts` [PV6] が機械検出)
+- [ ] **cross-backend 3 経路**: 同一 migration SQL でも実行 semantics が backend で異なる —
+      ① PGlite/NUC = raw SQL 記載順 ② sqlite = lazy-startup (`tableExists` guard) ③ DSQL =
+      `transform.ts` plan 経由 (runner が source 順 statements を per-statement autocommit 適用、#3928)。
+      **片側 (PGlite) の verify だけで Done としない**。順序依存 migration (DDL→DML→DDL 型の
+      fold 等) は transform+runner pipeline test ([PV7]/[PV8]) でも確認する
+- [ ] **不変条件**: 「同一 migration は全 executor で同一終端 schema に到達する」— 逸脱は
+      staging (release gate) でなく unit 層で検出する (ADR-0061 push-down-pyramid)
 
 ### 4. startup migration の fail-fast 落とし穴（#3286 infra-1）
 

--- a/src/lib/server/db/dsql/migration/runner.ts
+++ b/src/lib/server/db/dsql/migration/runner.ts
@@ -9,11 +9,13 @@
 // だけ独自」)。
 //
 // ── 適用順序 (責務 4/6 + ASYNC UNIQUE build 順序、hard 制約) ─────────────────
-//   1. plan.ddl を順に適用。各文は **autocommit (1 DDL/txn)** — txn 一括禁止 (検証 2)。
+//   1. plan.statements を **source 順に** 適用。各文は **autocommit (1 文/txn)** — txn 一括禁止
+//      (検証 2)。DSQL 制約は「同一 txn に複数 DDL / DDL⇄DML を混在させない」であり、per-statement
+//      autocommit で満たされる。旧「DDL 全適用 → DML」並び替えは DDL→DML→DDL 型 migration
+//      (0004 fold) の依存順序を壊し fresh DSQL provision を fail させたため廃止 (#3928)。
 //   2. ASYNC index は「発行前に watermark 捕捉 → CREATE INDEX ASYNC → 今回 build に限定した
 //      sys.jobs status='completed' poll」の順で適用 (検証 3)。
 //      → CREATE TABLE → watermark → ASYNC UNIQUE CREATE → job=completed poll → 書込開放 を保証。
-//   3. 全 DDL 適用後に plan.dml (seed) を **別 txn** で適用 — DDL⇄DML 混在禁止 (検証 2)。
 //
 // ⚠️ executor は **autocommit** であること (drizzle transaction の中で呼ばない)。
 //    複数文を 1 BEGIN で束ねると `multiple ddl` / `ddl and dml` で 0A000 になる (検証 2)。
@@ -66,13 +68,13 @@ export async function applyDsqlMigrationPlan(
 	executor: RawSqlExecutor,
 	opts: ApplyMigrationOptions = {},
 ): Promise<void> {
-	// 1. DDL を autocommit で 1 文ずつ適用 + ASYNC index の後に build 完了 poll。
-	for (const stmt of plan.ddl) {
+	// source 順に autocommit で 1 文ずつ適用 (#3928) + ASYNC index の後に build 完了 poll。
+	for (const stmt of plan.statements) {
 		if (stmt.asyncIndexName) {
 			// 発行**前**に watermark を捕捉し、今回の build (watermark より新しい行) に限定して
 			// poll する (過去 build の completed 行による fail-open を排除、検証 3)。
 			const watermark = await captureIndexBuildWatermark(executor, stmt.asyncIndexName);
-			opts.onStatement?.('ddl', stmt.sql);
+			opts.onStatement?.(stmt.kind, stmt.sql);
 			await executor.execute(stmt.sql);
 			// 書込を開放する前に build=completed を待つ (F3 hard 制約)。失敗/timeout は throw。
 			await pollAsyncIndexBuild(executor, stmt.asyncIndexName, {
@@ -80,14 +82,9 @@ export async function applyDsqlMigrationPlan(
 				afterWatermark: watermark,
 			});
 		} else {
-			opts.onStatement?.('ddl', stmt.sql);
+			opts.onStatement?.(stmt.kind, stmt.sql);
 			await executor.execute(stmt.sql);
 		}
-	}
-	// 2. 全 DDL 完了後に seed(DML) を別 txn で適用 (DDL⇄DML 混在禁止)。
-	for (const stmt of plan.dml) {
-		opts.onStatement?.('dml', stmt.sql);
-		await executor.execute(stmt.sql);
 	}
 }
 

--- a/src/lib/server/db/dsql/migration/transform.ts
+++ b/src/lib/server/db/dsql/migration/transform.ts
@@ -24,7 +24,8 @@
 //   5. SERIAL/SEQUENCE   — SERIAL は reject (UUID PK 前提)。明示 SEQUENCE は CACHE≥65536 or =1 のみ許容。
 //                         (実測: 42704 `type "serial" does not exist` /
 //                          0A000 `CREATE SEQUENCE is not supported without an explicit cache size`)。
-//   6. DDL/DML 分離      — DDL と seed(DML) を別リストへ (runner が別 txn で適用)。
+//   6. DDL/DML 非混在    — 各文を kind (ddl/dml) 付きで source 順 statements に保持し、runner が
+//                         per-statement autocommit で適用 (同一 txn に混在させない、#3928)。
 //                         (実測: 0A000 `ddl and dml are not supported in the same transaction`)。
 
 /** DSQL に適用可能な 1 文の DDL/DML。 */
@@ -38,12 +39,21 @@ export interface DsqlStatement {
 	asyncIndexName?: string;
 }
 
+/** source 順の適用単位。kind は観測 hook / 表示用の分類 (適用 semantics は同一 = autocommit 1 文)。 */
+export interface DsqlPlannedStatement extends DsqlStatement {
+	kind: 'ddl' | 'dml';
+}
+
 /**
  * drizzle-kit 出力 SQL を DSQL 用に変換した適用計画。
- * runner は **ddl を全て適用 (各 autocommit + ASYNC poll) → その後 dml を別 txn で適用**する
- * (責務 4/6、DDL⇄DML 混在禁止)。
+ * runner は **statements を source 順に、各文 autocommit (1 文/txn) で適用**する (#3928)。
+ * DSQL 制約 (責務 4/6) は「同一 txn に複数 DDL / DDL⇄DML を混在させない」であり、per-statement
+ * autocommit で満たされる。旧「DDL 全適用 → DML」の並び替えは DDL→DML→DDL 型 migration
+ * (0004 fold: CREATE shell → INSERT fold → DROP) の依存順序を壊すため廃止した。
+ * ddl / dml は statements から導出される分類 view (dry-run 表示 / ASYNC 集計用)。
  */
 export interface DsqlMigrationPlan {
+	statements: DsqlPlannedStatement[];
 	ddl: DsqlStatement[];
 	dml: DsqlStatement[];
 }
@@ -219,11 +229,13 @@ function transformUniqueAlterToAsyncIndex(stmt: string): DsqlStatement {
  * @throws SERIAL 検出時 / 非準拠 CREATE SEQUENCE 時 / 非 FK・非 UNIQUE の ADD CONSTRAINT ALTER 時。
  */
 export function transformDrizzleSqlToDsql(sqlText: string): DsqlMigrationPlan {
-	const statements = splitStatements(sqlText);
-	const ddl: DsqlStatement[] = [];
-	const dml: DsqlStatement[] = [];
+	const raw = splitStatements(sqlText);
+	const statements: DsqlPlannedStatement[] = [];
+	// source 順を保持したまま分類 view へも積む helper (#3928)。
+	const pushDdl = (s: DsqlStatement) => statements.push({ ...s, kind: 'ddl' });
+	const pushDml = (s: DsqlStatement) => statements.push({ ...s, kind: 'dml' });
 
-	for (const stmt of statements) {
+	for (const stmt of raw) {
 		// ── ALTER TABLE … ADD CONSTRAINT の網羅処理 (責務 1 + fail-close) ──
 		// DSQL は `ALTER TABLE ADD CONSTRAINT` を非対応 (検証 2)。制約種別ごとに:
 		//   FK     → 除去 (app 層 relations() + fitness で整合担保)
@@ -239,7 +251,7 @@ export function transformDrizzleSqlToDsql(sqlText: string): DsqlMigrationPlan {
 				continue; // FK 除去
 			}
 			if (/\bUNIQUE\b/i.test(structural)) {
-				ddl.push(transformUniqueAlterToAsyncIndex(stmt));
+				pushDdl(transformUniqueAlterToAsyncIndex(stmt));
 				continue;
 			}
 			throw new Error(
@@ -252,33 +264,38 @@ export function transformDrizzleSqlToDsql(sqlText: string): DsqlMigrationPlan {
 
 		// 責務 6: DML (seed) は別リストへ。
 		if (startsWith(stmt, 'INSERT') || startsWith(stmt, 'UPDATE') || startsWith(stmt, 'DELETE')) {
-			dml.push({ sql: stmt });
+			pushDml({ sql: stmt });
 			continue;
 		}
 
 		// 責務 2: index は ASYNC 化。
 		if (/^CREATE\s+(?:UNIQUE\s+)?INDEX\b/i.test(stmt.trimStart())) {
-			ddl.push(transformIndex(stmt));
+			pushDdl(transformIndex(stmt));
 			continue;
 		}
 
 		// 責務 5: SEQUENCE は CACHE 準拠を検証。
 		if (startsWith(stmt, 'CREATE\\s+SEQUENCE')) {
 			assertSequenceCacheCompliant(stmt);
-			ddl.push({ sql: stmt });
+			pushDdl({ sql: stmt });
 			continue;
 		}
 
 		// 責務 5 + 1: CREATE TABLE は SERIAL 拒否 + inline/表レベル FK 除去。
 		if (startsWith(stmt, 'CREATE\\s+TABLE')) {
 			assertNoSerial(stmt);
-			ddl.push({ sql: stripForeignKeys(stmt) });
+			pushDdl({ sql: stripForeignKeys(stmt) });
 			continue;
 		}
 
 		// その他 DDL (CREATE TYPE / ALTER TABLE ADD COLUMN 等) はそのまま DDL として保持。
-		ddl.push({ sql: stmt });
+		pushDdl({ sql: stmt });
 	}
 
-	return { ddl, dml };
+	const toView = ({ kind: _kind, ...rest }: DsqlPlannedStatement): DsqlStatement => rest;
+	return {
+		statements,
+		ddl: statements.filter((s) => s.kind === 'ddl').map(toView),
+		dml: statements.filter((s) => s.kind === 'dml').map(toView),
+	};
 }

--- a/tests/unit/db/dsql-migration-provision.test.ts
+++ b/tests/unit/db/dsql-migration-provision.test.ts
@@ -152,3 +152,72 @@ describe('DSQL schema provisioning (#3424 M5 DoD2、provision.ts)', () => {
 		}
 	}, 120_000);
 });
+
+describe('DSQL pipeline fresh provision 回帰 (#3928、transform + runner 実経路)', () => {
+	// #3926 は raw SQL (PGlite/NUC 経路) のみ verify し DSQL 経路 (transform の ddl/dml 分離 +
+	// runner の DDL-first 適用) で fold が並び替えで fail した。本 test は **実 0003+0004 を
+	// transform + runner (dsql-migrate と同一 pipeline) で適用**し、cross-backend 片側 verify の
+	// 再発を封鎖する (0003/0004 は ASYNC index を含まないため PGlite で実行可能)。
+	async function makePipelineExecutor() {
+		const { PGlite } = await import('@electric-sql/pglite');
+		const client = new PGlite();
+		const executor = {
+			execute: async (sqlText: string) => {
+				const res = await client.query(sqlText);
+				return { rows: res.rows as unknown[] };
+			},
+		};
+		return { client, executor };
+	}
+
+	function loadRealTagSql(tag: '0003' | '0004'): string {
+		const realDir = resolve(process.cwd(), 'drizzle', 'pglite');
+		const file = loadMigrationFiles(realDir).find((f) => f.tag.startsWith(tag));
+		if (!file) throw new Error(`tag ${tag} not found`);
+		return file.sqlText;
+	}
+
+	it('[PV7] fresh DB: 実 0003→0004 が runner 経由で成功する (staging run 30079522945 の再現封鎖)', async () => {
+		const { runDsqlMigration } = await import('../../../src/lib/server/db/dsql/migration/runner');
+		const { client, executor } = await makePipelineExecutor();
+		try {
+			await runDsqlMigration(loadRealTagSql('0003'), executor);
+			await runDsqlMigration(loadRealTagSql('0004'), executor);
+			const tables = await client.query(
+				`SELECT table_name FROM information_schema.tables
+				 WHERE table_name IN ('login_streaks', 'login_bonuses')`,
+			);
+			expect(tables.rows).toEqual([{ table_name: 'login_streaks' }]);
+		} finally {
+			await client.close();
+		}
+	}, 60_000);
+
+	it('[PV8] 既存 DB: seed 済 login_bonuses が runner 経由の 0004 で fold されてから DROP される (本番 data 保全)', async () => {
+		const { runDsqlMigration } = await import('../../../src/lib/server/db/dsql/migration/runner');
+		const { client, executor } = await makePipelineExecutor();
+		try {
+			await runDsqlMigration(loadRealTagSql('0003'), executor);
+			// 旧 login_bonuses (0000 時点 DDL の要点列) + 3 連続日 seed
+			await client.exec(`
+				CREATE TABLE "login_bonuses" (
+					"family_id" uuid NOT NULL,
+					"child_id" uuid NOT NULL,
+					"login_date" text NOT NULL,
+					"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+					CONSTRAINT "lb_pk" PRIMARY KEY("family_id","child_id","login_date")
+				);
+				INSERT INTO login_bonuses (family_id, child_id, login_date) VALUES
+					('00000000-0000-4000-8000-0000000000f1', '00000000-0000-4000-8000-0000000000c1', '2026-07-21'),
+					('00000000-0000-4000-8000-0000000000f1', '00000000-0000-4000-8000-0000000000c1', '2026-07-22'),
+					('00000000-0000-4000-8000-0000000000f1', '00000000-0000-4000-8000-0000000000c1', '2026-07-23');
+			`);
+			await runDsqlMigration(loadRealTagSql('0004'), executor);
+			// 旧実装 (DDL-first) は DROP が fold より先に走り data 喪失 or fail していた。
+			const res = await client.query('SELECT last_login_date, current_streak FROM login_streaks');
+			expect(res.rows).toEqual([{ last_login_date: '2026-07-23', current_streak: 3 }]);
+		} finally {
+			await client.close();
+		}
+	}, 60_000);
+});

--- a/tests/unit/db/dsql-migration-runner.test.ts
+++ b/tests/unit/db/dsql-migration-runner.test.ts
@@ -3,20 +3,32 @@
 // 設計 SSOT: docs/design/dsql/m4-implementation-plan.md §3.2 (F2/F3)
 //
 // mock executor で適用順序 (責務 4/6 + ASYNC UNIQUE build 順序 hard 制約) を検証:
-//   - 各 DDL を **1 文ずつ autocommit で適用** (txn 一括しない)。
+//   - 各文を **source 順に 1 文ずつ autocommit で適用** (txn 一括しない、#3928)。
 //   - ASYNC index の直後に poll (completed になるまで書込を開放しない)。
-//   - 全 DDL 完了後に DML(seed) を適用 (DDL⇄DML 分離)。
+//   - DDL→DML→DDL 型 (0004 fold) でも source 順が保持される (#3928 回帰)。
 //   - index build failed で runner が throw し以降を止める。
 
 import { describe, expect, it } from 'vitest';
 import {
 	applyDsqlMigrationPlan,
 	createDrizzleRawExecutor,
+	type DsqlMigrationPlan,
 	type RawSqlExecutor,
 	runDsqlMigration,
 } from '../../../src/lib/server/db/dsql/migration/runner';
+import type { DsqlPlannedStatement } from '../../../src/lib/server/db/dsql/migration/transform';
 
 const BP = '--> statement-breakpoint';
+
+/** source 順 statements から plan を組む test helper (ddl/dml view は transform と同じ導出)。 */
+function makePlan(statements: DsqlPlannedStatement[]): DsqlMigrationPlan {
+	const toView = ({ kind: _kind, ...rest }: DsqlPlannedStatement) => rest;
+	return {
+		statements,
+		ddl: statements.filter((s) => s.kind === 'ddl').map(toView),
+		dml: statements.filter((s) => s.kind === 'dml').map(toView),
+	};
+}
 
 /**
  * 適用文 / watermark 捕捉 / sys.jobs poll を記録する mock。
@@ -57,16 +69,15 @@ describe('applyDsqlMigrationPlan — 適用順序', () => {
 	it('DDL を 1 文ずつ適用し、ASYNC index の後に poll、その後 DML を適用する', async () => {
 		const exec = recordingExecutor();
 		await applyDsqlMigrationPlan(
-			{
-				ddl: [
-					{ sql: 'CREATE TABLE "members" (...)' },
-					{
-						sql: 'CREATE UNIQUE INDEX ASYNC "members_uq" ON "members" ("a")',
-						asyncIndexName: 'members_uq',
-					},
-				],
-				dml: [{ sql: 'INSERT INTO "members" VALUES (1)' }],
-			},
+			makePlan([
+				{ sql: 'CREATE TABLE "members" (...)', kind: 'ddl' },
+				{
+					sql: 'CREATE UNIQUE INDEX ASYNC "members_uq" ON "members" ("a")',
+					asyncIndexName: 'members_uq',
+					kind: 'ddl',
+				},
+				{ sql: 'INSERT INTO "members" VALUES (1)', kind: 'dml' },
+			]),
 			exec,
 		);
 		// 適用は「CREATE TABLE → CREATE INDEX ASYNC → INSERT」の順 (sys.jobs poll は applied に混ざらない)。
@@ -85,13 +96,15 @@ describe('applyDsqlMigrationPlan — 適用順序', () => {
 		const exec = recordingExecutor({ bad_uq: 'failed' });
 		await expect(
 			applyDsqlMigrationPlan(
-				{
-					ddl: [
-						{ sql: 'CREATE TABLE "t" (...)' },
-						{ sql: 'CREATE UNIQUE INDEX ASYNC "bad_uq" ON "t" ("a")', asyncIndexName: 'bad_uq' },
-					],
-					dml: [{ sql: 'INSERT INTO "t" VALUES (1)' }],
-				},
+				makePlan([
+					{ sql: 'CREATE TABLE "t" (...)', kind: 'ddl' },
+					{
+						sql: 'CREATE UNIQUE INDEX ASYNC "bad_uq" ON "t" ("a")',
+						asyncIndexName: 'bad_uq',
+						kind: 'ddl',
+					},
+					{ sql: 'INSERT INTO "t" VALUES (1)', kind: 'dml' },
+				]),
 				exec,
 				{ sleep: async () => {} },
 			),
@@ -108,13 +121,34 @@ describe('applyDsqlMigrationPlan — 適用順序', () => {
 		const exec = recordingExecutor();
 		const seen: Array<[string, string]> = [];
 		await applyDsqlMigrationPlan(
-			{ ddl: [{ sql: 'CREATE TABLE "t" (...)' }], dml: [{ sql: 'INSERT INTO "t" VALUES (1)' }] },
+			makePlan([
+				{ sql: 'CREATE TABLE "t" (...)', kind: 'ddl' },
+				{ sql: 'INSERT INTO "t" VALUES (1)', kind: 'dml' },
+			]),
 			exec,
 			{ onStatement: (phase, s) => seen.push([phase, s]) },
 		);
 		expect(seen).toEqual([
 			['ddl', 'CREATE TABLE "t" (...)'],
 			['dml', 'INSERT INTO "t" VALUES (1)'],
+		]);
+	});
+
+	it('DDL→DML→DDL 型 (0004 fold 同型) を source 順のまま適用する (#3928 回帰: DDL-first 並び替え禁止)', async () => {
+		const exec = recordingExecutor();
+		await applyDsqlMigrationPlan(
+			makePlan([
+				{ sql: 'CREATE TABLE IF NOT EXISTS "old" (...)', kind: 'ddl' },
+				{ sql: 'INSERT INTO "new" SELECT * FROM "old"', kind: 'dml' },
+				{ sql: 'DROP TABLE IF EXISTS "old" CASCADE', kind: 'ddl' },
+			]),
+			exec,
+		);
+		// 旧実装は DDL-first で「CREATE → DROP → INSERT」となり fold が relation 不在で fail した。
+		expect(exec.applied).toEqual([
+			'CREATE TABLE IF NOT EXISTS "old" (...)',
+			'INSERT INTO "new" SELECT * FROM "old"',
+			'DROP TABLE IF EXISTS "old" CASCADE',
 		]);
 	});
 });

--- a/tests/unit/db/dsql-migration-transform.test.ts
+++ b/tests/unit/db/dsql-migration-transform.test.ts
@@ -264,3 +264,22 @@ describe('transformDrizzleSqlToDsql — 変換後 DDL が Postgres valid (PGlite
 		expect(idx.rows[0]?.n).toBe(2);
 	});
 });
+
+describe('transformDrizzleSqlToDsql — source 順 statements (#3928)', () => {
+	it('DDL→DML→DDL 混在入力の source 順を statements が保持する (ddl/dml は導出 view)', () => {
+		const input = [
+			'CREATE TABLE IF NOT EXISTS "old_t" ("id" uuid PRIMARY KEY NOT NULL)',
+			'INSERT INTO "new_t" SELECT * FROM "old_t"',
+			'DROP TABLE IF EXISTS "old_t" CASCADE',
+		].join(`;\n${BP}\n`);
+		const plan = transformDrizzleSqlToDsql(input);
+		expect(plan.statements.map((s) => [s.kind, s.sql.split(' ')[0]])).toEqual([
+			['ddl', 'CREATE'],
+			['dml', 'INSERT'],
+			['ddl', 'DROP'],
+		]);
+		// 導出 view は従来どおり分類のみ (件数整合)。
+		expect(plan.ddl).toHaveLength(2);
+		expect(plan.dml).toHaveLength(1);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

第17回リリース blocker #4 の根治。#3926 (fresh-DB-safe shell) は PGlite/NUC 経路で解消したが、DSQL provision 経路では **transform の ddl/dml 分離 + runner の「DDL 全適用 → DML」並び替え**により 0004 fold が「CREATE shell → **DROP** → fold INSERT」の順で実行され、fold 時点で relation 不在で fail していた (staging run 30079522945)。並び替え自体を廃止し source 順適用に是正する。

**本修正は本番 data 保全にも必須**: 0004 未適用の本番 DSQL でも旧実装は DROP が fold より先に走り、login_bonuses の fold data を喪失するか fail していた ([PV8] で回帰固定)。

## 関連 Issue

Closes #3928

- 前段: #3925 / #3926 (PGlite 側) / fold 元: #3330 / transform/runner: EPIC #3424 M4 / 同型 cross-backend 差: #3851
- 検出: 第17回 release #3927 (staging env-parity required gate)

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証 | 状態 |
|---|---|---|---|
| DSQL provision path で 0004 の shell CREATE が実際に効く (issue 方針1) | 真因は shell の変形ではなく **runner の DDL-first 並び替え**と特定 (dry-run 解析)。plan に source 順 `statements` (kind 付き) を追加し、runner は source 順に per-statement autocommit 適用。DSQL 制約 0A000 は「同一 txn に混在させない」であり per-statement autocommit で充足 — 並び替えは不要かつ有害だった | transform statements 順 test + runner DDL→DML→DDL source 順 test | ✅ |
| fold の DSQL 互換 fresh-safe 化 (issue 方針2) | #3926 の shell + 本 PR の順序是正の組合せで成立 (DO ブロック不要のまま)。0004 SQL 自体は無変更 | [PV7] fresh path green | ✅ |
| fresh DSQL provision の回帰を test に追加 (issue 方針3) | [PV7] fresh / [PV8] seeded = **実 0003+0004 を transform+runner (dsql-migrate と同一 pipeline) で PGlite に貫通** (0003/0004 は ASYNC index 非含有で PGlite 実行可)。全 tag の網羅は「[PV6] raw 順 fresh 貫通」×「transform が source 順を保持する fitness」×「runner が statements 順に適用する test」の 3 点で構成的に担保 (ASYNC 構文が PGlite 非互換のため全 tag の pipeline 直接実行は不可) | migration 系 5 file **57 test 全 PASS** + svelte-check 0 error | ✅ |
| ASYNC index build 順序 (F3 hard 制約) の不変 | watermark 捕捉 → CREATE INDEX ASYNC → poll → 次文 のシーケンスは per-statement で不変。source 順化により「CREATE TABLE → index」の順序保証はむしろ強化 (drizzle 出力の source 順そのまま) | 既存 runner test (順序 / fail-throw) green | ✅ |
| 5-why 対策 Top2: skill の観点欠落修理 | `.claude/skills/db-migration/SKILL.md` に「§3 fresh-DB 互換 + cross-backend 3 経路検証」を必須化 (ADR-0031 既存データ互換と対)、stale な DynamoDB 節 (#3438 撤去済 backend) を置換 | 目視 + terminology gate | ✅ |

## 変更タイプ

- [x] fix（バグ修正 — リリース blocker / db-migration / dsql）

## 影響範囲・変更コンポーネント

- `src/lib/server/db/dsql/migration/transform.ts`: `DsqlPlannedStatement` / `plan.statements` (source 順) 追加。`ddl`/`dml` は導出 view として維持 → **consumer (scripts/dsql-migrate.ts の dry-run 表示 / provision.ts) は無変更**
- `src/lib/server/db/dsql/migration/runner.ts`: `plan.statements` を source 順に適用 (ASYNC poll シーケンス不変)
- `tests/unit/db/`: runner 3 test を statements 形式へ更新 + source 順回帰 1 / transform statements 順 1 / [PV7][PV8] pipeline 貫通 2 を追加
- `.claude/skills/db-migration/SKILL.md`: §1 の DynamoDB 行を dsql/schema.ts に置換 + §3 全面改稿

## テスト & 安全装置セルフチェック

- migration 系 5 test file (transform / runner / provision / async-poll / fold) **57 test 全 PASS**
- svelte-check 0 error / biome green
- ADR-0006 整合: 並び替え廃止は制約緩和ではない (0A000 制約は per-statement autocommit で従来どおり充足、ASYNC build poll の hard 制約も不変)
- 適用済み環境への影響: provision は tag 単位 applied 管理のため適用済み tag は skip。未適用環境 (fresh staging / 本番の 0004) はこの修正で初めて正しい順序で適用される

## スクリーンショット / ビジュアルデモ

N/A (migration 基盤 + unit test のみ)。

## コード品質セルフレビュー (#1481)

- 「なぜ並び替えを廃止できるか」(DSQL 制約の正確な範囲) を transform/runner の header コメントに記録し、旧設計の 責務 4/6 記述を新 semantics に同期
- test helper `makePlan` は transform と同一の導出規則でありドリフトしない (transform 側 test が実出力の statements/ddl/dml 整合を assert)

## 横展開・影響波及チェック

- **5-why (deep research、PO 指示) の成果を反映**: 真因チェーン =「検出点が release gate 1 点のみ」×「PGlite 片側 verify が DSQL 実行 semantics (plan 並び替え) を検証していなかった」×「skill checklist に fresh-DB / cross-backend 観点が欠落」。本 PR は Top1 (executor 等価 fitness の unit 押し下げ) + Top2 (skill 修理) を実装。Top3 (teardown 残置参照 sweep の impact-analysis カテゴリ化) は follow-up issue で起票予定
- plan 手組み箇所の全数確認: src/scripts に手組みなし (transform 経由のみ)、test 3 箇所は本 PR で更新済

## レビュー依頼事項・破壊的変更

- 破壊的変更なし (plan interface は additive、consumer 無変更)
- レビュー観点: ① per-statement autocommit で 0A000 制約 (multiple ddl / ddl and dml in txn) を破らないことの妥当性 (runner header の根拠記述) ② [PV8] の fold 期待値 (3 連続日 → streak 3)
- **リリース系統への申し送り**: 本 PR merge 後の release cut で staging「Provision DSQL schema」が貫通する見込み (fresh DSQL: CREATE shell → 0 行 fold → DROP が source 順で成立)

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 5 点実装 + migration 系 57 test 全 PASS + svelte-check 0 error
- [x] consumer 無変更の確認 (dry-run 表示 / provision)
- [x] 5-why Top1/Top2 対策の同梱、Top3 は follow-up 起票
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — unit/pipeline 層検証まで完遂、実 DSQL 発火は次 release lane で確認。最終承認は QM 責務、ADR-0022）

## QM レビュー結果

(QM 記入欄)
