### PR TITLE
docs(billing): #3990 webhook 購読 event 手順書をコードと一致させ、乖離を機械 gate 化する

### DIFF
--- a/docs/operations/stripe-dashboard-runbook.md
+++ b/docs/operations/stripe-dashboard-runbook.md
@@ -131,11 +131,18 @@ Phase 2 月次運用 / Phase 3 incident は頻度低 / ad-hoc のため最小限
    - Live mode: `https://ganbari-quest.com/api/stripe/webhook`
    - Test mode: `https://your-ngrok-or-staging-url/api/stripe/webhook`（ローカル検証時）
 2. Description: `がんばりクエスト Webhook（本番）`
-3. **Events to send** で以下 4 種を選択:
-   - `checkout.session.completed`（新規購入完了 → license 発行 + tenant plan 更新）
-   - `invoice.payment_succeeded`（継続課金成功 → license.expiresAt 延長）
-   - `customer.subscription.deleted`（解約 → 期限切れ予告 → 無料プラン移行、`license-key-requirements.md` §2.9）
+3. **Events to send** で以下 5 種を選択:
+   - `checkout.session.completed`（新規購入完了 → tenant plan 更新 + subscription 割り当て）
+   - `invoice.paid`（継続課金成功 → plan を subscription の現行 price から再解決）
+   - `invoice.payment_failed`（支払い失敗 → dunning 猶予へ）
    - `customer.subscription.updated`（プラン変更 / status 遷移 → tenant plan 反映）
+   - `customer.subscription.deleted`（解約 → subscription 割り当て解除）
+
+   > **この一覧はアプリの `handleWebhookEvent` の `case` と 1:1 で対応している**（`src/lib/server/services/stripe-service.ts`）。
+   > 片方だけ増減すると「購読しているのに handler が無い」「handler があるのに永久に発火しない」状態になり、
+   > **どちらも動作結果に現れない**（沈黙する）。`tests/unit/docs/stripe-dashboard-runbook.test.ts` が両者の一致を機械検証する（#3990）。
+   >
+   > `invoice.paid` と `invoice.payment_succeeded` は Stripe 上で**別 event**。本アプリが購読するのは `invoice.paid` のみ。
 4. 「Add endpoint」で保存
 5. 発行された **Signing secret（`whsec_xxx` で始まる文字列）をメモ**
 6. **Signing secret の配布証跡（ADR-0006 整合）**を以下 3 箇所に配備:

--- a/tests/unit/docs/stripe-dashboard-runbook.test.ts
+++ b/tests/unit/docs/stripe-dashboard-runbook.test.ts
@@ -18,6 +18,45 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const RUNBOOK_PATH = resolve(process.cwd(), 'docs/operations/stripe-dashboard-runbook.md');
+const STRIPE_SERVICE_PATH = resolve(process.cwd(), 'src/lib/server/services/stripe-service.ts');
+
+/**
+ * #3990: 「購読する event 一覧」と「handler が持つ case 一覧」の乖離を機械検知する。
+ *
+ * 手順書は `invoice.payment_succeeded` を 4 種の 1 つとして挙げていたが、コードが持つ case は
+ * `invoice.paid` / `invoice.payment_failed` を含む 5 種で、**両者は Stripe 上の別 event**。
+ * どちらか一方だけを購読していると、もう一方の handler は永久に発火しない。
+ *
+ * この乖離が厄介なのは **動作結果に現れない**ことにある。購読漏れは「その event が来ない」
+ * だけなので、ログにも UI にも「何も起きなかった」以上のものが残らない。#3985 (dedup 未配線) と
+ * 同じく、設定と実装のズレが沈黙する class である。
+ *
+ * したがって「手順書を直す」だけでは再発する。手順書とコードを**同時に落とす**ことで、
+ * どちらか片方だけを変更できないようにする。
+ */
+function readStripeService(): string {
+	return readFileSync(STRIPE_SERVICE_PATH, 'utf-8');
+}
+
+/** `handleWebhookEvent` の switch から `case 'xxx':` の event 名を抽出する。 */
+function handledEventTypes(source: string): string[] {
+	const fn = source.match(/export async function handleWebhookEvent[\s\S]*?^}/m);
+	if (!fn) throw new Error('handleWebhookEvent が見つかりません (関数名が変わった?)');
+	return [...fn[0].matchAll(/case '([\w.]+)':/g)]
+		.map((m) => m[1])
+		.filter((v): v is string => v !== undefined)
+		.sort();
+}
+
+/** 手順書の「Events to send」直後の箇条書きから event 名を抽出する。 */
+function subscribedEventTypes(content: string): string[] {
+	const section = content.match(/\*\*Events to send\*\*[\s\S]*?(?=^\d+\. )/m);
+	if (!section) throw new Error('「Events to send」節が見つかりません (手順書の構造が変わった?)');
+	return [...section[0].matchAll(/^\s*- `([\w.]+)`/gm)]
+		.map((m) => m[1])
+		.filter((v): v is string => v !== undefined)
+		.sort();
+}
 
 function readRunbook(): string {
 	if (!existsSync(RUNBOOK_PATH)) {
@@ -157,6 +196,38 @@ describe('Stripe Dashboard 立ち上げランブック (#2098 AC7)', () => {
 
 		it('ADR-0006 への参照がある', () => {
 			expect(content).toMatch(/ADR-0006/);
+		});
+	});
+
+	// #3990: 手順書とコードの乖離を「両方同時に落ちる」形で固定する。
+	describe('#3990: 購読 event 一覧 ↔ handleWebhookEvent の case 一覧', () => {
+		const handled = handledEventTypes(readStripeService());
+		const subscribed = subscribedEventTypes(content);
+
+		it('[W0] 双方から event を 1 件以上抽出できる (0 件マッチの素通りを防ぐ)', () => {
+			expect(handled.length).toBeGreaterThan(0);
+			expect(subscribed.length).toBeGreaterThan(0);
+		});
+
+		it('[W1] 手順書の購読一覧と handler の case 一覧が完全一致する', () => {
+			expect(
+				subscribed,
+				[
+					'手順書とコードで webhook event 一覧が食い違っています。',
+					`  手順書: ${subscribed.join(', ')}`,
+					`  コード: ${handled.join(', ')}`,
+					'',
+				].join('\n') +
+					'→ 購読しているのに handler が無い / handler があるのに永久に発火しない、のどちらかが起きます。' +
+					'この乖離は動作結果に現れない (沈黙する) ため、ここで落とします',
+			).toEqual(handled);
+		});
+
+		// `invoice.paid` と `invoice.payment_succeeded` は Stripe 上の別 event。
+		// 実際に手順書が後者を挙げていたのが本 Issue の発端なので、実名で固定する。
+		it('[W2] 手順書は invoice.payment_succeeded を挙げない (invoice.paid とは別 event)', () => {
+			expect(subscribed).not.toContain('invoice.payment_succeeded');
+			expect(subscribed).toContain('invoice.paid');
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（Stripe Dashboard を設定するオーナー）、間接的に有料プランの親

**解決する課題**: `stripe-dashboard-runbook.md` の「Events to send」が **アプリが購読していない event（`invoice.payment_succeeded`）を指示**し、**dunning の起点（`invoice.payment_failed`）が抜けていた**。手順書どおりに設定すると `handleInvoicePaid` が永久に発火せず、**継続課金が成功しても plan が更新されない**。

この乖離が厄介なのは**動作結果に現れない**ことにある。購読漏れは「その event が来ない」だけで、ログにも UI にも「何も起きなかった」以上のものが残らない（#3985 の dedup 未配線と同じ、設定と実装のズレが沈黙する class）。

**期待される効果**: 手順書どおりに設定すれば正しく動く状態にする。あわせて手順書とコードが片方だけ変更できないようにする。

## 関連 Issue

<!-- no-issue-close: #3990 の AC1「Stripe Dashboard (Live / Test 両方) の実設定を確認し結果を記録」は Dashboard へのログインが必要でオーナー作業のため本 PR では未達。手順書の是正と乖離 gate のみを扱うため Issue は閉じない。詳細は https://github.com/Takenori-Kusaka/ganbari-quest/issues/3990#issuecomment-5087404931 -->

- #3990 — 本体 Issue（**AC1 未達のため close しない**、下記「オーナー作業として残す AC」）
- #3985 — 設定と実装のズレが沈黙する同 class（webhook dedup 未配線）
- #3958 / #3959 — 2026-07-26 の課金 incident。本件が本番で成立していた場合、症状が重なりうる

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Stripe Dashboard（Live / Test 両方）の「Events to send」実設定を確認し、結果を Issue に記録 | Stripe Dashboard へのログイン | **未達（オーナー作業）**。手順は [Issue コメント](https://github.com/Takenori-Kusaka/ganbari-quest/issues/3990#issuecomment-5087404931) に記載。**手順書とコードの不一致は Dashboard の状態に依存せず確定**しているため先に是正した |
| AC2 | 実設定がコード側と食い違っていた場合、Dashboard 側を修正 | 同上 | **未達（AC1 の結果待ち）** |
| AC3 | `stripe-dashboard-runbook.md` をコードの dispatch 一覧と一致させる | `npx vitest run tests/unit/docs/stripe-dashboard-runbook.test.ts` → `[W1]` | **PASS — 24 tests passed**。4 種 → 5 種に是正（`invoice.payment_succeeded` を削除、`invoice.paid` / `invoice.payment_failed` を追加） |
| AC4 | 購読 event 一覧とコードの `case` 一覧が乖離したら落ちる gate | 同上 → `[W0]` `[W1]` `[W2]` | **PASS**。mutation を**両方向**で実施（下記） |
| AC5 | 設計文書内の混在の有無を確認 | `grep -rn "invoice.payment_succeeded\|invoice.paid\|invoice.payment_failed" docs/` | **確認済 — 混在なし**。`phase1-dunning-requirements.md` / `19-プライシング戦略書.md` / `08-データベース設計書.md` はいずれも `invoice.paid` / `invoice.payment_failed` を使用。**外れていたのは手順書 1 本のみ**（Issue 本文の「設計文書内でも混在」は確認範囲では該当せず） |
| AC6 | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4028` | 下記「テスト & 安全装置セルフチェック」参照 |

### mutation 検証（dev-session §QA 指摘台帳 観点 3「guard を外すと fail するか」）

**片方だけ変更できないことを両方向で確認**（いずれも検証後に復元、差分ゼロ）:

- **手順書を元の誤り（`invoice.payment_succeeded`）に戻す** → `[W1]` `[W2]` の **2 件 fail**
- **コード側の `case 'invoice.payment_failed'` を rename する** → `[W1]` の **1 件 fail**

```
× [W1] 手順書の購読一覧と handler の case 一覧が完全一致する
AssertionError: 手順書とコードで webhook event 一覧が食い違っています。
```

### オーナー作業として残す AC（AC1 / AC2）

Stripe Dashboard の実設定確認はログインが必要で私には実行できません。**確認を優先いただきたい理由**:

実設定が旧手順書どおり（`invoice.payment_succeeded` を購読）だった場合、**`handleInvoicePaid` は本番で一度も発火していない**ことになります。症状は「継続課金が成功しても plan が更新されない」で、#3958 / #3959 の課金 incident と重なりうるものです。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — 手順書 1 本 + 既存テスト 1 本への追記。**製品コードの変更ゼロ**

**影響を受ける画面・機能**: なし（手順書とテストのみ。Dashboard 設定は本 PR では変更していない）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/docs/stripe-dashboard-runbook.test.ts` — `#3990: 購読 event 一覧 ↔ handleWebhookEvent の case 一覧` describe を追加（`[W0]` 0 件マッチ防止 / `[W1]` 完全一致 / `[W2]` 実名固定）。既存 21 test は無変更
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:medium`）

## スクリーンショット / ビジュアルデモ

**該当なし（docs + テストのみ。`.svelte` / `.css` / `site/` の変更ゼロ）**

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 抽出ロジックを `handledEventTypes()` / `subscribedEventTypes()` の純関数に分離し、構造が変わったら明示的に throw する（silent に 0 件を返さない）
- [x] **DRY**: 新規テストファイルを作らず既存 `stripe-dashboard-runbook.test.ts` に同居させた（同じ手順書を対象にする検証を 2 箇所に分けない）
- [x] **YAGNI**: `/ops` への「直近 N 日に受信した event 種別」可視化（Issue の検討事項）は本 PR に含めない。手順書とコードの一致だけで本 Issue の再発は塞げる
- [x] **Security（OSS 公開前提）**: 手順書に実 secret 値は含まない（従来どおりプレースホルダ）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] **設計書同期 (ADR-0001)** — AC5 で `docs/` 全体を横断確認済み。手順書以外に混在なし
- [x] 並行 PR overlap 確認 (#1200) — open PR #4021 / #4019 / #4016 / #4010 / #4005 / #4002 / #3992 / #3989 と変更ファイル重複なし
- [x] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

1. **AC1 / AC2 を未達のまま Ready にする判断**。Dashboard 確認はオーナー作業のため、`<!-- no-issue-close -->` で Issue を閉じない形にしている
2. **gate の対象を「手順書 ↔ コード」にした判断**。本来の真実は Dashboard の実設定だが、それは機械検証できない。手順書を「Dashboard のあるべき姿の宣言」と位置づけ、コードとの一致を強制する形にした
3. AC5 の確認範囲は `docs/` 配下の grep。Issue 本文の「設計文書内でも invoice.paid / payment_succeeded が混在」は、確認した範囲では**手順書 1 本のみ**だった

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み — **AC1 / AC2 を除く**（オーナー作業のため意図的に未達、Issue は閉じない）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
