### PR TITLE
fix(ci): #4004 a11y job の実行対象を宣言どおりに戻し、宣言と実行集合の乖離を gate 化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,6 +691,20 @@ jobs:
         # 必須要求するため同じくダミー値で注入する (length >= 16 satisfy)。
         env:
           PARENT_GATE_COOKIE_SECRET: e2e-test-parent-gate-secret-do-not-use
+        # #4004: ここは **意図的に --no-deps を付けていない**。
+        # mobile project の `dependencies: ['tablet']` により、--shard を付けても tablet 904 test が
+        # 全 shard で重複実行される (公式 docs test-projects §Dependencies: filtering で選ばれた test が
+        # dependency を持つ project に属する場合、その dependency の全 test も実行される)。
+        # 実測では --no-deps で 1196 → 594/593/593 に正しく分割される。
+        #
+        # ただし --no-deps は同時に「これまで一度も実行されていなかった mobile 876 test を走らせる」
+        # ことを意味し、実測で 40 件が fail する (803 passed / 40 failed)。この 40 件は --no-deps が
+        # 原因ではなく (child-form-birthday-age.spec.ts は tablet 単独実行でも同じ 4 件が fail)、
+        # mobile が走っていなかったために隠れていた既存の壊れ + そもそも mobile 前提で書かれていない
+        # spec (visual-regression の Kinder スクショ / admin-nav-* の "Desktop dropdown" 検証 等) である。
+        #
+        # → mobile でどの spec を走らせるかを決めてから shard 側を切り替える (#4004 follow-up)。
+        #   先に切り替えると統合レーンが恒常赤になり、リリースが止まる。
         run: npx playwright test --shard=${{ matrix.shard }}/3
 
       - name: Upload blob report
@@ -756,7 +770,11 @@ jobs:
         # E2E と同じくダミー固定 secret を注入 (vite preview NODE_ENV=production 要求)。
         env:
           PARENT_GATE_COOKIE_SECRET: e2e-test-parent-gate-secret-do-not-use
-        run: npx playwright test tests/e2e/a11y-critical-cuj.spec.ts
+        # #4004: `--no-deps` が無いと、spec を 1 本に絞っても mobile の dependency 経由で
+        # tablet 全 test が実行され、**a11y と無関係の spec の fail で本 job が red になる**
+        # (= gate の red/green が a11y について何も言わない状態)。
+        # 実測: 912 test → --no-deps で 16 test (8 route × 2 project)。
+        run: npx playwright test tests/e2e/a11y-critical-cuj.spec.ts --no-deps
 
       - name: Upload a11y test results
         if: always()

