### PR TITLE
feat(process): #3918 PO 決裁ブリーフを一枚絵 (mermaid) 型に改修 — 図 1 枚で Yes/No 判断可能に

### DIFF
--- a/.claude/skills/dev-open-pr/SKILL.md
+++ b/.claude/skills/dev-open-pr/SKILL.md
@@ -309,14 +309,16 @@ rm tmp/pr-bodies/<num>-<slug>.md
 
 **PR が高リスク・不可逆変更に該当する場合**（`.github/labeler.yml` の `po-decision:required` glob 該当 = labeler 自動付与、または [pr-review SKILL.md](../pr-review/SKILL.md) §「Step 0-2」の判断層 checklist 該当 = 手動付与）、PR body 末尾（PR template 共通セクション + kind 別追加セクションの後ろ）に **`templates/po-decision-brief.md` を append** する。
 
-### 生成手順（6 項目）
+### 生成手順（一枚絵、#3918 — PO 恒久要件 2026-07-23）
+
+**主成果物は mermaid 一枚絵**（雛形の flowchart ①〜⑤）。PO は原則その図 1 枚（+ UI 変更時は実機 SS）だけを見て Yes/No を判断する。長文説明を主成果物にしない。
 
 1. **triage 自己判定**: PR 起票前に変更 file 一覧を `.github/labeler.yml` の `po-decision:required` glob と突合 + Step 0-2 checklist（運用/保守コスト増・新規デザインアーキテクチャパターン採用・技術負債積み残し 等）を自問。該当なしなら本セクション不要（append しない）
 2. **雛形 append**: `templates/po-decision-brief.md` を PR body 末尾にコピー
-3. **項目 1〜3 記入**: リスク分類（可逆/不可逆 + 顧客面）/ ロールバック可否・データ破壊 / trade-off（ADR-0010 紐付け + PO 追加軸）
-4. **項目 4 記入**: `adversarial-reviewer` skill を dispatch し `tmp/adversarial-evidence/<pr>.json` の objections 3 件（business / UX / security）を表に転記 + 自身の推奨を 1 行
-5. **項目 5 記入**: 実機 SS（UI 変更時、screenshots branch）+ 顧客面の変化を具体的に。**PO がプロダクト実態を把握するための核**であり「テスト green」の羅列で代替しない
-6. **項目 6 記入**: PO への判断依頼を Yes/No 形式 1〜3 個に絞る
+3. **図 ①〜④ 記入**: リスク・可逆性 / trade-off / 反対理由 / 顧客面の変化 の各 node の `___` を **1 行 15〜25 字で言い切る**（5 秒把握、ADR-0012 整合）。③ は `adversarial-reviewer` skill を dispatch し `tmp/adversarial-evidence/<pr>.json` の objections 3 件（business / UX / security）を転記（未生成のまま埋めない）
+4. **図 ⑤ 記入**: PO への判断依頼を Yes/No 形式 1〜3 個に絞る（Q2/Q3 が要るなら ASK subgraph に node 追加）
+5. **④ の実体**: UI 変更なら mermaid 直下に実機 SS（screenshots branch）を embed。**PO がプロダクト実態を把握するための核**であり「テスト green」の羅列で代替しない。非 UI なら「変化なし + 根拠」を node に書く
+6. **視認性の自己検証**: PR body preview で mermaid が GitHub 上で描画されることを確認（syntax error で図が出ない = ブリーフ不成立）。図に収まらない根拠は `<details>` 折りたたみへ（PO は原則読まない前提）
 
 ### ルール
 

--- a/.claude/skills/dev-open-pr/templates/po-decision-brief.md
+++ b/.claude/skills/dev-open-pr/templates/po-decision-brief.md
@@ -1,44 +1,61 @@
 ## PO 決裁ブリーフ (po-decision:required)
 
