### PR TITLE
fix(db): #3948 drizzle journal `when` の値域 gate を追加 — #3946 同型事故の class-lock

### DIFF
--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -59,7 +59,7 @@ drizzle-orm の migrator（pg-core dialect）は `適用済み最大 created_at 
 - [ ] 既存 migration の `when` を後から編集しない（既に本番 `__drizzle_migrations.created_at` に記録済のため、編集は「適用済みだが journal 上は未適用」の不整合になる）
 - [ ] 機械 gate: `scripts/lib/db/drizzle-journal-gate.mjs`（`tests/unit/db/pglite-journal-when-range-3948.test.ts` が CI で hard-fail）
 
-**grandfather 例外**: `1784500000000` / `1784500000001` / `1784500000002`（0002 / 0003 / 0004）は #3946 以前に手書きで入り、既に本番 DB へ記録済のため値そのものは修正せず gate の例外として固定している。**新規にこの例外を増やさないこと**（根拠と一覧の SSOT は `scripts/lib/db/drizzle-journal-gate.mjs` 冒頭コメント）。
+**grandfather 例外**: `1784500000000` / `1784500000001` / `1784500000002`（0002 / 0003 / 0004）は値そのものを修正せず gate の例外として固定している。実生成時刻へ書き戻すと、**#3947 以前の backup から restore した DB（適用済み最大 `created_at` = 1784500000000）で 0003/0004 が永久 skip され #3946 が再発する**ため（`[WR7]` が実 migrator で固定）。**新規にこの例外を増やさないこと**（根拠と一覧の SSOT は `scripts/lib/db/drizzle-journal-gate.mjs` 冒頭コメント）。
 
 `when` を参照するのは PGlite（NUC）経路のみ。DSQL（cloud）の `provision.ts` は `idx` 順 + tag 単位冪等で `when` を見ない（`[WR4]` で固定）。
 

--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -49,6 +49,20 @@ ADR-0031 (既存データ互換) と**対**で必須。migration は「既存 st
 - [ ] 不可逆 / 失敗時に手当てが要る migration は startup ではなく **明示的な運用手順（runbook）** に置く
 - [ ] migration が throw しうる場合、cold-start brick の影響範囲（全リクエスト 5xx）を許容できるか事前評価する
 
+### 5. journal `when` を手で書き換えない（#3946 本番 500 / #3948 class-lock）
+
+`drizzle/pglite/meta/_journal.json` の `when` は **drizzle-kit が入れた `Date.now()` をそのまま使う**。手で書き換えてはならない。
+
+drizzle-orm の migrator（pg-core dialect）は `適用済み最大 created_at < folderMillis` の migration だけを適用する。つまり **実時刻より未来の `when` を一度でも本番 DB へ適用すると、以降 drizzle-kit が生成する全 migration（`when` は実時刻）が既存 DB で永久に skip される**。#3946 はこれで NUC 本番の `/preschool/home` が 500 になった（0002 の手書き丸め値 1784500000000 が未来 → 0003/0004 が永久 skip → `login_streaks` 未作成）。
+
+- [ ] `when` は `npx drizzle-kit generate` の出力のまま（丸め値・連番・未来値にしない）
+- [ ] 既存 migration の `when` を後から編集しない（既に本番 `__drizzle_migrations.created_at` に記録済のため、編集は「適用済みだが journal 上は未適用」の不整合になる）
+- [ ] 機械 gate: `scripts/lib/db/drizzle-journal-gate.mjs`（`tests/unit/db/pglite-journal-when-range-3948.test.ts` が CI で hard-fail）
+
+**grandfather 例外**: `1784500000000` / `1784500000001` / `1784500000002`（0002 / 0003 / 0004）は #3946 以前に手書きで入り、既に本番 DB へ記録済のため値そのものは修正せず gate の例外として固定している。**新規にこの例外を増やさないこと**（根拠と一覧の SSOT は `scripts/lib/db/drizzle-journal-gate.mjs` 冒頭コメント）。
+
+`when` を参照するのは PGlite（NUC）経路のみ。DSQL（cloud）の `provision.ts` は `idx` 順 + tag 単位冪等で `when` を見ない（`[WR4]` で固定）。
+
 ## 出力フォーマット
 
 ```markdown

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -215,6 +215,7 @@ Denorm
 dependabot
 Dependabot
 Deque
+deschain
 describedby
 dflt
 DMARC

