### PR TITLE
fix(billing): #3982 解約時の subscription/plan クリアを実効化 + #3976 部分更新契約テスト

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -548,3 +548,5 @@ inlang
 jscodeshift
 mebibytes
 crond
+# ===== #3982 demo auth-repo の型導出コメント (TS の method shorthand はパラメータが双変) =====
+bivariant

--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -12,7 +12,7 @@
 | **アップグレード (プラン昇格)** | `/admin/license` 「プラン変更・支払い管理」 | PIN 確認 → `POST /api/stripe/portal` → Stripe Customer Portal → `customer.subscription.updated` Webhook | Portal の return URL = `/admin/license` → 新プラン反映 |
 | **ダウングレード** | 同上（Customer Portal） | 同上 → Portal で下位プランに変更 → `customer.subscription.updated` Webhook | 同上 → 新プラン反映＋PlanStatusCard で超過リソースを警告 |
 | **月額↔年額切替** | 同上（Customer Portal） | 同上（Stripe 標準 UI） | 同上 |
-| **解約 (cancel)** | 同上（Customer Portal） | 同上 → Portal で「解約」 → `customer.subscription.deleted` Webhook | DB: `plan=undefined, status=suspended`（テナントは残る） |
+| **解約 (cancel)** | 同上（Customer Portal） | 同上 → Portal で「解約」 → `customer.subscription.deleted` Webhook | DB: `stripe_subscription_id=NULL, plan=NULL, status=suspended`（テナントは残る、#3982）。到着順に依らない収束規則は §10.5 |
 | **支払い失敗** | Stripe (自動) | `invoice.payment_failed` Webhook | DB: `status=grace_period, planExpiresAt=now+7d` → 猶予期間中は機能維持 |
 | **ライセンスキー適用** | `/admin/license` フォーム | `applyLicenseKey` action → `consumeLicenseKey` (Stripe を経由しない) | テナント plan を直接昇格、Stripe 課金は発生しない |
 