-<!-- #3862: pr-review skill「Step 0: PO 決裁 triage」該当 PR にのみ添付する条件付きセクション。
-     kind 別追加セクションと同じ慣行で、PR template 共通セクションの後ろに append する
-     (PR_TEMPLATE_SECTIONS.json の必須 13 セクションには含めない = 全 PR 強制ではない)。
-     ADR 型 1 ページ・5 分読了。AI は triage + ブリーフ生成のみ、判断は PO が行う。 -->
+<!-- #3862 / #3918: pr-review skill「Step 0: PO 決裁 triage」該当 PR にのみ添付する条件付きセクション。
+     PR template 共通セクションの後ろに append する (PR_TEMPLATE_SECTIONS.json の必須セクション外)。
 
-### 1. リスク分類
+     様式 = 一枚絵 (PO 恒久要件 2026-07-23): PO は下の mermaid 図 1 枚 (+ UI 変更時は実機 SS) だけを
+     見て Yes/No を判断できること。長文説明を主成果物にしない (補足は折りたたみへ)。
+     記入原則: 各 node は 1 行 15〜25 字で言い切る / 5 秒で要点把握 (ADR-0012 整合、装飾より情報設計) /
+     深刻度は 🔴🟡🟢 絵文字 + classDef 色で二重表現 / 「___」を全て置換してから起票する。 -->
 
-<!-- 可逆 / 不可逆の別 + 影響する顧客面 (子供画面 / 親画面 / 課金 / データ / 法務) を 1-2 行で -->
+```mermaid
+flowchart TB
+  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
+  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
+  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a
 
-### 2. ロールバック可否 / データ破壊の有無
+  subgraph RISK["① リスク・可逆性"]
+    R1["可逆性: 🟢可逆 / 🔴不可逆 → ___"]
+    R2["顧客面: 子供画面/親画面/課金/データ/法務 → ___"]
+    R3["ロールバック: revert のみで戻る? データ破壊? → ___"]
+  end
+  subgraph TRADE["② trade-off (ADR-0010)"]
+    T1["得る: ___"]
+    T2["捨てる/負債: 運用保守コスト・新アーキ・積み残し → ___"]
+  end
+  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
+    O1["business: ___"]
+    O2["UX: ___"]
+    O3["security: ___"]
+  end
+  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
+    C1["___ (UI 変更なら直下の実機 SS / 変化なしなら根拠)"]
+  end
+  subgraph ASK["⑤ PO 判断依頼 (Yes/No で回答可能に、1〜3 個)"]
+    Q1["Q1: ___"]
+  end
 
-<!-- revert PR だけで戻るか。migration / 物理削除等でデータが破壊されるなら復旧手段を明記 -->
+  RISK --> ASK
+  TRADE --> ASK
+  OBJ --> ASK
+  CUST --> ASK
 
-### 3. trade-off (Pre-PMF スコープ判断、ADR-0010)
+  class R1,R3 danger
+  class T2,O1,O2,O3 warn
+  class T1,C1 ok
+  class Q1 ask
+```
 
-<!-- 何を得て何を捨てるか。運用コスト / 保守コスト増・新規デザインアーキテクチャパターン採用・
-     技術負債の積み残しの有無 (PO 決裁 2026-07-19 追加軸) を明示 -->
+<!-- UI 変更時: mermaid 直下に実機 SS (screenshots branch) を embed する。図 + SS の 2 点で完結させる。
+     mermaid で表現しきれない複雑な構図 (アーキ図等) が要る場合のみ画像 SS 添付に切替可 (GitHub 上で
+     直接視認できる形が必須。外部ツールを開かせない)。 -->
 
-### 4. 推奨 + 反対理由 3 つ
+<details>
+<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>
 
