### PR TITLE
fix(test): #3972 同 class 3 例目 — export authz テストの初回 import timeout (#3994 追補)

### DIFF
--- a/tests/unit/routes/export-authz-symmetry-3246.test.ts
+++ b/tests/unit/routes/export-authz-symmetry-3246.test.ts
@@ -12,7 +12,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { glob } from 'glob';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { asChildId } from '$lib/domain/ids';
 
 const ROOT = resolve(__dirname, '../../..');
@@ -68,9 +68,28 @@ async function callGet(
 	}
 }
 
+const ROUTE_MODULES = [
+	'../../../src/routes/api/v1/special-rewards/export/+server',
+	'../../../src/routes/api/v1/checklists/export/+server',
+	'../../../src/routes/api/v1/activities/export/+server',
+];
+
 describe('#3246 (B) child role は export に到達できない (403)', () => {
+	// #3972 / #3975 と同 class の 3 例目。本 describe の主張は「child は 403」であって
+	// 「速いこと」ではないのに、**最初の 1 件だけ**が既定 testTimeout (5s) を超えて落ちていた
+	// (route module の初回 dynamic import が service / db グラフごと transform するため。
+	// 2 件目以降は module cache に載るので速い = 先頭 1 件だけ赤くなる紛らわしい壊れ方)。
+	//
+	// 各 it に timeout を配るのではなく beforeAll で module を温める:
+	// そうすれば **it 側は既定 5s のまま**でよく、「GET が本当に固まる」回帰は今までどおり
+	// 素早く落ちる。時間の猶予を与える対象を「module ロード」に限定するのが要点
+	// (it に 60s を配ると、ハングする実装回帰まで 60s 待って通ってしまう)。
+	beforeAll(async () => {
+		await Promise.all(ROUTE_MODULES.map((m) => import(m)));
+	}, 60_000);
+
 	it('special-rewards/export: child=403 / parent はgate通過 (childId 無で 400)', async () => {
-		const p = '../../../src/routes/api/v1/special-rewards/export/+server';
+		const p = ROUTE_MODULES[0] as string;
 		const child = await callGet(
 			p,
 			childLocals(),
@@ -83,7 +102,7 @@ describe('#3246 (B) child role は export に到達できない (403)', () => {
 
 	it('checklists/export: child=403', async () => {
 		const child = await callGet(
-			'../../../src/routes/api/v1/checklists/export/+server',
+			ROUTE_MODULES[1] as string,
 			childLocals(),
 			'http://x/api/v1/checklists/export?templateId=5',
 		);
@@ -92,7 +111,7 @@ describe('#3246 (B) child role は export に到達できない (403)', () => {
 
 	it('activities/export: child=403', async () => {
 		const child = await callGet(
-			'../../../src/routes/api/v1/activities/export/+server',
+			ROUTE_MODULES[2] as string,
 			childLocals(),
 			'http://x/api/v1/activities/export',
 		);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（開発・QA プロセス）

**解決する課題**: PR #3994 で解消した「テストの主張が速度ではないのに既定 timeout に当たる」class の **3 例目**が develop に残っている。`export-authz-symmetry-3246.test.ts` の (B) 先頭 1 件が、**単独実行および範囲限定実行 (`vitest run <file>` / `vitest run tests/unit/routes/`) で決定的に** `Test timed out in 5000ms` で落ちる。原因は route module の初回 dynamic import が service / db グラフごと transform するコストで、**先行する他 test file が同じグラフを温めていない実行形態でのみ現れる cold import 問題**である。

**期待される効果**: 範囲限定実行が決定的に green になり、red = 本物の異常という信号に戻る。#4007 (b) 採用後は**ローカル実行が範囲限定 (`vitest related` 相当) に変わる**ため、本 class はこれから最も踏みやすい失敗モードになる（PO #4007 AC4-b / AC4-c）。

### [訂正] 初版の課題記述を撤回します（QA #4005 レビュー指摘 / PO 支持）

初版本文にあった「**develop 上のどのブランチでも `npm run pre-ready` が Step 3 を越えられない**」を**撤回**します。

- **本 PR 内に、それを支える full suite の実測が 1 件もありません。** AC1 / AC2 は単一 file 実行、AC4 は 3 file 実行で、いずれも範囲限定です。AC5 は full ですが実行ログを本文に残していませんでした（QA 指摘）
- **単一 file 実行の結果を full suite へ外挿したもの**で、外挿が成り立たない理由を本文の「原因」節が自分で述べていました（先行 file がグラフを温めるかどうかで挙動が変わる）
- **full suite で本 file が落ちたという実測は、私も QA も持っていません。** QA の同一親 commit (`1824ff00`) の full run で落ちた 5 file に本 file は含まれていません（ただし当該生ログは現存せず、QA 自身が再提示不能と開示済み）

「full suite を止めている」は本 PR の merge 根拠ではありません。**範囲限定実行で決定的に再現し、mutation 検証で warm-up が load-bearing と示せていること**が根拠です。

### [追記 2026-07-27] 上記 3 点目「full suite で落ちた実測は無い」は、その後に反例が出ました

**撤回の 1 点目・2 点目は維持します。merge 根拠も変えません。** 3 点目だけが古くなりました。

本 PR の [02:20Z のコメント](https://github.com/Takenori-Kusaka/ganbari-quest/pull/4005#issuecomment-5086648904)で、別ブランチ（PR #4016）の `npm run pre-ready` **full 実行の Step 3** が、本 file の 2 件 timeout で停止したと報告されています。

| 主張 | 状態 | 根拠 |
|---|---|---|
| #4016 の差分は docs 2 file のみで `src/` / `tests/` に触れていない = 当該テストが落ちる余地は差分側に無い | **[検証済み]** | `gh pr view 4016 --json files` → `docs/CLAUDE.md` (+1/-0) / `docs/design/billing-redesign/contract-state-matrix.md` (+147/-0) の 2 件のみ |
| その full 実行で本 file が 2 件 timeout した | **[未確認]** | 別セッションの実行報告のみ。**実行ログはディスク上に見つかりません** — `E:\Github\ganbari-quest-dev` 配下（`node_modules` 除外 / depth 4 / 直近 2 日）と `.scratch` 直下を `*.log` で走査して 0 件。**再提示不能**です |
| その実行が単独条件だったか | **[未確認]** | コメントに並走の開示がありません |

**したがって「full suite でも落ちる」は、本文の主張としては [未確認] のまま置きます。** 訂正するのは「**実測は存在しない**」という不在の断定のほうです — 反例の報告が同一 PR 上に存在する以上、それを無いことにはできません（`docs/sessions/dev-session.md` 証跡規律 §3「『無い』は『起きていない』ではない」の裏返しで、**不在の主張こそ後から覆る**）。

**この追記で merge 根拠は増えも減りもしません。** full suite での挙動は依然 [未確認] であり、本 PR が依拠するのは範囲限定実行での決定的再現と mutation 検証です。

## 関連 Issue

<!-- no-issue-close: 本 PR は PR #3994 (#3972 / #3975) の追補であり、単独で close する Issue を持たない。#3972 / #3975 は #3994 に closing keyword があり develop→main 反映時に close される。ここで重複して closing keyword を置くと、本 PR が先に main へ入った場合に #3994 未反映のまま Issue が閉じる。 -->

- #3972 / #3975 — 同 class の 1・2 例目（PR #3994 で merge 済み）

本 PR は #3994 の追補です。**#3994 の Ready 化後に本件を発見**したため間に合わず、独立 PR にしました。#3972 / #3975 は develop→main 反映時に close されるため、本 PR に closing keyword は置いていません（`Refs` のみ）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 当該 test file が安定して pass する | `npx vitest run tests/unit/routes/export-authz-symmetry-3246.test.ts` | **PASS — 4 tests passed / 8.31s** |
| AC2 | 本件が本 PR 起因でないことを示す | `git checkout origin/develop` して同コマンド実行（**単一 file = 範囲限定**） | **確認済み — develop でも `Tests 1 failed \| 3 passed` で同一 fail**。本 PR / #3954 の差分とは無関係。**本行は full suite の主張ではありません**（下記「測定条件の開示」参照） |
| AC3 | timeout を伸ばすだけで実質無検査にしていない | `git diff` + 下記「なぜ it に timeout を配らないか」 | **PASS**。assertion は 1 行も変更なし（ADR-0006）。`it` 側の timeout は既定 5s のまま |
| AC4 | 3 例そろって green | `npx vitest run <3 file>` | **PASS — 3 files / 37 tests passed**（export-authz + cdk-hook-timeout-guard + check-license-key-leak） |
| AC5 | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4005` / **同一 HEAD の CI** | **ローカル実行ログは残っていません**（QA 指摘、自己申告のみ）。**独立検証が CI 側にあります** — run [`30223924217`](https://github.com/Takenori-Kusaka/ganbari-quest/actions/runs/30223924217) の `head_sha` が本 PR HEAD `989f51e0` に一致（QA が `gh api` で突合）、`unit-test (1)` 8m58s / `unit-test (2)` 9m23s / `unit-test-merge` / `lint-and-test` すべて pass |

### 原因と、なぜ `it` に timeout を配らないか

route module の初回 dynamic import が service / db グラフごと transform するため 5s を超えます。**同一 file 内では** 2 件目以降が module cache に載って速いので、**先頭 1 件だけが赤くなる**紛らわしい壊れ方でした。

#### file 間で何が温まるか（[検証済み] — 私自身の初版記述も併せて訂正します）

「full suite では他の test file が module グラフを温める」という説明は、**module cache の共有としては成立しません**。

- **[検証済み] `vite.config.ts:54` `fileParallelism: false`** — test file は**直列実行**（公式 docs「When disabled, it will override maxWorkers option to 1」）
- **[検証済み] `isolate: true`（既定）** — 同 file の `:39-40` のコメントが SSOT として「**test file ごとに worker を新規生成 + 終了し module cache を再利用しない**」と明記
- **[検証済み] 当該 3 route module を import する test file は本 file のみ**（走査: `grep -rln 'special-rewards/export/+server|checklists/export/+server|activities/export/+server' tests/` → 1 件）

したがって file 間で共有され得るのは worker 内の module cache ではなく、**vitest main process 側の Vite transform キャッシュ**です。本 file の route module 自体は他 file から一度も import されないため、full suite で温まるとすれば**推移的な service / db グラフの transform 結果**を経由することになります。**この経路が実際に効いているかは [未測定]** です（full suite 実測を私は持っていません）。

**この訂正が効く先**: `vite.config.ts:44-46` のコメントは「vitest 4.x default `pool: 'forks'` では 16 fork 並列実行下…」と読めますが、これは `fileParallelism: false` **採用前**の観察記録です。現行設定では full suite に vitest 内部の 16 並列はありません。#4000 で「full suite の並列負荷」を原因に置く仮説は、この行を現行仕様として読むと成立しません。

`it` に 60s を配れば通りますが、それは **「GET が本当にハングする実装回帰」まで 60s 待って通してしまう**ため assertion が実質緩みます（ADR-0006 assertion 弱体化）。そこで `beforeAll` で module を温め、**猶予を与える対象を module ロードだけに限定**し、`it` 側は既定 5s のままにしました。

**mutation 検証**（dev-session §QA 指摘台帳 観点 3「guard を外すと fail するか」）: `beforeAll` の warm-up を無効化すると当該 1 件が **5009ms で timeout fail** することを実行確認済み（`Tests 1 failed | 3 passed`）。warm-up が load-bearing であることの証跡です。

### 測定条件の開示（QA レビュー依頼 2 / PO #4000 AC1・QA proposal 006）

**AC1 / AC2 / mutation 検証の 3 測定が単独（他エージェントの重量プロセス非並走）だったかは [未確認] です。**

- **3 測定とも、当時プロセス列挙を取っていません。** 実施時刻は 2026-07-26 22:3x〜22:4xZ 帯で、GQ-Dev が並行して記録した並走窓（22:36〜22:45Z、フルスイート 3 本 + pre-ready 2 本）と**重なります**。したがって「単独だった」とは書けません
- **生ログもディスクに残っていません。** 本文の数値（8.31s / 5009ms / `Tests 1 failed | 3 passed`）は実行直後に転記したもので、再提示できません。**「重い / 軽いを問わず実行ログはファイルに落とす」を守れていなかった実害**です
- **並走が結論に効く向き**: 並走は timeout を**増やす**方向にしか働かないため、**AC1 の PASS（8.31s）は汚染に強い**方向の証跡です。一方 **AC2 と mutation 検証は fail 側**なので、単独条件では負荷が原因の可能性を排除できません。ただし mutation 検証は**同一条件下で warm-up の有無だけを切り替えた差分**であり、負荷は両側に等しく乗るため、**差分の向き（warm-up 無しのみ fail）は負荷では説明できません**
- **[未実施] 再測定**: 本文修正時点（2026-07-27 00:3xZ）で別セッションが `pre-ready --pr 4011` + full `vitest run` を実行中のため、再測定は行っていません（`agent-concurrency.md` §4「待たずに別作業へ移る」）。**能力の限界ではなく、並走下の再測定は根拠にならないという選択です。** 単独条件が空き次第、AC1 / AC2 / mutation の 3 測定を**ログをファイルに落として**取り直し、本欄を差し替えます

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — **テスト 1 ファイルのみ。製品コードの変更ゼロ**

**影響を受ける画面・機能**: なし

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
  - **作者のローカル実行ログは非保持**（`[x]` を一度外した経緯は初版どおり）。**代わりに QM が独立実行しました** — QA clone (`ganbari-quest-qa`) で同一 HEAD `989f51e0` を checkout し `npm run pre-ready -- --pr 4005` を実行。**Step 1 / 1b / 2 / 3 / 4 / 7 / 7b / 7c / 7d PASS、Step 5 / 6 / 8 は変更検知 NO で skip**。Step 9 のみ本 body 由来の 2 件（禁止語 1 件 + 未チェック 1 件）で fail したため、**QM が本 body を修正して解消し、修正後に再実行**。2 回目は **Step 1 / 1b / 2 / 3 / 4 / 7 / 7b / 7c / 7d / 9 / 10 / 11 がすべて PASS**、LP / UI を触らないため Step 5 / 6 / 8 / 11b / 12 が条件 skip（この 5 件を `--skip 指定` と表示して `PARTIAL PASS` になるのは #4018 の既知の誤表示であり、実行対象 step の失敗はゼロ）。self-report ではなく QM 側の独立検証です。
  - **CI 側の独立証跡**: 同一 HEAD (`989f51e0`) の CI run [`30223924217`](https://github.com/Takenori-Kusaka/ganbari-quest/actions/runs/30223924217) — `unit-test (1)` / `unit-test (2)` / `unit-test-merge` / `lint-and-test` すべて pass（AC5 行）。**self-report ではなく独立検証です。**
- [x] 追加・変更したテストの概要: `tests/unit/routes/export-authz-symmetry-3246.test.ts` に `beforeAll` warm-up を追加（assertion 不変、module パスを `ROUTE_MODULES` に集約して warm-up と本体の対象ずれを防止）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（テスト 1 ファイルのみ。`.svelte` / `.css` / `site/` の変更ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（テスト内の準備処理のみ）
- [x] **DRY**: module パスが warm-up と各 `it` の 2 箇所に散らないよう `ROUTE_MODULES` 定数に集約。**片方だけ書き換えて warm-up が空振りする**事故を構造的に防ぐ
- [x] **YAGNI**: 汎用 guard（「route module を dynamic import する test は warm-up を持て」）は今回入れていない。同形 38 file 中 fail は 1 件のみで、現時点では false positive の方が多くなる
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: warm-up は元々各 `it` が払っていた import コストを前倒しするだけ（合計は不変、実測 8.31s）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200) — open PR #3996 / #3992 / #3989 と変更ファイル重複なし
- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

1. 汎用 guard を今回見送った判断（上記 YAGNI）に異論がないか。**QA より「同意。むしろ今 guard を増やすのは方向が逆」との回答を受領済み**。再検討の基準は初版に書いた「4 例目が出たら」ではなく、**#4000 AC1 の結論が出たら**に改めます（#4000 AC3' が #3994 の gate 撤去まで枝に置いているため、例数を基準にすると撤去判断と衝突する）
2. #3994 の Ready 化後に発見したため独立 PR にしましたが、追補として妥当か

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** を確認した — **作者のローカル実行ログは非保持のため、QM が QA clone で同一 HEAD `989f51e0` を checkout して独立実行し、実行対象の全 Step PASS を確認**（LP / UI 非変更による条件 skip 5 件を除く。内訳は上記「テスト & 安全装置セルフチェック」）。CI 側の独立証跡は run `30223924217`
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


