### PR TITLE
fix(test): #3972 #3975 ローカル pre-ready の恒常 red 2 件を解消し同 class を gate 化

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -86,6 +86,7 @@
 		"datname",
 		"gitdir",
 		"hana",
+		"jsii",
 		"millis",
 		"multiplexing",
 		"multitenant",

--- a/tests/unit/infra/cdk-hook-timeout-guard.test.ts
+++ b/tests/unit/infra/cdk-hook-timeout-guard.test.ts
@@ -46,8 +46,8 @@ function readHookTimeouts(source: string): (number | null)[] {
 		const open = m.index + m[0].length - 1;
 		const args = extractCallArgs(source, open);
 		// 末尾引数が数値リテラル (`60_000` / `60000`) のときだけ timeout 指定とみなす。
-		const tail = args?.trimEnd().match(/,\s*([\d_]+)\s*$/);
-		results.push(tail ? Number(tail[1].replaceAll('_', '')) : null);
+		const digits = args?.trimEnd().match(/,\s*([\d_]+)\s*$/)?.[1];
+		results.push(digits === undefined ? null : Number(digits.replaceAll('_', '')));
 		m = marker.exec(source);
 	}
 	return results;

--- a/tests/unit/infra/cdk-hook-timeout-guard.test.ts
+++ b/tests/unit/infra/cdk-hook-timeout-guard.test.ts
@@ -1,0 +1,97 @@
+// tests/unit/infra/cdk-hook-timeout-guard.test.ts
+// #3975: 「infra suite の beforeAll が明示 timeout を持たない」class を機械 gate 化する。
+//
+// 背景: CDK 合成 (`new cdk.App()` → `Template.fromStack()`) は 1 回目に `aws-cdk-lib` の
+// cold load を含み、Windows ローカルでは vite.config.ts の既定 `hookTimeout: 10_000` を超える。
+// CI (Linux) は収まるため **ローカルだけが恒常 red** になり、pre-ready Step 3 の red が
+// 「またいつものやつ」として無視される — gate が形式だけ残って実効を失う経路 (ADR-0061)。
+//
+// 本ディレクトリの 7 suite のうち 6 本は既に明示 timeout を持ち、`dsql-cdk.test.ts` だけが
+// 欠けていた = 「規約はあるが機械強制がなく、新しい suite が黙って外れる」same-class N 状態。
+// 新規 infra suite が timeout 指定を忘れても、次に遅くなるまで誰も気付かないため gate 化する。
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const INFRA_TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** 既定 hookTimeout (10s) では CDK 合成に足りないため、最低これ以上を要求する。 */
+const MIN_HOOK_TIMEOUT_MS = 60_000;
+
+/**
+ * `beforeAll(` の開き括弧から対応する閉じ括弧までを取り出す。
+ * 正規表現では入れ子の括弧・文字列を数え切れないため、括弧の対応を実際に走査する。
+ */
+function extractCallArgs(source: string, callStart: number): string | null {
+	let depth = 0;
+	for (let i = callStart; i < source.length; i++) {
+		const ch = source[i];
+		if (ch === '(') depth++;
+		else if (ch === ')') {
+			depth--;
+			if (depth === 0) return source.slice(callStart + 1, i);
+		}
+	}
+	return null;
+}
+
+/** `beforeAll(fn, 60_000)` の第 2 引数 (ms) を返す。未指定なら null。 */
+function readHookTimeouts(source: string): (number | null)[] {
+	const results: (number | null)[] = [];
+	const marker = /\bbeforeAll\s*\(/g;
+	let m: RegExpExecArray | null = marker.exec(source);
+	while (m !== null) {
+		const open = m.index + m[0].length - 1;
+		const args = extractCallArgs(source, open);
+		// 末尾引数が数値リテラル (`60_000` / `60000`) のときだけ timeout 指定とみなす。
+		const tail = args?.trimEnd().match(/,\s*([\d_]+)\s*$/);
+		results.push(tail ? Number(tail[1].replaceAll('_', '')) : null);
+		m = marker.exec(source);
+	}
+	return results;
+}
+
+describe('#3975 infra suite の beforeAll は明示 hook timeout を持つ', () => {
+	const files = fs
+		.readdirSync(INFRA_TEST_DIR)
+		.filter((f) => f.endsWith('.test.ts'))
+		.filter((f) => f !== path.basename(fileURLToPath(import.meta.url)));
+
+	it('[G0] 走査対象の infra test file を 1 本以上発見する (0 件マッチの素通りを防ぐ)', () => {
+		expect(files.length).toBeGreaterThan(0);
+	});
+
+	it(`[G1] beforeAll を持つ全 suite が ${MIN_HOOK_TIMEOUT_MS}ms 以上の明示 timeout を渡す`, () => {
+		const violations: string[] = [];
+		for (const file of files) {
+			const source = fs.readFileSync(path.join(INFRA_TEST_DIR, file), 'utf8');
+			readHookTimeouts(source).forEach((ms, i) => {
+				if (ms === null) {
+					violations.push(`${file}: beforeAll #${i + 1} に timeout 指定がない`);
+				} else if (ms < MIN_HOOK_TIMEOUT_MS) {
+					violations.push(`${file}: beforeAll #${i + 1} の timeout ${ms}ms が下限未満`);
+				}
+			});
+		}
+		expect(
+			violations,
+			`infra suite の beforeAll は CDK 合成の cold load を含むため明示 timeout が必須:\n` +
+				`${violations.join('\n')}\n` +
+				`→ 該当 beforeAll の第 2 引数に ${MIN_HOOK_TIMEOUT_MS} 以上を渡す ` +
+				`(理由は dsql-cdk.test.ts の beforeAll コメントを参照)`,
+		).toEqual([]);
+	});
+
+	// 抽出ロジック自体の検証。規約に従うデータだけを見て「違反を検出できないこと」を
+	// 見逃さないよう、**規約から外れた形**を実名で混ぜる (dev-session §QA 指摘台帳 観点 3)。
+	it('[G2] timeout 未指定 / 下限未満 / 入れ子括弧 を正しく読み分ける', () => {
+		expect(readHookTimeouts('beforeAll(() => { synth(); });')).toEqual([null]);
+		expect(readHookTimeouts('beforeAll(() => { synth(); }, 10_000);')).toEqual([10000]);
+		expect(readHookTimeouts('beforeAll(() => { synth(); }, 60_000);')).toEqual([60000]);
+		expect(readHookTimeouts('beforeAll(() => { f(g(h())); }, 120000);')).toEqual([120000]);
+		// 同一 file に複数 beforeAll があっても各々を独立に読む
+		expect(readHookTimeouts('beforeAll(a);\nbeforeAll(b, 60_000);')).toEqual([null, 60000]);
+	});
+});

--- a/tests/unit/infra/dsql-cdk.test.ts
+++ b/tests/unit/infra/dsql-cdk.test.ts
@@ -16,11 +16,16 @@ import { DsqlStack } from '../../../infra/lib/dsql-stack';
 describe('DsqlStack (EPIC #3424 M4-E item 12)', () => {
 	let template: Template;
 
+	// #3975: CDK 合成 1 回目は `aws-cdk-lib` (jsii bundle) の cold load を含み、Windows ローカルでは
+	// vite.config.ts の既定 `hookTimeout: 10_000` を超える (実測 18.1s / CI Linux は収まるため CI のみ green)。
+	// 「ローカル pre-ready Step 3 だけが恒常 red」= 本物の fail が「またいつものやつ」として無視される状態を作る。
+	// 本ディレクトリの他 6 suite は既に明示 timeout (60s / 120s) を持っており、本 suite だけが未指定だった。
+	// 60s は実測の約 3.3x。合成が壊れて戻らないケースは打ち切られるため無検査化ではない。
 	beforeAll(() => {
 		const app = new cdk.App();
 		const stack = new DsqlStack(app, 'TestDsql', { opsEmail: 'ops@example.com' });
 		template = Template.fromStack(stack);
-	});
+	}, 60_000);
 
 	it('[I1] DSQL cluster が deletion protection true で 1 個作成される (#3429)', () => {
 		template.resourceCountIs('AWS::DSQL::Cluster', 1);

--- a/tests/unit/scripts/check-license-key-leak.test.ts
+++ b/tests/unit/scripts/check-license-key-leak.test.ts
@@ -120,18 +120,29 @@ describe('check-license-key-leak (#2836)', () => {
 	});
 
 	describe('findAllViolations (実 repo gate)', () => {
-		it('現在の src/ + site/ に再導入された license key 参照はゼロ (本 PR 自身が PASS)', () => {
-			const violations = findAllViolations();
-			if (violations.length > 0) {
-				// 失敗時に違反箇所を表示
-				throw new Error(
-					`license key 再導入を ${violations.length} 件検出:\n` +
-						violations
-							.map((v: { file: string; line: number }) => `  ${v.file}:${v.line}`)
-							.join('\n'),
-				);
-			}
-			expect(violations).toHaveLength(0);
-		});
+		// #3972: 本 test の主張は「violations 0 件」であって「速いこと」ではない。
+		// `findAllViolations()` 自体は実測 ~250ms (Dev 261ms / QA 241ms、いずれも 0 件) だが、
+		// repo 全走査を伴うため vitest harness の負荷次第で既定 5s を超え、環境依存で赤になる。
+		// 「pre-ready は 1 件既知 fail」が常態化すると本物の fail が紛れるため、実測の約 120x を
+		// 明示して環境揺らぎを吸収する (走査が壊れて戻らないケースは 30s で打ち切られる)。
+		const REPO_SCAN_TIMEOUT_MS = 30_000;
+
+		it(
+			'現在の src/ + site/ に再導入された license key 参照はゼロ (本 PR 自身が PASS)',
+			() => {
+				const violations = findAllViolations();
+				if (violations.length > 0) {
+					// 失敗時に違反箇所を表示
+					throw new Error(
+						`license key 再導入を ${violations.length} 件検出:\n` +
+							violations
+								.map((v: { file: string; line: number }) => `  ${v.file}:${v.line}`)
+								.join('\n'),
+					);
+				}
+				expect(violations).toHaveLength(0);
+			},
+			REPO_SCAN_TIMEOUT_MS,
+		);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 (開発・QA プロセス)

**解決する課題**: `npm run pre-ready` Step 3 (vitest) が **CI では green なのにローカルだけ恒常 red** という状態が 2 件あり、「pre-ready は既知 fail 1 件」が常態化していた。gate は green / red のどちらかに決定的でなければ実効を失い、**本物の fail が「またいつものやつ」として見逃される**（QA 指摘: 「次回は許容しません」）。

**期待される効果**: pre-ready が全 Step PASS に戻り、red = 本物の異常という信号に復帰する。あわせて同 class の再発を機械 gate で塞ぐ。

## 関連 Issue

closes #3972
closes #3975

**2 件を 1 PR にまとめた理由**: どちらも「CI green / ローカル red」の同一 class で、**どちらか一方を残すと pre-ready は red のままとなり、もう一方の PR が全 Step PASS を証明できない**（相互に前提となる）。分割すると先行 PR が「既知 fail 込みで Ready」となり、本 PR が解消しようとしている状態そのものを再生産する。

- #3969 — 同じく「ローカル gate の結果が信用できない」class（別 PR #3979 で対応中）
- #3984 — 同じ pre-ready 信頼性の別 class（CRLF + shebang、本 PR スコープ外）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (#3972) | `npx vitest run` で当該 test file が安定して pass する | `npx vitest run tests/unit/scripts/check-license-key-leak.test.ts` | **PASS — 30 tests passed / 2.08s**（tests 実処理 304ms） |
| AC2 (#3972) | 延長値の根拠（実測 ~250ms に対する倍率）をコメントで残す | `tests/unit/scripts/check-license-key-leak.test.ts:123-128` | **PASS**。実測 Dev 261ms / QA 241ms に対し 30s（約 120x）を明示。「走査が壊れて戻らないケースは 30s で打ち切られる」ため無検査化ではないことも明記 |
| AC3 (#3975) | Windows ローカル（実体パス）で `npx vitest run tests/unit/infra/dsql-cdk.test.ts` が green | 同コマンド | **PASS — 20 tests passed（guard 同時実行）/ 20.95s**。従来は `Hook timed out in 10000ms` で 13 tests skipped |
| AC4 (#3975) | timeout を伸ばすだけで実質無検査にしていないこと | `git diff` | **PASS**。assertion は 1 行も変更なし（ADR-0006）。変更は `beforeAll` 第 2 引数の追加のみ |
| AC5 (両者) | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 3993` | 下記「テスト & 安全装置セルフチェック」参照 |

### 同 class の再発 gate（#3975 追加分）

調査の結果、`tests/unit/infra/` の **7 suite 中 6 本は既に明示 timeout（60s / 120s）を持ち、`dsql-cdk.test.ts` だけが規約から外れていた**。つまり「規約はあるが機械強制がなく、新しい suite が黙って外れる」same-class N 状態（ADR-0061 same-class N→guard）。

`tests/unit/infra/cdk-hook-timeout-guard.test.ts` を新設し、infra 配下の全 `beforeAll` が 60s 以上の明示 timeout を渡すことを FS 走査で検証する:

- `[G0]` 走査対象を 1 本以上発見することを assert（**0 件マッチ = 素通り**という新しい silent skip を作らない）
- `[G1]` 全 suite の `beforeAll` に 60s 以上の明示 timeout
- `[G2]` 抽出ロジック自体の検証。規約に従う形だけでなく **規約から外れた形**（timeout 未指定 / 下限未満 / 入れ子括弧 / 同一 file 複数 `beforeAll`）を混ぜる

**guard の実効性検証**（dev-session §QA 指摘台帳 観点 3「guard を外すと fail するか」）: `dsql-cdk.test.ts` の `, 60_000` を削除して実行したところ `[G1]` が

```
dsql-cdk.test.ts: beforeAll #1 に timeout 指定がない
Tests  1 failed | 2 passed (3)
```

で fail することを実行確認済み（検証後に復元、差分ゼロ）。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — **テストのみ。`src/` / `infra/` の製品コードは 1 行も変更していない**

**影響を受ける画面・機能**: なし（テスト実行設定のみ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/scripts/check-license-key-leak.test.ts` — 実 repo gate に 30s の明示 timeout（assertion 不変）
  - `tests/unit/infra/dsql-cdk.test.ts` — `beforeAll` に 60s の明示 timeout（assertion 不変）
  - `tests/unit/infra/cdk-hook-timeout-guard.test.ts` — **新規**。infra 全 suite の hook timeout 規約を機械検証（G0 / G1 / G2）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（テストのみ。`.svelte` / `.css` / `site/` の変更ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: guard の抽出ロジックを `extractCallArgs` / `readHookTimeouts` の純関数に分離し、`[G2]` で単体検証
- [x] **DRY**: 既存 6 suite が持つ timeout 値はそのまま維持（一括置換して既存の意図的な 120s を潰さない）
- [x] **YAGNI**: 共通定数ファイルの新設は見送り。既存 suite が 60s / 120s と正当に異なる値を持つため、下限のみを guard で強制する形にした
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: timeout の上限を上げただけで、正常系の実行時間は不変（license-key gate は実測 304ms のまま）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200) — open PR #3992 / #3989 / #3979 / #3945 と変更ファイル重複なし
- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

1. 2 件を 1 PR にまとめた判断（上記「関連 Issue」の理由）に異論がないか
2. `[G1]` の下限 60s が妥当か（既存 suite の実測は最大 18.1s、120s を使う suite が 2 本ある）
3. `#3984`（CRLF + shebang）は別 class として本 PR に含めていない

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