--- a/scripts/lib/db/drizzle-journal-gate.mjs
+++ b/scripts/lib/db/drizzle-journal-gate.mjs
@@ -1,0 +1,171 @@
+// scripts/lib/db/drizzle-journal-gate.mjs
+// #3948 — drizzle journal (`meta/_journal.json`) の `when` 値域を機械検証する gate (pure function)。
+//
+// ## なぜ必要か (#3946 の class)
+//
+// drizzle-orm 公式 migrator (pg-core dialect) は
+//   `Number(lastDbMigration.created_at) < migration.folderMillis` の時だけ migration を適用する。
+// つまり journal の `when` は「適用済み最大値より大きいか」だけで判定され、**一度でも実時刻より
+// 未来の `when` が本番 DB に記録されると、それ以降に drizzle-kit が生成する migration は
+// (実時刻ベースの `when` を持つため) 永久に skip される**。
+//
+// 実際に #3946 で本番障害になった: 0002 の `when` が手書きの丸め値 1784500000000 (当時から見て
+// 未来) で本番へ適用され、後から生成された 0003/0004 (`when` = 実生成時刻) が NUC で永久 skip →
+// `login_streaks` 未作成 → `/preschool/home` が 500。
+//
+// #3947 が追加した [JM1] は **狭義単調増加のみ**を assert しており、末尾 entry に遠い未来値を
+// 手書きすれば PASS したまま同型事故が再発する。本 gate はその穴 (値域の無検証) を塞ぐ。
+//
+// ## 検証ルール
+//
+//   [R1] `when` が未来でないこと (`when <= now`)
+//        → #3946 の instance はこの 1 本で防げた。手書き未来値は「書いた瞬間の CI」で落ちる。
+//   [R2] `when` が手書きの丸め値・連番でないこと (100 秒境界から 10ms 未満のズレを手書きと見なす)
+//        → drizzle-kit は `Date.now()` をそのまま入れるため、この範囲に落ちる確率は約 1/10,000。
+//   [R3] `when` が明らかに過去すぎないこと (プロジェクト開始前 = 明らかな手書き / 破損)
+//   [R4] `idx` 連番 + `when` 狭義単調増加 ([JM1] と同じ不変条件。gate 単体で完結させる)
+//
+// ## grandfather (既存の手書き値の許容)
+//
+// `GRANDFATHERED_WHEN` の 3 値は #3946 以前に手書きで journal へ入り、**既に本番 DB の
+// `__drizzle_migrations.created_at` として記録済み**のため、今から実生成時刻へ書き換えると
+// 「適用済みだが journal 上は未適用」の不整合が起きる (再適用 or 永久 skip)。したがって値そのものは
+// 修正せず、R2 の例外として固定する。R1 (未来でない) は 3 値とも既に満たしている。
+//
+//   1784500000000 = 0002_evaluations_week_unique  — #3946 の原因値 (手書きの丸め値)
+//   1784500000001 = 0003_login_streaks_counter    — #3947 で 0002 を上回らせるため手書きした連番
+//   1784500000002 = 0004_drop_login_bonuses       — 同上
+//
+// **新規 migration でこの例外を増やしてはならない**。`npx drizzle-kit generate` が入れた `when` を
+// 手で書き換えないこと (手順 SSOT: `.claude/skills/db-migration/SKILL.md`)。
+
+/** 0002_evaluations_week_unique の手書き `when` — #3946 の原因値。 */
+export const HANDWRITTEN_WHEN_0002 = 1784500000000;
+/** 0003_login_streaks_counter の手書き `when` — #3947 で 0002 を上回らせるために採番した連番。 */
+export const HANDWRITTEN_WHEN_0003 = 1784500000001;
+/** 0004_drop_login_bonuses の手書き `when` — 同上。 */
+export const HANDWRITTEN_WHEN_0004 = 1784500000002;
+
+/** #3946 以前に本番 DB へ記録済みの手書き `when` (R2 の例外)。新規追加は禁止。 */
+export const GRANDFATHERED_WHEN = Object.freeze([
+	HANDWRITTEN_WHEN_0002,
+	HANDWRITTEN_WHEN_0003,
+	HANDWRITTEN_WHEN_0004,
+]);
+
+/**
+ * 「手書きらしさ」の判定境界。`when % ROUND_UNIT_MS` が ROUND_SLACK_MS 未満なら手書きと見なす。
+ * drizzle-kit の `Date.now()` が偶然ここに落ちる確率は ROUND_SLACK_MS / ROUND_UNIT_MS = 1/10,000。
+ */
+export const ROUND_UNIT_MS = 100_000;
+export const ROUND_SLACK_MS = 10;
+
+/**
+ * これより過去の `when` は手書き / 破損と見なす (2023-01-01T00:00:00Z、本プロジェクト開始より前)。
+ *
+ * **絶対値の固定閾値**であり `now` からの相対ではない。journal の `when` は「その migration が
+ * 生成された時刻」で以後不変なので、古い branch を checkout しても・長期間 merge されない branch で
+ * CI を回しても、entries は「現在の journal の部分集合 (先頭 N 件)」にしかならず値自体は動かない。
+ * したがって branch の鮮度で誤 fail しない (相対閾値にすると逆に「古い branch ほど落ちる」になる)。
+ * 実 journal の最古 entry は 1783659891383 (2026-07) で、本閾値から 3 年半以上の余裕がある。
+ */
+export const MIN_PLAUSIBLE_WHEN = 1_672_531_200_000;
+
+/**
+ * journal entries の `when` 値域・順序を検証し、違反を配列で返す (違反ゼロ = 空配列)。
+ *
+ * @param {{ idx: number, when: number, tag: string }[]} entries
+ * @param {{ now?: number, grandfathered?: readonly number[] }} [options]
+ * @returns {{ rule: string, tag: string, when: number, message: string }[]}
+ */
+export function findJournalWhenViolations(entries, options = {}) {
+	const now = options.now ?? Date.now();
+	const grandfathered = new Set(options.grandfathered ?? GRANDFATHERED_WHEN);
+	/** @type {{ rule: string, tag: string, when: number, message: string }[]} */
+	const violations = [];
+
+	entries.forEach((entry, i) => {
+		const { tag, when, idx } = entry;
+
+		if (idx !== i) {
+			violations.push({
+				rule: 'R4-idx',
+				tag,
+				when,
+				message:
+					`idx が配列順と一致しない (idx=${idx}, 期待=${i})。
+` + `    → entries の並べ替え・手編集を戻し、drizzle-kit が生成した idx 連番へ戻してください。`,
+			});
+		}
+
+		if (when > now) {
+			violations.push({
+				rule: 'R1-future',
+				tag,
+				when,
+				message:
+					`when=${when} が現在時刻 (${now}) より未来。未来値を本番 DB へ適用すると、` +
+					`以降 drizzle-kit が生成する全 migration が既存 DB で永久 skip される (#3946 と同型)。\n` +
+					`    → 手書きした値を戻し、drizzle-kit が生成した実時刻をそのまま使ってください。`,
+			});
+		}
+
+		if (when < MIN_PLAUSIBLE_WHEN) {
+			violations.push({
+				rule: 'R3-too-old',
+				tag,
+				when,
+				message:
+					`when=${when} がプロジェクト開始 (${MIN_PLAUSIBLE_WHEN}) より過去。手書き値か journal 破損の疑い。\n` +
+					`    → epoch 秒 (10 桁) を epoch ミリ秒 (13 桁) と取り違えていないか確認し、` +
+					`drizzle-kit が生成した実時刻へ戻してください。`,
+			});
+		}
+
+		if (!grandfathered.has(when) && when % ROUND_UNIT_MS < ROUND_SLACK_MS) {
+			violations.push({
+				rule: 'R2-handwritten',
+				tag,
+				when,
+				message:
+					`when=${when} が手書きの丸め値・連番に見える (${ROUND_UNIT_MS}ms 境界から ${ROUND_SLACK_MS}ms 未満)。\n` +
+					`    → 手で書き換えた場合: 書き換えを戻し、drizzle-kit が生成した実時刻をそのまま使ってください。\n` +
+					`    → これが本当に drizzle-kit 生成値の場合 (約 1/${ROUND_UNIT_MS / ROUND_SLACK_MS} の偶然): ` +
+					`migration を再生成 (\`npx drizzle-kit generate\` をやり直す) してください。` +
+					`未適用の migration なら再生成が最も安全です。既に本番へ適用済みで再生成できない場合のみ、` +
+					`GRANDFATHERED_WHEN (scripts/lib/db/drizzle-journal-gate.mjs) へ理由付きで追加してください。`,
+			});
+		}
+	});
+
+	entries.reduce(
+		(prev, entry) => {
+			if (prev && entry.when <= prev.when) {
+				violations.push({
+					rule: 'R4-monotonic',
+					tag: entry.tag,
+					when: entry.when,
+					message:
+						`when=${entry.when} が直前 ${prev.tag} (when=${prev.when}) 以下。` +
+						`逆転した migration は既存 DB で永久 skip される (#3946 の直接原因)。
+` +
+						`    → 先行 entry の when を下げるのではなく、本 entry を drizzle-kit で再生成して実時刻を入れ直してください。`,
+				});
+			}
+			return entry;
+		},
+		/** @type {{ idx: number, when: number, tag: string } | null} */ (null),
+	);
+
+	return violations;
+}
+
+/**
+ * 違反配列を人間可読な 1 本のメッセージへ整形する。
+ *
+ * @param {{ rule: string, tag: string, when: number, message: string }[]} violations
+ * @returns {string}
+ */
+export function formatJournalWhenViolations(violations) {
+	return violations.map((v) => `  [${v.rule}] ${v.tag}: ${v.message}`).join('\n');
+}

