### PR TITLE
fix: #3967 #3977 バックアップ対象 backend をアプリの実態から決め、状態の読み手を配線する

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1342,6 +1342,30 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 }
 ```
 
+**`backup` フィールド（`DATA_SOURCE=pglite` のときだけ付与、#3977）:**
+
+```json
+{
+  "backup": {
+    "lastSuccessAt": "2026-07-27T18:00:00.000Z",
+    "lastSuccessFilename": "pglite-20260727-180000.tgz",
+    "lastSuccessBytes": 1234567,
+    "lastSuccessDurationMs": 4210,
+    "lastFailureAt": null,
+    "lastFailureMessage": null
+  }
+}
+```
+
+| 項目 | 仕様 |
+|---|---|
+| 付与条件 | `DATA_SOURCE === 'pglite'`（= NUC セルフホスト）のときのみ。**クラウド（`dsql`）の公開 Lambda のレスポンスは本フィールドを持たない** |
+| なぜ pglite 限定か | 「いつからバックアップが止まっているか」は外部に教えうる運用情報で、`/api/health` は未認証公開のため。露出範囲の拡大は PO 決裁事項とし、NUC 内でしか成立しない分岐に閉じる |
+| なぜ載せるか | `scripts/backup-nuc.cjs` が backend 同定のため既に `/api/health` を参照する（#3967）。バックアップの生死も同じ口から読めれば運用側の参照点が 1 つで済む。`getPgliteBackupStatus` は #3950 で export されたが caller 不在の dead export で、本配線がその caller |
+| 取得失敗時 | **フィールドを省略するだけで 503 にしない**。状態ファイルが読めないことは DB の生死と無関係で、ここで落とすと「状態ファイルが無いだけで liveness が赤」になり監視の意味が変わる |
+
+回帰は `tests/unit/routes/health-backup-status.test.ts`（付与条件と失敗時の省略）が固定する。
+
 #### GET /api/ready
 
 readiness probe（shallow、#3657）。**プロセスが HTTP を受けられることのみを証明し、DB には一切接触しない**。LWA（Lambda Web Adapter）の `AWS_LWA_READINESS_CHECK_PATH` が参照する（`Dockerfile.lambda`）。readiness を `/api/health`（deep DB probe）に結合すると DB 障害時に LWA が never-ready → 全リクエスト 502 + cold start init timeout ループになるため分離する（13-AWSサーバレスアーキテクチャ設計書 §3.3）。

--- a/scripts/backup-nuc.cjs
+++ b/scripts/backup-nuc.cjs
@@ -3,8 +3,15 @@
 // docker-compose の backup サービス (crond) から 1 日 1 回呼ばれる。DATA_SOURCE を見て
 // 実データの backend に対応した経路へ振り分ける。
 //
-//   DATA_SOURCE=pglite  -> アプリの /api/cron/pglite-backup を叩く (本番 NUC の現行構成)
-//   それ以外            -> 従来の SQLite 経路 (backup-db.cjs + verify-backup-restore.cjs)
+//   pglite  -> アプリの /api/cron/pglite-backup を叩く (本番 NUC の現行構成)
+//   それ以外 -> 従来の SQLite 経路 (backup-db.cjs + verify-backup-restore.cjs)
+//
+// ── backend の決め方 (#3967) ────────────────────────────────────────────
+// 判定の一次情報は **env ではなく /api/health の dataSource** (= アプリが実際に使っている
+// backend)。env の DATA_SOURCE は照合にのみ使い、食い違ったら実行前に落とす。
+// 旧実装 `process.env.DATA_SOURCE || 'sqlite'` は未設定・typo・配布漏れのいずれでも黙って
+// SQLite 経路に落ちるため、間違った backend を「成功」と報告しうる形だった。
+// 判定ロジック本体は scripts/lib/backup-backend.cjs (unit test 対象)。
 //
 // ── なぜ HTTP 越しなのか ────────────────────────────────────────────────
 // PGlite は dataDir を単一プロセスで占有するため、backup コンテナから直接 open できない。
@@ -17,7 +24,7 @@
 // 二度と作らないため、backend の判定をこの 1 箇所に集約し、対象外の経路は明示的に skip する。
 //
 // Environment variables:
-//   DATA_SOURCE          - 実データの backend (pglite / sqlite ...)
+//   DATA_SOURCE          - 実データの backend (pglite / sqlite ...)。/api/health との照合用
 //   APP_URL              - アプリのベース URL (default: http://app:3000)
 //   CRON_SECRET          - /api/cron/* の認証シークレット (pglite 経路で必須)
 //   DISCORD_ALERT_WEBHOOK_URL - 失敗通知先 (任意)
@@ -25,6 +32,7 @@
 const { execFileSync } = require('node:child_process');
 const path = require('node:path');
 const fs = require('node:fs');
+const { resolveBackupBackend } = require('./lib/backup-backend.cjs');
 
 // .env 読み込み (backup-db.cjs と同じ最小実装)
 const envPath = path.join(__dirname, '..', '.env');
@@ -43,7 +51,9 @@ if (fs.existsSync(envPath)) {
 	}
 }
 
-const DATA_SOURCE = process.env.DATA_SOURCE || 'sqlite';
+// #3967: 既定値を置かない。未設定は「未設定」のまま resolveBackupBackend に渡し、
+// /api/health を真実の源として解決させる (暗黙の sqlite フォールバックを作らない)。
+const ENV_DATA_SOURCE = process.env.DATA_SOURCE;
 const APP_URL = process.env.APP_URL || 'http://app:3000';
 const CRON_SECRET = process.env.CRON_SECRET || process.env.OPS_SECRET_KEY || '';
 const DISCORD_WEBHOOK =
@@ -62,7 +72,7 @@ async function notifyFailure(detail) {
 	}
 	const embed = {
 		title: '🚨 [CRITICAL] NUC バックアップ 失敗',
-		description: `DATA_SOURCE=${DATA_SOURCE} のバックアップに失敗しました。data 保全リスク。`,
+		description: `NUC のバックアップに失敗しました。data 保全リスク。`,
 		color: 10038562,
 		fields: [
 			{ name: 'Detail', value: `\`\`\`${detail.slice(0, 800)}\`\`\`` },
