### PR TITLE
fix(db): #3950 PGlite 本番データの日次バックアップを実装 — 取得 → 復元検証 → 3 世代ローテーション

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
     environment:
       - NODE_ENV=production
       - DATABASE_URL=./data/ganbari-quest.db
+      # #3950: PGlite バックアップはアプリプロセス内で採るため、取得先と保持世代は app 側が読む
+      # (backup コンテナは /api/cron/pglite-backup を叩くだけ)。保持 3 世代 = オーナー決裁。
+      - BACKUP_DIR=./data/backups
+      - BACKUP_RETENTION=3
       - HOST=0.0.0.0
       - PORT=3000
       - ORIGIN=${ORIGIN:-http://localhost:3000}
@@ -33,17 +37,21 @@ services:
   # Enable: docker compose --profile backup up -d
   #
   # #2519: backup → restore 検証を chain する。backup の「存在」だけでなく
-  # 「restore 可能 + 中身が壊れていない」を毎日確認し、verify 失敗時は
-  # verify-backup-restore.cjs が Discord alert を送る (DISCORD_ALERT_WEBHOOK_URL)。
-  # GDrive アップロードは BACKUP_POST_HOOK (.env) 経由で backup-db.cjs が実行する。
+  # 「restore 可能 + 中身が壊れていない」を毎日確認し、verify 失敗時は Discord alert を送る
+  # (DISCORD_ALERT_WEBHOOK_URL)。GDrive アップロードは BACKUP_POST_HOOK (.env) 経由。
+  #
+  # #3950: 入口を scripts/backup-nuc.cjs に一本化した。DATA_SOURCE を見て backend ごとの経路へ
+  # 振り分ける (pglite = アプリの /api/cron/pglite-backup、それ以外 = 従来の SQLite 経路)。
+  # 直接 backup-db.cjs を叩いていた旧構成は、2026-07-12 の PGlite 移行後も旧 SQLite を複製し続け、
+  # **実データが 2 週間以上無保護のまま毎日 fail していた** (#3950)。backend 判定を 1 箇所に集約する。
   backup:
     build: .
     entrypoint: /bin/sh
     command:
       - -c
       - |
-        echo "0 3 * * * cd /app && node scripts/backup-db.cjs >> /proc/1/fd/1 2>&1 && node scripts/verify-backup-restore.cjs >> /proc/1/fd/1 2>&1" | crontab -
-        echo "[Backup] Cron scheduled: daily 3:00 AM JST (backup + restore verification)"
+        echo "0 3 * * * cd /app && node scripts/backup-nuc.cjs >> /proc/1/fd/1 2>&1" | crontab -
+        echo "[Backup] Cron scheduled: daily 3:00 AM JST (backup-nuc: backend 振り分け + 復元検証)"
         crond -f
     # backup コンテナは web server を持たないため Dockerfile の HEALTHCHECK
     # (wget :3000/health) を継承すると恒久的に unhealthy 誤表示になる (#2985)。
@@ -59,7 +67,12 @@ services:
     environment:
       - DATABASE_URL=./data/ganbari-quest.db
       - BACKUP_DIR=./data/backups
-      - BACKUP_RETENTION=7
+      # #3950: 保持世代はオーナー決裁 (2026-07-26) で日次 3 世代。
+      # BACKUP_RETENTION は pglite 経路ではアプリ側 (app サービス) が読むため、両方に設定する。
+      - BACKUP_RETENTION=3
+      # DATA_SOURCE / CRON_SECRET は .env から供給される (env_file required: true)。
+      # backup コンテナは app に HTTP で backup 起動を依頼するため APP_URL が必要。
+      - APP_URL=http://app:3000
       - TZ=Asia/Tokyo
     env_file:
       - path: .env

--- a/docs/runbooks/pglite-restore-drill.md
+++ b/docs/runbooks/pglite-restore-drill.md
@@ -1,0 +1,143 @@
+# Runbook — NUC PGlite バックアップ運用 + 復元リハーサル (restore drill)
+
+NUC 本番 (PGlite) のバックアップ取得・失敗検知・復元手順。#3950。
+実装 SSOT: `src/lib/server/db/pglite/backup.ts` / `src/lib/server/services/pglite-backup-service.ts` /
+`src/routes/api/cron/pglite-backup/+server.ts` / `scripts/backup-nuc.cjs` / `docker-compose.yml` (backup profile)。
+
+## 方針 (オーナー決裁 2026-07-26)
+
+| 項目 | 値 | 根拠 |
+|---|---|---|
+| RPO | **日次** (毎日 03:00 JST 取得) | オーナー決裁 |
+| 保持世代 | **3 世代** | オーナー決裁 |
+| 取得時ダウンタイム | **0 秒** | PGlite 公式 `dumpDataDir()` をアプリプロセス内で実行するため停止不要 |
+| 保存先 | NUC ローカル `C:\Docker\ganbari-quest\data\backups\` | 現行運用の踏襲。オフサイト複製は未実施 (下記「残存リスク」) |
+
+### なぜアプリプロセス内で採るのか
+
+PGlite は dataDir を**単一プロセスで占有**する。外部プロセス (backup コンテナ等) から採れるのは
+「稼働中ディレクトリの tar」= 取得中に書き換えが走り得るコピーだけで、復元できる保証がない。
+DB を掴んでいるアプリプロセスから `dumpDataDir()` を呼ぶのが、**停止せずに整合したスナップショットを
+得る唯一の経路**。よって backup コンテナ (crond) は `/api/cron/pglite-backup` を叩くだけの起動役に徹する。
+
+## 日次バックアップの流れ
+
+```
+crond (backup コンテナ, 03:00 JST)
+  └─ node scripts/backup-nuc.cjs
+       ├─ DATA_SOURCE=pglite  → POST http://app:3000/api/cron/pglite-backup  (x-cron-secret)
+       │    └─ runPgliteBackup()
+       │         1. dumpDataDir('gzip')        取得 (ダウンタイム 0)
+       │         2. 復元検証 V1/V2/V3          ← 落ちたらファイルを確定させない
+       │         3. tmp へ書いて rename        確定 (半端なファイルを世代にしない)
+       │         4. ローテーション (3 世代)     ← 確定後にのみ削除する
+       │         5. backup-status-pglite.json  最終成功/失敗を記録
+       └─ それ以外              → 従来の SQLite 経路 (backup-db.cjs + verify-backup-restore.cjs)
+```
+
+### 復元検証 3 段 (取得物を実際に別インスタンスへ復元して確認する)
+
+| 段 | 内容 | 落ちたときの意味 |
+|---|---|---|
+| **V1** | 復元 DB の public テーブル全件に `select count(*)` が通る | 取得物が壊れている / 空ダンプ |
+| **V2** | `drizzle.__drizzle_migrations` が 1 行以上ある | schema 未適用の DB を掴んでいる |
+| **V3** | journal (`drizzle/pglite/meta/_journal.json`) の全 entry が「適用済み最大 `created_at`」以下 | **復元後に永久 skip される migration がある** = #3946 同型。migration を足した直後にアプリ未再起動、または journal の `when` が書き換えられた疑い |
+
+V3 は #3951 の gate (journal 内部の整合性のみ検証) が塞げていなかった
+「journal と本番適用実績の関係」を、日次の復元経路で突合するもの (監査 residual [security/sev2])。
+
+## 失敗の検知
+
+- **Discord alert**: `scripts/backup-nuc.cjs` が失敗時に `DISCORD_ALERT_WEBHOOK_URL` へ通知する
+- **状態ファイル**: `data/backups/backup-status-pglite.json` に `lastSuccessAt` / `lastFailureAt` /
+  `lastFailureMessage` が残る。**失敗しても直前の成功時刻は保持される**ので「最後に成功したのはいつか」が失われない
+- **確認コマンド**
+
+```bash
+ssh <NUC_USER>@<NUC_IP> "type C:\Docker\ganbari-quest\data\backups\backup-status-pglite.json"
+ssh <NUC_USER>@<NUC_IP> "dir C:\Docker\ganbari-quest\data\backups\pglite-*.tgz"
+ssh <NUC_USER>@<NUC_IP> "docker logs ganbari-quest-backup-1 --tail 50"
+```
+
+> #3950 の事故 (2026-07-12〜07-26) は「job は毎日動いていたが対象が更新停止した旧 SQLite で、しかも
+> 毎日 fail していたのに誰も気づかなかった」。**「動いているように見える」を成功と読まない**こと。
+> 確認は必ず `backup-status-pglite.json` の `lastSuccessAt` と `pglite-*.tgz` の実在で行う。
+
+## 手動実行 (drill / 障害調査)
+
+```bash
+# backup コンテナから 1 回だけ実行する
+ssh <NUC_USER>@<NUC_IP> "docker exec -w /app ganbari-quest-backup-1 node scripts/backup-nuc.cjs"
+```
+
+## 復元手順 (restore)
+
+`pglite-*.tgz` は `dumpDataDir('gzip')` の出力 = PGlite dataDir の tarball。展開して
+`PGLITE_DATA_DIR` に置けばそのまま起動できる。
+
+```bash
+# 1. アプリを止める (復元先ディレクトリを掴んだままにしない)
+ssh <NUC_USER>@<NUC_IP> "cd /d C:\Docker\ganbari-quest && docker compose stop app"
+
+# 2. 現状を退避してから展開する (復元に失敗したときに戻れるようにする)
+ssh <NUC_USER>@<NUC_IP> "cd /d C:\Docker\ganbari-quest\data && ren pglite pglite.before-restore"
+ssh <NUC_USER>@<NUC_IP> "cd /d C:\Docker\ganbari-quest\data && mkdir pglite && tar -xzf backups\pglite-<TS>.tgz -C pglite --strip-components=1"
+
+# 3. 起動して health を確認する
+ssh <NUC_USER>@<NUC_IP> "cd /d C:\Docker\ganbari-quest && docker compose --profile backup up -d app"
+curl -s http://<NUC_IP>:3000/api/health
+```
+
+- 起動時に drizzle migrator が走るため、**バックアップ時点より新しい migration があれば復元後に自動適用される**
+- 退避した `pglite.before-restore` は、復元後の動作確認が終わるまで消さないこと
+
+## 復元リハーサル実測 (2026-07-26 実施)
+
+### A. 2026-07-26 手動スナップショット (稼働中 tar / 案 1 相当) からの復元
+
+`pglite-snapshot-20260726-0738-pre-pr3947.tgz` (5,662,497 bytes) を実際に展開し PGlite で開いた結果:
+
+```
+open + crash recovery : 866ms
+public tables         : 59
+total rows            : 2,063   (全テーブルの count(*) 合計、全件読めた)
+children              : 2
+__drizzle_migrations  : max created_at = 1784500000000  (id=35 / 2 / 1)
+public tables 状態     : login_bonuses あり / login_streaks なし
+```
+
+- **復元できた**。取得と `tar -tzf` までしか確認していなかったものが、実際に開けて全件読めることを確認した
+- ただしこれは **hotfix #3947 適用前の状態** (`login_streaks` 未作成 / `login_bonuses` 残存)。
+  現行 journal (grandfather 3 値) で起動すれば 0003/0004 の `when` (…001 / …002) が
+  適用済み最大 `created_at` (…000) より大きいため正しく適用され、#3947 相当の状態まで進む
+  (下記 B で実測)。**grandfather 3 値を実生成時刻へ書き換えるとこの復旧が永久 skip される** ため、
+  `scripts/lib/db/drizzle-journal-gate.mjs` の grandfather は外してはならない (#3951 `[WR7]`)
+
+### B. 現行実装での full cycle (上記スナップショットを boot 相当まで進めた実データに対して)
+
+```
+boot migrate (0003/0004 適用)      :   79ms   → login_streaks 作成 / login_bonuses 撤去
+backup (dump + 復元検証 + 確定)     : 1,256ms  → 5,898,260 bytes
+  verification: tablesVerified=59 / migrationsApplied=5 / maxAppliedCreatedAt=1784500000002 / journalEntries=5
+restore (取得物 → 別インスタンス)   :   447ms  → children=2 / login_streaks=2
+```
+
+### 実測 RTO / RPO
+
+| 指標 | 実測 | 備考 |
+|---|---|---|
+| **RPO** | 最大 24 時間 | 日次 03:00 JST 取得 |
+| **RTO (DB 復元のみ)** | **1 秒未満** (447ms〜866ms) | 現在のデータ量 (59 テーブル / 約 2,000 行 / 圧縮 5.7MB) での実測 |
+| **RTO (実運用、手順込み)** | **数分** | 上記「復元手順」の stop → 展開 → 起動 → health 確認。DB 復元自体は支配的ではない |
+
+> データ量が増えれば RTO も伸びる。**上記は 2026-07-26 時点のデータ量での実測値**であり、
+> 桁が変わる規模になったら再測定すること。
+
+## 残存リスク (本 Runbook 時点で塞げていないもの)
+
+- **オフサイト複製が無い**。バックアップは NUC ローカルの同一ディスク上にあり、**NUC 本体・ディスクの
+  物理故障では本体もバックアップも同時に失われる**。`scripts/backup-to-gdrive.cjs` / `BACKUP_POST_HOOK`
+  の経路は存在するが PGlite 経路には未接続。保持 3 世代の決裁と合わせて、別途オーナー判断が要る
+- **定期的な restore drill が自動化されていない**。日次の復元検証 (V1/V2/V3) は取得物を毎回別インスタンスへ
+  復元して行うため「復元可能性」は毎日確認されるが、**本番ディレクトリへ戻す手順そのもの**の実行は
+  本 Runbook の手動実施に依存する

--- a/scripts/backup-nuc.cjs
+++ b/scripts/backup-nuc.cjs
@@ -1,0 +1,147 @@
+// scripts/backup-nuc.cjs - NUC 日次バックアップの入口 (#3950)
+//
+// docker-compose の backup サービス (crond) から 1 日 1 回呼ばれる。DATA_SOURCE を見て
+// 実データの backend に対応した経路へ振り分ける。
+//
+//   DATA_SOURCE=pglite  -> アプリの /api/cron/pglite-backup を叩く (本番 NUC の現行構成)
+//   それ以外            -> 従来の SQLite 経路 (backup-db.cjs + verify-backup-restore.cjs)
+//
+// ── なぜ HTTP 越しなのか ────────────────────────────────────────────────
+// PGlite は dataDir を単一プロセスで占有するため、backup コンテナから直接 open できない。
+// 整合したスナップショットを採れるのは DB を掴んでいるアプリプロセスだけなので、そこへ起動を
+// 依頼する形になる (詳細: src/lib/server/db/pglite/backup.ts 冒頭)。
+//
+// ── なぜ振り分けが要るのか (#3950 の事故) ────────────────────────────────
+// 2026-07-12 の PGlite 移行後も backup サービスは旧 SQLite を複製し続け、しかもその SQLite に
+// 残った FK violation で毎日 fail していた。「毎日動いているように見えて実データは無保護」を
+// 二度と作らないため、backend の判定をこの 1 箇所に集約し、対象外の経路は明示的に skip する。
+//
+// Environment variables:
+//   DATA_SOURCE          - 実データの backend (pglite / sqlite ...)
+//   APP_URL              - アプリのベース URL (default: http://app:3000)
+//   CRON_SECRET          - /api/cron/* の認証シークレット (pglite 経路で必須)
+//   DISCORD_ALERT_WEBHOOK_URL - 失敗通知先 (任意)
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+
+// .env 読み込み (backup-db.cjs と同じ最小実装)
+const envPath = path.join(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+	const envContent = fs.readFileSync(envPath, 'utf-8');
+	for (const line of envContent.split('\n')) {
+		const trimmed = line.trim();
+		if (trimmed && !trimmed.startsWith('#')) {
+			const eqIdx = trimmed.indexOf('=');
+			if (eqIdx > 0) {
+				const key = trimmed.slice(0, eqIdx).trim();
+				const val = trimmed.slice(eqIdx + 1).trim();
+				if (!process.env[key]) process.env[key] = val;
+			}
+		}
+	}
+}
+
+const DATA_SOURCE = process.env.DATA_SOURCE || 'sqlite';
+const APP_URL = process.env.APP_URL || 'http://app:3000';
+const CRON_SECRET = process.env.CRON_SECRET || process.env.OPS_SECRET_KEY || '';
+const DISCORD_WEBHOOK =
+	process.env.DISCORD_ALERT_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_INCIDENT || '';
+
+/**
+ * バックアップ失敗を Discord に通知する。webhook 未設定なら no-op。
+ * fail が沈黙しないための最小実装 (verify-backup-restore.cjs と同じ形)。
+ *
+ * @param {string} detail
+ */
+async function notifyFailure(detail) {
+	if (!DISCORD_WEBHOOK) {
+		console.error('[backup-nuc] Discord webhook 未設定のため通知を送れません');
+		return;
+	}
+	const embed = {
+		title: '🚨 [CRITICAL] NUC バックアップ 失敗',
+		description: `DATA_SOURCE=${DATA_SOURCE} のバックアップに失敗しました。data 保全リスク。`,
+		color: 10038562,
+		fields: [
+			{ name: 'Detail', value: `\`\`\`${detail.slice(0, 800)}\`\`\`` },
+			{ name: '対応', value: 'docs/runbooks/pglite-restore-drill.md / backup cron を確認' },
+		],
+		timestamp: new Date().toISOString(),
+		footer: { text: 'がんばりクエスト backup (#3950)' },
+	};
+	try {
+		await fetch(DISCORD_WEBHOOK, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ content: '@everyone', embeds: [embed] }),
+		});
+		console.log('[backup-nuc] Discord alert sent');
+	} catch (err) {
+		console.error(
+			'[backup-nuc] Discord alert failed (non-fatal):',
+			err instanceof Error ? err.message : String(err),
+		);
+	}
+}
+
+/** PGlite 経路: アプリの cron エンドポイントを叩き、結果を判定する。 */
+async function runPgliteBackup() {
+	if (!CRON_SECRET) {
+		throw new Error('CRON_SECRET が未設定です (/api/cron/pglite-backup の認証に必要)');
+	}
+	const url = `${APP_URL.replace(/\/$/, '')}/api/cron/pglite-backup`;
+	console.log(`[backup-nuc] POST ${url}`);
+	const res = await fetch(url, {
+		method: 'POST',
+		headers: { 'x-cron-secret': CRON_SECRET, 'Content-Type': 'application/json' },
+	});
+	const text = await res.text();
+	if (!res.ok) {
+		throw new Error(`HTTP ${res.status}: ${text.slice(0, 500)}`);
+	}
+	/** @type {{ ok?: boolean, filename?: string, bytes?: number, durationMs?: number, generationsKept?: number, verification?: unknown, error?: string }} */
+	let body;
+	try {
+		body = JSON.parse(text);
+	} catch {
+		throw new Error(`レスポンスが JSON ではありません: ${text.slice(0, 500)}`);
+	}
+	// HTTP 200 でも ok:false なら失敗として扱う (silent success を作らない)。
+	if (!body.ok) {
+		throw new Error(body.error || 'エンドポイントが ok:false を返しました');
+	}
+	console.log(
+		`[backup-nuc] OK: ${body.filename} (${body.bytes} bytes, ${body.durationMs}ms, ` +
+			`保持 ${body.generationsKept} 世代)`,
+	);
+	console.log(`[backup-nuc] verification: ${JSON.stringify(body.verification)}`);
+}
+
+/** SQLite 経路: 従来どおり backup-db.cjs + verify-backup-restore.cjs を直列実行する。 */
+function runSqliteBackup() {
+	console.log('[backup-nuc] DATA_SOURCE が pglite ではないため SQLite 経路で実行します');
+	for (const script of ['backup-db.cjs', 'verify-backup-restore.cjs']) {
+		execFileSync(process.execPath, [path.join(__dirname, script)], { stdio: 'inherit' });
+	}
+}
+
+async function main() {
+	console.log('=== Ganbari Quest NUC Backup ===');
+	console.log(`Time: ${new Date().toISOString()}`);
+	console.log(`DATA_SOURCE: ${DATA_SOURCE}`);
+
+	if (DATA_SOURCE === 'pglite') {
+		await runPgliteBackup();
+	} else {
+		runSqliteBackup();
+	}
+}
+
+main().catch(async (err) => {
+	const message = err instanceof Error ? err.message : String(err);
+	console.error('[backup-nuc] FAILED:', message);
+	await notifyFailure(message);
+	process.exit(1);
+});

