### PR TITLE
fix(ci): #3922 main-pr-base-guard の bot exempt 撤去 — dependabot security 更新の main 直行を fail-close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1145,7 +1145,12 @@ jobs:
   #   - 未設定: gate inactive（既存 open PR を block しない、§8 step 6 の無停止 cutover）
   #   - 設定後: 設定日時より後に作成された main 向け PR のみ enforce
   #     （設定日時より前に作成された open PR は grandfather 免除 = §8 step 6「retarget しない」）
-  # bot（dependabot / renovate）は exempt（dependabot.yml の target-branch 切替は cutover 完了時に別途）。
+  # bot（dependabot / renovate）exempt は #3922 で撤去: dependabot.yml は target-branch=develop
+  # 確立済 (#3072) のため、bot の main 向け PR は本来存在しない。唯一の到達経路 = dependabot
+  # "セキュリティ更新" が target-branch を無視して default branch (main) に直行する仕様であり、
+  # 旧 exempt はこれを素通しして auto-merge が develop 軽量レーン + 8 領域監査をすり抜けていた
+  # (#3158 better-sqlite3 → #3190 SIGSEGV / #3920 hono と same-class 2 例)。bot も enforce し、
+  # required check fail で auto-merge を構造的に阻止 → 人間が develop 経由へ re-route する。
   main-pr-base-guard:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.base_ref == 'main'
@@ -1165,8 +1170,9 @@ jobs:
           fi
           case "$PR_ACTOR" in
             dependabot\[bot\]|renovate\[bot\])
-              echo "bot PR ($PR_ACTOR) → exempt"
-              exit 0 ;;
+              # #3922: security 更新の main 直行を検知して fail-close (exempt 廃止)。
+              echo "::error::dependabot/renovate の main 向け PR を検知しました (security 更新は target-branch=develop を無視して main に直行する仕様)。auto-merge は本 check の fail で阻止されます。対処: 本 PR は merge せず close し、同 version への更新を develop 向けに反映してください (次回 grouped bump を待つ / 手動で develop 向け bump PR を作成)。緊急の security fix は develop 反映後に統合 release で main へ。背景: #3922 / #3158→#3190 (develop 監査すり抜け → SIGSEGV) / branch-strategy.md §7。"
+              exit 1 ;;
           esac
           # ISO 8601 UTC (YYYY-MM-DDTHH:MM:SSZ) 同士の辞書順比較
           if [[ "$PR_CREATED_AT" < "$CUTOVER_AT" ]]; then


### PR DESCRIPTION
## 顧客価値・目的

dependabot の **security 更新が develop 軽量レーン + 8 領域監査をすり抜けて main へ auto-merge される穴**の封鎖。#3158 (better-sqlite3 main 直行 → 統合監査で SIGSEGV #3190) と #3920 (hono、QM が手動検知して auto-merge 無効化) の same-class 2 例目で、ADR-0061 の class-lock 条件を満たしたため guard 化する。監査を経ない依存が本番に入る経路は顧客品質の直接リスク。

## 関連 Issue

Closes #3922

- same-class: #3158 → #3190 (SIGSEGV chain) / 検知事例: #3920 / 既存 guard: #3191 (dependabot.yml の target-branch 喪失検出 — security 経路は範囲外だった) / #3072 (target-branch=develop 確立)

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証 | 状態 |
|---|---|---|---|
| dependabot security PR の main 直行を CI で検知し auto-merge を阻止 (issue 対処案 3) | `main-pr-base-guard` の bot 全面 exempt (cutover 移行期の残置) を撤去し、dependabot/renovate の base=main PR を **fail-close** (明示 error + re-route 手順つき)。`ci-gate` の needs に含まれる required check のため fail 中は auto-merge 不成立 | YAML parse OK + guard ロジックは shell case 文 (dependabot[bot]/renovate[bot] → exit 1) | ✅ |
| security 更新機能は無効化しない (対処案 2(a) の副作用回避) | dependabot.yml は不変更 — 検知・PR 作成は従来どおり、merge 経路だけ矯正 (人間が develop 向けに反映 → 統合 release で main へ) | diff 実測 (dependabot.yml 変更 0) | ✅ |
| 通常 bump (base=develop) への影響なし | guard は `if: base_ref == 'main'` のみ発火。develop 向け grouped bump は従来どおり #1808 exempt 群で処理 | job 条件の目視 + 本 PR (base=develop) 自体が非発火の実証 | ✅ |
| 誤爆時の運用手順を error message に内蔵 | 「merge せず close → develop 向けに反映 (grouped bump 待ち or 手動 bump) → 緊急時は統合 release で main へ」を ::error に記載 | message 目視 | ✅ |

## 変更タイプ

- [x] fix（CI gate の穴封鎖）
- [x] infra（workflow）

## 影響範囲・変更コンポーネント

- `.github/workflows/ci.yml` `main-pr-base-guard` job のみ (exempt 撤去 + fail-close message + header コメント改稿)。他 job / ruleset 不変更
- **残余 (PO 判断向け、issue comment に記載予定)**: 対処案 2(a) Dependabot security updates 自体の無効化 (dependency-review + 通常 bump 一本化) はセキュリティ posture の変更を伴うため本 PR では実施せず。本 guard で実害 (監査すり抜け merge) は封鎖済みのため、(a) の要否は運用実績を見て判断可能

## テスト & 安全装置セルフチェック

- js-yaml parse OK。guard は既存 shell の case 分岐 1 箇所の変更で、CUTOVER_AT 未設定時 inactive / grandfather 免除の既存挙動は不変 (exempt check は CUTOVER_AT check の後段のまま)
- ADR-0006 整合: exempt 撤去 = gate 強化方向 (弱体化ではない)
- native dep の追加防衛 (`scripts/check-native-dep-pin.mjs` #3192) は既存のまま併存 (二層防御)

## スクリーンショット / ビジュアルデモ

N/A (CI workflow のみ)。

## コード品質セルフレビュー (#1481)

- exempt 撤去の根拠 (target-branch=develop 確立済で bot の main 向け PR は本来存在しない → 到達 = security 直行のみ) を job header コメントに記録

## 横展開・影響波及チェック

- #3191 (dependabot.yml parse guard) は「設定の喪失」、本 PR は「設定を無視する経路」を守る補完関係 — 両輪で main 直行 class を封鎖
- #3940 (better-sqlite3 13.x 評価) は同 class の native dep 案件。本 guard 導入後は同様の main 直行が発生しても auto-merge されない

## レビュー依頼事項・破壊的変更

- 破壊的変更なし。レビュー観点: security 更新 PR が fail で放置された場合の可視性 (dependabot は PR を open し続けるため QM の PR 一覧で検知可能。追加通知が要るなら follow-up)

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC 4 点実装 + YAML parse 検証
- [x] dependabot.yml / 通常 bump への無影響確認
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — static 検証まで完遂、実発火は次回 security PR で確認。最終承認は QM 責務、ADR-0022）

## QM レビュー結果

(QM 記入欄)