--- a/scripts/lib/db/drizzle-journal-gate.mjs
+++ b/scripts/lib/db/drizzle-journal-gate.mjs
@@ -27,10 +27,26 @@
 //
 // ## grandfather (既存の手書き値の許容)
 //
-// `GRANDFATHERED_WHEN` の 3 値は #3946 以前に手書きで journal へ入り、**既に本番 DB の
-// `__drizzle_migrations.created_at` として記録済み**のため、今から実生成時刻へ書き換えると
-// 「適用済みだが journal 上は未適用」の不整合が起きる (再適用 or 永久 skip)。したがって値そのものは
-// 修正せず、R2 の例外として固定する。R1 (未来でない) は 3 値とも既に満たしている。
+// `GRANDFATHERED_WHEN` の 3 値は #3946 以前に手書きで journal へ入ったものだが、
+// **実生成時刻へ書き戻してはならない**。値そのものは修正せず R2 の例外として固定する
+// (R1 = 未来でない は 3 値とも既に満たしている)。
+//
+// 理由は **#3947 以前の backup から restore した DB で #3946 がそのまま再発する**からである。
+// migrator は「適用済み最大 `created_at` の 1 行」だけを見て
+// `lastDbMigration.created_at < folderMillis` で判定し、**per-tag の突合はしない**
+// (drizzle-orm/pg-core/dialect.js `migrate()`)。したがって:
+//
+//   - 現行の本番 DB (適用済み最大 = 1784500000002) では、値を書き戻しても
+//     **再適用も skip も起きない** (「適用済みだが journal 上は未適用」という状態は
+//     この migrator には存在しない)。
+//   - 一方、**適用済み最大が 1784500000000 の DB** — すなわち #3947 以前の backup を
+//     restore した DB — では、実生成時刻 (1784415769652 / 1784415789368) はそれより小さいため
+//     **0003/0004 が永久 skip され、`login_streaks` 未作成 → #3946 が再発する**。
+//
+// pre-hotfix backup (`pglite-snapshot-20260726-0738-pre-pr3947.tgz` 等) は #3950 の
+// restore drill 対象として現に存在するため、これは机上の話ではない。
+// この振る舞いは `[WR7]` (tests/unit/db/pglite-journal-when-range-3948.test.ts) が
+// 実 migrator + 実 migration SQL で固定している。
 //
 //   1784500000000 = 0002_evaluations_week_unique  — #3946 の原因値 (手書きの丸め値)
 //   1784500000001 = 0003_login_streaks_counter    — #3947 で 0002 を上回らせるため手書きした連番