-<!-- 推奨 (merge すべきか) を 1 行 + adversarial-reviewer skill の objections 3 件を転記。
-     tmp/adversarial-evidence/<pr>.json が未生成なら .claude/skills/adversarial-reviewer/SKILL.md の
-     手順で生成してから転記する (AI 要約への過信を構造的に打ち消す) -->
+<!-- 図に収まらない根拠のみ簡潔に。③ の反対理由は tmp/adversarial-evidence/<pr>.json を
+     .claude/skills/adversarial-reviewer/SKILL.md の手順で生成してから転記する
+     (AI 要約への過信を構造的に打ち消す)。未生成のまま ③ を埋めない -->
 
-**推奨**:
-
-| 軸 | 反対理由 (adversarial-reviewer 転記) |
-|---|---|
-| business | |
-| UX | |
-| security | |
-
-### 5. プロダクト実態 (実機 SS + 顧客面の変化)
-
-<!-- PO が「プロダクトで何が起きるか」を読む核。UI 変更なら実機 SS (screenshots branch 参照)、
-     非 UI なら顧客に届く挙動・データ・料金面の変化を具体的に。「変化なし」ならその根拠を書く -->
-
-### 6. PO への判断依頼事項 (1〜3 個)
-
-<!-- Yes/No で答えられる形に絞る。例: 「この migration を本番適用してよいか (Yes/No)」 -->
-
-1.
+</details>

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -41,7 +41,7 @@ A〜I のレビューに入る前に、本 PR が **PO 決裁対象か** を判�
 
 ### 0-3. label 付与時の義務
 
-`po-decision:required` の PR は、PR body に **「## PO 決裁ブリーフ」条件付きセクション**（`dev-open-pr` skill の `templates/po-decision-brief.md`、6 項目）を必須添付し、**PO の Yes/No 判断を得てから merge する**（QM / audit-manager 単独で merge しない）。ブリーフ生成手順は [dev-open-pr SKILL.md](../dev-open-pr/SKILL.md) §「PO 決裁ブリーフ」を参照。非該当 PR は通常フロー（A〜I → QM 判定）で進み、抜き取り監査（`docs/sessions/audit-team.md` §3.9）の対象になる。
+`po-decision:required` の PR は、PR body に **「## PO 決裁ブリーフ」条件付きセクション**（`dev-open-pr` skill の `templates/po-decision-brief.md`、**mermaid 一枚絵** = リスク・可逆性 / trade-off / 反対理由 3 軸 / 顧客面の変化 / 判断依頼を 1 図に圧縮、#3918 PO 恒久要件）を必須添付し、**PO の Yes/No 判断を得てから merge する**（QM / audit-manager 単独で merge しない）。ブリーフ生成手順は [dev-open-pr SKILL.md](../dev-open-pr/SKILL.md) §「PO 決裁ブリーフ」を参照。非該当 PR は通常フロー（A〜I → QM 判定）で進み、抜き取り監査（`docs/sessions/audit-team.md` §3.9）の対象になる。
 
 ## 必須 9 項目（A〜I 全項目）
 

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -537,3 +537,7 @@ misconfig
 upcasting
 Postel
 combinators
+Sigstore
+dsse
+SIGSEGV
+ISTQB

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -541,3 +541,7 @@ Sigstore
 dsse
 SIGSEGV
 ISTQB
+blocklist
+NFKC
+inlang
+jscodeshift

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -192,17 +192,17 @@ audit-manager が統合 PR の merge を判定する際に揃えるべき人間�
 
 ### §3.8 毎回 run の標準 9 ステップ（release/* → main 統合監査サイクル、branch-strategy.md §3.1）
 
-事前準備ゲート（§3.7）充足後、各 run（1 日 1 回 gate）は以下 9 ステップを順に実行する。audit-manager が orchestrate し、deepresearch / テスト追加 / 起票は subagent へ dispatch、不可逆 action（PR 発行 / merge / 起票実行）は orchestrator 専権（§3.3）。
+事前準備ゲート（§3.7）充足後、各 run（1 日 1 回 gate）は以下 9 ステップを順に実行する。audit-manager が orchestrate し、deep research / テスト追加 / 起票は subagent へ dispatch、不可逆 action（PR 発行 / merge / 起票実行）は orchestrator 専権（§3.3）。
 
 | step | 内容 | 主体 | 不可逆 |
 |---|---|---|---|
 | 1 | develop→main の変更差分を整理（含有 feature/fix を §3.5 一覧化） | audit-manager | — |
 | 2 | 差分に対し実施すべきテスト範囲を洗い出す（影響領域 × テスト種別） | 技術調査 / テスト品質 | — |
