### PR TITLE
fix: #3962 po-decision:required label 付き PR の PO 決裁ブリーフ欠落を機械検出する

### DIFF
--- a/.claude/skills/dev-open-pr/SKILL.md
+++ b/.claude/skills/dev-open-pr/SKILL.md
@@ -133,12 +133,24 @@ npm run pre-ready -- --pr <N>
 **#2618 deploy 後**: `check-recent-deploy-deletion.mjs` 自身が `--pr` 指定時に HEAD mismatch を検出すると exit 3 で BLOCK する self-defense を実装済 (ADR-0056 §D defense in depth 第 2 層)。**ただし本 prelude (第 1 層) は引き続き必須**。Agent 側で事前 checkout する習慣を default 化することで gate 起動回数自体を最小化する。
 
 ```bash
-# 雛形に直接ローカル検証（PR 未作成でも動く）
-node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/<slug>.md --skip-mergeable
+# 雛形に直接ローカル検証（PR 未作成 = label がまだ存在しないので --no-labels）
+node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/<slug>.md --skip-mergeable --no-labels
 
 # pre-ready CLI 経由（ADR-0030、PR 番号不要時は --pr 0 でも内部 skip 設計）
 npm run pre-ready -- --pr <PR番号後で発番>
 ```
+
+### `--no-labels` を書いてよい場面 (#3962 QA 指摘)
+
+`--no-labels` は label 条件付き gate（hotfix env 配布証跡 #2343 / PO 決裁ブリーフ #3962）を **検査しない**宣言。fail-closed の縮退先なので、**PR 番号が取れる呼び出しでは書かない**:
+
+| 場面 | 書き方 |
+|---|---|
+| PR 作成**前**の雛形 dry-run（label がまだ存在しない） | `--body-file <path> --skip-mergeable --no-labels` |
+| PR 作成**後**（Ready 化前検証 / pre-push / pre-ready） | `--pr <num> --body-file <path> --skip-mergeable`（`--no-labels` を書かない） |
+| 付く予定の label を先に検証したい | `--labels po-decision:required --body-file <path>` |
+
+`--no-labels` 指定時は `SKIPPED — label 条件付き gate 2 件は検査していません` が gate 名付きで出力される。**この行が出ている pass は「全部通った」ではない**。label を付けた後に `--pr <num>` で必ず再実行すること。
 
 `check-pr-body.mjs` は以下を検出:
 - 必須セクション欠落（PR template / SSOT JSON との完全一致、#2060 で SSOT 化）
@@ -156,7 +168,8 @@ npm run pre-ready -- --pr <PR番号後で発番>
 ```bash
 # 既存 PR の body を取得して SSOT JSON と diff
 gh pr view <num> --json body --jq .body > /tmp/pr-body-check.md
-node scripts/check-pr-body.mjs --body-file /tmp/pr-body-check.md --skip-mergeable
+# --pr <num> は label 取得用（label 条件付き gate を発火させるため必須）。body は --body-file 優先
+node scripts/check-pr-body.mjs --pr <num> --body-file /tmp/pr-body-check.md --skip-mergeable
 # missing-required-sections 違反が出たら .github/PR_TEMPLATE_SECTIONS.json から逐語コピーして補完
 ```
 
@@ -247,7 +260,7 @@ rm tmp/pr-bodies/<num>-<slug>.md
 
 | # | Gate | ローカル検証 |
 |---|---|---|
-| 1 | AC 検証マップ全行埋め | `node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable` |
+| 1 | AC 検証マップ全行埋め | `node scripts/check-pr-body.mjs --pr <num> --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable` |
 | 2 | 必須セクション 12 個 全存在 | 同上 |
 | 3 | Ready チェックリスト `[x]` 完了 (虚偽禁止) | 同上 |
 | 4 | UI 変更時 SS 4 スロット添付 | 修正前 × Mobile/PC + 修正後 × Mobile/PC を `docs/screenshots/pr-<num>/` または screenshots branch に配置 |

--- a/.claude/skills/dev-open-pr/SKILL.md
+++ b/.claude/skills/dev-open-pr/SKILL.md
@@ -323,6 +323,7 @@ rm tmp/pr-bodies/<num>-<slug>.md
 ### ルール
 
 - 本セクションは **必須 13 セクション（`PR_TEMPLATE_SECTIONS.json`）に含まれない条件付き append**（`--kind lp` の「LP メトリクス結果」と同じ慣行）。`check-pr-body.mjs` は追加セクションを許容する
+- **`po-decision:required` label が付いている PR では本セクションが機械必須**（#3962）。`check-pr-body.mjs` の `checkPoDecisionBrief` が、見出し欠落 / mermaid 欠落 / 未置換 `___` 残置を fail させる（`npm run pre-ready` の Readiness gate step で発火）。label 誤付与なら理由を PR body に明記のうえ label を外す。#3944 / #3956 で「label は付いているがブリーフがない」まま Ready 化 → QA merge gate 指摘、が 2 回連続したことによる gate 化
 - `po-decision:required` label が付いた PR は **PO の Yes/No 判断を得てから merge**（QM / audit-manager 単独 merge 禁止）。判断待ちで Ready 化まで進めるのは可
 - label が synchronize（push）で後から自動付与された場合も、気づいた時点でブリーフを `gh pr edit <N> --body-file` で追補する
 

--- a/.claude/skills/dev-open-pr/ready-gate-checklist.md
+++ b/.claude/skills/dev-open-pr/ready-gate-checklist.md
@@ -55,7 +55,7 @@ node scripts/check-new-required-env.mjs
 **確認方法**:
 ```bash
 # ローカル
-node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable
+node scripts/check-pr-body.mjs --pr <num> --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable
 # CI 上
 gh pr checks <num> --watch
 ```
@@ -95,7 +95,7 @@ SSOT: `.github/PR_TEMPLATE_SECTIONS.json` の `sections` 配列を**逐語コピ
 **確認方法**:
 ```bash
 # SSOT JSON 経由でローカル検証 (#2060)
-node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable
+node scripts/check-pr-body.mjs --pr <num> --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable
 # template ↔ SSOT JSON 同期検証
 node scripts/check-pr-template-sections-sync.mjs
 # CI: pr-template-gate.yml「必須セクションの存在確認」ジョブ + check-pr-template-sections-sync.yml
@@ -127,7 +127,7 @@ node scripts/check-pr-template-sections-sync.mjs
 
 **確認方法**:
 ```bash