--- a/src/lib/runtime/env.ts
+++ b/src/lib/runtime/env.ts
@@ -84,6 +84,12 @@ const envSchema = z.object({
 	//   PGLITE_MIGRATIONS_DIR は生成済み migration (drizzle/pglite) の解決先 (既定 = cwd 相対)。
 	PGLITE_DATA_DIR: z.string().optional(),
 	PGLITE_MIGRATIONS_DIR: z.string().optional(),
+	// #3950 (NUC PGlite 日次バックアップ): 取得先と保持世代。
+	//   BACKUP_DIR は既存 SQLite backup (docker-compose backup service) と同じ既定 `./data/backups`
+	//   を共有する (取得物は prefix `pglite-` で区別)。BACKUP_RETENTION はオーナー決裁で 3 世代。
+	//   いずれも optional — 未設定でも既定値で動く (ADR-0029 の required env 追加に当たらない)。
+	BACKUP_DIR: z.string().optional(),
+	BACKUP_RETENTION: z.coerce.number().int().positive().optional(),
 
 	// ----- Stripe -----
 	STRIPE_SECRET_KEY: z.string().optional(),

--- a/src/lib/server/db/pglite/backup.ts
+++ b/src/lib/server/db/pglite/backup.ts
@@ -1,0 +1,182 @@
+// src/lib/server/db/pglite/backup.ts
+// #3950 — NUC PGlite 本番データの日次バックアップ (取得 → 検証 → ローテーション)。
+//
+// ── なぜアプリプロセス内で採るのか ─────────────────────────────────────────
+// PGlite は dataDir を **単一プロセスで占有**する (connection.ts が `new PGlite(PGLITE_DATA_DIR)` を
+// singleton 保持)。そのため外部プロセスから採れるのは「稼働中ディレクトリの tar」= 取得中に書き換えが
+// 走り得る crash-consistent 相当のコピーだけで、復元できる保証がない。整合したスナップショットを
+// ダウンタイムなしで得る唯一の経路が、DB を掴んでいる当プロセスから叩く公式 API `dumpDataDir()`。
+// よって backup は「app プロセス内で実行し、外からは cron エンドポイントで起動する」形を採る。
+//
+// ── 「取れている」と「復旧できる」は別物 (監査指摘 / #3946 の教訓) ──────────
+// 取得しただけの tarball は復元可能性ゼロ検証。本モジュールは **取得物を実際に別 PGlite へ復元して
+// 検証が通ったものだけをバックアップとして確定**する (verify-then-commit)。検証は 3 段:
+//   V1. 復元した DB の public テーブル全件に `select count(*)` が通る (物理的に読めること)
+//   V2. `drizzle.__drizzle_migrations` が存在し 1 行以上ある (schema 適用済みであること)
+//   V3. journal (`drizzle/pglite/meta/_journal.json`) の全 entry が「適用済み最大 created_at」以下
+//       = **復元後に永久 skip される migration が無い** こと (#3951 監査 residual [security/sev2])。
+//       #3946 はまさに「journal と適用実績の関係」の破れで起きたため、restore 経路で毎日突合する。
+//
+// ── ローテーションは成功後にのみ行う ────────────────────────────────────────
+// 取得や検証が落ちた回に古い世代を消すと、失敗が続くほど手持ちが減る。削除は確定後だけ。
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+
+/** バックアップファイル名の prefix。既存 SQLite backup (`ganbari-quest-*.db`) と同居しても区別できる。 */
+export const PGLITE_BACKUP_PREFIX = 'pglite-';
+/** バックアップファイルの拡張子 (dumpDataDir('gzip') の出力は gzip 圧縮 tar)。 */
+export const PGLITE_BACKUP_EXT = '.tgz';
+/** オーナー決裁 (2026-07-26): 日次取得・3 世代保持。 */
+export const DEFAULT_BACKUP_RETENTION = 3;
+
+/** 復元検証の結果。どの段で落ちたかを呼び出し側 (アラート) が識別できるようにする。 */
+export interface PgliteBackupVerification {
+	/** V1: 復元 DB で count(*) が通った public テーブル数。 */
+	tablesVerified: number;
+	/** V2: `drizzle.__drizzle_migrations` の行数。 */
+	migrationsApplied: number;
+	/** V3: 復元 DB の適用済み最大 created_at。 */
+	maxAppliedCreatedAt: number;
+	/** V3: journal entry 数 (突合対象)。 */
+	journalEntries: number;
+}
+
+/** 1 回のバックアップ実行結果。 */
+export interface PgliteBackupResult {
+	/** 確定したバックアップファイル名 (backupDir 相対)。 */
+	filename: string;
+	/** 取得物のバイト数 (圧縮後)。 */
+	bytes: number;
+	/** 復元検証の内訳。 */
+	verification: PgliteBackupVerification;
+	/** ローテーションで削除したファイル名。 */
+	rotated: string[];
+	/** 保持世代数 (削除後に残っている世代数)。 */
+	generationsKept: number;
+	/** 取得開始から確定までの所要時間 (ms)。RTO/RPO の実測値として記録する。 */
+	durationMs: number;
+}
+
+/** 検証段で落ちたことを呼び出し側が識別するためのエラー。 */
+export class PgliteBackupVerificationError extends Error {
+	constructor(
+		readonly stage: 'V1-table-read' | 'V2-migrations-table' | 'V3-journal-reconcile',
+		message: string,
+	) {
+		super(`[${stage}] ${message}`);
+		this.name = 'PgliteBackupVerificationError';
+	}
+}
+
+interface JournalEntry {
+	idx: number;
+	when: number;
+	tag: string;
+}
+
+/**
+ * バックアップ tarball を **別インスタンスへ実際に復元**し、V1-V3 を検証する。
+ *
+ * 検証に落ちたら例外を投げる = そのバックアップは確定させない。`loadDataDir` は渡した Blob を
+ * 消費し得るため、呼び出し側は保持している Buffer から毎回新しい Blob を作って渡すこと。
+ */
+export async function verifyPgliteDump(
+	dump: Blob,
+	journalEntries: JournalEntry[],
+): Promise<PgliteBackupVerification> {
+	// dataDir を指定しない = in-memory。復元検証が本番ディレクトリへ書き戻すことは無い。
+	const restored = new PGlite({ loadDataDir: dump });
+	try {
+		await restored.waitReady;
+
+		// V1: 物理的に読めること。テーブル名は復元 DB 自身の catalog から採るので、
+		//     schema が増減しても検証範囲が自動で追従する (ハードコード一覧の陳腐化を作らない)。
+		const tables = await restored.query<{ tablename: string }>(
+			"select tablename from pg_tables where schemaname = 'public' order by tablename",
+		);
+		if (tables.rows.length === 0) {
+			throw new PgliteBackupVerificationError(
+				'V1-table-read',
+				'復元した DB に public テーブルが 1 つも存在しません (空ダンプの疑い)',
+			);
+		}
+		for (const { tablename } of tables.rows) {
+			// tablename は復元 DB の catalog 由来だが、識別子は parameterize できないため形状を明示 assert する
+			// (connection.ts の dbName 検証と同じ防御。unsafe pattern の横展開防止)。
+			if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(tablename)) {
+				throw new PgliteBackupVerificationError(
+					'V1-table-read',
+					`不正なテーブル識別子: ${tablename}`,
+				);
+			}
+			await restored.query(`select count(*) from "${tablename}"`);
+		}
+
+		// V2: schema が適用済みであること。
+		const migrations = await restored.query<{ created_at: string }>(
+			'select created_at from drizzle.__drizzle_migrations order by created_at desc',
+		);
+		const newestMigration = migrations.rows[0];
+		if (!newestMigration) {
+			throw new PgliteBackupVerificationError(
+				'V2-migrations-table',
+				'drizzle.__drizzle_migrations が空です (migration 未適用の DB を復元した疑い)',
+			);
+		}
+		const maxAppliedCreatedAt = Number(newestMigration.created_at);
+
+		// V3: journal ↔ 適用実績の突合。migrator は「適用済み最大 created_at」1 行だけを見て
+		//     `created_at < entry.when` の entry を適用するため、**when がこの最大値以下の entry は
+		//     永久に適用されない**。#3946 はこの関係が破れて発生した本番 500 そのもの。
+		const notApplied = journalEntries.filter((e) => e.when > maxAppliedCreatedAt);
+		if (notApplied.length > 0) {
+			throw new PgliteBackupVerificationError(
+				'V3-journal-reconcile',
+				`復元 DB の適用済み最大 created_at (${maxAppliedCreatedAt}) より大きい when を持つ ` +
+					`journal entry が ${notApplied.length} 件あります ` +
+					`(${notApplied.map((e) => `${e.tag}:${e.when}`).join(', ')})。` +
+					'→ これらは「未適用」として次回 boot 時に適用されます。意図した新規 migration なら ' +
+					'アプリを再起動して適用を完了させてください。意図していないなら journal の when が ' +
+					'書き換えられた疑いがあります (#3946 同型)。',
+			);
+		}
+
+		return {
+			tablesVerified: tables.rows.length,
+			migrationsApplied: migrations.rows.length,
+			maxAppliedCreatedAt,
+			journalEntries: journalEntries.length,
+		};
+	} finally {
+		await restored.close();
+	}
+}
+
+/** `drizzle/pglite/meta/_journal.json` を読む。 */
+export async function loadJournalEntries(migrationsDir: string): Promise<JournalEntry[]> {
+	const raw = await readFile(join(migrationsDir, 'meta', '_journal.json'), 'utf-8');
+	const parsed = JSON.parse(raw) as { entries?: JournalEntry[] };
+	if (!parsed.entries || parsed.entries.length === 0) {
+		throw new Error(`[pglite/backup] journal に entry がありません: ${migrationsDir}`);
+	}
+	return parsed.entries;
+}
+
+/** `pglite-20260726T034500.tgz` 形式のファイル名を作る (UTC、辞書順 = 時系列順)。 */
+export function backupFilename(now: Date): string {
+	const ts = now
+		.toISOString()
+		.replace(/[-:]/g, '')
+		.replace(/\.\d{3}Z$/, 'Z');
+	return `${PGLITE_BACKUP_PREFIX}${ts}${PGLITE_BACKUP_EXT}`;
+}
+
+/** バックアップディレクトリ内の PGlite バックアップを新しい順に返す。 */
+export function sortBackupsNewestFirst(filenames: string[]): string[] {
+	return filenames
+		.filter((f) => f.startsWith(PGLITE_BACKUP_PREFIX) && f.endsWith(PGLITE_BACKUP_EXT))
+		.sort()
+		.reverse();
+}

--- a/src/lib/server/db/pglite/connection.ts
+++ b/src/lib/server/db/pglite/connection.ts
@@ -135,6 +135,23 @@ export async function getPgliteDb(): Promise<PgliteDatabase> {
 	return _db;
 }
 
+/**
+ * #3950: PGlite の **生 client** を返す (singleton、await 必須)。
+ *
+ * PGlite は dataDir を単一プロセスで占有するため、バックアップを外部プロセスから取ろうとすると
+ * 「稼働中ディレクトリの tar」= crash-consistent 相当のコピーしか採れない。整合したスナップショットを
+ * 得る唯一の経路が本 client の `dumpDataDir()` (プロセス内で一貫性を取って tarball を吐く公式 API)
+ * であるため、drizzle 面 (SqlExecutor) ではなく生 client を返す口をここに 1 つだけ開ける。
+ *
+ * ⚠️ 用途は **バックアップ/診断に限る**。データ読み書きは必ず repo (drizzle db + runner) を経由すること
+ * — 生 client で SQL を直接発行すると tenant 述語 (ADR-0063) と txn guard を素通りする。
+ */
+export async function getPgliteClient(): Promise<PGlite> {
+	await initPgliteConnection();
+	if (!_client) throw new Error('[pglite/connection] init 後も client が null です (到達不能)');
+	return _client;
+}
+
 /** PGlite backend の TransactionRunner を返す (singleton、await 必須)。 */
 export async function getPgliteTransactionRunner(): Promise<TransactionRunner<PgliteTx>> {
 	await initPgliteConnection();

--- a/src/lib/server/services/pglite-backup-service.ts
+++ b/src/lib/server/services/pglite-backup-service.ts
@@ -1,0 +1,175 @@
+// src/lib/server/services/pglite-backup-service.ts
+// #3950 — PGlite バックアップの実行サービス (取得 → 検証 → 確定 → ローテーション → 状態記録)。
+//
+// 純粋な検証・命名ロジックは $lib/server/db/pglite/backup.ts、FS と PGlite client を伴う
+// オーケストレーションは本ファイル、HTTP 面は /api/cron/pglite-backup に分ける。
+
+import { mkdir, readdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import type { PGlite } from '@electric-sql/pglite';
+import { getEnv } from '$lib/runtime/env';
+import {
+	backupFilename,
+	DEFAULT_BACKUP_RETENTION,
+	loadJournalEntries,
+	type PgliteBackupResult,
+	sortBackupsNewestFirst,
+	verifyPgliteDump,
+} from '$lib/server/db/pglite/backup';
+import { getPgliteClient } from '$lib/server/db/pglite/connection';
+import { logger } from '$lib/server/logger';
+
+/**
+ * 最終成功/最終失敗を残すファイル名。fail が沈黙しないための可視化点 (#3950 AC)。
+ *
+ * ⚠️ `PGLITE_BACKUP_PREFIX` (`pglite-`) で始めないこと。同 prefix にするとローテーション対象の
+ * 一覧に混ざり、世代数を 1 つ食う (拡張子フィルタで実害は出ないが、意図しない結合を作らない)。
+ */
+export const BACKUP_STATUS_FILENAME = 'backup-status-pglite.json';
+
+export interface PgliteBackupStatus {
+	lastSuccessAt: string | null;
+	lastSuccessFilename: string | null;
+	lastSuccessBytes: number | null;
+	lastSuccessDurationMs: number | null;
+	lastFailureAt: string | null;
+	lastFailureMessage: string | null;
+}
+
+export interface RunPgliteBackupOptions {
+	/** PGlite client。省略時は稼働中 singleton (本番経路)。テストは自前の client を渡す。 */
+	client?: PGlite;
+	/** 取得先ディレクトリ。省略時は BACKUP_DIR (既定 ./data/backups)。 */
+	backupDir?: string;
+	/** 保持世代数。省略時は BACKUP_RETENTION (既定 3 = オーナー決裁)。 */
+	retention?: number;
+	/** journal の解決先。省略時は PGLITE_MIGRATIONS_DIR (既定 ./drizzle/pglite)。 */
+	migrationsDir?: string;
+	/** ファイル名に使う時刻。テストで固定するための注入点。 */
+	now?: Date;
+}
+
+function resolveBackupDir(explicit?: string): string {
+	const env = getEnv();
+	return resolve(explicit ?? env.BACKUP_DIR ?? join(process.cwd(), 'data', 'backups'));
+}
+
+function resolveMigrationsDir(explicit?: string): string {
+	const env = getEnv();
+	return resolve(explicit ?? env.PGLITE_MIGRATIONS_DIR ?? join(process.cwd(), 'drizzle', 'pglite'));
+}
+
+function resolveRetention(explicit?: number): number {
+	const env = getEnv();
+	return explicit ?? env.BACKUP_RETENTION ?? DEFAULT_BACKUP_RETENTION;
+}
+
+/** 現在の状態ファイルを読む (無ければ全 null)。 */
+async function readStatus(backupDir: string): Promise<PgliteBackupStatus> {
+	const empty: PgliteBackupStatus = {
+		lastSuccessAt: null,
+		lastSuccessFilename: null,
+		lastSuccessBytes: null,
+		lastSuccessDurationMs: null,
+		lastFailureAt: null,
+		lastFailureMessage: null,
+	};
+	try {
+		const raw = await readFile(join(backupDir, BACKUP_STATUS_FILENAME), 'utf-8');
+		return { ...empty, ...(JSON.parse(raw) as Partial<PgliteBackupStatus>) };
+	} catch {
+		// 初回実行では状態ファイルが無いのが正常。読めないこと自体は失敗にしない。
+		return empty;
+	}
+}
+
+async function writeStatus(backupDir: string, status: PgliteBackupStatus): Promise<void> {
+	await writeFile(join(backupDir, BACKUP_STATUS_FILENAME), `${JSON.stringify(status, null, 2)}\n`);
+}
+
+/** 最終成功時刻などを外部 (運用調査 / 監視) から読むための口。 */
+export async function getPgliteBackupStatus(backupDir?: string): Promise<PgliteBackupStatus> {
+	return readStatus(resolveBackupDir(backupDir));
+}
+
+/**
+ * バックアップを 1 回実行する。
+ *
+ * 取得 → **復元検証** → 確定 (atomic rename) → ローテーション、の順。検証に落ちた場合は
+ * ファイルを確定させず、状態ファイルへ失敗を記録した上で例外を投げる (silent fail させない)。
+ * ローテーションは確定後にのみ行う — 失敗し続ける状況で手持ちの世代を削らないため。
+ */
+export async function runPgliteBackup(
+	options: RunPgliteBackupOptions = {},
+): Promise<PgliteBackupResult> {
+	const startedAt = Date.now();
+	const backupDir = resolveBackupDir(options.backupDir);
+	const migrationsDir = resolveMigrationsDir(options.migrationsDir);
+	const retention = resolveRetention(options.retention);
+	const now = options.now ?? new Date();
+
+	await mkdir(backupDir, { recursive: true });
+
+	try {
+		const client = options.client ?? (await getPgliteClient());
+		const journalEntries = await loadJournalEntries(migrationsDir);
+
+		// 取得: プロセス内で一貫性を取った tarball を得る (ダウンタイム 0)。
+		const dumped = await client.dumpDataDir('gzip');
+		const bytes = Buffer.from(await dumped.arrayBuffer());
+
+		// 検証: 取得物を別インスタンスへ実際に復元して読めることを確認する。
+		// loadDataDir は渡した Blob を消費し得るため、保持している Buffer から新しい Blob を作る。
+		const verification = await verifyPgliteDump(new Blob([bytes]), journalEntries);
+
+		// 確定: tmp へ書いてから rename する (取得中に落ちた半端なファイルを世代として残さない)。
+		const filename = backupFilename(now);
+		const finalPath = join(backupDir, filename);
+		const tmpPath = `${finalPath}.tmp`;
+		await writeFile(tmpPath, bytes);
+		await rename(tmpPath, finalPath);
+
+		// ローテーション: 確定後にのみ削除する。
+		const existing = sortBackupsNewestFirst(await readdir(backupDir));
+		const rotated = existing.slice(retention);
+		for (const stale of rotated) {
+			await rm(join(backupDir, stale), { force: true });
+		}
+
+		const durationMs = Date.now() - startedAt;
+		const previous = await readStatus(backupDir);
+		await writeStatus(backupDir, {
+			...previous,
+			lastSuccessAt: new Date().toISOString(),
+			lastSuccessFilename: filename,
+			lastSuccessBytes: bytes.byteLength,
+			lastSuccessDurationMs: durationMs,
+		});
+
+		const result: PgliteBackupResult = {
+			filename,
+			bytes: bytes.byteLength,
+			verification,
+			rotated,
+			generationsKept: existing.length - rotated.length,
+			durationMs,
+		};
+		logger.info('[pglite-backup] completed', {
+			service: 'pglite-backup',
+			context: { ...result, rotated: rotated.length },
+		});
+		return result;
+	} catch (e) {
+		const message = e instanceof Error ? e.message : String(e);
+		const previous = await readStatus(backupDir);
+		await writeStatus(backupDir, {
+			...previous,
+			lastFailureAt: new Date().toISOString(),
+			lastFailureMessage: message,
+		}).catch(() => {
+			// 状態ファイルすら書けない場合でも、元の失敗を握り潰さずそのまま投げる。
+		});
+		logger.error('[pglite-backup] failed', { service: 'pglite-backup', error: message });
+		throw e;
+	}
+}

--- a/src/routes/api/cron/pglite-backup/+server.ts
+++ b/src/routes/api/cron/pglite-backup/+server.ts
@@ -1,0 +1,58 @@
+// src/routes/api/cron/pglite-backup/+server.ts
+// #3950: NUC PGlite 本番データの日次バックアップ起動エンドポイント。
+//
+// PGlite は dataDir を単一プロセスで占有するため、整合したスナップショットを採れるのは DB を
+// 掴んでいる **アプリプロセス自身**だけ (詳細: src/lib/server/db/pglite/backup.ts 冒頭)。
+// 外部 (docker compose の backup サービス / crond) からは本エンドポイントを叩いて起動する。
+//
+// 認証は既存 cron 群と同じ verifyCronAuth (x-cron-secret / Authorization: Bearer)。
+//
+// ⚠️ scheduleRegistry には **登録しない**。tests/unit/cron/schedule-consistency.test.ts が
+// 「registry の全 job が AWS cron-dispatcher の KNOWN_ENDPOINTS にも存在すること」を強制するため、
+// 登録すると AWS (DATA_SOURCE=dsql) 側にも PGlite バックアップ job を生やすことになる。本 job は
+// NUC 専用なので、NUC ローカルの crond (docker-compose backup profile) から起動する。
+//
+// 使い方:
+//   POST /api/cron/pglite-backup
+//   x-cron-secret: <CRON_SECRET>
+//
+// レスポンス:
+//   200 { ok: true, filename, bytes, verification, rotated, generationsKept, durationMs }
+//   401 Unauthorized
+//   409 DATA_SOURCE が pglite でない (誤配線を silent success にしない)
+//   500 取得 or 復元検証に失敗
+
+import { json } from '@sveltejs/kit';
+import { getEnv } from '$lib/runtime/env';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
+import { logger } from '$lib/server/logger';
+import { runPgliteBackup } from '$lib/server/services/pglite-backup-service';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request }) => {
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
+
+	const dataSource = getEnv().DATA_SOURCE;
+	if (dataSource !== 'pglite') {
+		// 200 を返すと「バックアップが回っている」と誤認させる (#3950 の事故そのもの) ため 409。
+		return json(
+			{
+				ok: false,
+				error: `DATA_SOURCE=${dataSource} では PGlite バックアップは実行できません (pglite 専用)`,
+			},
+			{ status: 409 },
+		);
+	}
+
+	logger.info('[pglite-backup] endpoint started', { service: 'pglite-backup' });
+
+	try {
+		const result = await runPgliteBackup();
+		return json({ ok: true, ...result });
+	} catch (e) {
+		const message = e instanceof Error ? e.message : String(e);
+		// 失敗は必ず 500 で返す。呼び出し側 (crond) が exit code とアラートに変換する。
+		return json({ ok: false, error: message }, { status: 500 });
+	}
+};

--- a/tests/unit/db/pglite-backup-3950.test.ts
+++ b/tests/unit/db/pglite-backup-3950.test.ts
@@ -1,0 +1,237 @@
+// tests/unit/db/pglite-backup-3950.test.ts
+// #3950 — PGlite 日次バックアップ (取得 → 復元検証 → 確定 → ローテーション) のテスト。
+//
+// 本 Issue の事故は「バックアップ job が毎日動いているように見えて、実データは 2 週間以上
+// 1 件も保護されていなかった」。したがって本テストが固定すべきは **『取れた』ではなく『復旧できる』**。
+//
+//   [BK1] 実 migration を適用した PGlite から採ったダンプが、別インスタンスへ復元でき、
+//         投入したデータが復元後も読める (往復の実証)
+//   [BK2] 復元検証 V3: journal と適用実績が乖離した DB のダンプは **検証で落ちる**
+//         (= #3946 同型の「永久 skip される migration」を含む復元先を合格にしない)
+//   [BK3] 検証に落ちた回は **バックアップファイルを確定させない** (verify-then-commit)
+//   [BK4] ローテーションは保持世代を超えた古い世代だけを消す
+//   [BK5] 失敗した回は **古い世代を消さない** (失敗が続くほど手持ちが減る事故を作らない)
+//   [BK6] 最終成功時刻が状態ファイルに残る (fail が沈黙しないための可視化点)
+//
+// [BK2] / [BK3] / [BK5] は「gate を書いたが実は何も落とせていない」を防ぐ実効性検証。
+
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PGlite } from '@electric-sql/pglite';
+import { drizzle } from 'drizzle-orm/pglite';
+import { migrate } from 'drizzle-orm/pglite/migrator';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+	backupFilename,
+	loadJournalEntries,
+	PGLITE_BACKUP_PREFIX,
+	PgliteBackupVerificationError,
+	sortBackupsNewestFirst,
+	verifyPgliteDump,
+} from '../../../src/lib/server/db/pglite/backup';
+import {
+	BACKUP_STATUS_FILENAME,
+	runPgliteBackup,
+} from '../../../src/lib/server/services/pglite-backup-service';
+
+const MIGRATIONS_DIR = join(process.cwd(), 'drizzle', 'pglite');
+
+const tempDirs: string[] = [];
+function tempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+const clients: PGlite[] = [];
+/** 実 migration を適用した PGlite (in-memory) を作る。 */
+async function migratedClient(): Promise<PGlite> {
+	const client = new PGlite();
+	await client.waitReady;
+	clients.push(client);
+	await client.exec("SET TIME ZONE 'UTC';");
+	await migrate(drizzle(client), { migrationsFolder: MIGRATIONS_DIR });
+	return client;
+}
+
+afterAll(async () => {
+	for (const c of clients) await c.close().catch(() => {});
+	for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('#3950 PGlite backup — 復元できることの実証', () => {
+	let journalEntries: Awaited<ReturnType<typeof loadJournalEntries>>;
+
+	beforeAll(async () => {
+		journalEntries = await loadJournalEntries(MIGRATIONS_DIR);
+	});
+
+	it('[BK1] 採ったダンプを別インスタンスへ復元すると、投入したデータが読める', async () => {
+		const client = await migratedClient();
+		// 復元後に「同じ行が読める」ことを見るための目印を 1 行入れる。
+		await client.exec(`
+			create table if not exists backup_roundtrip_probe (id text primary key, note text);
+			insert into backup_roundtrip_probe (id, note) values ('bk1', 'restored');
+		`);
+
+		const dumped = await client.dumpDataDir('gzip');
+		const bytes = Buffer.from(await dumped.arrayBuffer());
+		expect(bytes.byteLength).toBeGreaterThan(0);
+
+		const verification = await verifyPgliteDump(new Blob([bytes]), journalEntries);
+		expect(verification.migrationsApplied).toBe(journalEntries.length);
+		expect(verification.tablesVerified).toBeGreaterThan(0);
+
+		// 検証関数の外でも独立に往復を確認する (検証関数が実は何も見ていない可能性を潰す)。
+		const restored = new PGlite({ loadDataDir: new Blob([bytes]) });
+		clients.push(restored);
+		await restored.waitReady;
+		const rows = await restored.query<{ note: string }>(
+			"select note from backup_roundtrip_probe where id = 'bk1'",
+		);
+		expect(rows.rows[0]?.note).toBe('restored');
+	}, 120_000);
+
+	it('[BK2] journal に「適用済み最大 created_at より後の entry」があるダンプは検証で落ちる', async () => {
+		const client = await migratedClient();
+		const dumped = await client.dumpDataDir('gzip');
+		const bytes = Buffer.from(await dumped.arrayBuffer());
+
+		// #3946 同型: 適用実績より後ろの when を持つ entry = 復元先で未適用のまま残る migration。
+		const drifted = [
+			...journalEntries,
+			{ idx: journalEntries.length, when: 9_999_999_999_999, tag: '9999_unapplied' },
+		];
+
+		await expect(verifyPgliteDump(new Blob([bytes]), drifted)).rejects.toThrow(
+			PgliteBackupVerificationError,
+		);
+		await expect(verifyPgliteDump(new Blob([bytes]), drifted)).rejects.toThrow(
+			/V3-journal-reconcile/,
+		);
+	}, 120_000);
+
+	it('[BK3] 検証に落ちた回はバックアップファイルを確定させない', async () => {
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk3-');
+		// journal 側を細工して V3 を必ず落とす (migrationsDir をテスト用に差し替える)。
+		const brokenMigrations = tempDir('gq-bk3-journal-');
+		mkdirSync(join(brokenMigrations, 'meta'), { recursive: true });
+		writeFileSync(
+			join(brokenMigrations, 'meta', '_journal.json'),
+			JSON.stringify({ entries: [{ idx: 0, when: 9_999_999_999_999, tag: '9999_unapplied' }] }),
+		);
+
+		await expect(
+			runPgliteBackup({ client, backupDir, migrationsDir: brokenMigrations, retention: 3 }),
+		).rejects.toThrow(/V3-journal-reconcile/);
+
+		const produced = readdirSync(backupDir).filter((f) => f.startsWith(PGLITE_BACKUP_PREFIX));
+		expect(produced).toEqual([]);
+	}, 120_000);
+
+	it('[BK4] ローテーションは保持世代を超えた古い世代だけを消す', async () => {
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk4-');
+
+		const filenames: string[] = [];
+		// 保持 3 世代に対して 4 回取得する。now を注入してファイル名を時系列で固定する。
+		for (let i = 0; i < 4; i++) {
+			const result = await runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 3,
+				now: new Date(Date.UTC(2026, 6, 20 + i, 3, 0, 0)),
+			});
+			filenames.push(result.filename);
+		}
+
+		const remaining = sortBackupsNewestFirst(readdirSync(backupDir));
+		expect(remaining).toHaveLength(3);
+		// 残るのは新しい 3 世代。最初の 1 世代だけが消える。
+		expect(remaining).toEqual(filenames.slice(1).reverse());
+		expect(remaining).not.toContain(filenames[0]);
+	}, 120_000);
+
+	it('[BK5] 失敗した回は古い世代を消さない', async () => {
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk5-');
+
+		// まず正常に 2 世代作る。
+		const kept: string[] = [];
+		for (let i = 0; i < 2; i++) {
+			const r = await runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 1, // 保持 1 世代でも、失敗回に削除が走らないことを見たい
+				now: new Date(Date.UTC(2026, 6, 20 + i, 3, 0, 0)),
+			});
+			kept.push(r.filename);
+		}
+		const beforeFailure = sortBackupsNewestFirst(readdirSync(backupDir));
+		expect(beforeFailure).toHaveLength(1);
+
+		// 次に必ず落ちる実行を挟む。
+		const brokenMigrations = tempDir('gq-bk5-journal-');
+		mkdirSync(join(brokenMigrations, 'meta'), { recursive: true });
+		writeFileSync(
+			join(brokenMigrations, 'meta', '_journal.json'),
+			JSON.stringify({ entries: [{ idx: 0, when: 9_999_999_999_999, tag: '9999_unapplied' }] }),
+		);
+		await expect(
+			runPgliteBackup({ client, backupDir, migrationsDir: brokenMigrations, retention: 1 }),
+		).rejects.toThrow();
+
+		// 失敗回で手持ちが減っていないこと。
+		expect(sortBackupsNewestFirst(readdirSync(backupDir))).toEqual(beforeFailure);
+	}, 120_000);
+
+	it('[BK6] 成功・失敗ともに状態ファイルへ記録され、最終成功時刻が読める', async () => {
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk6-');
+
+		const ok = await runPgliteBackup({
+			client,
+			backupDir,
+			migrationsDir: MIGRATIONS_DIR,
+			retention: 3,
+		});
+		const afterSuccess = JSON.parse(
+			readFileSync(join(backupDir, BACKUP_STATUS_FILENAME), 'utf-8'),
+		) as Record<string, unknown>;
+		expect(afterSuccess.lastSuccessFilename).toBe(ok.filename);
+		expect(typeof afterSuccess.lastSuccessAt).toBe('string');
+		expect(afterSuccess.lastFailureAt).toBeNull();
+
+		const brokenMigrations = tempDir('gq-bk6-journal-');
+		mkdirSync(join(brokenMigrations, 'meta'), { recursive: true });
+		writeFileSync(
+			join(brokenMigrations, 'meta', '_journal.json'),
+			JSON.stringify({ entries: [{ idx: 0, when: 9_999_999_999_999, tag: '9999_unapplied' }] }),
+		);
+		await expect(
+			runPgliteBackup({ client, backupDir, migrationsDir: brokenMigrations, retention: 3 }),
+		).rejects.toThrow();
+
+		const afterFailure = JSON.parse(
+			readFileSync(join(backupDir, BACKUP_STATUS_FILENAME), 'utf-8'),
+		) as Record<string, unknown>;
+		// 失敗しても直前の成功時刻は保持される (「最後に成功したのはいつか」が失われない)。
+		expect(afterFailure.lastSuccessFilename).toBe(ok.filename);
+		expect(typeof afterFailure.lastFailureAt).toBe('string');
+		expect(String(afterFailure.lastFailureMessage)).toMatch(/V3-journal-reconcile/);
+	}, 120_000);
+
+	it('[BK7] ファイル名は辞書順 = 時系列順になる (ローテーションの前提)', () => {
+		const older = backupFilename(new Date(Date.UTC(2026, 6, 26, 3, 0, 0)));
+		const newer = backupFilename(new Date(Date.UTC(2026, 6, 27, 3, 0, 0)));
+		expect(older < newer).toBe(true);
+		expect(sortBackupsNewestFirst([older, newer, 'ganbari-quest-20260725030000.db'])).toEqual([
+			newer,
+			older,
+		]);
+	});
+});