--- a/tests/unit/db/pglite-journal-when-range-3948.test.ts
+++ b/tests/unit/db/pglite-journal-when-range-3948.test.ts
@@ -1,0 +1,224 @@
+// tests/unit/db/pglite-journal-when-range-3948.test.ts
+// #3948 — drizzle journal `when` の **値域** を機械検証する gate のテスト (class-lock)。
+//
+// #3947 が追加した [JM1] (pglite-journal-monotonic-3946.test.ts) は `when` の狭義単調増加のみを
+// assert しており、**末尾 entry に遠い未来値を手書きすれば PASS したまま**、以後 drizzle-kit が
+// 生成する全 migration が本番既存 DB で永久 skip される (#3946 と完全に同型の本番 500)。
+// 本テストはその穴を塞ぐ gate (scripts/lib/db/drizzle-journal-gate.mjs) を CI で hard-fail させる。
+//
+//   [WR1] 実 journal (drizzle/pglite/meta/_journal.json) が gate の全ルールを満たす
+//   [WR2] gate 自体の実効性: 未来値 / 手書き丸め値 / 逆転 / 過去すぎる値 の fixture で fail する
+//   [WR3] grandfather は既存 3 値限定 — 同型の新規丸め値は grandfather されず fail する
+//   [WR4] DSQL provision は `when` を参照しない (idx 順 + tag 冪等) ことの固定
+//
+// [WR2] は「gate を書いたが実は何も落とせていない」を防ぐ実効性検証 (#3072 と同型の考え方)。
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+import {
+	findJournalWhenViolations,
+	formatJournalWhenViolations,
+	GRANDFATHERED_WHEN,
+	HANDWRITTEN_WHEN_0002,
+	MIN_PLAUSIBLE_WHEN,
+	ROUND_UNIT_MS,
+} from '../../../scripts/lib/db/drizzle-journal-gate.mjs';
+import { loadMigrationFiles } from '../../../src/lib/server/db/dsql/migration/provision';
+
+interface JournalEntry {
+	idx: number;
+	when: number;
+	tag: string;
+}
+
+const PGLITE_MIGRATIONS_DIR = join(process.cwd(), 'drizzle', 'pglite');
+
+function loadRealJournal(): JournalEntry[] {
+	const raw = readFileSync(join(PGLITE_MIGRATIONS_DIR, 'meta', '_journal.json'), 'utf-8');
+	return (JSON.parse(raw) as { entries: JournalEntry[] }).entries;
+}
+
+/** 実 journal 相当の「正常な」entries (drizzle-kit が生成した実時刻を模した値)。 */
+function healthyEntries(): JournalEntry[] {
+	return [
+		{ idx: 0, when: 1_783_659_891_383, tag: '0000_first' },
+		{ idx: 1, when: 1_784_100_586_276, tag: '0001_second' },
+		{ idx: 2, when: 1_784_415_769_652, tag: '0002_third' },
+	];
+}
+
+const tempDirs: string[] = [];
+afterAll(() => {
+	for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeMigrationsDir(entries: { idx: number; when: number; tag: string }[]): string {
+	const dir = join(tmpdir(), `journal-when-3948-${process.pid}-${tempDirs.length}`);
+	tempDirs.push(dir);
+	mkdirSync(join(dir, 'meta'), { recursive: true });
+	writeFileSync(
+		join(dir, 'meta', '_journal.json'),
+		JSON.stringify({ version: '7', dialect: 'postgresql', entries }),
+	);
+	for (const e of entries) {
+		writeFileSync(join(dir, `${e.tag}.sql`), `-- ${e.tag}\nSELECT 1;`);
+	}
+	return dir;
+}
+
+describe('drizzle journal `when` 値域 gate (#3948)', () => {
+	it('[WR1] 実 journal (drizzle/pglite) が gate の全ルールを満たす', () => {
+		const entries = loadRealJournal();
+		expect(entries.length).toBeGreaterThan(0);
+		const violations = findJournalWhenViolations(entries);
+		expect(
+			violations,
+			`journal 違反あり:\n${formatJournalWhenViolations(violations)}`,
+		).toStrictEqual([]);
+	});
+
+	it('[WR1b] 実 journal の grandfather 例外は既知 3 値のみ (新規追加が混ざっていない)', () => {
+		const entries = loadRealJournal();
+		// grandfather を無効化すると、既知 3 値 **だけ** が R2 で落ちる = 例外が増えていない。
+		const withoutGrandfather = findJournalWhenViolations(entries, { grandfathered: [] });
+		expect(withoutGrandfather.every((v) => v.rule === 'R2-handwritten')).toBe(true);
+		expect(withoutGrandfather.map((v) => v.when).sort()).toStrictEqual([...GRANDFATHERED_WHEN]);
+	});
+
+	it('[WR2a] 未来値を末尾に手書きすると fail する (#3946 と同型の再発を hard-fail)', () => {
+		const now = 1_785_000_000_000;
+		const entries = [
+			...healthyEntries(),
+			// [JM1] (単調増加のみ) は PASS してしまう値。gate はこれを落とさなければならない。
+			{ idx: 3, when: 1_900_000_000_000, tag: '0003_far_future' },
+		];
+		const violations = findJournalWhenViolations(entries, { now });
+		expect(violations.map((v) => v.rule)).toContain('R1-future');
+		expect(violations.some((v) => v.tag === '0003_far_future')).toBe(true);
+	});
+
+	it('[WR2b] 手書きの丸め値・連番は fail する', () => {
+		const now = 1_785_000_000_000;
+		const rounded = 1_784_800_000_000; // 100 秒境界ちょうど = 手書きの丸め値
+		const sequential = rounded + 1; // 丸め値の直後に手書きした連番
+		expect(rounded % ROUND_UNIT_MS).toBe(0);
+
+		const violations = findJournalWhenViolations(
+			[
+				...healthyEntries(),
+				{ idx: 3, when: rounded, tag: '0003_rounded' },
+				{ idx: 4, when: sequential, tag: '0004_sequential' },
+			],
+			{ now },
+		);
+		const handwritten = violations.filter((v) => v.rule === 'R2-handwritten');
+		expect(handwritten.map((v) => v.tag)).toStrictEqual(['0003_rounded', '0004_sequential']);
+	});
+
+	it('[WR2c] 逆転 / idx 不整合 / 過去すぎる値も fail する', () => {
+		const now = 1_785_000_000_000;
+		const reversed = findJournalWhenViolations(
+			[...healthyEntries(), { idx: 3, when: 1_783_000_000_000, tag: '0003_reversed' }],
+			{ now },
+		);
+		expect(reversed.map((v) => v.rule)).toContain('R4-monotonic');
+
+		const badIdx = findJournalWhenViolations(
+			[{ idx: 7, when: 1_784_415_769_652, tag: '0000_bad_idx' }],
+			{ now },
+		);
+		expect(badIdx.map((v) => v.rule)).toContain('R4-idx');
+
+		const tooOld = findJournalWhenViolations([{ idx: 0, when: 1000, tag: '0000_too_old' }], {
+			now,
+		});
+		expect(tooOld.map((v) => v.rule)).toContain('R3-too-old');
+		expect(MIN_PLAUSIBLE_WHEN).toBeGreaterThan(1000);
+	});
+
+	it('[WR2d] 正常な entries は 1 件も違反を出さない (false positive を出さない)', () => {
+		expect(findJournalWhenViolations(healthyEntries(), { now: 1_785_000_000_000 })).toStrictEqual(
+			[],
+		);
+	});
+
+	it('[WR3] grandfather は既存 3 値限定 — 同型の新規丸め値は救済されない', () => {
+		const now = 1_785_000_000_000;
+		// 既存の grandfather 値そのものは許容される。
+		const grandfathered = findJournalWhenViolations(
+			[{ idx: 0, when: HANDWRITTEN_WHEN_0002, tag: '0000_grandfathered' }],
+			{ now },
+		);
+		expect(grandfathered).toStrictEqual([]);
+
+		// 「grandfather があるから丸め値を足してよい」にはならない。
+		const newRounded = findJournalWhenViolations(
+			[
+				{ idx: 0, when: HANDWRITTEN_WHEN_0002, tag: '0000_grandfathered' },
+				{ idx: 1, when: 1_784_900_000_000, tag: '0001_new_rounded' },
+			],
+			{ now },
+		);
+		expect(newRounded.map((v) => v.rule)).toContain('R2-handwritten');
+	});
+
+	it('[WR5] #3946 発生時点の journal を再現すると gate が fail する (この gate があれば防げた)', () => {
+		// 0002 の手書き値 1784500000000 が書かれた当時 (2026-07-12 前後) の時刻。
+		const nowAtIncident = 1_784_000_000_000;
+		expect(nowAtIncident).toBeLessThan(HANDWRITTEN_WHEN_0002); // 当時 0002 の when は「未来」だった
+
+		// #3947 以前の実 journal (0003/0004 は drizzle-kit 生成の実時刻 = 0002 より過去 → 逆転)。
+		const brokenJournal = [
+			{ idx: 0, when: 1_783_659_891_383, tag: '0000_pretty_wolfsbane' },
+			{ idx: 1, when: 1_784_100_586_276, tag: '0001_overrated_roland_deschain' },
+			{ idx: 2, when: 1_784_500_000_000, tag: '0002_evaluations_week_unique' },
+			{ idx: 3, when: 1_784_415_769_652, tag: '0003_login_streaks_counter' },
+			{ idx: 4, when: 1_784_415_789_368, tag: '0004_drop_login_bonuses' },
+		];
+
+		// 0002 を grandfather しても、「未来値」であることは当時の時刻で必ず落ちる。
+		const violations = findJournalWhenViolations(brokenJournal, { now: nowAtIncident });
+		expect(violations.some((v) => v.rule === 'R1-future' && v.tag.startsWith('0002_'))).toBe(true);
+		// 0003/0004 の逆転も同時に検出される。
+		expect(violations.filter((v) => v.rule === 'R4-monotonic').map((v) => v.tag)).toStrictEqual([
+			'0003_login_streaks_counter',
+		]);
+	});
+
+	it('[WR6] 失敗メッセージが「次に何をすればいいか」を含む (踏んだ開発者が詰まらない)', () => {
+		const now = 1_785_000_000_000;
+		const violations = findJournalWhenViolations(
+			[
+				{ idx: 0, when: 1_784_800_000_000, tag: '0000_rounded' },
+				{ idx: 1, when: 1_900_000_000_000, tag: '0001_future' },
+				{ idx: 2, when: 1_000_000_000_000, tag: '0002_too_old' },
+			],
+			{ now },
+		);
+		const byRule = (rule: string) => violations.find((v) => v.rule === rule)?.message ?? '';
+
+		// R2 は false positive (約 1/10,000) があり得るため、「本当に生成値だった場合」の導線が要る。
+		expect(byRule('R2-handwritten')).toContain('drizzle-kit generate');
+		expect(byRule('R2-handwritten')).toContain('GRANDFATHERED_WHEN');
+		// R1 / R3 は手書き / 取り違えが原因なので戻し方を示す。
+		expect(byRule('R1-future')).toContain('→');
+		expect(byRule('R3-too-old')).toContain('→');
+		// どのルールも「→」で始まる次アクション行を必ず持つ。
+		for (const v of violations) {
+			expect(v.message, `${v.rule} に次アクションがない`).toContain('→');
+		}
+	});
+
+	it('[WR4] DSQL provision は `when` を参照しない (idx 順 + tag 冪等) — 影響波及なしの固定', () => {
+		// `when` を意図的に逆転させても、DSQL の loadMigrationFiles は idx 順で読む。
+		// = #3946 / #3948 の class は PGlite (drizzle-orm migrator) 固有であり cloud には波及しない。
+		const dir = makeMigrationsDir([
+			{ idx: 0, when: 3000, tag: '0000_a' },
+			{ idx: 1, when: 2000, tag: '0001_b' },
+			{ idx: 2, when: 1000, tag: '0002_c' },
+		]);
+		expect(loadMigrationFiles(dir).map((f) => f.tag)).toStrictEqual(['0000_a', '0001_b', '0002_c']);
+	});
+});

--- a/tests/unit/db/pglite-journal-when-range-3948.test.ts
+++ b/tests/unit/db/pglite-journal-when-range-3948.test.ts
@@ -10,12 +10,17 @@
 //   [WR2] gate 自体の実効性: 未来値 / 手書き丸め値 / 逆転 / 過去すぎる値 の fixture で fail する
 //   [WR3] grandfather は既存 3 値限定 — 同型の新規丸め値は grandfather されず fail する
 //   [WR4] DSQL provision は `when` を参照しない (idx 順 + tag 冪等) ことの固定
+//   [WR7] grandfather 3 値を「実生成時刻へ直す」と pre-hotfix backup の restore で #3946 が再発する
+//         (grandfather が必要である理由そのものを実 migrator + 実 migration で固定する)
 //
 // [WR2] は「gate を書いたが実は何も落とせていない」を防ぐ実効性検証 (#3072 と同型の考え方)。
 
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle } from 'drizzle-orm/pglite';
+import { migrate } from 'drizzle-orm/pglite/migrator';
 import { afterAll, describe, expect, it } from 'vitest';
 import {
 	findJournalWhenViolations,
@@ -68,6 +73,29 @@ function makeMigrationsDir(entries: { idx: number; when: number; tag: string }[]
 	return dir;
 }
 
+/** 実 migration SQL を使い、指定 entries の journal を持つ temp migrations dir を作る。 */
+function makeRealMigrationsDir(entries: JournalEntry[]): string {
+	const dir = join(tmpdir(), `journal-when-3948-real-${process.pid}-${tempDirs.length}`);
+	tempDirs.push(dir);
+	mkdirSync(join(dir, 'meta'), { recursive: true });
+	writeFileSync(
+		join(dir, 'meta', '_journal.json'),
+		JSON.stringify({ version: '7', dialect: 'postgresql', entries }),
+	);
+	for (const e of entries) {
+		copyFileSync(join(PGLITE_MIGRATIONS_DIR, `${e.tag}.sql`), join(dir, `${e.tag}.sql`));
+	}
+	return dir;
+}
+
+async function tableExists(client: PGlite, table: string): Promise<boolean> {
+	const result = await client.query<{ exists: boolean }>(
+		'SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1) AS exists',
+		[table],
+	);
+	return result.rows[0]?.exists === true;
+}
+
 describe('drizzle journal `when` 値域 gate (#3948)', () => {
 	it('[WR1] 実 journal (drizzle/pglite) が gate の全ルールを満たす', () => {
 		const entries = loadRealJournal();
@@ -84,7 +112,9 @@ describe('drizzle journal `when` 値域 gate (#3948)', () => {
 		// grandfather を無効化すると、既知 3 値 **だけ** が R2 で落ちる = 例外が増えていない。
 		const withoutGrandfather = findJournalWhenViolations(entries, { grandfathered: [] });
 		expect(withoutGrandfather.every((v) => v.rule === 'R2-handwritten')).toBe(true);
-		expect(withoutGrandfather.map((v) => v.when).sort()).toStrictEqual([...GRANDFATHERED_WHEN]);
+		expect(withoutGrandfather.map((v) => v.when).sort((a, b) => a - b)).toStrictEqual([
+			...GRANDFATHERED_WHEN,
+		]);
 	});
 
 	it('[WR2a] 未来値を末尾に手書きすると fail する (#3946 と同型の再発を hard-fail)', () => {
@@ -210,6 +240,63 @@ describe('drizzle journal `when` 値域 gate (#3948)', () => {
 			expect(v.message, `${v.rule} に次アクションがない`).toContain('→');
 		}
 	});
+
+	it('[WR7] grandfather 3 値を実生成時刻へ直すと pre-hotfix backup の restore で #3946 が再発する', async () => {
+		// grandfather が必要な本当の理由を実 migrator + 実 migration SQL で固定する。
+		// drizzle migrator (pg-core dialect) は `適用済み最大 created_at < folderMillis` の
+		// 1 条件だけで判定し、per-tag の突合はしない。したがって「再適用」は起きない一方、
+		// **適用済み最大が 1784500000000 の DB (= #3947 以前の backup を restore した DB)** では、
+		// 0003/0004 を実生成時刻 (それより小さい) へ「直す」と永久 skip されて #3946 が再発する。
+		// pre-hotfix backup は #3950 の restore drill 対象として現に存在するため、これは机上の話ではない。
+		const entries = loadRealJournal();
+		const idx0002 = entries.findIndex((e) => e.tag.startsWith('0002_'));
+		expect(idx0002).toBeGreaterThanOrEqual(0);
+
+		// 0003/0004 を「drizzle-kit の実生成時刻」へ書き戻した journal (#3947 以前の値)。
+		const REAL_GENERATED_WHEN: Record<string, number> = {
+			'0003_': 1_784_415_769_652,
+			'0004_': 1_784_415_789_368,
+		};
+		const rewritten = entries.map((e) => {
+			const key = Object.keys(REAL_GENERATED_WHEN).find((k) => e.tag.startsWith(k));
+			return key ? { ...e, when: REAL_GENERATED_WHEN[key] as number } : e;
+		});
+		// 「直した」journal は 0002 の grandfather 値より小さくなる = 逆転する。
+		expect(rewritten[idx0002 + 1]?.when).toBeLessThan(HANDWRITTEN_WHEN_0002);
+
+		// pre-hotfix backup 相当 (0000-0002 適用済み) を 2 つ用意し、以後の journal だけを変える。
+		const preHotfixDir = makeRealMigrationsDir(entries.slice(0, idx0002 + 1));
+		const rewrittenDir = makeRealMigrationsDir(rewritten);
+
+		const broken = new PGlite();
+		try {
+			const db = drizzle(broken);
+			await migrate(db, { migrationsFolder: preHotfixDir });
+			expect(await tableExists(broken, 'login_streaks')).toBe(false);
+
+			// 「直した」journal で migrate → 0003/0004 が永久 skip され #3946 が再発する。
+			await migrate(db, { migrationsFolder: rewrittenDir });
+			expect(
+				await tableExists(broken, 'login_streaks'),
+				'grandfather を外すと pre-hotfix restore で login_streaks が作られず #3946 が再発する',
+			).toBe(false);
+			expect(await tableExists(broken, 'login_bonuses')).toBe(true);
+		} finally {
+			await broken.close();
+		}
+
+		// 対照: grandfather を維持した現行 journal なら同じ backup から正しく復旧する。
+		const healthy = new PGlite();
+		try {
+			const db = drizzle(healthy);
+			await migrate(db, { migrationsFolder: preHotfixDir });
+			await migrate(db, { migrationsFolder: PGLITE_MIGRATIONS_DIR });
+			expect(await tableExists(healthy, 'login_streaks')).toBe(true);
+			expect(await tableExists(healthy, 'login_bonuses')).toBe(false);
+		} finally {
+			await healthy.close();
+		}
+	}, 120_000);
 
 	it('[WR4] DSQL provision は `when` を参照しない (idx 順 + tag 冪等) — 影響波及なしの固定', () => {
 		// `when` を意図的に逆転させても、DSQL の loadMigrationFiles は idx 順で読む。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供 / 親（管理者） — 間接的に、システム全体の可用性を守る変更

**解決する課題**: #3946 では journal の `when` に手書きの未来値が入ったことで、以後の DB migration が本番既存 DB で永久に skip され、**子供ホーム (`/preschool/home`) が第17回リリース以降ずっと 500** になっていた。instance は #3947 で修正済みだが、**同じ事故をもう一度起こせる状態**が残っている。#3947 が追加した `[JM1]` は `when` の単調増加しか見ておらず、末尾 entry に遠い未来値を手書きすれば PASS したまま同型障害が再発する。

**期待される効果**: `when` の値域を CI で機械検証し、同型事故を **PR 段階で hard-fail** させる。子供が「昨日まで使えた画面が今日は開かない」状況に遭遇する経路を 1 本潰す。

## 関連 Issue

closes #3948

関連: #3946（instance / 本番 500）/ #3947（instance の hotfix）/ ADR-0061 原則 2（shift-left / class-lock）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 全 entry について `when` が未来時刻でないこと (`when <= Date.now()`) を検証する assertion を追加する | `scripts/lib/db/drizzle-journal-gate.mjs` の `R1-future` / `npx vitest run tests/unit/db/pglite-journal-when-range-3948.test.ts` (`[WR1]` `[WR2a]`) | **PASS** — 10 tests PASS。`[WR2a]` は末尾に `when=1900000000000` を仕込み `R1-future` が出ることを assert |
| AC2 | `when` が手書きの丸め値パターン (末尾に多数の 0 / 連番) でないことを検証する | 同 gate の `R2-handwritten`（`when % 100000 < 10` を手書きと判定）/ `[WR2b]` `[WR3]` | **PASS** — 丸め値 `1784800000000` と連番 `...001` の両方を検出。`[WR1b]` で「grandfather を外すと既知 3 値だけが落ちる」= 例外が増えていないことを固定 |
| AC3 | cloud (DSQL) 側にも同様に適用するか、適用不要なら「DSQL provision は `idx` 順 + tag 冪等で `when` を参照しない」ことをテストで固定する | `[WR4]`（`when` を逆転させた fixture を `loadMigrationFiles` に渡し idx 順で読まれることを assert） | **PASS** — `drizzle/dsql/meta/_journal.json` は存在せず（migration SQL の SSOT は `drizzle/pglite/`、`provision.ts:6-9`）、`provision.ts:34-44` は `idx` と `tag` のみ参照。**テストで固定**した |
| AC4 | 意図的に未来値を仕込んだ fixture で gate が fail することを確認するテストを含める | `[WR2a]` 未来値 / `[WR2b]` 丸め値・連番 / `[WR2c]` 逆転・idx 不整合・過去すぎ / `[WR2d]` 正常値で false positive を出さない / `[WR5]` #3946 当時の journal 再現 | **PASS** — `[WR5]` は #3946 発生時点の実 journal を当時の時刻で評価し `R1-future`(0002) + `R4-monotonic`(0003) が出ることを assert = **この gate があれば #3946 は防げた**ことの証明 |
| AC5 | 0002 の `when` が手書き値である事実を journal 近傍 or docs にコメントで記録し、gate が既存値を許容する根拠 (grandfather) を明示する | `scripts/lib/db/drizzle-journal-gate.mjs` 冒頭コメント §grandfather / `.claude/skills/db-migration/SKILL.md` §5 / `[WR7]` | **PASS** — 3 値を実生成時刻へ書き戻してはならない理由を「**#3947 以前の backup から restore した DB (適用済み最大 `created_at` = 1784500000000) で 0003/0004 が永久 skip され #3946 が再発する**」と明記し、`[WR7]` が実 migrator + 実 migration SQL で両方向 (直すと再発 / grandfather 維持なら復旧) を固定 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — テスト + gate スクリプト + skill ドキュメントの追加のみ

**影響を受ける画面・機能**: なし（**production の実行コードは 1 行も変更していない**。追加したのは CI で走る検証ロジックとドキュメントのみ。`drizzle/` 配下の migration / journal も未変更）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3951` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/db/pglite-journal-when-range-3948.test.ts`（新規 11 本）
    - `[WR1]` 実 journal が gate の全ルールを満たす / `[WR1b]` grandfather 例外が既知 3 値のみ
    - `[WR2a-d]` gate 実効性: 未来値 / 丸め値・連番 / 逆転・idx 不整合・過去すぎ で fail、正常値で false positive なし
    - `[WR3]` grandfather は既存 3 値限定（新規丸め値は救済されない）
    - `[WR5]` #3946 発生時点の journal 再現で fail
    - `[WR6]` 失敗メッセージが「次に何をすればいいか」を含む
    - `[WR7]` grandfather 3 値を実生成時刻へ直すと pre-hotfix backup の restore で #3946 が再発する (実 migrator + 実 migration SQL)
    - `[WR4]` DSQL provision が `when` を参照しないことの固定
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（#3438 で DynamoDB backend は撤去済）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（本 PR は `priority:high` の class-lock。instance の critical 修正は #3947 で完了済）

## スクリーンショット / ビジュアルデモ

**該当なし（テスト + スクリプト + ドキュメントのみで、UI 変更を含まないため）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: gate は副作用のない pure function（`findJournalWhenViolations` / `formatJournalWhenViolations`）に分離。ファイル読み込み・assert はテスト側が担い、判定ロジックは入力 → 違反配列の写像に閉じている
- [x] **DRY**: `[JM1]`（#3947）と単調増加の検証が重なるが、**意図的に gate 側でも保持**した。gate 単体で「journal が健全か」を完結して答えられる必要があり、`[JM1]` は本 PR の scope 外（#3947 の成果物）なので削除・改変していない
- [x] **YAGNI**: `scripts/check-*.mjs` の CLI wrapper と pre-ready step は追加していない（後述「設計判断」）
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: entries は 5 件、判定は O(n)。CI 実行時間への影響は測定不能なレベル

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] N/A — 並行実装の影響範囲外（production 実行コード・DB スキーマ・UI のいずれも変更していない）

`when` を参照する backend は PGlite（NUC）経路のみで、DSQL（cloud）は `idx` 順 + tag 冪等、SQLite（退役中）は lazy-startup の別機構。この横展開結果は `[WR4]` と gate モジュールのコメントに固定した。

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

監査から事前にいただいた 2 点に回答します。

**1. `R2` の false positive 時の導線**

判定は「`when % 100000 < 10`」で、正規の drizzle-kit 生成値を誤検出する確率は約 1/10,000。踏んだ開発者が詰まらないよう、失敗メッセージに **場合分けした次アクション**を入れました。

```text
[R2-handwritten] 0005_foo: when=1785100000003 が手書きの丸め値・連番に見える (100000ms 境界から 10ms 未満)。
    → 手で書き換えた場合: 書き換えを戻し、drizzle-kit が生成した実時刻をそのまま使ってください。
    → これが本当に drizzle-kit 生成値の場合 (約 1/10000 の偶然): migration を再生成
      (`npx drizzle-kit generate` をやり直す) してください。未適用の migration なら再生成が最も安全です。
      既に本番へ適用済みで再生成できない場合のみ、GRANDFATHERED_WHEN
      (scripts/lib/db/drizzle-journal-gate.mjs) へ理由付きで追加してください。
```

R1 / R3 / R4 にも同様に `→` 始まりの次アクション行を入れ、**「全ルールの失敗メッセージが次アクションを含む」ことを `[WR6]` で機械的に固定**しました（文言が痩せたら CI が落ちます）。実際 `[WR6]` を書いた時点で R4 の 2 ルールに次アクションが無いことが検出され、その場で補いました。

**2. `R3`（過去すぎない）の閾値と、古い branch での誤 fail**

閾値は `MIN_PLAUSIBLE_WHEN = 1672531200000`（2023-01-01T00:00:00Z）。**古い branch でも誤 fail しません。**

- journal の `when` は「その migration が生成された時刻」で、生成後は不変。古い branch / 長期間 merge されない branch が持つのは **現在の journal の部分集合（先頭 N 件）**であり、値そのものは動かない。したがって branch の鮮度は R3 の判定に影響しない。
- 逆に「`now` からの相対」で閾値を引くと、**古い branch ほど落ちる**という誤 fail をむしろ作り込む。そのため意図的に絶対値の固定閾値にした（根拠は gate モジュールの `MIN_PLAUSIBLE_WHEN` の JSDoc に記載）。
- 実 journal の最古 entry は `1783659891383`（2026-07）で、閾値まで **3 年半以上**の余裕がある。R3 が現実的に発火するのは「epoch 秒（10 桁）を epoch ミリ秒（13 桁）と取り違えた」ようなケースで、失敗メッセージにもその確認を促す文言を入れた。

**3. 設計判断: `pre-ready` に step を追加していない**

gate は vitest（必須 CI の `unit-test` job）で hard-fail する。`scripts/check-*.mjs` として pre-ready の step を増やすと現行 12 step の番号付け替えが全体に波及する一方、強制力は「Dev がローカルで走らせる」pre-ready より CI の方が上。既存の `[JM1]` と同じ層（`tests/unit/db`）に置いた。

**4. 監査差し戻しへの対応 (severity 2 / 修正済)**

監査の中間レビューで「grandfather の結論は正しいがコメントの機構説明が誤り」と指摘を受け、修正した。`drizzle-orm/pg-core/dialect.js` の `migrate()` を直接確認したところ、確かに `select ... order by created_at desc limit 1` の 1 行だけを `lastDbMigration.created_at < folderMillis` と比較するだけで、**per-tag の突合はしていない**。旧コメントにあった「適用済みだが journal 上は未適用 → 再適用」という状態はこの migrator に存在しない。

実際の危険は **#3947 以前の backup から restore した DB (適用済み最大 = 1784500000000) で 0003/0004 が永久 skip され #3946 が再発する**こと。コメントをこの機構へ書き換え、`[WR7]` で両方向 (直すと再発 / grandfather 維持なら復旧) を実 migrator で固定した。あわせて `[WR1b]` の `.sort()` を数値比較へ修正した (辞書順ソートは grandfather に桁の違う値が入った瞬間に壊れる)。

**5. `[JM1]` を置き換えず残している**

`[JM1]`（#3947）と本 gate の `R4-monotonic` は検証内容が重なる。`[JM1]` は #3947 の成果物であり本 PR の scope 外なので削除・改変していない。重複は許容する判断。統合すべきなら別 Issue で扱うのが安全と考える。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3951` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