-node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable
+node scripts/check-pr-body.mjs --pr <num> --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable
 # Output: "Ready for Review / 完了チェックリストの未チェック残置" 検出
 ```
 

--- a/.claude/skills/dev-open-pr/scripts/init-pr-body.mjs
+++ b/.claude/skills/dev-open-pr/scripts/init-pr-body.mjs
@@ -323,7 +323,7 @@ async function main() {
 	console.log('次の手順:');
 	console.log(`  1. ${relative(REPO_ROOT, outputPath)} を編集して穴埋め`);
 	console.log(
-		`  2. node scripts/check-pr-body.mjs --body-file ${relative(REPO_ROOT, outputPath)} --skip-mergeable で検証`,
+		`  2. node scripts/check-pr-body.mjs --body-file ${relative(REPO_ROOT, outputPath)} --skip-mergeable --no-labels で検証`,
 	);
 	console.log(`  3. node scripts/check-gh-account-before-pr.mjs で gh アカウント確認`);
 	console.log(

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,7 +35,7 @@ closes #
 ## 変更タイプ
 
 <!-- ⚠️ 1 つ以上 [x] を必ず選択 — 未選択のままだと CI 必須 gate「変更タイプの選択」が hard-fail する (#3846、3 PR 連続再発 #3835/#3837/#3844)。
-     PR 作成前に `node scripts/check-pr-body.mjs --body-file <path> --skip-mergeable` で機械検証できる -->
+     PR 作成前に `node scripts/check-pr-body.mjs --body-file <path> --skip-mergeable --no-labels` で機械検証できる -->
 
 - [ ] feat: 新機能
 - [ ] fix: バグ修正

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -136,9 +136,11 @@ if [ -n "$PR_NUM" ]; then
 	}
 	echo "[pre-push]     OK: 本日 deploy 削除 0 件"
 
-	echo "[pre-push] (3/3) PR body 13 セクション + AC 4 列 + 禁止語 verify (PR #$PR_NUM)"
+	echo "[pre-push] (3/3) PR body 13 セクション + AC 4 列 + 禁止語 + PO 決裁ブリーフ verify (PR #$PR_NUM)"
 	# 本 step は PR body の 13 セクション網羅 + AC 4 列 + 禁止語 0 件 + mojibake 不在を検証する
 	# (#2060 / #2576 / #2586 / #2633 第 5 弾)。
+	# #3962: `po-decision:required` label 付き PR の PO 決裁ブリーフ欠落もここで落ちる
+	# (label は labeler.yml が自動付与するため、body 側の追従漏れが #3944 / #3956 で 2 回連続した)。
 	node scripts/check-pr-body.mjs --pr "$PR_NUM" --skip-mergeable || {
 		EXIT_CODE=$?
 		echo "[pre-push] FAIL: PR body 検証 fail (exit $EXIT_CODE)"
@@ -146,7 +148,7 @@ if [ -n "$PR_NUM" ]; then
 		echo "                詳細: .claude/skills/dev-open-pr/SKILL.md §「Ready 化前必須」"
 		exit 1
 	}
-	echo "[pre-push]     OK: PR body 13 セクション + AC 4 列 + 禁止語 0 件"
+	echo "[pre-push]     OK: PR body 13 セクション + AC 4 列 + 禁止語 0 件 + PO 決裁ブリーフ"
 else
 	echo "[pre-push] (2/3) PR 未作成のため deploy 削除 / PR body verify を skip"
 	echo "[pre-push] (3/3) (同上)"

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -124,6 +124,22 @@ server side gate (`.github/workflows/pr-author-guard.yml`) で違反 PR が即�
 4. 同じブランチから `gh pr create --draft ...` で再起票（既存 commit 履歴は再利用、新ブランチ不要）
 5. 旧 PR (closed) は 違反コメント保全のため reopen / 削除しない (ADR-0022 監査証跡)
 
+### QA 指摘の再発防止台帳（CRITICAL — #3962、PO 指示 2026-07-26）
+
+**同じ class の QA 指摘を 2 度受けたら、その時点で instance 修正ではなく機械 gate 化する。** 記憶と注意力に依存した再発防止は必ず破れる（ADR-0061 same-class-N→guard）。
+
+以下は実際に 2 回以上受けた指摘。**1 は `npm run pre-ready` で機械検出されるため暗記不要。2〜3 は着手時に読む**。
+
+| # | 指摘 class | 発生 PR | 現在の防御 |
+|---|-----------|---------|-----------|
+| 1 | `po-decision:required` label 付きなのに PO 決裁ブリーフが PR body にない | #3944 / #3956 | **機械 gate**: `scripts/check-pr-body.mjs` の `checkPoDecisionBrief`（pre-ready Readiness gate step に内蔵）。見出し欠落 / mermaid 欠落 / 未置換 `___` を fail させる |
+| 2 | 構造化識別子を `startsWith` / `endsWith` の緩い一致で判定した | #3956 | レビュー観点（下記） |
+| 3 | guard の fixture が「規則に従うデータ」だけで、規則から外れた実在物を含まない | #3956 | レビュー観点（下記） |
+
+**2 の観点 — 命名規則のあるファイル名・ID・key を判定するときは、prefix/suffix 一致ではなく正規表現の完全一致で書く。** 生成側にも同じパターンの assert を置き、命名変更時に silent に壊れないようにする。#3956 では `pglite-` prefix + `.tgz` suffix 一致にしたため、同居する手動スナップショット `pglite-snapshot-*.tgz` が「世代」として数えられ、実保持が 3 → 2 世代に減っていた。
+
+**3 の観点 — guard を書いたら「その guard を外すと fail するか」を実行して証跡に貼る。** fixture には*規則に従わないが実在するもの*（手動退避ファイル、サブディレクトリ、旧命名の残骸）を実名で混ぜる。規則に従うデータだけを並べた fixture は、規則違反を検出できないことを検出できない。
+
 ## 新規実装時
 
 1. AC を読む。不明点は Issue にコメント確認

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -111,7 +111,7 @@ PO セッションが定めた AC を全て満たし、スクラップ&ビルド
    gh pr create --draft --base develop --body-file tmp/pr-bodies/<num>-<slug>.md
    ```
 8. **UI 変更時、Ready 化前に SS 撮影必須**（次節参照）
