### PR TITLE
fix: #3960 invoice.paid の plan 判定を subscription 現行 price SSOT へ + silent fallback 廃止

### DIFF
--- a/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
+++ b/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
@@ -162,7 +162,16 @@ historical record (旧設計): Sentry TypeError 検知 + Dashboard `webhookEndpo
 | **ロールバック手順** | (1) Dashboard で **新 destination を新 api_version で新規作成** (副次制約 4 整合) (2) Phase 6 子 1 #2667 §3 Step 4-a (shadow mode) → §3 Step 4-b (cutover) → §3 Step 4-c (retire) の 5 phase migration を改めて実施 (3) 旧 destination は cutover 完了まで disabled で残置 |
 | **再発防止** | (a) [phase5-stripe-product-architecture.md §4.4](phase5-stripe-product-architecture.md) #2683 副次制約 4 を SSOT として参照必須化 (b) Phase 7 Step 4 (および将来の apiVersion bump PR) の Pre-Ready unit test で **`webhookEndpoints.update({api_version})` が 400 を返すことを assert** (c) Phase 6 子 1 #2667 §5 Webhook 5 phase migration を Pre-Ready 必須化 |
 
-### 3.10 想定リスク 8 件 SSOT サマリ表 (#2683 補強で +R8 / +R9、R3 / R5 historical 化)
+### 3.10-a R10 (#3960 新規): webhook payload から plan を確定できない → silent fallback で誤 plan 書込み
+
+| 項目 | 内容 |
+|---|---|
+| **シナリオ** | `invoice.paid` / `customer.subscription.updated` / `checkout.session.completed` の各 handler が plan を解決できなかったとき、旧実装は `plan ?? tenant.plan ?? SUBSCRIPTION_PLAN.MONTHLY` で**暗黙にスタンダードへ落として書き込んでいた**。プレミアム契約者の plan が standard に巻き戻り、顧客は上位プランの代金を払いながら下位プランの機能しか使えない。2026-07-26 の課金 incident (#3957 系列) の調査で `invoice.paid` の `lines.data[0]` 盲目参照と併せて確認された |
+| **検知 method** | (a) Discord alert `stripe-plan-unresolved` (warning level、本 #3960 で新規追加) (b) CloudWatch Logs Insights `filter kind = "stripe-plan-unresolved"` で tenantId / event / currentPlan を特定 (c) `[STRIPE] <event> — plan を解決できませんでした` の `logger.warn` |
+| **ロールバック手順** | (1) alert の `tags.subscriptionId` で Stripe 上の現行 price を確認 (2) price が env var (`STRIPE_PRICE_*_MONTHLY`) / lookup_key (`standard_monthly` / `premium_monthly`) のどちらにも一致しない原因を切り分け (Price 差し替え / env var 未同期 / `transfer_lookup_key` 実行中) (3) env var を Stripe の現行 Price に同期して Lambda 再 deploy。**plan は既存値が保持されているため DB の手動修復は不要** |
+| **再発防止** | (a) plan 解決を `resolvePlanFromSubscription()` (subscription の現行 price → priceId 逆引き → lookup_key 逆引き) に集約し SSOT 化 (b) `planUpdateOrKeep()` で silent fallback を構造的に不能化 (未解決時は `plan` キー自体を渡さず既存値保持 + alert) (c) proration 複数行 invoice fixture + `subscription.updated` / `invoice.paid` の**両配信順序**の unit test (`tests/unit/services/stripe-service.test.ts`) |
+
+### 3.10 想定リスク 8 件 SSOT サマリ表 (#2683 補強で +R8 / +R9、R3 / R5 historical 化、#3960 で +R10)
 
 | # | リスク | 検知 method (主) | ロールバック手順 (簡略) | 再発防止 (CI / Pre-Ready) |
 |---|---|---|---|---|
@@ -175,6 +184,7 @@ historical record (旧設計): Sentry TypeError 検知 + Dashboard `webhookEndpo
 | R7 | archive 未呼出 (forward-fix) | シナリオ 5 E2E + cutover 後整合チェック | Phase 7 PR-X で `handleSubscriptionDeleted` archive 追加 | シナリオ 5 Pre-Ready 必須化 + integration test |
 | **R8 (#2683 新規)** | **ダウン credit memo の顧客信頼毀損** | 顧客 inquiry + シナリオ 3 E2E | Phase 3 hybrid confirm UI + 請求履歴 credit memo 表示 | Step 3 hybrid confirm UI 実装 + シナリオ 3 E2E |
 | **R9 (#2683 新規)** | **Webhook destination api_version immutable 見落とし** | Dashboard UI エラー + Stripe SDK `StripeInvalidRequestError` | 新 destination 新規作成 + 5 phase migration 再実施 | Pre-Ready unit test (`webhookEndpoints.update({api_version})` 400 assert) + Phase 6 子 1 §5 Webhook 5 phase migration 必須化 |
+| **R10 (#3960 新規)** | **plan 未解決時の silent fallback で誤 plan 書込み** | Discord alert `stripe-plan-unresolved` + CloudWatch Logs Insights | env var / lookup_key を Stripe 現行 Price に同期 + Lambda 再 deploy (plan は既存値保持のため DB 修復不要) | `resolvePlanFromSubscription()` / `planUpdateOrKeep()` に集約 + proration 複数行 fixture + 両配信順序 unit test |
 
 ## 4. #2627 Stripe Dashboard ロールバック 3 期間別マトリクス (§4)
 

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -10,6 +10,7 @@ import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { notifyBillingEvent } from '$lib/server/services/discord-notify-service';
+import { notifyStripeAlert } from '$lib/server/stripe/alert';
 import { getStripeClient, isStripeEnabled } from '$lib/server/stripe/client';
 import {
 	CURRENCY,
@@ -17,6 +18,7 @@ import {
 	getPlans,
 	getWebhookSecret,
 	type PlanId,
+	planIdFromLookupKey,
 	planIdFromPriceId,
 } from '$lib/server/stripe/config';
 
@@ -264,12 +266,25 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
 	// 認可は `tenant.stripeSubscriptionId` + `tenant.status` から計算される
 	// (license key を読まない)。Phase 1 補強 3 §3.3 でライセンスキー発行 +
 	// メール送信の冗長層 (issueLicenseKey / sendLicenseKeyEmail) を削除した。
-	const plan = (planId as Tenant['plan']) ?? SUBSCRIPTION_PLAN.MONTHLY;
+	//
+	// #3960: `planId` は自前で `metadata` に載せた値なので通常必ず解決するが、
+	// 旧 silent fallback (`?? MONTHLY`) は「未知の planId が来たらスタンダードとして
+	// 課金確定する」挙動だった。未知値は plan を書かずに alert を上げ、
+	// status のみ ACTIVE にする (support で正しい plan を確定させる)。
+	const plan = isKnownPlanId(planId) ? planId : null;
+	if (!plan) {
+		notifyStripeAlert({
+			kind: 'stripe-plan-unresolved',
+			message: `checkout.session.completed の metadata.planId が未知のため plan を更新しませんでした (status のみ ACTIVE)`,
+			errorSummary: `plan_unresolved:checkout.session.completed:${session.id}`,
+			tags: { tenantId, event: 'checkout.session.completed', receivedPlanId: String(planId) },
+		});
+	}
 	const repos = getRepos();
 	await repos.auth.updateTenantStripe(tenantId, {
 		stripeCustomerId: customerId ?? undefined,
 		stripeSubscriptionId: subscriptionId ?? undefined,
-		plan,
+		plan: plan ?? undefined,
 		status: SUBSCRIPTION_STATUS.ACTIVE,
 		trialUsedAt: new Date().toISOString(),
 	});
@@ -285,26 +300,32 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 	const subscriptionId = extractSubscriptionId(invoice);
 	if (!subscriptionId) return;
 
-	const tenant = await findTenantBySubscription(subscriptionId);
-	if (!tenant) {
+	const context = await resolveSubscriptionContext(subscriptionId);
+	if (!context) {
 		logger.warn(`[STRIPE] invoice.paid — tenant not found for subscription=${subscriptionId}`);
 		return;
 	}
+	const { tenant, subscription } = context;
 
-	// Determine plan from invoice line items
-	const lineItem = invoice.lines?.data?.[0];
-	const priceDetails = lineItem?.pricing?.price_details;
-	const priceId =
-		typeof priceDetails?.price === 'string' ? priceDetails.price : priceDetails?.price?.id;
-	const plan = priceId ? planIdFromPriceId(priceId) : null;
+	// #3960: plan は invoice の line item から推測せず、**subscription の現行 price** を SSOT とする。
+	//
+	// 旧実装は `invoice.lines.data[0]` を盲目参照していた。プラン変更 (proration) の invoice は
+	// 複数行になり、`data[0]` は「変更前プランの未使用分クレジット行」であるため、
+	// スタンダード → プレミアムの変更で `plan=monthly` (変更前) を書き込んでいた。
+	// Stripe は `customer.subscription.updated` と `invoice.paid` の配信順序を保証しないので、
+	// invoice.paid が後着すると正しく書かれた plan を巻き戻すレースになる (#3960 実測)。
+	// subscription を SSOT にすれば、どちらの順序でも最終状態は現行 price に収束する。
+	const plan = resolvePlanFromSubscription(subscription);
 
 	const repos = getRepos();
 	await repos.auth.updateTenantStripe(tenant.tenantId, {
 		status: SUBSCRIPTION_STATUS.ACTIVE,
-		plan: plan ?? tenant.plan ?? SUBSCRIPTION_PLAN.MONTHLY,
+		// #3960: plan 未解決時は silent fallback せず **既存 plan を保持** する
+		// (`plan: undefined` は repo 実装で「更新しない」として扱われる)。
+		...planUpdateOrKeep(plan, tenant, 'invoice.paid', subscription.id),
 	});
 
-	logger.info(`[STRIPE] Invoice paid: tenant=${tenant.tenantId}`);
+	logger.info(`[STRIPE] Invoice paid: tenant=${tenant.tenantId} plan=${plan ?? 'unresolved'}`);
 
 	notifyBillingEvent(tenant.tenantId, 'invoice_paid', `plan=${plan ?? 'unknown'}`).catch(() => {});
 }
@@ -313,7 +334,7 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
 	const subscriptionId = extractSubscriptionId(invoice);
 	if (!subscriptionId) return;
 
-	const tenant = await findTenantBySubscription(subscriptionId);
+	const tenant = (await resolveSubscriptionContext(subscriptionId))?.tenant;
 	if (!tenant) {
 		logger.warn(
 			`[STRIPE] invoice.payment_failed — tenant not found for subscription=${subscriptionId}`,
@@ -339,12 +360,10 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 	const tenantId = subscription.metadata?.tenantId;
 	const tenant = tenantId
 		? await getRepos().auth.findTenantById(tenantId)
-		: await findTenantBySubscription(subscription.id);
+		: (await resolveSubscriptionContext(subscription.id))?.tenant;
 	if (!tenant) return;
 
-	const item = subscription.items?.data?.[0];
-	const priceId = item?.price?.id;
-	const plan = priceId ? planIdFromPriceId(priceId) : null;
+	const plan = resolvePlanFromSubscription(subscription);
 
 	const repos = getRepos();
 	// Stripe SDK 側の subscription.status ('active'|'trialing'|'past_due'|…) を
@@ -357,7 +376,8 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 				: SUBSCRIPTION_STATUS.SUSPENDED;
 
 	await repos.auth.updateTenantStripe(tenant.tenantId, {
-		plan: plan ?? tenant.plan ?? SUBSCRIPTION_PLAN.MONTHLY,
+		// #3960: silent fallback (`?? MONTHLY`) 廃止。未解決時は既存 plan を保持 + alert。
+		...planUpdateOrKeep(plan, tenant, 'customer.subscription.updated', subscription.id),
 		status,
 	});
 
@@ -374,7 +394,7 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription): Pro
 	const tenantId = subscription.metadata?.tenantId;
 	const tenant = tenantId
 		? await getRepos().auth.findTenantById(tenantId)
-		: await findTenantBySubscription(subscription.id);
+		: (await resolveSubscriptionContext(subscription.id))?.tenant;
 	if (!tenant) return;
 
 	const repos = getRepos();
@@ -401,15 +421,85 @@ function extractSubscriptionId(invoice: Stripe.Invoice): string | undefined {
 	return typeof sub === 'string' ? sub : sub?.id;
 }
 
-async function findTenantBySubscription(subscriptionId: string): Promise<Tenant | undefined> {
-	// Look up via Stripe API to get customer, then find tenant by customer ID
+/**
+ * subscription ID から tenant と **Stripe 上の現行 subscription** を同時に解決する (#3960)。
+ *
+ * 旧 `findTenantBySubscription()` は同じ `subscriptions.retrieve()` を呼びながら
+ * customer だけ取り出して subscription 本体を捨てていた。plan 判定の SSOT を
+ * subscription の現行 price に寄せるため、retrieve 結果をそのまま返す
+ * (Stripe API 呼び出し回数は従来と同じ 1 回)。
+ */
+async function resolveSubscriptionContext(
+	subscriptionId: string,
+): Promise<{ tenant: Tenant; subscription: Stripe.Subscription } | undefined> {
 	try {
 		const stripe = getStripeClient();
-		const sub = await stripe.subscriptions.retrieve(subscriptionId);
-		const customerId = typeof sub.customer === 'string' ? sub.customer : sub.customer?.id;
+		const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+		const customerId =
+			typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id;
 		if (!customerId) return undefined;
-		return await getRepos().auth.findTenantByStripeCustomerId(customerId);
+		const tenant = await getRepos().auth.findTenantByStripeCustomerId(customerId);
+		if (!tenant) return undefined;
+		return { tenant, subscription };
 	} catch {
 		return undefined;
 	}
+}
+
+/**
+ * subscription の現行 price から plan を解決する (#3960)。
+ *
+ * 解決順:
+ *   1. `planIdFromPriceId()` — env var (`STRIPE_PRICE_*_MONTHLY`) 由来の priceId 逆引き
+ *   2. `planIdFromLookupKey()` — `USE_LOOKUP_KEY=true` 経路で env var と異なる Price を
+ *      指し得るため、Price object の `lookup_key` で 2 段目の逆引きを行う
+ *
+ * どちらでも確定できない場合は `null` を返し、呼び出し側は plan を更新しない。
+ */
+function resolvePlanFromSubscription(subscription: Stripe.Subscription): PlanId | null {
+	const price = subscription.items?.data?.[0]?.price;
+	if (!price) return null;
+	return planIdFromPriceId(price.id) ?? planIdFromLookupKey(price.lookup_key);
+}
+
+/** `metadata.planId` 等の外部由来文字列が既知の PlanId か判定する (#3960) */
+function isKnownPlanId(value: string | null | undefined): value is PlanId {
+	return value === SUBSCRIPTION_PLAN.MONTHLY || value === SUBSCRIPTION_PLAN.FAMILY_MONTHLY;
+}
+
+/**
+ * plan の更新差分を組み立てる (#3960 silent fallback 廃止の SSOT)。
+ *
+ * 解決できた場合は `{ plan }`、できなかった場合は **空オブジェクト**を返す。
+ * `updateTenantStripe()` は `data.plan === undefined` を「更新しない」として扱うため、
+ * 空オブジェクトを spread すれば既存 plan が保持される。
+ *
+ * 旧実装の `plan ?? tenant.plan ?? MONTHLY` は、解決失敗時に暗黙で
+ * スタンダードへ落とす silent fallback であり、今回の課金 incident 系列
+ * (#3957 / #3958 / #3960) で繰り返し現れたパターン。未解決は「観測すべき異常」として扱う。
+ */
+function planUpdateOrKeep(
+	plan: PlanId | null,
+	tenant: Tenant,
+	eventType: string,
+	subscriptionId: string,
+): { plan?: PlanId } {
+	if (plan) return { plan };
+
+	logger.warn(
+		`[STRIPE] ${eventType} — plan を解決できませんでした。既存 plan を保持します: ` +
+			`tenant=${tenant.tenantId} subscription=${subscriptionId} currentPlan=${tenant.plan ?? 'none'}`,
+	);
+	notifyStripeAlert({
+		kind: 'stripe-plan-unresolved',
+		message: `${eventType} で subscription の現行 price から plan を確定できませんでした (既存 plan を保持)`,
+		errorSummary: `plan_unresolved:${eventType}:${subscriptionId}`,
+		tags: {
+			tenantId: tenant.tenantId,
+			event: eventType,
+			subscriptionId,
+			currentPlan: tenant.plan ?? 'none',
+		},
+	});
+	return {};
 }

--- a/src/lib/server/stripe/alert.ts
+++ b/src/lib/server/stripe/alert.ts
@@ -34,7 +34,10 @@ import { redactPii, redactPiiInTags } from '$lib/server/stripe/pii-redaction';
 export type StripeAlertKind =
 	| 'stripe-lookup-failed'
 	| 'stripe-webhook-unknown-type'
-	| 'stripe-webhook-handler-typeerror';
+	| 'stripe-webhook-handler-typeerror'
+	// #3960: webhook payload から plan を確定できなかった。silent fallback で
+	// 誤った plan を書き込む代わりに既存 plan を保持し、本 alert で観測可能化する。
+	| 'stripe-plan-unresolved';
 
 export interface StripeAlertOptions {
 	/** alert 種別 (Phase 6 子 5 §6 SSOT 3 種) */

--- a/src/lib/server/stripe/config.ts
+++ b/src/lib/server/stripe/config.ts
@@ -27,6 +27,11 @@ export type PlanId = typeof SUBSCRIPTION_PLAN.MONTHLY | typeof SUBSCRIPTION_PLAN
 
 export interface PlanConfig {
 	priceId: string;
+	/**
+	 * Stripe Price の `lookup_key` (#3960)。plan ⇄ lookup_key マッピングの SSOT。
+	 * webhook payload の Price から plan を逆引きする `planIdFromLookupKey()` が参照する。
+	 */
+	lookupKey: LookupKey;
 	amount: number;
 	interval: 'month';
 	tier: 'standard' | 'family';
@@ -46,6 +51,7 @@ function buildPlanConfigs(): Record<PlanId, PlanConfig> {
 	return {
 		[SUBSCRIPTION_PLAN.MONTHLY]: {
 			priceId: process.env.STRIPE_PRICE_STANDARD_MONTHLY ?? '',
+			lookupKey: 'standard_monthly',
 			amount: 500,
 			interval: 'month',
 			tier: 'standard',
@@ -53,6 +59,9 @@ function buildPlanConfigs(): Record<PlanId, PlanConfig> {
 		},
 		[SUBSCRIPTION_PLAN.FAMILY_MONTHLY]: {
 			priceId: process.env.STRIPE_PRICE_FAMILY_MONTHLY ?? '',
+			// premium = family (PLAN_TERMS.premium / .family は同値、ADR-0058 rename 過渡期)。
+			// lookup_key 側は `premium_` 接頭辞で、`tier` の 'family' とは語彙が異なる。
+			lookupKey: 'premium_monthly',
 			amount: 780,
 			interval: 'month',
 			tier: 'family',
@@ -76,6 +85,28 @@ export function planIdFromPriceId(priceId: string): PlanId | null {
 	const plans = getPlans();
 	for (const [id, config] of Object.entries(plans)) {
 		if (config.priceId === priceId) return id as PlanId;
+	}
+	return null;
+}
+
+/**
+ * lookup_key からプラン種別を逆引き (#3960)。
+ *
+ * `planIdFromPriceId()` は env var (`STRIPE_PRICE_*_MONTHLY`) 由来の priceId しか
+ * 逆引きできない。`USE_LOOKUP_KEY=true` 経路 (`getPriceId()`) では lookup_key から
+ * 解決した Price が env var と異なる Price を指し得るため、priceId 逆引き失敗時の
+ * 2 段目として lookup_key を突き合わせる。
+ *
+ * Stripe の Price object は `lookup_key` を保持するので、subscription item の
+ * price から version 差異に依存せず plan を確定できる。
+ *
+ * **マッピングは新規定義せず `PlanConfig.lookupKey` を SSOT とする**
+ * (`buildPlanConfigs()` が唯一の定義箇所)。lookup_key の命名が変わっても追従は 1 箇所。
+ */
+export function planIdFromLookupKey(lookupKey: string | null | undefined): PlanId | null {
+	if (!lookupKey) return null;
+	for (const [id, config] of Object.entries(getPlans())) {
+		if (config.lookupKey === lookupKey) return id as PlanId;
 	}
 	return null;
 }

--- a/tests/unit/server/stripe/lookup-key-config.test.ts
+++ b/tests/unit/server/stripe/lookup-key-config.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../../../src/lib/server/stripe/alert', () => ({
 }));
 
 import { notifyStripeAlert } from '$lib/server/stripe/alert';
-import { getPriceId, isLookupKeyEnabled } from '$lib/server/stripe/config';
+import { getPriceId, isLookupKeyEnabled, planIdFromLookupKey } from '$lib/server/stripe/config';
 import { getPriceByLookupKey } from '$lib/server/stripe/price-cache';
 
 const ENV_KEYS = ['USE_LOOKUP_KEY', 'STRIPE_PRICE_STANDARD_MONTHLY', 'STRIPE_PRICE_FAMILY_MONTHLY'];
@@ -171,5 +171,29 @@ describe('getPriceId — 並行運用整合 (両モードで同じ Price ID 解�
 
 		expect(offResult).toBe(onResult);
 		expect(offResult).toBe('price_same');
+	});
+});
+
+// ==========================================================
+// planIdFromLookupKey (#3960)
+// ==========================================================
+
+describe('planIdFromLookupKey (#3960)', () => {
+	// `planIdFromPriceId()` は env var (`STRIPE_PRICE_*_MONTHLY`) 由来の priceId しか
+	// 逆引きできない。`USE_LOOKUP_KEY=true` 経路では lookup_key から解決した Price が
+	// env var と別 Price を指し得るため、2 段目の逆引き経路として lookup_key を使う。
+	it('standard_monthly → monthly', () => {
+		expect(planIdFromLookupKey('standard_monthly')).toBe('monthly');
+	});
+
+	it('premium_monthly → family-monthly', () => {
+		expect(planIdFromLookupKey('premium_monthly')).toBe('family-monthly');
+	});
+
+	it('未知の lookup_key / null / undefined → null (silent fallback しない)', () => {
+		expect(planIdFromLookupKey('standard_yearly')).toBeNull();
+		expect(planIdFromLookupKey('')).toBeNull();
+		expect(planIdFromLookupKey(null)).toBeNull();
+		expect(planIdFromLookupKey(undefined)).toBeNull();
 	});
 });

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -43,10 +43,23 @@ vi.mock('$lib/server/stripe/config', () => ({
 		if (priceId === 'price_family_monthly_789') return 'family-monthly';
 		return null;
 	},
+	// #3960: `USE_LOOKUP_KEY=true` 経路で env var と異なる Price を指し得るため、
+	// priceId 逆引き失敗時の 2 段目として lookup_key を突き合わせる。
+	planIdFromLookupKey: (lookupKey: string | null | undefined) => {
+		if (lookupKey === 'standard_monthly') return 'monthly';
+		if (lookupKey === 'premium_monthly') return 'family-monthly';
+		return null;
+	},
 	getWebhookSecret: () => 'whsec_test',
 	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
+}));
+
+// #3960: plan 未解決時は silent fallback せず alert を上げる。発火を assert するため spy 化。
+const mockNotifyStripeAlert = vi.fn();
+vi.mock('$lib/server/stripe/alert', () => ({
+	notifyStripeAlert: (...args: unknown[]) => mockNotifyStripeAlert(...args),
 }));
 
 vi.mock('$lib/server/logger', () => ({
@@ -85,6 +98,56 @@ function makeTenant(overrides: Record<string, unknown> = {}) {
 		createdAt: '2026-01-01T00:00:00Z',
 		updatedAt: '2026-01-01T00:00:00Z',
 		...overrides,
+	};
+}
+
+/**
+ * Stripe subscription の mock (#3960)。
+ *
+ * `handleInvoicePaid` は plan を invoice の line item ではなく **subscription の現行 price**
+ * から解決するため、`subscriptions.retrieve()` の戻り値に `items.data[0].price` が必要。
+ */
+function makeSubscription(
+	priceId: string,
+	overrides: { lookupKey?: string | null; status?: string; id?: string } = {},
+) {
+	return {
+		id: overrides.id ?? 'sub_123',
+		customer: 'cus_123',
+		status: overrides.status ?? 'active',
+		metadata: {},
+		items: { data: [{ price: { id: priceId, lookup_key: overrides.lookupKey ?? null } }] },
+	};
+}
+
+/**
+ * プラン変更 (proration) の invoice.paid payload (#3960 実測 fixture)。
+ *
+ * スタンダード → プレミアム変更時、Stripe は 2 行の invoice を発行する:
+ *   line 0: amount -499 / standard の未使用時間クレジット  ← 旧実装が盲目参照していた行
+ *   line 1: amount  779 / premium の残り時間
+ * つまり `lines.data[0]` は **変更前**の price であり、plan の SSOT にしてはならない。
+ */
+function makeProrationInvoicePaidEvent(subscriptionId = 'sub_123') {
+	return {
+		type: 'invoice.paid',
+		data: {
+			object: {
+				parent: { subscription_details: { subscription: subscriptionId } },
+				lines: {
+					data: [
+						{
+							amount: -499,
+							pricing: { price_details: { price: 'price_monthly_123' } },
+						},
+						{
+							amount: 779,
+							pricing: { price_details: { price: 'price_family_monthly_789' } },
+						},
+					],
+				},
+			},
+		},
 	};
 }
 
@@ -328,9 +391,9 @@ describe('handleWebhookEvent', () => {
 	});
 
 	it('invoice.paid → テナントステータスを active に更新', async () => {
-		const mockSubscriptionsRetrieve = vi.fn().mockResolvedValue({
-			customer: 'cus_123',
-		});
+		const mockSubscriptionsRetrieve = vi
+			.fn()
+			.mockResolvedValue(makeSubscription('price_monthly_123'));
 		mockGetStripeClient.mockReturnValue({
 			subscriptions: { retrieve: mockSubscriptionsRetrieve },
 		});
@@ -363,6 +426,156 @@ describe('handleWebhookEvent', () => {
 				status: 'active',
 				plan: 'monthly',
 			}),
+		);
+	});
+
+	// ==========================================================
+	// #3960: invoice.paid の plan 解決を subscription の現行 price に寄せる
+	// ==========================================================
+
+	it('invoice.paid — proration 複数行 invoice で lines.data[0] (変更前 price) に引きずられず premium になる (#3960)', async () => {
+		// 実測 (2026-07-26 本番 live subscription への create_preview):
+		//   line 0 = standard の未使用時間クレジット / line 1 = premium の残り時間
+		// 旧実装は line 0 を読んで plan=monthly を書き込み、プレミアム契約者を
+		// スタンダード扱いに巻き戻していた。
+		const mockSubscriptionsRetrieve = vi
+			.fn()
+			.mockResolvedValue(makeSubscription('price_family_monthly_789'));
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: { retrieve: mockSubscriptionsRetrieve },
+		});
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+
+		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
+
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith(
+			't-test',
+			expect.objectContaining({ status: 'active', plan: 'family-monthly' }),
+		);
+	});
+
+	it('invoice.paid — env var と異なる Price でも lookup_key から plan を解決する (#3960 USE_LOOKUP_KEY 経路)', async () => {
+		// `USE_LOOKUP_KEY=true` では lookup_key 経由で解決した Price が env var
+		// (`STRIPE_PRICE_FAMILY_MONTHLY`) と別 Price を指し得る。priceId 逆引きが
+		// null でも Price object の lookup_key で確定できることを担保する。
+		const mockSubscriptionsRetrieve = vi
+			.fn()
+			.mockResolvedValue(
+				makeSubscription('price_unknown_to_env', { lookupKey: 'premium_monthly' }),
+			);
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: { retrieve: mockSubscriptionsRetrieve },
+		});
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+
+		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
+
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith(
+			't-test',
+			expect.objectContaining({ status: 'active', plan: 'family-monthly' }),
+		);
+	});
+
+	it('invoice.paid — plan が解決できない場合は plan を上書きせず既存値を保持し alert を上げる (#3960 silent fallback 廃止)', async () => {
+		// 旧実装は `plan ?? tenant.plan ?? MONTHLY` で暗黙にスタンダードへ落としていた。
+		// premium 契約者の plan を誤って書き換えるより、更新せず観測する方が安全。
+		const mockSubscriptionsRetrieve = vi
+			.fn()
+			.mockResolvedValue(makeSubscription('price_unknown_to_env', { lookupKey: null }));
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: { retrieve: mockSubscriptionsRetrieve },
+		});
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'family-monthly' }));
+
+		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
+
+		// plan キー自体が渡らない = repo 実装 (`if (data.plan !== undefined)`) で既存値保持
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith('t-test', { status: 'active' });
+		expect(mockNotifyStripeAlert).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: 'stripe-plan-unresolved' }),
+		);
+	});
+
+	it('#3960 — customer.subscription.updated → invoice.paid の順で最終 plan が premium になる', async () => {
+		const subscription = makeSubscription('price_family_monthly_789');
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: { retrieve: vi.fn().mockResolvedValue(subscription) },
+		});
+		mockFindTenantById.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+
+		await handleWebhookEvent({
+			type: 'customer.subscription.updated',
+			data: { object: { ...subscription, metadata: { tenantId: 't-test' } } },
+		} as never);
+		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
+
+		for (const call of mockUpdateTenantStripe.mock.calls) {
+			expect(call[1].plan).toBe('family-monthly');
+		}
+	});
+
+	it('#3960 — invoice.paid → customer.subscription.updated の逆順でも最終 plan が premium になる', async () => {
+		// Stripe は 2 event の配信順序を保証しない。subscription を SSOT にすることで
+		// どちらの順序でも最終状態が現行 price に収束することを担保する。
+		const subscription = makeSubscription('price_family_monthly_789');
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: { retrieve: vi.fn().mockResolvedValue(subscription) },
+		});
+		mockFindTenantById.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+
+		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
+		await handleWebhookEvent({
+			type: 'customer.subscription.updated',
+			data: { object: { ...subscription, metadata: { tenantId: 't-test' } } },
+		} as never);
+
+		for (const call of mockUpdateTenantStripe.mock.calls) {
+			expect(call[1].plan).toBe('family-monthly');
+		}
+	});
+
+	it('customer.subscription.updated — plan 未解決なら plan を上書きせず alert を上げる (#3960)', async () => {
+		mockFindTenantById.mockResolvedValue(makeTenant({ plan: 'family-monthly' }));
+
+		await handleWebhookEvent({
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					id: 'sub_123',
+					metadata: { tenantId: 't-test' },
+					status: 'active',
+					items: { data: [{ price: { id: 'price_unknown_to_env', lookup_key: null } }] },
+				},
+			},
+		} as never);
+
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith('t-test', { status: 'active' });
+		expect(mockNotifyStripeAlert).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: 'stripe-plan-unresolved' }),
+		);
+	});
+
+	it('checkout.session.completed — 未知の metadata.planId なら plan を書かず alert を上げる (#3960)', async () => {
+		await handleWebhookEvent({
+			type: 'checkout.session.completed',
+			data: {
+				object: {
+					id: 'cs_unknown_plan',
+					metadata: { tenantId: 't-test', planId: 'lifetime' },
+					customer: 'cus_new',
+					subscription: 'sub_new',
+				},
+			},
+		} as never);
+
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith(
+			't-test',
+			expect.objectContaining({ status: 'active', plan: undefined }),
+		);
+		expect(mockNotifyStripeAlert).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: 'stripe-plan-unresolved' }),
 		);
 	});
 


