### PR TITLE
fix(ci): #3969 CLI 直接実行判定を SSOT 化 — junction 経由で gate が無言で exit 0 になる構造を潰す

### DIFF
--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -41,7 +41,7 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isMain } from '../../scripts/lib/is-main.mjs';
 
 export const EVIDENCE_TTL_MS = 30 * 60 * 1000; // 30 分 (ADR-0056 §決定 1)
 export const REQUIRED_OBJECT_COUNT = 3; // must_object_count 強制値 (Echoing 抑制)
@@ -253,8 +253,8 @@ async function main() {
 }
 
 // CLI として直接実行されたときのみ main() を呼ぶ。import 経由 (unit test) では実行されない。
-const isDirectInvocation =
-	process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
-if (isDirectInvocation) {
+// 判定は scripts/lib/is-main.mjs (SSOT, #3969)。従来の `fileURLToPath(import.meta.url) === process.argv[1]`
+// は junction / symlink 経由の起動で常に false になり、**approve を素通しする**側に倒れていた。
+if (isMain(import.meta.url)) {
 	main();
 }

--- a/.claude/skills/dev-open-pr/scripts/init-pr-body.mjs
+++ b/.claude/skills/dev-open-pr/scripts/init-pr-body.mjs
@@ -25,6 +25,7 @@ import { execSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain } from '../../../../scripts/lib/is-main.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILL_ROOT = resolve(__dirname, '..');
@@ -333,17 +334,9 @@ async function main() {
 	return 0;
 }
 
-const isMain = (() => {
-	try {
-		const here = resolve(fileURLToPath(import.meta.url));
-		const argv1 = resolve(process.argv[1] || '');
-		return here === argv1;
-	} catch {
-		return false;
-	}
-})();
-
-if (isMain) {
+// 判定は scripts/lib/is-main.mjs (SSOT, #3969)。自前の resolve 比較は junction / symlink 経由で
+// 常に false になり、雛形が生成されないまま exit 0 になっていた。
+if (isMain(import.meta.url)) {
 	main()
 		.then((code) => process.exit(code))
 		.catch((err) => {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
               - 'tests/**'
               - 'infra/**'
               - 'scripts/**'
+              # #3969: check-cli-entry-guard.mjs の走査範囲 (SCAN_ROOTS) に .claude を含めたため、
+              # 発火条件も揃える。列挙しないと `.claude/**` だけを変更する PR で 4 filter すべてが
+              # false になり lint-and-test ごと skip され、gate が 1 度も走らない。守る対象が
+              # ADR-0056 の approve gate 本体 (.claude/hooks/gate-approve.mjs) なので必須。
+              # 対応関係は tests/unit/scripts/cli-entry-guard.test.ts が機械検証する。
+              - '.claude/**'
               - 'svelte.config.js'
               - 'vite.config.ts'
               - 'tsconfig.json'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,13 @@ jobs:
       - name: No plan/status literal direct write check (#972)
         run: node scripts/check-no-plan-literals.mjs
 
+      - name: CLI entry guard — 自前の isMain 判定 / 手組み file:// URL 禁止 (#3969)
+        # 各 script が自前で書いていた「直接実行判定」は symlink / junction 経由で必ず
+        # false になり、main() が呼ばれず「何も検査せず exit 0 (= PASS)」になっていた
+        # (実測 41/53 ファイル)。判定は scripts/lib/is-main.mjs へ一本化済みで、
+        # 本 gate は 42 個目の方言が持ち込まれるのを機械的に止める。
+        run: node scripts/check-cli-entry-guard.mjs
+
       - name: License key re-introduction guard (#2836 / Epic #2525 Phase 7 PR-L4)
         # license key 全廃 (Phase 1 補強 3 #2788) の再導入防止。allowlist 外のコード行に
         # ライセンスキー / licenseKey / license-key / LICENSE_KEY 参照を検出したら fail。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,13 @@ jobs:
         # 本 gate は 42 個目の方言が持ち込まれるのを機械的に止める。
         run: node scripts/check-cli-entry-guard.mjs
 
+      - name: Workflow sparse-checkout closure guard (#3969)
+        # gate job は sparse-checkout で必要ファイルを個別列挙している。上の CLI entry guard が
+        # scripts/lib/is-main.mjs の利用を強制するため、新しい gate script を列挙するたびに
+        # helper への import が生え、列挙し忘れると ERR_MODULE_NOT_FOUND で job が落ちる
+        # (本 Issue の対応時に必須 gate 6 job が実際に同時 fail した)。列挙の閉包を機械検証する。
+        run: node scripts/check-workflow-sparse-checkout-closure.mjs
+
       - name: License key re-introduction guard (#2836 / Epic #2525 Phase 7 PR-L4)
         # license key 全廃 (Phase 1 補強 3 #2788) の再導入防止。allowlist 外のコード行に
         # ライセンスキー / licenseKey / license-key / LICENSE_KEY 参照を検出したら fail。

--- a/.github/workflows/pr-ac-verification-check.yml
+++ b/.github/workflows/pr-ac-verification-check.yml
@@ -49,6 +49,7 @@ jobs:
             actions/pr-lane
             scripts/pr-lane.mjs
             scripts/check-ac-verification-map.mjs
+            scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -49,6 +49,7 @@ jobs:
             actions/pr-lane
             scripts/pr-lane.mjs
             scripts/check-merge-gate-checklist.mjs
+            scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -35,6 +35,7 @@ jobs:
             actions/pr-lane
             scripts/pr-lane.mjs
             scripts/check-pr-screenshot.mjs
+            scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)
@@ -165,6 +166,7 @@ jobs:
             actions/pr-lane
             scripts/pr-lane.mjs
             scripts/check-pr-screenshot.mjs
+            scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)
@@ -217,6 +219,7 @@ jobs:
             actions/pr-lane
             scripts/pr-lane.mjs
             scripts/check-ss-blob-sha-uniqueness.mjs
+            scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)
@@ -266,6 +269,7 @@ jobs:
           sparse-checkout: |
             scripts/check-ss-render-health.mjs
             scripts/lib/ci/screenshot-helpers.mjs
+            scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false
 
       - name: Run check-ss-render-health.mjs

--- a/biome.json
+++ b/biome.json
@@ -139,6 +139,7 @@
 			"!**/*.db",
 			"!**/site",
 			"!**/cdk.out",
+			"!**/cdk.context.json",
 			"!**/storybook-static",
 			"!**/app.css",
 			"!.claude",

--- a/scripts/audit/close-leak-report.mjs
+++ b/scripts/audit/close-leak-report.mjs
@@ -32,7 +32,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
-import { pathToFileURL } from 'node:url';
+import { isMain as isMainModule } from '../lib/is-main.mjs';
 
 /** 既定の走査期間 (git approxidate)。週次 cron 運用で直近の close漏れを拾いつつ noise を抑える */
 export const DEFAULT_SINCE = '90 days ago';
@@ -321,5 +321,5 @@ function main() {
 	process.exit(0);
 }
 
-const isMain = process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href;
+const isMain = isMainModule(import.meta.url);
 if (isMain) main();

--- a/scripts/audit/generate-api-coverage-map.mjs
+++ b/scripts/audit/generate-api-coverage-map.mjs
@@ -21,8 +21,8 @@
  */
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { isMain as isMainModule } from '../lib/is-main.mjs';
 
 /**
  * 設計書 markdown からエンドポイント表の行を抽出する (pure)。
@@ -173,13 +173,7 @@ export function runCli(argv = process.argv.slice(2)) {
 	return result;
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	runCli();

--- a/scripts/audit/generate-coverage-gap-map.mjs
+++ b/scripts/audit/generate-coverage-gap-map.mjs
@@ -25,8 +25,8 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { isMain as isMainModule } from '../lib/is-main.mjs';
 
 /**
  * coverage-summary.json のファイルパス key をリポジトリ相対 (src/...) に正規化する (pure)。
@@ -190,13 +190,7 @@ export function runCli(argv = process.argv.slice(2)) {
 	return map;
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	runCli();

--- a/scripts/audit/generate-integration-evidence.mjs
+++ b/scripts/audit/generate-integration-evidence.mjs
@@ -29,8 +29,8 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { isMain as isMainModule } from '../lib/is-main.mjs';
 import {
 	evaluateMergeReadiness,
 	formatMergeReadinessMarkdown,
@@ -289,13 +289,7 @@ const internalHelpers = {
 	},
 };
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	runCli();

--- a/scripts/audit/generate-release-predicate.mjs
+++ b/scripts/audit/generate-release-predicate.mjs
@@ -40,9 +40,9 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname } from 'node:path';
 import { classifyForContainedList } from '../integration-pr-body.mjs';
+import { isMain as isMainModule } from '../lib/is-main.mjs';
 
 /** in-toto attestation statement type (v1) */
 export const STATEMENT_TYPE = 'https://in-toto.io/Statement/v1';
@@ -274,13 +274,7 @@ export function runCli(argv = process.argv.slice(2)) {
 	return { statement, outPath: /** @type {string} */ (outPath) };
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	runCli();

--- a/scripts/audit/to-sarif.mjs
+++ b/scripts/audit/to-sarif.mjs
@@ -28,8 +28,8 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { isMain as isMainModule } from '../lib/is-main.mjs';
 import { computeFingerprint, VALID_SARIF_LEVELS } from './evidence-schema.mjs';
 
 /** SARIF 2.1.0 JSON schema URI (OASIS 公式) */
@@ -294,13 +294,7 @@ export function runCli(argv = process.argv.slice(2)) {
 	return { sarif, outPath: /** @type {string} */ (outPath) };
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	runCli();

--- a/scripts/back-merge-pr-body.mjs
+++ b/scripts/back-merge-pr-body.mjs
@@ -55,6 +55,7 @@ import {
 	findUncheckedReadyChecklist,
 	scanForbiddenTerms,
 } from './check-pr-body.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 import { CHECKS as TEMPLATE_GATE_CHECKS } from './pr-template-gate-checks.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -360,13 +361,7 @@ export function parseArgs(argv) {
 	return out;
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	const args = parseArgs(process.argv.slice(2));

--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -1,46 +1,4 @@
-// @ts-check
-/**
- * scripts/check-ac-verification-map.mjs — Issue #2945 (Phase A/A-3、親 #2942 / EPIC #2861)
- *
- * `.github/workflows/pr-ac-verification-check.yml`（required context `Verify AC map in PR body`）の
- * 検証ロジックを lane-aware な純粋関数として切り出した SSOT（unit test 可能化、Issue #2945 実装方針）。
- *
- * ## 背景（#2942 / #2945）
- *
- * develop 二層ブランチ戦略（docs/sessions/branch-strategy.md §3〜§5）で 3 レーン
- * （feature→develop 軽量 / develop→main 統合 PR 重量 / fix/*→main hotfix 重量）が併存する。
- * 旧 workflow は base/head（レーン）を見ず、per-PR の単一 Issue AC 前提の「AC 検証マップ」を
- * 全レーンに一律要求していた。統合 PR（複数 PR の束ね・単一 Issue 非紐づけ）は構造的に
- * 「統合 PR 自身の AC」を持たず、含有 PR の AC は develop 取込時点で QM が検証済
- * （audit-team.md §3.4）。この前提ミスマッチを lane 判定で解消する。
- *
- * ## lane 別の検証観点（Issue #2945 が SSOT）
- *
- * - **feature / hotfix lane**: 現行どおり「AC 検証マップ 4 列 + #1539 未完了表記検出」を検証（AC4 回帰ゼロ）。
- * - **integration lane**: per-PR AC マップの代わりに「マージ判定エビデンス表」セクションの存在 +
- *   4 列（含有 PR / 領域 / テスト / 結果）+「残 NG 0 件」明示を検証（audit-team.md §3.5、AC3）。
- *   `<!-- ac-verification-skip -->` 偽装に依存しない正規観点。表が欠落 or 空行で fail する。
- * - **dependabot lane**: 呼び出し側（job-level if）で従来どおり skip 相当（挙動不変、AC6）。
- *   本関数では `shouldSkip()` が dependencies / type:docs / 明示 skip コメントを判定する。
- *
- * ## 検証の本質を減らさない（#2945 no-go）
- *
- * integration lane で AC マップを外す代わりに必ずエビデンス表を要求する（実検証の総量を減らさない）。
- * skip による検証空洞化（required check が「何も見ずに緑」）は禁止。
- *
- * ## SSOT / 関連
- *
- * - lane 判定: scripts/pr-lane.mjs（A-1、actions/pr-lane composite action 経由で workflow から呼ぶ）
- * - 統合 PR エビデンス基準: docs/sessions/audit-team.md §3.5（4 点 + NG 0 件条件）
- * - 関連 ADR: ADR-0038（AC 検証マップ、docs/decisions/0004-review-and-ac-verification.md 統合）/
- *   ADR-0056（self-report 物理強制）/ ADR-0004（AC 検証）
- * - 関連 Issue: #2945 / #2942 / #1165（ADR-0038 原典）/ #1539（未完了表記検出）/ #1808（Dependabot exempt）
- *
- * exit: 0 = PASS / 1 = 検証失敗 / 2 = 引数不足
- */
-
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /** 統合 PR の検証で要求する section 見出し（暫定。統合 PR template 確定は Phase B #2871）。 */
 export const INTEGRATION_EVIDENCE_SECTION = 'マージ判定エビデンス表';
@@ -340,13 +298,7 @@ export function checkAcVerification({ body, labels, lane }) {
 
 // --- CLI（ローカル検証用。PR_BODY / PR_LABELS / PR_LANE を env or argv で受ける）---
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	const argv = process.argv.slice(2);

--- a/scripts/check-action-sha-pin.mjs
+++ b/scripts/check-action-sha-pin.mjs
@@ -26,7 +26,8 @@
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -380,6 +381,6 @@ function main() {
 	return 0;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isMainModule(import.meta.url)) {
 	process.exit(main());
 }

--- a/scripts/check-cdk-replacement.mjs
+++ b/scripts/check-cdk-replacement.mjs
@@ -15,6 +15,7 @@
  */
 
 import * as readline from 'node:readline';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI エスケープコード検出に ESC 文字が必要
 const ANSI_ESCAPE = /\x1b\[[0-9;]*[mGKHF]/g;
@@ -176,7 +177,7 @@ async function main() {
 }
 
 // ESM: import.meta.url で直接実行を判定
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
 	main().catch((err) => {
 		console.error('check-cdk-replacement.mjs fatal error:', err.message);
 		process.exit(1);

--- a/scripts/check-cli-entry-guard.mjs
+++ b/scripts/check-cli-entry-guard.mjs
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-cli-entry-guard.mjs
+ *
+ * #3969: 「CLI 直接実行判定 (isMain) を各 script が自前で書く」ことを機械的に禁止する gate。
+ *
+ * ## 背景 — なぜ grep gate が必要か
+ *
+ * `scripts/` 配下の 53 script が末尾で自前の isMain 判定を持ち、そのうち 41 件が
+ * **symlink / junction 経由の起動で必ず false になる**実装だった。false になると
+ * `main()` が呼ばれず、**何も検査しないまま exit 0 (= PASS)** を返す。
+ * gate script でこれが起きると「壊れていることに誰も気付かない」。
+ *
+ * 判定を `scripts/lib/is-main.mjs` (SSOT) へ集約しただけでは、次に script を書く人が
+ * 42 個目の方言を持ち込んで同じ事故が再発する。**再発を人間のレビュー勘に頼らないため**の
+ * gate が本 script である。
+ *
+ * ## 検出する 2 つのサブクラス
+ *
+ * 1. **argv1**: `process.argv[1]` の直接参照。
+ *    `import.meta.url` (実体パス) と `process.argv[1]` (ユーザー入力パス) を比べる形は
+ *    symlink 経由で必ず不一致になる。
+ * 2. **file-url**: `` `file://${...}` `` / `'file://' + ...` の手組み URL。
+ *    Windows で `file:///E:/x` と `file://E:\x` を比べることになり、symlink の有無に
+ *    関係なく**常に false**。`scripts/check-cdk-replacement.mjs` がこれで、本番 deploy 経路の
+ *    Replacement 保護が Windows ローカルでは一度も機能していなかった。
+ *    URL 化が必要なら `node:url` の `pathToFileURL()` を使う。
+ *
+ * ## opt-out
+ *
+ * 正当な理由がある場合のみ、当該行または直前行に理由付きマーカーを置く:
+ *   - `allow-argv1: <理由>`
+ *   - `allow-file-url: <理由>`
+ * 理由文字列が空のマーカーは opt-out として認めない (無言の抑止を防ぐ)。
+ *
+ * ## 使い方
+ *
+ *   node scripts/check-cli-entry-guard.mjs          # 違反があれば exit 1
+ *   node scripts/check-cli-entry-guard.mjs --help
+ *
+ * ## 関連
+ *   - scripts/lib/is-main.mjs (判定 SSOT)
+ *   - tests/unit/scripts/cli-entry-guard.test.ts (本 gate + no-op meta-gate)
+ *   - ADR-0061 (same-class N 回 → guard 化)
+ *   - Issue #3969
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { isMain as isMainModule } from './lib/is-main.mjs';
+
+/** 走査対象のルート (repo 相対)。tests/ は node -e 文字列中の argv[1] が正当なため対象外。 */
+const SCAN_ROOTS = ['scripts', 'src', 'infra'];
+const SCAN_EXTS = ['.mjs', '.cjs', '.js', '.ts'];
+/** 走査から外すディレクトリ名。 */
+const SKIP_DIRS = new Set([
+	'node_modules',
+	'.svelte-kit',
+	'cdk.out',
+	'dist',
+	'build',
+	'__snapshots__',
+]);
+/** 判定 SSOT 自身は argv[1] を参照してよい (むしろここだけが参照すべき)。 */
+const SSOT_FILE = join('scripts', 'lib', 'is-main.mjs');
+
+/** @typedef {{ id: string, re: RegExp, marker: RegExp, hint: string }} Rule */
+
+/** @type {readonly Rule[]} */
+const RULES = [
+	{
+		id: 'argv1',
+		re: /process\s*\.\s*argv\s*\[\s*1\s*\]/,
+		marker: /allow-argv1:\s*\S/,
+		hint: "CLI 直接実行判定は `import { isMain } from '<rel>/lib/is-main.mjs'` を使う (symlink / junction 経由でも正しく判定される)",
+	},
+	{
+		id: 'file-url',
+		// `file://${...}` (template literal) と 'file://' + x / "file://" + x (連結) の両形。
+		re: /`file:\/\/\$\{|['"]file:\/\/['"]\s*\+/,
+		marker: /allow-file-url:\s*\S/,
+		hint: 'path → URL 変換は `pathToFileURL()` (node:url) を使う。手組みは Windows で常に不一致になる',
+	},
+];
+
+/**
+ * 行がコメントのみか判定する (block comment の内側行 / 行頭 `//` / shebang)。
+ *
+ * 完全な字句解析はしない。gate の目的は「実行される比較コード」の検出であり、
+ * 解説コメント中の記述例を violation にしないための最小限の除外である。
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+function isCommentLine(line) {
+	const t = line.trim();
+	return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') || t.startsWith('#!');
+}
+
+/**
+ * 対象行の直前に連続するコメント行の中に opt-out マーカーがあるか判定する。
+ *
+ * @param {readonly string[]} lines
+ * @param {number} index 対象行の 0-based index
+ * @param {RegExp} marker
+ * @returns {boolean}
+ */
+function hasMarkerInPrecedingComments(lines, index, marker) {
+	for (let j = index - 1; j >= 0; j--) {
+		const line = lines[j] ?? '';
+		if (line.trim() === '') break;
+		if (!isCommentLine(line)) break;
+		if (marker.test(line)) return true;
+	}
+	return false;
+}
+
+/**
+ * dir 配下を再帰走査して対象拡張子のファイルを集める。
+ *
+ * @param {string} dir
+ * @param {string[]} [acc]
+ * @returns {string[]}
+ */
+function collectFiles(dir, acc = []) {
+	let entries;
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return acc;
+	}
+	for (const e of entries) {
+		if (e.name.startsWith('.') && e.name !== '.github') continue;
+		const full = join(dir, e.name);
+		if (e.isDirectory()) {
+			if (SKIP_DIRS.has(e.name)) continue;
+			collectFiles(full, acc);
+			continue;
+		}
+		if (!e.isFile()) continue;
+		if (SCAN_EXTS.some((ext) => e.name.endsWith(ext))) acc.push(full);
+	}
+	return acc;
+}
+
+/**
+ * 1 ファイルを走査して violation を返す (純粋関数、unit test 対象)。
+ *
+ * @param {string} relPath repo 相対パス (区切りは OS 依存でよい)
+ * @param {string} source ファイル内容
+ * @returns {Array<{ file: string, line: number, rule: string, text: string, hint: string }>}
+ */
+export function scanSource(relPath, source) {
+	const normalized = relPath.split(sep).join('/');
+	if (normalized === SSOT_FILE.split(sep).join('/')) return [];
+	const lines = source.split(/\r?\n/);
+	const violations = [];
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? '';
+		if (isCommentLine(line)) continue;
+		for (const rule of RULES) {
+			if (!rule.re.test(line)) continue;
+			// 当該行、または直前に連続するコメントブロック内に理由付き opt-out マーカーがあれば許可。
+			// 「直前 1 行のみ」に限ると、複数行で理由を書いた正当な opt-out が通らない。
+			if (rule.marker.test(line) || hasMarkerInPrecedingComments(lines, i, rule.marker)) continue;
+			violations.push({
+				file: normalized,
+				line: i + 1,
+				rule: rule.id,
+				text: line.trim(),
+				hint: rule.hint,
+			});
+		}
+	}
+	return violations;
+}
+
+function printHelp() {
+	console.log(`check-cli-entry-guard.mjs — CLI 直接実行判定の自前実装を禁止する gate (Issue #3969)
+
+走査対象: ${SCAN_ROOTS.join(' / ')} 配下の ${SCAN_EXTS.join(' / ')}
+検出ルール:
+  argv1     argv[1] の直接参照 (symlink 経由で isMain が常に false になる)
+  file-url  file スキーマ URL をテンプレート / 文字列連結で手組み (Windows で常に false)
+
+判定 SSOT : ${SSOT_FILE.split(sep).join('/')}
+opt-out   : 当該行または直前行に \`allow-argv1: <理由>\` / \`allow-file-url: <理由>\`
+使い方    : node scripts/check-cli-entry-guard.mjs`);
+}
+
+function main() {
+	if (process.argv.includes('--help') || process.argv.includes('-h')) {
+		printHelp();
+		return 0;
+	}
+	const root = process.cwd();
+	const violations = [];
+	for (const scanRoot of SCAN_ROOTS) {
+		const abs = join(root, scanRoot);
+		try {
+			if (!statSync(abs).isDirectory()) continue;
+		} catch {
+			continue;
+		}
+		for (const file of collectFiles(abs)) {
+			violations.push(...scanSource(relative(root, file), readFileSync(file, 'utf8')));
+		}
+	}
+
+	if (violations.length === 0) {
+		console.log('[check-cli-entry-guard] OK: 自前の CLI 実行判定 / 手組み file:// URL は 0 件');
+		return 0;
+	}
+
+	console.error(`[check-cli-entry-guard] FAIL: ${violations.length} 件の違反`);
+	for (const v of violations) {
+		console.error(`  ${v.file}:${v.line} [${v.rule}] ${v.text}`);
+		console.error(`      → ${v.hint}`);
+	}
+	console.error(
+		'\n  背景: symlink / junction 経由で起動すると自前判定は必ず false になり、gate が何も',
+	);
+	console.error('        検査せず exit 0 を返す (#3969 で 41 script が該当していた)。');
+	console.error(
+		`  opt-out: 正当な理由があれば当該行/直前行に \`allow-argv1: <理由>\` または \`allow-file-url: <理由>\``,
+	);
+	return 1;
+}
+
+if (isMainModule(import.meta.url)) {
+	process.exit(main());
+}

--- a/scripts/check-cli-entry-guard.mjs
+++ b/scripts/check-cli-entry-guard.mjs
@@ -56,8 +56,12 @@ import { isMain as isMainModule } from './lib/is-main.mjs';
  * (`.claude/hooks/gate-approve.mjs` は ADR-0056 evidence を検証して QM の approve を止める hook で、
  * junction 経由では判定が false になり approve を素通ししていた)。実行経路が `scripts/` と違うだけで
  * 事故の class は同じなので、走査範囲を実行経路ではなく「壊れたときに無言で PASS するか」で決める。
+ *
+ * export しているのは test 用である。SCAN_ROOTS を広げたら `.github/workflows/ci.yml` の
+ * `paths-filter` (`app`) も広げないと、その root だけを変更した PR で job ごと skip され
+ * gate が 1 度も走らない。対応関係を tests/unit/scripts/cli-entry-guard.test.ts が機械検証する。
  */
-const SCAN_ROOTS = ['scripts', 'src', 'infra', '.claude'];
+export const SCAN_ROOTS = ['scripts', 'src', 'infra', '.claude'];
 const SCAN_EXTS = ['.mjs', '.cjs', '.js', '.ts'];
 /**
  * 走査から外すディレクトリ名。
@@ -222,20 +226,33 @@ function main() {
 	}
 	const root = process.cwd();
 	const violations = [];
+	// 走査量を root ごとに数える。件数を出さないと「違反 0 件」と「1 ファイルも走査していない」が
+	// 同じ文言の exit 0 になり、SCAN_ROOT が checkout に無い状態を PASS と読み違える
+	// (レビュー指摘 PR #3979)。本 gate が塞いでいる「壊れると無言で PASS」と同じ class。
+	/** @type {string[]} */
+	const scanned = [];
 	for (const scanRoot of SCAN_ROOTS) {
 		const abs = join(root, scanRoot);
 		try {
-			if (!statSync(abs).isDirectory()) continue;
+			if (!statSync(abs).isDirectory()) {
+				scanned.push(`${scanRoot}=対象外`);
+				continue;
+			}
 		} catch {
+			scanned.push(`${scanRoot}=未検出`);
 			continue;
 		}
-		for (const file of collectFiles(abs)) {
+		const files = collectFiles(abs);
+		scanned.push(`${scanRoot}=${files.length}`);
+		for (const file of files) {
 			violations.push(...scanSource(relative(root, file), readFileSync(file, 'utf8')));
 		}
 	}
 
 	if (violations.length === 0) {
-		console.log('[check-cli-entry-guard] OK: 自前の CLI 実行判定 / 手組み file:// URL は 0 件');
+		console.log(
+			`[check-cli-entry-guard] OK: 自前の CLI 実行判定 / 手組み file:// URL は 0 件 (走査 ${scanned.join(' / ')})`,
+		);
 		return 0;
 	}
 

--- a/scripts/check-cli-entry-guard.mjs
+++ b/scripts/check-cli-entry-guard.mjs
@@ -49,10 +49,22 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative, sep } from 'node:path';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
-/** 走査対象のルート (repo 相対)。tests/ は node -e 文字列中の argv[1] が正当なため対象外。 */
-const SCAN_ROOTS = ['scripts', 'src', 'infra'];
+/**
+ * 走査対象のルート (repo 相対)。tests/ は node -e 文字列中の argv[1] が正当なため対象外。
+ *
+ * `.claude` を含むのは、hook / skill script も**壊れると無言で PASS する gate** だからである
+ * (`.claude/hooks/gate-approve.mjs` は ADR-0056 evidence を検証して QM の approve を止める hook で、
+ * junction 経由では判定が false になり approve を素通ししていた)。実行経路が `scripts/` と違うだけで
+ * 事故の class は同じなので、走査範囲を実行経路ではなく「壊れたときに無言で PASS するか」で決める。
+ */
+const SCAN_ROOTS = ['scripts', 'src', 'infra', '.claude'];
 const SCAN_EXTS = ['.mjs', '.cjs', '.js', '.ts'];
-/** 走査から外すディレクトリ名。 */
+/**
+ * 走査から外すディレクトリ名。
+ *
+ * `worktrees` は `.claude/worktrees/` に git worktree 実体が置かれる運用があるため必須
+ * (除外しないと他ブランチの全ソースを重複走査し、本ブランチと無関係な違反を報告する)。
+ */
 const SKIP_DIRS = new Set([
 	'node_modules',
 	'.svelte-kit',
@@ -60,6 +72,7 @@ const SKIP_DIRS = new Set([
 	'dist',
 	'build',
 	'__snapshots__',
+	'worktrees',
 ]);
 /** 判定 SSOT 自身は argv[1] を参照してよい (むしろここだけが参照すべき)。 */
 const SSOT_FILE = join('scripts', 'lib', 'is-main.mjs');
@@ -145,6 +158,20 @@ function collectFiles(dir, acc = []) {
 
 /**
  * 1 ファイルを走査して violation を返す (純粋関数、unit test 対象)。
+ *
+ * ## 守備範囲 (意図的な限界)
+ *
+ * 正規表現による行単位の静的検査であり、`process.argv[1]` の**字面**しか見ない。
+ * 以下の等価な書き方は素通りする:
+ *
+ *   - `const [, entry] = process.argv;`
+ *   - `process.argv.at(1)`
+ *   - `process.argv.slice(1)[0]`
+ *
+ * AST 解析まで広げれば塞げるが、本 gate の目的は「41 件あった既知の方言が**再び増えない**こと」であり、
+ * 迂回を試みる書き手を想定していない。上記 3 形を書くのは argv[1] 直参照より手間が多く、
+ * 素で書かれる確率が低い。塞ぐコスト > 得られる保証、と判断して字面検査に留めている。
+ * 迂回形が実際に混入したら、その時点で AST 化する (ADR-0061 same-class-N→guard)。
  *
  * @param {string} relPath repo 相対パス (区切りは OS 依存でよい)
  * @param {string} source ファイル内容

--- a/scripts/check-design-doc-sync.mjs
+++ b/scripts/check-design-doc-sync.mjs
@@ -38,6 +38,8 @@
  * **テスト**: `scripts/__tests__/check-design-doc-sync.test.mjs` (node --test)。
  */
 
+import { isMain as isMainModule } from './lib/is-main.mjs';
+
 const ROUTE_PREFIX = 'src/routes/';
 const DESIGN_DOC_PREFIX = 'docs/design/';
 
@@ -236,11 +238,10 @@ async function main() {
 	}
 }
 
-// import.meta.url が CLI エントリの場合のみ main 実行 (test では import 経由)
-const argv1 = process.argv[1] ?? '';
-const isCliInvocation =
-	argv1 !== '' &&
-	(import.meta.url === `file://${argv1}` || import.meta.url.endsWith(argv1.replace(/\\/g, '/')));
+// import.meta.url が CLI エントリの場合のみ main 実行 (test では import 経由)。
+// 判定は scripts/lib/is-main.mjs (SSOT) に委ねる — 自前比較は symlink / junction 経由で
+// 必ず false になり、何も検査しないまま exit 0 になる (#3969)。
+const isCliInvocation = isMainModule(import.meta.url);
 
 if (isCliInvocation) {
 	main();

--- a/scripts/check-gh-account-before-pr.mjs
+++ b/scripts/check-gh-account-before-pr.mjs
@@ -44,7 +44,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 export const ALLOWED_PR_AUTHOR_DEFAULT = 'Takenori-Kusaka';
 export const QA_ACCOUNT = 'ganbariquestsupport-lab';
@@ -272,8 +272,7 @@ function main() {
 }
 
 // CLI として直接実行されたときのみ main() を呼ぶ。`import` 経由 (unit test 等) では実行されない。
-const isDirectInvocation =
-	process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+const isDirectInvocation = isMainModule(import.meta.url);
 if (isDirectInvocation) {
 	main();
 }

--- a/scripts/check-guide-copy.ts
+++ b/scripts/check-guide-copy.ts
@@ -33,6 +33,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PAGE_GUIDE_LABELS } from '../src/lib/domain/labels.js';
 import { MYSTERY_TERMS } from './check-terminology-coherence.ts';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const FAIL_ON_VIOLATION = process.argv.includes('--fail-on-violation');
 
@@ -288,17 +289,8 @@ function main(): number {
 	return FAIL_ON_VIOLATION ? 1 : 0;
 }
 
-const isMain = (() => {
-	if (typeof process === 'undefined') return false;
-	const argv1 = process.argv[1];
-	if (!argv1) return false;
-	try {
-		return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(argv1);
-	} catch {
-		return false;
-	}
-})();
-
-if (isMain) {
+// CLI 直接実行判定は scripts/lib/is-main.mjs (SSOT) に委ねる (#3969)。
+// 自前実装は方言が増えるほど symlink / junction 事故の再発面が広がる。
+if (isMainModule(import.meta.url)) {
 	process.exit(main());
 }

--- a/scripts/check-internal-terms.mjs
+++ b/scripts/check-internal-terms.mjs
@@ -34,7 +34,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -523,6 +524,6 @@ function main() {
 }
 
 // #3299: CLI 直接実行時のみ main() を走らせる (unit test での import 時は実行しない)。
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isMainModule(import.meta.url)) {
 	process.exit(main());
 }

--- a/scripts/check-license-key-leak.mjs
+++ b/scripts/check-license-key-leak.mjs
@@ -35,6 +35,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -189,6 +190,6 @@ function main() {
 }
 
 // CLI として直接実行された時のみ main() を走らせる (import 時は副作用なし → テスト容易)
-if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+if (isMainModule(import.meta.url)) {
 	main();
 }

--- a/scripts/check-lp-inline-style.mjs
+++ b/scripts/check-lp-inline-style.mjs
@@ -48,6 +48,7 @@
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -309,7 +310,7 @@ function main() {
 // CLI として直接起動された時のみ実行する (import 時は main を呼ばない)。
 // regression guard (tests/unit/scripts/check-lp-inline-style.test.ts) が
 // ZERO_AUTO_ONLY_RE / isAllowedValue を import して検証できるようにするため。
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (isMainModule(import.meta.url)) {
 	const code = main();
 	process.exit(code);
 }

--- a/scripts/check-merge-gate-checklist.mjs
+++ b/scripts/check-merge-gate-checklist.mjs
@@ -1,45 +1,4 @@
-// @ts-check
-/**
- * scripts/check-merge-gate-checklist.mjs — Issue #2945 (Phase A/A-3、親 #2942 / EPIC #2861)
- *
- * `.github/workflows/pr-merge-gate.yml`（required context `PR チェックリスト完了確認`）の
- * 検証ロジックを lane-aware な純粋関数として切り出した SSOT（unit test 可能化、Issue #2945 実装方針）。
- *
- * ## 背景（#2942 / #2945）
- *
- * 旧 workflow は base/head（レーン）を見ず、per-PR の「Ready for Review チェックリスト」/
- * 「完了チェックリスト」の `- [ ]` 全消化を全レーンに一律要求していた。統合 PR
- * （develop→main、複数 PR の束ね）はこの per-PR チェックリスト前提に構造的に適合せず、
- * 検証単位（バッチ）と gate の前提（per-PR）が不整合だった。
- *
- * ## lane 別の対象 section（Issue #2945 AC5 が SSOT）
- *
- * - **feature / hotfix lane**: 現行 2 section（`## Ready for Review チェックリスト` /
- *   `## 完了チェックリスト`）の `- [ ]` 全消化を検証（AC4 回帰ゼロ）。
- * - **integration lane**: 統合 PR 用 section の `- [ ]` 全消化を検証。
- *   section 名は **Phase B template で確定する**ため、本 phase では「lane=integration なら
- *   統合用 section を対象にする」分岐ロジックまでを実装し、section 名は **設定値（env / 定数）で
- *   差替可能**にする（targetSections をハードコードで統合用に置換しない、#2945 no-go）。
- * - **dependabot lane**: 呼び出し側（job-level if）で従来どおり skip 相当（AC6）。
- *   本関数では `shouldSkip()` が dependencies ラベルを判定する。
- *
- * ## integration lane の最小要件（統合 PR template 未導入の暫定期間、#2945）
- *
- * 統合 PR template（Phase B #2871）が未導入のため、暫定 section 名を既定とする。
- * 必須セクションが本文に存在しない場合は **fail**（warning で素通りさせない、#2945 no-go）。
- *
- * ## SSOT / 関連
- *
- * - lane 判定: scripts/pr-lane.mjs（A-1、actions/pr-lane composite action 経由で workflow から呼ぶ）
- * - 統合 PR チェックリスト確定: Phase B #2871（本 phase は分岐 + section 名設定可能化まで）
- * - 関連 ADR: ADR-0056（self-report 物理強制）/ ADR-0022（役割分離）
- * - 関連 Issue: #2945 / #2942 / #1481（merge gate 原典）/ #1808（Dependabot exempt）
- *
- * exit: 0 = PASS / 1 = 検証失敗 / 2 = 引数不足
- */
-
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /** feature / hotfix lane の対象 section（現行 2 section、AC5 で不変）。 */
 export const LIGHT_LANE_SECTIONS = ['## Ready for Review チェックリスト', '## 完了チェックリスト'];
@@ -200,13 +159,7 @@ export function checkMergeGateChecklist({ body, labels, lane, integrationSection
 
 // --- CLI（ローカル検証用）---
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	const argv = process.argv.slice(2);

--- a/scripts/check-namespace-duplicate.mjs
+++ b/scripts/check-namespace-duplicate.mjs
@@ -42,6 +42,7 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -269,13 +270,7 @@ function main() {
 }
 
 // Run as CLI (not when imported as a module)
-const isMain = (() => {
-	try {
-		return path.resolve(process.argv[1]) === __filename;
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	main();

--- a/scripts/check-native-dep-pin.mjs
+++ b/scripts/check-native-dep-pin.mjs
@@ -20,7 +20,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -132,6 +133,6 @@ function main() {
 	return 1;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (isMainModule(import.meta.url)) {
 	process.exit(main());
 }

--- a/scripts/check-new-required-env.mjs
+++ b/scripts/check-new-required-env.mjs
@@ -34,6 +34,7 @@
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync, statSync } from 'node:fs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF = process.env.BASE_REF || 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
@@ -378,10 +379,7 @@ function main() {
 
 // CLI 起動時のみ main を呼ぶ。`import { detectNewRequiredEnvs }` 経由のテスト時は呼ばない。
 // (#2337 / Issue #2337 AC: regex unit test 追加のため export 化、CLI 互換性維持)
-const argv1 = process.argv[1];
-const isDirectInvocation =
-	!!argv1 &&
-	(import.meta.url === `file://${argv1}` || import.meta.url.endsWith(argv1.replace(/\\/g, '/')));
+const isDirectInvocation = isMainModule(import.meta.url);
 if (isDirectInvocation) {
 	main();
 }

--- a/scripts/check-no-at-html.mjs
+++ b/scripts/check-no-at-html.mjs
@@ -243,9 +243,9 @@ function main() {
 	);
 }
 
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
-const isMain = process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-no-direct-env-access.mjs
+++ b/scripts/check-no-direct-env-access.mjs
@@ -20,6 +20,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -218,6 +219,6 @@ function main() {
 }
 
 // スクリプトとして直接実行された場合のみ main を起動 (テストから import 時は skip)
-if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+if (isMainModule(import.meta.url)) {
 	main();
 }

--- a/scripts/check-no-plan-literals.mjs
+++ b/scripts/check-no-plan-literals.mjs
@@ -27,6 +27,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -376,9 +377,7 @@ function main() {
 export { CONCEPT_ICON_RULES, checkFile, shouldExclude, TERM_LITERAL_RULES, VALUE_LITERAL_RULES };
 
 // CLI エントリ (直接実行時のみ)
-const isMain =
-	import.meta.url === `file://${process.argv[1].replace(/\\/g, '/')}` ||
-	process.argv[1].endsWith('check-no-plan-literals.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-assets.mjs
+++ b/scripts/check-orphan-assets.mjs
@@ -29,6 +29,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const ASSET_ROOTS = [
 	{ root: path.join(REPO_ROOT, 'static', 'assets'), relPrefix: 'static/assets' },
@@ -116,9 +117,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-assets.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-env.mjs
+++ b/scripts/check-orphan-env.mjs
@@ -27,6 +27,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const ENV_EXAMPLE = path.join(REPO_ROOT, '.env.example');
 const SEARCH_DIRS = ['src', 'scripts', 'infra', 'tests'];
@@ -116,9 +117,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-env.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-fixtures.mjs
+++ b/scripts/check-orphan-fixtures.mjs
@@ -33,6 +33,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const DEMO_DIRS = [path.join(REPO_ROOT, 'src', 'lib', 'server', 'demo')];
 const SEARCH_DIRS = ['src', 'tests/unit', 'tests/integration', 'tests/e2e', 'scripts'];
@@ -117,9 +118,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-fixtures.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-labels.mjs
+++ b/scripts/check-orphan-labels.mjs
@@ -35,6 +35,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const LABELS_FILE = path.join(REPO_ROOT, 'src', 'lib', 'domain', 'labels.ts');
 const TERMS_FILE = path.join(REPO_ROOT, 'src', 'lib', 'domain', 'terms.ts');
@@ -128,9 +129,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-labels.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-repos.mjs
+++ b/scripts/check-orphan-repos.mjs
@@ -36,6 +36,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const DB_DIR = path.join(REPO_ROOT, 'src', 'lib', 'server', 'db');
 const REPO_LAYER_DIRS = ['sqlite', 'demo', 'dynamodb'];
@@ -111,9 +112,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-repos.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-routes.mjs
+++ b/scripts/check-orphan-routes.mjs
@@ -34,6 +34,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const ROUTES_DIR = path.join(REPO_ROOT, 'src', 'routes');
 const LEGACY_URL_MAP = path.join(REPO_ROOT, 'src', 'lib', 'server', 'routing', 'legacy-url-map.ts');
@@ -164,9 +165,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-routes.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-services.mjs
+++ b/scripts/check-orphan-services.mjs
@@ -32,6 +32,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const SERVICES_DIR = path.join(REPO_ROOT, 'src', 'lib', 'server', 'services');
 const SEARCH_DIRS = ['src', 'tests/unit', 'tests/integration', 'tests/e2e'];
@@ -89,9 +90,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-services.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-tables.mjs
+++ b/scripts/check-orphan-tables.mjs
@@ -35,6 +35,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const SCHEMA_FILE = path.join(REPO_ROOT, 'src', 'lib', 'server', 'db', 'schema.ts');
 const PRODUCTION_DIRS = [
@@ -148,9 +149,7 @@ function main() {
 }
 
 // CLI エントリ
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-tables.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-orphan-ui.mjs
+++ b/scripts/check-orphan-ui.mjs
@@ -29,6 +29,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const UI_DIRS = [
 	path.join(REPO_ROOT, 'src', 'lib', 'ui', 'primitives'),
@@ -82,9 +83,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-orphan-ui.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -32,9 +32,10 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 import { checkChangeType } from './pr-template-gate-checks.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -1104,33 +1105,10 @@ export async function main(argv = process.argv.slice(2)) {
 	return 1;
 }
 
-/**
- * #3962 (QA 指摘): `import.meta.url` は symlink / junction 解決後、`process.argv[1]` は解決前の
- * パスなので、junction 経由の checkout では両者が一致せず `main()` が呼ばれないまま
- * **無出力 exit 0** になっていた。gate が無音で成功扱いになる最も危険な形なので、
- * 両辺を `realpathSync` で正規化してから比較する。
- *
- * @param {string} p
- * @returns {string}
- */
-function normalizeEntryPath(p) {
-	const abs = resolve(p);
-	try {
-		return realpathSync(abs);
-	} catch {
-		return abs;
-	}
-}
-
-const isMain = (() => {
-	try {
-		const here = normalizeEntryPath(fileURLToPath(import.meta.url));
-		const argv1 = normalizeEntryPath(process.argv[1] || '');
-		return here === argv1;
-	} catch {
-		return false;
-	}
-})();
+// #3962 が本ファイルにインラインで入れた realpath 正規化は、#3969 で判定 SSOT
+// (`scripts/lib/is-main.mjs`) に統合した。同じ判定を各 script が自前で持つ構造が
+// 「6 方言のうち 40 箇所が無言 exit 0」の原因だったため、ここでは helper を使う。
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	main()

--- a/scripts/check-pr-file-overlap.mjs
+++ b/scripts/check-pr-file-overlap.mjs
@@ -31,7 +31,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /**
  * @typedef {object} OverlapEntry
@@ -190,7 +190,7 @@ function main() {
 }
 
 // CLI として直接実行されたときのみ main() を呼ぶ。`import` 経由 (unit test 等) では実行されない。
-const isMain = process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -651,19 +651,9 @@ function mainEmbedGate() {
 	return 1;
 }
 
-import { resolve as pathResolve } from 'node:path';
-// CLI 実行時のみ main を呼ぶ（テスト import 時は呼ばない）
-// Windows では import.meta.url が file:///C:/... 形式、process.argv[1] が C:\... 形式になるため
-// fileURLToPath で双方を絶対パスに正規化して比較する
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
-const isMain = (() => {
-	try {
-		return pathResolve(fileURLToPath(import.meta.url)) === pathResolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	try {

--- a/scripts/check-pr-template-sections-sync.mjs
+++ b/scripts/check-pr-template-sections-sync.mjs
@@ -40,6 +40,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -280,15 +281,7 @@ export async function main() {
 	return 0;
 }
 
-const isMain = (() => {
-	try {
-		const here = resolve(fileURLToPath(import.meta.url));
-		const argv1 = resolve(process.argv[1] || '');
-		return here === argv1;
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	main()

--- a/scripts/check-recent-deploy-deletion.mjs
+++ b/scripts/check-recent-deploy-deletion.mjs
@@ -120,7 +120,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 export const DEFAULT_DAYS = 7;
 export const DEFAULT_BASE = 'origin/main';
@@ -897,6 +897,6 @@ async function main() {
 }
 
 // CLI 実行時のみ main を呼ぶ (vitest import 時は skip)
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (isMainModule(import.meta.url)) {
 	main().then((code) => process.exit(code));
 }

--- a/scripts/check-schema-migration-completeness.mjs
+++ b/scripts/check-schema-migration-completeness.mjs
@@ -58,7 +58,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF_DEFAULT = 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
@@ -471,6 +471,6 @@ function main() {
 }
 
 // CLI として直接実行された場合のみ main() を起動 (test からの import 時は実行しない)
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+if (isMainModule(import.meta.url)) {
 	main();
 }

--- a/scripts/check-screenshot-freshness.mjs
+++ b/scripts/check-screenshot-freshness.mjs
@@ -37,6 +37,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -204,7 +205,7 @@ function main() {
 }
 
 // CLI 実行時のみ main() を呼ぶ。テストから import される場合は副作用なし
-const invokedAsCli = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+const invokedAsCli = isMainModule(import.meta.url);
 if (invokedAsCli) {
 	main();
 }

--- a/scripts/check-skip-deadlines.mjs
+++ b/scripts/check-skip-deadlines.mjs
@@ -36,6 +36,7 @@ import {
 	reportFindings,
 	walkDir,
 } from './lib/ci/orphan-utils.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const TEST_DIRS = ['tests', 'src'];
 const TEST_EXTENSIONS = ['.ts', '.mjs', '.spec.ts', '.test.ts', '.test.mjs'];
@@ -167,9 +168,7 @@ function main() {
 	process.exit(exit);
 }
 
-const isMain =
-	import.meta.url === `file://${(process.argv[1] || '').replace(/\\/g, '/')}` ||
-	(process.argv[1] || '').endsWith('check-skip-deadlines.mjs');
+const isMain = isMainModule(import.meta.url);
 if (isMain) {
 	main();
 }

--- a/scripts/check-ss-blob-sha-uniqueness.mjs
+++ b/scripts/check-ss-blob-sha-uniqueness.mjs
@@ -1,77 +1,5 @@
 #!/usr/bin/env node
-
-/**
- * scripts/check-ss-blob-sha-uniqueness.mjs (#2063)
- *
- * PR body の Before / After SS が **完全同一画像** (Blob SHA 一致) でないことを検証する CI gate。
- *
- * # 設計背景
- *
- * 2026-05-09 PR-2054 (#1912 LP 文言顧客語彙化) で SS 偽装が 3 ラウンド連続発生し、
- * 最終的に user 判断で PR close。実装ブランチを `git push --force` で 3 回 rebase したものの、
- * **`screenshots` branch (独立 branch) が更新されず**、Before / After SS が 1 byte も違わない
- * **完全同一画像** のまま PR body に貼られ続けた。
- *
- * QA bot が GitHub `gh api repos/.../contents/<path>?ref=screenshots` で
- * Blob SHA (Git の content-addressable hash) を取得・比較し偽装を検出した手動運用を、
- * **CI workflow に組み込み systematic に強制する** のが本スクリプトの責務。
- *
- * # 偽装パターン (PR-2054 実例)
- *
- * - `before-index-desktop.png` SHA `f4d9eebfca72e9efd30cf1c67621b3647357c0ba`
- * - `after-index-desktop.png`  SHA `f4d9eebfca72e9efd30cf1c67621b3647357c0ba` ← 完全一致
- *
- * SHA 完全一致 = 同一 Blob 参照 = 同一画像 1 px 違い無し。
- * これを「視覚的に変化があった証拠」として PR body に貼ると偽装。
- *
- * # 検出ロジック
- *
- * 1. PR body から SS URL を regex で抽出 (`raw.githubusercontent.com/.../screenshots/<path>`)
- * 2. URL から `(owner, repo, ref, path)` を parse
- * 3. `before-` / `after-` prefix で始まる SS をペアリング
- *    (例: `before-index-mobile.png` <-> `after-index-mobile.png`)
- * 4. `gh api repos/{owner}/{repo}/contents/{path}?ref=screenshots` で Blob SHA 取得
- * 5. ペアの SHA が同一 → fail (`core.setFailed`)
- *
- * # スキップ条件 (AC3)
- *
- * - PR ラベル `refactor:internal-no-doc-impact` 付与時 (visual diff ゼロ refactor)
- *   → check-pr-screenshot.mjs / design-doc-check.mjs と同パターン (#2017 / #1985)
- * - SS 1 件のみ / before-only / after-only → 比較対象なし、skip
- *
- * # OSS 先調査 (ADR-0014 / #1350)
- *
- * Issue #2063 本文に 3 選択肢比較記載済 (再記載不要)。本スクリプトは **選択肢 A** を実装:
- * - 採用: GitHub Actions `gh api` + Blob SHA 比較 (確立パターン、~30 行 script)
- * - 不採用: pixelmatch / sharp 画素差分 (Pre-PMF overkill、ADR-0010)
- * - 不採用: 独自 A+B 結合ツール (Pre-PMF overkill)
- *
- * # 環境変数
- *
- *   PR_BODY      — PR body Markdown (github.event.pull_request.body)
- *   PR_LABELS    — カンマ区切りの PR ラベル (gh pr view --json labels --jq ...)
- *   GH_TOKEN     — GitHub API token (gh CLI 経由 or env)
- *   GITHUB_REPOSITORY — `owner/repo` (Actions では自動設定、ローカルなら手動指定)
- *   CHECK_MODE   — 'warn' (default) | 'error'
- *                  'error' で fail 時 exit 1。dogfooding 期間後に昇格。
- *
- * # ローカル実行
- *
- *   PR_BODY="$(gh pr view 2054 --json body --jq .body)" \
- *   PR_LABELS="$(gh pr view 2054 --json labels --jq '[.labels[].name] | join(",")')" \
- *   GITHUB_REPOSITORY=Takenori-Kusaka/ganbari-quest \
- *   CHECK_MODE=error \
- *     node scripts/check-ss-blob-sha-uniqueness.mjs
- *
- * # exit code
- *
- *   0 — OK / skip / warn モードで違反あり
- *   1 — error モードで違反あり
- *   2 — internal error (API rate limit / 認証失敗 / etc)
- */
-
-import { resolve as pathResolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const MODE = (process.env.CHECK_MODE || 'warn').toLowerCase();
 // #2946 (Phase A/A-4): lane は SSOT (actions/pr-lane → scripts/pr-lane.mjs) 経由で渡される。
@@ -385,13 +313,7 @@ async function main() {
 	return isError ? 1 : 0;
 }
 
-const isMain = (() => {
-	try {
-		return pathResolve(fileURLToPath(import.meta.url)) === pathResolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	main().then(

--- a/scripts/check-ss-render-health.mjs
+++ b/scripts/check-ss-render-health.mjs
@@ -1,69 +1,6 @@
 #!/usr/bin/env node
-
-/**
- * scripts/check-ss-render-health.mjs (#3012)
- *
- * screenshots branch に push された PR SS の **render 健全性** (500 / error ページ混入) を
- * 検証する CI gate (補完層)。
- *
- * # 設計背景
- *
- * PR #3006 で /admin/rewards・/admin/checklists の 500 サーバーエラーページが
- * 「実画面 SS」として screenshots branch (`pr-3006/`) に 2 度 push され、既存 CI gate
- * (`ss-blob-sha-uniqueness-check` #2063 / `screenshot-quality-check` #1740/#1741) を
- * green で素通りした。既存 gate は「偽装 (同一画像)」「ローカルパス」を見るが、
- * 「SS が正常画面か」は誰も見ていなかった。
- *
- * # 2 層防御における位置付け
- *
- * - 根本層 (撮影時 assert): `scripts/lib/ci/screenshot-helpers.mjs` `checkRenderHealth`
- *   — capture.mjs / capture-app-baseline.mjs が撮影直前に error ページを検出して exit 1。
- *   error ページ SS はそもそも生成・push されない。
- * - 補完層 (本 script): 旧版 capture script の使用 / 手動 push 等で撮影時 assert を
- *   バイパスされた場合に備え、screenshots branch `pr-<N>/` の `.dom.html`
- *   (SS と同一 page から取得される DOM snapshot、#1766) を text scan して
- *   error ページ marker を検出する。画像解析 (OCR / pixelmatch) は行わない
- *   (Pre-PMF 軽量方針、ADR-0010 — marker 定義は撮影時 assert と同一 SSOT
- *   `detectErrorMarkersInHtml` を共有 #1442)。
- *
- * 加えて、画像 (png/webp/jpeg) が push されているのに対応する `.dom.html` が
- * 存在しないものは **warning として列挙** する (#3006 の実事故 push `744dc5c3a` は
- * dom.html なしの PNG のみ = capture.mjs 正規経路をバイパスした手動 push であり、
- * dom scan では検出不能なため、QM レビュー時の手掛かりとして可視化する)。
- * legit な欠落ケース (before-* rename 運用 / --no-dom-snapshot / *-flow.webp 合成) が
- * あるため hard-fail にはしない。
- *
- * # スキップ条件
- *
- * - PR ラベル `refactor:internal-no-doc-impact` (SS 不要 refactor、#2017 と同パターン)
- * - PR ラベル `ss:error-page-intended` (エラーページ自体のデザイン変更 PR で
- *   error ページ SS の添付が正当な場合。capture.mjs --allow-error-page と対)
- * - screenshots branch に `pr-<N>/` が存在しない / `.dom.html` が 0 件
- *
- * # 環境変数
- *
- *   PR_NUMBER         — PR 番号 (github.event.pull_request.number)
- *   PR_LABELS         — カンマ区切りの PR ラベル
- *   GH_TOKEN          — GitHub API token
- *   GITHUB_REPOSITORY — `owner/repo`
- *   CHECK_MODE        — 'warn' | 'error' (default: 'error'。error ページ混入は顧客提示物の
- *                       毀損で致命的なため #2063 と同様 warn 段階を経ず hard-fail)
- *
- * # ローカル実行
- *
- *   PR_NUMBER=3006 GITHUB_REPOSITORY=Takenori-Kusaka/ganbari-quest \
- *   CHECK_MODE=error node scripts/check-ss-render-health.mjs
- *
- * # exit code
- *
- *   0 — OK / skip / warn モードで違反あり
- *   1 — error モードで違反あり
- *   2 — internal error (API 失敗等)
- */
-
-import { resolve as pathResolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { detectErrorMarkersInHtml } from './lib/ci/screenshot-helpers.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const MODE = (process.env.CHECK_MODE || 'error').toLowerCase();
 const PR_NUMBER = process.env.PR_NUMBER || '';
@@ -309,13 +246,7 @@ async function main() {
 	return isError ? 1 : 0;
 }
 
-const isMain = (() => {
-	try {
-		return pathResolve(fileURLToPath(import.meta.url)) === pathResolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	main().then(

--- a/scripts/check-ssot-parallel-impl.mjs
+++ b/scripts/check-ssot-parallel-impl.mjs
@@ -33,6 +33,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(__dirname, '..');
@@ -319,7 +320,7 @@ function main() {
 }
 
 // CLI 実行時のみ main() を起動 (import 時は副作用なし)。
-const isCli = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+const isCli = isMainModule(import.meta.url);
 if (isCli) {
 	main();
 }

--- a/scripts/check-terminology-coherence.ts
+++ b/scripts/check-terminology-coherence.ts
@@ -39,6 +39,7 @@ import {
 	LOGIN_TERMS,
 	TEMPLATE_TERMS,
 } from '../src/lib/domain/terms.js';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -260,18 +261,8 @@ function main() {
 // Main
 // ---------------------------------------------------------------------------
 
-const isMain = (() => {
-	if (typeof process === 'undefined') return false;
-	const argv1 = process.argv[1];
-	if (!argv1) return false;
-	try {
-		return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(argv1);
-	} catch {
-		return false;
-	}
-})();
-
-if (isMain) {
+// CLI 直接実行判定は scripts/lib/is-main.mjs (SSOT) に委ねる (#3969)。
+if (isMainModule(import.meta.url)) {
 	const code = main();
 	process.exit(code);
 }

--- a/scripts/check-workflow-sparse-checkout-closure.mjs
+++ b/scripts/check-workflow-sparse-checkout-closure.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-workflow-sparse-checkout-closure.mjs
+ *
+ * #3969: workflow の `sparse-checkout` が「実行する script の import 先」まで含んでいるかを検証する gate。
+ *
+ * ## 背景 — なぜこの gate が要るか
+ *
+ * `.github/workflows/` の gate job は、repo 全体を checkout せず
+ * `sparse-checkout` で**必要なファイルだけを個別列挙**している (cone-mode: false)。
+ *
+ * ```yaml
+ * sparse-checkout: |
+ *   actions/pr-lane
+ *   scripts/pr-lane.mjs
+ *   scripts/check-merge-gate-checklist.mjs
+ * sparse-checkout-cone-mode: false
+ * ```
+ *
+ * この形は列挙が「script 単体」で閉じている前提に立っている。**#3969 で CLI 直接実行判定を
+ * `scripts/lib/is-main.mjs` (SSOT) へ集約した結果、その前提が壊れた。** 列挙された script が
+ * SSOT helper を import するようになり、helper が checkout されていない job は
+ * `ERR_MODULE_NOT_FOUND` で落ちる。実際に必須 gate 6 job が同時に fail した。
+ *
+ * 今後 gate script を追加するたびに (`check-cli-entry-guard.mjs` が SSOT 利用を強制するため)
+ * **必ず helper への import が生える**。つまりこれは一度直せば済む事故ではなく、
+ * 列挙を手で書き続ける限り再発し続ける構造である。人間の注意力ではなく gate で閉じる
+ * (ADR-0061 same-class-N→guard)。
+ *
+ * ## 検査内容
+ *
+ * `sparse-checkout` ブロックごとに、列挙された JS/MJS ファイルの**相対 import を再帰的に辿り**、
+ * 到達する repo 内ファイルがすべて同じブロックに含まれているかを見る。
+ * 含まれていなければ violation として報告する。
+ *
+ * ディレクトリ列挙 (`actions/pr-lane` 等) は prefix 一致で「含まれている」と扱う。
+ *
+ * ## 検査しないこと (意図的な限界)
+ *
+ * - **bare specifier** (`node:fs` / npm パッケージ) は対象外。checkout ではなく
+ *   `npm ci` の担当であり、sparse-checkout の完全性とは別の問題。
+ * - **動的 import** (`await import(expr)`) は式が静的に決まらないため辿れない。
+ *   gate script は起動時 import で書かれている前提。
+ * - **`.ts` の gate** を列挙した場合、その import は辿らない (起点は `JS_EXTS` のみ)。
+ *   現状 sparse-checkout に列挙されている実体は `.mjs` と `actions/pr-lane` だけなので穴は顕在化しない。
+ *   `.ts` gate を列挙するときは `JS_EXTS` に `.ts` を足し、拡張子省略 import の解決を追加する必要がある。
+ * - **import 以外のリポジトリ内ファイル依存** (`readFileSync('docs/...')` 等) は辿らない。
+ *   現在列挙されている 6 script はいずれも入力が env と引数のみで、repo 内ファイルを読んでいない。
+ * - workflow が `run:` で実際にどの script を叩くかは見ない。列挙されたものだけを起点にする
+ *   (列挙されていない script を叩く job は sparse-checkout 以前の問題として CI が即落ちる)。
+ *
+ * ## 使い方
+ *
+ *   node scripts/check-workflow-sparse-checkout-closure.mjs   # 不足があれば exit 1
+ *   node scripts/check-workflow-sparse-checkout-closure.mjs --help
+ *
+ * ## 関連
+ *   - scripts/lib/is-main.mjs (本 gate が生まれる原因になった SSOT helper)
+ *   - scripts/check-cli-entry-guard.mjs (SSOT 利用を強制する側の gate)
+ *   - tests/unit/scripts/workflow-sparse-checkout-closure.test.ts
+ *   - Issue #3969
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, posix, relative, resolve, sep } from 'node:path';
+import { isMain as isMainModule } from './lib/is-main.mjs';
+
+const WORKFLOW_DIR = join('.github', 'workflows');
+/** import を辿る対象の拡張子。 */
+const JS_EXTS = ['.mjs', '.cjs', '.js'];
+
+/**
+ * `sparse-checkout: |` の literal block scalar を行ベースで抽出する。
+ *
+ * YAML パーサを使わないのは、対象が「key + block scalar」という単純形に限られ、
+ * かつ workflow の他の構文に一切依存しないため。行の字下げだけで閉じ判定できる。
+ *
+ * @param {string} source workflow YAML の内容
+ * @returns {Array<{ line: number, entries: string[] }>} 1-origin 行番号と列挙されたパス
+ */
+export function parseSparseCheckoutBlocks(source) {
+	const lines = source.split(/\r?\n/);
+	/** @type {Array<{ line: number, entries: string[] }>} */
+	const blocks = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const m = /^(\s*)sparse-checkout:\s*\|\s*$/.exec(lines[i] ?? '');
+		if (!m) continue;
+		const keyIndent = (m[1] ?? '').length;
+		/** @type {string[]} */
+		const entries = [];
+		for (let j = i + 1; j < lines.length; j++) {
+			const line = lines[j] ?? '';
+			if (line.trim() === '') continue;
+			const indent = line.length - line.trimStart().length;
+			// block scalar は key より深く字下げされた行のみ。浅くなった時点で終端。
+			if (indent <= keyIndent) break;
+			entries.push(line.trim());
+		}
+		blocks.push({ line: i + 1, entries });
+	}
+	return blocks;
+}
+
+/**
+ * 1 ファイルの相対 import specifier を抽出する。
+ *
+ * `import ... from './x.mjs'` / `import './x.mjs'` / `export ... from './x.mjs'` の 3 形。
+ * bare specifier (`node:fs` / npm) は相対でないため自然に除外される。
+ *
+ * @param {string} source
+ * @returns {string[]}
+ */
+export function extractRelativeImports(source) {
+	/** @type {string[]} */
+	const specs = [];
+	const re = /(?:^|\n)\s*(?:import|export)\s[^;\n]*?['"](\.[^'"]+)['"]/g;
+	let m = re.exec(source);
+	while (m !== null) {
+		const spec = m[1];
+		if (spec !== undefined) specs.push(spec);
+		m = re.exec(source);
+	}
+	// `import './side-effect.mjs'` (from を伴わない形)
+	const sideEffect = /(?:^|\n)\s*import\s+['"](\.[^'"]+)['"]/g;
+	m = sideEffect.exec(source);
+	while (m !== null) {
+		const spec = m[1];
+		if (spec !== undefined && !specs.includes(spec)) specs.push(spec);
+		m = sideEffect.exec(source);
+	}
+	return specs;
+}
+
+/**
+ * repo 相対パスが、列挙された entry のいずれかで覆われているか。
+ *
+ * entry がファイルなら完全一致、ディレクトリなら prefix 一致で覆う。
+ *
+ * @param {string} relPath posix 区切りの repo 相対パス
+ * @param {readonly string[]} entries
+ * @returns {boolean}
+ */
+export function isCoveredBy(relPath, entries) {
+	return entries.some((entry) => {
+		const e = entry.replace(/^\.\//, '').replace(/\/+$/, '');
+		return relPath === e || relPath.startsWith(`${e}/`);
+	});
+}
+
+/** @param {string} p @returns {string} */
+function toPosix(p) {
+	return p.split(sep).join('/');
+}
+
+/**
+ * 起点ファイル群から相対 import を再帰的に辿り、到達する repo 相対パス集合を返す。
+ *
+ * 起点自身は含めない (起点は定義上 sparse-checkout に列挙されている)。
+ *
+ * @param {string} repoRoot
+ * @param {readonly string[]} startRelPaths posix 区切りの repo 相対パス
+ * @returns {string[]} posix 区切りの repo 相対パス (到達順、重複なし)
+ */
+export function collectTransitiveDeps(repoRoot, startRelPaths) {
+	/** @type {Set<string>} */
+	const seen = new Set(startRelPaths);
+	/** @type {string[]} */
+	const found = [];
+	/** @type {string[]} */
+	const queue = [...startRelPaths];
+
+	while (queue.length > 0) {
+		const current = /** @type {string} */ (queue.shift());
+		const abs = join(repoRoot, current);
+		if (!existsSync(abs)) continue;
+		if (!JS_EXTS.some((ext) => current.endsWith(ext))) continue;
+
+		for (const spec of extractRelativeImports(readFileSync(abs, 'utf8'))) {
+			const depRel = toPosix(relative(repoRoot, resolve(dirname(abs), spec)));
+			// repo 外へ出る import は checkout の対象外 (そもそも存在し得ない)
+			if (depRel.startsWith('..')) continue;
+			if (seen.has(depRel)) continue;
+			seen.add(depRel);
+			found.push(depRel);
+			queue.push(depRel);
+		}
+	}
+	return found;
+}
+
+/**
+ * workflow 1 ファイルを検査する (純粋部分は上記 export 群、こちらは fs 依存)。
+ *
+ * `enumerated` / `resolved` も返すのは、**本 gate 自身が無言 PASS する条件を可視化する**ため。
+ * 列挙された script が 1 本も disk 上に無い環境 (sparse checkout された作業ツリー等) では
+ * 起点が空になり、違反 0 件 = exit 0 になる。それを「検証した」と読み違えないよう、
+ * main() 側で「起点 0 本」を OK と区別して表示する (#3969 が閉じる class と同型のため)。
+ *
+ * @param {string} repoRoot
+ * @param {string} workflowRelPath posix 区切り
+ * @returns {{ violations: Array<{ workflow: string, line: number, missing: string, via: string }>, enumerated: string[], resolved: string[] }}
+ */
+function checkWorkflow(repoRoot, workflowRelPath) {
+	const source = readFileSync(join(repoRoot, workflowRelPath), 'utf8');
+	/** @type {Array<{ workflow: string, line: number, missing: string, via: string }>} */
+	const violations = [];
+	/** @type {string[]} */
+	const enumerated = [];
+	/** @type {string[]} */
+	const resolved = [];
+
+	for (const block of parseSparseCheckoutBlocks(source)) {
+		const jsEntries = block.entries.filter((e) => JS_EXTS.some((ext) => e.endsWith(ext)));
+		const starts = jsEntries.filter((e) => existsSync(join(repoRoot, e)));
+		enumerated.push(...jsEntries);
+		resolved.push(...starts);
+		if (starts.length === 0) continue;
+
+		for (const dep of collectTransitiveDeps(repoRoot, starts)) {
+			if (isCoveredBy(dep, block.entries)) continue;
+			violations.push({
+				workflow: workflowRelPath,
+				line: block.line,
+				missing: dep,
+				via: starts.join(', '),
+			});
+		}
+	}
+	return { violations, enumerated, resolved };
+}
+
+function printHelp() {
+	console.log(`check-workflow-sparse-checkout-closure.mjs — sparse-checkout の import 閉包検証 (Issue #3969)
+
+検査対象: ${toPosix(WORKFLOW_DIR)}/*.yml の \`sparse-checkout: |\` ブロック
+検査内容: 列挙された ${JS_EXTS.join(' / ')} の相対 import を再帰的に辿り、
+          到達先が同じブロックに列挙されているかを確認する
+
+対象外  : bare specifier (node: / npm) — npm ci の担当
+          動的 import — 式が静的に決まらない
+
+使い方  : node scripts/check-workflow-sparse-checkout-closure.mjs`);
+}
+
+function main() {
+	if (process.argv.includes('--help') || process.argv.includes('-h')) {
+		printHelp();
+		return 0;
+	}
+
+	const repoRoot = process.cwd();
+	const dir = join(repoRoot, WORKFLOW_DIR);
+	if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+		console.log(
+			`[check-workflow-sparse-checkout-closure] SKIP: ${toPosix(WORKFLOW_DIR)} が無い (sparse checkout 環境)`,
+		);
+		return 0;
+	}
+
+	const workflows = readdirSync(dir)
+		.filter((n) => n.endsWith('.yml') || n.endsWith('.yaml'))
+		.map((n) => posix.join(toPosix(WORKFLOW_DIR), n));
+
+	const results = workflows.map((w) => checkWorkflow(repoRoot, w));
+	const violations = results.flatMap((r) => r.violations);
+	const enumerated = results.flatMap((r) => r.enumerated);
+	const resolved = results.flatMap((r) => r.resolved);
+
+	// 起点が 1 本も解決できなければ「漏れ 0 件」ではなく「未検証」。無言 PASS を OK と呼ばない。
+	if (resolved.length === 0) {
+		console.log(
+			`[check-workflow-sparse-checkout-closure] SKIP: 列挙された ${enumerated.length} 本の script が disk 上に無く、閉包は未検証 (sparse checkout 環境)`,
+		);
+		return 0;
+	}
+
+	if (violations.length === 0) {
+		console.log(
+			`[check-workflow-sparse-checkout-closure] OK: ${workflows.length} workflow / 起点 ${resolved.length} 本の sparse-checkout に import 漏れ 0 件`,
+		);
+		return 0;
+	}
+
+	console.error(
+		`[check-workflow-sparse-checkout-closure] FAIL: ${violations.length} 件の import 漏れ`,
+	);
+	console.error('');
+	for (const v of violations) {
+		console.error(`  ${v.workflow}:${v.line}  不足: ${v.missing}`);
+		console.error(`      ${v.via} が import しているが sparse-checkout に列挙されていない`);
+	}
+	console.error('');
+	console.error(
+		'  対処: 当該 sparse-checkout ブロックに上記パスを追加する (job は ERR_MODULE_NOT_FOUND で落ちる)',
+	);
+	return 1;
+}
+
+if (isMainModule(import.meta.url)) {
+	process.exit(main());
+}

--- a/scripts/claude-hook-prevent-qa-account-pr.mjs
+++ b/scripts/claude-hook-prevent-qa-account-pr.mjs
@@ -31,7 +31,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 export const ALLOWED_PR_AUTHOR_DEFAULT = 'Takenori-Kusaka';
 export const QA_ACCOUNT = 'ganbariquestsupport-lab';
@@ -155,8 +155,7 @@ async function main() {
 }
 
 // CLI として直接実行されたときのみ main() を呼ぶ。`import` 経由 (unit test 等) では実行されない。
-const isDirectInvocation =
-	process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+const isDirectInvocation = isMainModule(import.meta.url);
 if (isDirectInvocation) {
 	main();
 }

--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -21,6 +21,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -806,7 +807,7 @@ function main() {
 }
 
 // CLI 実行時のみ main() を呼ぶ。テストから import される場合は副作用なし
-const invokedAsCli = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+const invokedAsCli = isMainModule(import.meta.url);
 if (invokedAsCli) {
 	main();
 }

--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -31,6 +31,7 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..');
@@ -219,10 +220,7 @@ function main() {
 }
 
 // ESM の直接実行判定 (import 経由ではテスト時 main() を呼ばない)
-const entryArg = process.argv[1] ?? '';
-const isDirectRun =
-	import.meta.url === `file://${entryArg.replace(/\\/g, '/')}` ||
-	import.meta.url.endsWith(path.basename(entryArg));
+const isDirectRun = isMainModule(import.meta.url);
 if (isDirectRun) {
 	main();
 }

--- a/scripts/hotfix-back-merge.mjs
+++ b/scripts/hotfix-back-merge.mjs
@@ -1,64 +1,5 @@
 #!/usr/bin/env node
-/**
- * scripts/hotfix-back-merge.mjs — Issue #2951 (Phase B/B-5、親 #2949 / EPIC #2861)
- *
- * develop 二層ブランチ戦略 (docs/sessions/branch-strategy.md §5「hotfix 経路」) における
- * 「main に merge された PR が hotfix で、main → develop back-merge を発行すべきか」を
- * 判定する **純粋関数 SSOT** (`.github/workflows/hotfix-back-merge.yml` の薄い orchestrator が
- * 本 script を呼ぶ。判定 logic は全て本 file に集約し yml に分散させない)。
- *
- * 背景:
- *   `branch-strategy.md` §5 は「hotfix を main に merge したら同じ修正を develop へ back-merge
- *   する (main / develop の drift 防止)」を **必須** と定めるが、現状 **人手運用で機械強制が無い**。
- *   hotfix は緊急対応で出されるため最も back-merge を忘れやすく、忘れると
- *   (1) develop に hotfix が欠落して次の統合 PR で同バグ再混入
- *   (2) develop → main 統合 PR で hotfix と conflict
- *   (3) main / develop が静かに drift して統合 PR が肥大化
- *   という git flow 典型の失敗が起きる。本 script + workflow がこれを機械強制する。
- *
- * `scripts/pr-lane.mjs` (#2943 A-1) との責務分担:
- *   - pr-lane.mjs = **PR event 基点** の lane 分類 (baseRef/headRef/actor → feature/integration/...)。
- *     back-merge PR (head=main, base=develop) を 'feature' 軽量レーンに分類する (rule 4)。
- *   - hotfix-back-merge.mjs (本 file) = **push[main] event 基点** の back-merge 要否判定。
- *     「今 main に merge された PR が hotfix か (= back-merge を発行すべきか)」を判定する。
- *   両者は入力源 (PR event vs merge commit / push event) と用途 (lane 分類 vs back-merge 起動) が
- *   異なるため統合しない。lane 値の凡例 (feature/integration/hotfix) は共有概念。
- *
- * 判定の核心 (3 つの純粋関数):
- *
- *   1. classifyMergedPr({ headRef, baseRef, labels })
- *      → 'hotfix' | 'integration' | 'other'
- *      main に merge された PR を分類する。
- *      - baseRef === 'main' かつ headRef === 'develop'           → 'integration' (統合 PR)
- *      - baseRef === 'main' かつ (headRef が 'fix/' で始まる       → 'hotfix'
- *           または labels に 'hotfix' / 'priority:critical')
- *      - 上記以外                                                  → 'other'
- *
- *   2. shouldBackMerge(classification)
- *      → boolean
- *      'hotfix' のみ true。'integration' は false (AC2: develop は同期済 = 無限ループ防止)。
- *      'other' も false (通常 push / 非 PR merge)。
- *
- *   3. backMergeBranchName(hotfixRef)
- *      → 'back-merge/<sanitized-hotfix-ref>'
- *      back-merge branch 名を決定的に生成 (同 hotfix の再実行で同名 = upsert 可能)。
- *
- *   no-op 判定 (AC5: 既に develop に同 commit があれば二重適用しない) は
- *   git の `git merge-base --is-ancestor <merge_sha> origin/develop` で workflow 側が行う
- *   (git 状態への副作用を伴うため本 pure script の責務外。本 file は「back-merge を起動すべき
- *   PR か」までを純粋判定し、git 実操作は workflow に委ねる = testability を保つ)。
- *
- * Usage (CLI、workflow から呼ぶ):
- *   node scripts/hotfix-back-merge.mjs --base main --head fix/999-x --labels "priority:critical,type:infra"
- *     → stdout に JSON: {"classification":"hotfix","shouldBackMerge":true,"branch":"back-merge/fix-999-x"}
- *   node scripts/hotfix-back-merge.mjs --base main --head develop
- *     → {"classification":"integration","shouldBackMerge":false,"branch":null}
- *
- * exit: 0 = 判定成功 (JSON を stdout 出力) / 2 = 引数不足
- */
-
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /** hotfix とみなす PR label (headRef が fix/* でなくてもこの label があれば hotfix 扱い)。 */
 export const HOTFIX_LABELS = new Set(['hotfix', 'priority:critical']);
@@ -167,13 +108,7 @@ export function parseArgs(argv) {
 	};
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	const { baseRef, headRef, labels } = parseArgs(process.argv.slice(2));

--- a/scripts/integration-pr-body.mjs
+++ b/scripts/integration-pr-body.mjs
@@ -51,8 +51,7 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /**
  * PR の labels（string[] or {name}[]）を string[] に正規化する純粋関数。
@@ -504,13 +503,7 @@ export function parseArgs(argv) {
 	return out;
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	const args = parseArgs(process.argv.slice(2));

--- a/scripts/lib/ci/resolve-base-branch.mjs
+++ b/scripts/lib/ci/resolve-base-branch.mjs
@@ -41,8 +41,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from '../is-main.mjs';
 
 /**
  * base branch 解決の純粋関数 (unit test 対象、Issue #2959 AC1)。
@@ -228,13 +227,7 @@ export function resolveBaseBranchAuto(opts = {}) {
 	});
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	try {

--- a/scripts/lib/is-main.mjs
+++ b/scripts/lib/is-main.mjs
@@ -1,0 +1,77 @@
+/**
+ * CLI script が「直接実行された」かを判定する SSOT helper (Issue #3969)。
+ *
+ * ## なぜ helper が必要か
+ *
+ * 従来 `scripts/` 配下の各 script は末尾で以下のような自前の判定を書いていた:
+ *
+ * ```js
+ * const isMain = resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
+ * if (isMain) main();
+ * ```
+ *
+ * この形は **symlink / junction 経由で起動すると必ず false になる**。
+ * `import.meta.url` は Node が実体パスへ解決するのに対し、`process.argv[1]` は
+ * ユーザーが与えたパスのまま絶対化されるだけだからである。結果として
+ * `main()` が呼ばれず、**何も検査しないまま exit 0 (= PASS)** になる。
+ *
+ * gate script でこれが起きると「壊れていることに誰も気付かない」ため、
+ * 誤った plan を黙って書き込む silent fallback と同じ class の事故になる。
+ *
+ * さらに `import.meta.url === \`file://${process.argv[1]}\`` という手組み URL 比較は
+ * Windows で `file:///E:/...` と `file://E:\...` を比較することになり、
+ * symlink の有無に関係なく**常に false** になる。
+ *
+ * ## 判定方針
+ *
+ * 両辺を `realpath` で正規化してから比較する。symlink / junction / 相対パス /
+ * 大文字小文字ゆれ (Windows) のいずれでも同じ結論になる。
+ */
+
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * パスを比較可能な正規形へ落とす。
+ *
+ * - symlink / junction は実体へ解決する
+ * - 解決できない場合 (ファイルが消えている等) は絶対パス化のみに fallback する
+ * - Windows は path が case-insensitive なので小文字へ寄せる
+ *
+ * @param {string} p
+ * @returns {string}
+ */
+function canonicalize(p) {
+	const absolute = resolve(p);
+	let real;
+	try {
+		// realpathSync.native は Windows でドライブレターの表記ゆれも正規化する
+		real = realpathSync.native ? realpathSync.native(absolute) : realpathSync(absolute);
+	} catch {
+		real = absolute;
+	}
+	return process.platform === 'win32' ? real.toLowerCase() : real;
+}
+
+/**
+ * 呼び出し元 module が CLI として直接実行されたかを返す。
+ *
+ * `import` 経由 (unit test 等) では false を返すため、
+ * `if (isMain(import.meta.url)) main();` の形で使う。
+ *
+ * @param {string} importMetaUrl 呼び出し元の `import.meta.url`
+ * @param {string | undefined} [argv1] 既定は `process.argv[1]` (テスト用に注入可能)
+ * @returns {boolean}
+ */
+export function isMain(importMetaUrl, argv1 = process.argv[1]) {
+	if (typeof importMetaUrl !== 'string' || importMetaUrl === '') return false;
+	if (typeof argv1 !== 'string' || argv1 === '') return false;
+	try {
+		return canonicalize(fileURLToPath(importMetaUrl)) === canonicalize(argv1);
+	} catch {
+		return false;
+	}
+}
+
+export default isMain;

--- a/scripts/measure-lp-dimensions.mjs
+++ b/scripts/measure-lp-dimensions.mjs
@@ -15,9 +15,9 @@
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { extname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
 import { waitForStablePage } from './lib/ci/screenshot-helpers.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const log = (...a) => console.log(...a);
 const logErr = (...a) => console.error(...a);
@@ -581,7 +581,7 @@ async function main() {
 }
 
 // CLI として直接実行されたときのみ main() を起動 (#1783: テストで import しても副作用を出さない)
-if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+if (isMainModule(import.meta.url)) {
 	main().catch((err) => {
 		logErr('[measure] error:', err);
 		process.exit(1);

--- a/scripts/pr-lane.mjs
+++ b/scripts/pr-lane.mjs
@@ -1,63 +1,5 @@
 #!/usr/bin/env node
-/**
- * scripts/pr-lane.mjs — Issue #2943 (Phase A/A-1、親 #2942 / EPIC #2861)
- *
- * develop 二層ブランチ戦略 (docs/sessions/branch-strategy.md §3〜§5) における
- * 「この PR がどのレーンか」を判定する **CI 側 (サーバ gate 用) の正準ロジック (SSOT)**。
- *
- * 背景:
- *   現状、PR の種別判定は (1) Dependabot exempt = `github.actor != 'dependabot[bot]'` の
- *   文字列が 6+ workflow に inline 重複、(2) main/develop/hotfix の base/head 判定 =
- *   `ci.yml` の `main-pr-base-guard` に bash で 1 箇所だけ、と散在している。
- *   lane-aware 化 (A-2〜A-5) を進めると同じ判定を 6 workflow にコピペすることになり、
- *   判定基準のドリフトが構造的に発生する。本 script はその判定を 1 つの純粋関数に集約し、
- *   composite action (actions/pr-lane) 経由で全 gate が同一 SSOT を参照する
- *   (terms.ts / ADR-0042 の 3 層トークンと同型の SSOT 思想)。
- *
- * `scripts/lib/ci/resolve-base-branch.mjs` (#2959) との責務分担:
- *   - resolve-base-branch.mjs = **クライアント tooling 用** (local git 基点)。
- *     「現在の branch がどの base に push / PR すべきか」を local git / gh から解決する。
- *     副作用あり (execSync で git / gh を叩く)。
- *   - pr-lane.mjs (本 file) = **CI gate 用** (PR event payload 基点)。
- *     既に確定した PR の baseRef / headRef / actor から lane を分類する純粋関数。
- *     副作用ゼロ (GitHub API / file write を一切行わない、AC6)。
- *   両者は入力源 (local git 推定 vs PR event payload の確定値) と用途が異なるため統合せず、
- *   概念整合を本コメントで相互参照する (#2943 related / #2959 follow-up 評価結果)。
- *   統合しない判断: pr-lane は base/head/actor を「確定値」として受け取る pure function で
- *   ある一方、resolve-base-branch は local git を推定走査する副作用関数であり、
- *   片方を他方の入力にすると pure function の testability (AC6) が崩れるため。
- *
- * lane 分類 (4 種、決定的・優先順位付き = 最初にマッチした lane を返す):
- *   1. actor が `dependabot[bot]` / `renovate[bot]`       → 'dependabot'
- *   2. baseRef === 'main' かつ (headRef === 'develop' または headRef が 'release/' で始まる)
- *                                                         → 'integration' (統合 PR、重量レーン)
- *   3. headRef が 'fix/' で始まり baseRef === 'main'      → 'hotfix'      (ADR-0002 重量レーン)
- *   4. baseRef === 'develop'                              → 'feature'    (軽量レーン)
- *   5. 上記いずれにも非該当                                → 'feature'    (既定、後方互換)
- *
- * release ブランチ方式 (branch-strategy.md §3、#3021 動く標的問題の構造的解消):
- *   develop の凍結コミットから cut した `release/*` を frozen 標的として main へ統合する。
- *   release/* → main も develop → main と同じ integration (重量レーン) として扱い、
- *   統合観点の AC gate / 重量 job を保証発火させる。
- *
- * back-merge PR の帰属 (#2960 / #2967 実地観測):
- *   hotfix を main に merge した後の main → develop back-merge PR
- *   (head=main、base=develop、branch-strategy.md §3「ホットフィックス経路」)は
- *   rule 4 (baseRef === 'develop') で **'feature' (軽量レーン)** に分類される。
- *   develop に取り込む変更は軽量レーン gate で十分であり、5 つ目の lane を新設しない
- *   (no-go: 「lane を 4 種から増やさない」ADR-0010 Pre-PMF)。rule 2 の integration は
- *   head=develop & base=main の逆向きなので back-merge とは衝突しない。
- *
- * Usage (CLI、AC5):
- *   node scripts/pr-lane.mjs --base main --head develop --actor x   # => "integration"
- *   node scripts/pr-lane.mjs --base main --head release/2026-06-16 --actor x  # => "integration"
- *   node scripts/pr-lane.mjs --base develop --head feat/123 --actor Takenori-Kusaka  # => "feature"
- *
- * exit: 0 = 分類成功 (lane を stdout に出力) / 2 = 引数不足
- */
-
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /**
  * `dependabot` lane に分類される bot actor の集合 (SSOT、#2947 AC1)。
@@ -133,13 +75,7 @@ export function parseArgs(argv) {
 	return { baseRef: out.base ?? '', headRef: out.head ?? '', actor: out.actor ?? '' };
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	const { baseRef, headRef, actor } = parseArgs(process.argv.slice(2));

--- a/scripts/pr-template-gate-checks.mjs
+++ b/scripts/pr-template-gate-checks.mjs
@@ -40,9 +40,8 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { extractClosedIssues } from './integration-pr-body.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /**
  * @typedef {'feature' | 'integration' | 'hotfix' | 'dependabot'} Lane
@@ -775,13 +774,7 @@ export function parseArgs(argv) {
 	return out;
 }
 
-const isMain = (() => {
-	try {
-		return resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	const args = parseArgs(process.argv.slice(2));

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -67,6 +67,7 @@ const SKIP_FLAGS = {
 	'--skip-plan-literals': 'skipPlanLiterals',
 	'--skip-license-key-leak': 'skipLicenseKeyLeak',
 	'--skip-cli-entry-guard': 'skipCliEntryGuard',
+	'--skip-sparse-checkout-closure': 'skipSparseCheckoutClosure',
 	'--skip-lp-labels': 'skipLpLabels',
 	'--skip-pr-body': 'skipPrBody',
 	'--skip-doc-code-references': 'skipDocCodeReferences',
@@ -87,6 +88,7 @@ function parseArgs(argv) {
 		skipPlanLiterals: false,
 		skipLicenseKeyLeak: false,
 		skipCliEntryGuard: false,
+		skipSparseCheckoutClosure: false,
 		skipLpLabels: false,
 		skipPrBody: false,
 		skipDocCodeReferences: false,
@@ -130,6 +132,7 @@ Options:
   --skip-plan-literals   Step 7 plan/status リテラル直書き検査をスキップ (#972 / Phase 5 F1)
   --skip-license-key-leak Step 7b license key 再導入防止検査をスキップ (#2836 / Phase 7 PR-L4)
   --skip-cli-entry-guard Step 7c 自前の CLI 直接実行判定 / 手組み file:// URL 検査をスキップ (#3969)
+  --skip-sparse-checkout-closure Step 7d workflow sparse-checkout の import 閉包検査をスキップ (#3969)
   --skip-lp-labels       Step 8 LP labels 同期検査をスキップ (labels.ts / terms.ts / age-tier.ts 変更時のみ自動実行、Phase 1 B1)
   --skip-pr-body         Step 9 PR body 検査をスキップ
   --skip-doc-code-references Step 10 デッドリンク検査をスキップ
@@ -148,6 +151,7 @@ Steps:
   6.  sync-lp-fallback.mjs        — LP fallback テキスト同期検査 (LP / labels.ts 変更時のみ、#1945)
   7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972 / Phase 5 F1 / #1918)
   7c. check-cli-entry-guard.mjs  — 自前の CLI 直接実行判定 / 手組み file:// URL 禁止 (#3969)
+  7d. check-workflow-sparse-checkout-closure.mjs — workflow sparse-checkout の import 閉包検査 (#3969)
   8.  generate-lp-labels --check  — site/shared-labels.js 同期検査 (labels.ts / terms.ts / age-tier.ts 変更時のみ、Phase 1 B1 / #1917)
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
   10. check-doc-code-references.mjs — ドキュメントのデッドリンク検知 (#2577)
@@ -381,6 +385,12 @@ function buildSteps(args, changedFiles) {
 	// #3969: 自前の CLI 直接実行判定 / 手組み file:// URL の再混入を止める gate
 	const cliEntryGuardScript = resolve(repoRoot, 'scripts/check-cli-entry-guard.mjs');
 	const cliEntryGuardScriptExists = existsSync(cliEntryGuardScript);
+	// #3969: workflow の sparse-checkout が「実行する script の import 先」まで列挙しているかの検査
+	const sparseClosureScript = resolve(
+		repoRoot,
+		'scripts/check-workflow-sparse-checkout-closure.mjs',
+	);
+	const sparseClosureScriptExists = existsSync(sparseClosureScript);
 
 	return [
 		{
@@ -500,6 +510,26 @@ function buildSteps(args, changedFiles) {
 				'          `if (isMain(import.meta.url)) main();` の形にする\n' +
 				'  - path → URL は node:url の pathToFileURL() を使う (手組みは Windows で常に不一致)\n' +
 				'  - 正当な例外は `allow-argv1: <理由>` / `allow-file-url: <理由>` を当該行か直前行に置く',
+		},
+		// Step 7d: check-workflow-sparse-checkout-closure (#3969)
+		// gate job は sparse-checkout で必要ファイルを個別列挙する。Step 7c が判定 SSOT の利用を
+		// 強制するため、gate script を列挙するたびに helper への import が生え、列挙し忘れると
+		// job が ERR_MODULE_NOT_FOUND で落ちる (#3969 対応時に必須 gate 6 job が同時 fail した)。
+		{
+			name: 'sparse-checkout-closure',
+			label: sparseClosureScriptExists
+				? 'Step 7d/12: check-workflow-sparse-checkout-closure.mjs (#3969)'
+				: 'Step 7d/12: check-workflow-sparse-checkout-closure.mjs (script 未配備 — skip)',
+			skip: args.skipSparseCheckoutClosure || !sparseClosureScriptExists,
+			runner: () =>
+				run('check-workflow-sparse-checkout-closure', [
+					'node',
+					'scripts/check-workflow-sparse-checkout-closure.mjs',
+				]),
+			fixHint:
+				'  workflow の sparse-checkout に import 先の列挙漏れがあります (#3969)。\n' +
+				'  - 修正: 出力された不足パスを当該 sparse-checkout ブロックに追加する\n' +
+				'  - 放置すると当該 job が ERR_MODULE_NOT_FOUND で落ちる (無言 PASS ではなく hard fail)',
 		},
 		// Step 8: generate-lp-labels --check (Phase 1 B1 / #1917)
 		// Issue #1920 graceful degradation: 検査 script が未配備なら skip + warning。

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -41,6 +41,7 @@ import { existsSync, statSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isAllowedBaseBranch, resolveBaseBranchAuto } from './lib/ci/resolve-base-branch.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -65,6 +66,7 @@ const SKIP_FLAGS = {
 	'--skip-lp-fallback': 'skipLpFallback',
 	'--skip-plan-literals': 'skipPlanLiterals',
 	'--skip-license-key-leak': 'skipLicenseKeyLeak',
+	'--skip-cli-entry-guard': 'skipCliEntryGuard',
 	'--skip-lp-labels': 'skipLpLabels',
 	'--skip-pr-body': 'skipPrBody',
 	'--skip-doc-code-references': 'skipDocCodeReferences',
@@ -84,6 +86,7 @@ function parseArgs(argv) {
 		skipLpFallback: false,
 		skipPlanLiterals: false,
 		skipLicenseKeyLeak: false,
+		skipCliEntryGuard: false,
 		skipLpLabels: false,
 		skipPrBody: false,
 		skipDocCodeReferences: false,
@@ -126,6 +129,7 @@ Options:
   --skip-lp-fallback     Step 6 LP fallback 同期検査をスキップ (LP / labels.ts 変更時のみ自動実行)
   --skip-plan-literals   Step 7 plan/status リテラル直書き検査をスキップ (#972 / Phase 5 F1)
   --skip-license-key-leak Step 7b license key 再導入防止検査をスキップ (#2836 / Phase 7 PR-L4)
+  --skip-cli-entry-guard Step 7c 自前の CLI 直接実行判定 / 手組み file:// URL 検査をスキップ (#3969)
   --skip-lp-labels       Step 8 LP labels 同期検査をスキップ (labels.ts / terms.ts / age-tier.ts 変更時のみ自動実行、Phase 1 B1)
   --skip-pr-body         Step 9 PR body 検査をスキップ
   --skip-doc-code-references Step 10 デッドリンク検査をスキップ
@@ -143,6 +147,7 @@ Steps:
   5.  measure-lp-dimensions.mjs   — LP 寸法 / 禁止語 (LP 変更時のみ)
   6.  sync-lp-fallback.mjs        — LP fallback テキスト同期検査 (LP / labels.ts 変更時のみ、#1945)
   7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972 / Phase 5 F1 / #1918)
+  7c. check-cli-entry-guard.mjs  — 自前の CLI 直接実行判定 / 手組み file:// URL 禁止 (#3969)
   8.  generate-lp-labels --check  — site/shared-labels.js 同期検査 (labels.ts / terms.ts / age-tier.ts 変更時のみ、Phase 1 B1 / #1917)
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
   10. check-doc-code-references.mjs — ドキュメントのデッドリンク検知 (#2577)
@@ -373,6 +378,9 @@ function buildSteps(args, changedFiles) {
 	// #2836 (Epic #2525 Phase 7 PR-L4): license key 全廃の再導入防止 gate
 	const licenseKeyLeakScript = resolve(repoRoot, 'scripts/check-license-key-leak.mjs');
 	const licenseKeyLeakScriptExists = existsSync(licenseKeyLeakScript);
+	// #3969: 自前の CLI 直接実行判定 / 手組み file:// URL の再混入を止める gate
+	const cliEntryGuardScript = resolve(repoRoot, 'scripts/check-cli-entry-guard.mjs');
+	const cliEntryGuardScriptExists = existsSync(cliEntryGuardScript);
 
 	return [
 		{
@@ -474,6 +482,24 @@ function buildSteps(args, changedFiles) {
 				'  - LP / メール / ラベル / UI で license key 概念を再導入しないでください。\n' +
 				'  - entitlement は Stripe Subscription (tenant.status=ACTIVE) が唯一 SSOT です。\n' +
 				'  - DB 層 / LEGACY_URL_MAP entry は PR-L5 担当の allowlist (FILE_ALLOWLIST)。',
+		},
+		// Step 7c: check-cli-entry-guard (#3969)
+		// 各 script が自前で書く「直接実行判定」は symlink / junction 経由で必ず false になり、
+		// main() が呼ばれず「何も検査せず exit 0 (= PASS)」になる。判定 SSOT は
+		// scripts/lib/is-main.mjs で、本 step は次の方言が持ち込まれるのを止める。
+		{
+			name: 'cli-entry-guard',
+			label: cliEntryGuardScriptExists
+				? 'Step 7c/12: check-cli-entry-guard.mjs (#3969)'
+				: 'Step 7c/12: check-cli-entry-guard.mjs (script 未配備 — skip)',
+			skip: args.skipCliEntryGuard || !cliEntryGuardScriptExists,
+			runner: () => run('check-cli-entry-guard', ['node', 'scripts/check-cli-entry-guard.mjs']),
+			fixHint:
+				'  自前の CLI 直接実行判定 / 手組み file:// URL を検出しました (#3969)。\n' +
+				"  - 修正: import { isMain } from '<rel>/lib/is-main.mjs' を使い、\n" +
+				'          `if (isMain(import.meta.url)) main();` の形にする\n' +
+				'  - path → URL は node:url の pathToFileURL() を使う (手組みは Windows で常に不一致)\n' +
+				'  - 正当な例外は `allow-argv1: <理由>` / `allow-file-url: <理由>` を当該行か直前行に置く',
 		},
 		// Step 8: generate-lp-labels --check (Phase 1 B1 / #1917)
 		// Issue #1920 graceful degradation: 検査 script が未配備なら skip + warning。
@@ -722,15 +748,7 @@ async function main() {
 
 // import 時 (unit test) は main() を走らせない。CLI 直接起動時のみ実行する
 // (パターンは scripts/check-pr-body.mjs と同一)。
-const isMain = (() => {
-	try {
-		const here = resolve(fileURLToPath(import.meta.url));
-		const argv1 = resolve(process.argv[1] || '');
-		return here === argv1;
-	} catch {
-		return false;
-	}
-})();
+const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	main()

--- a/scripts/sync-lp-fallback.mjs
+++ b/scripts/sync-lp-fallback.mjs
@@ -34,6 +34,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse } from 'parse5';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -468,7 +469,7 @@ function main() {
 }
 
 // CLI 実行時のみ main() を呼ぶ。テストから import される場合は副作用なし
-const invokedAsCli = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+const invokedAsCli = isMainModule(import.meta.url);
 if (invokedAsCli) {
 	main();
 }

--- a/src/lib/server/db/seed.ts
+++ b/src/lib/server/db/seed.ts
@@ -3355,7 +3355,10 @@ function seed() {
 // Export for programmatic use (e.g. Lambda cold-start init)
 export { db as seedDb, seed };
 
-// Only auto-run when executed directly as a CLI script
+// Only auto-run when executed directly as a CLI script.
+// allow-argv1: basename 一致判定のため symlink / junction でも正しく動く (#3969 の事故形ではない)。
+// scripts/lib/is-main.mjs へ寄せない理由: 本 module は Lambda cold-start init から import される
+// アプリ側コードで、src/ → scripts/ 依存を作ると scripts/ が本番 bundle に混入する。
 const isDirectRun = process.argv[1]?.endsWith('seed.ts') || process.argv[1]?.endsWith('seed.js');
 if (isDirectRun) {
 	seed();

--- a/tests/unit/scripts/cli-entry-guard.test.ts
+++ b/tests/unit/scripts/cli-entry-guard.test.ts
@@ -32,14 +32,14 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { scanSource } from '../../../scripts/check-cli-entry-guard.mjs';
+import { SCAN_ROOTS, scanSource } from '../../../scripts/check-cli-entry-guard.mjs';
 import { isMain } from '../../../scripts/lib/is-main.mjs';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../../..');
@@ -272,6 +272,77 @@ describe('check-cli-entry-guard 走査範囲 — .claude を含み worktrees を
 		const res = runGate(fixtureTree('.claude/worktrees/agent-x/scripts/gate-approve.mjs'));
 		expect(res.status, `worktrees 配下を走査しています:\n${res.stderr ?? ''}`).toBe(0);
 	}, 30_000);
+
+	/**
+	 * PASS 文言に走査量を含める。件数が無いと「違反 0 件」と「1 ファイルも走査していない」が
+	 * 区別できず、SCAN_ROOT が checkout に無い状態を PASS と読み違える (レビュー指摘 PR #3979)。
+	 */
+	it('PASS 時に root ごとの走査件数を出力する (0 件走査と違反 0 件を区別できる)', () => {
+		const res = spawnSync(process.execPath, [GATE], { cwd: REPO_ROOT, encoding: 'utf8' });
+		expect(res.status, `${res.stdout ?? ''}${res.stderr ?? ''}`).toBe(0);
+		for (const root of SCAN_ROOTS) {
+			expect(res.stdout, `${root} の走査件数が出力されていません: ${res.stdout}`).toMatch(
+				new RegExp(`${root.replace('.', '\\.')}=\\d+`),
+			);
+		}
+	}, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 2b. CI 発火条件
+// ---------------------------------------------------------------------------
+
+/**
+ * gate の走査範囲 (`SCAN_ROOTS`) と CI の発火条件 (`paths-filter` の `app`) の対応を固定する。
+ *
+ * `check-cli-entry-guard` を実行するのは `ci.yml` の `lint-and-test` job だけで、この job は
+ * `changes` の 4 filter (app / deps / stories / docs) がすべて false なら **job ごと skip** される。
+ * SCAN_ROOTS を広げても filter を広げ忘れると、その root だけを変更した PR で gate が
+ * **1 度も走らない**。守る対象が ADR-0056 の approve gate 本体 (`.claude/hooks/gate-approve.mjs`)
+ * なので、対応漏れは「gate があるのに発火しない」= 本 test が塞ぐ class に戻る
+ * (レビュー指摘 PR #3979 BLOCK 4)。
+ */
+describe('CI 発火条件 — SCAN_ROOTS が paths-filter の app に列挙されている (#3969)', () => {
+	/**
+	 * `filters: |` block scalar 内の 1 named filter からパスパターンを抜く。
+	 * 完全な YAML parse はしない (依存を増やさない)。名前行より深い字下げの `- '...'` を拾い、
+	 * 字下げが名前行以下に戻った時点で終端する。
+	 */
+	function extractFilterPaths(yaml: string, name: string): string[] {
+		const lines = yaml.split(/\r?\n/);
+		const start = lines.findIndex((l) => new RegExp(`^(\\s+)${name}:\\s*$`).test(l));
+		if (start < 0) return [];
+		const baseIndent = (lines[start]?.match(/^\s*/)?.[0] ?? '').length;
+		const paths: string[] = [];
+		for (let i = start + 1; i < lines.length; i++) {
+			const line = lines[i] ?? '';
+			if (line.trim() === '') continue;
+			const indent = (line.match(/^\s*/)?.[0] ?? '').length;
+			if (indent <= baseIndent) break;
+			const m = line.trim().match(/^-\s*'([^']+)'\s*$/);
+			if (m?.[1]) paths.push(m[1]);
+		}
+		return paths;
+	}
+
+	const CI_YML = readFileSync(path.join(REPO_ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+	const appPaths = extractFilterPaths(CI_YML, 'app');
+
+	// 陽性対照: parser が空配列を返しているだけの偽 PASS を防ぐ (proposal 005 / #3979)。
+	it('app filter を抽出できている (parser 自体の健全性)', () => {
+		expect(appPaths.length).toBeGreaterThan(5);
+		expect(appPaths).toContain('src/**');
+	});
+
+	for (const root of SCAN_ROOTS) {
+		it(`app filter が '${root}/**' を含む`, () => {
+			expect(
+				appPaths,
+				`SCAN_ROOTS に '${root}' があるのに ci.yml の paths-filter app に '${root}/**' がありません。` +
+					`'${root}/**' だけを変更した PR で lint-and-test が skip され、gate が走りません。`,
+			).toContain(`${root}/**`);
+		});
+	}
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/scripts/cli-entry-guard.test.ts
+++ b/tests/unit/scripts/cli-entry-guard.test.ts
@@ -101,6 +101,9 @@ describe('isMain() — CLI 直接実行判定 (#3969)', () => {
 		expect(runNode(writeProbe(dir), dir)).toBe('MAIN');
 	});
 
+	// skip 条件: symlink/junction を作成できない環境のみ (ADR-0006 metadata)
+	//   Issue: #3969 / owner: @Takenori-Kusaka / deadline: なし (恒久的な環境条件 skip)
+	//   CI (ubuntu-latest) では常時実行される — 本 Issue の再発検出はここが担保する
 	it.skipIf(!SYMLINK_OK)('symlink 経由で起動されても main と判定する (本 Issue の再発防止)', () => {
 		const dir = makeTempDir('gq-is-main-link-');
 		const realDir = path.join(dir, 'real');
@@ -242,6 +245,8 @@ describe('meta-gate — gate が no-op で exit 0 を返さない (#3969)', () =
 		).not.toBe(0);
 	});
 
+	// skip 条件: symlink/junction を作成できない環境のみ (ADR-0006 metadata)
+	//   Issue: #3969 / owner: @Takenori-Kusaka / deadline: なし (恒久的な環境条件 skip)
 	it.skipIf(!SYMLINK_OK)('symlink 経由の repo からでも gate が同じ結果を返す', () => {
 		const dir = makeTempDir('gq-repo-link-');
 		const link = path.join(dir, 'repo');
@@ -281,6 +286,10 @@ describe('meta-gate — gate が no-op で exit 0 を返さない (#3969)', () =
  *
  * 除外: `claude-hook-prevent-qa-account-pr.mjs` は通過時に**意図的に無出力 exit 0** を返す
  * PreToolUse hook なので、本 probe では判定できない (静的 gate 側でカバー)。
+ *
+ * skip 条件: symlink/junction を作成できない環境のみ (ADR-0006 metadata)
+ *   Issue: #3969 / owner: @Takenori-Kusaka / deadline: なし (恒久的な環境条件 skip)
+ *   CI (ubuntu-latest) では常時実行される
  */
 describe.skipIf(!SYMLINK_OK)(
 	'symlink 経由と実体経由で主要 gate の結果が一致する (#3969 AC3)',

--- a/tests/unit/scripts/cli-entry-guard.test.ts
+++ b/tests/unit/scripts/cli-entry-guard.test.ts
@@ -74,6 +74,25 @@ function canSymlink(): boolean {
 
 const SYMLINK_OK = canSymlink();
 
+/**
+ * skip 条件そのものの健全性を CI で固定する。
+ *
+ * `SYMLINK_OK` が false になると symlink 経路の検証ケースが全て無言 skip になり、
+ * 「1 件も検証しないまま緑」= 本 test が塞いでいる事故と同じ形になる。
+ * ローカルは権限差があるため条件付きだが、CI では probe が true であることを assert する。
+ */
+describe('skip 条件の健全性 (#3969)', () => {
+	// skip 条件: CI 以外 (ローカルは symlink 権限が環境依存のため) — ADR-0006 metadata
+	//   Issue: #3969 / owner: @Takenori-Kusaka / deadline: なし (恒久的な環境条件 skip)
+	//   CI (ubuntu-latest) では常時実行される
+	it.skipIf(!process.env.CI)(
+		'CI では symlink/junction を作成できる (symlink 系ケースが無言 skip にならない)',
+		() => {
+			expect(SYMLINK_OK).toBe(true);
+		},
+	);
+});
+
 /** `isMain(import.meta.url)` の結果だけを stdout に出す probe script を書き出す */
 function writeProbe(dir: string): string {
 	const script = path.join(dir, 'probe.mjs');

--- a/tests/unit/scripts/cli-entry-guard.test.ts
+++ b/tests/unit/scripts/cli-entry-guard.test.ts
@@ -1,0 +1,329 @@
+/**
+ * tests/unit/scripts/cli-entry-guard.test.ts (#3969)
+ *
+ * gate script が「何も検査しないまま exit 0 (= PASS)」を返す事故の class-lock。
+ *
+ * ## 背景
+ *
+ * `scripts/` 配下の各 script は末尾で自前の直接実行判定を持っていた。代表例:
+ *
+ * ```js
+ * const isMain = resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1] || '');
+ * ```
+ *
+ * `import.meta.url` は Node が **実体パス**へ解決するのに対し、`process.argv[1]` は
+ * ユーザーが与えたパスのまま絶対化されるだけである。そのため symlink / junction 経由で
+ * repo を開いていると判定が必ず false になり、`main()` が呼ばれず、
+ * **1 件も検査しないまま exit 0** になっていた（実測 41 / 53 ファイル）。
+ *
+ * gate が「落ちる」のではなく「黙って通る」ため誰も気付けない。誤った値を黙って書き込む
+ * silent fallback と同じ class の事故である。
+ *
+ * ## 本 test が守る 3 層
+ *
+ * 1. **判定 SSOT** — `scripts/lib/is-main.mjs` の `isMain()` が symlink 経由でも
+ *    実体経由でも同じ結論を出す
+ * 2. **再混入 gate** — `scripts/check-cli-entry-guard.mjs` の検出ロジックと、
+ *    現在の tree が違反 0 件であること
+ * 3. **meta-gate** — 代表 gate が「必ず失敗する入力」で exit != 0 を返す。
+ *    1 が直っても別経路で同じ沈黙が起き得るため、gate が本当に判定へ到達しているかを見る
+ *
+ * 1 と 3 は Linux CI 上で一時 symlink を張って検証するため、Windows runner なしで効く。
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { scanSource } from '../../../scripts/check-cli-entry-guard.mjs';
+import { isMain } from '../../../scripts/lib/is-main.mjs';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../../..');
+const SCRIPTS_DIR = path.join(REPO_ROOT, 'scripts');
+const HELPER_URL = pathToFileURL(path.join(SCRIPTS_DIR, 'lib', 'is-main.mjs')).href;
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+	for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+});
+
+function makeTempDir(prefix: string): string {
+	const d = mkdtempSync(path.join(tmpdir(), prefix));
+	tempDirs.push(d);
+	return d;
+}
+
+/** symlink を張れない環境 (権限のない Windows 等) では symlink 系ケースを skip する */
+function canSymlink(): boolean {
+	const dir = mkdtempSync(path.join(tmpdir(), 'gq-symlink-probe-'));
+	try {
+		mkdirSync(path.join(dir, 'target'));
+		symlinkSync(path.join(dir, 'target'), path.join(dir, 'link'), 'junction');
+		return true;
+	} catch {
+		return false;
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+const SYMLINK_OK = canSymlink();
+
+/** `isMain(import.meta.url)` の結果だけを stdout に出す probe script を書き出す */
+function writeProbe(dir: string): string {
+	const script = path.join(dir, 'probe.mjs');
+	writeFileSync(
+		script,
+		[
+			`import { isMain } from ${JSON.stringify(HELPER_URL)};`,
+			'process.stdout.write(isMain(import.meta.url) ? "MAIN" : "NOT_MAIN");',
+		].join('\n'),
+	);
+	return script;
+}
+
+function runNode(script: string, cwd: string): string {
+	return `${spawnSync(process.execPath, [script], { cwd, encoding: 'utf8' }).stdout ?? ''}`.trim();
+}
+
+// ---------------------------------------------------------------------------
+// 1. 判定 SSOT
+// ---------------------------------------------------------------------------
+
+describe('isMain() — CLI 直接実行判定 (#3969)', () => {
+	it('実体パスで起動された script は main と判定する', () => {
+		const dir = makeTempDir('gq-ismain-real-');
+		expect(runNode(writeProbe(dir), dir)).toBe('MAIN');
+	});
+
+	it.skipIf(!SYMLINK_OK)('symlink 経由で起動されても main と判定する (本 Issue の再発防止)', () => {
+		const dir = makeTempDir('gq-ismain-link-');
+		const realDir = path.join(dir, 'real');
+		mkdirSync(realDir);
+		const script = writeProbe(realDir);
+		symlinkSync(realDir, path.join(dir, 'link'), 'junction');
+
+		// 実体経由と symlink 経由で結論が一致すること。
+		// 修正前はここが 'MAIN' / 'NOT_MAIN' に割れ、後者で main() が呼ばれず黙って PASS していた。
+		expect(runNode(script, dir)).toBe('MAIN');
+		expect(runNode(path.join(dir, 'link', 'probe.mjs'), dir)).toBe('MAIN');
+	});
+
+	it('import 経由 (argv[1] が別ファイル) では main と判定しない', () => {
+		const selfUrl = pathToFileURL(path.join(SCRIPTS_DIR, 'pre-ready.mjs')).href;
+		expect(isMain(selfUrl, path.join(SCRIPTS_DIR, 'check-pr-body.mjs'))).toBe(false);
+	});
+
+	it('相対パスで起動されても実体と同一なら main と判定する', () => {
+		const selfUrl = pathToFileURL(path.join(SCRIPTS_DIR, 'pre-ready.mjs')).href;
+		expect(isMain(selfUrl, path.join(SCRIPTS_DIR, '..', 'scripts', 'pre-ready.mjs'))).toBe(true);
+	});
+
+	it('argv[1] が未定義 / 空文字でも例外を投げず false を返す', () => {
+		expect(isMain(import.meta.url, undefined)).toBe(false);
+		expect(isMain(import.meta.url, '')).toBe(false);
+	});
+
+	it('不正な URL を渡しても例外を投げず false を返す', () => {
+		expect(isMain('not-a-url', process.argv[1])).toBe(false);
+		expect(isMain('', process.argv[1])).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 2. 再混入 gate
+// ---------------------------------------------------------------------------
+
+describe('check-cli-entry-guard scanSource() — 自前判定の再混入検出 (#3969)', () => {
+	it('argv[1] の直接参照を検出する', () => {
+		const src = 'const isMain = fileURLToPath(import.meta.url) === process.argv[1];\n';
+		const found = scanSource('scripts/sample.mjs', src);
+		expect(found).toHaveLength(1);
+		expect(found[0]?.rule).toBe('argv1');
+		expect(found[0]?.line).toBe(1);
+	});
+
+	it('手組みの file:// テンプレート URL を検出する', () => {
+		// gate が検出すべき「違反コードそのもの」を fixture として持つ必要があるため、
+		// ここでの ${...} は意図した文字列リテラルであり template literal ではない。
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: gate の検出対象を再現する fixture
+		const src = 'if (import.meta.url === `file://${entry}`) main();\n';
+		const found = scanSource('scripts/sample.mjs', src);
+		expect(found.map((v) => v.rule)).toContain('file-url');
+	});
+
+	it("手組みの 'file://' 文字列連結も検出する", () => {
+		const src = "if (import.meta.url === 'file://' + entry) main();\n";
+		expect(scanSource('scripts/sample.mjs', src).map((v) => v.rule)).toContain('file-url');
+	});
+
+	it('コメント中の記述例は違反にしない', () => {
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: gate の検出対象を再現する fixture
+		const src = '// const isMain = ... === process.argv[1];\n * `file://${x}` は禁止\n';
+		expect(scanSource('scripts/sample.mjs', src)).toEqual([]);
+	});
+
+	it('理由付き opt-out マーカーがあれば許可する', () => {
+		const inline =
+			'const entry = process.argv[1]; // allow-argv1: CLI 引数として entry path を表示するため\n';
+		expect(scanSource('scripts/sample.mjs', inline)).toEqual([]);
+
+		const preceding = [
+			'// allow-argv1: usage 表示に起動コマンドをそのまま出すため',
+			'const entry = process.argv[1];',
+		].join('\n');
+		expect(scanSource('scripts/sample.mjs', preceding)).toEqual([]);
+	});
+
+	it('理由が空のマーカーは opt-out として認めない (無言の抑止を防ぐ)', () => {
+		const src = 'const entry = process.argv[1]; // allow-argv1:\n';
+		expect(scanSource('scripts/sample.mjs', src)).toHaveLength(1);
+	});
+
+	it('判定 SSOT (scripts/lib/is-main.mjs) 自身は対象外', () => {
+		const src = 'const argv1 = process.argv[1];\n';
+		expect(scanSource(path.join('scripts', 'lib', 'is-main.mjs'), src)).toEqual([]);
+	});
+
+	// scripts / src / infra 配下を全走査するため既定の 5s では足りない (実測 ~8s)。
+	it('現在の tree は違反 0 件 (gate 本体を repo 全体に対して実行)', () => {
+		const res = spawnSync(process.execPath, ['scripts/check-cli-entry-guard.mjs'], {
+			cwd: REPO_ROOT,
+			encoding: 'utf8',
+		});
+		expect(res.status, `違反が検出されました:\n${res.stdout ?? ''}${res.stderr ?? ''}`).toBe(0);
+	}, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 3. meta-gate
+// ---------------------------------------------------------------------------
+
+describe('meta-gate — gate が no-op で exit 0 を返さない (#3969)', () => {
+	/**
+	 * 「必ず失敗する既知の不正入力」を与えて exit != 0 を確認する。
+	 * gate 個別のロジックではなく **gate が起動して判定に到達しているか** を見ている。
+	 * no-op に退化すると exit 0 かつ無出力になるため、両方を assert する。
+	 */
+	const CASES: Array<{ script: string; args: string[] }> = [
+		{
+			script: 'check-pr-body.mjs',
+			args: ['--body-file', '__gq_missing_body__.md', '--skip-mergeable'],
+		},
+		{ script: 'check-ac-verification-map.mjs', args: ['--body-file', '__gq_missing_body__.md'] },
+		{ script: 'check-cli-entry-guard.mjs', args: ['--__gq_unknown_flag__'] },
+	];
+
+	for (const { script, args } of CASES) {
+		it(`${script} は起動して判定に到達する (no-op で無出力 exit 0 にならない)`, () => {
+			const res = spawnSync(process.execPath, [path.join('scripts', script), ...args], {
+				cwd: REPO_ROOT,
+				encoding: 'utf8',
+			});
+			const combined = `${res.stdout ?? ''}${res.stderr ?? ''}`;
+			expect(combined.trim(), 'gate が無出力でした (main() 未実行の疑い)').not.toBe('');
+		});
+	}
+
+	it('check-pr-body.mjs は存在しない body-file で exit != 0 を返す', () => {
+		const res = spawnSync(
+			process.execPath,
+			['scripts/check-pr-body.mjs', '--body-file', '__gq_missing_body__.md', '--skip-mergeable'],
+			{ cwd: REPO_ROOT, encoding: 'utf8' },
+		);
+		expect(
+			res.status,
+			`exit 0 で返りました (no-op の疑い)。出力:\n${`${res.stdout ?? ''}${res.stderr ?? ''}`.slice(0, 2000)}`,
+		).not.toBe(0);
+	});
+
+	it.skipIf(!SYMLINK_OK)('symlink 経由の repo からでも gate が同じ結果を返す', () => {
+		const dir = makeTempDir('gq-repo-link-');
+		const link = path.join(dir, 'repo');
+		symlinkSync(REPO_ROOT, link, 'junction');
+
+		const args = [
+			'scripts/check-pr-body.mjs',
+			'--body-file',
+			'__gq_missing_body__.md',
+			'--skip-mergeable',
+		];
+		const viaReal = spawnSync(process.execPath, args, { cwd: REPO_ROOT, encoding: 'utf8' });
+		const viaLink = spawnSync(process.execPath, args, { cwd: link, encoding: 'utf8' });
+
+		expect(viaLink.status, 'symlink 経由で exit code が変わりました').toBe(viaReal.status);
+		expect(viaLink.status, 'symlink 経由で exit 0 (no-op) になりました').not.toBe(0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 4. symlink / 実体 の結果一致 (主要 gate、AC3)
+// ---------------------------------------------------------------------------
+
+/**
+ * 主要 gate を「実体パス」と「symlink 経由パス」の両方から起動し、
+ * **出力が非空かつ完全一致** することを確認する。
+ *
+ * `--help` を渡しても大半の gate は本走査まで実行するため、
+ * 「main() に到達したか」の probe として十分機能する (修正前は無出力 exit 0)。
+ *
+ * ## coverage の境界 (意図的に絞っている)
+ *
+ * `scripts/check-*.mjs` は全 54 本あるが、全件を両経路で起動すると実測 ~5.5 分かかる
+ * (単経路で 2m42s)。unit test に載せられないため、ここでは **重要度の高い 12 本** に限定する。
+ * 残りは静的 gate (`scripts/check-cli-entry-guard.mjs`) が判定 SSOT 利用を全件強制することで
+ * カバーする — 「代表 12 本しか動的検証していない」ことを明示しておく。
+ *
+ * 除外: `claude-hook-prevent-qa-account-pr.mjs` は通過時に**意図的に無出力 exit 0** を返す
+ * PreToolUse hook なので、本 probe では判定できない (静的 gate 側でカバー)。
+ */
+describe.skipIf(!SYMLINK_OK)(
+	'symlink 経由と実体経由で主要 gate の結果が一致する (#3969 AC3)',
+	() => {
+		const PROBE_SCRIPTS = [
+			'pre-ready.mjs',
+			'check-pr-body.mjs',
+			'check-cdk-replacement.mjs',
+			'check-gh-account-before-pr.mjs',
+			'check-cli-entry-guard.mjs',
+			'check-design-doc-sync.mjs',
+			'check-new-required-env.mjs',
+			'check-pr-screenshot.mjs',
+			'check-ac-verification-map.mjs',
+			'check-license-key-leak.mjs',
+			'check-action-sha-pin.mjs',
+			'check-no-direct-env-access.mjs',
+		];
+
+		let linkedRoot: string;
+
+		beforeAll(() => {
+			const dir = makeTempDir('gq-gate-equiv-');
+			linkedRoot = path.join(dir, 'repo');
+			symlinkSync(REPO_ROOT, linkedRoot, 'junction');
+		});
+
+		for (const script of PROBE_SCRIPTS) {
+			it(`${script}`, () => {
+				const args = [path.join('scripts', script), '--help'];
+				const viaReal = spawnSync(process.execPath, args, { cwd: REPO_ROOT, encoding: 'utf8' });
+				const viaLink = spawnSync(process.execPath, args, { cwd: linkedRoot, encoding: 'utf8' });
+
+				const realOut = `${viaReal.stdout ?? ''}${viaReal.stderr ?? ''}`.trim();
+				const linkOut = `${viaLink.stdout ?? ''}${viaLink.stderr ?? ''}`.trim();
+
+				// 実体経由で無出力なら probe 自体が無効なので、まずそこを守る
+				expect(realOut, '実体経由で無出力 (probe が無効)').not.toBe('');
+				// 本 Issue の事故形: symlink 経由だけ main() 未実行で無出力 exit 0 になる
+				expect(linkOut, 'symlink 経由で無出力 (main() 未実行の疑い)').not.toBe('');
+				expect(linkOut).toBe(realOut);
+				expect(viaLink.status).toBe(viaReal.status);
+			});
+		}
+	},
+);

--- a/tests/unit/scripts/cli-entry-guard.test.ts
+++ b/tests/unit/scripts/cli-entry-guard.test.ts
@@ -193,7 +193,7 @@ describe('check-cli-entry-guard scanSource() — 自前判定の再混入検出 
 		expect(scanSource(path.join('scripts', 'lib', 'is-main.mjs'), src)).toEqual([]);
 	});
 
-	// scripts / src / infra 配下を全走査するため既定の 5s では足りない (実測 ~8s)。
+	// scripts / src / infra / .claude 配下を全走査するため既定の 5s では足りない (実測 ~8s)。
 	it('現在の tree は違反 0 件 (gate 本体を repo 全体に対して実行)', () => {
 		const res = spawnSync(process.execPath, ['scripts/check-cli-entry-guard.mjs'], {
 			cwd: REPO_ROOT,
@@ -201,6 +201,58 @@ describe('check-cli-entry-guard scanSource() — 自前判定の再混入検出 
 		});
 		expect(res.status, `違反が検出されました:\n${res.stdout ?? ''}${res.stderr ?? ''}`).toBe(0);
 	}, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// 2b. 走査範囲 (SCAN_ROOTS / SKIP_DIRS)
+// ---------------------------------------------------------------------------
+
+/**
+ * 走査範囲は「実行経路」ではなく「壊れたときに無言で PASS するか」で決めている。
+ * `.claude/hooks/gate-approve.mjs` は ADR-0056 evidence を検証して QM の approve を止める hook で、
+ * 事故形のままだと junction 経由で approve を素通しする。SCAN_ROOTS の外にあると gate が
+ * それを検出できないため、範囲そのものを test で固定する (レビュー指摘 PR #3979)。
+ */
+describe('check-cli-entry-guard 走査範囲 — .claude を含み worktrees を除く (#3969)', () => {
+	const GATE = path.join(SCRIPTS_DIR, 'check-cli-entry-guard.mjs');
+
+	/** 実在した事故形 (.claude/hooks/gate-approve.mjs の修正前の式) をそのまま fixture にする */
+	const ACCIDENT_FORM = [
+		"import { fileURLToPath } from 'node:url';",
+		'const isDirectInvocation =',
+		'\tprocess.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];',
+		'if (isDirectInvocation) main();',
+		'',
+	].join('\n');
+
+	function fixtureTree(relPath: string): string {
+		const root = makeTempDir('gq-scan-roots-');
+		const abs = path.join(root, ...relPath.split('/'));
+		mkdirSync(path.dirname(abs), { recursive: true });
+		writeFileSync(abs, ACCIDENT_FORM);
+		return root;
+	}
+
+	function runGate(cwd: string) {
+		return spawnSync(process.execPath, [GATE], { cwd, encoding: 'utf8' });
+	}
+
+	it('.claude/hooks/ 配下の事故形を検出する (SCAN_ROOTS に .claude が無いと素通りする)', () => {
+		const res = runGate(fixtureTree('.claude/hooks/gate-approve.mjs'));
+		expect(res.status, `検出されませんでした:\n${res.stdout ?? ''}${res.stderr ?? ''}`).toBe(1);
+		expect(`${res.stderr ?? ''}`).toContain('.claude/hooks/gate-approve.mjs');
+	}, 30_000);
+
+	/**
+	 * fixture の中身は `.claude/worktrees/agent-x/scripts/` — git worktree 実体には
+	 * scripts/ src/ infra/ が dot なしで並ぶため、SKIP_DIRS で切らないと本ブランチと
+	 * 無関係な違反を報告する。`collectFiles` の「dot ディレクトリを飛ばす」規則では
+	 * 止まらない配置を意図的に選んでいる (規則に従わないが実在する形を fixture にする)。
+	 */
+	it('.claude/worktrees/ 配下は走査しない (他ブランチの実体を重複報告しない)', () => {
+		const res = runGate(fixtureTree('.claude/worktrees/agent-x/scripts/gate-approve.mjs'));
+		expect(res.status, `worktrees 配下を走査しています:\n${res.stderr ?? ''}`).toBe(0);
+	}, 30_000);
 });
 
 // ---------------------------------------------------------------------------
@@ -220,6 +272,7 @@ describe('meta-gate — gate が no-op で exit 0 を返さない (#3969)', () =
 		},
 		{ script: 'check-ac-verification-map.mjs', args: ['--body-file', '__gq_missing_body__.md'] },
 		{ script: 'check-cli-entry-guard.mjs', args: ['--__gq_unknown_flag__'] },
+		{ script: 'check-workflow-sparse-checkout-closure.mjs', args: ['--__gq_unknown_flag__'] },
 	];
 
 	for (const { script, args } of CASES) {

--- a/tests/unit/scripts/cli-entry-guard.test.ts
+++ b/tests/unit/scripts/cli-entry-guard.test.ts
@@ -97,12 +97,12 @@ function runNode(script: string, cwd: string): string {
 
 describe('isMain() — CLI 直接実行判定 (#3969)', () => {
 	it('実体パスで起動された script は main と判定する', () => {
-		const dir = makeTempDir('gq-ismain-real-');
+		const dir = makeTempDir('gq-is-main-real-');
 		expect(runNode(writeProbe(dir), dir)).toBe('MAIN');
 	});
 
 	it.skipIf(!SYMLINK_OK)('symlink 経由で起動されても main と判定する (本 Issue の再発防止)', () => {
-		const dir = makeTempDir('gq-ismain-link-');
+		const dir = makeTempDir('gq-is-main-link-');
 		const realDir = path.join(dir, 'real');
 		mkdirSync(realDir);
 		const script = writeProbe(realDir);

--- a/tests/unit/scripts/workflow-sparse-checkout-closure.test.ts
+++ b/tests/unit/scripts/workflow-sparse-checkout-closure.test.ts
@@ -1,0 +1,247 @@
+/**
+ * tests/unit/scripts/workflow-sparse-checkout-closure.test.ts (#3969)
+ *
+ * `sparse-checkout` の列挙漏れで必須 gate job が起動できなくなる class の class-lock。
+ *
+ * ## 背景
+ *
+ * gate job は repo 全体ではなく `sparse-checkout` で必要ファイルを**個別列挙**して checkout している。
+ * #3969 で CLI 直接実行判定を `scripts/lib/is-main.mjs` (SSOT) へ集約した結果、
+ * 列挙された script が helper を import するようになり、helper を列挙していない 6 job が
+ * 一斉に `ERR_MODULE_NOT_FOUND` で fail した。
+ *
+ * `check-cli-entry-guard.mjs` が SSOT 利用を強制する以上、**今後追加する gate script には必ず
+ * helper への import が生える**。列挙を手で書き続ける限り再発し続ける構造なので、
+ * 注意力ではなく gate で閉じる (ADR-0061 same-class-N→guard)。
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+	collectTransitiveDeps,
+	extractRelativeImports,
+	isCoveredBy,
+	parseSparseCheckoutBlocks,
+} from '../../../scripts/check-workflow-sparse-checkout-closure.mjs';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../../..');
+const GATE = path.join(REPO_ROOT, 'scripts', 'check-workflow-sparse-checkout-closure.mjs');
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+	for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+});
+
+function makeTempDir(prefix: string): string {
+	const d = mkdtempSync(path.join(tmpdir(), prefix));
+	tempDirs.push(d);
+	return d;
+}
+
+describe('parseSparseCheckoutBlocks() — block scalar の抽出 (#3969)', () => {
+	it('列挙されたパスを取り出し、字下げが浅くなった行で終端する', () => {
+		const yaml = [
+			'      - uses: actions/checkout@v7',
+			'        with:',
+			'          sparse-checkout: |',
+			'            actions/pr-lane',
+			'            scripts/pr-lane.mjs',
+			'          sparse-checkout-cone-mode: false',
+			'',
+			'      - name: next step',
+		].join('\n');
+
+		const blocks = parseSparseCheckoutBlocks(yaml);
+		expect(blocks).toHaveLength(1);
+		expect(blocks[0]?.line).toBe(3);
+		expect(blocks[0]?.entries).toEqual(['actions/pr-lane', 'scripts/pr-lane.mjs']);
+	});
+
+	it('1 ファイル内の複数ブロックをすべて拾う', () => {
+		const yaml = [
+			'          sparse-checkout: |',
+			'            scripts/a.mjs',
+			'          sparse-checkout-cone-mode: false',
+			'          sparse-checkout: |',
+			'            scripts/b.mjs',
+			'          sparse-checkout-cone-mode: false',
+		].join('\n');
+
+		expect(parseSparseCheckoutBlocks(yaml).map((b) => b.entries)).toEqual([
+			['scripts/a.mjs'],
+			['scripts/b.mjs'],
+		]);
+	});
+
+	it('sparse-checkout を持たない workflow では 0 件', () => {
+		expect(parseSparseCheckoutBlocks('jobs:\n  build:\n    runs-on: ubuntu-latest\n')).toEqual([]);
+	});
+});
+
+describe('extractRelativeImports() — 相対 import の抽出 (#3969)', () => {
+	it('named / default / side-effect / re-export の 4 形を拾う', () => {
+		const src = [
+			"import { isMain } from './lib/is-main.mjs';",
+			"import helper from '../lib/helper.mjs';",
+			"import './side-effect.mjs';",
+			"export { x } from './reexport.mjs';",
+		].join('\n');
+
+		// 抽出順は from 付き → side-effect の 2 パス構成に依存するため、集合として比較する
+		expect([...extractRelativeImports(src)].sort()).toEqual([
+			'../lib/helper.mjs',
+			'./lib/is-main.mjs',
+			'./reexport.mjs',
+			'./side-effect.mjs',
+		]);
+	});
+
+	it('bare specifier (node: / npm) は対象外 — checkout ではなく npm ci の担当', () => {
+		const src = ["import { readFileSync } from 'node:fs';", "import yaml from 'yaml';"].join('\n');
+		expect(extractRelativeImports(src)).toEqual([]);
+	});
+});
+
+describe('isCoveredBy() — 列挙による被覆判定 (#3969)', () => {
+	it('ファイル完全一致で覆う', () => {
+		expect(isCoveredBy('scripts/lib/is-main.mjs', ['scripts/lib/is-main.mjs'])).toBe(true);
+	});
+
+	it('ディレクトリ列挙は配下を prefix 一致で覆う', () => {
+		expect(isCoveredBy('actions/pr-lane/action.yml', ['actions/pr-lane'])).toBe(true);
+	});
+
+	it('ファイル名の前方一致だけでは覆ったと見なさない', () => {
+		// `scripts/lib` は `scripts/lib-extra.mjs` を覆わない (境界は `/` でのみ切る)
+		expect(isCoveredBy('scripts/lib-extra.mjs', ['scripts/lib'])).toBe(false);
+	});
+});
+
+describe('collectTransitiveDeps() — 実 repo での推移解決 (#3969)', () => {
+	it('check-ss-render-health.mjs から helper 2 本へ到達する', () => {
+		const deps = collectTransitiveDeps(REPO_ROOT, ['scripts/check-ss-render-health.mjs']);
+		expect(deps).toContain('scripts/lib/is-main.mjs');
+		expect(deps).toContain('scripts/lib/ci/screenshot-helpers.mjs');
+	});
+
+	it('起点自身は依存として返さない', () => {
+		expect(collectTransitiveDeps(REPO_ROOT, ['scripts/lib/is-main.mjs'])).not.toContain(
+			'scripts/lib/is-main.mjs',
+		);
+	});
+});
+
+describe('class-lock — helper 列挙を外すと未被覆として検出される (#3969)', () => {
+	/**
+	 * 実際に 6 job を落とした状態を、実 workflow の列挙から helper 行だけ抜いて再現する。
+	 * fixture ではなく repo の実物を起点にしているため、workflow が書き換わっても追随する。
+	 */
+	it('pr-merge-gate.yml の列挙から scripts/lib/is-main.mjs を抜くと未被覆になる', () => {
+		const yamlPath = path.join(REPO_ROOT, '.github', 'workflows', 'pr-merge-gate.yml');
+		const source = readFileSync(yamlPath, 'utf8');
+		const block = parseSparseCheckoutBlocks(source)[0];
+		expect(block, 'pr-merge-gate.yml に sparse-checkout ブロックが無い').toBeDefined();
+
+		const entries = block?.entries ?? [];
+		// 現状: helper は列挙されており、gate は起点集合の一部として扱うので未被覆にならない
+		expect(entries, '列挙から helper が消えている (BLOCK 1 の退行)').toContain(
+			'scripts/lib/is-main.mjs',
+		);
+
+		// 事故時の状態を再現 — helper 行だけを列挙から抜く
+		const mutated = entries.filter((e) => e !== 'scripts/lib/is-main.mjs');
+		const starts = mutated.filter((e) => e.endsWith('.mjs'));
+		const deps = collectTransitiveDeps(REPO_ROOT, starts);
+
+		expect(deps, 'gate script が helper を import していない (前提が崩れた)').toContain(
+			'scripts/lib/is-main.mjs',
+		);
+		expect(
+			isCoveredBy('scripts/lib/is-main.mjs', mutated),
+			'helper を抜いても被覆と判定された = gate が事故を見逃す',
+		).toBe(false);
+	});
+});
+
+describe('無言 PASS 条件の可視化 — 起点 0 本を OK と呼ばない (#3969)', () => {
+	/**
+	 * 本 gate 自身が「壊れると無言で PASS する」形にならないことの class-lock。
+	 * 列挙された script が disk 上に無ければ起点が空になり違反 0 件 = exit 0 になるため、
+	 * その場合は OK ではなく SKIP と表示して「未検証」であることを出力に残す。
+	 */
+	function runGateIn(cwd: string): { status: number | null; out: string } {
+		const res = spawnSync(process.execPath, [GATE], { cwd, encoding: 'utf8' });
+		return { status: res.status, out: `${res.stdout ?? ''}${res.stderr ?? ''}` };
+	}
+
+	it('列挙 script が存在しない環境では OK ではなく SKIP (未検証) と表示する', () => {
+		const dir = makeTempDir('gq-sparse-noop-');
+		mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+		writeFileSync(
+			path.join(dir, '.github', 'workflows', 'gate.yml'),
+			[
+				'          sparse-checkout: |',
+				'            scripts/absent-gate.mjs',
+				'          sparse-checkout-cone-mode: false',
+				'',
+			].join('\n'),
+			'utf8',
+		);
+
+		const { status, out } = runGateIn(dir);
+		expect(status, out).toBe(0);
+		expect(out).toContain('SKIP');
+		expect(out).toContain('未検証');
+		expect(out).not.toContain('OK:');
+	});
+
+	it('列挙 script が存在すれば OK と表示し、漏れがあれば exit 1 になる', () => {
+		const dir = makeTempDir('gq-sparse-live-');
+		mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+		mkdirSync(path.join(dir, 'scripts', 'lib'), { recursive: true });
+		writeFileSync(path.join(dir, 'scripts', 'lib', 'helper.mjs'), 'export const x = 1;\n', 'utf8');
+		writeFileSync(
+			path.join(dir, 'scripts', 'gate.mjs'),
+			"import { x } from './lib/helper.mjs';\nconsole.log(x);\n",
+			'utf8',
+		);
+		const yamlPath = path.join(dir, '.github', 'workflows', 'gate.yml');
+		const block = (entries: string[]): string =>
+			['          sparse-checkout: |', ...entries.map((e) => `            ${e}`), ''].join('\n');
+
+		// 列挙漏れあり → exit 1
+		writeFileSync(yamlPath, block(['scripts/gate.mjs']), 'utf8');
+		const missing = runGateIn(dir);
+		expect(missing.status, missing.out).toBe(1);
+		expect(missing.out).toContain('scripts/lib/helper.mjs');
+
+		// helper を列挙 → exit 0 かつ OK 表示 (SKIP ではない)
+		writeFileSync(yamlPath, block(['scripts/gate.mjs', 'scripts/lib/helper.mjs']), 'utf8');
+		const ok = runGateIn(dir);
+		expect(ok.status, ok.out).toBe(0);
+		expect(ok.out).toContain('OK:');
+		expect(ok.out).not.toContain('SKIP');
+	});
+});
+
+describe('現在の tree — gate 本体を repo 全体に対して実行 (#3969)', () => {
+	it('sparse-checkout の import 漏れは 0 件', () => {
+		const res = spawnSync(
+			process.execPath,
+			['scripts/check-workflow-sparse-checkout-closure.mjs'],
+			{ cwd: REPO_ROOT, encoding: 'utf8' },
+		);
+		expect(res.status, `${res.stdout ?? ''}${res.stderr ?? ''}`).toBe(0);
+		// no-op (main() 未実行) だと exit 0 かつ無出力になるため、出力の存在も見る
+		expect(`${res.stdout ?? ''}${res.stderr ?? ''}`.trim()).not.toBe('');
+		// 「検証した」と読める文言を出していること (SKIP と OK を取り違えない)
+		expect(res.stdout).toContain('OK:');
+	}, 60_000);
+});


### PR DESCRIPTION
<!-- ============================================================
hotfix PR runbook checklist (#2343)
============================================================
- [x] Step 1: Skill 雛形 (本 template) を使って起票している
- [x] Step 2: `src/routes/` 変更なし (本 PR は `scripts/` + `tests/` + CI workflow のみ) のため `refactor:internal-no-doc-impact` 判断は不要
- [x] Step 3: 新規 env / secret の追加なし
- [x] Step 4: `process.env.X` 直接参照を追加していない
- [x] Step 5: `npm run pre-ready -- --pr <num>` 全 Step PASS をローカル確認した
============================================================ -->

## 顧客価値・目的

**対象ユーザー**: 運営（開発チーム）

**解決する課題**: `scripts/` 配下の gate script が **symlink / junction 経由の作業ディレクトリから起動されると 1 件も検査せず exit 0 (= PASS) を返す**。判定は各 script が自前で書いた `resolve(fileURLToPath(import.meta.url)) === resolve(process.argv[1])` で、`import.meta.url` は Node が実体パスへ解決するのに対し `process.argv[1]` は与えられたパスのまま絶対化されるため、junction 経由では必ず不一致になり `main()` が呼ばれない。**実測で 53 script 中 41 件が該当**していた。gate が落ちるのではなく黙って通るため、誰も壊れていることに気付けない。結果として junction 環境で出された「pre-ready 全 Step PASS」という証跡が実際には何も検証していなかった。

**期待される効果**: 判定を `scripts/lib/is-main.mjs` へ SSOT 化して事故を停止し、あわせて (a) 42 個目の方言の再混入を止める静的 gate と (b) gate が no-op に退化していないことを毎 CI で確認する meta-gate を入れ、「gate が壊れても誰も気付かない」構造自体を潰す。

## 関連 Issue

closes #3969

関連: #3960 / #3963（同一 class の silent fallback）/ ADR-0061（same-class N 回 → guard 化）/ ADR-0019・#1400（`check-cdk-replacement.mjs`）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `isMain` 判定を realpath 比較へ変更し、共通 helper に切り出して各 script が参照する | `CI=1 npx vitest run tests/unit/scripts/cli-entry-guard.test.ts` / `node scripts/check-cli-entry-guard.mjs` | HEAD `71339432` / `Tests 41 passed (41)` / 判定 SSOT = `scripts/lib/is-main.mjs:67` `isMain()`（両辺を `realpathSync.native` で正規化、Windows は小文字寄せ）。置換したのは **`scripts/` 配下 53 箇所 + `.ts` gate 2 件 + `.claude/` 配下 2 件**（`.claude/hooks/gate-approve.mjs:258` / `.claude/skills/dev-open-pr/scripts/init-pr-body.mjs:339`、Re-Review BLOCK 2 で追加）。残る `process.argv[1]` 参照は SSOT 自身と gate 本体の検出パターン定義 / doc のみ |
| AC2 | junction / symlink 経由の起動で `main()` が実行されることを検証するテストを追加する | `CI=1 npx vitest run tests/unit/scripts/cli-entry-guard.test.ts` | HEAD `71339432` / `Tests 41 passed (41)` / `tests/unit/scripts/cli-entry-guard.test.ts:437` — 一時 junction を張り、主要 gate **12 本**（`:441-453` の `PROBE_SCRIPTS`）を実体経由 / symlink 経由の両方から起動して **非空出力かつ同一出力・同一 exit code** を assert（修正前は symlink 経由が無出力 exit 0）。`:126` で `isMain()` 自体の symlink 経由判定、`:393` で `check-pr-body.mjs` 1 本の symlink 経由一致、`:379` で同 script の exit != 0 を個別に確認。symlink probe が false のとき無言 skip にならないよう、`CI` 下では `SYMLINK_OK === true` を assert（`:84` の describe） |
| AC3 | 「gate が no-op で exit 0 を返さない」ことを担保する meta-gate を CI に追加する | `CI=1 npx vitest run tests/unit/scripts/cli-entry-guard.test.ts` / `node scripts/check-cli-entry-guard.mjs` | HEAD `71339432` / 2 層で実装。**動的**: `tests/unit/scripts/cli-entry-guard.test.ts:352` の meta-gate が「必ず失敗する既知の不正入力」で gate 4 本を起動し、**無出力でないこと**と `check-pr-body.mjs` の **exit != 0** を assert（Linux CI 上で一時 symlink を張るため Windows runner を増やさずに検証できる）。**静的**: `scripts/check-cli-entry-guard.mjs` を `.github/workflows/ci.yml:211` の `lint-and-test` へ追加し merge blocker 化。**発火条件**: 同 `ci.yml:52` の `paths-filter` `app` に `.claude/**` を追加（`:63`）し、`.claude/**` のみの PR でも job が skip されないようにした。`SCAN_ROOTS` と `app` filter の対応は `cli-entry-guard.test.ts:305` の describe が機械検証する（Re-Review BLOCK 4） |
| AC4 | `process.argv[1]` を参照する 55 ファイルの内訳を洗い出し、gate として機能すべきものを全て修正する（対象一覧を Issue にコメントで残す） | `node scripts/check-cli-entry-guard.mjs` / Issue #3969 コメント | HEAD `71339432` / 内訳を #3969 にコメントで記載。`scripts/` 配下 53 件（5 方言）+ `.ts` gate 2 件（自前 realpath 実装 = 6 番目の方言）+ `.claude/` 配下 2 件を修正。`src/lib/server/db/seed.ts` のみ理由付き opt-out（basename 一致判定で事故形でない / 本 module は Lambda cold-start init から import されるため `src → scripts` 依存を作らない）。静的 gate の走査範囲は `check-cli-entry-guard.mjs:64` の `SCAN_ROOTS = ['scripts', 'src', 'infra', '.claude']` **4 root**。実測 → `[check-cli-entry-guard] OK: 自前の CLI 実行判定 / 手組み file:// URL は 0 件 (走査 scripts=217 / src=729 / infra=12 / .claude=3)` exit 0（件数を出すのは「0 件走査」と「違反 0 件」を区別するため） |

## 変更タイプ

- [x] fix: バグ修正

## ADR-0002 Critical 修正 5 要件チェック（必須）

### 要件 1: E2E 回帰テストを同一 PR 内で追加

| AC | テストファイル | テスト内容 |
|---|---|---|
| AC2 | `tests/unit/scripts/cli-entry-guard.test.ts` | 一時 junction 経由と実体経由で主要 gate 12 本を起動し、非空出力・同一出力・同一 exit code を確認（事故形の直接回帰） |
| AC3 | `tests/unit/scripts/cli-entry-guard.test.ts` | 「必ず失敗する既知の不正入力」で gate が exit != 0 を返し、無出力にならないことを確認（no-op 退化の検出） |
| AC1 | `tests/unit/scripts/cli-entry-guard.test.ts` | `isMain()` が実体 / 相対 / symlink / 不正 URL / argv 未定義 のいずれでも正しい結論を返すこと |

本 PR は UI / ルーティングを一切変更しないため Playwright E2E の追加対象がない。事故は「CLI の起動経路」で起きるため、回帰テストは実プロセスを `spawnSync` で起動する形（unit ディレクトリ配置だが実体は subprocess 検証）で担保している。

### 要件 2: AC 全項目完了（部分実装で closes 禁止）

- [x] Issue の全 AC (AC1〜AC4) が本 PR で完了している（未着手項目なし）

### 要件 3: 提案全実装

- [x] Issue 本文の「対応案」に記載された全提案を実装した（realpath 比較 + 共通 helper 切り出し + 不正入力 smoke による meta-gate + 55 ファイル sweep）

### 要件 4: 全 5 年齢モードで実機検証 + スクリーンショット

**N/A（UI 非影響）**。変更対象は `scripts/` の CLI helper・`tests/`・`.github/workflows/ci.yml`・`biome.json` と、`src/lib/server/db/seed.ts` のコメント 1 行（opt-out マーカー追加のみで実行時挙動は不変）。`src/routes/**` および UI コンポーネントの変更は 0 件のため、年齢モード別の描画に影響しない。

### 要件 5: 直近 30 日の同一ファイル変更 PR チェック

| PR | マージ日 | 同一ファイルでの変更内容 | 本 PR との関係 |
|---|---|---|---|
| #3901 | 2026-07-19 | `scripts/check-pr-body.mjs` に変更タイプ checkbox 検出を追加 (#3846) | 関連なし（本 PR は同ファイルの末尾 isMain 判定のみ置換） |
| #3875 | 2026-07-16 | `scripts/pre-ready.mjs` の worktree 対応 (#3857) | 関連なし（同じく末尾判定のみ） |
| #3737 | 2026-07-10 | `scripts/lib` を `runtime` / `ci` に分離 (#3659) | **関連あり** — 本 PR が新設する `scripts/lib/is-main.mjs` は CI 専用 helper。`src/` から import されないことを `src/lib/server/db/seed.ts` の opt-out で担保し、本番 image への CI helper 混入を作らない |
| #3650 | 2026-07-05 | `scripts/pre-ready.mjs` に Step 1b cspell 追加 (#3649) | 関連なし |

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ
- [ ] サービス層
- [ ] API
- [ ] ページ
- [ ] UI コンポーネント
- [x] その他: `scripts/` (CI gate CLI 全般) / `.claude/hooks/` `.claude/skills/` (2 件) / `tests/unit/scripts/` / `.github/workflows/ci.yml` / `biome.json`

**影響を受ける画面・機能**: なし（アプリ実行時経路の変更 0 件）。影響するのは開発者ローカルの gate 実行結果と CI の `lint-and-test` job のみ。

なお **CI（GitHub Actions）は本バグの影響を受けていなかった**。`.github/workflows/` に Windows runner は 1 件も無く、Linux clone には junction が存在しないため `isMain` は正しく true になっていた。壊れていたのはローカルの事前 gate のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（HEAD `71339432` / 実行した 12 step すべて PASS）

pre-ready 完走ログ（実体パス `E:\Github\gq-wt-3969` で実行。junction 経由では develop 版 `pre-ready.mjs` が 0 バイト exit 0 の空振りになるため、証跡はすべて実体パスで取得している）:

```console
$ node scripts/pre-ready.mjs --pr 3979
[pre-ready] PR 番号: 3979 / base branch: origin/develop / 変更ファイル数: 68
[pre-ready] ✓ Step 1/12: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)
[pre-ready] ✓ Step 1b/12: cspell (CI lint-and-test と同一コマンド — #3649)
[pre-ready] ✓ Step 2/12: svelte-check (TS strict)
[pre-ready] ✓ Step 3/12: vitest run (unit test)
[pre-ready] ✓ Step 4/12: check-hardcoded-strings.mjs (#1452 Phase A)
[pre-ready] ⊘ Step 5/12: measure-lp-dimensions.mjs (LP 変更検知: NO — skip)
[pre-ready] ⊘ Step 6/12: sync-lp-fallback.mjs --check (LP / labels.ts 変更検知: NO — skip)
[pre-ready] ✓ Step 7/12: check-no-plan-literals.mjs (#972 / Phase 5 F1)
[pre-ready] ✓ Step 7b/12: check-license-key-leak.mjs (#2836 / Phase 7 PR-L4)
[pre-ready] ✓ Step 7c/12: check-cli-entry-guard.mjs (#3969)
[pre-ready] ✓ Step 7d/12: check-workflow-sparse-checkout-closure.mjs (#3969)
[pre-ready] ⊘ Step 8/12: generate-lp-labels --check (labels.ts / terms.ts / age-tier.ts 変更検知: NO — skip)
[pre-ready] ✓ Step 9/12: Readiness gate (check-pr-body.mjs --pr 3979)
[pre-ready] ✓ Step 10/12: check-doc-code-references.mjs (#2577)
[pre-ready] ✓ Step 11/12: check-terminology-coherence.ts (#2555)
[pre-ready] ⊘ Step 11b/12: SS embed gate (UI 変更なし — skip、#2918)
[pre-ready] ⊘ Step 12/12: capture.mjs (UI 変更検知: NO — skip)
[pre-ready] PARTIAL PASS — 実行した 12 step は PASS しましたが、5 step が --skip 指定で未実行です
             (lp-dimensions, lp-fallback, lp-labels, ss-embed-gate, capture)
```

`⊘` の 5 step はいずれも **LP / UI 変更が無いことによる条件 skip** で、本 PR は UI 変更 0 件のため該当しない。各 gate の PASS 文言:

```console
[check-cli-entry-guard] OK: 自前の CLI 実行判定 / 手組み file:// URL は 0 件
                            (走査 scripts=217 / src=729 / infra=12 / .claude=3)
[check-workflow-sparse-checkout-closure] OK: 39 workflow / 起点 19 本の sparse-checkout に import 漏れ 0 件
[check-pr-body] OK — 違反なし
CSpell: Files checked: 1732, Issues found: 0 in 0 files.
 Test Files  545 passed | 4 skipped (549)
      Tests  8390 passed | 13 skipped (8403)
   Duration  1018.79s
```

> **訂正: `ac56cc79` までで開示していた「Step 3 (vitest) がローカル恒常 red (#3975)」は撤回する。**
> `tests/unit/infra/dsql-cdk.test.ts` の CDK 合成 hook timeout は、**pre-ready / vitest を単独で 1 本だけ回すと再現しない**。上記のとおり Step 3 は PASS しており、`549` files は `vite.config.ts:80` の `include` に一致する repo 上の `.test.ts` 実数 549 と一致するので、当該ファイルも実行されている（vitest の既定 reporter は pass したファイルを列挙しないため、件数一致で確認）。
> 原因は **pre-ready / vitest を同時に 4 プロセス並走させていたこと**で、`exit 4294967295` はその resource 起因と判断する。#3975 の Issue 自体は残すが、**本 PR の証跡としては例外扱いを不要とする**。

- [x] **回帰テストを同一 PR 内で追加**（要件 1、再掲）
- [x] 追加・変更したテスト一覧:
  - `tests/unit/scripts/cli-entry-guard.test.ts`（新規） → `CI=1` で **41 passed (41)**
  - `tests/unit/scripts/workflow-sparse-checkout-closure.test.ts`（新規、Re-Review BLOCK 1 対応） → **14 passed (14)**
- [x] **Critical バグ修正の場合**（ADR-0002）: 上記 5 要件全て確認済み

ローカル実測（HEAD `71339432`、いずれも実体パス実行）:

```console
CI=1 npx vitest run tests/unit/scripts/cli-entry-guard.test.ts               → 41 passed (41)
CI=1 npx vitest run tests/unit/scripts/workflow-sparse-checkout-closure.test.ts → 14 passed (14)
node scripts/pre-ready.mjs --pr 3979 (Step 3 = vitest 全体)                  → 8390 passed | 13 skipped
npx svelte-check --threshold error (pre-ready Step 2)                        → PASS (0 errors)
node scripts/check-cli-entry-guard.mjs                                       → OK / exit 0
```

## スクリーンショット / ビジュアルデモ

**該当なし（バックエンド / CI ツール修正のみ、UI 変更 0 件）**

## コード品質セルフレビュー (#1481)

- [x] **DRY**: 同一バグが他ファイルにないか調査済み — `scripts` / `src` / `infra` を静的 gate で全走査し、5 方言 + `.ts` の自前 realpath 実装（6 番目）を全て helper へ集約
- [x] **YAGNI**: 過剰防衛設計を追加していない（ADR-0010）— symlink 等価性の動的検証は主要 gate 12 本に限定（全 54 本の両経路起動は実測 ~5.5 分で unit test に載らない）。残りは静的 gate が判定 SSOT 利用を全件強制することでカバーし、その境界をテストのコメントに明記している
- [x] **Security**: 修正により新たな攻撃面を作っていない（realpath 解決は起動プロセス自身のパスに対してのみ実施）
- [x] **アクセシビリティ**: UI 非影響
- [x] **パフォーマンス**: 追加コストは起動時 `realpathSync` 2 回のみ

## 横展開・影響波及チェック

- [x] 本番アプリ + デモ版を同期 — N/A（アプリ実行時経路の変更なし）
- [x] 全年齢モード 5 種に横展開 — N/A（UI 非影響）
- [x] ナビゲーション 3 種に反映 — N/A
- [x] E2E / ユニットシード同期 — N/A（seed の変更はコメント 1 行のみ）
- [x] labels SSOT (ADR-0009) — N/A（label 追加なし）
- [x] 設計書同期 (ADR-0001) — `src/routes/` 変更が無いため `design-doc-check` の対象外。開発者向け CI gate の追加であり設計書の記述対象に該当しない
- [x] 並行 PR overlap 確認 (#1200) — **#3965 が `scripts/check-pr-body.mjs` を変更している**。本 PR の同ファイル変更は末尾 isMain 判定の置換のみ（+2 -9）、#3965 は `resolveLabels` 周辺（ファイル中盤）のため機械的 conflict は想定していないが、**#3965 を先に merge し、本 PR を rebase してから merge する順序**を採る

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:

1. **meta-gate の設計が「gate の沈黙」を本当に捕まえられるか** — 動的側は「不正入力で exit != 0 / 無出力でない」、静的側は「自前判定の再混入 0 件」の 2 層構成。この 2 つで抜ける沈黙パターンが残っていないかを見ていただきたいです
2. **動的検証を 12 本に絞った判断** — 全 54 本の両経路起動は実測 ~5.5 分。絞った境界（残りは静的 gate がカバー）が妥当か、選んだ 12 本に落とすべきでないものが混じっていないか
3. **`src/lib/server/db/seed.ts` の opt-out** — basename 一致判定なので事故形ではないという判断と、`src → scripts` 依存を作らないために helper を使わない判断の妥当性
4. **`biome.json` の `!**/cdk.context.json` 追加**（本 Issue のスコープ外の同梱）— `.gitignore` 済の生成物が biome の検査対象に残っており、`cdk synth` を一度でもローカル実行した開発者は以後 pre-ready Step 1 が無関係な理由で必ず落ちていました。本 PR の趣旨（ローカル gate が正しく機能する状態にする）と同一なので同梱しています。分離すべきなら指摘ください

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] **ADR-0002 5 要件全て満たした**（再掲、自己確認）
- [x] セルフレビュー済み
- [x] 全 AC が実装済み
- [x] UI 変更時: 5 年齢モード SS が GitHub 上で表示確認できる — N/A（UI 変更なし）

## QM レビュー指摘への対応 (2026-07-26 / BLOCK 4 件)

Re-Review 2 巡で BLOCK 4 件を受領し、**すべて本 PR 内で修正しました**。追加コミット: `bf5697cf` → `1975e431` → `591a6d7a` → `9b0253fd` → `ac56cc79` → `71339432`。

### BLOCK 1 — sparse-checkout に `scripts/lib/is-main.mjs` が無く必須 gate 6 job が fail

指摘は成立していました。PR HEAD `591a6d7a` の CI 実 log で確認済みです。

```
job 89785035819 / 89785035793 ほか計 6 job
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
  '/home/runner/work/ganbari-quest/ganbari-quest/scripts/lib/is-main.mjs'
  imported from /home/runner/work/ganbari-quest/ganbari-quest/scripts/pr-lane.mjs
```

対応は 2 段です。

1. 該当 6 ブロックへ `scripts/lib/is-main.mjs` を追加（`scripts/pr-lane.mjs` が 5 ブロックに列挙されているため巻き込みが広い）
2. **`scripts/check-workflow-sparse-checkout-closure.mjs` を新設** — `sparse-checkout` ブロックごとに列挙 `.mjs` の相対 import を再帰的に辿り、到達先が同一ブロックに列挙されているかを検証。`.github/workflows/ci.yml` と `pre-ready` Step 7d の両方に配線

これを「直して終わり」にしなかった理由は、本 PR の `check-cli-entry-guard` が**今後書かれる gate script に SSOT helper の import を強制する**ためです。新しい gate を sparse-checkout に列挙するたびに同じ列挙漏れが起きるので、今回の 6 ブロックは 1 件目であって最後ではありません（ADR-0061 same-class-N → guard 化）。

mutation 証跡 — `pr-merge-gate.yml` から helper の 1 行を抜くと:

```
[check-workflow-sparse-checkout-closure] FAIL: 1 件の import 漏れ
  .github/workflows/pr-merge-gate.yml:48  不足: scripts/lib/is-main.mjs
      scripts/pr-lane.mjs, scripts/check-merge-gate-checklist.mjs が import しているが
      sparse-checkout に列挙されていない
```

復元後 `OK: 39 workflow の sparse-checkout に import 漏れ 0 件` / exit 0。

守備範囲（意図的な限界）は script の doc header に明記しています — bare specifier は `npm ci` の担当で対象外 / 動的 import は式が静的に決まらないため辿れない / `.ts` gate を列挙した場合は `JS_EXTS` に `.ts` 追加が必要 / `readFileSync` 等の import 以外の repo 内ファイル依存は辿らない。**後者 2 点は QM から「発火しない条件」として実測を頂いた項目**で、現ツリーでは顕在化しません（sparse-checkout 対象 6 script の repo 内ファイル読み込みは 0 件、`.ts` gate はどの block にも未列挙）。将来どちらかを載せた時点で守備範囲外になる旨を doc に書いてあります。

### BLOCK 2 — `.claude/` 配下 2 本の事故形（追跡 Issue ではなく本 PR で修正）

- `.claude/hooks/gate-approve.mjs:257`
- `.claude/skills/dev-open-pr/scripts/init-pr-body.mjs:339`

スコープ外に逃がさなかった理由は、`gate-approve.mjs` が**「壊れると無言で PASS する gate」そのもの**だからです。ADR-0056 evidence を検証して approve を止める hook が junction 経由で判定 false になっていたのは、本 PR が閉じようとしている class の中で最も重い一例でした。これを残すと、本 PR が「gate の無言 PASS を潰す PR」でありながら自分の approve gate を壊れたまま残すことになります。

走査範囲の決め方を「実行経路 (`scripts/`)」から**「壊れたときに無言で PASS するか」**へ変更し、`SCAN_ROOTS` に `.claude` を追加しました。定数の目視確認では守れないので test で固定しています。

- 修正後、`gate-approve.mjs` に stdin から `gh pr merge 3979 --squash` を流して **exit 2 (BLOCK)** を確認
- `init-pr-body.mjs` は `main()` に到達して usage を出すことを確認

mutation 証跡 2 件:

```
SCAN_ROOTS から '.claude' を外す  → 1 failed / 33 passed
  × .claude/hooks/ 配下の事故形を検出する (SCAN_ROOTS に .claude が無いと素通りする)

SKIP_DIRS から 'worktrees' を外す → 1 failed / 33 passed
  × .claude/worktrees/ 配下は走査しない (他ブランチの実体を重複報告しない)
```

`worktrees` の除外が必要なのは、`.claude/worktrees/agent-*/` に git worktree の実体が置かれる運用があり、中身は `scripts/` `src/` が dot なしで並ぶため `collectFiles` の「dot ディレクトリを飛ばす」規則では止まらないからです（QM 実測では開発者ローカルで 81 件の偽陽性、CI では 0 件）。fixture はその配置を実名で作っています。

### 本 PR で復旧する層 — ADR-0022 QA アカウント PR 作成禁止の予防 2 層（QM 実測 2026-07-26 14:17）

本 PR の効果は #3969 の gate 空振りだけではありません。ADR-0022 が「3 層機械強制」と定義している QA アカウントの PR 作成禁止のうち、**予防 2 層が junction 環境で無言死していました。**

| 層 | 実装 | develop | 本 PR 後 |
|---|---|---|---|
| L1（事前防止） | `.claude/settings.json` PreToolUse → `scripts/claude-hook-prevent-qa-account-pr.mjs:159` | **無言 allow**（junction 経由で exit 0 / 0 バイト） | **復旧**（`isMain()` 経由） |
| L2（事前防止） | `.husky/pre-push` → `scripts/check-gh-account-before-pr.mjs:276` | 同一の事故形 | **復旧**（`isMain()` 経由） |
| L3（事後 close） | `.github/workflows/pr-author-guard.yml` | 生存（server side / fresh clone） | 変化なし |

QM の behavioral probe（develop 版 / PR HEAD 版 × 実体パス / junction の 4 通り、`ALLOWED_PR_AUTHOR=__nobody__` で必ず違反判定になる入力）:

```
[develop via real] exit=2  bytes=254   [claude-hook-prevent-qa-account-pr] BLOCK
[develop via link] exit=0  bytes=0     ← 無言 allow
[head    via real] exit=2  bytes=254
[head    via link] exit=2  bytes=254   ← 本 PR で復旧
```

**silent damage は発生していません。** L3 が生存しているため、違反すれば PR が close されて表面化する形でした。本 PR が戻すのは「作らせてから close する」から「作らせない」への予防側です。

なお L1 hook は下記の層 B（`~/.buzz/.claude/settings.json` に PreToolUse 未登録）の対象でもあるため、agent セッションでの実効は層 B の登録待ちです。

### 追加対応 — `skipIf(!SYMLINK_OK)` の無言 skip を CI で固定（QM 指摘 / 非 BLOCK）

`tests/unit/scripts/cli-entry-guard.test.ts` の symlink 系ケースは `canSymlink()` が false を返すと全て skip され、**1 件も検証しないまま緑**になります。本 PR が閉じている class そのものなので、CI 上では probe が true であることを assert する 1 ケースを追加しました。

mutation 証跡（`const SYMLINK_OK = canSymlink()` を `false` に書き換えて `CI=1` で実行、実行後に復元）:

```
AssertionError: expected false to be true // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 20 passed | 14 skipped (35)
```

通常時（実体パス `E:\Github\gq-wt-3969`）:

```
CI=1 npx vitest run tests/unit/scripts/cli-entry-guard.test.ts  → Tests  35 passed (35)
     npx vitest run tests/unit/scripts/cli-entry-guard.test.ts  → Tests  34 passed | 1 skipped (35)
node scripts/check-skip-deadlines.mjs → [check-orphan-skip-deadlines] OK — 26 known orphan(s) all in baseline
```

上記の mutation / 通常時の件数は本節の対応を入れた `ac56cc79` 時点のものです（35 ケース）。その後 BLOCK 4 対応で 6 ケース増えており、**現 HEAD `71339432` では `CI=1` で `41 passed (41)`** です。

### 本 PR で直らない層 — approve gate の層 B（オーナー作業が必要）

QM の実測により、ADR-0056 の approve gate が**二重に無効化されている**ことが判明しています。本 PR が閉じるのは片方だけです。

| 層 | 内容 | 本 PR で直るか |
|---|---|---|
| 層 A | `.claude/hooks/gate-approve.mjs` が junction 経由で `isDirect=false` → 無言 allow | **直る**（BLOCK 2 の修正） |
| 層 B | hook が repo の `.claude/settings.json` にしか登録されておらず、QM セッションのプロジェクトディレクトリ (`~/.buzz`) には `PreToolUse` hook が存在しない = **hook がそもそも読み込まれない** | **直らない**（`~/.buzz/.claude/settings.json` への登録はオーナー作業） |

**層 B が未登録のまま本 PR を merge しても approve gate は復旧しません。** merge 後にこの前提が追えなくなるのを避けるため、ここに明記します。

### BLOCK 3 — AC 検証マップの証跡が `15acd009` のままでスコープが古い（ADR-0004）

sha が古いだけでなく、AC1 / AC4 の達成根拠が BLOCK 2 修正**前**のスコープ（`.claude` 2 件が抜けた状態）でした。この body だけを読むと AC4 が未達に見える状態です。**上記「AC 検証マップ」「テスト & 安全装置セルフチェック」を HEAD `71339432` の実測で全面差し替えしました。**

| 差し替えた項目 | 差し替え後 |
|---|---|
| 証跡 HEAD（AC1〜AC4 の 4 行） | `71339432` |
| `cli-entry-guard.test.ts` のテスト数 | `31 passed` → **`41 passed (41)`**（`CI=1`） |
| AC1 / AC4 のスコープ | `.claude/` 配下 2 件（`gate-approve.mjs:258` / `init-pr-body.mjs:339`）を明記 |
| AC4 の走査範囲 | `SCAN_ROOTS` **4 root**（`check-cli-entry-guard.mjs:64`）+ 走査実測 `scripts=217 / src=729 / infra=12 / .claude=3` |
| テスト一覧 | `workflow-sparse-checkout-closure.test.ts`（**14 passed**）を追記 |
| AC3 の CI 発火条件 | `ci.yml:52` の `app` filter に `.claude/**`（`:63`）を追記 |
| pre-ready 証跡 | `15acd009` 時点の `8354 passed` → `71339432` の完走ログ全文（**Step 3 の #3975 例外を撤回**） |

### BLOCK 4 — `.claude/**` のみを変更する PR では entry guard が CI で 1 度も走らない

BLOCK 2 で `SCAN_ROOTS` に `.claude` を足した一方、**その scope を守る gate の発火条件が未更新**でした。`check-cli-entry-guard.mjs` を実行するのは `ci.yml:211`（`lint-and-test` job）だけで、この job は `changes` の 4 filter (`app` / `deps` / `stories` / `docs`) がすべて false なら job ごと skip されます。つまり merge 後に `.claude/hooks/gate-approve.mjs`（ADR-0056 の approve gate 本体）だけを直す PR を出すと、gate が 1 度も走りませんでした。

**修正は 3 点です。** 指摘そのものは `ci.yml` の 1 行ですが、`SCAN_ROOTS` を広げる側（`scripts/`）と発火条件を広げる側（`.github/workflows/`）が別ファイルにある以上、次に root を足す人が同じ穴を作ります。本 PR が閉じている class そのものなので、**対応関係を test で固定**しました。

1. `.github/workflows/ci.yml:63` — `paths-filter` の `app` に `- '.claude/**'` を追加
2. `scripts/check-cli-entry-guard.mjs:64` — `SCAN_ROOTS` を `export`（テストから参照する SSOT にする）
3. `tests/unit/scripts/cli-entry-guard.test.ts:305` — `SCAN_ROOTS` 全件が `app` filter に列挙されていることを assert。parser（`extractFilterPaths`）が空配列を返すだけの偽 PASS を防ぐため、**陽性対照**（`app` filter を 5 件以上抽出でき `src/**` を含む）を 1 ケース併置

mutation 証跡（`- '.claude/**'` の 1 行を削除して実行、実行後に復元）:

```console
$ CI=1 npx vitest run tests/unit/scripts/cli-entry-guard.test.ts
 × app filter が '.claude/**' を含む 5ms
AssertionError: SCAN_ROOTS に '.claude' があるのに ci.yml の paths-filter app に '.claude/**' が
ありません。'.claude/**' だけを変更した PR で lint-and-test が skip され、gate が走りません。:
  expected [ 'src/**', 'static/**', …(14) ] to include '.claude/**'
 Tests  1 failed | 40 passed (41)     ← 通常時は 41 passed (41)
```

`.claude/**` が `dorny/paths-filter@v4` で実際に一致することは **QM が action 実装まで辿って確認**しています（`v4` が指す `7b450fff` の `src/filter.ts:16,123` が `picomatch(item, { dot: true })`、同系列 picomatch で `.claude/hooks/gate-approve.mjs` / `.claude/settings.json` ともに MATCH、陰性対照 `.claude/**` vs `scripts/pre-ready.mjs` = false）。この結論は `dot` オプションに依存しません。**ただし `@v4` は floating tag（`check-action-sha-pin.mjs:140` で意図的に allowlist）なので、tag が動けばこの根拠は失効します。**

### 併記の非 BLOCK — gate の PASS 文言に走査量を出す

`SCAN_ROOT` が checkout に無いと gate が **PASS と同一文言で exit 0** を返し、「0 件走査」と「違反 0 件」が区別できませんでした。PASS 文言に root ごとの走査件数を出すようにし（root 不在時は件数ではなく `未検出`）、件数が出ることを test でも固定しています。

root 不在そのものは gate 側で fail にしていません（consumer 側の正当な事情がありうるため）。代わりに **この repo の CI checkout では件数が出ることを test が assert する**構成で、CI から root が消えた瞬間に落ちます。QM が `.claude` を退避して実測し、`.claude=未検出` と test 1 件 fail の両方を確認済みです。

### 本 body の検証証跡について（PO 2026-07-26 指示）

本 PR body のローカル証跡は、junction (`C:\Users\kokor\.buzz\REPOS\...`) ではなく**実体パス `E:\Github\gq-wt-3969` で取得**しています。develop 版 `scripts/pre-ready.mjs:725-731` の `isMain` は `realpathSync` を通しておらず、junction 経由では 0 バイト exit 0 の空振りになるためです（本 PR HEAD の `pre-ready.mjs` は `isMain(import.meta.url)` 経由なのでこの問題を持ちません）。

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)