@@ -313,28 +313,44 @@ DynamoDB: PK=`GRADUATION_CONSENT`, SK=`<isoTs>#<uuid>` (single global partition�
 
 `stripe-service.ts:handleSubscriptionUpdated()`
 
-1. `subscription.metadata.tenantId` か `findTenantBySubscription(subscription.id)` でテナント特定
-2. `subscription.items[0].price.id` から `planIdFromPriceId()` で `Tenant['plan']` を解決
-3. `subscription.status` を DB 用に正規化:
+1. `subscription.metadata.tenantId` か `resolveSubscriptionContext(subscription.id)` でテナント特定
+   （後者は `subscriptions.retrieve()` → `customer` → `findTenantByStripeCustomerId()` の逆引き。
+   **subscription ID ではなく customer ID を鍵にしている**ため、解約で
+   `stripe_subscription_id` をクリアしても逆引きは壊れない、#3982）
+2. **終端判定 (#3982)**: `subscription.status ∈ {canceled, incomplete_expired}` なら §10.5 の
+   終端状態へ収束させて終了（plan を書き戻さない）
+3. `subscription.items[0].price.id` から `planIdFromPriceId()` → `planIdFromLookupKey()` の順で
+   `Tenant['plan']` を解決。解決できなければ **plan 列を更新せず既存値を保持** + alert（#3960、
+   旧 `?? MONTHLY` の silent fallback は廃止）
+4. `subscription.status` を DB 用に正規化:
    | Stripe status | DB status |
    |---------------|-----------|
    | `active` / `trialing` | `'active'` |
    | `past_due` | `'grace_period'` |
-   | その他 (`canceled` / `unpaid` / `incomplete_expired`) | `'suspended'` |
-4. `repos.auth.updateTenantStripe()` で `plan, status` を保存
-5. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_updated', 'status=..., plan=...')`
+   | `unpaid` / `paused` / `incomplete` | `'suspended'` |
+   | `canceled` / `incomplete_expired` | 終端収束（手順 2 で処理済、§10.5） |
+5. `repos.auth.updateTenantStripe()` で `plan, status` を保存
+6. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_updated', 'status=..., plan=...')`
 
 ### 3.4 Webhook 処理 — `customer.subscription.deleted`
 
-`stripe-service.ts:handleSubscriptionDeleted()`
+`stripe-service.ts:handleSubscriptionDeleted()` → `clearSubscriptionAssignment()`
 
 1. テナント特定（同上）
 2. `repos.auth.updateTenantStripe()` で:
-   - `stripeSubscriptionId` = undefined
-   - `plan` = undefined
+   - `stripeSubscriptionId` = **`null`**（= SQL で `NULL` を書く）
+   - `plan` = **`null`**（同上）
    - `status` = `'suspended'`
-3. **重要**: テナント・子供データ・活動履歴は削除しない（解約と削除は別概念。アカウント削除は `/admin/settings` 経由 → `account-deletion-flow.md` 参照）
-4. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_deleted')`
+   - `stripeCustomerId` は**意図的に残す**（再購読時の Stripe customer 再利用 + 後続 webhook の逆引き鍵）
+3. **`undefined` ではなく `null` である理由 (#3982)**: `updateTenantStripe` は部分更新 API で、
+   `undefined` = 「その列を更新しない」、`null` = 「NULL でクリアする」という 2 値セマンティクス
+   （契約は `IAuthRepo.updateTenantStripe` の JSDoc が SSOT）。
+   旧実装は `undefined` を渡しており **クリアが丸ごと no-op** だった。その結果
+   `stripe_subscription_id` が解約後も残り、`createCheckoutSession()` の
+   `if (tenant.stripeSubscriptionId) return { error: 'ALREADY_SUBSCRIBED' }` が発火して
+   **解約済みユーザーの再購読導線が塞がっていた**
+4. **重要**: テナント・子供データ・活動履歴は削除しない（解約と削除は別概念。アカウント削除は `/admin/settings` 経由 → `account-deletion-flow.md` 参照）
+5. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_deleted')`
 
 ---
 
@@ -345,6 +361,8 @@ DynamoDB: PK=`GRADUATION_CONSENT`, SK=`<isoTs>#<uuid>` (single global partition�
 `stripe-service.ts:handlePaymentFailed()`
 
 1. テナント特定
+1b. **終端判定 (#3982)**: retrieve した現行 subscription が `canceled` / `incomplete_expired` なら
+   状態を更新せず終了（解約後に後着した payment_failed で終端状態を `grace_period` に戻さない）
 2. **猶予期間設定**: `GRACE_PERIOD_DAYS = 7` (`src/lib/server/stripe/config.ts`)
    ```ts
    const graceExpires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
@@ -584,6 +602,54 @@ Customer Portal 経由のみ。Portal 内の「プラン変更」UI から切り
 現状、明示的なロールバックは未実装。Webhook が成功した時点で DB は新状態に更新される。
 
 **将来検討 (#823)**: Stripe 側を正として DB を eventually consistent に保つため、定期的に `stripe.subscriptions.list` で全 active subscription をスキャンし、DB と乖離があれば修正する reconcile job を追加する想定。
+
+### 10.5 Webhook 到着順序と収束規則（SSOT — #3960 / #3982）
+
+**Stripe は webhook の配信順序を保証しない**（公式: [Event ordering](https://docs.stripe.com/webhooks#event-ordering)）。
+1 回のユーザー操作が複数 event を発火するため、**「どの順序で届いても最終状態が一致する」ことを
+設計要件として明示**する。ここが曖昧なまま個別 handler を書いた結果、#3960（plan の巻き戻し）と
+#3982（解約状態の巻き戻し）が連続して発生した。
+
+> **本節は「順序」の SSOT であり、「重複」の SSOT ではない。** 同一 `event.id` の重複到達
+> （at-least-once delivery / replay）に対する dedup は
+> [`billing-redesign/phase5-webhook-idempotency-architecture.md`](billing-redesign/phase5-webhook-idempotency-architecture.md)
+> で設計確定済だが **実装は未着手**（同 doc のステータス欄「コード変更は Phase 7」）。
+> 順序ガード（本節）と dedup（#2641 設計）は別の防御であり、片方では他方を代替できない。
+
+#### 10.5.1 収束の 2 原則
+
+| # | 原則 | 実装 |
+|---|------|------|
+| **P1** | **可変な属性は「event の payload」ではなく「Stripe 上の現行 subscription」から解決する** | `handleInvoicePaid` は `invoice.lines` を読まず `subscriptions.retrieve()` の現行 price を SSOT にする（#3960）。retrieve は常に最新を返すため、後着 event でも古い値を書かない |
+| **P2** | **終端状態 (`canceled` / `incomplete_expired`) を検出した handler は、契約ありきの状態を書き戻さない** | `isSubscriptionTerminal()`（`stripe-service.ts`）。この 2 status は Stripe 上で他の status に戻らないため、「契約はもう存在しない」ことの確定印として使える（#3982） |
+
+`paused` / `unpaid` / `incomplete` は復帰し得るため終端に含めない（含めると復帰経路を殺す）。
+
+#### 10.5.2 ユースケース × 到着順 収束表
+
+`E1 → E2` は E1 が先着。**「最終状態」列がどちらの順序でも一致すること**が受入基準。
+
+| # | ユースケース | 発火 event | 到着順 | 最終状態 | 担保 |
+|---|---|---|---|---|---|
+| U1 | 新規購入 | `checkout.session.completed`, `customer.subscription.updated`(active) | どちらでも | `id=sub_x` / `plan=購入プラン` / `active` | P1（updated は現行 price を書く） |
+| U2 | プラン変更（standard → premium） | `customer.subscription.updated`(active), `invoice.paid` | どちらでも | `plan=premium` | P1（#3960。旧実装は `invoice.lines.data[0]` = 変更前 price を書いて巻き戻していた） |
+| U3 | 支払い失敗 | `invoice.payment_failed` | — | `grace_period` / `planExpiresAt=+7d` | — |
+| U4 | 支払い失敗 → 更新して復帰 | `invoice.payment_failed`, `invoice.paid` | 実時系列どおり | `active` | Stripe が時系列に発火（同時発火ではない） |
+| U5 | **解約** | `customer.subscription.updated`(canceled), `customer.subscription.deleted` | **どちらでも** | `id=NULL` / `plan=NULL` / `suspended` | **P2**（updated 側も終端収束させる。P2 がないと updated 後着で `id=NULL` かつ `plan≠NULL` という DB 上ありえない組合せが残る） |
+| U6 | **解約後に当期分請求が後着** | `customer.subscription.deleted`, `invoice.paid` | **どちらでも** | `id=NULL` / `plan=NULL` / `suspended` | **P2**（P2 がないと `invoice.paid` が `status=active` を書き戻し、**解約済みテナントが課金中として復活**する） |
+| U7 | **解約後に payment_failed が後着** | `customer.subscription.deleted`, `invoice.payment_failed` | **どちらでも** | 同上 | **P2**（P2 がないと `grace_period` へ巻き戻る） |
+| U8 | 解約 → 再購読 | `...deleted`, `checkout.session.completed`(新 sub) | 実時系列どおり | `id=sub_new` / `plan=新プラン` / `active` | `stripeCustomerId` を残すこと。かつ U5/U6/U7 の収束が効いていること（`id` が残っていると `createCheckoutSession` が `ALREADY_SUBSCRIBED` で弾き、そもそも U8 に入れない = #3982 の実害） |
+
+回帰テスト: `tests/unit/services/stripe-service.test.ts`
+（U2 = `#3960 — ... の順で` 2 本 / U5・U6・U7 = `#3982 — ...` 4 本 + 終端でない `past_due` の対照 1 本）。
+
+#### 10.5.3 未カバー（既知の残課題）
+
+| 項目 | 状態 |
+|---|---|
+| 同一 `event.id` の重複到達（dedup） | 設計確定・**実装未着手**（#2641 / phase5-webhook-idempotency-architecture.md） |
+| 同一 tenant への webhook 並行処理（handler 間の競合） | 未設計。Lambda 並行実行下では U1〜U8 の順序ガードも read-modify-write の間に割り込まれ得る |
+| DB ↔ Stripe の定期 reconcile | 未実装（#823、§10.4） |
 
 ---
 

--- a/src/lib/server/db/demo/auth-repo.ts
+++ b/src/lib/server/db/demo/auth-repo.ts
@@ -92,16 +92,13 @@ export async function updateTenantStatus(
 	// Stub: no-op
 }
 
+// #3982: 引数型を interface から導出する。インラインで再宣言すると、`IAuthRepo` の
+// method shorthand 記法によりパラメータが bivariant になり、**狭めても型エラーにならない**
+// (実測: `string | null` → `string` に戻しても svelte-check 0 errors。末尾の
+// `_typecheck: IAuthRepo` でも検出できない)。導出にすれば乖離自体が表現不能になる。
 export async function updateTenantStripe(
 	_tenantId: string,
-	_data: {
-		stripeCustomerId?: string;
-		stripeSubscriptionId?: string | null;
-		plan?: Tenant['plan'] | null;
-		planExpiresAt?: string;
-		trialUsedAt?: string;
-		status?: Tenant['status'];
-	},
+	_data: Parameters<IAuthRepo['updateTenantStripe']>[1],
 ): Promise<void> {
 	// Stub: no-op
 }

--- a/src/lib/server/db/demo/auth-repo.ts
+++ b/src/lib/server/db/demo/auth-repo.ts
@@ -96,8 +96,8 @@ export async function updateTenantStripe(
 	_tenantId: string,
 	_data: {
 		stripeCustomerId?: string;
-		stripeSubscriptionId?: string;
-		plan?: Tenant['plan'];
+		stripeSubscriptionId?: string | null;
+		plan?: Tenant['plan'] | null;
 		planExpiresAt?: string;
 		trialUsedAt?: string;
 		status?: Tenant['status'];

--- a/src/lib/server/db/dsql/auth-repo.ts
+++ b/src/lib/server/db/dsql/auth-repo.ts
@@ -283,6 +283,9 @@ export function createDsqlAuthRepo<TTx extends SqlExecutor>(
 		},
 
 		async updateTenantStripe(tenantId, data) {
+			// #3982: `!== undefined` ガードは「渡されたキーだけ SET を積む」部分更新の SSOT。
+			// `null` は SET を積んだうえで NULL を書くため、クリアは null で表現する
+			// (interface の JSDoc が契約、`dsql-auth-repo.test.ts` [T4b] が固定)。
 			const sets: ReturnType<typeof sql>[] = [];
 			if (data.stripeCustomerId !== undefined)
 				sets.push(sql`stripe_customer_id = ${data.stripeCustomerId}`);

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -31,12 +31,25 @@ export interface IAuthRepo {
 	listAllTenants(): Promise<Tenant[]>;
 	createTenant(input: CreateTenantInput): Promise<Tenant>;
 	updateTenantStatus(tenantId: string, status: Tenant['status']): Promise<void>;
+	/**
+	 * テナントの Stripe 関連属性を **部分更新**する。
+	 *
+	 * フィールドごとの意味論 (#3982):
+	 * - `undefined` (キー省略含む) = **その列を更新しない**。既存値を保持する。
+	 *   `handleInvoicePaid` / `handleSubscriptionUpdated` が plan を解決できなかったとき、
+	 *   既存 plan を壊さないためにこの意味論に依存している (#3960)。
+	 * - `null` = **その列を NULL でクリアする**。`customer.subscription.deleted` で
+	 *   subscription 参照を解消する用途 (null を渡せるのは nullable 列のみ)。
+	 *
+	 * 実装は「渡されたキーだけ SET 句を積む」方式であり、全フィールド `undefined`
+	 * (= SET 句 0 件) の場合は UPDATE 自体を発行しない。
+	 */
 	updateTenantStripe(
 		tenantId: string,
 		data: {
 			stripeCustomerId?: string;
-			stripeSubscriptionId?: string;
-			plan?: Tenant['plan'];
+			stripeSubscriptionId?: string | null;
+			plan?: Tenant['plan'] | null;
 			planExpiresAt?: string;
 			trialUsedAt?: string;
 			status?: Tenant['status'];

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -307,6 +307,19 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 	}
 	const { tenant, subscription } = context;
 
+	// #3982: Stripe は配信順序を保証しないため、解約後に当期分の invoice.paid が**後着**し得る。
+	// `subscription` は Stripe から retrieve した現行状態なので、terminal ならその契約は
+	// 二度と復活しない (Stripe 仕様)。ここで ACTIVE を書くと `customer.subscription.deleted` が
+	// 確定させた終端状態を巻き戻し、**解約済みテナントが課金中として復活する**。
+	// 到着順に依らず終端へ収束させるため skip する (#3960 と同じ「現行 subscription が SSOT」原則)。
+	if (isSubscriptionTerminal(subscription)) {
+		logger.warn(
+			`[STRIPE] invoice.paid — subscription が終端状態 (${subscription.status}) のため状態を更新しません: ` +
+				`tenant=${tenant.tenantId} subscription=${subscription.id}`,
+		);
+		return;
+	}
+
 	// #3960: plan は invoice の line item から推測せず、**subscription の現行 price** を SSOT とする。
 	//
 	// 旧実装は `invoice.lines.data[0]` を盲目参照していた。プラン変更 (proration) の invoice は
@@ -334,10 +347,21 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
 	const subscriptionId = extractSubscriptionId(invoice);
 	if (!subscriptionId) return;
 
-	const tenant = (await resolveSubscriptionContext(subscriptionId))?.tenant;
-	if (!tenant) {
+	const context = await resolveSubscriptionContext(subscriptionId);
+	if (!context) {
 		logger.warn(
 			`[STRIPE] invoice.payment_failed — tenant not found for subscription=${subscriptionId}`,
+		);
+		return;
+	}
+	const { tenant, subscription } = context;
+
+	// #3982: invoice.paid と同様、解約後に後着した payment_failed で
+	// 終端状態 (suspended + subscription 参照なし) を grace_period へ巻き戻さない。
+	if (isSubscriptionTerminal(subscription)) {
+		logger.warn(
+			`[STRIPE] invoice.payment_failed — subscription が終端状態 (${subscription.status}) のため状態を更新しません: ` +
+				`tenant=${tenant.tenantId} subscription=${subscription.id}`,
 		);
 		return;
 	}
@@ -362,6 +386,25 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 		? await getRepos().auth.findTenantById(tenantId)
 		: (await resolveSubscriptionContext(subscription.id))?.tenant;
 	if (!tenant) return;
+
+	// #3982: `customer.subscription.deleted` と `customer.subscription.updated` (status=canceled) は
+	// 解約時に**両方**飛び、Stripe は到着順を保証しない。updated 側が後着したときに plan だけ
+	// 書き戻すと「subscription 参照なし・plan あり」という DB 上ありえない組み合わせが残る。
+	// canceled は Stripe 上 revert しない終端状態なので、**deleted と同じ終端状態へ収束**させる。
+	// これで deleted→updated / updated→deleted のどちらの順序でも最終状態が一致する。
+	if (isSubscriptionTerminal(subscription)) {
+		await clearSubscriptionAssignment(tenant.tenantId);
+		logger.info(
+			`[STRIPE] Subscription updated (terminal=${subscription.status}): ` +
+				`tenant=${tenant.tenantId} — subscription 参照と plan をクリアし suspended へ収束`,
+		);
+		notifyBillingEvent(
+			tenant.tenantId,
+			'subscription_updated',
+			`status=${SUBSCRIPTION_STATUS.SUSPENDED}, plan=cleared`,
+		).catch(() => {});
+		return;
+	}
 
 	const plan = resolvePlanFromSubscription(subscription);
 
@@ -397,12 +440,7 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription): Pro
 		: (await resolveSubscriptionContext(subscription.id))?.tenant;
 	if (!tenant) return;
 
-	const repos = getRepos();
-	await repos.auth.updateTenantStripe(tenant.tenantId, {
-		stripeSubscriptionId: undefined,
-		plan: undefined,
-		status: SUBSCRIPTION_STATUS.SUSPENDED,
-	});
+	await clearSubscriptionAssignment(tenant.tenantId);
 
 	logger.info(`[STRIPE] Subscription deleted: tenant=${tenant.tenantId}`);
 
@@ -412,6 +450,49 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription): Pro
 // ============================================================
 // Helpers
 // ============================================================
+
+/**
+ * Stripe subscription の **終端状態** (#3982)。
+ *
+ * この 2 値は Stripe 上で二度と他の status に戻らない (公式: Subscription lifecycle)。
+ * よって「この subscription はもう契約として存在しない」ことが確定した印として使える。
+ *
+ * Stripe は webhook の配信順序を保証しないため、解約後に `invoice.paid` /
+ * `invoice.payment_failed` / `customer.subscription.updated` が後着し得る。
+ * 終端状態を検出したハンドラは、契約ありきの状態 (ACTIVE / GRACE_PERIOD / plan) を
+ * **書き戻さない**。これにより到着順に依らず最終状態が一致する。
+ *
+ * `paused` / `unpaid` / `incomplete` は復帰し得るため終端に含めない。
+ */
+const TERMINAL_SUBSCRIPTION_STATUSES = [
+	'canceled',
+	'incomplete_expired',
+] as const satisfies readonly Stripe.Subscription.Status[];
+
+function isSubscriptionTerminal(subscription: Stripe.Subscription): boolean {
+	return (TERMINAL_SUBSCRIPTION_STATUSES as readonly string[]).includes(subscription.status);
+}
+
+/**
+ * subscription 参照と plan を解除し、テナントを解約済み終端状態にする (#3982)。
+ *
+ * 旧 `handleSubscriptionDeleted` は `undefined` を渡していたが、`updateTenantStripe` の
+ * 部分更新セマンティクス (undefined = その列を更新しない) により **両方とも no-op** だった。
+ * 結果 `stripe_subscription_id` が解約後も残り、`createCheckoutSession()` の
+ * `if (tenant.stripeSubscriptionId)` ガードが ALREADY_SUBSCRIBED を返して
+ * **再購読導線が塞がっていた**。クリアは `null` (= NULL を書く) で表現する。
+ *
+ * `stripeCustomerId` は意図的に残す: 同一顧客の再購読で Stripe customer を再利用するため
+ * (`resolveSubscriptionContext` の customer 逆引きの鍵でもあり、消すと後続 webhook が
+ * tenant を解決できなくなる)。
+ */
+async function clearSubscriptionAssignment(tenantId: string): Promise<void> {
+	await getRepos().auth.updateTenantStripe(tenantId, {
+		stripeSubscriptionId: null,
+		plan: null,
+		status: SUBSCRIPTION_STATUS.SUSPENDED,
+	});
+}
 
 /** Invoice から subscription ID を抽出（Stripe SDK v21: parent.subscription_details） */
 function extractSubscriptionId(invoice: Stripe.Invoice): string | undefined {

--- a/tests/unit/db/dsql-auth-repo.test.ts
+++ b/tests/unit/db/dsql-auth-repo.test.ts
@@ -172,6 +172,50 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 		expect(partial?.stripeCustomerId).toBe('cus_r2test');
 	});
 
+	// #3982: `undefined` = 更新しない / `null` = NULL クリア の 2 値セマンティクスを実 DB 値で固定する。
+	// 旧 `handleSubscriptionDeleted` は「クリアのつもりで undefined」を渡しており、両方 no-op だった
+	// (結果 stripe_subscription_id が解約後も残り createCheckoutSession が ALREADY_SUBSCRIBED を返した)。
+	it('[T4b] updateTenantStripe: undefined = 保持 / null = NULL クリア (#3982)', async () => {
+		const tenant = await repo.createTenant({ name: '解約家', ownerId: USER_B });
+		await repo.updateTenantStripe(tenant.tenantId, {
+			stripeCustomerId: 'cus_3982',
+			stripeSubscriptionId: 'sub_3982',
+			plan: SUBSCRIPTION_PLAN.MONTHLY,
+			status: 'active',
+		});
+
+		// undefined を渡しても既存値は消えない (= 旧実装が no-op だった証明)
+		await repo.updateTenantStripe(tenant.tenantId, {
+			stripeSubscriptionId: undefined,
+			plan: undefined,
+			status: 'suspended',
+		});
+		const kept = await repo.findTenantById(tenant.tenantId);
+		expect(kept?.stripeSubscriptionId).toBe('sub_3982');
+		expect(kept?.plan).toBe(SUBSCRIPTION_PLAN.MONTHLY);
+		expect(kept?.status).toBe('suspended');
+
+		// null を渡すと実際に NULL が書かれる (handleSubscriptionDeleted の現行経路)
+		await repo.updateTenantStripe(tenant.tenantId, {
+			stripeSubscriptionId: null,
+			plan: null,
+			status: 'suspended',
+		});
+		const cleared = await repo.findTenantById(tenant.tenantId);
+		expect(cleared?.stripeSubscriptionId).toBeUndefined();
+		expect(cleared?.plan).toBeUndefined();
+		// customer は再購読の顧客再利用 + webhook 逆引きの鍵なので残る
+		expect(cleared?.stripeCustomerId).toBe('cus_3982');
+
+		// 実列も NULL であること (entity マッピングの ?? undefined に隠されていないか)
+		const row = await t.db.execute(
+			sql`SELECT stripe_subscription_id, plan FROM families WHERE family_id = ${tenant.tenantId}`,
+		);
+		const record = (row as unknown as { rows: Record<string, unknown>[] }).rows[0];
+		expect(record?.stripe_subscription_id).toBeNull();
+		expect(record?.plan).toBeNull();
+	});
+
 	it('[T5] updateTenantLastActiveAt (存在しない tenant は silent no-op)', async () => {
 		const tenant = await repo.createTenant({ name: '活動家', ownerId: USER_A });
 		const ts = '2026-07-04T01:02:03.000Z';

--- a/tests/unit/db/dsql-auth-repo.test.ts
+++ b/tests/unit/db/dsql-auth-repo.test.ts
@@ -216,6 +216,96 @@ describe('DSQL auth-repo (PR-R2、実 schema PGlite)', () => {
 		expect(record?.plan).toBeNull();
 	});
 
+	// #3976: 部分更新セマンティクスは #3960 (plan 解決失敗時に既存 plan を壊さない) の前提そのもの。
+	// 「undefined = 更新しない」を DSQL 実装が守り続けることを **全 6 キー** で固定する。
+	// plan だけ守っても他キーで同型事故 (未指定キーが NULL 落ちする) が起きるため全キーを対象にする。
+	it('[T4c] updateTenantStripe: 全 6 キーで undefined = 保持 / 値 = 更新 (#3976)', async () => {
+		const tenant = await repo.createTenant({ name: '契約家', ownerId: USER_A });
+		const seeded = {
+			stripeCustomerId: 'cus_3976',
+			stripeSubscriptionId: 'sub_3976',
+			plan: SUBSCRIPTION_PLAN.MONTHLY,
+			planExpiresAt: '2026-09-01T00:00:00.000Z',
+			trialUsedAt: '2026-06-01T00:00:00.000Z',
+			status: 'active',
+		} as const;
+		await repo.updateTenantStripe(tenant.tenantId, { ...seeded });
+
+		const readAll = async () => {
+			const t2 = await repo.findTenantById(tenant.tenantId);
+			return {
+				stripeCustomerId: t2?.stripeCustomerId,
+				stripeSubscriptionId: t2?.stripeSubscriptionId,
+				plan: t2?.plan,
+				planExpiresAt: t2?.planExpiresAt,
+				trialUsedAt: t2?.trialUsedAt,
+				status: t2?.status,
+			};
+		};
+		const expectSeeded = (
+			actual: Awaited<ReturnType<typeof readAll>>,
+			except: keyof typeof seeded | null,
+			exceptValue?: string,
+		) => {
+			for (const key of Object.keys(seeded) as (keyof typeof seeded)[]) {
+				const want = key === except ? exceptValue : seeded[key];
+				if (key === 'planExpiresAt' || key === 'trialUsedAt') {
+					expect(Date.parse(actual[key] ?? '')).toBe(Date.parse(want ?? ''));
+				} else {
+					expect(actual[key]).toBe(want);
+				}
+			}
+		};
+		expectSeeded(await readAll(), null);
+
+		// 各キーを単独で更新 → そのキーだけ変わり、残り 5 キーは不変であること
+		const updates: { key: keyof typeof seeded; value: string }[] = [
+			{ key: 'stripeCustomerId', value: 'cus_3976_new' },
+			{ key: 'stripeSubscriptionId', value: 'sub_3976_new' },
+			{ key: 'plan', value: SUBSCRIPTION_PLAN.FAMILY_MONTHLY },
+			{ key: 'planExpiresAt', value: '2026-12-31T00:00:00.000Z' },
+			{ key: 'trialUsedAt', value: '2026-06-15T00:00:00.000Z' },
+			{ key: 'status', value: 'suspended' },
+		];
+		for (const { key, value } of updates) {
+			// 都度 seed 値に戻してから 1 キーだけ更新する (キー間の干渉を排除)
+			await repo.updateTenantStripe(tenant.tenantId, { ...seeded });
+			await repo.updateTenantStripe(tenant.tenantId, {
+				[key]: value,
+			} as Parameters<typeof repo.updateTenantStripe>[1]);
+			expectSeeded(await readAll(), key, value);
+		}
+	});
+
+	// #3976: 全キー undefined (SET 句 0 件) のとき UPDATE 自体を発行しない契約。
+	// updated_at が動かないことで「SQL を撃っていない」を観測する (発行していれば now() で必ず動く)。
+	it('[T4d] updateTenantStripe: 全キー undefined なら SQL を発行しない (#3976)', async () => {
+		const tenant = await repo.createTenant({ name: '無更新家', ownerId: USER_B });
+		await repo.updateTenantStripe(tenant.tenantId, { stripeCustomerId: 'cus_noop' });
+		const before = await t.db.execute(
+			sql`SELECT updated_at FROM families WHERE family_id = ${tenant.tenantId}`,
+		);
+		const beforeAt = (before as unknown as { rows: Record<string, unknown>[] }).rows[0]
+			?.updated_at as unknown;
+
+		await repo.updateTenantStripe(tenant.tenantId, {});
+		await repo.updateTenantStripe(tenant.tenantId, {
+			stripeCustomerId: undefined,
+			stripeSubscriptionId: undefined,
+			plan: undefined,
+			planExpiresAt: undefined,
+			trialUsedAt: undefined,
+			status: undefined,
+		});
+
+		const after = await t.db.execute(
+			sql`SELECT updated_at, stripe_customer_id FROM families WHERE family_id = ${tenant.tenantId}`,
+		);
+		const afterRow = (after as unknown as { rows: Record<string, unknown>[] }).rows[0];
+		expect(String(afterRow?.updated_at)).toBe(String(beforeAt));
+		expect(afterRow?.stripe_customer_id).toBe('cus_noop');
+	});
+
 	it('[T5] updateTenantLastActiveAt (存在しない tenant は silent no-op)', async () => {
 		const tenant = await repo.createTenant({ name: '活動家', ownerId: USER_A });
 		const ts = '2026-07-04T01:02:03.000Z';

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -207,6 +207,22 @@ describe('createCheckoutSession', () => {
 		expect(result).toEqual({ error: 'ALREADY_SUBSCRIBED' });
 	});
 
+	// #3982: 解約 (customer.subscription.deleted) 後に `stripe_subscription_id` が残っていると
+	// この経路が ALREADY_SUBSCRIBED を返し、**再購読導線が塞がる**。クリアが効いていることを
+	// 「解約後の tenant 形状で checkout が通る」側から固定する (上の ALREADY_SUBSCRIBED と対)。
+	it('解約後 (subscriptionId クリア済み) のテナントは再購読の checkout を開始できる (#3982)', async () => {
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: undefined, plan: undefined, status: 'suspended' }),
+		);
+		const result = await createCheckoutSession({
+			tenantId: 't-test',
+			planId: 'monthly',
+			successUrl: 'https://app/success',
+			cancelUrl: 'https://app/cancel',
+		});
+		expect(result).toEqual({ url: 'https://checkout.stripe.com/session_1' });
+	});
+
 	it('正常にチェックアウトURL返却', async () => {
 		const result = await createCheckoutSession({
 			tenantId: 't-test',
@@ -661,7 +677,10 @@ describe('handleWebhookEvent', () => {
 		);
 	});
 
-	it('customer.subscription.deleted → suspended + サブスクリプションID解除', async () => {
+	// #3982: 旧 assertion は `stripeSubscriptionId: undefined` / `plan: undefined` を期待しており、
+	// **no-op をそのまま追認していた** (updateTenantStripe は undefined = 更新しない)。
+	// クリアの意図を DB まで届かせるには null でなければならないため、null を固定する。
+	it('customer.subscription.deleted → suspended + subscriptionId/plan を null でクリア (#3982)', async () => {
 		mockFindTenantById.mockResolvedValue(makeTenant());
 
 		const event = {
@@ -675,13 +694,141 @@ describe('handleWebhookEvent', () => {
 		};
 
 		await handleWebhookEvent(event as never);
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith('t-test', {
+			status: 'suspended',
+			stripeSubscriptionId: null,
+			plan: null,
+		});
+		// stripeCustomerId は再購読時の customer 再利用 + webhook 逆引きの鍵なので消さない
+		expect(mockUpdateTenantStripe.mock.calls[0]?.[1]).not.toHaveProperty('stripeCustomerId');
+	});
+
+	// ======================================================
+	// #3982: 解約の終端状態が「後着イベント」で巻き戻らないこと
+	//
+	// Stripe は webhook の配信順序を保証しない (公式)。解約時は
+	// `customer.subscription.updated` (status=canceled) と `customer.subscription.deleted` が
+	// **両方**飛び、さらに当期分の `invoice.paid` / `invoice.payment_failed` が後着し得る。
+	// #3982 で `deleted` が実際に NULL を書くようになったため、後着イベントが
+	// 契約ありきの状態 (ACTIVE / GRACE_PERIOD / plan) を書き戻すと
+	// 「subscription 参照なし・plan あり」「解約済みなのに ACTIVE」という不整合が生まれる。
+	// 終端状態 (canceled / incomplete_expired) を検出して skip / 収束させることで担保する。
+	// ======================================================
+
+	/** 解約済み tenant の形状 (deleted 適用後に DB から読み直したときの値) */
+	function makeCancelledTenant() {
+		return makeTenant({ stripeSubscriptionId: undefined, plan: undefined, status: 'suspended' });
+	}
+
+	const TERMINAL_STATE = { status: 'suspended', stripeSubscriptionId: null, plan: null };
+
+	function deletedEvent(subscriptionId = 'sub_123') {
+		return {
+			type: 'customer.subscription.deleted',
+			data: { object: { id: subscriptionId, metadata: { tenantId: 't-test' } } },
+		};
+	}
+
+	function cancelledUpdatedEvent(priceId = 'price_family_monthly_789') {
+		return {
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					...makeSubscription(priceId, { status: 'canceled' }),
+					metadata: { tenantId: 't-test' },
+				},
+			},
+		};
+	}
+
+	it('#3982 — deleted → updated(canceled) の順でも plan が復活せず終端状態に収束する', async () => {
+		mockFindTenantById.mockResolvedValue(makeTenant());
+
+		await handleWebhookEvent(deletedEvent() as never);
+		// deleted 適用後の tenant を読む (id / plan はクリア済み)
+		mockFindTenantById.mockResolvedValue(makeCancelledTenant());
+		await handleWebhookEvent(cancelledUpdatedEvent() as never);
+
+		// 2 event とも同じ終端状態を書く = 到着順に依らず収束する
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(2);
+		for (const call of mockUpdateTenantStripe.mock.calls) {
+			expect(call[1]).toEqual(TERMINAL_STATE);
+		}
+	});
+
+	it('#3982 — updated(canceled) → deleted の逆順でも最終状態が一致する', async () => {
+		mockFindTenantById.mockResolvedValue(makeTenant());
+
+		await handleWebhookEvent(cancelledUpdatedEvent() as never);
+		mockFindTenantById.mockResolvedValue(makeCancelledTenant());
+		await handleWebhookEvent(deletedEvent() as never);
+
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(2);
+		for (const call of mockUpdateTenantStripe.mock.calls) {
+			expect(call[1]).toEqual(TERMINAL_STATE);
+		}
+	});
+
+	it('#3982 — 解約後に invoice.paid が後着しても status が active に戻らない', async () => {
+		// Stripe から retrieve される現行 subscription は canceled (終端)
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: {
+				retrieve: vi
+					.fn()
+					.mockResolvedValue(makeSubscription('price_monthly_123', { status: 'canceled' })),
+			},
+		});
+		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeCancelledTenant());
+
+		await handleWebhookEvent(deletedEvent() as never);
+		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
+
+		// deleted の 1 回だけ。invoice.paid は終端検出で skip されるため書き込まない
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+		expect(mockUpdateTenantStripe.mock.calls[0]?.[1]).toEqual(TERMINAL_STATE);
+	});
+
+	it('#3982 — 解約後に invoice.payment_failed が後着しても grace_period に戻らない', async () => {
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: {
+				retrieve: vi
+					.fn()
+					.mockResolvedValue(makeSubscription('price_monthly_123', { status: 'canceled' })),
+			},
+		});
+		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeCancelledTenant());
+
+		await handleWebhookEvent(deletedEvent() as never);
+		await handleWebhookEvent({
+			type: 'invoice.payment_failed',
+			data: { object: { parent: { subscription_details: { subscription: 'sub_123' } } } },
+		} as never);
+
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+		expect(mockUpdateTenantStripe.mock.calls[0]?.[1]).toEqual(TERMINAL_STATE);
+	});
+
+	it('#3982 — 終端でない subscription (past_due) の invoice.payment_failed は従来どおり grace_period にする', async () => {
+		// 終端判定が「解約以外まで巻き込んで無効化」していないことの対照 (guard の空振り検出)
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: {
+				retrieve: vi
+					.fn()
+					.mockResolvedValue(makeSubscription('price_monthly_123', { status: 'past_due' })),
+			},
+		});
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant());
+
+		await handleWebhookEvent({
+			type: 'invoice.payment_failed',
+			data: { object: { parent: { subscription_details: { subscription: 'sub_123' } } } },
+		} as never);
+
 		expect(mockUpdateTenantStripe).toHaveBeenCalledWith(
 			't-test',
-			expect.objectContaining({
-				status: 'suspended',
-				stripeSubscriptionId: undefined,
-				plan: undefined,
-			}),
+			expect.objectContaining({ status: 'grace_period' }),
 		);
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 運営

**解決する課題**: サブスクリプションを解約したテナントで `stripe_subscription_id` が DB に残り続けるため、**同じ家族が再び有料プランに申し込もうとすると `ALREADY_SUBSCRIBED` で弾かれ、再購読の導線が完全に塞がっていた**。加えて `subscription.deleted` の後に `updated` / `invoice.paid` / `payment_failed` が遅れて到着すると、解約済みのはずのテナントが ACTIVE / 有料 plan に巻き戻る。

**期待される効果**: 解約後は subscription 割り当てが実際に NULL クリアされ、(1) 再購読が通る (2) 後着 webhook で契約状態が巻き戻らない。

## 関連 Issue

closes #3982

- #3960 / PR #3968 — `plan: undefined` = 「更新しない」を load-bearing にした変更（本 Issue の起点）
- #3976 — `updateTenantStripe` の部分更新セマンティクスの明文化・契約テスト（本 PR で interface JSDoc + 契約テストを入れたため実質前倒し対応）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `licenseStatus` が `suspended` と `none` で挙動が変わる箇所を洗い出す | `grep -rn "licenseStatus" src/` で全参照を追跡 | **PASS**（下記「AC1 調査結果」）。実害の本体は `licenseStatus` ではなく **`stripeSubscriptionId` が残ること**だった: `stripe-service.ts:57` の `ALREADY_SUBSCRIBED` ガードが発火し再購読不能。plan tier は `plan-limit-service.ts:108` が ACTIVE 以外を全て trial/free に落とすため suspended / none で差なし。認可も `authorization.ts:154,171` で両者とも `allowed: true` |
| AC2 | 案 A / 案 B のどちらかを選び根拠を残す | 本 PR body + `stripe-service.ts:476-488` の JSDoc | **PASS — 案 A（クリアが意図。実装を合わせる）を採用**。根拠: 残置は再購読を塞ぐ実害があり「意図的な保持」では説明できない。ただし `stripeCustomerId` は再購読での customer 再利用 + webhook 逆引きの鍵のため意図的に残す（JSDoc に明記） |
| AC3 | 選んだ案を実装する | `git show --stat HEAD` / `src/lib/server/services/stripe-service.ts` | **PASS**。`clearSubscriptionAssignment()` を新設し `deleted` / `updated(canceled)` で共有。interface に `null` = NULL クリアの 2 値セマンティクスを型 + JSDoc で明文化 (`auth-repo.interface.ts`)、dsql / demo 両実装を追従 |
| AC4 | `handleSubscriptionDeleted` 後の DB 実値を assert する unit test を追加 | `npx vitest run tests/unit/services/stripe-service.test.ts tests/unit/db/dsql-auth-repo.test.ts` | **PASS — 2 files / 57 tests passed**。`stripe_subscription_id` / `plan` が NULL、`status` が SUSPENDED になることを assert。後着 webhook で巻き戻らないことも別 case で assert |
| AC5 | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 3992` | 下記「テスト & 安全装置セルフチェック」参照 |

## AC1 調査結果（`suspended` と `none` の差分）

| 経路 | 差分の有無 | 根拠 |
|---|---|---|
| ルート認可 (`checkLicenseAccess`) | **差分なし** | `authorization.ts:154` が NONE を、`:171` が SUSPENDED を、いずれも `allowed: true` で返す |
| プラン tier (`resolvePlanTier`) | **差分なし** | `plan-limit-service.ts:108` — ACTIVE のみが有料 tier。suspended / none はどちらも trial 判定 → free |
| **再購読 (`createCheckoutSession`)** | **差分あり（実害）** | `stripe-service.ts:57` `if (tenant.stripeSubscriptionId) return { error: 'ALREADY_SUBSCRIBED' }` — ID が残る限り恒久的に再購読不能 |
| 後着 webhook の巻き戻し | **差分あり（実害）** | `deleted` 後に `updated` / `invoice.paid` が届くと ACTIVE + 有料 plan が書き戻される |

→ 「suspended か none か」自体より **subscription 割り当てが残ること**が実害。よって案 A（クリア実装）を採用した。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — repo interface のセマンティクス明文化のみ。**テーブル定義・マイグレーションの変更なし**
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 解約後の再購読フロー（`/admin/subscription` → Stripe Checkout）、Stripe webhook 処理全般（`subscription.deleted` / `updated` / `invoice.paid` / `payment_failed`）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 3992` 全 Step PASS**（#1775 / ADR-0030）
  - **実行環境**: 実体パス `E:\Github\ganbari-quest-dev\.claude\worktrees\ch-c0aa48d4-3992`（junction 経由ではない）。HEAD `783c8eeb` = PR head と一致。他セッションの重い検証が走っていないことを `~/.buzz/.locks/heavy.lock` の保持者 pid 生存確認で判定してから単独実行した。
  - **2026-07-26 に `[x]` を一度撤回した理由**: develop 版 `scripts/pre-ready.mjs:725-731` の CLI 直接実行判定が `resolve()` のみで realpath を通しておらず、`~/.buzz/REPOS/` (= `E:\Github\` への junction) 経由では **0 バイト exit 0 の空振り**になっていた (#3969 / PR #3979 が閉じる class そのもの。QM 実測 2026-07-26 14:06)。今回は実体パスから起動し、2000 行超の実出力を得ている（空振りではない）。
  - 完走ログは下記「pre-ready 完走ログ (2026-07-27)」に貼付。

### 証跡の所在（2026-07-27 更新）

- **初回の Step 3 実行ログ（2026-07-26、HEAD `8f44f3ce`）の実体パス `E:\Github\gq-wt-3982` は現存しません。** `git worktree list` で prunable、`ls` で不在。commit は remote に残っていたため失われたものはありませんが、**当時のチャンネル投稿が引用した実体パスは辿れません**。
- 以後、本 PR の作業と証跡はすべて `E:\Github\ganbari-quest-dev\.claude\worktrees\ch-c0aa48d4-3992`（チャンネル専用 worktree）で扱います。

### 2026-07-27: Ready を止めていた真因は develop 由来ではなく本 PR の diff でした

前回の報告では「Step 3 の 2 件 timeout（#4000 の class、develop 由来）が残件」としていましたが、**CI 側にそれとは別の確定した赤が 1 件ありました。**

```console
$ gh api .../commits/47d38a6c/check-runs
lint-and-test  failure      ci-gate  failure
unit-test (1)  success      unit-test (2)  success      unit-test-merge  success

$ gh run view --job 89854574430 --log | grep "Unknown word"
src/lib/server/db/demo/auth-repo.ts:96:33 - Unknown word (bivariant)
```

`bivariant` は TS の method shorthand によるパラメータ双変性を指す正規の用語で、**QA 観点 1（型 mutation）の実測根拠そのもの**のため語は消さず `.cspell/project-words.txt` に登録しました。

```console
$ npx cspell src/lib/server/db/demo/auth-repo.ts
CSpell: Files checked: 1, Issues found: 0 in 0 files.     (exit 0)
```

**構造的な問題として記録します** — ローカル `pre-ready` は Step 3（vitest フルスイート）で停止すると **Step 4 以降（cspell はここ）が一度も走りません**。Step 3 の停止原因が他セッションとの並走由来だった場合、**本物の赤が偽の赤に隠されます**。#4006 と同じ場所の話です。

### rebase 済み（HEAD `783c8eeb`）

```console
$ git rebase origin/develop      # 1824ff00 → 48ac2500、conflict 0 / 4 commits
$ git push --force-with-lease
 + 47d38a6c...783c8eeb HEAD -> fix/3982-subscription-deleted-clear (forced update)
```
- [x] 追加・変更したテストの概要:
  - `tests/unit/services/stripe-service.test.ts` — `handleSubscriptionDeleted` 後の DB 実値 assert / 終端状態検出後に後着 `updated`・`invoice.paid`・`payment_failed` が契約状態を書き戻さないことの assert
  - `tests/unit/db/dsql-auth-repo.test.ts` — `updateTenantStripe` の 3 値セマンティクス契約テスト（`undefined` = 更新しない / `null` = NULL クリア / 値 = 設定）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（DynamoDB backend は #3438 で撤去済）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:medium`）

## スクリーンショット / ビジュアルデモ

**該当なし（サーバーサイド課金ロジック + repo interface のみ。`.svelte` / `.css` / `site/` の変更ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: クリア処理を `clearSubscriptionAssignment()` に単一責任で切り出し、`deleted` / `updated(canceled)` の 2 経路が同一実装を共有（重複した終端処理の分岐を排除）
- [x] **DRY**: `grep -rn "updateTenantStripe" src/` で全呼び出しを確認し、終端状態のクリアが 1 関数に集約されていることを確認
- [x] **YAGNI**: `null` セマンティクスは現に必要な列（`stripeSubscriptionId` / `plan`）にのみ導入。`stripeCustomerId` は残す設計を JSDoc で明示
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: N/A（クエリ本数・形状の変化なし）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — `src/lib/server/db/demo/auth-repo.ts` を dsql 実装と同一セマンティクスに追従
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — `docs/design/plan-change-flow.md` §10.5 に「webhook 到着順 × 収束」の SSOT (U1-U8) を新設
- [x] 並行 PR overlap 確認 (#1200) — open PR #3989 / #3979 / #3945 と変更ファイル重複なし

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

`updateTenantStripe` は `undefined` の既存挙動（更新しない）を維持したまま `null` を追加で受け付ける拡張のため、既存呼び出しの挙動は不変。

**レビュー依頼事項・QA**:

1. `stripeCustomerId` を残す判断（再購読での customer 再利用 + webhook 逆引きの鍵）に異論がないか
2. 終端状態 (`canceled` / `incomplete_expired`) を検出した handler が契約ありきの状態を書き戻さないガードの範囲が妥当か（`plan-change-flow.md` §10.5 の U1-U8）
3. **既に解約済みで `stripe_subscription_id` が残っている本番テナントは本 PR では自動修復されない**（webhook が再送されない限り残置）。データ修復が必要かは PO 判断を仰ぎたい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 3992` 全 Step PASS** をローカル確認した — 完走ログは下記「pre-ready 完走ログ (2026-07-27)」
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## pre-ready 完走ログ (2026-07-27)

実行パス `E:\Github\ganbari-quest-dev\.claude\worktrees\ch-c0aa48d4-3992`（実体パス、HEAD `783c8eeb`）。

```console
$ npm run pre-ready -- --pr 3992
[pre-ready] PR 番号: 3992
[pre-ready] base branch: origin/develop (#2959 SSOT 解決)
[pre-ready] 変更ファイル数: 8
[pre-ready] ✓ Step 1/12: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)
[pre-ready] ✓ Step 1b/12: cspell (CI lint-and-test と同一コマンド — #3649)
[pre-ready] ✓ Step 2/12: svelte-check (TS strict)
[pre-ready] ✓ Step 3/12: vitest run (unit test)
[pre-ready] ✓ Step 4/12: check-hardcoded-strings.mjs (#1452 Phase A)
[pre-ready] ⊘ Step 5/12: measure-lp-dimensions.mjs (LP 変更検知: NO — skip)
[pre-ready] ⊘ Step 6/12: sync-lp-fallback.mjs --check (LP / labels.ts 変更検知: NO — skip)
[pre-ready] ✓ Step 7/12: check-no-plan-literals.mjs (#972 / Phase 5 F1)
[pre-ready] ✓ Step 7b/12: check-license-key-leak.mjs (#2836 / Phase 7 PR-L4)
[pre-ready] ✓ Step 7c/12: check-cli-entry-guard.mjs (#3969)
[pre-ready] ✓ Step 7d/12: check-workflow-sparse-checkout-closure.mjs (#3969)
[pre-ready] ⊘ Step 8/12: generate-lp-labels --check (labels.ts / terms.ts / age-tier.ts 変更検知: NO — skip)
[pre-ready] ✓ Step 9/12: Readiness gate (check-pr-body.mjs --pr 3992)
[pre-ready] ✓ Step 10/12: check-doc-code-references.mjs (#2577)
[pre-ready] ✓ Step 11/12: check-terminology-coherence.ts (#2555)
[pre-ready] ⊘ Step 11b/12: SS embed gate (UI 変更なし — skip、#2918)
[pre-ready] ⊘ Step 12/12: capture.mjs (UI 変更検知: NO — skip)
[pre-ready] PARTIAL PASS — 実行した 12 step は PASS しましたが、5 step が --skip 指定で未実行です (lp-dimensions, lp-fallback, lp-labels, ss-embed-gate, capture)。
EXIT=0
```

`⊘` の 5 step は LP / labels.ts / UI いずれの変更も含まないための自動 skip であり、Dev が `--skip` を明示指定したものではない。本 PR の変更 8 ファイルに `site/` / `labels.ts` / `.svelte` は含まれない。

**1 回目の実行 (`WORK_LOGS/preready-3992.log`) は Step 9 で停止した。** 違反は「Ready for Review チェックリストに未チェック項目が 1 件」の 1 件のみで、その 1 件は本 body の pre-ready 欄自身だった。Step 1〜8 は 1 回目も PASS しており、本欄を埋めたうえで再実行した 2 回目 (`WORK_LOGS/preready-3992-run2.log`) が上記の完走ログである。

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)



