### PR TITLE
docs(process): #3930 impact-analysis に「撤去系: 残置参照 sweep」カテゴリ追加 (21→22、第17回 5-why Top3)

### DIFF
--- a/.claude/skills/impact-analysis/SKILL.md
+++ b/.claude/skills/impact-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impact-analysis
-description: 大規模リファクタリング/モデル変更/rename の影響範囲調査 (Change Impact Analysis)。grep 単独は禁止、4 layer 防御 (構文/意味/構造/派生 artifact 21 カテゴリ) で網羅性を担保する
+description: 大規模リファクタリング/モデル変更/rename の影響範囲調査 (Change Impact Analysis)。grep 単独は禁止、4 layer 防御 (構文/意味/構造/派生 artifact 22 カテゴリ) で網羅性を担保する
 trigger: rename PR / モデル変更 / API 廃止 / DB schema 変更 / 大規模リファクタリング着手前
 ---
 
@@ -17,6 +17,7 @@ trigger: rename PR / モデル変更 / API 廃止 / DB schema 変更 / 大規模
 - 設計層の境界変更 (feature 移動・モジュール分割)
 - LP / 法務文書 / 用語辞書の改訂
 - 50 ファイル超の影響を伴う可能性のある変更
+- **resource / 機構の撤去 (teardown)** — table・stack・workflow step・vault・CFN export 等を消す変更 (§H 残置参照 sweep 必須)
 
 **禁止**: 「grep で○○件確認、影響範囲調査完了」と書くこと。grep は L1 構文層の一部のみ。
 
@@ -89,11 +90,11 @@ npx jelly --target src/lib/server/services/stripe-service.ts
 
 検出するもの: N hop 先の依存 / 取り残し / boundary 違反
 
-### L4: 派生 artifact (21 カテゴリ checklist、人間目視)
+### L4: 派生 artifact (22 カテゴリ checklist、人間目視)
 
-下記 §「21 カテゴリ checklist」を 1 件ずつ確認。grep / AST では原理的に検出できない。
+下記 §「22 カテゴリ checklist」を 1 件ずつ確認。grep / AST では原理的に検出できない。
 