-| 3 | テスト範囲・方針・影響範囲見積もりを deepresearch し抜け漏れを確認 | 技術調査（deep-research） | — |
+| 3 | テスト範囲・方針・影響範囲見積もりを deep research し抜け漏れを確認 | 技術調査（deep-research） | — |
 | 4 | テストケース一覧 + 自動テスト追加（E2E / Storybook / API）。**develop に既存のテストとの網羅性マッピング**を行い冗長を排除 | テスト品質 | — |
 | 5 | 追加テスト一式を **develop ブランチへ PR** として提出 | audit-manager（PR 発行） | **可** |
 | 6 | テスト取込後の develop の**特定コミットを凍結**し `release/<YYYY-MM-DD>` を cut → **release/* → main 統合 PR を発行**（branch-strategy.md §3.1。以後 develop が動いても release HEAD 不変＝frozen 標的で監査が無効化されない） | audit-manager（PR 発行） | **可** |
-| 7 | 統合 PR の全 CI 成功を確認。fail は **1 件で止めず全件洗い出し**、各々 deepresearch で真因特定・なぜなぜ分析・横展開（影響範囲）まで行い **Issue 起票**。監査中の修正は release branch への commit（append）で対応するが、**approve 後に append したら adversarial evidence を再生成し再 approve する**（`PR_Mearge` は `dismiss_stale_reviews_on_push=false` のため stale approval が残り未監査差分が merge され得る。approve HEAD = merge HEAD を一致させる） | audit-manager（起票） + 各領域 agent | **可** |
+| 7 | 統合 PR の全 CI 成功を確認。fail は **1 件で止めず全件洗い出し**、各々 deep research で真因特定・なぜなぜ分析・横展開（影響範囲）まで行い **Issue 起票**。監査中の修正は release branch への commit（append）で対応するが、**approve 後に append したら adversarial evidence を再生成し再 approve する**（`PR_Mearge` は `dismiss_stale_reviews_on_push=false` のため stale approval が残り未監査差分が merge され得る。approve HEAD = merge HEAD を一致させる） | audit-manager（起票） + 各領域 agent | **可** |
 | 8 | 全緑なら統合 PR を **merge commit（`gh pr merge --merge`、squash 禁止、§3.5 / branch-strategy.md §3.1）** で merge → 本番 deploy actions を watch し成功確認 → **main → develop back-merge sync PR** で main の merge commit を develop へ取り込む（§5 / #2951・#3061） | audit-manager（merge） | **可** |
 | 9 | deploy 完了後、本番 **AWS 版・ローカル NUC 版の両方へ health check** | audit-manager + deploy-verify skill | — |
 

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -217,7 +217,8 @@ audit-manager が統合 PR の merge を判定する際に揃えるべき人間�
 **運用定義**:
 
 1. **抽出**: 統合 PR 監査 run（§3.8）ごとに、含有 feature/fix PR のうち `po-decision:required` 非該当のものから **無作為に 1〜2 件**を audit-manager が抽出する（run 内に非該当 PR が無ければ skip し evidence に明記）。
-2. **提示**: 抽出 PR について audit-manager が「変更概要 / 顧客面の変化（実機挙動）/ AI（QM・監査）の判定結果」を 5 分読了以内の人間可読サマリで PO に提示し、**PO が直接レビュー**する（ブリーフ 6 項目のうち 1 / 5 / 6 相当の縮約版で足りる）。
+2. **提示**: 抽出 PR について audit-manager が「変更概要 / 顧客面の変化（実機挙動）/ AI（QM・監査）の判定結果」を 5 分読了以内の人間可読サマリで PO に提示し、**PO が直接レビュー**する（ブリーフ一枚絵 (#3918) のうち ①リスク / ④顧客面の変化 / ⑤判断依頼 相当の縮約版で足りる）。
+   - **一枚絵の可読性も評価軸に含める** (#3918 AC4): 抽出 PR が `po-decision:required` ブリーフを持つ場合、「PO が図 1 枚 + SS だけで判断できたか / 補足を開かざるを得なかったか」を evidence に記録し、不可読なら様式改善を #3918 系 follow-up に乗せる。
 3. **complacency 指標**: PO 判定と AI 判定の一致 / 不一致を run ごとに evidence へ記録する。**高一致の継続は good performance ではなく complacency の兆候**として扱う（LLM review 追認バイアスの実証研究、#3862 deep research）。不一致 0 が続く場合は「AI が正しい」と結論せず、(a) 抽出件数を増やす、(b) triage パス表（`.github/labeler.yml` `po-decision:required`）と Step 0-2 判断層 checklist を見直す、のいずれかを実施する。
 4. **不一致時**: PO 指摘は §3.6 の起票/棄却 flow に乗せる。triage の false negative（本来 `po-decision:required` であるべきだった）と判明した場合は、labeler glob + `tests/unit/github/po-decision-labeler.test.ts` の代表パスを同一 PR で追加し class を lock する（ADR-0061 原則 2）。
 


### PR DESCRIPTION
<!-- no-issue-close: AC5 (適用第 2 号以降の po-decision:required PR での実地検証) が次の該当 PR 待ちのため、#3918 は close せず tracking で残す。本 PR は AC1〜AC4 (様式改修 + skill 3 点同期) を完遂 -->

## 顧客価値・目的

PO 恒久要件（2026-07-23 直接指示）「レビュー依頼時には文章ではなくイメージで可視化した**一枚絵だけ**を見ればレビューできる状態」への対応。PO の決裁速度と判断品質が上がる = 高リスク変更の意思決定 loop が短くなり、プロダクト改善の速度に直結する。

## 関連 Issue

- #3918（tracking、AC5 実地検証後に close）
- 親: #3862（framework 配線、close 済）/ 適用第 1 号 (text 様式): #3912 / 別論点: #3916

## AC 検証マップ (ADR-0004)

| AC | 実装 | 検証 | 状態 |
|---|---|---|---|
| AC1: 一枚絵 1 枚で PO が可否判断できる様式 | `templates/po-decision-brief.md` を **mermaid flowchart 1 図**（①リスク・可逆性 ②trade-off ③反対理由 3 軸 ④顧客面の変化 ⑤判断依頼 → ASK へ収束する構図）に全面改修。長文は `<details>` 折りたたみへ降格し「PO は原則読まなくてよい」と明記 | 雛形目視 + 記入原則（1 行 15〜25 字 / 5 秒把握）を雛形コメントに内蔵 | ✅ |
| AC2: 可視化技法自由 + 5 要素を 1 枚に圧縮 | flowchart + classDef 4 色（danger/warn/ok/ask）+ 🔴🟡🟢 絵文字の二重表現。subgraph ①〜⑤ = issue AC2 の (a)〜(e) に 1:1 対応 | 図構造の目視照合（(a)=①、(b)=②、(c)=③、(d)=④、(e)=⑤） | ✅ |
| AC3: GitHub 上で外部ツールなしに視認 | mermaid fence（GitHub native 描画）を第一候補に採用。複雑構図のみ SS 添付へ切替可と雛形に明記。生成手順 6 に「PR body preview で描画確認（syntax error = ブリーフ不成立）」を必須化 | 本 PR の下の「様式プレビュー」節で実描画を実証 | ✅ |
| AC4: skill 同期 + §3.9 可読性評価軸 | dev-open-pr 生成手順を一枚絵手順に改稿 / pr-review Step 0 の様式説明を更新 / audit-team §3.9 に「一枚絵の可読性」評価軸（図 1 枚で判断できたか / 補足を開かざるを得なかったか を evidence 記録）を追加 | 3 file の diff 目視 + doc gate green | ✅ |
| AC5: 適用第 2 号での実地検証 | 次の po-decision:required PR で確認（本 PR は該当 label なし） | — | ⬜ tracking（no-issue-close 宣言） |

## 様式プレビュー（AC3 実証 — 雛形の空欄をダミー値で埋めた描画例）

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🔴不可逆: 旧表 DROP を含む"]
    R2["顧客面: データ (ログイン記録)"]
    R3["ロールバック: revert 不可・backup 復元手順あり"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: DB 行数 99% 減・DPU 削減"]
    T2["捨てる: per-date 履歴の粒度"]
  end
  subgraph OBJ["③ 反対理由 (adversarial)"]
    O1["business: 履歴分析の将来価値を捨てる"]
    O2["UX: 表示は counter で同等 (影響なし)"]
    O3["security: fold 中の部分適用リスク"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["画面変化なし (streak 表示は同値)"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 旧表 DROP を本番適用してよいか (Yes/No)"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3 danger
  class T2,O1,O3 warn
  class T1,C1,O2 ok
  class Q1 ask
```

## 変更タイプ

- [x] docs（process / skill テンプレ）

## 影響範囲・変更コンポーネント

- `templates/po-decision-brief.md`: テキスト 6 項目 → mermaid 一枚絵 + details 補足
- `dev-open-pr/SKILL.md`: 生成手順を一枚絵手順（6 step）に改稿
- `pr-review/SKILL.md`: Step 0 の様式説明 1 行更新
- `docs/sessions/audit-team.md` §3.9: 可読性評価軸 1 項目追加（**監査チーム所管 doc のため最小差分。追加妥当性は QM/監査チームのレビューで確認いただきたい**）
- `check-pr-body.mjs` / PR_TEMPLATE_SECTIONS.json は不変更（条件付き append セクションは必須 13 外の既存慣行のまま）

## テスト & 安全装置セルフチェック

- 本 PR body の「様式プレビュー」節が GitHub 上で mermaid 描画されること = AC3 の実機実証（QM レビュー時に視認ください）
- doc gate: check-doc-code-references 新規違反なし / terminology PASS / cspell は変更 file の既存 8 語のみ（追加行に新語なし、develop 版と同数を確認）

## スクリーンショット / ビジュアルデモ

上記「様式プレビュー」節が実描画デモ（アプリ UI 変更なし）。

## コード品質セルフレビュー (#1481)

- 記入原則（字数 / 5 秒把握 / 色の二重表現 / `___` 全置換）を雛形コメントに内蔵し、次の起票者が手順書なしで正しく書ける自足性を担保
- ADR-0012 整合（装飾でなく情報設計）を雛形に明記

## 横展開・影響波及チェック

- §3.9 サンプリング監査の縮約版参照（旧「6 項目のうち 1/5/6」）を新様式の「①/④/⑤」に同期（stale 参照ゼロ）
- 適用第 2 号（次の po-decision:required PR）で AC5 検証 → 結果を #3918 に記録して close

## レビュー依頼事項・破壊的変更

- 破壊的変更なし（条件付きセクションの様式変更のみ、必須 gate 不変）
- レビュー観点: ① 様式プレビューの mermaid が実描画されるか ② 5 秒で要点把握できる情報密度か ③ audit-team.md への最小差分の妥当性

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] AC1〜AC4 実装 + doc gate green + 描画実証を PR body に内蔵
- [x] AC5 の tracking 宣言（no-issue-close）
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言 — doc gate + 描画実証まで完遂。最終承認は QM 責務、ADR-0022）

## QM レビュー結果

(QM 記入欄)
