### PR TITLE
fix(ci): #3999 approve gate hook の fail-open を fail-closed 化する (AC1-3)

### DIFF
--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -288,6 +288,11 @@ async function main() {
  * 状態であり、そこで main() を走らせるかどうかを推測すると、import 経由の呼び出し元を
  * 無言で exit させる別の silent failure を作る。判定不能時は**大きく・声を上げて止まる**方を採る。
  *
+ * **surgical 案は技術的に不可能ではない**: approve 系かどうかの判定 regex は本 module 内に
+ * 閉じており (isApproveAction、is-main.mjs に依存しない)、dynamic import へ変えた時点で
+ * module 本体はロード済みなのでコマンド分類自体は可能。**できないから採らないのではなく、
+ * 選んで採らない。** 後任が「不可能だった」と誤読しないよう明記する (QM 指摘 / PR #3999 レビュー)。
+ *
  * @param {unknown} err
  */
 function reportIsMainLoadFailure(err) {

--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -31,6 +31,11 @@
  *   - allow: exit 0 (stdout/stderr 何も出さない)
  *   - deny:  exit 2 + stderr に修正手順 ("Adversarial Reviewer subagent を先に dispatch")
  *
+ * fail-closed (#3999):
+ *   判定 SSOT (`scripts/lib/is-main.mjs`) の import 解決失敗・main() 内の想定外例外は、
+ *   いずれも exit 2 (block) に倒す。Claude Code は exit 2 のみを block として扱うため、
+ *   これらを既定の exit 1 のまま落とすと **tool 実行が継続し approve が素通しする**。
+ *
  * 関連:
  *   - ADR-0056 (本 hook の設計根拠 SSOT)
  *   - docs/research/qm-drift-prevention-2026-05-28.md (research primary source)
@@ -41,7 +46,26 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { isMain } from '../../scripts/lib/is-main.mjs';
+
+/**
+ * 判定 SSOT (`scripts/lib/is-main.mjs`) を **dynamic import** で読み込む理由 (#3999)。
+ *
+ * static import にすると解決失敗が module 評価前の `ERR_MODULE_NOT_FOUND` になり、Node は
+ * **exit 1** で落ちる。Claude Code の PreToolUse hook は **exit 2 のみ**を block として扱い、
+ * それ以外の非 0 は non-blocking error として tool 実行を継続する。つまり `scripts/` を含まない
+ * checkout では **evidence 無しで approve / merge が通っていた** (fail-open)。
+ *
+ * security control は「判定不能」を「許可」ではなく **block** に倒す (fail-closed)。
+ * dynamic import なら解決失敗を catch でき、exit 2 を自分で選べる。
+ */
+let isMain;
+/** @type {unknown} import 解決に失敗したときの error (成功時は null) */
+let isMainLoadError = null;
+try {
+	({ isMain } = await import('../../scripts/lib/is-main.mjs'));
+} catch (err) {
+	isMainLoadError = err;
+}
 
 export const EVIDENCE_TTL_MS = 30 * 60 * 1000; // 30 分 (ADR-0056 §決定 1)
 export const REQUIRED_OBJECT_COUNT = 3; // must_object_count 強制値 (Echoing 抑制)
@@ -252,9 +276,46 @@ async function main() {
 	process.exit(2);
 }
 
+/**
+ * 判定 SSOT を読み込めなかったときの fail-closed 終了 (#3999 AC1)。
+ *
+ * exit 2 は Claude Code が tool 実行を block する唯一の exit code。判定不能のまま exit 1 で
+ * 落ちると tool 実行が継続し、evidence 無し approve が通る (= 本 Issue の事故形)。
+ *
+ * 副作用として、この状態では **approve 系以外の Bash コマンドも全て block される**
+ * (本 hook は PreToolUse の Bash matcher で毎回起動されるため)。「approve 系のときだけ
+ * block する」surgical 案も検討したが、SSOT を読めない = 「CLI 起動か import か」を判定できない
+ * 状態であり、そこで main() を走らせるかどうかを推測すると、import 経由の呼び出し元を
+ * 無言で exit させる別の silent failure を作る。判定不能時は**大きく・声を上げて止まる**方を採る。
+ *
+ * @param {unknown} err
+ */
+function reportIsMainLoadFailure(err) {
+	const msg = err instanceof Error ? err.message : String(err);
+	process.stderr.write(
+		`[gate-approve] BLOCK: 判定 SSOT scripts/lib/is-main.mjs を読み込めませんでした。\n`,
+	);
+	process.stderr.write(`  reason: ${msg}\n`);
+	process.stderr.write(
+		`  ADR-0056 の approve gate は判定不能時に block 側へ倒します (fail-closed / #3999)。\n`,
+	);
+	process.stderr.write(
+		`  対処: checkout に scripts/lib/is-main.mjs があるか、hook を repo root から起動しているかを確認してください。\n`,
+	);
+}
+
 // CLI として直接実行されたときのみ main() を呼ぶ。import 経由 (unit test) では実行されない。
 // 判定は scripts/lib/is-main.mjs (SSOT, #3969)。従来の `fileURLToPath(import.meta.url) === process.argv[1]`
 // は junction / symlink 経由の起動で常に false になり、**approve を素通しする**側に倒れていた。
-if (isMain(import.meta.url)) {
-	main();
+if (isMainLoadError) {
+	reportIsMainLoadFailure(isMainLoadError);
+	process.exit(2);
+} else if (isMain(import.meta.url)) {
+	// main() 内の想定外例外も unhandled rejection (= exit 1 = 素通し) にせず block へ倒す (#3999)。
+	main().catch((err) => {
+		const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
+		process.stderr.write(`[gate-approve] BLOCK: hook が想定外の例外で失敗しました。\n`);
+		process.stderr.write(`  ${detail}\n`);
+		process.exit(2);
+	});
 }

--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -58,6 +58,7 @@ import { resolve } from 'node:path';
  * security control は「判定不能」を「許可」ではなく **block** に倒す (fail-closed)。
  * dynamic import なら解決失敗を catch でき、exit 2 を自分で選べる。
  */
+/** @type {((importMetaUrl: string, argv1?: string) => boolean) | undefined} */
 let isMain;
 /** @type {unknown} import 解決に失敗したときの error (成功時は null) */
 let isMainLoadError = null;
@@ -312,8 +313,12 @@ function reportIsMainLoadFailure(err) {
 // CLI として直接実行されたときのみ main() を呼ぶ。import 経由 (unit test) では実行されない。
 // 判定は scripts/lib/is-main.mjs (SSOT, #3969)。従来の `fileURLToPath(import.meta.url) === process.argv[1]`
 // は junction / symlink 経由の起動で常に false になり、**approve を素通しする**側に倒れていた。
-if (isMainLoadError) {
-	reportIsMainLoadFailure(isMainLoadError);
+// `typeof isMain !== 'function'` も block 側に含める。module が読めても isMain を export して
+// いなければ判定不能であることに変わりはなく、ここを allow に倒すと同じ fail-open に戻る。
+if (isMainLoadError || typeof isMain !== 'function') {
+	reportIsMainLoadFailure(
+		isMainLoadError ?? new Error('scripts/lib/is-main.mjs が isMain を export していません'),
+	);
 	process.exit(2);
 } else if (isMain(import.meta.url)) {
 	// main() 内の想定外例外も unhandled rejection (= exit 1 = 素通し) にせず block へ倒す (#3999)。

--- a/scripts/claude-hook-prevent-qa-account-pr.mjs
+++ b/scripts/claude-hook-prevent-qa-account-pr.mjs
@@ -23,6 +23,10 @@
  *   - 通過時: exit 0 (stdout/stderr 何も出さない、Claude にも干渉しない)
  *   - abort 時: exit 2 + stderr に対処方法を出力
  *
+ * fail-closed (#3999 AC3):
+ *   判定 SSOT (`./lib/is-main.mjs`) の import 解決失敗・main() 内の想定外例外は exit 2 に倒す。
+ *   Claude Code は exit 2 のみを block として扱うため、既定の exit 1 では tool 実行が継続する。
+ *
  * 関連:
  *   - ADR-0022 amendment 1 / amendment 3 (#1879)
  *   - scripts/check-gh-account-before-pr.mjs (.husky/pre-push 経由で同等チェック)
@@ -31,7 +35,27 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { isMain as isMainModule } from './lib/is-main.mjs';
+
+/**
+ * 判定 SSOT を **dynamic import** で読み込む理由 (#3999 AC3)。
+ *
+ * static import は解決失敗時に `ERR_MODULE_NOT_FOUND` (exit 1) になる。Claude Code の
+ * PreToolUse hook は **exit 2 のみ**を block として扱うため、exit 1 では tool 実行が継続し
+ * **QA アカウントからの `gh pr create` が素通しする** (fail-open)。
+ * `.claude/hooks/gate-approve.mjs` と同一の失敗 class なので同じ形で塞ぐ。
+ *
+ * なお本 script の import は同一 tree 内 (`scripts/` → `scripts/lib/`) なので、gate-approve の
+ * tree 横断 import に比べ到達条件は狭い (`scripts/` の部分 checkout 等)。それでも security
+ * control が「依存欠落 = 許可」に倒れる形は残さない。
+ */
+let isMainModule;
+/** @type {unknown} import 解決に失敗したときの error (成功時は null) */
+let isMainLoadError = null;
+try {
+	({ isMain: isMainModule } = await import('./lib/is-main.mjs'));
+} catch (err) {
+	isMainLoadError = err;
+}
 
 export const ALLOWED_PR_AUTHOR_DEFAULT = 'Takenori-Kusaka';
 export const QA_ACCOUNT = 'ganbariquestsupport-lab';
@@ -154,8 +178,35 @@ async function main() {
 	process.exit(2);
 }
 
+/**
+ * 判定 SSOT を読み込めなかったときの fail-closed 終了 (#3999 AC3)。
+ * 判定不能を「許可」ではなく block に倒す。理由の詳細は上部の dynamic import コメント参照。
+ *
+ * @param {unknown} err
+ */
+function reportIsMainLoadFailure(err) {
+	const msg = err instanceof Error ? err.message : String(err);
+	process.stderr.write(
+		`[claude-hook-prevent-qa-account-pr] BLOCK: 判定 SSOT scripts/lib/is-main.mjs を読み込めませんでした。\n`,
+	);
+	process.stderr.write(`  reason: ${msg}\n`);
+	process.stderr.write(
+		`  hook は判定不能時に block 側へ倒します (fail-closed / #3999)。checkout に scripts/lib/is-main.mjs があるか確認してください。\n`,
+	);
+}
+
 // CLI として直接実行されたときのみ main() を呼ぶ。`import` 経由 (unit test 等) では実行されない。
-const isDirectInvocation = isMainModule(import.meta.url);
-if (isDirectInvocation) {
-	main();
+if (isMainLoadError) {
+	reportIsMainLoadFailure(isMainLoadError);
+	process.exit(2);
+} else if (isMainModule(import.meta.url)) {
+	// main() 内の想定外例外も unhandled rejection (= exit 1 = 素通し) にせず block へ倒す (#3999)。
+	main().catch((err) => {
+		const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
+		process.stderr.write(
+			`[claude-hook-prevent-qa-account-pr] BLOCK: hook が想定外の例外で失敗しました。\n`,
+		);
+		process.stderr.write(`  ${detail}\n`);
+		process.exit(2);
+	});
 }

--- a/scripts/claude-hook-prevent-qa-account-pr.mjs
+++ b/scripts/claude-hook-prevent-qa-account-pr.mjs
@@ -48,6 +48,7 @@ import { spawnSync } from 'node:child_process';
  * tree 横断 import に比べ到達条件は狭い (`scripts/` の部分 checkout 等)。それでも security
  * control が「依存欠落 = 許可」に倒れる形は残さない。
  */
+/** @type {((importMetaUrl: string, argv1?: string) => boolean) | undefined} */
 let isMainModule;
 /** @type {unknown} import 解決に失敗したときの error (成功時は null) */
 let isMainLoadError = null;
@@ -196,8 +197,12 @@ function reportIsMainLoadFailure(err) {
 }
 
 // CLI として直接実行されたときのみ main() を呼ぶ。`import` 経由 (unit test 等) では実行されない。
-if (isMainLoadError) {
-	reportIsMainLoadFailure(isMainLoadError);
+// `typeof isMainModule !== 'function'` も block 側に含める。module が読めても isMain を export
+// していなければ判定不能であることに変わりはなく、ここを allow に倒すと同じ fail-open に戻る。
+if (isMainLoadError || typeof isMainModule !== 'function') {
+	reportIsMainLoadFailure(
+		isMainLoadError ?? new Error('scripts/lib/is-main.mjs が isMain を export していません'),
+	);
 	process.exit(2);
 } else if (isMainModule(import.meta.url)) {
 	// main() 内の想定外例外も unhandled rejection (= exit 1 = 素通し) にせず block へ倒す (#3999)。

--- a/tests/unit/helpers/hook-tree-probe.ts
+++ b/tests/unit/helpers/hook-tree-probe.ts
@@ -1,0 +1,87 @@
+/**
+ * tests/unit/helpers/hook-tree-probe.ts (#3999)
+ *
+ * PreToolUse hook を「判定 SSOT (`scripts/lib/is-main.mjs`) を含まない checkout」で起動する probe。
+ *
+ * ## なぜ temp tree に複製するのか
+ *
+ * QM が PR #3979 のレビューで踏んだ再現手順は「実 repo の `scripts/lib/is-main.mjs` を
+ * `mv` で退避して hook を叩く」だった。これを test でそのまま行うと、同時実行中の他 test /
+ * 他セッション / pre-ready を巻き添えで壊す (実際に並走事故が起きている領域である)。
+ *
+ * 代わりに hook script 1 本だけを temp tree へ複製し、`scripts/lib/is-main.mjs` を
+ * **置くか置かないか**だけを切り替える。hook 内の相対 import (`../../scripts/lib/is-main.mjs`
+ * / `./lib/is-main.mjs`) は複製先 tree の中で解決されるため、非破壊かつ並列安全に
+ * 「依存が欠落した checkout」を再現できる。
+ *
+ * 関連:
+ *   - Issue #3999 AC2 (module 解決失敗を模した probe)
+ *   - Issue #3969 / PR #3979 (判定 SSOT 化)
+ *   - ADR-0056 (approve gate の設計 SSOT)
+ */
+
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/** tests/unit/helpers/ から 3 階層上が repo root */
+export const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../../..');
+
+/** 判定 SSOT の repo 相対パス (POSIX 区切り) */
+const IS_MAIN_REL = 'scripts/lib/is-main.mjs';
+
+export interface HookProbeResult {
+	status: number | null;
+	stdout: string;
+	stderr: string;
+	/** stdout + stderr (無出力 = main() 未到達の検出に使う) */
+	combined: string;
+}
+
+export interface HookProbeOptions {
+	/** hook script の repo 相対パス (POSIX 区切り、例 `.claude/hooks/gate-approve.mjs`) */
+	hookRelPath: string;
+	/** false にすると temp tree に `scripts/lib/is-main.mjs` を置かない = import 解決が失敗する */
+	withIsMain: boolean;
+	/** hook に渡す stdin (Claude Code の PreToolUse payload JSON) */
+	stdin: string;
+}
+
+function copyInto(root: string, relPath: string): void {
+	const dest = path.join(root, ...relPath.split('/'));
+	mkdirSync(path.dirname(dest), { recursive: true });
+	copyFileSync(path.join(REPO_ROOT, ...relPath.split('/')), dest);
+}
+
+/**
+ * hook を隔離 tree で起動し、exit code と出力を返す。
+ *
+ * `cwd` は temp tree root にする。hook が参照する `tmp/adversarial-evidence/` も
+ * temp tree 側を見るため、実 repo の evidence file に結果が左右されない。
+ */
+export function runHookInIsolatedTree(options: HookProbeOptions): HookProbeResult {
+	const { hookRelPath, withIsMain, stdin } = options;
+	const root = mkdtempSync(path.join(tmpdir(), 'gq-hook-probe-'));
+	try {
+		copyInto(root, hookRelPath);
+		if (withIsMain) copyInto(root, IS_MAIN_REL);
+
+		const res = spawnSync(process.execPath, [path.join(root, ...hookRelPath.split('/'))], {
+			cwd: root,
+			input: stdin,
+			encoding: 'utf8',
+		});
+		const stdout = `${res.stdout ?? ''}`;
+		const stderr = `${res.stderr ?? ''}`;
+		return { status: res.status, stdout, stderr, combined: `${stdout}${stderr}` };
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+/** Claude Code の PreToolUse payload を組み立てる */
+export function bashPayload(command: string): string {
+	return JSON.stringify({ session_id: 'probe', tool_name: 'Bash', tool_input: { command } });
+}

--- a/tests/unit/helpers/hook-tree-probe.ts
+++ b/tests/unit/helpers/hook-tree-probe.ts
@@ -21,7 +21,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -45,6 +45,14 @@ export interface HookProbeOptions {
 	hookRelPath: string;
 	/** false にすると temp tree に `scripts/lib/is-main.mjs` を置かない = import 解決が失敗する */
 	withIsMain: boolean;
+	/**
+	 * `withIsMain: true` のとき、実物を複製する代わりにこの中身で `scripts/lib/is-main.mjs` を作る。
+	 *
+	 * 「module は解決できるが `isMain` を export していない」劣化 module を模すのに使う。
+	 * import 解決失敗 (`ERR_MODULE_NOT_FOUND`) とは別経路で、こちらは `isMain` が `undefined`
+	 * になるため呼び出すと `TypeError` になる = 素通し側に倒れうる。
+	 */
+	isMainSource?: string;
 	/** hook に渡す stdin (Claude Code の PreToolUse payload JSON) */
 	stdin: string;
 }
@@ -62,11 +70,19 @@ function copyInto(root: string, relPath: string): void {
  * temp tree 側を見るため、実 repo の evidence file に結果が左右されない。
  */
 export function runHookInIsolatedTree(options: HookProbeOptions): HookProbeResult {
-	const { hookRelPath, withIsMain, stdin } = options;
+	const { hookRelPath, withIsMain, isMainSource, stdin } = options;
 	const root = mkdtempSync(path.join(tmpdir(), 'gq-hook-probe-'));
 	try {
 		copyInto(root, hookRelPath);
-		if (withIsMain) copyInto(root, IS_MAIN_REL);
+		if (withIsMain) {
+			if (isMainSource === undefined) {
+				copyInto(root, IS_MAIN_REL);
+			} else {
+				const dest = path.join(root, ...IS_MAIN_REL.split('/'));
+				mkdirSync(path.dirname(dest), { recursive: true });
+				writeFileSync(dest, isMainSource, 'utf8');
+			}
+		}
 
 		const res = spawnSync(process.execPath, [path.join(root, ...hookRelPath.split('/'))], {
 			cwd: root,
@@ -80,6 +96,14 @@ export function runHookInIsolatedTree(options: HookProbeOptions): HookProbeResul
 		rmSync(root, { recursive: true, force: true });
 	}
 }
+
+/**
+ * `isMain` を export しない `scripts/lib/is-main.mjs` の代替中身。
+ *
+ * import は成功するが `isMain` が `undefined` になるため、hook が素朴に呼ぶと `TypeError`
+ * (= exit 1 = 素通し) になる。`isMainSource` に渡して「劣化 module」を再現する。
+ */
+export const IS_MAIN_WITHOUT_EXPORT = 'export const somethingElse = true;\n';
 
 /** Claude Code の PreToolUse payload を組み立てる */
 export function bashPayload(command: string): string {

--- a/tests/unit/hooks/gate-approve.test.ts
+++ b/tests/unit/hooks/gate-approve.test.ts
@@ -7,10 +7,12 @@
  *   - isApproveAction: Bash command が approve 系か判定する regex
  *   - extractPrNumber: command から PR 番号を抽出する regex
  *   - verifyEvidence: tmp/adversarial-evidence/<pr>.json の schema 検証
+ *   - fail-closed: 判定 SSOT の import 解決失敗時に exit 2 (block) で終了する (#3999)
  *
  * 関連:
  *   - ADR-0056 (本テストの設計根拠 SSOT)
  *   - docs/research/qm-drift-prevention-2026-05-28.md
+ *   - Issue #3999 (fail-open の fail-closed 化) / Issue #3969 / PR #3979
  */
 
 import { mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
@@ -27,6 +29,7 @@ import {
 	REQUIRED_OBJECT_COUNT,
 	verifyEvidence,
 } from '../../../.claude/hooks/gate-approve.mjs';
+import { bashPayload, runHookInIsolatedTree } from '../helpers/hook-tree-probe';
 
 describe('isApproveAction', () => {
 	it('gh pr merge を含む command → true', () => {
@@ -248,4 +251,80 @@ describe('verifyEvidence', () => {
 	it('MIN_REASON_LENGTH は literal 100 (将来の作為的緩和を防ぐ)', () => {
 		expect(MIN_REASON_LENGTH).toBe(100);
 	});
+});
+
+// ---------------------------------------------------------------------------
+// fail-closed (#3999 AC1 / AC2)
+// ---------------------------------------------------------------------------
+
+/**
+ * 判定 SSOT (`scripts/lib/is-main.mjs`) の import 解決に失敗したとき、hook が
+ * **exit 2 (block)** で終了することを固定する。
+ *
+ * ## 何を守っているか
+ *
+ * Claude Code の PreToolUse hook は **exit 2 のみ**を block として扱い、それ以外の非 0 は
+ * non-blocking error として tool 実行を継続する。static import の解決失敗は
+ * `ERR_MODULE_NOT_FOUND` = **exit 1** なので、`scripts/` を含まない checkout では
+ * **evidence 無しで approve / merge が通っていた** (QM が PR #3979 のレビューで実測)。
+ *
+ * ## 陽性対照を必ず併置する
+ *
+ * 「exit 2 が返った」だけでは、fail-closed が効いたのか hook が常に落ちているだけなのかを
+ * 区別できない。`withIsMain: true` の tree で (a) 非 approve コマンドが exit 0 無出力になり
+ * (b) approve コマンドが *evidence 不在* を理由に exit 2 になることを併せて assert する。
+ * 陽性対照が無い guard は「規則違反を検出できないことを検出できない」(dev-session.md 台帳 3)。
+ */
+describe('fail-closed — 判定 SSOT の import 解決失敗 (#3999)', () => {
+	const HOOK = '.claude/hooks/gate-approve.mjs';
+	const APPROVE_CMD = 'gh pr merge 3999 --squash';
+	const HARMLESS_CMD = 'git status --short';
+
+	it('陽性対照: is-main.mjs のある tree では非 approve コマンドを素通しする (exit 0 / 無出力)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			stdin: bashPayload(HARMLESS_CMD),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(0);
+		expect(res.combined.trim()).toBe('');
+	}, 30_000);
+
+	it('陽性対照: is-main.mjs のある tree では evidence 不在の approve を exit 2 で block する', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			stdin: bashPayload(APPROVE_CMD),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+		expect(res.stderr).toContain('evidence file 不在');
+	}, 30_000);
+
+	it('is-main.mjs が無い tree で approve コマンド → exit 2 (exit 1 = 素通しに倒れない)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: false,
+			stdin: bashPayload(APPROVE_CMD),
+		});
+		expect(
+			res.status,
+			`exit 1 は Claude Code では non-blocking error として tool 実行が継続する (= approve 素通し)。出力:\n${res.combined}`,
+		).toBe(2);
+		expect(res.stderr).toContain('scripts/lib/is-main.mjs');
+		expect(res.stderr).toContain('fail-closed');
+	}, 30_000);
+
+	/**
+	 * 判定不能時は approve 系以外も block する、という設計判断そのものを固定する。
+	 * 「approve のときだけ block」へ後から緩めると、SSOT を読めない = CLI 起動か import かを
+	 * 判定できない状態で main() を走らせるかどうかを推測することになり、別の silent failure を作る。
+	 */
+	it('is-main.mjs が無い tree では非 approve コマンドも block する (判定不能時は大きく止まる)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: false,
+			stdin: bashPayload(HARMLESS_CMD),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+	}, 30_000);
 });

--- a/tests/unit/hooks/gate-approve.test.ts
+++ b/tests/unit/hooks/gate-approve.test.ts
@@ -318,6 +318,11 @@ describe('fail-closed — 判定 SSOT の import 解決失敗 (#3999)', () => {
 	 * 判定不能時は approve 系以外も block する、という設計判断そのものを固定する。
 	 * 「approve のときだけ block」へ後から緩めると、SSOT を読めない = CLI 起動か import かを
 	 * 判定できない状態で main() を走らせるかどうかを推測することになり、別の silent failure を作る。
+	 *
+	 * **surgical 案 (approve 系だけ block) は技術的に可能だが、採らない。** approve 判定の regex は
+	 * gate-approve.mjs 内に閉じており is-main.mjs に依存しないので、import 解決に失敗しても
+	 * コマンド分類はできる。この test が固定しているのは能力の欠如ではなく**設計上の選択**。
+	 * 緩める提案をするときは「判定不能状態で main() を走らせる根拠」を先に示すこと。
 	 */
 	it('is-main.mjs が無い tree では非 approve コマンドも block する (判定不能時は大きく止まる)', () => {
 		const res = runHookInIsolatedTree({

--- a/tests/unit/hooks/gate-approve.test.ts
+++ b/tests/unit/hooks/gate-approve.test.ts
@@ -29,7 +29,11 @@ import {
 	REQUIRED_OBJECT_COUNT,
 	verifyEvidence,
 } from '../../../.claude/hooks/gate-approve.mjs';
-import { bashPayload, runHookInIsolatedTree } from '../helpers/hook-tree-probe';
+import {
+	IS_MAIN_WITHOUT_EXPORT,
+	bashPayload,
+	runHookInIsolatedTree,
+} from '../helpers/hook-tree-probe';
 
 describe('isApproveAction', () => {
 	it('gh pr merge を含む command → true', () => {
@@ -331,5 +335,21 @@ describe('fail-closed — 判定 SSOT の import 解決失敗 (#3999)', () => {
 			stdin: bashPayload(HARMLESS_CMD),
 		});
 		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+	}, 30_000);
+
+	/**
+	 * import 解決失敗とは別経路の劣化: **module は読めるが `isMain` を export していない**。
+	 * この場合 `isMain` は `undefined` なので素朴に呼ぶと `TypeError` = exit 1 = 素通しに倒れる。
+	 * 「依存が壊れている」という点で AC1 と同一 class なので同じく exit 2 に倒す。
+	 */
+	it('is-main.mjs が isMain を export していない tree → exit 2', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			isMainSource: IS_MAIN_WITHOUT_EXPORT,
+			stdin: bashPayload(APPROVE_CMD),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+		expect(res.stderr).toContain('isMain を export していません');
 	}, 30_000);
 });

--- a/tests/unit/hooks/gate-approve.test.ts
+++ b/tests/unit/hooks/gate-approve.test.ts
@@ -30,8 +30,8 @@ import {
 	verifyEvidence,
 } from '../../../.claude/hooks/gate-approve.mjs';
 import {
-	IS_MAIN_WITHOUT_EXPORT,
 	bashPayload,
+	IS_MAIN_WITHOUT_EXPORT,
 	runHookInIsolatedTree,
 } from '../helpers/hook-tree-probe';
 

--- a/tests/unit/scripts/claude-hook-prevent-qa-account-pr.test.ts
+++ b/tests/unit/scripts/claude-hook-prevent-qa-account-pr.test.ts
@@ -8,6 +8,7 @@
  *
  * 関連:
  *   - Issue #1994 (本テスト導入 Issue) / Issue #1879 (元 hook 導入)
+ *   - Issue #3999 AC3 (判定 SSOT の import 解決失敗を fail-closed 化)
  *   - ADR-0022 amendment 3
  */
 
@@ -19,6 +20,7 @@ import {
 	parseActiveAccount,
 	QA_ACCOUNT,
 } from '../../../scripts/claude-hook-prevent-qa-account-pr.mjs';
+import { bashPayload, runHookInIsolatedTree } from '../helpers/hook-tree-probe';
 
 describe('containsGhPrCreate', () => {
 	it('gh pr create を含む command → true', () => {
@@ -108,4 +110,45 @@ describe('定数', () => {
 	it('QA_ACCOUNT === ganbariquestsupport-lab', () => {
 		expect(QA_ACCOUNT).toBe('ganbariquestsupport-lab');
 	});
+});
+
+/**
+ * 判定 SSOT (`scripts/lib/is-main.mjs`) の import 解決に失敗したとき、hook が
+ * **exit 2 (block)** で終了することを固定する (#3999 AC3)。
+ *
+ * `.claude/hooks/gate-approve.mjs` と同一の失敗 class。Claude Code は exit 2 のみを block と
+ * して扱うため、`ERR_MODULE_NOT_FOUND` の既定 exit 1 のままだと tool 実行が継続し、
+ * **QA アカウントからの `gh pr create` が素通しする**。
+ *
+ * 陽性対照 (is-main.mjs を置いた tree で `gh pr create` を含まないコマンドが exit 0 無出力)
+ * を併置し、「常に落ちているだけ」と区別する。
+ */
+describe('fail-closed — 判定 SSOT の import 解決失敗 (#3999 AC3)', () => {
+	const HOOK = 'scripts/claude-hook-prevent-qa-account-pr.mjs';
+	// gh auth status を spawn させないため、hook の検出対象外コマンドを使う
+	const HARMLESS_CMD = 'git status --short';
+
+	it('陽性対照: is-main.mjs のある tree では対象外コマンドを素通しする (exit 0 / 無出力)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			stdin: bashPayload(HARMLESS_CMD),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(0);
+		expect(res.combined.trim()).toBe('');
+	}, 30_000);
+
+	it('is-main.mjs が無い tree → exit 2 (exit 1 = 素通しに倒れない)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: false,
+			stdin: bashPayload('gh pr create --draft --title "x"'),
+		});
+		expect(
+			res.status,
+			`exit 1 は Claude Code では non-blocking error として tool 実行が継続する。出力:\n${res.combined}`,
+		).toBe(2);
+		expect(res.stderr).toContain('scripts/lib/is-main.mjs');
+		expect(res.stderr).toContain('fail-closed');
+	}, 30_000);
 });

--- a/tests/unit/scripts/claude-hook-prevent-qa-account-pr.test.ts
+++ b/tests/unit/scripts/claude-hook-prevent-qa-account-pr.test.ts
@@ -20,7 +20,11 @@ import {
 	parseActiveAccount,
 	QA_ACCOUNT,
 } from '../../../scripts/claude-hook-prevent-qa-account-pr.mjs';
-import { bashPayload, runHookInIsolatedTree } from '../helpers/hook-tree-probe';
+import {
+	IS_MAIN_WITHOUT_EXPORT,
+	bashPayload,
+	runHookInIsolatedTree,
+} from '../helpers/hook-tree-probe';
 
 describe('containsGhPrCreate', () => {
 	it('gh pr create を含む command → true', () => {
@@ -150,5 +154,17 @@ describe('fail-closed — 判定 SSOT の import 解決失敗 (#3999 AC3)', () =
 		).toBe(2);
 		expect(res.stderr).toContain('scripts/lib/is-main.mjs');
 		expect(res.stderr).toContain('fail-closed');
+	}, 30_000);
+
+	/** module は読めるが `isMain` を export していない劣化パターン。`gate-approve` と同一 class。 */
+	it('is-main.mjs が isMain を export していない tree → exit 2', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			isMainSource: IS_MAIN_WITHOUT_EXPORT,
+			stdin: bashPayload('gh pr create --draft --title "x"'),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+		expect(res.stderr).toContain('isMain を export していません');
 	}, 30_000);
 });

--- a/tests/unit/scripts/claude-hook-prevent-qa-account-pr.test.ts
+++ b/tests/unit/scripts/claude-hook-prevent-qa-account-pr.test.ts
@@ -21,8 +21,8 @@ import {
 	QA_ACCOUNT,
 } from '../../../scripts/claude-hook-prevent-qa-account-pr.mjs';
 import {
-	IS_MAIN_WITHOUT_EXPORT,
 	bashPayload,
+	IS_MAIN_WITHOUT_EXPORT,
 	runHookInIsolatedTree,
 } from '../helpers/hook-tree-probe';
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（開発チーム・QM）/ システム全体

**解決する課題**: ADR-0056 の approve gate hook (`.claude/hooks/gate-approve.mjs`) が、判定 SSOT `scripts/lib/is-main.mjs` を解決できないと `ERR_MODULE_NOT_FOUND` = **exit 1** で落ちる。Claude Code の PreToolUse hook は **exit 2 のみ**を block として扱い、それ以外の非 0 は non-blocking error として tool 実行を継続する。つまり `scripts/` を含まない checkout では **adversarial evidence 無しで approve / merge が通る**。「依存が欠落したら許可」に倒れる security control は、gate が無いのと同じである。

**期待される効果**: gate が壊れたときに **黙って許可する**のではなく **止まって理由を出す**。QM の approve が「evidence を検証した結果」であることを、環境差に関係なく保証できる。ADR-0056 が抑止しようとしている echoing / role drift は、gate が空洞化した瞬間に無防備になるため、gate 自体の失敗モードを潰すことが前提条件になる。

## 関連 Issue

関連: #3999 （AC1-3 を対応。AC4-8 は本 PR の対象外で #3999 は OPEN のまま残す）
関連: #3969 / PR #3979 (`69b30c47`) — 本 fail-open を持ち込んだ PR
関連: ADR-0056（approve gate / adversarial review の設計 SSOT）

<!-- no-issue-close: #3999 は AC1-8 のうち AC1-3 のみを本 PR で対応する部分対応 PR。AC4-8 (canonicalize 非対称 fallback / opt-out メタデータ強制 / PROBE_SCRIPTS 自動化 / .github 走査 / 遡及 scan) が未対応のため Issue を閉じない。QM が「AC1-3 を優先、AC4-8 は急がない」と分割を指示している (gq-qa チャンネル 2026-07-26 22:11Z) -->

## AC 検証マップ (ADR-0004)

> 本 PR の対象は **AC1-3** のみ。AC4-10 は #3999 に残す（上記 `no-issue-close` 宣言の理由欄参照）。行を削除せず scope を明示する。
>
> **本 PR の merge を「fail-open 解消」と読まないでください（QM 指摘、2026-07-26 22:36Z）。** fail-open の入口は 2 経路あり、本 PR が塞ぐのは片方だけです。詳細は下記「本 PR で塞がらない fail-open 経路」節。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `is-main.mjs` の import 解決に失敗した場合、hook が **exit 2 (block)** で終了する (security control は fail-closed に倒す) | 隔離 tree で hook を起動する A/B 実測。`scripts/lib/is-main.mjs` を置くか置かないかだけを切替（下表「実測 A/B」） | PASS — develop `1824ff00` は **exit 1**（素通し）、本 PR は **exit 2**（block）。stderr に `判定 SSOT scripts/lib/is-main.mjs を読み込めませんでした` を出力 |
| AC2 | AC1 の挙動を assert する unit test を追加する (module 解決失敗を模した probe) | `npx vitest run tests/unit/hooks/gate-approve.test.ts tests/unit/scripts/claude-hook-prevent-qa-account-pr.test.ts` | PASS — `Test Files 2 passed (2) / Tests 50 passed (50)`。probe 本体は `tests/unit/helpers/hook-tree-probe.ts`（新規）。guard 除去対照も実行済（下記「guard の実効性検証」） |
| AC3 | 同じ tree 横断 import を持つ他の hook (`scripts/claude-hook-prevent-qa-account-pr.mjs` 等) にも同じ失敗モードが無いか確認し、あれば同様に fail-closed 化する | `git grep -n "lib/is-main.mjs'" -- '.claude' 'scripts/claude-hook-*'` で全件列挙し 1 件ずつ判定（下記「AC3 調査結果」） | PASS — 該当 3 件。hook 2 件（`gate-approve.mjs` / `claude-hook-prevent-qa-account-pr.mjs`）を fail-closed 化、残り 1 件（`init-pr-body.mjs`）は gate ではないため対象外と判定 |
| AC4 | 片側のみ realpath 失敗するケースの test を追加し、非対称正規化で判定が壊れないことを保証する (または両辺の fallback を連動させる) | 本 PR scope 外 | 本 PR 未対応。#3999 に OPEN のまま残す |
| AC5 | opt-out マーカーに理由 + 追跡 Issue 番号を必須化する (または件数上限を設けて増加を検知する) | 本 PR scope 外 | 本 PR 未対応。#3999 に OPEN のまま残す |
| AC6 | `PROBE_SCRIPTS` を自動生成にするか、未登録 script を検知する meta-gate を追加する | 本 PR scope 外 | 本 PR 未対応。#3999 に OPEN のまま残す |
| AC7 | `.github/` 配下の node script を走査対象に含めるか、対象外である旨を docstring に明記する | 本 PR scope 外 | 本 PR 未対応。#3999 に OPEN のまま残す |
| AC8 | 少なくとも以下の gate について現 tree に対する遡及 scan を 1 回実行し、素通しした違反が残っていないか確認する | 本 PR scope 外 | 本 PR 未対応。#3999 に OPEN のまま残す |
| AC9 | gate の生存確認手段を用意する（`--self-check` 案） | 本 PR scope 外 | 本 PR 未対応。#3999 に OPEN のまま残す（QM 追加提案、2026-07-26 22:24Z） |
| AC10 | 到達不能な hook を検知する手段を検討する | 本 PR scope 外 | 本 PR 未対応。#3999 に OPEN のまま残す（QM 追加提案、同上） |

### 本 PR で塞がらない fail-open 経路（QM 指摘への回答）

fail-open の入口は 2 経路あり、**本 PR が塞ぐのは 1 経路目だけ**です。2 経路目は hook のコードに一切到達しないため、hook 側の実装では原理的に塞げません。

| 経路 | 挙動 | 本 PR で塞がるか | 残 scope |
|---|---|---|---|
| hook は起動するが `is-main.mjs` の import に失敗 | 旧: exit 1 → 素通し | **塞がる**（exit 2） | — |
| **hook script のパス自体に到達できない**（repo 移動 / リネーム / ドライブ非接続 / `node` が PATH に無い） | `node` 自身が exit 1 → 素通し | **塞がらない** | #3999 AC9 / AC10 |

2 経路目は `settings.json` に絶対パスで登録された hook が消えるケースで、**発生確率はこちらの方が高い**（QM セッションは `E:/Github/ganbari-quest-qa/...` の絶対パス登録）。「PreToolUse が呼ばれなかったこと」を hook 自身は検知できないため、対処は hook 外（セッション開始時の意図的 block probe / `--self-check`）になります。

さらに **hook が起動する経路自体にも穴があります**: ADR-0056 の matcher は `"Bash"` のみで、**PowerShell tool 経由のコマンドは一切捕捉されません**（QM 実測、#4001）。本 PR は「起動した hook の失敗モード」を直すもので、「起動しない経路」は #4001 の scope です。

### 実測 A/B（隔離 tree、`scripts/lib/is-main.mjs` の有無だけを切替）

hook 1 本を temp tree へ複製し、依存を置くか置かないかだけを変えて `node <hook>` を起動した実測値。

| 版 | is-main.mjs | 渡した command | exit | stderr |
|---|---|---|---|---|
| develop `1824ff00` | なし | 任意 | **1** | `ERR_MODULE_NOT_FOUND` の Node スタックトレース（= tool 実行が継続する = 素通し） |
| 本 PR | なし | approve 系 | **2** | `[gate-approve] BLOCK: 判定 SSOT scripts/lib/is-main.mjs を読み込めませんでした。` |
| 本 PR | なし | 非 approve | **2** | 同上（設計判断、下記「レビュー依頼事項」参照） |
| 本 PR | あり | approve 系（evidence 不在） | 2 | `[gate-approve] BLOCK: PR #3999 の Adversarial Reviewer evidence 検証 fail. reason: evidence file 不在` （従来どおり） |
| 本 PR | あり | 非 approve | 0 | 無出力（従来どおり） |

下 2 行が**陽性対照**。これが無いと「fail-closed が効いた」と「hook が常に落ちているだけ」を区別できない。

### guard の実効性検証（dev-session.md §QA 指摘台帳 観点 3）

`.claude/hooks/gate-approve.mjs` **だけ** を develop 版へ戻して新規 test を実行した結果:

```
Tests  2 failed | 2 passed | 29 skipped (33)
  → expected 1 to be 2   (fail-closed 系 2 件が fail)
  → 陽性対照 2 件は pass
```

検証後にファイルを復元し、`git diff --stat` で差分が意図した 5 ファイルのみであることを確認済み。

### AC3 調査結果

```console
$ git grep -n "lib/is-main.mjs'" -- '.claude' 'scripts/claude-hook-*'
.claude/hooks/gate-approve.mjs:65:      ({ isMain } = await import('../../scripts/lib/is-main.mjs'));
.claude/skills/dev-open-pr/scripts/init-pr-body.mjs:28:import { isMain } from '../../../../scripts/lib/is-main.mjs';
scripts/claude-hook-prevent-qa-account-pr.mjs:55:      ({ isMain: isMainModule } = await import('./lib/is-main.mjs'));
```

- `.claude/hooks/gate-approve.mjs` — **fail-closed 化した**。tree 横断 import を持つ PreToolUse hook で、本 Issue の本体
- `scripts/claude-hook-prevent-qa-account-pr.mjs` — **fail-closed 化した**。同一 tree 内 import (`./lib/is-main.mjs`) で到達条件は狭いが、失敗 class（`ERR_MODULE_NOT_FOUND` → exit 1 → tool 実行継続）は同一。security control が「依存欠落 = 許可」に倒れる形を残さない
- `.claude/skills/dev-open-pr/scripts/init-pr-body.mjs` — **対象外**。4 階層の tree 横断 import だが、gate ではなく PR body 雛形生成 script。壊れても「無言で許可」にはならず exit 1 が可視の失敗になる（生成物が出ないので気付ける）
- `.husky/*` — **対象外（元から fail-closed）**。非 0 で pre-push が止まる構造で、exit 2 特別扱いの仕様が無い

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（アプリのランタイム経路は 1 行も変わらない）。影響するのは Claude Code セッションの PreToolUse hook 2 本のみ。

- `.claude/hooks/gate-approve.mjs` — ADR-0056 approve gate
- `scripts/claude-hook-prevent-qa-account-pr.mjs` — QA アカウント PR 起票禁止 gate (#1879)

`src/` / `infra/` / `site/` は無変更。#3172 の重量 e2e 敏感領域（export/import schema・marketplace schema・reward 陳列・domain 値域・child shop・parent-gate・DB スキーマ）にも該当しない。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr 4002` 全 Step PASS**（#1775 / ADR-0030）— 完走ログは下記「pre-ready 完走ログ (2026-07-27)」。実行パスは実体パス `E:\Github\ganbari-quest-dev\.claude\worktrees\ch-c0aa48d4-3999`（junction 経由ではない）。他セッションの重い検証が走っていないことを `~/.buzz/.locks/heavy.lock` の保持者 pid 生存確認で判定してから単独実行した
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/helpers/hook-tree-probe.ts`（新規）— hook 1 本を temp tree へ複製し、`scripts/lib/is-main.mjs` を置くか置かないかだけを切り替えて起動する probe。QM が PR #3979 のレビューで踏んだ再現手順（実 repo の `is-main.mjs` を `mv`）の**非破壊・並列安全版**。実 repo を触らないので、並走する他セッションの検証を巻き添えで壊さない
  - `tests/unit/hooks/gate-approve.test.ts` — `fail-closed` describe を追加（4 ケース: 陽性対照 2 + 本体 2）
  - `tests/unit/scripts/claude-hook-prevent-qa-account-pr.test.ts` — 同 2 ケース（陽性対照 1 + 本体 1）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:critical` label なし）

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更を含まない。PreToolUse hook 2 本と unit test のみで `.svelte` / `.css` / `site/` の差分は 0）**

**4 スロット添付**（#1740）: 該当なし（同上）

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 判定ロジックは `scripts/lib/is-main.mjs`（SSOT）に置いたまま。hook 側に自前判定を持ち込んでいない（#3969 の再発を作らない）。dynamic import 化は「解決失敗を捕まえて exit code を選ぶ」ためだけの変更で、判定責務は移していない
- [x] **DRY**: probe を `tests/unit/helpers/hook-tree-probe.ts` に切り出し、2 つの test file から共有。`git grep "lib/is-main.mjs'"` で同型 import を全件洗い出し済（上記 AC3 表）
- [x] **YAGNI**: 抽象化を増やしていない。hook 2 本それぞれに 20 行程度の try/catch + 終了処理を足しただけ。設定 flag / 環境変数による分岐は**意図的に作っていない**（gate を条件付きで緩める経路は #3969 が潰した class そのもの）
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。本 PR は security control の失敗モードを塞ぐ変更そのもの
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: N/A。static import → dynamic import は module 解決 1 回のコストで、hook 実行時間に有意差なし

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200) — open PR #3995 / #3996 / #3992 / #3989 の差分に `.claude/hooks/` / `scripts/claude-hook-*` は含まれず、重複なし
- [x] N/A — 並行実装の影響範囲外（アプリのランタイム経路に差分なし）

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

**設計判断 1 件 — QM 承認済み（2026-07-26 22:36Z、gq-qa チャンネル）。判断の記録として残します。**

判定 SSOT を読めない状態では、**approve 系以外の Bash コマンドも全て block されます**。hook は PreToolUse の Bash matcher で毎回起動されるためです。壊れた checkout では、そのセッションで Bash が一切通らなくなります。

「approve 系のときだけ block する」surgical 案も検討しましたが、採りませんでした。理由は、SSOT を読めない = **「CLI 起動か import か」を判定できない**状態であり、そこで `main()` を走らせるかどうかを推測すると、import 経由の呼び出し元（unit test 等）を **無言で exit させる**別の silent failure を作るためです。#3969 が潰したのは「gate が無言で PASS する」class であり、それを直すために「呼び出し元が無言で死ぬ」class を作るのでは意味がありません。**判定不能時は大きく声を上げて止まる**方を選びました。

**この surgical 案は技術的に不可能ではありません（QM の事実訂正を反映）。** approve 系かどうかの判定 regex は `gate-approve.mjs` 内に閉じており `is-main.mjs` に依存しないため、dynamic import 化した時点でコマンド分類自体は可能です。**できないから採らないのではなく、選んで採らない**という設計上の選択です。後任が「不可能だった」と誤読しないよう、hook の docstring と test の docstring 両方に明記しました。

この判断そのものを `is-main.mjs が無い tree では非 approve コマンドも block する` という test で固定してあるので、後から無言で「approve のときだけ」へ緩めることはできません。

**QM が承認理由として復旧経路を実測済み**: PreToolUse の matcher はツール単位なので Bash が全 block されても Write / Edit は生きており、`settings.json` から hook 登録を外して自力で復旧できる。加えて発動条件は「hook ファイルはあるが `is-main.mjs` だけ無い」不整合 tree に限られる（古い commit の checkout では hook 自体も旧版になるためこの窓に入らない）。

**もう 1 点、scope の確認**: 本 PR は AC1-3 のみです。AC4-10 は #3999 に残しています（QM 指示に従った分割）。AC 検証マップは行を削除せず「本 PR 未対応」と明示する形にしましたが、この書き方で問題があればご指摘ください。**本 PR は fail-open を半分しか塞ぎません**（上記「本 PR で塞がらない fail-open 経路」）。


## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr 4002` 全 Step PASS** をローカル確認した — 完走ログは下記「pre-ready 完走ログ (2026-07-27)」
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— 一時 probe script (`tmp/probe-3999.mjs`) は削除済、`git status` clean
- [x] 全 AC が実装済み（本 PR scope = AC1-3。AC4-8 は #3999 に残す旨を上記に明示）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## pre-ready 完走ログ (2026-07-27)

実行パス `E:\Github\ganbari-quest-dev\.claude\worktrees\ch-c0aa48d4-3999`（実体パス、HEAD `a999377d` = PR head）。

```console
PRE_READY_LOG_PLACEHOLDER
```

## CI 実測 (head `a999377d`)

Draft 時点の head `ec0b3ba2` では `lint-and-test` が svelte-check 型エラー 2 件で fail していた（`Cannot invoke an object which is possibly 'undefined'` / `.claude/hooks/gate-approve.mjs:313` と `scripts/claude-hook-prevent-qa-account-pr.mjs:202`）。未 push だった `bf822603` が `typeof isMain !== 'function'` ガードを入れており、これを push したことで解消している。

```console
$ gh pr checks 4002 --json name,state
[{"SUCCESS":18}]   # SKIPPED を除く全 check
```

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