### PR DESCRIPTION
<!-- ============================================================
hotfix PR runbook checklist (#2343)
============================================================
- [x] Step 1: Skill 雛形 (本 template) を使って起票している (手書き禁止、#2342 教訓)
- [x] Step 2: `src/routes/` 変更あり。追加は `/api/cron/pglite-backup` の新規内部エンドポイントのみで、既存 URL の振替・fallback・no-op 化は無い (顧客向け画面の仕様変化なし)
- [x] Step 3: 新規 env は `BACKUP_DIR` / `BACKUP_RETENTION` の 2 つだが、いずれも `optional` + コード側既定値ありで **required env ではない** (未配布でも動作する)。配布経路の記載は「配布済み env / secret」節を参照
- [x] Step 4: `process.env.X` の直接参照なし。`$lib/runtime/env` 経由化済み (ADR-0040 P1)。`scripts/backup-nuc.cjs` は SvelteKit 外の CommonJS 運用スクリプトで、既存 `scripts/backup-db.cjs` と同じ層
- [x] Step 5: `npm run pre-ready -- --pr 3954` 全 Step PASS をローカル確認した
============================================================ -->

## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 子供（データの持ち主として）

**解決する課題**: **NUC 本番の実データが 2026-07-12 の PGlite 移行以降、一度もバックアップされていなかった。** 日次バックアップ job は稼働していたが、対象が更新の止まった旧 SQLite ファイル (`data/ganbari-quest.db`、mtime 2026-07-12) のままで、実データである PGlite ディレクトリは完全に対象外だった。しかもその job 自体が旧 SQLite に残る FK violation で毎日 fail しており、失敗も 2 週間以上検知されていなかった。この間に NUC のディスク障害・データ破損・誤操作が起きていれば、子供と保護者が蓄積した全データ (チェックリスト実績・評価・ポイント・ショップ購入等) は復旧不能だった。

**期待される効果**: RPO が「無限大」から**日次**になる。加えて、取得物を毎日実際に復元して検証するため「バックアップが取れているつもりで復旧できない」状態を構造的に排除する。失敗は Discord alert と状態ファイルで可視化され、沈黙しない。

## 関連 Issue

closes #3950

関連 (直近 30 日の同一ファイル変更): 「ADR-0002 Critical 修正 5 要件チェック」の要件 5 を参照。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | PGlite データ (`PGLITE_DATA_DIR` = `/app/data/pglite`) を日次でバックアップする経路を実装する | `docker-compose.yml` backup サービス (crond `0 3 * * *`) → `scripts/backup-nuc.cjs` → `POST /api/cron/pglite-backup` → `runPgliteBackup()` (`src/lib/server/services/pglite-backup-service.ts`)。NUC staging 実機で 1 サイクル実行 | **PASS** — NUC staging (実機) で取得成功。`pglite-*.tgz` が `data/backups/` に生成されたことを確認 (「NUC 実機検証」節) |
| AC2 | バックアップの**整合性を検証**する (取得物から実際にリストアして最低限のクエリが通ることを確認する。現行 `scripts/verify-backup-restore.cjs` の PGlite 版) | `verifyPgliteDump()` が取得物を `loadDataDir` で別インスタンスへ復元し V1 (public 全テーブルの `count(*)`) / V2 (`__drizzle_migrations` 非空) / V3 (journal 突合) を検証。`npx vitest run tests/unit/db/pglite-backup-3950.test.ts` の `[BK1]` `[BK2]` | **PASS** — 7 tests PASS。実データでの実測は `tablesVerified=59` / `migrationsApplied=5` |
| AC3 | **バックアップ失敗が検知できる**こと (fail が沈黙しない。少なくとも health / ログから最終成功時刻が分かる) | `data/backups/backup-status-pglite.json` に `lastSuccessAt` / `lastFailureAt` / `lastFailureMessage` を記録 (`[BK6]` が固定)。失敗時は `scripts/backup-nuc.cjs` が `DISCORD_ALERT_WEBHOOK_URL` へ通知。エンドポイントは失敗を必ず HTTP 500 で返し、`ok:false` を成功に読み替えない | **PASS** — `[BK6]` で「失敗しても直前の成功時刻が保持される」ことまで固定 |
| AC4 | 旧 SQLite 向け backup 経路の扱いを決める (PGlite へ切替 / SQLite 環境が残るなら dataSource で分岐)。旧 SQLite の FK violation で PGlite バックアップまで巻き添え fail しないこと | `scripts/backup-nuc.cjs` が `DATA_SOURCE` で分岐する単一の入口。`pglite` のときは SQLite 経路 (`backup-db.cjs` / `verify-backup-restore.cjs`) を**一切実行しない**ため、旧 SQLite の FK violation は PGlite バックアップに影響しない | **PASS** — `docker-compose.yml` の crontab が `backup-nuc.cjs` 単独呼び出しになったことを diff で確認。NUC staging 実機ログに SQLite 経路の実行が出ないことを確認 |
| AC5 | 保持世代・保存先の方針を明文化する (現行 `BACKUP_RETENTION=7`。NUC ローカルのみで良いか、`scripts/backup-to-gdrive.cjs` 経路を使うかを含む) | `docs/runbooks/pglite-restore-drill.md` §方針 (オーナー決裁 2026-07-26: RPO 日次 / 保持 3 世代 / ダウンタイム 0 / 保存先 NUC ローカル)。`docker-compose.yml` の `BACKUP_RETENTION=3` と一致 | **PASS** — オフサイト複製が未接続であることは同 Runbook §残存リスクに明記 |
| AC6 | NUC 実機で 1 サイクル実行し、取得 → 検証 → 復元まで通ることを確認する | 本ブランチを `Deploy to NUC (Staging)` (PGlite lane) で NUC 実機へ deploy し、`docker exec ... node scripts/backup-nuc.cjs` を 1 回実行 | **PASS** — 「NUC 実機検証」節に実行ログ |
| AC7 | **復元リハーサル (restore drill) を実施する** — 取得済みバックアップから実際に DB を復元し、アプリが起動して主要クエリが通ることを確認する。所要時間を計測して RTO の実測値として記録する | `docs/runbooks/pglite-restore-drill.md` §復元リハーサル実測。2026-07-26 取得の暫定スナップショット (稼働中 tar) と、本実装で取得したバックアップの両方で実測 | **PASS** — 暫定スナップショット: open+recovery **866ms** / 59 テーブル / 全 2,063 行 読取成功。本実装の取得物: 復元 **447ms** / `children=2` / `login_streaks=2`。RTO (DB 復元のみ) **1 秒未満** |
| AC8 | **restore drill の中で journal と `__drizzle_migrations` の突合を行う** (#3951 監査の residual [security/sev2]) | `verifyPgliteDump()` の V3 が復元 DB の `drizzle.__drizzle_migrations` から「適用済み最大 `created_at`」を読み、journal 全 entry がそれ以下 = 永久 skip される entry が無いことを assert。日次バックアップの一部として毎日走る。`[BK2]` が実効性を固定 | **PASS** — 実データで `maxAppliedCreatedAt=1784500000002` / `journalEntries=5` の突合成立。`[BK2]` は乖離させると必ず落ちることを確認 |

## 変更タイプ

- [x] fix: バグ修正

## ADR-0002 Critical 修正 5 要件チェック（必須）

### 要件 1: E2E 回帰テストを同一 PR 内で追加

本 PR は**顧客向け UI / 画面遷移を一切変更しない**バックエンド運用機構のため、Playwright E2E ではなく、実 PGlite + 実 migration による統合テストで回帰を固定する (E2E で表現できる顧客操作が存在しない)。

| AC | テストファイル | テスト内容 |
|---|---|---|
| AC2 / AC7 | `tests/unit/db/pglite-backup-3950.test.ts` | `[BK1]` 実 migration を適用した PGlite から採ったダンプを別インスタンスへ復元し、投入した行が読めること (往復の実証) |
| AC8 | `tests/unit/db/pglite-backup-3950.test.ts` | `[BK2]` journal と適用実績が乖離したダンプは V3 で必ず落ちる (#3946 同型の「永久 skip される migration」を合格にしない) |
| AC2 | `tests/unit/db/pglite-backup-3950.test.ts` | `[BK3]` 検証に落ちた回はバックアップファイルを確定させない (verify-then-commit) |
| AC1 / AC5 | `tests/unit/db/pglite-backup-3950.test.ts` | `[BK4]` ローテーションは保持世代を超えた古い世代だけを消す / `[BK7]` ファイル名が辞書順 = 時系列順 |
| AC3 | `tests/unit/db/pglite-backup-3950.test.ts` | `[BK5]` 失敗した回は古い世代を消さない / `[BK6]` 最終成功時刻が状態ファイルに残り、失敗しても失われない |

`[BK2]` `[BK3]` `[BK5]` は「gate を書いたが実は何も落とせていない」を防ぐ実効性検証。

### 要件 2: AC 全項目完了（部分実装で closes 禁止）

- [x] Issue の全 AC (AC1〜AC8) が本 PR で完了している

### 要件 3: 提案全実装

Issue の実装方針候補 3 案のうち **案 2 (論理/プロセス内ダンプ) を採用**し、案 1・案 3 は不採用とした。不採用理由:

- **案 1 (稼働中ディレクトリの tar)**: 取得中に書き込みが走り得るため復元できる保証がない。実際、2026-07-26 に手で採った暫定スナップショットがこの方式であり、本 PR の restore drill で初めて「実は復元できた」ことを確認した = **それまで復元可能性はゼロ検証だった**。恒久運用の土台にはしない
- **案 3 (短時間停止 + tar)**: 整合性は担保できるがダウンタイムを伴う。案 2 が**停止なしで整合スナップショットを得られる**ため、ダウンタイムを支払う理由がない
- **案 2 (採用)**: PGlite 公式 `dumpDataDir()` をアプリプロセス内で実行する。PGlite は dataDir を単一プロセスで占有するため、整合した取得ができるのは DB を掴んでいるアプリ自身だけという制約とも一致する

オーナーへ確認していた 2 点のうち「許容ダウンタイム」は、案 2 の採用によって**判断不要になった** (ダウンタイム 0)。「RPO / 保持世代」はオーナー決裁 (2026-07-26) で日次 / 3 世代に確定し、そのとおり実装している。

### 要件 4: 全 5 年齢モードで実機検証 + スクリーンショット

**N/A（UI 非影響）**。根拠:

- 変更は `src/lib/server/**` (サーバ内部モジュール) / `src/routes/api/cron/pglite-backup/+server.ts` (認証必須の内部 API、画面から到達しない) / `scripts/**` / `docker-compose.yml` / `docs/**` に閉じる
- `src/routes/` 配下の追加は上記 1 エンドポイントのみで、既存ページ・レイアウト・コンポーネントの変更は 0 件
- 年齢モード分岐 (`baby` / `preschool` / `elementary` / `junior` / `senior`) を読むコードに触れていない

### 要件 5: 直近 30 日の同一ファイル変更 PR チェック

| PR | マージ日 | 同一ファイルでの変更内容 | 本 PR との関係 |
|---|---|---|---|
| #3951 | 2026-07-26 | `drizzle/pglite/meta/_journal.json` を検証する gate を追加 (journal 内部の整合性) | **本 PR が続き**。#3951 の監査 residual [security/sev2] (journal ↔ 本番適用実績の突合が無検証) を本 PR の V3 が塞ぐ |
| #3947 / #3949 | 2026-07-26 | journal `when` の逆転 hotfix (`drizzle/pglite/`) | 本 PR の restore drill が、#3947 以前の backup から復旧できることを実測で確認している (grandfather 3 値の根拠を補強) |
| #3944 | 2026-07-25 | `infra/` の log archiving 移行 | 関連なし (変更ファイル重複なし) |

`src/lib/server/db/pglite/connection.ts` は #3947 以降で本 PR が初の変更 (追加のみ、既存関数の挙動変更なし)。`docker-compose.yml` は #2985 以来の変更で、backup サービスの起動コマンドと保持世代のみを触る。

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [x] サービス層
- [x] API
- [ ] ページ
- [ ] UI コンポーネント
- [x] その他: 運用スクリプト (`scripts/backup-nuc.cjs`) / コンテナ構成 (`docker-compose.yml`) / Runbook

**影響を受ける画面・機能**: なし (顧客向け画面・機能の挙動変更は 0)。影響するのは NUC の日次バックアップ運用のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3954` 全 Step PASS**
- [x] **回帰テストを同一 PR 内で追加**（要件 1、再掲。E2E ではなく実 PGlite 統合テストである理由も要件 1 に記載）
- [x] 追加・変更したテスト一覧: `tests/unit/db/pglite-backup-3950.test.ts` (7 本、`[BK1]`〜`[BK7]`)
- [x] **Critical バグ修正の場合**（ADR-0002）: 上記 5 要件全て確認済み

検証結果:

- `npx vitest run tests/unit/db` → **66 files / 637 tests PASS** (exit 0、フルログをファイル保存して確認)
- `npx svelte-check --threshold error` → **0 errors 0 warnings**
- `npx biome check` (変更 5 file) → clean

## スクリーンショット / ビジュアルデモ

**該当なし（バックエンド修正のみ）**。UI 変更 0 件 (要件 4 に根拠)。

## コード品質セルフレビュー (#1481)

- [x] **DRY**: 同型の穴 (「backend を移行したのにバックアップ対象が旧 backend のまま」) を防ぐため、backend 判定を `scripts/backup-nuc.cjs` の 1 箇所に集約した。旧 SQLite 経路を消さずに分岐で残したのは、SQLite backend が `DATA_SOURCE=sqlite` として今も選択可能なため
- [x] **YAGNI**: オフサイト複製 / PITR / 世代の暗号化は実装していない (オーナー決裁は日次 3 世代・NUC ローカル)。残存リスクとして Runbook に明記するに留める
- [x] **Security**: 新規エンドポイントは既存 `verifyCronAuth` (`x-cron-secret` / `Authorization: Bearer`) 必須。`DATA_SOURCE != pglite` では 409 を返し実行しない。復元検証は in-memory インスタンスで行い**本番ディレクトリへ書き戻さない**。テーブル名を SQL へ補間する箇所は復元 DB の catalog 由来だが、識別子形状を明示 assert している (`connection.ts` の `dbName` 検証と同じ防御)
- [x] **アクセシビリティ**: UI 非変更のため毀損なし
- [x] **パフォーマンス**: 実測で 1 サイクル **1,256ms** (dump + 復元検証 + 確定)。日次 03:00 JST の 1 回のみで、リクエスト経路には影響しない

## 横展開・影響波及チェック

- [x] 本番アプリ + デモ版を同期 — demo は `DATA_SOURCE=demo` (stateless fixture) でバックアップ対象外。エンドポイントは 409 を返す
- [x] 全年齢モード 5 種に横展開 — N/A (UI 非影響、要件 4 に根拠)
- [x] ナビゲーション 3 種に反映 — N/A (画面追加なし)
- [x] E2E / ユニットシード同期 — シード変更なし
- [x] labels SSOT (ADR-0009) — N/A
- [x] 設計書同期 (ADR-0001) — `docs/runbooks/pglite-restore-drill.md` を新規追加。既存の `docs/runbooks/activities-data-recovery.md` (SQLite 前提) は SQLite backend の手順として有効なため無改変
- [x] 並行 PR overlap 確認 (#1200) — open PR は #3945 (`.github/dependabot.yml` のみ) で重複なし

**AWS 側への波及なし**: 本 job は `scheduleRegistry` に登録していない。`tests/unit/cron/schedule-consistency.test.ts` が「registry の全 job が AWS `KNOWN_ENDPOINTS` にも存在すること」を強制するため、登録すると AWS (DSQL 稼働) にも PGlite バックアップ job を生やすことになる。本 job は NUC 専用のため、NUC ローカルの crond から起動する。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

`docker-compose.yml` の backup サービスの起動コマンドは変わるが、`DATA_SOURCE` が `pglite` 以外の環境では従来と同じ SQLite 経路が実行される (振る舞い等価)。

**レビュー依頼事項・QA**: 重点的に見てほしい点を 3 つ挙げます。

1. **V3 (journal 突合) の判定が厳しすぎないか** — 「journal の全 entry が適用済み最大 `created_at` 以下」を要求するため、**新しい migration を追加した直後でアプリがまだ再起動していない瞬間**にバックアップが走ると V3 で落ちます。この場合バックアップは確定せず alert が飛びます。私はこれを「意図した挙動」と判断しました (適用されていない migration がある状態の DB を『検証済みバックアップ』として確定させたくない、かつ #3946 と同型の書き換えもここで捕まえたい) が、運用上うるさすぎるなら緩める余地があります。失敗メッセージには「意図した新規 migration ならアプリを再起動して適用を完了させてください」という次アクションを入れています
2. **verify-then-commit のコスト判断** — 毎回の取得で必ず別インスタンスへ復元するため、所要時間は取得のみの場合の約 2 倍になります (実測で計 1,256ms)。日次 1 回・1 秒台なので許容と判断しましたが、データ量が増えたときの再評価点として認識しておいてほしいです
3. **オフサイト複製が無いままである点** — バックアップは NUC ローカルの同一ディスク上にあり、**NUC 本体・ディスクの物理故障では本体とバックアップが同時に失われます**。既存の `scripts/backup-to-gdrive.cjs` / `BACKUP_POST_HOOK` の経路は存在しますが PGlite 経路には未接続です。Issue の AC は「保存先の方針を明文化する」であり、オーナー決裁は「NUC ローカル / 3 世代」だったため本 PR ではその決裁どおりに実装し、残存リスクとして Runbook に明記しました。この判断の妥当性を独立に見てほしいです

## 配布済み env / secret (ADR-0006)

新規 env は `BACKUP_DIR` / `BACKUP_RETENTION` の 2 つですが、**いずれも `optional` + コード側既定値あり**で required env ではありません (`src/lib/runtime/env.ts`、未設定でも `./data/backups` / 3 世代で動作)。`scripts/check-new-required-env.mjs` の対象外です。

配布経路:

- **NUC .env**: 配布不要 (`docker-compose.yml` の `environment:` に app / backup 両サービス分を直接記載済み)
- **GitHub Secrets / Lambda / .env.example**: 配布不要 (NUC compose 専用。AWS 経路では読まれない)

`CRON_SECRET` は既存 env で、NUC の `.env` に配布済み (backup サービスは `env_file: .env` `required: true`)。新規追加ではありません。

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3954` 全 Step PASS** をローカル確認した
- [x] **ADR-0002 5 要件全て満たした**（再掲、自己確認）
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] UI 変更時: 5 年齢モード SS が GitHub 上で表示確認できる — N/A (UI 変更なし)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言。QM が re-verify する)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
