### PR TITLE
chore(deps): #3940 better-sqlite3 13.x を dependabot ignore に追加 (12.10.0 維持の判断反映)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,9 +29,14 @@ updates:
         update-types: ["version-update:semver-patch"]
       # #3302: better-sqlite3 12.11.x は demo/SQLite (file-backed + WAL) を SIGSEGV crash させる
       # (#3190/#3192 で 12.10.0 exact pin に根治)。upstream 修正確認まで 12.11.x を ignore。
-      # 12.12+ は再提案を許可 (修正版採用時は scripts/check-native-dep-pin.mjs の pin と同期更新)。
+      # #3940: 13.x は N-API 全面 rewrite (2026-07-21 リリース) を評価のうえ不採用 (12.10.0 維持) と判断。
+      # smoke は #3190 SIGSEGV class を再現できない (gate 空洞化) ため CI green を採用根拠にできず、
+      # EPIC #3424 (PGlite 一本化) で依存縮小方向のため実機検証投資も defer。#3937 close 済み。
+      # 【再評価条件】13.1.x 以降 or 13.0.x の 1 ヶ月 soak + upstream WiseLibs/better-sqlite3#1503
+      # (Windows install regression) close。解除時は本 ignore から "13.x" を外し、採用時は
+      # scripts/check-native-dep-pin.mjs の pin と同期更新 (Issue #3940 再開手順参照)。
       - dependency-name: "better-sqlite3"
-        versions: ["12.11.x"]
+        versions: ["12.11.x", "13.x"]
       # #3636: typescript 7.x は @sveltejs/kit@2.69.x の peer (^5.3.3 || ^6.0.0) が除外し
       # npm ci が ERESOLVE で失敗する。kit が TS7 peer 対応版を出したら本 ignore を削除して TS7 を取り込む。
       # major (6→7) のみ保留し 6.x の minor/patch 更新は許可する。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体 (demo/NUC の SQLite runtime 安定性)

**解決する課題**: better-sqlite3 13.x (N-API 全面 rewrite、2026-07-21 リリース) を dependabot が再提案し続けると、#3190 SIGSEGV class を CI smoke で検出できない (gate 空洞化、#3302) まま危険な native major bump が繰り返し提案される。#3940 の Dev 評価で「12.10.0 維持・13.x defer」と判断済みのため、その判断を dependabot 設定に反映して再提案 churn を止める。

**期待される効果**: 13.0.2+ の再提案 PR が発生せず、QM/Dev のトリアージコストがゼロになる。再評価条件 (13.1.x or 1 ヶ月 soak + upstream #1503 close) は yml コメントと Issue #3940 に記録され、解除手順が明確。**#3940 は close せず再評価 watcher として open で残す** — ignore で dependabot の再提案 (= 事実上のリマインダー) が止まるため、条件成立を見る主体を Issue 側に残す必要がある。

## 関連 Issue

refs #3940 (**close しません**)

**`closes` を使わない理由** (QM BLOCK 指摘、PR #3945 レビュー): 13.x を ignore に入れると dependabot の再提案が止まり、**再提案そのものが果たしていた再評価リマインダー機能が同時に消える** (#3937 → #3940 の評価はまさにその経路で起動した)。ここで #3940 も close すると、再評価条件 (13.1.x 以降 or 13.0.x の 1 ヶ月 soak + upstream WiseLibs/better-sqlite3#1503 close) は yml コメントと閉じた Issue にしか残らず、**トリガー成立を見る主体がいなくなる**。よって #3940 は open のまま「13.x ignore 解除の再評価 watcher」として残す。本 PR 自体の変更 (ignore 追加) は #3940 の AC4 を満たすが、Issue の残スコープは再評価そのものである。

- #3937 (dependabot PR、QM が 2026-07-25 に close 済み) / #3302 (pin gate) / #3190/#3192 (SIGSEGV pin chain) / #3191 (native-dep-smoke) / EPIC #3424 / ADR-0064

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | better-sqlite3 13.x の breaking changes を upstream CHANGELOG で確認。使用箇所に破壊的影響がないか | upstream Releases 精査 + 使用箇所確認 | PASS — 評価詳細は [#3940 コメント](https://github.com/Takenori-Kusaka/ganbari-quest/issues/3940#issuecomment-5077740289)。JS API 表面の破壊なし、破壊の本丸は N-API rewrite の binding/install 層 (Windows install regression upstream#1503 open) |
| AC2 | 採用する場合の pin 同期更新 + ignore 整合 | `node scripts/check-native-dep-pin.mjs` | N/A (不採用判断) — pin は 12.10.0 のまま無変更。check-native-dep-pin exit 0 (pre-ready Step 内) |
| AC3 | native-dep-smoke + demo SQLite E2E で SIGSEGV 非再現 | — | N/A (不採用判断) — 13.x を導入しないため実機検証は再評価条件成立時に実施。現行 12.10.0 は既知問題なし |
| AC4 | 採用しない判断なら #3937 close + 13.x を dependabot ignore に追加 or 理由記録 | 本 PR diff (`.github/dependabot.yml`) | PASS — #3937 は QM close 済み (2026-07-25)。本 PR で ignore へ `"13.x"` 追加 + 不採用根拠と再評価条件を yml コメントに記録 |
| AC5 | EPIC #3424 進捗次第で better-sqlite3 要否を再評価 | Issue #3940 記録 | PASS — 再評価条件に「EPIC #3424 帰結で撤去確定なら Issue close」を記録済み ([#3940 コメント](https://github.com/Takenori-Kusaka/ganbari-quest/issues/3940#issuecomment-5077740289)) |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**:
なし (dependabot の提案挙動のみ。アプリコード・依存 version は無変更)

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）: N/A (yml 設定 + コメントのみ、既存 `check-native-dep-pin.mjs` gate と dependabot ignore の二重防御構造は不変)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（設定ファイルのみの変更、UI 変更なし）**

**4 スロット添付**（#1740）: 該当なし (同上)

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A (yml 設定のみ)
- [x] **DRY**: ignore 根拠コメントは #3302 (12.11.x) の既存様式に追記。pin SSOT (`check-native-dep-pin.mjs`) は無変更で二重管理を増やさない
- [x] **YAGNI**: ignore 追加は `"13.x"` 1 エントリのみ。14.x 以降の投機的 ignore はしない
- [x] **Security（OSS 公開前提）**: 秘密情報なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外 (dependabot 設定のみ。関連 SSOT `scripts/check-native-dep-pin.mjs` は 12.10.0 pin のまま変更不要で整合)
- [x] 並行 PR overlap 確認 (#1200): open PR #3944 と変更ファイル重複なし (`.github/dependabot.yml` は #3944 の diff に含まれない)

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
- dependabot `versions` の複数指定 (`["12.11.x", "13.x"]`) が意図どおり両レンジを抑止するかの目線確認
- npm-minor-patch group の `exclude-patterns: better-sqlite3` (#3311) は既存のまま変更なし — group 経由すり抜けの再発防御は維持

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み (AC2/AC3 は不採用判断により N/A、根拠は AC 検証マップ参照)
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