-## 21 カテゴリ Checklist (Pre-flight、PR body に記載)
+## 22 カテゴリ Checklist (Pre-flight、PR body に記載)
 
 ```markdown
 ## 影響範囲調査 (Change Impact Analysis)
@@ -110,7 +111,7 @@ npx jelly --target src/lib/server/services/stripe-service.ts
 - [ ] Knip 取り残し export: N 件
 - [ ] 依存グラフで N hop 先確認: 完了/未完了
 
-### L4 派生 artifact (人間目視 21 カテゴリ)
+### L4 派生 artifact (人間目視 22 カテゴリ)
 
 #### A. データ永続層
 - [ ] 1. DB schema (column / table / enum / FK / view / trigger / BI tool)
@@ -146,6 +147,15 @@ npx jelly --target src/lib/server/services/stripe-service.ts
 - [ ] 19. fixture / seed / golden / snapshot (`__snapshots__/*.snap`)
 - [ ] 20. 過去 PR / commit / Issue / ADR (検索性のため**更新しない**)
 - [ ] 21. audit log / 過去レコード (「old → new mapping table」で保全)
+
+#### H. 撤去系 (teardown、#3930 — 第17回リリース 4 連続 blocker の 5-why Top3)
+- [ ] 22. 残置参照 sweep — 撤去対象の識別子 (table 名 / stack 名 / workflow step 名 / vault 名 /
+      CFN export 名) を `.github/workflows` + `scripts` + `infra` + `docs/runbooks` に対して
+      grep し、残置参照 0 を PR で証跡化。destroy 時挙動 (RETAIN / rollback-orphan /
+      recovery point 残存) も明記する。事例: #3921 (撤去済 table を参照する workflow step が
+      TableNotFound で release 赤化) / #3907 (vault destroy が recovery point で block) /
+      #3881 (rollback-orphan の named resource "already exists")。「本番は既存 state で動くが
+      fresh provision / destroy 時に壊れる」class は本 sweep でしか事前検出できない
 ```
 
 ## ツール推奨 stack (TS / SvelteKit、Pre-PMF コスト最良)
@@ -187,9 +197,9 @@ CodeQL は重く Pre-PMF オーバーキル、security review 用途で別軸。
 
 1. **Issue 起票時**: 影響範囲調査の規模見積を Issue body に記載 (50 ファイル超なら本 skill 適用宣言)
 2. **着手前**: L1 → L2 → L3 → L4 の 4 layer を順次実行、結果を tmp/ に保存
-3. **PR body**: 上記 §21 カテゴリ checklist を PR body にコピー、各項目に確認結果記載
+3. **PR body**: 上記 §22 カテゴリ checklist を PR body にコピー、各項目に確認結果記載
 4. **CI gate**: ast-grep + Knip + baseline pinning を CI に組込
-5. **review**: QA レビューで「L4 21 カテゴリの確認漏れ」を必ずチェック
+5. **review**: QA レビューで「L4 22 カテゴリの確認漏れ」を必ずチェック
 
 ## 関連 SSOT
 
@@ -201,7 +211,7 @@ CodeQL は重く Pre-PMF オーバーキル、security review 用途で別軸。
 ## 禁忌
 
 - **「grep だけで影響範囲調査完了」と PR body に書く** → 必ず L1-L4 全実行確認結果を併記
-- **21 カテゴリ checklist を skip** → 漏れたカテゴリは PR で明示 (例:「14 bookmarks/SEO は新規プロダクトのため対象外」)
+- **22 カテゴリ checklist を skip** → 漏れたカテゴリは PR で明示 (例:「14 bookmarks/SEO は新規プロダクトのため対象外」)
 - **CI gate なしで rename PR をマージ** → ast-grep CI gate 未整備なら整備 PR を先行
 - **「現利用ユーザーゼロだから影響範囲調査不要」と判断** → Pre-PMF でも将来ユーザーの bookmarks / SEO / 法務文書整合は必要
 

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -157,7 +157,7 @@
 | ディレクトリ | 役割 |
 |---|---|
 | `.claude/agents/` | セッション ロール定義 (po-session.md / dev-session.md / qa-session.md、起動時自動活性化)。外部品質監査チームの役割定義は [docs/sessions/audit-team.md](sessions/audit-team.md) が SSOT (audit-manager + 8 チーム + ポリシー準拠判定、新設 skill = competitive-research / policy-compliance / audit-manager の 3 点に限定、実装は EPIC #2861 の B 系 sub-issue が担う) |
-| `.claude/skills/` | タスク固有 Skills (14 件): `pr-review` / `issue-triage` / `pre-pmf-check` / `dev-open-pr` / `lp-review` / `db-migration` / `cost-review` / `age-mode-check` / `brand-check` / `customer-voice` / `deploy-verify` / `flake-hunt` / `regression-check` / **`impact-analysis`** (rename/モデル変更/大規模リファクタリングの Change Impact Analysis、4 layer 防御 + 21 カテゴリ checklist、2026-05-28 追加) |
+| `.claude/skills/` | タスク固有 Skills (14 件): `pr-review` / `issue-triage` / `pre-pmf-check` / `dev-open-pr` / `lp-review` / `db-migration` / `cost-review` / `age-mode-check` / `brand-check` / `customer-voice` / `deploy-verify` / `flake-hunt` / `regression-check` / **`impact-analysis`** (rename/モデル変更/大規模リファクタリングの Change Impact Analysis、4 layer 防御 + 22 カテゴリ checklist (§H 撤去系 残置参照 sweep #3930 含む)) |
 | `.claude/settings.json` | 全体設定 (permissions / hooks / env) |
 | `.claude/worktrees/` | 並行 Agent 用 worktree 分離 dir (Agent tool `isolation: "worktree"` 必須) |
 


### PR DESCRIPTION
## 顧客価値・目的

第17回リリース 4 連続 blocker の 5-why (deep research、PO 指示) で特定した class —「resource を消す変更が、その resource を参照 / 保持する他 artifact を sweep しない」— を、teardown 変更の着手前 checklist として機械化する。リリース blocker 連発はリリース速度 = 全 growth 施策の前提を毀損するため、その再発防止はユーザー価値到達の速度に直結する。

## 関連 Issue

Closes #3930

- 事例: #3921 (撤去済 table を参照する workflow step) / #3907 (vault destroy が recovery point で block) / #3881 (rollback-orphan) / 5-why 全文: PR #3929 §横展開 + issue #3930 本文

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証 | 状態 |
|---|---|---|---|
| impact-analysis SKILL.md に「撤去系: 残置参照 sweep」カテゴリ追加 (grep 対象 4 領域 + destroy 時挙動明記を必須項目化) | §H カテゴリ 22 を新設: 撤去対象識別子 (table / stack / workflow step / vault / CFN export 名) を `.github/workflows` + `scripts` + `infra` + `docs/runbooks` に grep → 残置参照 0 を PR 証跡化 + destroy 時挙動 (RETAIN / rollback-orphan / recovery point) 明記。起動タイミングにも teardown trigger 追加 | 目視 + 21→22 の全参照同期を grep 確認 | ✅ |
| #3921 / #3907 / #3881 を同カテゴリの事例として参照 | §H 本文に 3 事例 + 「本番は動くが fresh provision / destroy 時に壊れる class は本 sweep でしか事前検出できない」根拠を記載 | 目視 | ✅ |
| 新規 CI script を追加していない | doc 変更のみ (SKILL.md + codebase-map.md の 2 file)。最終ネットは常時化済み staging lane (#3685) に委ねる (ADR-0010 過剰防衛回避) | diff 実測 (scripts/ 変更 0) | ✅ |

## 変更タイプ

- [x] docs（プロセス / skill checklist）

## 影響範囲・変更コンポーネント

- `.claude/skills/impact-analysis/SKILL.md`: §H (カテゴリ 22) 追加 + 起動タイミングに teardown trigger + 「21 カテゴリ」表記を「22 カテゴリ」へ全同期
- `docs/codebase-map.md` §8: skill 説明の 21→22 同期
- **据置 (意図的)**: `docs/design/billing-redesign/**` の「21 カテゴリ」記述は過去 phase への適用**記録** (当時の checklist で適用した履歴) のため書き換えない (docs SSOT 原則 #2440: 経緯は改変しない)

## テスト & 安全装置セルフチェック

- `check-doc-code-references` baseline 内・新規違反なし / `check-terminology-coherence` PASS / biome green
- 検証系 script への影響なし (doc のみ)

## スクリーンショット / ビジュアルデモ

N/A (skill doc のみ)。

## コード品質セルフレビュー (#1481)

- カテゴリ本文は「何を grep するか (識別子 5 種 × 領域 4 つ)」と「なぜ本 sweep でしか捕捉できないか」を自足的に記述し、issue 番号は出典 pointer に留めた

## 横展開・影響波及チェック

- 5-why 対策 3 点の最終piece (Top1 executor 等価 fitness = #3929 / Top2 db-migration skill = #3929 / **Top3 = 本 PR**)。これで第17回の blocker 4 件すべてに対応する構造対策が閉じる
- pr-review skill は skill 適用確認を既に持つため、teardown PR で本カテゴリが機械的に要求される

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。レビュー観点: §H の grep 対象領域 4 つの過不足 (ops runbook を含めた妥当性)

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 3 点実装 + doc gate (doc-code-references / terminology / biome) green
- [x] 過去 phase 記録の非改変判断を明記
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — doc gate 検証まで完遂。最終承認は QM 責務、ADR-0022）

## QM レビュー結果

(QM 記入欄)