-9. **Ready 化前に 4 必須 CI gate チェック**（[Skill: dev-open-pr ready-gate-checklist](../../.claude/skills/dev-open-pr/ready-gate-checklist.md)）— AC 検証マップ / 必須セクション (`.github/PR_TEMPLATE_SECTIONS.json` SSOT 13 件、#2060) / `[x]` 完了 / SS 4 スロット を機械的に確認。**特に必須セクション全件確認は PR #2039 / #2043 で「12 件全欠落」が連続再発した教訓に基づき、`gh pr ready` 直前の `node scripts/check-pr-body.mjs --body-file <PR body取得物> --skip-mergeable` 実行を skill 内で必須化** (#2060)
+9. **Ready 化前に 4 必須 CI gate チェック**（[Skill: dev-open-pr ready-gate-checklist](../../.claude/skills/dev-open-pr/ready-gate-checklist.md)）— AC 検証マップ / 必須セクション (`.github/PR_TEMPLATE_SECTIONS.json` SSOT 13 件、#2060) / `[x]` 完了 / SS 4 スロット を機械的に確認。**特に必須セクション全件確認は PR #2039 / #2043 で「12 件全欠落」が連続再発した教訓に基づき、`gh pr ready` 直前の `node scripts/check-pr-body.mjs --pr <num> --body-file <PR body取得物> --skip-mergeable` 実行を skill 内で必須化** (#2060)
 10. CI 全通過後 Ready: `gh pr ready <num>`
 
 ### PR 起票アカウント違反からの復旧 (#1994)
@@ -287,7 +287,7 @@ const source = getEnv().DATA_SOURCE;
 
 ```bash
 # 1. PR body 全体検証 (必須セクション 13 件 / AC マップ 4 列 / 禁止語 / Ready チェックリスト)
-node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable
+node scripts/check-pr-body.mjs --pr <num> --body-file tmp/pr-bodies/<num>-<slug>.md --skip-mergeable
 
 # 2. 設計書同期 (src/routes/ 変更時に docs/design/ 同期 or label exempt 確認)
 PR_FILES="$(gh pr diff <num> --name-only)" \

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -13,6 +13,7 @@
  *   5. `mergeable: CONFLICTING` 事前検知（GitHub API 経由）
  *   6. 変更タイプ checkbox 未選択（#3846、CI gate「変更タイプの選択」の shift-left。
  *      判定は scripts/pr-template-gate-checks.mjs の checkChangeType を SSOT として再利用）
+ *   7. `po-decision:required` label 付きなのに PO 決裁ブリーフが body にない（#3944/#3956/#3962）
  *
  * 必須セクション SSOT:
  *   `.github/PULL_REQUEST_TEMPLATE.md` を runtime parse し、
@@ -372,6 +373,112 @@ export function checkEnvDistributionForHotfix(body, labels) {
 			`対応 1: env 追加がない hotfix なら明示的に \`- [x] N/A — 新規 env / secret の追加なし\` を本文に記載\n` +
 			`対応 2: env 追加がある hotfix なら 4 経路全て (GitHub Secrets / Lambda / NUC .env / .env.example) の「配布済み:」行を列挙 (#2341 教訓)`,
 	};
+}
+
+// ---------------------------------------------------------------------------
+// PO 決裁ブリーフ欠落チェック (#3962)
+// ---------------------------------------------------------------------------
+
+/**
+ * `.github/labeler.yml` が高リスクパス touch 時に自動付与するラベル (#3862)。
+ * 付与された PR は PR body に PO 決裁ブリーフ (一枚絵 mermaid) が必須。
+ */
+export const PO_DECISION_LABEL = 'po-decision:required';
+
+/**
+ * PO 決裁ブリーフの見出し SSOT。
+ * `.claude/skills/dev-open-pr/templates/po-decision-brief.md` の先頭見出しと一致させること。
+ */
+export const PO_DECISION_HEADING = '## PO 決裁ブリーフ';
+
+/**
+ * @param {string[]} labels
+ * @returns {boolean}
+ */
+export function hasPoDecisionLabel(labels) {
+	return labels.some((l) => l.trim().toLowerCase() === PO_DECISION_LABEL);
+}
+
+/**
+ * `## PO 決裁ブリーフ` セクションを抽出する。`## ` を含む次セクションまでが対象。
+ *
+ * @param {string} body
+ * @returns {string | null}
+ */
+export function extractPoDecisionSection(body) {
+	const startMatch = body.match(/^## PO 決裁ブリーフ.*$/m);
+	if (!startMatch) return null;
+	const startIdx = body.indexOf(startMatch[0]);
+	const remaining = body.slice(startIdx + startMatch[0].length);
+	const nextSectionIdx = remaining.search(/^## /m);
+	return nextSectionIdx === -1 ? remaining : remaining.slice(0, nextSectionIdx);
+}
+
+/**
+ * `po-decision:required` label 付き PR に PO 決裁ブリーフが実体を伴って存在するかを検証する (#3962)。
+ *
+ * 発生経緯: PR #3944 / #3956 の 2 回連続で「label は付いているがブリーフが body にない」まま
+ * Ready 化し、QA レビューで merge gate 指摘を受けた。label 付与 (labeler.yml) は自動化済みだが、
+ * 付与に対応する body 要件が人間の記憶に依存していたため同型が再発した。ADR-0061
+ * same-class-N→guard に従い、instance 修正 (その PR にブリーフを足す) ではなく機械 gate 化する。
+ *
+ * 検出する違反 (label 付き PR のみ適用):
+ *   1. `## PO 決裁ブリーフ` 見出しが body にない (#3944 / #3956 の実際の形)
+ *   2. 見出しはあるが mermaid ブロックがない (「一枚絵で判断できる」という様式要件を満たさない)
+ *   3. 見出しはあるが template の未置換プレースホルダ `___` が残っている
+ *
+ * 検出しないもの: ブリーフの中身の妥当性 (判断層は QA / PO レビューの担当)。
+ * ここで固定するのは「label と body の対応が取れていること」だけ。
+ *
+ * @param {string} body
+ * @param {string[]} labels - PR ラベル一覧
+ * @returns {{ id: string; message: string } | null}
+ */
+export function checkPoDecisionBrief(body, labels) {
+	if (!hasPoDecisionLabel(labels)) return null;
+
+	// 見出しが HTML コメント内にあるだけのケースを「存在する」と誤判定しないよう、
+	// コメントを剥がしてから探す。コードブロックは mermaid 図の実体なので残す。
+	const cleaned = stripMarkdownComments(body);
+	const section = extractPoDecisionSection(cleaned);
+
+	if (!section) {
+		return {
+			id: 'po-decision-brief-missing-section',
+			message:
+				`\`${PO_DECISION_LABEL}\` label が付いていますが、PR body に \`${PO_DECISION_HEADING}\` ` +
+				`セクションがありません (#3944 / #3956 と同型)。\n` +
+				`対応 1: \`.claude/skills/dev-open-pr/templates/po-decision-brief.md\` を PR body 末尾に append し、\n` +
+				`        「___」を全て実際の内容に置換する (mermaid 一枚絵で PO が Yes/No を判断できること)。\n` +
+				`対応 2: label が誤付与なら、外した理由を PR body に明記したうえで label を外す ` +
+				`(判定 SSOT = .github/labeler.yml の po-decision:required エントリ)。`,
+		};
+	}
+
+	if (!/```mermaid/.test(section)) {
+		return {
+			id: 'po-decision-brief-missing-diagram',
+			message:
+				`\`${PO_DECISION_HEADING}\` セクションに mermaid ブロックがありません。\n` +
+				`様式 SSOT (PO 恒久要件 2026-07-23): PO は mermaid 図 1 枚 (+ UI 変更時は実機 SS) だけで ` +
+				`Yes/No を判断できること。長文説明を主成果物にしない。\n` +
+				`対応: \`.claude/skills/dev-open-pr/templates/po-decision-brief.md\` の flowchart をコピーして記入する。`,
+		};
+	}
+
+	const placeholderCount = (section.match(/___/g) ?? []).length;
+	if (placeholderCount > 0) {
+		return {
+			id: 'po-decision-brief-unfilled-placeholder',
+			message:
+				`\`${PO_DECISION_HEADING}\` セクションに template の未置換プレースホルダ \`___\` が ` +
+				`${placeholderCount} 件残っています。\n` +
+				`対応: 全ての「___」を 1 行 15〜25 字で言い切った内容に置換する。` +
+				`③ 反対理由は tmp/adversarial-evidence/<pr>.json を生成してから転記する (AI 要約への過信を打ち消すため)。`,
+		};
+	}
+
+	return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -810,6 +917,10 @@ function collectViolations(body, requiredSections, template, args) {
 	if (selfReviewEvidence) {
 		violations.push({ ...selfReviewEvidence, issue: '#2475/#2815 D-1' });
 	}
+
+	// #3962: po-decision:required label と PO 決裁ブリーフの対応固定 (#3944 / #3956 同型の再発防止)
+	const poDecision = checkPoDecisionBrief(body, labels);
+	if (poDecision) violations.push({ ...poDecision, issue: '#3944/#3956/#3962' });
 
 	// #3846: 変更タイプ checkbox 未選択の shift-left 検出 (CI gate と同一 SSOT を再利用)
 	const changeType = checkChangeTypeSelection(body, template, labels);

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -22,7 +22,7 @@
  *
  * Usage:
  *   node scripts/check-pr-body.mjs --pr 1775
- *   node scripts/check-pr-body.mjs --body-file path/to/body.md         # gh pr view 不要なテスト用
+ *   node scripts/check-pr-body.mjs --body-file path/to/body.md --no-labels  # PR 未作成の dry-run
  *   node scripts/check-pr-body.mjs --pr 1775 --skip-mergeable          # GitHub API を呼ばない
  *
  * exit:
@@ -32,7 +32,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { checkChangeType } from './pr-template-gate-checks.mjs';
@@ -573,7 +573,7 @@ export function checkChangeTypeSelection(body, template, labels = []) {
 		message:
 			`${result.message}\n` +
 			'背景: 未選択のまま提出 → CI 必須 gate「変更タイプの選択」hard-fail が 3 PR 連続再発 (#3835 / #3837 / #3844)。\n' +
-			'対応: PR 作成前に `node scripts/check-pr-body.mjs --body-file <path> --skip-mergeable` で本検証を PASS させる。\n' +
+			'対応: PR 作成前に `node scripts/check-pr-body.mjs --body-file <path> --skip-mergeable --no-labels` で本検証を PASS させる。\n' +
 			'      `npm run dev:open-pr -- --issue <num>` 経由なら Issue の type:* label から自動 [x] 化される (init-pr-body.mjs)。',
 	};
 }
@@ -689,13 +689,19 @@ function fetchPrBody(prNumber) {
 
 /**
  * `gh pr view <num> --json labels` で PR ラベル一覧を取得する (#2343)。
- * gh CLI 未インストール / オフライン / PR 未作成時は空配列を返す。
+ *
+ * #3962 (QA 指摘): 旧実装は gh 失敗を `catch { return [] }` で潰していたため、
+ * 「label が付いていない」と「label を取得できなかった」を呼び出し側が区別できず、
+ * label 条件付き検査 (hotfix / po-decision) が**黙って消えたうえで `OK — 違反なし`**
+ * と表示された。gate の縮退方向が pass 側に倒れる典型なので、
+ * **取得不能は `null` を返して呼び出し側で fail-closed させる**。
+ * 空配列は「gh 取得に成功し、label が 1 件も無い」場合だけを意味する。
  *
  * @param {string|number|null} prNumber
- * @returns {string[]}
+ * @returns {string[] | null} 取得できなければ null (= 未解決)
  */
 function fetchPrLabels(prNumber) {
-	if (!prNumber) return [];
+	if (!prNumber) return null;
 	try {
 		const raw = execSync(`gh pr view ${prNumber} --json labels --jq '[.labels[].name]'`, {
 			encoding: 'utf-8',
@@ -703,10 +709,90 @@ function fetchPrLabels(prNumber) {
 			timeout: 15_000,
 		});
 		const parsed = JSON.parse(raw.trim() || '[]');
-		return Array.isArray(parsed) ? parsed.map((l) => String(l)) : [];
+		return Array.isArray(parsed) ? parsed.map((l) => String(l)) : null;
 	} catch {
-		return [];
+		return null;
 	}
+}
+
+/**
+ * CLI 引数と `fetchPrLabels()` の結果から、検査に使う label 一覧を確定する (#3962)。
+ *
+ * label 条件付き検査 (hotfix #2343 / po-decision #3962) は「label が無い」なら
+ * 正しく skip されるべきだが、「label が分からない」で skip すると gate が消える。
+ * この 2 つを型で分離するのが本関数の目的で、**未解決は必ず error を返す** (fail-closed)。
+ * dry-run で label がまだ存在しないことが分かっている場合は `--no-labels` で明示する。
+ *
+ * @param {{ pr: string | null; labels: string | null; noLabels: boolean }} args
+ * @param {string[] | null} fetched `fetchPrLabels()` の戻り (未解決なら null)
+ * @returns {{ labels: string[] } | { error: string }}
+ */
+/**
+ * label が付いているときだけ発火する gate の SSOT (#3962 QA 指摘)。
+ *
+ * `--no-labels` は「label が無い」ことの明示なので、これらの gate は正しく skip される。
+ * ただし **何を検査しなかったかが出力に出ない限り、通常 pass と見分けがつかない**。
+ * 見分けがつかない pass は本 Issue が塞ごうとしている失敗 class そのものなので、
+ * skip した gate 名を件数付きで出すための一覧をここに固定する。
+ *
+ * @type {ReadonlyArray<{ name: string; issue: string; label: string }>}
+ */
+export const LABEL_CONDITIONAL_GATES = [
+	{
+		name: 'hotfix env 配布証跡 (ADR-0006)',
+		issue: '#2343',
+		label: HOTFIX_LABELS.join(' / '),
+	},
+	{
+		name: 'PO 決裁ブリーフ',
+		issue: '#3962',
+		label: PO_DECISION_LABEL,
+	},
+];
+
+/**
+ * `--no-labels` 指定時に「検査しなかった gate」を明示する出力行を組み立てる (#3962 QA 指摘)。
+ *
+ * 呼び出し側が `console.log` するだけで済むよう、行配列で返す。
+ * 将来メッセージを整理した拍子に無言化しないよう、gate 名の出現を test で固定している ([LB7])。
+ *
+ * @returns {string[]}
+ */
+export function formatSkippedLabelGates() {
+	return [
+		`[check-pr-body] SKIPPED — label 条件付き gate ${LABEL_CONDITIONAL_GATES.length} 件は検査していません (--no-labels)`,
+		...LABEL_CONDITIONAL_GATES.map((g) => `  - ${g.name} (${g.issue}) — 発火 label: ${g.label}`),
+		`  ※ label が付いた後に --pr <N> で再実行しないと、上記 gate は一度も動きません`,
+	];
+}
+
+export function resolveLabels(args, fetched) {
+	if (args.noLabels) return { labels: [] };
+	if (args.labels !== null) {
+		return {
+			labels: args.labels
+				.split(',')
+				.map((s) => s.trim())
+				.filter(Boolean),
+		};
+	}
+	if (fetched !== null) return { labels: fetched };
+	if (args.pr) {
+		return {
+			error:
+				`PR #${args.pr} の label を取得できませんでした (gh 未認証 / オフライン / timeout など)。\n` +
+				`  label 条件付き検査 (hotfix #2343 / po-decision #3962) を実行できないため、pass 側に倒さず中断します。\n` +
+				`  対応: gh auth status を確認して再実行するか、--labels <csv> / --no-labels で明示してください。`,
+		};
+	}
+	return {
+		error:
+			`--body-file 単独では label を解決できません。\n` +
+			`  label 条件付き検査 (hotfix #2343 / po-decision #3962) が黙って skip されるのを防ぐため、\n` +
+			`  --labels <csv> か --no-labels のどちらかを明示してください。\n` +
+			`  例: --no-labels                      # PR 未作成で label がまだ付いていない\n` +
+			`      --labels po-decision:required    # 付く予定の label を先に検証する`,
+	};
 }
 
 // ---------------------------------------------------------------------------
@@ -738,14 +824,15 @@ function tryParseStringArg(argv, i, aliases) {
 
 /**
  * @param {string[]} argv
- * @returns {{ pr: string | null; bodyFile: string | null; labels: string | null; skipMergeable: boolean; help: boolean }}
+ * @returns {{ pr: string | null; bodyFile: string | null; labels: string | null; noLabels: boolean; skipMergeable: boolean; help: boolean }}
  */
 function parseArgs(argv) {
-	/** @type {{ pr: string | null; bodyFile: string | null; labels: string | null; skipMergeable: boolean; help: boolean }} */
+	/** @type {{ pr: string | null; bodyFile: string | null; labels: string | null; noLabels: boolean; skipMergeable: boolean; help: boolean }} */
 	const args = {
 		pr: null,
 		bodyFile: null,
 		labels: null,
+		noLabels: false,
 		skipMergeable: false,
 		help: false,
 	};
@@ -770,6 +857,7 @@ function parseArgs(argv) {
 		}
 		const a = argv[i];
 		if (a === '--skip-mergeable') args.skipMergeable = true;
+		else if (a === '--no-labels') args.noLabels = true;
 		else if (a === '--help' || a === '-h') args.help = true;
 	}
 	return args;
@@ -781,14 +869,22 @@ check-pr-body.mjs — PR body のセルフチェック (Issue #1775 AC2)
 
 Usage:
   node scripts/check-pr-body.mjs --pr <number>
-  node scripts/check-pr-body.mjs --body-file <path>      # 単体テスト・dry-run 用
   node scripts/check-pr-body.mjs --pr <number> --skip-mergeable
+  node scripts/check-pr-body.mjs --pr <number> --body-file <path> --skip-mergeable
+  node scripts/check-pr-body.mjs --body-file <path> --no-labels          # PR 未作成の dry-run
   node scripts/check-pr-body.mjs --body-file <path> --labels priority:critical,hotfix
+
+label の解決方法 (#3962):
+  label 条件付き gate (hotfix env 配布証跡 #2343 / PO 決裁ブリーフ #3962) が黙って
+  skip されるのを防ぐため、label が解決できない呼び出しは exit 2 で中断する (fail-closed)。
+  PR 番号が取れるなら --pr を渡すこと。--no-labels は PR 作成前の dry-run 専用で、
+  指定すると「検査しなかった gate」が SKIPPED 行として出力される。
 
 Options:
   --pr <num>          GitHub PR 番号 (gh pr view で body 取得 + label 自動検出)
   --body-file <path>  ローカルファイルから body を読む（PR 未作成時の dry-run 用）
   --labels <csv>      PR ラベルをカンマ区切りで明示指定（--body-file 時の hotfix 検出用、#2343）
+  --no-labels         label が 1 件も無いことを明示（--body-file dry-run 用、#3962）
   --skip-mergeable    GitHub API 呼び出しをスキップ (オフライン環境用)
   --help, -h          このヘルプを表示
 
@@ -948,18 +1044,28 @@ export async function main(argv = process.argv.slice(2)) {
 	const template = readFileSync(TEMPLATE_PATH, 'utf-8');
 	const requiredSections = extractRequiredSections(template);
 
-	// #2343: hotfix label 検出のためラベル取得
-	const labels = args.labels
-		? args.labels
-				.split(',')
-				.map((s) => s.trim())
-				.filter(Boolean)
-		: fetchPrLabels(args.pr);
+	// #2343: hotfix label 検出のためラベル取得 / #3962: 未解決は fail-closed
+	const needsFetch = args.labels === null && !args.noLabels;
+	const resolved = resolveLabels(args, needsFetch ? fetchPrLabels(args.pr) : null);
+	if ('error' in resolved) {
+		console.error(`[check-pr-body] ERROR: ${resolved.error}`);
+		return 2;
+	}
+	const labels = resolved.labels;
+
+	// #3962 (QA 指摘): skip した gate を通常 pass と見分けられる形で先に出す。
+	if (args.noLabels) {
+		for (const line of formatSkippedLabelGates()) console.log(line);
+	}
 
 	const violations = collectViolations(body, requiredSections, template, { ...args, labels });
 
 	if (violations.length === 0) {
-		console.log('[check-pr-body] OK — 違反なし');
+		console.log(
+			args.noLabels
+				? `[check-pr-body] OK (label 条件付き gate ${LABEL_CONDITIONAL_GATES.length} 件は未検査) — 違反なし`
+				: '[check-pr-body] OK — 違反なし',
+		);
 		return 0;
 	}
 
@@ -971,10 +1077,28 @@ export async function main(argv = process.argv.slice(2)) {
 	return 1;
 }
 
+/**
+ * #3962 (QA 指摘): `import.meta.url` は symlink / junction 解決後、`process.argv[1]` は解決前の
+ * パスなので、junction 経由の checkout では両者が一致せず `main()` が呼ばれないまま
+ * **無出力 exit 0** になっていた。gate が無音で成功扱いになる最も危険な形なので、
+ * 両辺を `realpathSync` で正規化してから比較する。
+ *
+ * @param {string} p
+ * @returns {string}
+ */
+function normalizeEntryPath(p) {
+	const abs = resolve(p);
+	try {
+		return realpathSync(abs);
+	} catch {
+		return abs;
+	}
+}
+
 const isMain = (() => {
 	try {
-		const here = resolve(fileURLToPath(import.meta.url));
-		const argv1 = resolve(process.argv[1] || '');
+		const here = normalizeEntryPath(fileURLToPath(import.meta.url));
+		const argv1 = normalizeEntryPath(process.argv[1] || '');
 		return here === argv1;
 	} catch {
 		return false;

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -743,18 +743,6 @@ export function extractLabelNames(raw) {
 }
 
 /**
- * CLI 引数と `fetchPrLabels()` の結果から、検査に使う label 一覧を確定する (#3962)。
- *
- * label 条件付き検査 (hotfix #2343 / po-decision #3962) は「label が無い」なら
- * 正しく skip されるべきだが、「label が分からない」で skip すると gate が消える。
- * この 2 つを型で分離するのが本関数の目的で、**未解決は必ず error を返す** (fail-closed)。
- * dry-run で label がまだ存在しないことが分かっている場合は `--no-labels` で明示する。
- *
- * @param {{ pr: string | null; labels: string | null; noLabels: boolean }} args
- * @param {string[] | null} fetched `fetchPrLabels()` の戻り (未解決なら null)
- * @returns {{ labels: string[] } | { error: string }}
- */
-/**
  * label が付いているときだけ発火する gate の SSOT (#3962 QA 指摘)。
  *
  * `--no-labels` は「label が無い」ことの明示なので、これらの gate は正しく skip される。
@@ -793,6 +781,18 @@ export function formatSkippedLabelGates() {
 	];
 }
 
+/**
+ * CLI 引数と `fetchPrLabels()` の結果から、検査に使う label 一覧を確定する (#3962)。
+ *
+ * label 条件付き検査 (hotfix #2343 / po-decision #3962) は「label が無い」なら
+ * 正しく skip されるべきだが、「label が分からない」で skip すると gate が消える。
+ * この 2 つを型で分離するのが本関数の目的で、**未解決は必ず error を返す** (fail-closed)。
+ * dry-run で label がまだ存在しないことが分かっている場合は `--no-labels` で明示する。
+ *
+ * @param {{ pr: string | null; labels: string | null; noLabels: boolean }} args
+ * @param {string[] | null} fetched `fetchPrLabels()` の戻り (未解決なら null)
+ * @returns {{ labels: string[] } | { error: string }}
+ */
 export function resolveLabels(args, fetched) {
 	if (args.noLabels) return { labels: [] };
 	if (args.labels !== null) {

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -703,16 +703,43 @@ function fetchPrBody(prNumber) {
 function fetchPrLabels(prNumber) {
 	if (!prNumber) return null;
 	try {
-		const raw = execSync(`gh pr view ${prNumber} --json labels --jq '[.labels[].name]'`, {
+		// `--jq '[.labels[].name]'` を使わない (#3962): execSync は Windows で cmd.exe を経由し、
+		// cmd.exe は単一引用符を引用符として扱わないため、jq が `'[.labels[].name]'` を
+		// リテラル受領して `unexpected token "'"` で落ちる。旧実装は catch { return [] } で
+		// これを潰していたので、**Windows のローカル開発機では label 条件付き検査
+		// (hotfix #2343 / po-decision #3962) が一度も実行されないまま `OK — 違反なし` が
+		// 出ていた**。shell の引用規則に依存しないよう、JSON を素で受けて JS 側で取り出す。
+		const raw = execSync(`gh pr view ${prNumber} --json labels`, {
 			encoding: 'utf-8',
 			stdio: ['ignore', 'pipe', 'ignore'],
 			timeout: 15_000,
 		});
-		const parsed = JSON.parse(raw.trim() || '[]');
-		return Array.isArray(parsed) ? parsed.map((l) => String(l)) : null;
+		return extractLabelNames(raw);
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * `gh pr view --json labels` の生 JSON から label 名配列を取り出す (#3962)。
+ *
+ * 取り出せない形 (パース不能 / `labels` が配列でない) は **空配列に落とさず `null`**。
+ * 「label が無い」と「label が読めなかった」を混ぜないのが本 Issue の主題であり、
+ * ここで潰すと `resolveLabels()` の fail-closed が効かなくなる。
+ *
+ * @param {string} raw
+ * @returns {string[] | null} 取り出せなければ null (= 未解決)
+ */
+export function extractLabelNames(raw) {
+	let parsed;
+	try {
+		parsed = JSON.parse(raw.trim() || 'null');
+	} catch {
+		return null;
+	}
+	const labels = parsed && typeof parsed === 'object' ? parsed.labels : null;
+	if (!Array.isArray(labels)) return null;
+	return labels.map((l) => String(l?.name ?? l));
 }
 
 /**

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -23,10 +23,13 @@ import {
 	FORBIDDEN_TERMS,
 	findMissingSections,
 	findUncheckedReadyChecklist,
+	formatSkippedLabelGates,
 	HOTFIX_LABELS,
 	hasHotfixLabel,
 	hasPoDecisionLabel,
+	LABEL_CONDITIONAL_GATES,
 	PO_DECISION_LABEL,
+	resolveLabels,
 	scanForbiddenTerms,
 	stripCodeBlocks,
 	stripMarkdownComments,
@@ -823,5 +826,93 @@ describe('PO 決裁ブリーフ gate の SSOT 整合 (#3962)', () => {
 		// 見出しと mermaid は満たす。「___」は記入前提なので残っているのが正しい。
 		const v = checkPoDecisionBrief(template, [PO_DECISION_LABEL]);
 		expect(v?.id).toBe('po-decision-brief-unfilled-placeholder');
+	});
+});
+
+/**
+ * #3962 QA 指摘 (BLOCK 1): label 取得に失敗すると label 条件付き検査が黙って消え、
+ * 出力は `OK — 違反なし` になっていた。
+ *
+ * 原因は `fetchPrLabels()` が gh 失敗を `catch { return [] }` で潰し、
+ * 「label が付いていない」と「label を取得できなかった」を呼び出し側が区別できなかったこと。
+ * `resolveLabels()` はこの 2 状態を型で分離し、**未解決は必ず error** (fail-closed) を返す。
+ */
+describe('resolveLabels — label 未解決は fail-closed (#3962 QA BLOCK 1)', () => {
+	const noLabelArgs = { pr: null, labels: null, noLabels: false };
+
+	it('[LB1] --pr 指定で label 取得に失敗したら error を返す (空配列に落とさない)', () => {
+		const r = resolveLabels({ ...noLabelArgs, pr: '3956' }, null);
+		expect(r).not.toHaveProperty('labels');
+		expect('error' in r && r.error).toContain('label を取得できませんでした');
+	});
+
+	it('[LB2] --pr 指定で label が 1 件も無い場合は空配列 (取得成功なので検査は正しく skip される)', () => {
+		const r = resolveLabels({ ...noLabelArgs, pr: '3956' }, []);
+		expect(r).toEqual({ labels: [] });
+	});
+
+	it('[LB3] --body-file 単独 (label を解決する手段が無い) も error にする', () => {
+		const r = resolveLabels(noLabelArgs, null);
+		expect('error' in r && r.error).toContain('--body-file 単独では label を解決できません');
+	});
+
+	it('[LB4] --no-labels は「label が無い」ことの明示なので空配列を返す', () => {
+		expect(resolveLabels({ ...noLabelArgs, noLabels: true }, null)).toEqual({ labels: [] });
+	});
+
+	it('[LB5] --labels の csv は trim して解釈する', () => {
+		const r = resolveLabels({ ...noLabelArgs, labels: 'po-decision:required, hotfix ,' }, null);
+		expect(r).toEqual({ labels: [PO_DECISION_LABEL, 'hotfix'] });
+	});
+
+	it('[LB6] 未解決と label 無しが同じ結果にならない — 同一 body で検査が消えないことの回帰', () => {
+		// QA の再現 (PR #3956 の実 body 相当: po-decision:required 付きだがブリーフ無し)
+		const bodyWithoutBrief = '## 顧客価値・目的\n\n本文\n';
+
+		// A: label 解決済み (po-decision:required あり) → 違反が出る
+		const resolvedA = resolveLabels({ ...noLabelArgs, labels: PO_DECISION_LABEL }, null);
+		expect('labels' in resolvedA).toBe(true);
+		if ('labels' in resolvedA) {
+			expect(checkPoDecisionBrief(bodyWithoutBrief, resolvedA.labels)?.id).toBe(
+				'po-decision-brief-missing-section',
+			);
+		}
+
+		// B: label 未解決 → 旧実装は [] に落ちて checkPoDecisionBrief が null (= 検査消滅) になった。
+		//    現行は error を返すので、そもそも検査を走らせる前に中断できる。
+		const resolvedB = resolveLabels({ ...noLabelArgs, pr: '3956' }, null);
+		expect('labels' in resolvedB).toBe(false);
+		expect(checkPoDecisionBrief(bodyWithoutBrief, [])).toBeNull(); // 旧実装が黙って通していた経路
+	});
+});
+
+/**
+ * #3962 QA 指摘 (2 巡目): `--no-labels` は fail-closed の縮退先なので、
+ * 出力が通常 pass と目視で区別できないと「gate が形式だけ通って実体が無い」class に戻る。
+ * skip した gate 名が出力に含まれることを固定し、将来メッセージを整理した拍子の無言化を防ぐ。
+ */
+describe('formatSkippedLabelGates — --no-labels は何を検査しなかったかを出す (#3962)', () => {
+	it('[LB7] skip した label 条件付き gate の名前と件数が出力に含まれる', () => {
+		const out = formatSkippedLabelGates().join('\n');
+
+		// 件数が LABEL_CONDITIONAL_GATES と一致する (gate を足したのに文言が古い、を防ぐ)
+		expect(out).toContain(`label 条件付き gate ${LABEL_CONDITIONAL_GATES.length} 件`);
+
+		// 個々の gate 名と発火 label が名指しされている
+		for (const gate of LABEL_CONDITIONAL_GATES) {
+			expect(out).toContain(gate.name);
+			expect(out).toContain(gate.issue);
+		}
+		expect(out).toContain(PO_DECISION_LABEL);
+
+		// 通常 pass (`OK — 違反なし`) と見分けるためのマーカー
+		expect(out).toContain('SKIPPED');
+	});
+
+	it('[LB8] LABEL_CONDITIONAL_GATES が実在の label 条件付き検査を網羅している', () => {
+		// hotfix (#2343) と po-decision (#3962) の 2 件。増えたら本 test が落ちて追記を促す。
+		expect(LABEL_CONDITIONAL_GATES.map((g) => g.issue)).toEqual(['#2343', '#3962']);
+		expect(hasPoDecisionLabel([PO_DECISION_LABEL])).toBe(true);
+		expect(hasHotfixLabel(HOTFIX_LABELS.slice(0, 1))).toBe(true);
 	});
 });

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -5,22 +5,28 @@
  * GitHub API 呼び出し (gh pr view) は本テストでは触れない（--body-file 経路でテスト可能）。
  */
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
 	checkAcMap,
 	checkChangeTypeSelection,
 	checkEnvDistributionForHotfix,
+	checkPoDecisionBrief,
 	checkSelfReviewEvidence,
 	detectMojibake,
 	extractAcMapSection,
 	extractEnvDistributionSection,
+	extractPoDecisionSection,
 	extractRequiredSections,
 	FORBIDDEN_TERMS,
 	findMissingSections,
 	findUncheckedReadyChecklist,
 	HOTFIX_LABELS,
 	hasHotfixLabel,
+	hasPoDecisionLabel,
+	PO_DECISION_LABEL,
 	scanForbiddenTerms,
 	stripCodeBlocks,
 	stripMarkdownComments,
@@ -710,5 +716,112 @@ describe('checkChangeTypeSelection (#3846)', () => {
 	it('dependencies label PR は skip (Dependabot exempt、#1808 整合)', () => {
 		const body = ['## 変更タイプ', '', '- [ ] feat: 新機能', '', '## 関連 Issue'].join('\n');
 		expect(checkChangeTypeSelection(body, TEMPLATE, ['dependencies'])).toBeNull();
+	});
+});
+
+describe('checkPoDecisionBrief (#3944 / #3956 / #3962)', () => {
+	const FILLED_BRIEF = [
+		'## PO 決裁ブリーフ (po-decision:required)',
+		'',
+		'```mermaid',
+		'flowchart TB',
+		'  R1["可逆性: 🟢可逆 — revert のみで戻る"]',
+		'  Q1["Q1: 日次バックアップ 3 世代で決裁してよいか"]',
+		'  R1 --> Q1',
+		'```',
+		'',
+	].join('\n');
+
+	it('label なしなら検査自体を skip する (通常 PR に負担を課さない)', () => {
+		expect(checkPoDecisionBrief('## 顧客価値・目的\n本文\n', [])).toBeNull();
+		expect(
+			checkPoDecisionBrief('## 顧客価値・目的\n本文\n', ['type:fix', 'area:admin']),
+		).toBeNull();
+	});
+
+	it('FAIL: label 付きでブリーフ見出しが無い (#3944 / #3956 の実際の形)', () => {
+		const body = [
+			'## 顧客価値・目的',
+			'PGlite 本番データの日次バックアップを取得する。',
+			'',
+			'## 変更内容',
+			'オーナー決裁 2026-07-26: RPO 日次 / 3 世代 / NUC ローカル',
+		].join('\n');
+		const v = checkPoDecisionBrief(body, [PO_DECISION_LABEL]);
+		expect(v?.id).toBe('po-decision-brief-missing-section');
+	});
+
+	it('FAIL: 見出しが HTML コメント内にあるだけでは「存在する」と認めない', () => {
+		const body = ['## 顧客価値・目的', '', '<!-- ## PO 決裁ブリーフ は後で書く -->'].join('\n');
+		const v = checkPoDecisionBrief(body, [PO_DECISION_LABEL]);
+		expect(v?.id).toBe('po-decision-brief-missing-section');
+	});
+
+	it('FAIL: 見出しはあるが mermaid 一枚絵が無い (長文説明だけの代替を認めない)', () => {
+		const body = [
+			'## PO 決裁ブリーフ (po-decision:required)',
+			'',
+			'リスクは低いです。可逆で、ロールバックは revert のみで戻ります。',
+			'',
+			'## 関連 Issue',
+		].join('\n');
+		const v = checkPoDecisionBrief(body, [PO_DECISION_LABEL]);
+		expect(v?.id).toBe('po-decision-brief-missing-diagram');
+	});
+
+	it('FAIL: template の未置換プレースホルダ ___ が残っている', () => {
+		const body = [
+			'## PO 決裁ブリーフ (po-decision:required)',
+			'',
+			'```mermaid',
+			'flowchart TB',
+			'  R1["可逆性: 🟢可逆 / 🔴不可逆 → ___"]',
+			'  Q1["Q1: ___"]',
+			'```',
+		].join('\n');
+		const v = checkPoDecisionBrief(body, [PO_DECISION_LABEL]);
+		expect(v?.id).toBe('po-decision-brief-unfilled-placeholder');
+		expect(v?.message).toContain('2 件');
+	});
+
+	it('PASS: 記入済みブリーフがあれば通る', () => {
+		const body = ['## 顧客価値・目的', '本文', '', FILLED_BRIEF].join('\n');
+		expect(checkPoDecisionBrief(body, [PO_DECISION_LABEL])).toBeNull();
+	});
+
+	it('PASS: 後続セクションの ___ は誤検出しない (セクション境界を守る)', () => {
+		const body = [FILLED_BRIEF, '## 補足', '', 'コード例: `const ___ = 1;`'].join('\n');
+		expect(checkPoDecisionBrief(body, [PO_DECISION_LABEL])).toBeNull();
+	});
+
+	it('label 判定は大小文字を無視する', () => {
+		expect(hasPoDecisionLabel(['PO-Decision:Required'])).toBe(true);
+		expect(hasPoDecisionLabel(['po-decision:optional'])).toBe(false);
+	});
+
+	it('extractPoDecisionSection は次の ## 見出しまでを返す', () => {
+		const body = [FILLED_BRIEF, '## 関連 Issue', 'closes #3962'].join('\n');
+		const section = extractPoDecisionSection(body);
+		expect(section).toContain('```mermaid');
+		expect(section).not.toContain('closes #3962');
+	});
+});
+
+describe('PO 決裁ブリーフ gate の SSOT 整合 (#3962)', () => {
+	const repoRoot = resolve(__dirname, '../../..');
+
+	it('labeler.yml が po-decision:required を定義している (label 名の rename で gate が黙って無効化されない)', () => {
+		const labeler = readFileSync(resolve(repoRoot, '.github/labeler.yml'), 'utf-8');
+		expect(labeler).toContain(`"${PO_DECISION_LABEL}":`);
+	});
+
+	it('template が gate の要求 (見出し + mermaid) を満たす — template だけ通せば必ず PASS する', () => {
+		const template = readFileSync(
+			resolve(repoRoot, '.claude/skills/dev-open-pr/templates/po-decision-brief.md'),
+			'utf-8',
+		);
+		// 見出しと mermaid は満たす。「___」は記入前提なので残っているのが正しい。
+		const v = checkPoDecisionBrief(template, [PO_DECISION_LABEL]);
+		expect(v?.id).toBe('po-decision-brief-unfilled-placeholder');
 	});
 });

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -18,6 +18,7 @@ import {
 	detectMojibake,
 	extractAcMapSection,
 	extractEnvDistributionSection,
+	extractLabelNames,
 	extractPoDecisionSection,
 	extractRequiredSections,
 	FORBIDDEN_TERMS,
@@ -914,5 +915,44 @@ describe('formatSkippedLabelGates — --no-labels は何を検査しなかった
 		expect(LABEL_CONDITIONAL_GATES.map((g) => g.issue)).toEqual(['#2343', '#3962']);
 		expect(hasPoDecisionLabel([PO_DECISION_LABEL])).toBe(true);
 		expect(hasHotfixLabel(HOTFIX_LABELS.slice(0, 1))).toBe(true);
+	});
+});
+
+/**
+ * #3962: fail-closed 化して初めて露見した実バグの回帰。
+ *
+ * `fetchPrLabels` は `gh pr view --json labels --jq '[.labels[].name]'` を execSync していたが、
+ * execSync は Windows で cmd.exe を経由し、cmd.exe は単一引用符を引用符として扱わない。
+ * jq が `'[.labels[].name]'` をリテラル受領して `unexpected token "'"` で落ちるため、
+ * **Windows のローカル開発機では label 条件付き検査が一度も走らないまま
+ * `OK — 違反なし` が出ていた** (旧実装の catch { return [] } が完全に無音化していた)。
+ * shell 引用に依存しない `--json labels` + JS 側パースへ変更した。
+ */
+describe('extractLabelNames — shell 引用に依存せず label を取り出す (#3962)', () => {
+	it('[LB9] gh pr view --json labels の生 JSON から name を取り出す', () => {
+		const raw = JSON.stringify({
+			labels: [{ name: 'type:fix' }, { name: PO_DECISION_LABEL }],
+		});
+		expect(extractLabelNames(raw)).toEqual(['type:fix', PO_DECISION_LABEL]);
+	});
+
+	it('[LB10] label が 0 件なら空配列 (取得成功なので検査は正しく skip される)', () => {
+		expect(extractLabelNames('{"labels":[]}')).toEqual([]);
+	});
+
+	it('[LB11] パース不能 / labels が配列でない場合は null — 空配列に落とさない', () => {
+		// jq が落ちて stdout が空 / エラー文字列だった場合に相当する。
+		// ここで [] を返すと resolveLabels の fail-closed が効かず、本 Issue の欠陥に戻る。
+		expect(extractLabelNames('')).toBeNull();
+		expect(extractLabelNames("failed to parse jq expression\n'[.labels[].name]'")).toBeNull();
+		expect(extractLabelNames('{"labels":null}')).toBeNull();
+		expect(extractLabelNames('{}')).toBeNull();
+	});
+
+	it('[LB12] 未解決 (null) は resolveLabels で error になる — 経路として繋がっていることの固定', () => {
+		const fetched = extractLabelNames('');
+		expect(fetched).toBeNull();
+		const r = resolveLabels({ pr: '3965', labels: null, noLabels: false }, fetched);
+		expect('labels' in r).toBe(false);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

<!-- 「何を変更したか」ではなく「なぜこの変更がユーザーにとって必要か」を書く。
     Issue 「顧客価値・目的」セクションの転記が起点。 -->

**対象ユーザー**: 運営 (開発チーム / QA チーム)

**解決する課題**: 高リスク・不可逆変更の PR に `po-decision:required` label が自動付与されても、その label が要求する PO 決裁ブリーフ (#3862) が PR body に無いまま Ready 化される。オーナーが「何を決裁するのか」を一枚絵で受け取れず、QA が毎回 merge gate として指摘する工数が発生し、PR #3944 / #3956 で 2 回連続した。

**期待される効果**: label と body の対応が `git push` 時点で機械検証されるため、オーナーは決裁が必要な PR で必ずブリーフを受け取れる。QA は同じ指摘を繰り返さずに済み、本質判定に時間を使える。

## 関連 Issue

closes #3962

<!-- 関連 Issue / ADR があれば追記 -->

## AC 検証マップ (ADR-0004)

<!-- ⚠️ 必須: Issue の Acceptance Criteria 1 行ごとに 1 行。検証手段は機械検証可能なコマンド / ファイルパス / スクリーンショット番号で書く。 -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | label 無しの PR では検査が skip される | `npx vitest run tests/unit/scripts/check-pr-body.test.ts -t "label なしなら検査自体を skip"` | PASS |
| AC2 | label 付き + 見出し欠落 → `po-decision-brief-missing-section` | 同上 `-t "label 付きでブリーフ見出しが無い"` | PASS |
| AC3 | label 付き + mermaid 欠落 → `po-decision-brief-missing-diagram` | 同上 `-t "mermaid 一枚絵が無い"` | PASS |
| AC4 | label 付き + 未置換 `___` → `po-decision-brief-unfilled-placeholder` (件数を message に含む) | 同上 `-t "未置換プレースホルダ"` | PASS (`2 件` を message に含むことも assert) |
| AC5 | 見出しが HTML コメント内だけでは「存在する」と認めない | 同上 `-t "HTML コメント内にあるだけでは"` | PASS |
| AC6 | 後続セクションの `___` を誤検出しない | 同上 `-t "後続セクションの ___ は誤検出しない"` | PASS |
| AC7 | 実効性検証 — PR #3956 の実 body で実際に fail する | `gh pr view 3956 --json body --jq .body > /tmp/b.md && node scripts/check-pr-body.mjs --body-file /tmp/b.md --labels "po-decision:required,type:fix" --skip-mergeable` | `✗ [po-decision-brief-missing-section]` を出力 (下記「レビュー依頼事項」に全文) |
| AC8 | template を通すと「見出し + mermaid は満たし `___` だけ残る」ことを固定 | 同上 `-t "template が gate の要求"` | PASS |
| AC9 | `PO_DECISION_LABEL` と `.github/labeler.yml` の label 名一致を固定 | 同上 `-t "labeler.yml が po-decision:required を定義"` | PASS |
| AC10 | `docs/sessions/dev-session.md` に「QA 指摘の再発防止台帳」を新設 | `docs/sessions/dev-session.md` §「QA 指摘の再発防止台帳」 | 追加済 (機械化 1 件 + レビュー観点 2 件) |

## 変更タイプ

<!-- ⚠️ 1 つ以上 [x] 必須 (CI 必須 gate「変更タイプの選択」hard-fail、#3846)。
     Issue に type:* label が無い場合は自動 [x] されないため、必ず手動で主変更タイプを選択する -->

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: アプリ画面への影響なし (開発ツールチェーンのみ)。影響先は `npm run pre-ready` の Readiness gate step と `.husky/pre-push` Step 3。`po-decision:required` label が付いた PR でのみ新しい検査が走る。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3965` 実行済**（#1775 / ADR-0030）。**Step 3 (vitest) がローカルで 1 件 fail しました。**詳細と、本 PR の差分に起因しないと判断した根拠は「レビュー依頼事項」§3 に全て記載しています
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  `tests/unit/scripts/check-pr-body.test.ts` に 11 件追加。内訳は「label 無し skip」「3 種の fail 判定」「HTML コメント内の見出しを認めない」「後続セクションの `___` を誤検出しない」「label 名の大小文字無視」「セクション境界抽出」に加え、SSOT 整合 2 件 (labeler.yml の label 名一致 / template を通すと `___` だけ残る)。同 file 全体で 77 PASS
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

<!-- ⚠️ UI 変更がある場合は必須。docs/DESIGN.md §9 禁忌事項 6 点を自己判定した証跡。 -->

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | <!-- ![before-mobile](URL) --> | <!-- ![before-pc](URL) --> |
| **修正後** | <!-- ![after-mobile](URL) --> | <!-- ![after-pc](URL) --> |

**該当なし（理由）**: UI 変更 0 件。差分は `scripts/` / `tests/` / `.husky/` / `docs/` / `.claude/` のみで、`.svelte` / `.css` / `site/**` を一切変更していない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `checkPoDecisionBrief` は純粋関数で「label 条件 → 3 種の検出」のみを担う。既存の `checkEnvDistributionForHotfix` と同じ責務境界に揃えた
- [x] **DRY**: 新規 script を作らず既存 `check-pr-body.mjs` に足した。同 CLI が既に `gh pr view --json labels` で label を取得しており、`collectViolations` に label 条件付き gate を足す前例 (#2343) があるため、label 取得も pre-ready / pre-push への配線も再実装していない
- [x] **YAGNI**: ブリーフの中身の妥当性判定 (判断層) は実装していない。固定するのは label と body の対応のみ
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **アクセシビリティ**: N/A (CLI)
- [x] **パフォーマンス**: 正規表現マッチのみ、I/O 追加なし

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [ ] 並行 PR overlap 確認 (#1200)
- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

**1. AC7 の実効性検証出力** — PR #3956 の実 body を取得して CLI に通した結果です。

```
✗ [po-decision-brief-missing-section] (#3944/#3956/#3962)
  `po-decision:required` label が付いていますが、PR body に `## PO 決裁ブリーフ` セクションがありません (#3944 / #3956 と同型)。
  対応 1: `.claude/skills/dev-open-pr/templates/po-decision-brief.md` を PR body 末尾に append し、
          「___」を全て実際の内容に置換する (mermaid 一枚絵で PO が Yes/No を判断できること)。
  対応 2: label が誤付与なら、外した理由を PR body に明記したうえで label を外す (判定 SSOT = .github/labeler.yml の po-decision:required エントリ)。
```

**2. 発火経路の確認をお願いします** — 新規 script を作らなかったため、`.husky/pre-push` の Step 3 (`.husky/pre-push:142`、`node scripts/check-pr-body.mjs --pr "$PR_NUM"`) からそのまま発火します。ただし**同 Step は `PR_NUM` が取れる場合 (= PR 作成済み) のみ実行される**ため、PR 作成前の初回 push では発火しません。`npm run pre-ready` 経路でも同じ関数が呼ばれます。この二経路で十分か、CI 側の hard-fail gate も要るかはご判断ください。

**3. ローカル `pre-ready` が Step 3 (vitest) で fail しています — 経緯を全て申告します**

HEAD `68fe0771` で `npm run pre-ready -- --pr 3965` を実行したところ、Step 3 で 1 件 fail しました。

```
FAIL tests/unit/scripts/check-license-key-leak.test.ts >
     findAllViolations (実 repo gate) > 現在の src/ + site/ に再導入された license key 参照はゼロ
Error: Test timed out in 5000ms.

Test Files  1 failed | 541 passed | 4 skipped (546)
     Tests  1 failed | 8299 passed | 12 skipped (8312)
  Duration  1377.85s
```

**本 PR の差分に起因しないと判断した根拠**は次の 3 点です。

1. **失敗の種類が assertion failure ではなく 5000ms のタイムアウト**です。同テストは `findAllViolations()` で実 repo の `src/` + `site/` を走査しますが、**本 PR は `src/` も `site/` も 1 行も変更していません** (差分は `scripts/` `tests/` `.husky/` `docs/` `.claude/` のみ)。
2. **`findAllViolations()` 自体の実行時間は 261ms、検出 0 件**です (clean な develop checkout で直接呼んで計測)。5000ms を超えるのは 546 test files の並列実行によるマシン負荷下に限られ、単独実行では 30 tests / 1.4s で PASS します。
3. **CI の `unit-test (1)` / `unit-test (2)` は両方 pass** しています (9m9s / 8m25s)。CI 上の同一テストは通っています。

したがって**ローカルマシンの負荷起因の flake**と判断しましたが、これは私の判断であり断定ではありません。なお同テストが明示 timeout を持たず default 5s に依存している点自体は潜在的な問題ですが、本 PR のスコープ外なので触っていません。必要なら別 Issue を起票します。**「pre-ready 全 Step PASS」を満たしていない状態で Ready にしている点**について、QA のご判断を仰ぎます。

**4. 機械化できなかった 2 件** — 本 Issue の起点であるオーナー指示は「QA 指摘を何度も受けないようにする」でしたが、#3956 で受けた指摘のうち機械 gate 化できたのは 1 件だけです。残り 2 件 (構造化識別子を緩い文字列一致で判定した / guard の fixture に規則外の実在物を混ぜていない) は静的検出が難しく、`docs/sessions/dev-session.md` にレビュー観点として文書化するにとどめました。これは記憶依存の防御であり、同型が 3 回目に達したら linter rule 化が要ると考えています。この判断の妥当性をレビューいただきたいです。

## 配布済み env / secret (ADR-0006)

- [ ] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3965` をローカル実行した**（Step 3 vitest で既知 flake 1 件。「レビュー依頼事項」§3 参照。CI の unit-test (1)(2) は両方 pass）
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A (UI 変更 0 件)
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