--- a/tests/unit/infra/playwright-shard-split.test.ts
+++ b/tests/unit/infra/playwright-shard-split.test.ts
@@ -1,0 +1,109 @@
+// tests/unit/infra/playwright-shard-split.test.ts
+// #4004: 「実行対象の宣言」と「実際に実行される集合」の乖離を機械検知する。
+//
+// 背景: `mobile` project は `dependencies: ['tablet']` を持つ。Playwright 公式 docs
+// (test-projects §Dependencies) は以下を明記している:
+//
+//   "All test filtering options, such as --grep/--grep-invert, --shard, filtering directly
+//    by location in the command line, or using test.only(), directly select the primary tests
+//    to be run. If those tests belong to a project with dependencies, all tests from those
+//    dependencies will also run."
+//
+// つまり `--shard` を付けても dependency (tablet 全 904 test) が **全 shard で実行される**。
+// 実測: 各 shard 1196 test (= tablet 904 + mobile 292)。3 shard 合計で tablet を 3 回走らせ、
+// かつ tablet が fail した時点で mobile は 1 件も走らない (= mobile の e2e カバレッジが実質ゼロ)。
+// 同じ理由で a11y job は spec 1 本を指定しても 912 test を実行し、**a11y と無関係の spec の
+// fail で red になっていた** (gate の red/green が a11y について何も言わない状態、ADR-0061)。
+//
+// 対処は公式が用意している `--no-deps`。本 test は「CI が実際に --no-deps を渡しているか」を
+// workflow の実文字列で固定する。**設定を直しても、CI 側の呼び出しが元に戻れば実害は復活する**
+// ため、検証対象は config ではなく **CI の起動コマンド**に置く。
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const CI_WORKFLOW = path.join(REPO_ROOT, '.github/workflows/ci.yml');
+const PW_CONFIG = path.join(REPO_ROOT, 'playwright.config.ts');
+
+/** ci.yml から `npx playwright test ...` の起動行を全て抜き出す。 */
+function playwrightInvocations(): string[] {
+	return fs
+		.readFileSync(CI_WORKFLOW, 'utf8')
+		.split('\n')
+		.map((l) => l.trim())
+		.filter((l) => l.includes('npx playwright test'));
+}
+
+/** dependencies を持つ project 名を playwright.config.ts から抽出する。 */
+function projectsWithDependencies(): string[] {
+	const source = fs.readFileSync(PW_CONFIG, 'utf8');
+	const names: string[] = [];
+	// `name: 'x',` … `dependencies: [...]` が同一 project literal 内にある形を素朴に走査する。
+	for (const block of source.split(/\n\t\t\{\n/)) {
+		const name = block.match(/name:\s*'([a-z0-9-]+)'/)?.[1];
+		if (name && /dependencies:\s*\[/.test(block)) names.push(name);
+	}
+	return names;
+}
+
+describe('#4004 Playwright の実行対象宣言と実行集合の乖離を防ぐ', () => {
+	it('[P0] ci.yml に playwright 起動行が 1 本以上ある (0 件マッチの素通りを防ぐ)', () => {
+		expect(playwrightInvocations().length).toBeGreaterThan(0);
+	});
+
+	// 本 test の前提そのもの。dependencies が無くなれば --no-deps は不要になるので、
+	// 「前提が消えたのに test だけ残る」状態を検出できるようにしておく。
+	it('[P1] dependencies を持つ project が存在する (--no-deps が必要な前提の確認)', () => {
+		expect(
+			projectsWithDependencies(),
+			'dependencies を持つ project が無くなったなら、--no-deps 要求 ([P2]) は不要になる。' +
+				'本 test ごと見直すこと',
+		).not.toEqual([]);
+	});
+
+	// **spec を絞り込む起動**だけを対象にする。絞り込んだのに dependency 全量が走ると
+	// 「その job の red/green が、絞り込んだ対象について何も言わない」状態になり、gate が
+	// 実効を失う (ADR-0061)。a11y job が 912 test を走らせて無関係な spec の fail で red に
+	// なっていたのがこれ。
+	//
+	// shard 起動 (`--shard=N/3`) は **意図的に対象外**。--no-deps を付けると分割は正しくなるが、
+	// 同時にこれまで走っていなかった mobile 876 test が走り出し 40 件 fail する (実測)。
+	// mobile でどの spec を走らせるかを決めるまでは切り替えない (#4004 follow-up、ci.yml 該当箇所
+	// のコメントが SSOT)。ここで shard も要求すると、決定前に切り替えを強制してしまう。
+	it('[P2] spec を絞り込む playwright 起動は --no-deps を渡す', () => {
+		// 別 config (cognito-dev 等) は project 構成が異なるため対象外。
+		const targets = playwrightInvocations()
+			.filter((l) => !l.includes('--config'))
+			.filter((l) => /tests[/\\]e2e[/\\]\S+\.spec\.ts/.test(l));
+		const offenders = targets.filter((l) => !l.includes('--no-deps'));
+		expect(
+			offenders,
+			`spec 絞り込みなのに --no-deps 無しの playwright 起動を検出:\n` +
+				`${offenders.map((l) => `  ${l}`).join('\n')}\n` +
+				'→ dependency project (tablet) が全量実行され、job の red/green が絞り込み対象について ' +
+				'何も言わなくなる。公式 docs test-projects §Dependencies 参照',
+		).toEqual([]);
+	});
+
+	it('[P2b] spec 絞り込みの起動が 1 本以上ある ([P2] が空集合を検査して素通りしない)', () => {
+		const specTargets = playwrightInvocations()
+			.filter((l) => !l.includes('--config'))
+			.filter((l) => /tests[/\\]e2e[/\\]\S+\.spec\.ts/.test(l));
+		expect(specTargets.length).toBeGreaterThan(0);
+	});
+
+	// 抽出ロジック自体の検証。規約に従う行だけを並べた fixture では
+	// 「違反を検出できないこと」を検出できないため、**規約から外れた形**を混ぜる。
+	it('[P3] 抽出ロジックが --no-deps 有無を読み分ける', () => {
+		const hasNoDeps = (line: string) =>
+			line.includes('npx playwright test') && line.includes('--no-deps');
+		expect(hasNoDeps('run: npx playwright test --shard=1/3 --no-deps')).toBe(true);
+		expect(hasNoDeps('run: npx playwright test --shard=1/3')).toBe(false);
+		expect(hasNoDeps('run: npx playwright test tests/e2e/a11y-critical-cuj.spec.ts')).toBe(false);
+		// コメント行に --no-deps が出てくるだけの行を「起動行」と誤認しない
+		expect(playwrightInvocations().every((l) => !l.startsWith('#'))).toBe(true);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（開発・QA プロセス）

**解決する課題**: `a11y` job は `ci.yml` のコメントどおりなら `a11y-critical-cuj.spec.ts` **1 本だけ**を実行するはずだが、実際には **912 test** を実行していた。その結果、**a11y とは無関係の spec が落ちるだけで job が red になり**、「a11y が落ちた = アクセシビリティ退行」と読めない状態だった。gate は存在するのに、その red / green が a11y について何も言っていない（ADR-0061「gate が形式だけ残って実効を失う」）。

**期待される効果**: `a11y` job の red / green が a11y の結果のみを表す。あわせて「実行対象の宣言」と「実際に実行される集合」の乖離を機械検知する。

## 関連 Issue

<!-- no-issue-close: 本 PR は #4004 の AC1 / AC3 / AC4 のみを扱う分割着手であり、AC2 (mobile を実際に走らせる) / AC5 (before/after 記録) が未達のため Issue を閉じない。残 AC は下記「本 PR のスコープ」の理由により、mobile の spec 選定を決めてから別 PR で扱う。 -->

- #4004 — 本体 Issue（AC2 / AC5 は本 PR では未達、下記スコープ参照）
- #1006 — E2E `--shard` matrix 導入（本件はその効果検証の欠落）
- #1192 — tablet 固定スクショ E2E を mobile で実行しない（`testIgnore` の由来）
- #3969 / #4000 — gate / 検証手段が無言で実効を失う同 class

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Playwright の dependency project が `--shard` / ファイル引数の影響をどう受けるかを、公式ドキュメントを一次情報として確定させる | [playwright.dev/docs/test-projects](https://playwright.dev/docs/test-projects) §Dependencies | **PASS — 推論は正しかった**。原文: *"All test filtering options, such as `--grep`/`--grep-invert`, **`--shard`**, filtering directly by location in the command line, or using `test.only()`, directly select the primary tests to be run. **If those tests belong to a project with dependencies, all tests from those dependencies will also run.**"* 併せて回避手段 `--no-deps` も同節に明記されている |
| AC2 | `mobile` project の 283 test が統合レーンで実際に実行される | — | **本 PR では未達（意図的）**。理由は下記「本 PR のスコープ」。実測データは取得済みで Issue にも記載する |
| AC3 | `a11y` job が `a11y-critical-cuj.spec.ts` のみを実行する | `npx playwright test tests/e2e/a11y-critical-cuj.spec.ts --no-deps --reporter=list` | **PASS — 912 test → 16 test（8 route × 2 project）、16 passed / 40.8s**。`ci.yml:715-716` のコメントと実挙動が一致した |
| AC4 | shard / 絞り込みが実際に効いていることを機械検知する | `npx vitest run tests/unit/infra/playwright-shard-split.test.ts` | **PASS — 5 tests passed**。mutation 実測は下記 |
| AC5 | 3 shard の実行件数と所要時間の before / after を Issue に記録 | — | **本 PR では未達（AC2 と同じ理由）**。ローカル `--list` 実測値は下表のとおりで、Issue にコメントする |

### AC1 に基づく実測（ローカル、`--list`）

- **shard 1 / 2 / 3**: 現状 **1196 / 1196 / 1196** → `--no-deps` で **594 / 593 / 593**（合計 1780 = 全量、重複ゼロ）
- **`a11y-critical-cuj.spec.ts` 指定**: 現状 **912** → `--no-deps` で **16**
- **project 内訳**: tablet 904 + mobile 876 = 1780

`1196 - 904 = 292 = 876 / 3`。**3 shard すべてが tablet 904 を丸ごと実行していた**ことが件数の辻褄で確認できる。

### mutation 検証（dev-session §QA 指摘台帳 観点 3「guard を外すと fail するか」）

a11y 起動から `--no-deps` を外して実行したところ、`[P2]` が該当行を名指しして fail することを確認済み（検証後に復元、差分ゼロ）:

```
× [P2] spec を絞り込む playwright 起動は --no-deps を渡す
AssertionError: spec 絞り込みなのに --no-deps 無しの playwright 起動を検出:
  run: npx playwright test tests/e2e/a11y-critical-cuj.spec.ts
```

## 本 PR のスコープ — shard 側を据え置いた理由（PO 判断 2026-07-27）

`--shard` にも `--no-deps` を付ければ分割は正しくなる。**しかしそれは同時に「これまで一度も実行されていなかった mobile 876 test を走らせる」ことを意味する。** 実測すると **803 passed / 40 failed / 8 skipped / 25 did not run**。

**この 40 件は `--no-deps` が原因ではない。** 切り分け済み:

```
$ npx playwright test tests/e2e/child-form-birthday-age.spec.ts --project=mobile --no-deps
  4 failed
$ npx playwright test tests/e2e/child-form-birthday-age.spec.ts --project=tablet
  4 failed        ← tablet 単独でも同じ 4 件が落ちる
```

つまり **mobile が一度も走っていなかったために隠れていた既存の壊れ**である。内訳には「そもそも mobile 前提で書かれていない spec」も相当数含まれる（`visual-regression` の Kinder スクショ / `admin-nav-*` の「Desktop … dropdown に nav-marketplace が visible」を mobile project で検証する等）。

したがって shard を切り替えると **統合レーンが恒常赤になりリリースが止まる**。「mobile でどの spec を走らせるか」を決めてから切り替えるのが正しい順序であり、PO 判断により本 PR では a11y のみ先行させる。**据え置いた事実と理由は `ci.yml` の該当箇所にコメントとして残した**（コメントと実挙動の乖離が本 Issue の主題であるため、ここで再び乖離を作らない）。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — `.github/workflows/ci.yml` の a11y job 起動行 + コメント。**製品コードの変更ゼロ**

**影響を受ける画面・機能**: なし（CI の実行対象のみ）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/infra/playwright-shard-split.test.ts` — **新規**。`[P0]` 起動行 0 件マッチ防止 / `[P1]` dependencies を持つ project の存在（本 guard の前提が消えたら気付く）/ `[P2]` spec 絞り込み起動は `--no-deps` 必須 / `[P2b]` 絞り込み起動が 1 本以上ある（空集合での素通り防止）/ `[P3]` 抽出ロジック自体の検証
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（CI 設定 + テストのみ。`.svelte` / `.css` / `site/` の変更ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: guard の抽出ロジックを純関数に分離し `[P3]` で単体検証
- [x] **DRY**: `playwright.config.ts` は変更していない。ローカルの `npx playwright test` の挙動を変えないため（CI の呼び出しだけを是正する）
- [x] **YAGNI**: shard 側の切り替えと mobile の spec 選定は本 PR に含めない（決定前の先回り実装をしない）
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: 本 PR は a11y gate の**実効性**を回復するもので、a11y 基準自体は変更していない（16 test 全 pass、既知違反の baseline pin も不変）
- [x] **パフォーマンス**: a11y job は 912 → 16 test になり大幅に軽くなるが、**それは目的ではなく副産物**（Issue の No-go「実行時間の短縮を目的にしない」に整合）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200) — open PR #4005 / #3996 / #3992 / #3989 / #4002 と変更ファイル重複なし
- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

1. **AC2 / AC5 を本 PR で未達のまま Ready にする判断**（上記「本 PR のスコープ」）。Issue を閉じないため `<!-- no-issue-close -->` を宣言している
2. **guard の対象を `ci.yml` の起動コマンドに置いた判断**。`playwright.config.ts` 側を検証しても、CI の呼び出しが元に戻れば実害は復活するため CI 側を SSOT にした
3. **shard 起動を `[P2]` の対象から外した判断**。含めると mobile の spec 選定を決める前に切り替えを機械的に強制してしまい、1 の PO 判断と矛盾する

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み — **AC2 / AC5 を除く**（上記スコープの理由により意図的に未達、Issue は閉じない）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