@@ -121,18 +131,50 @@ async function runPgliteBackup() {
 
 /** SQLite 経路: 従来どおり backup-db.cjs + verify-backup-restore.cjs を直列実行する。 */
 function runSqliteBackup() {
-	console.log('[backup-nuc] DATA_SOURCE が pglite ではないため SQLite 経路で実行します');
+	console.log('[backup-nuc] backend が pglite ではないため SQLite 経路で実行します');
 	for (const script of ['backup-db.cjs', 'verify-backup-restore.cjs']) {
 		execFileSync(process.execPath, [path.join(__dirname, script)], { stdio: 'inherit' });
+	}
+}
+
+/**
+ * `/api/health` を叩いて JSON を返す。到達できなければ null。
+ *
+ * ここで例外にせず null を返すのは、「取得できなかった」ことの扱いを
+ * resolveBackupBackend 側に一本化するため (env フォールバックの有無を 1 箇所で決める)。
+ */
+async function fetchHealth() {
+	const url = `${APP_URL.replace(/\/$/, '')}/api/health`;
+	try {
+		const res = await fetch(url);
+		// 503 (DB 到達不可) でも body に dataSource は載る。backend の同定には使えるので
+		// status では弾かず、dataSource の有無だけを resolveBackupBackend に判定させる。
+		return { url, body: await res.json() };
+	} catch (err) {
+		console.error(
+			`[backup-nuc] ${url} に到達できません:`,
+			err instanceof Error ? err.message : String(err),
+		);
+		return { url, body: null };
 	}
 }
 
 async function main() {
 	console.log('=== Ganbari Quest NUC Backup ===');
 	console.log(`Time: ${new Date().toISOString()}`);
-	console.log(`DATA_SOURCE: ${DATA_SOURCE}`);
+	console.log(`env DATA_SOURCE: ${ENV_DATA_SOURCE ?? '(未設定)'}`);
 
-	if (DATA_SOURCE === 'pglite') {
+	const health = await fetchHealth();
+	// 判定できない / env と食い違う場合はここで throw され、main().catch が alert する。
+	// **backend が確定するまでバックアップを実行しない** (間違った backend を成功と報告しない)。
+	const resolved = resolveBackupBackend({
+		envDataSource: ENV_DATA_SOURCE,
+		health: health.body,
+		healthUrl: health.url,
+	});
+	console.log(`[backup-nuc] backend=${resolved.backend} (${resolved.source}) — ${resolved.detail}`);
+
+	if (resolved.backend === 'pglite') {
 		await runPgliteBackup();
 	} else {
 		runSqliteBackup();

--- a/scripts/lib/backup-backend.cjs
+++ b/scripts/lib/backup-backend.cjs
@@ -1,0 +1,87 @@
+// scripts/lib/backup-backend.cjs
+// #3967 — 「どの backend をバックアップするか」の判定 SSOT (pure function)。
+//
+// ## なぜ env 単独で決めないか
+//
+// 旧実装は `process.env.DATA_SOURCE || 'sqlite'` だった。この形は
+// **未設定・typo・env 配布漏れのいずれでも黙って `'sqlite'` に落ちる**。
+//
+// 現状は SQLite 経路が必ず fail するため沈黙はしないが、依存しているのは
+// 「SQLite 経路がたまたま失敗すること」であって設計上の保証ではない。将来 SQLite 経路が
+// 動く構成が復活すると、**間違った backend のバックアップを取って成功と報告する**状態になる。
+// #3950 の事故 (PGlite 移行後も旧 SQLite を複製し続けた) と同じ形である。
+//
+// ## 真実の源はアプリ自身
+//
+// 「env に何が書いてあるか」ではなく「**アプリが実際にどの backend を使っているか**」を
+// 真実とする。`/api/health` は `dataSource` を返すので、これを一次情報にする。
+// env は照合用にのみ使い、食い違ったら実行前に落とす (config drift の検出)。
+//
+// 判定を fetch から切り離してあるのは、組み合わせを unit test で固定できるようにするため。
+
+/** 判定できないときに投げる。呼び出し側はこれを alert 対象として扱う。 */
+class BackendResolutionError extends Error {
+	/** @param {string} message */
+	constructor(message) {
+		super(message);
+		this.name = 'BackendResolutionError';
+	}
+}
+
+/**
+ * `/api/health` のレスポンス body と env から、バックアップ対象 backend を決める。
+ *
+ * @param {object} params
+ * @param {string | undefined} params.envDataSource `process.env.DATA_SOURCE` の値 (未設定なら undefined)
+ * @param {unknown} params.health `/api/health` の JSON (取得できなかった場合は null を渡す)
+ * @param {string} [params.healthUrl] エラーメッセージに載せる URL
+ * @returns {{backend: string, source: 'health' | 'health+env', detail: string}}
+ * @throws {BackendResolutionError} backend を特定できない / env と実態が食い違う
+ */
+function resolveBackupBackend({ envDataSource, health, healthUrl = '/api/health' }) {
+	const env = typeof envDataSource === 'string' ? envDataSource.trim() : '';
+
+	if (health === null || typeof health !== 'object') {
+		// **env へフォールバックしない。** ここで env に逃げると、health が落ちている間だけ
+		// 判定根拠が env に戻り、本 Issue が塞ごうとしている経路が復活する。
+		throw new BackendResolutionError(
+			`backend を特定できません: ${healthUrl} から dataSource を取得できませんでした` +
+				`${env ? ` (env DATA_SOURCE=${env} は照合用であり単独では採用しません)` : ''}`,
+		);
+	}
+
+	const actual = /** @type {{dataSource?: unknown}} */ (health).dataSource;
+	if (typeof actual !== 'string' || actual.trim() === '') {
+		throw new BackendResolutionError(
+			`backend を特定できません: ${healthUrl} のレスポンスに dataSource がありません ` +
+				`(received: ${JSON.stringify(actual)})`,
+		);
+	}
+	const backend = actual.trim();
+
+	if (env === '') {
+		// env 未設定でも health が答えられるなら続行してよい。ただし
+		// 「env が配られていない」ことは運用上の異常なので detail に残す。
+		return {
+			backend,
+			source: 'health',
+			detail: `DATA_SOURCE 未設定のため ${healthUrl} の dataSource=${backend} を採用`,
+		};
+	}
+
+	if (env !== backend) {
+		throw new BackendResolutionError(
+			`backend が食い違っています: env DATA_SOURCE=${env} / ${healthUrl} dataSource=${backend}。` +
+				'env の配布漏れか、アプリと backup コンテナが別の設定で動いています。' +
+				'どちらが正かを確認するまでバックアップを実行しません',
+		);
+	}
+
+	return {
+		backend,
+		source: 'health+env',
+		detail: `DATA_SOURCE=${env} と ${healthUrl} dataSource=${backend} が一致`,
+	};
+}
+
+module.exports = { resolveBackupBackend, BackendResolutionError };

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,5 +1,9 @@
 import { json } from '@sveltejs/kit';
 import { probePg, probeSqlite, type SqliteProbeResult } from '$lib/server/db/probe';
+import {
+	getPgliteBackupStatus,
+	type PgliteBackupStatus,
+} from '$lib/server/services/pglite-backup-service';
 import { APP_VERSION } from '$lib/version';
 import type { RequestHandler } from './$types';
 
@@ -28,6 +32,19 @@ export const GET: RequestHandler = async () => {
 		);
 	}
 
+	// #3977: PGlite (= NUC セルフホスト) のときだけ最終バックアップ状態を載せる。
+	//
+	// なぜ pglite 限定か: 本フィールドは「いつからバックアップが止まっているか」を外部に
+	// 教えうる運用情報である。クラウド (dsql) の /api/health は未認証で公開されているため、
+	// そこに載せるのは露出範囲の判断 (PO 決裁) を要する。**pglite は NUC 内でしか成立しない
+	// 分岐**なので、クラウド公開 Lambda のレスポンスは本変更で一切変わらない。
+	//
+	// なぜ載せるか: #3967 の backup-nuc.cjs が backend 同定のために既に /api/health を
+	// 参照する。バックアップの生死も同じ口から読めると、運用側の参照点が 1 つで済む。
+	// (`getPgliteBackupStatus` は #3950 で「運用調査から読む口」として export されたが
+	//  caller が存在せず dead export になっていた。本配線がその caller である)
+	const backup = DATA_SOURCE === 'pglite' ? await readBackupStatus() : undefined;
+
 	return json({
 		status: 'ok',
 		timestamp: new Date().toISOString(),
@@ -36,5 +53,20 @@ export const GET: RequestHandler = async () => {
 		region: process.env.AWS_REGION ?? 'local',
 		uptime: Math.floor(process.uptime()),
 		schema: schemaInfo,
+		...(backup ? { backup } : {}),
 	});
 };
+
+/**
+ * バックアップ状態の読み取り。**liveness probe を落とさない**ことを優先する。
+ *
+ * 状態ファイルが読めないこと自体は DB の生死と無関係なので、ここで 503 にすると
+ * 「バックアップ状態ファイルが無いだけでヘルスチェックが赤」になり、監視の意味が変わる。
+ */
+async function readBackupStatus(): Promise<PgliteBackupStatus | undefined> {
+	try {
+		return await getPgliteBackupStatus();
+	} catch {
+		return undefined;
+	}
+}

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -225,6 +225,16 @@ interactive primitive の play 関数 coverage:
 - 横展開: `.claude/skills/dev-open-pr/SKILL.md` (PR 起票時 CX-DoR 12 条件ガイダンス) / `.github/PULL_REQUEST_TEMPLATE.md` (customer-facing PR 用 12 条件チェック)
 - 研究: `tmp/research-cx-quality-verification.md` §4 / §G / §3 (DoR 1-8 起源) + `tmp/research-usability-test-comprehensiveness-2026-05-30.md` §1-§9 (DoR 9-12 拡張根拠)
 
+## 負例 fixture と cspell（#4009 / #3967 で 2 回連続で踏んだ）
+
+本リポジトリは guard / gate を多く書くため、**「規則から外れた形」を実名で置く負例 fixture** が頻出する（`git pushx` = push で始まるが push でない / `pglte` = `pglite` の typo / `sess-1` = session id）。これらは **cspell の未知語として CI `lint-and-test` で落ちる**。
+
+- **綴りを直して回避しない。** 綴りを直すと negative case が成立しなくなり、*規則違反を検出できないことを検出できなくなる*
+- **`.cspell.json` の global `words` に足さない。** `sess` を global 許可すると `session` の打ち間違いが repo 全体で素通りする
+- **当該 file 冒頭に `// cspell:ignore <語>` を置き、なぜその綴りが必要かをコメントで書く**（file scope に閉じる）
+
+`npm run cspell` は `tests/**/*.ts` を対象に含むため、**push 前にローカルで 1 回走らせれば CI 往復を防げる**（対象 glob は `package.json` の `cspell` script が SSOT）。
+
 ## 禁止事項
 
 - **カバレッジ閾値の引き下げ** — `vite.config.ts` `thresholds` 引き下げ PR は CI 自動拒否（`scripts/check-coverage-threshold.js`）。引き下げ必要なら ADR で復元計画と同時コミット

--- a/tests/unit/routes/health-backup-status.test.ts
+++ b/tests/unit/routes/health-backup-status.test.ts
@@ -1,0 +1,98 @@
+// tests/unit/routes/health-backup-status.test.ts
+// #3977 — `/api/health` の backup フィールドの配線を固定する。
+//
+// 本 Issue の root class は「**成果物はあるが呼ばれていない**」だった:
+// `getPgliteBackupStatus` は「運用調査から読む口」として export されたが caller も test も
+// 0 件で、doc comment だけが読み手の存在を前提にしていた。同 class は短期間に 2 件出ている
+// (#3962 の check-pr-body を実行する CI job 不在も同型)。
+//
+// したがって本 test は「backup が返る」ことより先に **「誰が読むか」が壊れたら落ちる**
+// ことを目的にする。具体的には:
+//   - pglite のときだけ載る (クラウド公開 Lambda の露出を増やしていないことの固定)
+//   - 状態ファイルが読めなくても liveness は落ちない (probe の意味を変えない)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const probeResult = { tables: 1 };
+
+vi.mock('$lib/server/db/probe', () => ({
+	probePg: vi.fn(async () => probeResult),
+	probeSqlite: vi.fn(async () => probeResult),
+}));
+
+const getPgliteBackupStatus = vi.fn();
+vi.mock('$lib/server/services/pglite-backup-service', () => ({
+	getPgliteBackupStatus: (...args: unknown[]) => getPgliteBackupStatus(...args),
+}));
+
+const STATUS = {
+	lastSuccessAt: '2026-07-27T00:00:00.000Z',
+	lastSuccessFilename: 'pglite-20260727T000000Z.tgz',
+	lastSuccessBytes: 1234,
+	lastSuccessDurationMs: 567,
+	lastFailureAt: null,
+	lastFailureMessage: null,
+};
+
+/** DATA_SOURCE は module top-level で読まれるため、毎回 module registry ごと作り直す。 */
+async function callHealth(dataSource: string) {
+	vi.resetModules();
+	process.env.DATA_SOURCE = dataSource;
+	const mod = await import('../../../src/routes/api/health/+server');
+	const res = await mod.GET({} as never);
+	return { status: res.status, body: await res.json() };
+}
+
+describe('#3977 /api/health の backup フィールド', () => {
+	const original = process.env.DATA_SOURCE;
+
+	beforeEach(() => {
+		getPgliteBackupStatus.mockReset();
+		getPgliteBackupStatus.mockResolvedValue(STATUS);
+	});
+
+	afterEach(() => {
+		if (original === undefined) delete process.env.DATA_SOURCE;
+		else process.env.DATA_SOURCE = original;
+	});
+
+	it('[H1] pglite では backup が載り、getPgliteBackupStatus が呼ばれる (dead export の解消)', async () => {
+		const { status, body } = await callHealth('pglite');
+		expect(status).toBe(200);
+		expect(getPgliteBackupStatus).toHaveBeenCalledTimes(1);
+		expect(body.backup).toEqual(STATUS);
+	});
+
+	// クラウド (dsql) の /api/health は**未認証で公開**されている。ここに運用情報を足すと
+	// 「いつからバックアップが止まっているか」を外部に教えることになるため、載せない判断
+	// (PO 決裁を要さない範囲に収める) を test で固定する。
+	it.each([
+		'dsql',
+		'sqlite',
+		'demo',
+	])('[H2] %s では backup を載せず、状態ファイルも読まない (公開範囲を広げない)', async (dataSource) => {
+		const { status, body } = await callHealth(dataSource);
+		expect(status).toBe(200);
+		expect(body).not.toHaveProperty('backup');
+		expect(getPgliteBackupStatus).not.toHaveBeenCalled();
+	});
+
+	it('[H3] 状態ファイルが読めなくても liveness は 200 のまま (probe の意味を変えない)', async () => {
+		getPgliteBackupStatus.mockRejectedValue(new Error('ENOENT'));
+		const { status, body } = await callHealth('pglite');
+		expect(status).toBe(200);
+		expect(body.status).toBe('ok');
+		expect(body).not.toHaveProperty('backup');
+	});
+
+	it('[H4] 失敗が記録されていればそのまま見える (成功だけ見せて沈黙させない)', async () => {
+		getPgliteBackupStatus.mockResolvedValue({
+			...STATUS,
+			lastFailureAt: '2026-07-27T01:00:00.000Z',
+			lastFailureMessage: 'verify failed',
+		});
+		const { body } = await callHealth('pglite');
+		expect(body.backup.lastFailureAt).toBe('2026-07-27T01:00:00.000Z');
+		expect(body.backup.lastFailureMessage).toBe('verify failed');
+	});
+});

--- a/tests/unit/scripts/backup-backend.test.ts
+++ b/tests/unit/scripts/backup-backend.test.ts
@@ -5,6 +5,12 @@
 // 黙って SQLite 経路に落ちた。現状は SQLite 経路が必ず fail するため沈黙しないが、
 // 依存しているのは「たまたま失敗すること」であり設計上の保証ではない。
 // 本 test は「**判定できないなら実行しない**」を実行可能な形で固定する。
+//
+// cspell 例外 (本 file 限定):
+//   - `pglte`: 「`pglite` の typo」を再現する負例 fixture。綴りを直すと negative case が
+//     成立しなくなる (typo を検出できないことを検出できなくなる)。global 辞書に足すと
+//     repo 全体で `pglite` の打ち間違いが素通りするため file scope に閉じる。
+// cspell:ignore pglte
 
 import { describe, expect, it } from 'vitest';
 

--- a/tests/unit/scripts/backup-backend.test.ts
+++ b/tests/unit/scripts/backup-backend.test.ts
@@ -1,0 +1,135 @@
+// tests/unit/scripts/backup-backend.test.ts
+// #3967 — 「どの backend をバックアップするか」の判定を env × /api/health の組合せで固定する。
+//
+// 旧実装 `process.env.DATA_SOURCE || 'sqlite'` は未設定・typo・env 配布漏れのいずれでも
+// 黙って SQLite 経路に落ちた。現状は SQLite 経路が必ず fail するため沈黙しないが、
+// 依存しているのは「たまたま失敗すること」であり設計上の保証ではない。
+// 本 test は「**判定できないなら実行しない**」を実行可能な形で固定する。
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	BackendResolutionError,
+	resolveBackupBackend,
+} from '../../../scripts/lib/backup-backend.cjs';
+
+/** `/api/health` の正常レスポンス相当 (必要な field のみ)。 */
+const health = (dataSource: unknown) => ({
+	status: 'ok',
+	dataSource,
+	version: '1.0.0',
+});
+
+describe('#3967 resolveBackupBackend', () => {
+	describe('AC1: DATA_SOURCE 未設定で SQLite に暗黙フォールバックしない', () => {
+		it('env 未設定 + health あり → health の dataSource を採用する', () => {
+			const r = resolveBackupBackend({ envDataSource: undefined, health: health('pglite') });
+			expect(r.backend).toBe('pglite');
+			expect(r.source).toBe('health');
+			// 運用上の異常 (env 配布漏れ) は握り潰さずログに残す
+			expect(r.detail).toContain('DATA_SOURCE 未設定');
+		});
+
+		it('env 未設定 + health 取得失敗 → sqlite に落ちず fail する', () => {
+			expect(() => resolveBackupBackend({ envDataSource: undefined, health: null })).toThrow(
+				BackendResolutionError,
+			);
+			expect(() => resolveBackupBackend({ envDataSource: undefined, health: null })).toThrow(
+				/backend を特定できません/,
+			);
+		});
+
+		it('空文字 / 空白のみの env は「未設定」と同じに扱う', () => {
+			expect(resolveBackupBackend({ envDataSource: '', health: health('pglite') }).source).toBe(
+				'health',
+			);
+			expect(resolveBackupBackend({ envDataSource: '   ', health: health('pglite') }).source).toBe(
+				'health',
+			);
+		});
+	});
+
+	describe('AC2: env と実態が食い違ったら実行前に fail する', () => {
+		it('env=sqlite / health=pglite → fail (#3950 の事故そのものの形)', () => {
+			expect(() =>
+				resolveBackupBackend({ envDataSource: 'sqlite', health: health('pglite') }),
+			).toThrow(/backend が食い違っています/);
+		});
+
+		it('env=pglite / health=sqlite → fail (逆向きも同じく落とす)', () => {
+			expect(() =>
+				resolveBackupBackend({ envDataSource: 'pglite', health: health('sqlite') }),
+			).toThrow(/backend が食い違っています/);
+		});
+
+		it('typo した env は一致しないので fail する', () => {
+			expect(() =>
+				resolveBackupBackend({ envDataSource: 'pglte', health: health('pglite') }),
+			).toThrow(/backend が食い違っています/);
+		});
+
+		it('メッセージに双方の値が載る (どちらが正かを人が判断できる)', () => {
+			try {
+				resolveBackupBackend({
+					envDataSource: 'sqlite',
+					health: health('pglite'),
+					healthUrl: 'http://app:3000/api/health',
+				});
+				throw new Error('should have thrown');
+			} catch (e) {
+				const msg = (e as Error).message;
+				expect(msg).toContain('DATA_SOURCE=sqlite');
+				expect(msg).toContain('dataSource=pglite');
+				expect(msg).toContain('http://app:3000/api/health');
+			}
+		});
+	});
+
+	describe('AC4: 一致する正常系は従来どおり動き、突合結果が残る', () => {
+		it('env=pglite / health=pglite → pglite 経路 + 一致した旨を残す', () => {
+			const r = resolveBackupBackend({ envDataSource: 'pglite', health: health('pglite') });
+			expect(r.backend).toBe('pglite');
+			expect(r.source).toBe('health+env');
+			expect(r.detail).toContain('一致');
+		});
+
+		it('env=sqlite / health=sqlite → sqlite 経路', () => {
+			expect(
+				resolveBackupBackend({ envDataSource: 'sqlite', health: health('sqlite') }).backend,
+			).toBe('sqlite');
+		});
+
+		it('前後の空白は無視して一致とみなす (docker env の末尾空白で落ちない)', () => {
+			expect(
+				resolveBackupBackend({ envDataSource: ' pglite ', health: health('pglite') }).source,
+			).toBe('health+env');
+		});
+	});
+
+	describe('health レスポンスが期待の形でない場合は fail closed', () => {
+		// 「規約に従うデータ」だけを並べた fixture は、規約違反を検出できないことを検出できない。
+		// 実際に起きうる壊れ方 (500 の HTML が JSON.parse された / field 名変更 / null) を混ぜる。
+		it.each([
+			['dataSource 欠落', { status: 'ok' }],
+			['dataSource が null', health(null)],
+			['dataSource が空文字', health('')],
+			['dataSource が数値', health(42)],
+			['body が配列', []],
+			['body が文字列', 'ok'],
+		])('%s → fail する', (_label, body) => {
+			expect(() => resolveBackupBackend({ envDataSource: 'pglite', health: body })).toThrow(
+				BackendResolutionError,
+			);
+		});
+
+		it('503 (DB 到達不可) でも dataSource があれば backend は同定できる', () => {
+			// backend の同定と DB の生死は別問題。ここで弾くと、DB 障害中に
+			// 「backend が分からない」という誤った理由で落ちることになる。
+			const r = resolveBackupBackend({
+				envDataSource: 'pglite',
+				health: { status: 'error', error: 'db_unreachable', dataSource: 'pglite' },
+			});
+			expect(r.backend).toBe('pglite');
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（NUC セルフホストのデータ保全）、間接的に全家庭のデータ

**解決する課題**: #3950 で入れた NUC バックアップに、「**宣言と実態が一致しているか誰も見ていない**」箇所が 2 つ残っていた。

- **#3967**: バックアップ対象 backend を `process.env.DATA_SOURCE || 'sqlite'` で決めており、**未設定・typo・env 配布漏れのいずれでも黙って SQLite 経路に落ちる**。現状は SQLite 経路が必ず fail するため沈黙しないが、依存しているのは「たまたま失敗すること」であって設計上の保証ではない。将来 SQLite 経路が動く構成が戻ると、**間違った backend を複製して「成功」と報告する**（#3950 の事故と同型）
- **#3977**: `getPgliteBackupStatus` が「運用調査から読む口」として export されたが **caller も test も 0 件**。doc comment だけが読み手の存在を前提にしていた

**期待される効果**: バックアップが「取れているつもりで別物を取っている」状態を構造的に作れなくする。バックアップの生死を運用が実際に読める口に繋ぐ。

## 関連 Issue

closes #3967
closes #3977

**2 件を 1 PR にまとめた理由**: どちらも `/api/health` を触る。#3967 は backend 同定のために health を参照する側、#3977 は health に情報を載せる側で、**同じエンドポイントの契約を両側から変える**ため分割すると片方だけ先に入った状態が生まれる。

- #3950 — 両者の出所（PGlite 日次バックアップ）
- #3962 — 「成果物はあるが呼ばれていない」同 class の 1 件目（check-pr-body を実行する CI job 不在）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 (#3967) | `DATA_SOURCE` 未設定で実行すると、SQLite 経路へ落ちずに「backend を特定できない」旨で fail する | `npx vitest run tests/unit/scripts/backup-backend.test.ts` | **PASS**。`env 未設定 + health 取得失敗 → sqlite に落ちず fail する` / `空文字・空白のみの env は「未設定」と同じに扱う`。env 未設定でも health が答えられる場合は続行し、`detail` に「DATA_SOURCE 未設定」を残す |
| AC2 (#3967) | `DATA_SOURCE` と `/api/health` の `dataSource` が食い違う場合、バックアップ実行前に fail + alert | 同上 + `scripts/backup-nuc.cjs` の `main()` | **PASS**。`env=sqlite / health=pglite`（#3950 の事故そのものの形）/ 逆向き / typo の 3 ケースで fail。`main().catch` が Discord alert を送る既存経路に乗る |
| AC3 (#3967) | 上記 2 経路の unit test を追加（env と health レスポンスの組合せを fixture 化） | 同上 | **PASS — 17 tests passed**。正常系 3 / 未設定系 3 / 不一致系 4 / health 異常系 7 |
| AC4 (#3967) | 一致する正常系では従来どおり動作し、突合結果がログに出る | `backup-nuc.cjs` の `console.log` | **PASS**。`[backup-nuc] backend=pglite (health+env) — DATA_SOURCE=pglite と .../api/health dataSource=pglite が一致` |
| AC5 (#3977) | 案 A / 案 B のいずれかを選び、根拠を残す | 本 PR body 下記 + `+server.ts:38-46` のコメント | **PASS — 案 A（`/api/health` に配線）を採用**。ただし**`pglite` 限定**にすることで PO 決裁のトリガー（公開エンドポイントへの運用情報追加）を踏まない形にした（下記） |
| AC6 (#3977) | 選んだ案を実装する | `src/routes/api/health/+server.ts` | **PASS**。`DATA_SOURCE === 'pglite'` のときのみ `backup` を返す |
| AC7 (#3977) | 実装後に `grep -rn "getPgliteBackupStatus" src tests scripts` が「定義 1 行のみ」でないこと | 同コマンド | **PASS — 定義 1 + caller 2**（`+server.ts:4` import / `:68` 呼び出し）。修正前は定義 1 行のみ |
| AC8 (#3977) | health の unit test に backup フィールドの assertion を足す（追加しない限り同じ class が再発する） | `npx vitest run tests/unit/routes/health-backup-status.test.ts` | **PASS — 6 tests passed**。`/api/health` の unit test は**本 PR で新規追加**（従来は存在しなかった） |
| AC9 | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4019` | 下記「テスト & 安全装置セルフチェック」参照 |

### AC5 の判断 — 案 A を採るが `pglite` 限定にする

Issue #3977 は案 A に留保を付けていた:

> `/api/health` は認証なしで公開されている。最終バックアップ時刻の露出は「いつバックアップが止まっているか」を外部に教えることになるため、露出可否は判断が要る（露出させない場合は `/ops/*` 側に置く）
> 案 A を採る場合、露出範囲の判断は PO 決裁事項になり得る

**`DATA_SOURCE === 'pglite'` で gate すると、この留保は成立しません。** `pglite` は NUC セルフホスト内でしか成立しない分岐であり、**クラウド（`dsql`）の公開 Lambda のレスポンスは本変更で 1 バイトも変わらない**からです。したがって「公開エンドポイントへの運用情報追加」という PO 決裁トリガーを踏みません。

この gate は test で固定しています（`[H2]`）。PO 判断で「NUC でも出すべきでない」となれば `/ops/*` へ移せますが、その場合 #3967 が参照する口と運用が読む口が分かれます。

**#3966（RTO 実測）との重複確認**: #3966 は「main 反映後の初回サイクルを実測する」追跡 Issue であり、**バックアップ状態の恒常的な参照口を定義するものではない**ため重複しません。

### mutation 検証（dev-session §QA 指摘台帳 観点 3「guard を外すと fail するか」）

`pglite` gate を外して全 backend で載せるようにしたところ、`[H2]` の 3 ケースが fail することを実行確認済み（検証後に復元、差分ゼロ）:

```
× [H2] dsql では backup を載せず、状態ファイルも読まない (公開範囲を広げない)
× [H2] sqlite では backup を載せず、状態ファイルも読まない (公開範囲を広げない)
× [H2] demo では backup を載せず、状態ファイルも読まない (公開範囲を広げない)
```

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`) — `/api/health` に `pglite` 限定で `backup` を追加
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — `scripts/backup-nuc.cjs` + `scripts/lib/backup-backend.cjs`（新規）

**影響を受ける画面・機能**: NUC の日次バックアップ（cron）/ `/api/health`（`pglite` 時のみレスポンスに 1 フィールド追加）。**UI 変更なし**

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/scripts/backup-backend.test.ts` — **新規 17 test**。env × health の全組合せ。**規約に従うデータだけを並べず**、実際に起きうる壊れ方（`dataSource` 欠落 / null / 空文字 / 数値 / body が配列 / body が文字列）を fixture に混ぜている
  - `tests/unit/routes/health-backup-status.test.ts` — **新規 6 test**。`/api/health` の unit test は従来存在しなかった
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A（`DATA_SOURCE` / `APP_URL` は既存）
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:medium` / `low`）

## スクリーンショット / ビジュアルデモ

**該当なし（サーバーサイド + スクリプト + テストのみ。`.svelte` / `.css` / `site/` の変更ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 判定ロジックを `scripts/lib/backup-backend.cjs` の純関数に切り出し、fetch（副作用）と分離。`agent-lock-policy.mjs` を hook 本体から切り離した既存パターンに倣った
- [x] **DRY**: `/api/health` を「backend 同定」と「バックアップ状態」の共通の口にし、運用側の参照点を 1 つに寄せた
- [x] **YAGNI**: `/ops/*` への新規ルート追加は行わない（クラウドでは PGlite バックアップが存在せず、ops 画面に出しても意味を持たない）
- [x] **Security（OSS 公開前提）**: **本 PR の主要な検討点**。公開エンドポイントへの運用情報追加を避けるため `pglite` gate を置き、test で固定した（上記 AC5）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: `pglite` 時のみ状態ファイル 1 個を読む。`dsql` / `sqlite` では読まない（`[H2]` で `not.toHaveBeenCalled()` を assert）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — **`docs/design/07-API設計書.md` §3.15 を同 PR で更新した** (2026-07-29 追記)。当初は「既存エンドポイントへのフィールド追加なので機能仕様の変化はない」と判断したが、**レスポンス表面が変わる以上は API 設計書の記述対象**であり、CI の `design-doc-check` も fail する。`backup` フィールドの JSON 例・付与条件・失敗時の挙動を追記した
- [x] 並行 PR overlap 確認 (#1200) — open PR #4016 / #4010 / #4005 / #4002 / #3996 / #3992 / #3989 と変更ファイル重複なし
- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [ ] このPRに破壊的変更は**含まれない**
- [x] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**運用上の挙動変化（コードの後方互換は保たれるが、運用として変わる点）**:

`backup-nuc.cjs` は **`/api/health` に到達できないとバックアップを実行せず fail する**ようになった。従来は health を見ずに env だけで経路を決めていたため、アプリが落ちていても SQLite 経路なら起動していた。

- **pglite 構成（現行本番 NUC）**: 従来もアプリ経由（`/api/cron/pglite-backup`）なのでアプリ停止時は失敗していた。**実質変化なし**
- **sqlite 構成**: アプリ停止中はバックアップが走らなくなる。ただし「アプリが答えられない = どの backend が正か分からない」状態であり、**この状況で複製を取ると #3950 と同じ事故になる**ため意図的にこの挙動を選んでいる
- 失敗時は既存の Discord alert 経路に乗るため沈黙しない

**レビュー依頼事項・QA**:

1. **上記の運用上の挙動変化を受容できるか**（sqlite 構成でアプリ停止中にバックアップが走らなくなる）。現行本番は pglite なので実害はないと判断したが、sqlite 構成を残す想定があれば方針を変える
2. **`pglite` gate で PO 決裁を回避した判断**（AC5）。「NUC でも公開すべきでない」なら `/ops/*` へ移す
3. **2 件を 1 PR にまとめた判断**（同一エンドポイントの契約を両側から変えるため）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


## 追記 (2026-07-29): `design-doc-check` の赤を是正

必須 check `design-doc-check` が fail していた。

```console
##[error]❌ src/routes/ に変更がありますが、docs/design/ の更新がありません (ADR-0003)。
```

`/api/health` のレスポンスに `backup` フィールドが増える = **API 表面の変化**なので、`refactor:internal-no-doc-impact` label の要件は満たさない。`docs/design/07-API設計書.md` §3.15 に次を追記した。

- `backup` の JSON 例（`lastSuccessAt` / `lastSuccessFilename` / `lastSuccessBytes` / `lastSuccessDurationMs` / `lastFailureAt` / `lastFailureMessage`）
- **付与条件が `DATA_SOURCE=pglite` 限定**であること（クラウド公開 Lambda のレスポンスは本 PR で一切変わらない）
- なぜ pglite 限定か（未認証公開の口に運用情報を載せる範囲の判断は PO 決裁事項なので NUC 内に閉じる）
- なぜ載せるか（`backup-nuc.cjs` が backend 同定で既に `/api/health` を参照する。運用側の参照点を 1 つにする）
- 取得失敗時は**フィールドを省略するだけで 503 にしない**設計と理由（状態ファイルの不在は DB の生死と無関係で、落とすと liveness の意味が変わる）
- 回帰 test（`tests/unit/routes/health-backup-status.test.ts`）の位置づけ

**mutation で「doc を外すと fail する」ことを実測してから PASS と書いている:**

```console
$ PR_FILES="$(gh pr diff 4019 --name-only)
docs/design/07-API設計書.md" PR_LABELS="..." node scripts/check-design-doc-sync.mjs
[pass] docs/design/ の同期更新あり     DESIGN_EXIT=0
$ (docs/design 行を外して同じコマンド)
[fail] src/routes/ に変更がありますが、docs/design/ の更新がありません (ADR-0003)。
```

`node scripts/check-doc-code-references.mjs` / `npm run cspell` (1737 files, Issues 0) とも exit 0。