### PR DESCRIPTION
<!-- ============================================================
hotfix PR runbook checklist (#2343)
本 template は priority:critical / hotfix 専用。起票前に下記 5 項目を必ず確認すること。
[詳細]: docs/sessions/dev-session.md §hotfix PR runbook
============================================================
- [x] Step 1: Skill 雛形 (本 template) を使って起票している (手書き禁止、#2342 教訓)
- [x] Step 2: `src/routes/` 変更なし (server service 層 + design doc のみ) のため `refactor:internal-no-doc-impact` 判断は非該当
- [x] Step 3: 新規 env / secret の追加なし
- [x] Step 4: `process.env.X` 直接参照を新規追加していない (`check-no-direct-env-access.mjs` PASS)
- [x] Step 5: `npm run pre-ready -- --pr <num>` 全 Step PASS をローカル確認した
============================================================ -->

## 顧客価値・目的

**対象ユーザー**: 親（管理者 / 課金者）

**解決する課題**: **課金ずれ（現に発生し得る顧客損害）**。プラン変更（proration）の `invoice.paid` を処理すると、アプリ上の plan が**変更前プランに巻き戻る**。顧客はプレミアムの代金を支払い、Stripe 上の subscription もプレミアムなのに、アプリ上はスタンダード扱いになる。2026-07-26 の課金 incident（#3957 系列）の調査中に PO が Stripe live 環境の read-only preview で実測確認した（[#3960 コメント](https://github.com/Takenori-Kusaka/ganbari-quest/issues/3960)）。

**期待される効果**:

1. **損害停止** — plan 判定の SSOT を invoice の line item から **subscription の現行 price** へ移す。Stripe が配信順序を保証しない `customer.subscription.updated` / `invoice.paid` の**どちらの順序でも最終状態が現行 price に収束する**
2. **再発防止メカニズム** — 本 incident 系列で 3 箇所目となる **nullish 合体による既定値降格**（解決失敗時に `tenant.plan` → `MONTHLY` へ黙って落とす形）を構造的に不能化。未解決時は `plan` キー自体を渡さず既存値を保持し、`logger.warn` + Discord alert（`stripe-plan-unresolved`）で観測可能化する

## 関連 Issue

closes #3960

**直近 30 日の同一ファイル変更 PR**: **該当なし**（後述「要件 5」に検証コマンドと結果）

同 incident から派生した別 Issue: #3957（webhook 到達経路の IaC 恒久化） / #3958（reconciliation） / #3959（未達アラート） / #3963（context_token の古い plan）。本 PR は PO の Wave 1 定義における 1 件目。

## AC 検証マップ (ADR-0004)

AC は Issue 本文（当初）と、PO の実測訂正コメント（2026-07-26、当初の API version 仮説を否定し `critical` へ引き上げ）の両方から転記した。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | proration を含む複数行 invoice（実測 2 行構成）を fixture にした unit test で、`invoice.paid` 処理後の plan が `family-monthly` になること | `npx vitest run tests/unit/services/stripe-service.test.ts` | **PASS** — `invoice.paid — proration 複数行 invoice で lines.data[0] (変更前 price) に引きずられず premium になる (#3960)`。fixture は PO 実測の `line 0 amount -499 (standard) / line 1 amount 779 (premium)` を再現 |
| AC2 | plan 解決失敗時に plan が上書きされないこと（既存値保持 + warn） | 同上 | **PASS** — `invoice.paid — plan が解決できない場合は plan を上書きせず既存値を保持し alert を上げる (#3960 silent fallback 廃止)` / `customer.subscription.updated — plan 未解決なら plan を上書きせず alert を上げる (#3960)`。`updateTenantStripe` 呼び出し引数に `plan` キーが**存在しない**ことを assert（DSQL 実装 `src/lib/server/db/dsql/auth-repo.ts:291` が `data.plan !== undefined` でのみ SET を積むため、既存値が保持される） |
| AC3 | `customer.subscription.updated` → `invoice.paid` / `invoice.paid` → `customer.subscription.updated` の**両順序**で最終状態が `family-monthly` になること | 同上 | **PASS** — `#3960 — customer.subscription.updated → invoice.paid の順で最終 plan が premium になる` / `#3960 — invoice.paid → customer.subscription.updated の逆順でも最終 plan が premium になる` |
| AC4（Issue 本文） | api_version 差異に依存しない形で priceId を解決するよう `handleInvoicePaid` を修正する | `git diff` / 実装 | **PASS** — `handleInvoicePaid` は `invoice.lines` を**一切読まなくなった**。plan は `resolvePlanFromSubscription(subscription)` が `subscription.items.data[0].price` から解決するため、invoice payload の version 差異に構造的に非依存 |
| AC5（Issue 本文の注記） | `USE_LOOKUP_KEY=true` 経路で lookup_key が env var と異なる Price を解決した場合に `planIdFromPriceId` が null を返す経路の確認 | `npx vitest run tests/unit/server/stripe/lookup-key-config.test.ts` + `tests/unit/services/stripe-service.test.ts` | **PASS** — 実在する経路として確認したため、`planIdFromLookupKey()` を 2 段目の逆引きとして追加。`invoice.paid — env var と異なる Price でも lookup_key から plan を解決する (#3960 USE_LOOKUP_KEY 経路)` / `planIdFromLookupKey (#3960)` 3 ケース |
| AC6（Issue 本文） | 当初仮説（API version 乖離）の検証結果をエビデンス付きで記録する | PO の Issue コメント | **PASS（PO 実施済み）** — 同一 event を `Stripe-Version: 2026-02-25.clover` / `2026-04-22.dahlia` の 2 通りで取得し `pricing.price_details` が完全同一であることを実測。**仮説は否定済み**。api_version 乖離自体は残存するが本 PR のスコープ外（#2683 の 5 phase migration 案件） |

**検証コマンド一括**:

```
$ npx vitest run tests/unit/services/stripe-service.test.ts tests/unit/server/stripe/
 Test Files  8 passed (8)
      Tests  151 passed (151)

$ npx biome check src/lib/server/stripe src/lib/server/services/stripe-service.ts
Checked 6 files in 12s. No fixes applied.

$ npm run check   # svelte-check
COMPLETED 8409 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

## 変更タイプ

- [x] fix: バグ修正

## ADR-0002 Critical 修正 5 要件チェック（必須）

### 要件 1: E2E 回帰テストを同一 PR 内で追加

| AC | テストファイル | テスト内容 |
|---|---|---|
| AC1 | `tests/unit/services/stripe-service.test.ts` | proration 複数行 invoice（`line 0` = 変更前 standard クレジット / `line 1` = 変更後 premium）で `invoice.paid` 処理後の plan が `family-monthly` |
| AC2 | `tests/unit/services/stripe-service.test.ts` | plan 未解決時に `updateTenantStripe` へ `plan` キーが渡らない（既存値保持）+ `stripe-plan-unresolved` alert 発火（`invoice.paid` / `customer.subscription.updated` / `checkout.session.completed` の 3 handler 全て） |
| AC3 | `tests/unit/services/stripe-service.test.ts` | `subscription.updated` → `invoice.paid` / 逆順の**両配信順序**で最終 plan が `family-monthly` |
| AC5 | `tests/unit/services/stripe-service.test.ts` / `tests/unit/server/stripe/lookup-key-config.test.ts` | env var と異なる Price でも `lookup_key` から plan を解決 / `planIdFromLookupKey` の正常系 2 件 + 未知値・null・undefined |

**Playwright E2E を追加していない理由（要件 1 の充足形態についての明示）**:

本修正の対象は **Stripe が送信する webhook を受ける server 側 handler** であり、ブラウザ操作の到達点ではない。Playwright から発火させるには (a) Stripe live/test 環境で実際にプラン変更を行い実費（¥280、PO 実測の `proration_behavior=always_invoice`）を発生させる、または (b) 署名済み webhook POST を偽装する、のいずれかが必要で、前者は CI で回せず後者は「Stripe が本当にその payload を送るか」を検証できない。

代わりに、**PO が live 環境から read-only で実測した payload 構造をそのまま fixture に落とした unit test** を回帰層とした。既存 e2e（`tests/e2e/plan-standard.spec.ts` / `plan-family.spec.ts` / `billing-portal.spec.ts`）は plan 反映**後**の UI を検証する層であり、本 PR では変更しておらず回帰なし（`tests/e2e/` 差分ゼロ）。

> `tests/CLAUDE.md` の「テストなし機能 PR 禁止」は満たしている。E2E 追加が構造的に不可能な層であることを QA に明示的にレビューいただきたい（後述「レビュー依頼事項」）。

**要件 1 の最終的な充足形態 = 本番実測（PO 合意済み）**:

PO と合意のうえ、本 PR の**実質的な受け入れ確認は本番環境での実測に置き換える**。Wave 1（#3960 / #3963 / #3957）を main へデプロイした後、**PO がスタンダード → プレミアムのプラン変更を 1 回実行し、DB の `plan` が `family-monthly` に収束すること**を確認する。

- この実測が通るまで、本 PR の要件 1 は「unit test 層で回帰を固定し、受け入れは本番実測で代替する」状態である
- 実測で巻き戻り（`plan=monthly`）が観測された場合は fix-forward で本 PR 系列の追加修正を行う
- 合意根拠: [PO コメント（2026-07-26, Buzz channel `ganbari-quest`）](https://github.com/Takenori-Kusaka/ganbari-quest/issues/3960) — 「この PR の実質的な受け入れ確認は本番での実測になります」


### 要件 2: AC 全項目完了（部分実装で closes 禁止）

- [x] Issue の全 AC が本 PR で完了している（未完了項目・先送り項目は残していない）

AC6（api_version 仮説の検証記録）は PO が Issue コメントで実測エビデンス付きで完了済み。本 PR で残 AC を全て閉じる。

### 要件 3: 提案全実装

- [x] Issue 本文の「修正方針（案）」に記載された提案を実装した
- [x] 一部だけ採用した場合は、不採用理由を以下に明記:
  - **案 1（PO 推奨）を採用**: `stripe.subscriptions.retrieve()` した subscription の `items.data[0].price` を SSOT にする
  - **案 2 は不採用**: 「`lines.data` から `amount > 0` かつ proration ではない行を選ぶ」は、Issue 本文の記載どおり case 分岐が増え脆い。加えて invoice payload の形状（= endpoint 側の api_version）に依存し続けるため、AC4「api_version 差異に依存しない解決」を満たせない
  - **両案共通の要求**（nullish 合体で `plan` → `tenant.plan` → `MONTHLY` と降格させる silent fallback の廃止 → 未更新 + warn + alert）は `planUpdateOrKeep()` に集約して実装し、`handleSubscriptionUpdated` / `handleCheckoutCompleted` にも**横展開**した（ADR-0002 横展開）

**追加実装（Issue 本文の注記に基づく）**: `planIdFromLookupKey()` を 2 段目の逆引きとして追加。Issue「影響範囲」節の注記が指摘した「`USE_LOOKUP_KEY=true` 経路で lookup_key が env var と異なる Price を解決すると `planIdFromPriceId` が null を返す」経路への対応。マッピングは新規定義せず `PlanConfig.lookupKey` を SSOT 化した（`buildPlanConfigs()` が唯一の定義箇所）。

### 要件 4: 全 5 年齢モードで実機検証 + スクリーンショット

**N/A（UI 非影響）**。

**根拠**:
- 差分は `src/lib/server/**`（server-only の Stripe webhook handler / config / alert 種別）と `tests/` と `docs/` のみ。`.svelte` / `.css` / `.scss` / `site/` の変更は**ゼロ**（`git diff --name-only` で確認）
- 年齢モードは子供向け UI の fontScale / タップサイズを制御する層であり、本変更は保護者の課金 plan を DB に書く server 経路。年齢モードの分岐に一切触れない
- plan 値そのものの意味・値域は不変（`monthly` / `family-monthly`）。plan を読む UI 側の表示ロジックは無変更

### 要件 5: 直近 30 日の同一ファイル変更 PR チェック

```bash
$ for f in src/lib/server/services/stripe-service.ts src/lib/server/stripe/config.ts src/lib/server/stripe/alert.ts; do
    git log --since="30 days ago" --oneline -- "$f"
  done
# → 本 PR の commit (817bda04) 以外の出力なし
```

| PR | マージ日 | 同一ファイルでの変更内容 | 本 PR との関係 |
|---|---|---|---|
| — | — | — | — |

**該当なし（直近 30 日に同一ファイル変更 PR なし）**。

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [x] サービス層
- [ ] API
- [ ] ページ
- [ ] UI コンポーネント
- [x] その他: 設計書（`docs/design/billing-redesign/phase6-rollback-and-kill-switches.md` に R10 を追記）

**影響を受ける画面・機能**: Stripe webhook 経由の plan 反映（`checkout.session.completed` / `invoice.paid` / `customer.subscription.updated` / `invoice.payment_failed` / `customer.subscription.deleted`）。**UI の描画コードは無変更**だが、plan が正しく DB に反映されるようになるため、プラン変更後の画面表示は結果として正しくなる（ただし `context_token` Cookie の問題 #3963 は本 PR では未解決 — Wave 1 の 2 件目で対応）。

**Stripe API 呼び出し回数は不変**: `findTenantBySubscription()` は元々 `subscriptions.retrieve()` を呼びながら customer だけ取り出して subscription 本体を捨てていた。`resolveSubscriptionContext()` はその retrieve 結果を再利用するだけで、呼び出し回数は 1 回のまま。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**
- [x] **回帰テストを同一 PR 内で追加**（要件 1、E2E 不可の理由を同節に明記）
- [x] 追加・変更したテスト一覧:
  - `tests/unit/services/stripe-service.test.ts` — proration 複数行 invoice / 両配信順序 / 3 handler の未解決時既存値保持 + alert / lookup_key 経路（計 7 ケース追加）
  - `tests/unit/server/stripe/lookup-key-config.test.ts` — `planIdFromLookupKey` 正常系 2 + 未知値 / null / undefined（計 3 ケース追加）
- [x] **Critical バグ修正の場合**（ADR-0002）: 上記 5 要件全て確認済み

## スクリーンショット / ビジュアルデモ

**該当なし（バックエンド修正のみ）**。`.svelte` / `.css` / `.scss` / `site/` の変更はゼロ。

## コード品質セルフレビュー (#1481)

- [x] **DRY**: 同一バグ（silent fallback / 先頭要素の盲目参照）を他ファイルに横展開調査済み。
  - nullish 合体で `SUBSCRIPTION_PLAN.MONTHLY` へ降格させる silent fallback は本 incident 系列で 3 箇所（`handleInvoicePaid` / `handleSubscriptionUpdated` / `handleCheckoutCompleted`）。**3 箇所とも本 PR で `planUpdateOrKeep()` / 明示 alert に統一**
  - plan 解決ロジックの重複（`handleInvoicePaid` と `handleSubscriptionUpdated` が別々に priceId 逆引きしていた）を `resolvePlanFromSubscription()` に集約
  - plan ⇄ lookup_key マッピングの新規ハードコードを避け、`PlanConfig.lookupKey` を SSOT 化
- [x] **YAGNI**: 過剰防衛設計を追加していない（ADR-0010）。新規 interface / 抽象化レイヤーは追加せず、既存の alert 基盤（`notifyStripeAlert`）に kind を 1 つ足しただけ。案 2 の case 分岐路線を採らなかったのも同趣旨
- [x] **Security**: 新たな攻撃面なし。webhook 署名検証（`stripe.webhooks.constructEvent`）の経路は無変更。**外部由来値の信頼度をむしろ下げた**（`metadata.planId` を `isKnownPlanId()` で検証してから採用するようにした。従来は未知値が来たら黙ってスタンダードとして課金確定していた）。alert の tags は既存の `redactPiiInTags` を通る
- [x] **アクセシビリティ**: UI 非影響のため毀損なし
- [x] **パフォーマンス**: Stripe API 呼び出し回数は不変（上記「影響範囲」参照）。DB 更新も 1 回のまま

## 横展開・影響波及チェック

- [x] 本番アプリ + デモ版を同期 — `src/lib/server/db/demo/auth-repo.ts` の `updateTenantStripe` は no-op stub（デモは課金しない）。**変更不要**であることを実コードで確認
- [x] 全年齢モード 5 種に横展開 — N/A（server 課金経路、年齢モード分岐に非接触）
- [x] ナビゲーション 3 種に反映 — N/A（UI 非変更）
- [x] E2E / ユニットシード同期 — plan の値域・スキーマとも不変のため seed 変更不要。`tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` の差分ゼロ
- [x] labels SSOT (ADR-0045 / 旧 ADR-0009) — 新規ユーザー可視文言なし。追加したのは server ログ / Discord alert 文言のみ
- [x] 設計書同期 (ADR-0001) — `phase6-rollback-and-kill-switches.md` に **R10（plan 未解決時の silent fallback で誤 plan 書込み）** を §3.10-a 詳細 + §3.10 サマリ表の 2 箇所に追記。alert kind `stripe-plan-unresolved` の SSOT も同ファイル
- [x] 並行 PR overlap 確認 (#1200) — 直近 30 日に同一ファイルを触る PR なし（要件 5）。#3963（`auth/providers/cognito.ts` + `context-token.ts`）とはファイルが重ならない

**DB スキーマ 3 箇所 SSOT**: 本 PR はスキーマを変更しない（`plan` カラムの値域も不変）。DSQL / SQLite / demo の 3 実装のうち、`updateTenantStripe` に実体があるのは DSQL のみで、`data.plan !== undefined` でのみ SET を積む実装（`src/lib/server/db/dsql/auth-repo.ts:291`）であることを読んで確認した。**この挙動が AC2「既存値保持」の前提**であるため、レビューで併せて確認いただきたい。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

1. **要件 1 の充足形態** — Stripe webhook handler に Playwright E2E を追加できない理由（実費発生 or 署名偽装のいずれかが必要）と、live 実測 payload を fixture 化した unit test を回帰層とする判断の妥当性
2. **AC2 の前提** — 「`plan` キーを渡さなければ既存値が保持される」は DSQL 実装の `data.plan !== undefined` ガードに依存する。この依存を test で assert しているのは「呼び出し引数に `plan` キーが無いこと」までであり、DSQL 実装側の挙動変更を検知する gate は本 PR に含めていない。gate 化すべきかの判断
3. **`handleCheckoutCompleted` の未解決時の扱い** — plan は書かず `status=ACTIVE` / `trialUsedAt` は書く設計にした（決済自体は成立しているため権限は付与し、plan だけ support で確定させる想定）。この非対称が妥当か
4. **本番反映後の実測確認は PO 担当** — PO がプレミアム変更のリハーサルで plan 遷移を実測する段取りになっている（本スレッド合意）。Dev 側では live 課金を発生させていない

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] **ADR-0002 5 要件全て満たした**（再掲、自己確認）
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] UI 変更時: 5 年齢モード SS が GitHub 上で表示確認できる → **N/A（UI 変更なし）**

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

