### PR TITLE
fix: #4003 #4020 週頭と今日の TZ 基準を JST に統一する (本番で毎日/毎週 9 時間の欠落)

### DIFF
--- a/docs/design/44-チャレンジ設計書.md
+++ b/docs/design/44-チャレンジ設計書.md
@@ -110,6 +110,24 @@
 
 multi-armed bandit / Thompson sampling、BirdBrain 型 ML 難度調整、DDA、曜日×カテゴリ×年齢の多変量 rule table は **MAU・学習データ前提で Pre-PMF 未到達**のため不採用（[ADR-0010](../decisions/0010-pre-pmf-scope-judgment.md) / YAGNI）。「3分岐＋2連続未達特例」を超えたら設計を止めて PO に戻す。
 
+### 3.4a 日付境界の基準は JST SSOT に統一する（#4003 / #4020）
+
+**週次チャレンジの「週頭」と、子供ホームの「今日」は、いずれも `src/lib/domain/date-utils.ts` の JST 関数を SSOT とする。**
+
+| 用途 | SSOT | 使用箇所 |
+|---|---|---|
+| その週の月曜 | `weekStartJST(date?)` | `child-challenge-service.ts`（生成時の `startDate` / `endDate`） |
+| 今日 | `todayDateJST()` | 子供ホーム `(child)/[uiMode]/home/+page.server.ts` / 活動記録の書き込み側 |
+
+**禁止**: 週頭・今日の算出に `Date` のローカル日付 getter（`getFullYear` / `getMonth` / `getDate` / `getDay`）を使うこと。本番 Lambda と CI runner は TZ 未設定（= UTC）で動くため、**JST 00:00〜09:00 の 9 時間だけ前日/前週として扱われる**。
+
+読み書きで基準がずれると次の実害が出る（いずれも実際に発生した）:
+
+- **週次チャレンジのバッジが毎週 9 時間まるごと消える**（#4003）— 書き込み側が UTC 基準で `endDate = その日曜` を入れる一方、読み出し側の `todayDateJST()` は既に翌週月曜を返すため `endDate >= today` が false になる
+- **「記録したのに今日のおやくそくが埋まらない」「チェックリストの進捗が戻る」**（#4020）— 書き込み側は `todayDateJST()`、読み出し側はローカル日付、と基準が食い違う
+
+実装方針は「JST の暦日を文字列にしてから UTC 深夜として再解釈し、以降の曜日算術を UTC 系で閉じる」。回帰は `tests/unit/domain/week-start-jst.test.ts` が UTC / JST 双方の TZ で固定する。
+
 ### 3.5 関連実装
 
 | 種別 | 実体 |

--- a/src/lib/domain/date-utils.ts
+++ b/src/lib/domain/date-utils.ts
@@ -40,6 +40,41 @@ export function prevDateJST(dateStr: string): string {
 }
 
 /**
+ * JST 基準で「その週の月曜」を YYYY-MM-DD で返す (#4003)。
+ *
+ * ## なぜ必要か
+ *
+ * 週次データの **書き込み側が週頭をローカル TZ で決め、読み出し側が `todayDateJST()` で
+ * active 判定する**と、両者の基準がずれる。プロセス TZ が UTC (CI runner / Lambda) のとき、
+ * UTC 日曜 15:00〜24:00 = **JST 月曜 00:00〜09:00** の 9 時間だけ:
+ *
+ *   - 書き込み: `startDate = 前週月曜` / `endDate = その日曜` (UTC ではまだ日曜のため)
+ *   - 読み出し: `todayDateJST()` は既に **翌週の月曜** を返す
+ *   → `endDate >= today` が false になり、その週のデータが「存在しない」ことになる
+ *
+ * 実害: 子供ホームの週次チャレンジバッジが毎週 9 時間まるごと消えていた (#4003)。
+ *
+ * ## 実装方針
+ *
+ * **ローカル TZ getter (`getDay` / `getFullYear` / `getMonth` / `getDate`) を一切使わない。**
+ * `toJSTDateString()` で JST の日付文字列にしてから、その文字列を UTC 深夜として解釈し
+ * UTC 算術で月曜まで戻す。同ファイルの `getLastWeekStart()` (child-challenge-service) が
+ * 既にこの形なので、それに揃えている。
+ *
+ * @param date 基準時刻 (省略時は現在時刻)
+ * @returns その週の月曜 (JST 基準) の YYYY-MM-DD
+ */
+export function weekStartJST(date: Date = new Date()): string {
+	// JST の暦日を取り出し、それを UTC 深夜として再解釈する。
+	// 以降の曜日計算は UTC 系で閉じるため、プロセス TZ の影響を受けない。
+	const jstDay = new Date(`${toJSTDateString(date)}T00:00:00Z`);
+	const dow = jstDay.getUTCDay(); // 0=Sun, 1=Mon, ...
+	const diff = dow === 0 ? -6 : 1 - dow; // 日曜は前週月曜まで 6 日戻す
+	jstDay.setUTCDate(jstDay.getUTCDate() + diff);
+	return jstDay.toISOString().slice(0, 10);
+}
+
+/**
  * YYYY-MM-DD 日付文字列を JST の表示用文字列に変換する。
  * 例: '2026-04-13' → '2026年4月13日'
  */

--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -18,7 +18,7 @@ import {
 	CATEGORY_CODES,
 	CATEGORY_NUMERIC_IDS,
 } from '$lib/domain/categories';
-import { todayDateJST } from '$lib/domain/date-utils';
+import { todayDateJST, weekStartJST } from '$lib/domain/date-utils';
 import { findAllChildren } from '$lib/server/db/child-repo';
 import { getRepos } from '$lib/server/db/factory';
 import type {
@@ -102,18 +102,22 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 /**
- * Get the current Monday's date string (YYYY-MM-DD) for a given date.
- * Uses local date components to avoid timezone issues.
+ * その週の月曜 (YYYY-MM-DD) を **JST 基準**で返す。
+ *
+ * #4003: 旧実装は `new Date()` のローカル日付要素 (`getDay` / `getFullYear` / `getMonth` /
+ * `getDate`) で週頭を算出しており、doc comment は "Uses local date components to avoid
+ * timezone issues" と書いていたが、**ローカル日付要素を使うことが timezone issue の原因
+ * そのもの**だった。
+ *
+ * 本関数の戻り値は `child_challenges.start_date` に書かれる一方、active 判定は
+ * `todayDateJST()` (JST 固定) で行われる。プロセス TZ が UTC (CI runner / Lambda) のとき、
+ * UTC 日曜 15:00〜24:00 = JST 月曜 00:00〜09:00 の 9 時間だけ両者の週がずれ、
+ * `endDate >= today` が false になって**週次チャレンジのバッジが全カテゴリで消えていた**。
+ *
+ * 算出は `weekStartJST()` に委譲する (ローカル TZ getter を使わない実装は SSOT 側に置く)。
  */
 export function getWeekStart(date: Date = new Date()): string {
-	const d = new Date(date);
-	const day = d.getDay(); // 0=Sun, 1=Mon, ...
-	const diff = day === 0 ? -6 : 1 - day; // Adjust to Monday
-	d.setDate(d.getDate() + diff);
-	const yyyy = d.getFullYear();
-	const mm = String(d.getMonth() + 1).padStart(2, '0');
-	const dd = String(d.getDate()).padStart(2, '0');
-	return `${yyyy}-${mm}-${dd}`;
+	return weekStartJST(date);
 }
 
 /** weekStart (YYYY-MM-DD, Monday) の 1 週間前の Monday を返す。 */

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
@@ -61,20 +61,21 @@ import { getCategoryXpSummary } from '$lib/server/services/status-service';
 import type { Actions, PageServerLoad } from './$types';
 
 /**
- * #4020: 旧実装は `new Date()` のローカル日付要素で「今日」を組んでいた。
+ * #4020: この route の「今日」は `date-utils.ts` の SSOT (`todayDateJST`) を直接呼ぶ。
  *
- * 本番 Lambda は TZ 未設定 (= UTC) のため、**JST 00:00〜09:00 の 9 時間**は前日を「今日」と
- * 見なす。一方、活動記録の**書き込み側**は `todayDateJST()` (JST 固定) を使う
- * (`activity-record-preparation.ts`)。読み書きで基準がずれるため、その時間帯は
- * 「記録したのに今日のおやくそくが埋まらない」「チェックリストの進捗が戻る」が起きる。
+ * 旧実装は `todayDate()` というファイル内ローカル関数を持ち、中身は `new Date()` の
+ * ローカル日付要素だった。本番 Lambda は TZ 未設定 (= UTC) のため **JST 00:00〜09:00 の
+ * 9 時間**は前日を「今日」と見なし、活動記録の**書き込み側** (`activity-record-preparation.ts`
+ * の JST 固定) と食い違って「記録したのに今日のおやくそくが埋まらない」が起きていた。
  *
- * ローカル定義を廃し `date-utils.ts` の SSOT (`todayDateJST`) を直接使う。
+ * **`todayDate` という名前をこのファイルに残さない。** `validation/activity.ts:314` に
+ * `export { todayDateJST as todayDate }` という**同名の JST 別名**が存在するため、
+ * ローカル関数が同名で居ると呼び出し側の見た目が JST 版と完全に一致し、grep でも
+ * 目視でも区別できない。この「名前による隠蔽」が #4020 が 5 か月間検出されなかった
+ * 直接の機構であり (Issue 5 Whys の 4)、wrapper として名前だけ残すと機構は残る。
+ *
  * `(child)` 配下の他 route (checklist / status / history) は既に JST 経由。
  */
-function todayDate(): string {
-	return todayDateJST();
-}
-
 export const load: PageServerLoad = async ({ parent, locals }) => {
 	const tenantId = requireTenantId(locals);
 	const parentData = await parent();
@@ -161,7 +162,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 		getLoginBonusStatus(child.id, tenantId),
 		getUnshownReward(child.id, tenantId),
 		getUnshownMessage(child.id, tenantId),
-		getChecklistsForChild(child.id, todayDate(), tenantId),
+		getChecklistsForChild(child.id, todayDateJST(), tenantId),
 		getTodayMissions(child.id, tenantId),
 		getStampCardStatus(child.id, tenantId),
 		getCategoryXpSummary(child.id, tenantId),
@@ -200,7 +201,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 	activitiesWithMission.sort((a, b) => (b.isMainQuest ? 1 : 0) - (a.isMainQuest ? 1 : 0));
 
 	// フォーカスモード: おすすめ活動の選定 (#0264)
-	const recommendations = selectRecommendations(rawActivities, todayDate());
+	const recommendations = selectRecommendations(rawActivities, todayDateJST());
 	const recommendedIds = new Set(recommendations.map((r) => r.activityId));
 
 	const birthdayBonus =
@@ -233,7 +234,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 	try {
 		mustStatus = await tryGrantMustCompletionBonus(
 			child.id,
-			todayDate(),
+			todayDateJST(),
 			parentData.uiMode as Parameters<typeof tryGrantMustCompletionBonus>[2],
 			tenantId,
 		);

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { todayDateJST } from '$lib/domain/date-utils';
 import { formIdString } from '$lib/domain/form-value';
 import { asActivityId, asCategoryId, asChildId, type CategoryId } from '$lib/domain/ids';
 import { getActivityDisplayName } from '$lib/domain/validation/activity';
@@ -59,9 +60,19 @@ import {
 import { getCategoryXpSummary } from '$lib/server/services/status-service';
 import type { Actions, PageServerLoad } from './$types';
 
+/**
+ * #4020: 旧実装は `new Date()` のローカル日付要素で「今日」を組んでいた。
+ *
+ * 本番 Lambda は TZ 未設定 (= UTC) のため、**JST 00:00〜09:00 の 9 時間**は前日を「今日」と
+ * 見なす。一方、活動記録の**書き込み側**は `todayDateJST()` (JST 固定) を使う
+ * (`activity-record-preparation.ts`)。読み書きで基準がずれるため、その時間帯は
+ * 「記録したのに今日のおやくそくが埋まらない」「チェックリストの進捗が戻る」が起きる。
+ *
+ * ローカル定義を廃し `date-utils.ts` の SSOT (`todayDateJST`) を直接使う。
+ * `(child)` 配下の他 route (checklist / status / history) は既に JST 経由。
+ */
 function todayDate(): string {
-	const now = new Date();
-	return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+	return todayDateJST();
 }
 
 export const load: PageServerLoad = async ({ parent, locals }) => {

--- a/tests/unit/domain/week-start-jst.test.ts
+++ b/tests/unit/domain/week-start-jst.test.ts
@@ -1,0 +1,104 @@
+// tests/unit/domain/week-start-jst.test.ts
+// #4003 / #4020 — 週頭と「今日」の TZ 基準を JST に固定する。
+//
+// ## 何を守るか
+//
+// 週次チャレンジは **書き込み側が `getWeekStart()` で週頭を決め、読み出し側が
+// `todayDateJST()` で active 判定する**。両者の TZ 基準がずれると、ずれた時間帯だけ
+// 「その週のデータが存在しない」ことになる。
+//
+// 旧実装は `getWeekStart()` が `new Date()` のローカル日付要素を使っていたため、
+// プロセス TZ が UTC (CI runner / 本番 Lambda) のとき **UTC 日曜 15:00〜24:00 =
+// JST 月曜 00:00〜09:00 の 9 時間**だけ週がずれ、子供ホームの週次チャレンジバッジが
+// 全カテゴリで消えていた (#4003)。
+//
+// ## なぜ e2e ではなくここで固定するか
+//
+// e2e (`child-challenge-card-badge.spec.ts`) はこの窓に入った時だけ落ちる。つまり
+// **実行時刻に依存して緑にも赤にもなる**ので、回帰の検出手段として信頼できない
+// (実際 #4003 は「日曜 UTC 夜に回した run だけが落ちた」形で表面化した)。
+// 時刻を固定できる層で境界そのものを assert する。
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { todayDateJST, weekStartJST } from '../../../src/lib/domain/date-utils';
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+/** 指定 UTC 時刻に固定する。TZ の影響を受けない ISO 文字列で与える。 */
+function freezeUtc(iso: string): void {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(iso));
+}
+
+describe('#4003 weekStartJST — 週頭を JST 基準で決める', () => {
+	// 2026-07-26(日) / 2026-07-27(月) 周辺を使う。
+	// UTC 日曜 15:00 = JST 月曜 00:00 が境界。
+	it('[W1] UTC 日曜 14:59 (JST 日曜 23:59) → その週の月曜は 07-20', () => {
+		freezeUtc('2026-07-26T14:59:00Z');
+		expect(weekStartJST()).toBe('2026-07-20');
+	});
+
+	// **ここが旧実装の欠陥そのもの。** UTC ではまだ日曜なので、ローカル日付要素を使うと
+	// 前週月曜 (07-20) を返してしまう。JST では既に月曜なので 07-27 でなければならない。
+	it('[W2] UTC 日曜 15:00 (JST 月曜 00:00) → 週が切り替わり 07-27', () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+		expect(weekStartJST()).toBe('2026-07-27');
+	});
+
+	it('[W3] UTC 日曜 23:59 (JST 月曜 08:59) → まだ 07-27 (窓の内側)', () => {
+		freezeUtc('2026-07-26T23:59:00Z');
+		expect(weekStartJST()).toBe('2026-07-27');
+	});
+
+	it('[W4] UTC 月曜 00:00 (JST 月曜 09:00) → 07-27 のまま (窓を抜けても不変)', () => {
+		freezeUtc('2026-07-27T00:00:00Z');
+		expect(weekStartJST()).toBe('2026-07-27');
+	});
+
+	// 書き込み (weekStartJST) と読み出し (todayDateJST) が同じ暦日を見ていることの固定。
+	// これが崩れると `startDate <= today <= endDate` の active 判定が壊れる。
+	it('[W5] 窓の内側で weekStart <= todayDateJST が成り立つ (active 判定の前提)', () => {
+		freezeUtc('2026-07-26T15:00:00Z'); // JST 月曜 00:00
+		const start = weekStartJST();
+		const today = todayDateJST();
+		expect(today).toBe('2026-07-27');
+		expect(start <= today).toBe(true);
+		// 週の終端 (日曜) は start + 6 日。today がその範囲に入ること。
+		const end = new Date(`${start}T00:00:00Z`);
+		end.setUTCDate(end.getUTCDate() + 6);
+		expect(today <= end.toISOString().slice(0, 10)).toBe(true);
+	});
+
+	it('[W6] 各曜日で正しい月曜を返す (JST 基準、UTC 深夜 = JST 午前 9 時で確認)', () => {
+		// UTC 00:00 は JST 09:00 なので暦日は UTC と同じ。曜日ロジックだけを見る。
+		const cases: [string, string][] = [
+			['2026-07-27T00:00:00Z', '2026-07-27'], // 月
+			['2026-07-28T00:00:00Z', '2026-07-27'], // 火
+			['2026-07-31T00:00:00Z', '2026-07-27'], // 金
+			['2026-08-01T00:00:00Z', '2026-07-27'], // 土
+			['2026-08-02T00:00:00Z', '2026-07-27'], // 日 → 前週月曜まで戻る
+			['2026-08-03T00:00:00Z', '2026-08-03'], // 翌月曜
+		];
+		for (const [iso, expected] of cases) {
+			freezeUtc(iso);
+			expect(weekStartJST(), `${iso} の週頭`).toBe(expected);
+			vi.useRealTimers();
+		}
+	});
+
+	it('[W7] 月またぎ / 年またぎでも UTC 算術で正しく戻る', () => {
+		freezeUtc('2026-01-01T00:00:00Z'); // 木
+		expect(weekStartJST()).toBe('2025-12-29');
+		vi.useRealTimers();
+		freezeUtc('2026-03-01T00:00:00Z'); // 日 → 前週月曜
+		expect(weekStartJST()).toBe('2026-02-23');
+	});
+
+	// 引数を渡した場合も同じ規則であること (既存 callsite は date を渡す形がある)。
+	it('[W8] 引数指定でも JST 基準で解釈する', () => {
+		expect(weekStartJST(new Date('2026-07-26T15:00:00Z'))).toBe('2026-07-27');
+		expect(weekStartJST(new Date('2026-07-26T14:59:00Z'))).toBe('2026-07-20');
+	});
+});

--- a/tests/unit/routes/child-home-must-bonus-jst.test.ts
+++ b/tests/unit/routes/child-home-must-bonus-jst.test.ts
@@ -131,8 +131,10 @@ vi.mock('$lib/server/db/activity-repo', () => ({
 // #4020 AC1 の 3 呼び出しすべてが同じ JST 当日を見ることを [B5] で確認する。
 // ------------------------------------------------------------------
 
-const getChecklistsForChild = vi.fn(async () => []);
-const selectRecommendations = vi.fn(() => []);
+const getChecklistsForChild = vi.fn(
+	async (_childId: unknown, _today: string, _tenantId: string) => [],
+);
+const selectRecommendations = vi.fn((_activities: unknown, _today: string) => []);
 
 vi.mock('$lib/server/auth/factory', () => ({ requireTenantId: () => 'test-tenant' }));
 vi.mock('$lib/server/logger', () => ({
@@ -282,10 +284,12 @@ describe('#4020 AC3 — 全達成ボーナスは JST の当日で判定される
 
 		// point_ledger に当日の 1 行が入っていること
 		expect(ledger).toHaveLength(1);
-		expect(ledger[0].type).toBe(MUST_COMPLETION_BONUS_TYPE);
-		expect(ledger[0].amount).toBe(5);
-		expect(ledger[0].recordedDate).toBe('2026-07-27');
-		expect(ledger[0].description).toContain('2026-07-27');
+		const [row] = ledger;
+		if (!row) throw new Error('point_ledger に行が入っていない');
+		expect(row.type).toBe(MUST_COMPLETION_BONUS_TYPE);
+		expect(row.amount).toBe(5);
+		expect(row.recordedDate).toBe('2026-07-27');
+		expect(row.description).toContain('2026-07-27');
 	});
 
 	it('[B3] 窓の内側で 2 回 load しても付与は 1 回だけ (冪等 / 演出 1 回限り)', async () => {

--- a/tests/unit/routes/child-home-must-bonus-jst.test.ts
+++ b/tests/unit/routes/child-home-must-bonus-jst.test.ts
@@ -1,0 +1,346 @@
+// tests/unit/routes/child-home-must-bonus-jst.test.ts
+// #4020 AC3 — 「今日のおやくそく」全達成ボーナスの JST 窓を閉じる。
+//
+// ## なぜ service 単体ではなくこの層で固定するか
+//
+// `tryGrantMustCompletionBonus(childId, today, uiMode, tenantId)` は **`today` を引数で
+// 受け取るだけ**で、内部に TZ 依存を 1 つも持たない (`activity-service.ts:444-491`)。
+// つまり #4020 の欠陥は 100% **呼び出し側** (`home/+page.server.ts`) にあり、service の
+// unit test を何本足しても窓は閉じない。ここでは実際に `load` を呼び、
+// **load → service → repo に渡る日付が JST の当日であること**を通しで固定する。
+//
+// ## 何が壊れていたか (顧客影響)
+//
+// 旧実装は `home/+page.server.ts` 内のローカル `todayDate()` が `new Date()` の
+// **ローカル日付要素**で「今日」を組んでいた。本番 Lambda は TZ 未設定 (= UTC) のため、
+// **UTC 15:00〜24:00 = JST 翌日 00:00〜09:00 の 9 時間**は前日を「今日」と見なす。
+// 一方、活動記録の書き込み (`activity_logs.recorded_date`) は JST 固定なので、
+// その時間帯は `logged=0 / total=N` となり **allComplete が成立せず、全達成ボーナスが
+// 付与も演出もされない**。朝の支度を記録する子供がまさにこの時間帯に当たる。
+//
+// ## 検証の作り方 (規則に従うデータだけを並べない)
+//
+// - repo 層 (`$lib/server/db/activity-repo`) を**日付キーの fake** に差し替える。
+//   fake は実 backend の述語をそのまま写す:
+//     - `findMustActivitiesWithToday` = `recorded_date = today AND cancelled = 0`
+//       (`sqlite/activity-repo.ts:294-303` / dsql 同義)
+//     - `insertPointLedger` の `recorded_date` = `todayDateJST()`
+//       (`dsql/point-write.ts:71` — 本番 backend の実装そのもの)
+//     - `countPointLedgerEntriesByTypeAndDate` = `recorded_date = date`
+//       (`dsql/activity-repo.ts:513-519`)
+// - service (`tryGrantMustCompletionBonus`) と SUT (`load`) は**実物**を使う。
+// - fixture は **JST 当日 (07-27) にだけ記録がある**状態。UTC 側の日付 (07-26) では
+//   `logged=0` になる。この非対称が無いと test は空振りするので、[B2] で fixture 自身が
+//   2 つの日付を区別することを直接 assert する。
+//
+// ## TZ 固定の規約 (#4020 AC2 / #4003 AC1''')
+//
+// - `process.env.TZ = 'UTC'` を beforeEach/afterEach で出し入れする。
+// - sentinel は `getTimezoneOffset()` で取る。**`expect(process.env.TZ).toBe('UTC')` は
+//   使わない** — `TZ=JST-9` のように env には載るが実効値が違う反例があるため。
+// - シェルの `TZ=... npm test` prefix には依存しない (Git Bash / MSYS で env が落ちる)。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { todayDateJST } from '$lib/domain/date-utils';
+import { asActivityId, asChildId } from '$lib/domain/ids';
+
+// ------------------------------------------------------------------
+// fixture: JST 2026-07-27 (月) の朝に must 活動 2 件を両方記録した子供
+// ------------------------------------------------------------------
+
+const CHILD_ID = 1;
+const MUST_ACTIVITIES = [
+	{ id: 101, name: 'はみがき', icon: '🪥' },
+	{ id: 102, name: 'おきがえ', icon: '👕' },
+];
+/** activity_logs 相当。recorded_date は書き込み側 (JST 固定) が入れた値。 */
+const ACTIVITY_LOGS = [
+	{ activityId: 101, recordedDate: '2026-07-27', cancelled: 0 },
+	{ activityId: 102, recordedDate: '2026-07-27', cancelled: 0 },
+];
+
+interface LedgerRow {
+	childId: string;
+	type: string;
+	amount: number;
+	description: string | null;
+	recordedDate: string;
+}
+let ledger: LedgerRow[] = [];
+
+/** `findMustActivitiesWithToday` の述語をそのまま写した fake。 */
+const findMustActivitiesWithToday = vi.fn(async (_childId: unknown, today: string) => {
+	const loggedSet = new Set(
+		ACTIVITY_LOGS.filter((l) => l.recordedDate === today && l.cancelled === 0).map(
+			(l) => l.activityId,
+		),
+	);
+	const activities = MUST_ACTIVITIES.map((a) => ({
+		id: asActivityId(a.id),
+		name: a.name,
+		icon: a.icon,
+		loggedToday: loggedSet.has(a.id) ? 1 : 0,
+	}));
+	return {
+		logged: activities.filter((a) => a.loggedToday === 1).length,
+		total: activities.length,
+		activities,
+	};
+});
+
+const countPointLedgerEntriesByTypeAndDate = vi.fn(
+	async (childId: unknown, type: string, date: string) =>
+		ledger.filter(
+			(e) => e.childId === String(childId) && e.type === type && e.recordedDate === date,
+		).length,
+);
+
+const insertPointLedger = vi.fn(
+	async (input: {
+		childId: unknown;
+		amount: number;
+		type: string;
+		description?: string | null;
+	}) => {
+		// dsql/point-write.ts:71 — recorded_date は entity 未公開のため JST 今日で導出する。
+		ledger.push({
+			childId: String(input.childId),
+			type: input.type,
+			amount: input.amount,
+			description: input.description ?? null,
+			recordedDate: todayDateJST(),
+		});
+	},
+);
+
+vi.mock('$lib/server/db/activity-repo', () => ({
+	findMustActivitiesWithToday: (...args: [unknown, string, string]) =>
+		findMustActivitiesWithToday(args[0], args[1]),
+	countPointLedgerEntriesByTypeAndDate: (...args: [unknown, string, string, string]) =>
+		countPointLedgerEntriesByTypeAndDate(args[0], args[1], args[2]),
+	insertPointLedger: (...args: [Parameters<typeof insertPointLedger>[0], string]) =>
+		insertPointLedger(args[0]),
+	getActivityLogCounts: vi.fn(),
+	hasActivityLogs: vi.fn(),
+	deleteDailyMissionsByActivity: vi.fn(),
+}));
+
+// ------------------------------------------------------------------
+// 周辺 service は「日付の意味論に関与しない」ので最小 stub に落とす。
+// ただし日付を受け取る 2 本 (checklist / recommendation) は spy として残し、
+// #4020 AC1 の 3 呼び出しすべてが同じ JST 当日を見ることを [B5] で確認する。
+// ------------------------------------------------------------------
+
+const getChecklistsForChild = vi.fn(async () => []);
+const selectRecommendations = vi.fn(() => []);
+
+vi.mock('$lib/server/auth/factory', () => ({ requireTenantId: () => 'test-tenant' }));
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('$lib/server/services/activity-log-service', () => ({
+	getTodayRecordedActivityCounts: vi.fn(async () => []),
+	hasAnyActivityRecords: vi.fn(async () => true),
+	cancelActivityLog: vi.fn(),
+	recordActivity: vi.fn(),
+}));
+vi.mock('$lib/server/services/activity-pin-service', () => ({
+	sortActivitiesWithPreferences: vi.fn(async () => []),
+	toggleActivityPin: vi.fn(),
+}));
+// activity-service は **部分 mock**。tryGrantMustCompletionBonus は実物を使い、
+// DB を引く getChildActivities だけ差し替える。
+vi.mock('$lib/server/services/activity-service', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/server/services/activity-service')>();
+	return { ...actual, getChildActivities: vi.fn(async () => []) };
+});
+vi.mock('$lib/server/services/birthday-bonus-service', () => ({
+	getBirthdayBonusStatus: vi.fn(async () => ({ eligible: false })),
+	claimBirthdayBonus: vi.fn(),
+}));
+vi.mock('$lib/server/services/checklist-service', () => ({
+	getChecklistsForChild: (...args: [unknown, string, string]) => getChecklistsForChild(...args),
+}));
+vi.mock('$lib/server/services/child-challenge-service', () => ({
+	getOrCreateWeeklyChildChallenge: vi.fn(async () => undefined),
+	getActiveChildChallengesWithSiblings: vi.fn(async () => []),
+	claimChildChallengeReward: vi.fn(),
+}));
+vi.mock('$lib/server/services/daily-mission-service', () => ({
+	getTodayMissions: vi.fn(async () => null),
+}));
+vi.mock('$lib/server/services/family-streak-service', () => ({
+	getFamilyStreak: vi.fn(async () => null),
+	getNextMilestone: vi.fn(() => null),
+}));
+vi.mock('$lib/server/services/login-bonus-service', () => ({
+	getLoginBonusStatus: vi.fn(async () => ({ claimedToday: false })),
+	claimLoginBonus: vi.fn(),
+}));
+vi.mock('$lib/server/services/message-service', () => ({
+	getUnshownMessage: vi.fn(async () => null),
+}));
+vi.mock('$lib/server/services/recommendation-service', () => ({
+	selectRecommendations: (...args: [unknown, string]) => selectRecommendations(...args),
+}));
+vi.mock('$lib/server/services/sibling-cheer-service', () => ({
+	getUnshownCheers: vi.fn(async () => []),
+	markCheersShown: vi.fn(),
+	sendCheer: vi.fn(),
+}));
+vi.mock('$lib/server/services/sibling-ranking-service', () => ({
+	getWeeklyRanking: vi.fn(async () => null),
+	isRankingEnabled: vi.fn(async () => false),
+}));
+vi.mock('$lib/server/services/special-reward-service', () => ({
+	getSpecialRewardProgress: vi.fn(async () => null),
+	getUnshownReward: vi.fn(async () => null),
+}));
+vi.mock('$lib/server/services/stamp-card-service', () => ({
+	getStampCardStatus: vi.fn(async () => null),
+	autoRedeemPreviousWeek: vi.fn(),
+	redeemStampCard: vi.fn(),
+	stampToday: vi.fn(),
+}));
+vi.mock('$lib/server/services/status-service', () => ({
+	getCategoryXpSummary: vi.fn(async () => null),
+}));
+
+// 実装側の定数をそのまま使う (test 側で文字列を直書きすると type 名変更に silent に追従する)。
+import { MUST_COMPLETION_BONUS_TYPE } from '../../../src/lib/server/services/activity-service';
+import { load } from '../../../src/routes/(child)/[uiMode=uiMode]/home/+page.server';
+
+const ORIGINAL_TZ = process.env.TZ;
+
+/** 指定 UTC 時刻に固定する。TZ の影響を受けない ISO 文字列で与える。 */
+function freezeUtc(iso: string): void {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(iso));
+}
+
+/** `load` を PageServerLoad の最小 event で呼ぶ。 */
+// biome-ignore lint/suspicious/noExplicitAny: SvelteKit の LoadEvent 全体は本 test の関心外
+async function runLoad(uiMode = 'preschool'): Promise<any> {
+	// biome-ignore lint/suspicious/noExplicitAny: 同上
+	return await (load as any)({
+		locals: {},
+		parent: async () => ({
+			child: { id: asChildId(CHILD_ID), age: 5 },
+			uiMode,
+			planLimits: { canSiblingRanking: false },
+		}),
+	});
+}
+
+beforeEach(() => {
+	// 本番 Lambda と CI runner の条件 (TZ 未設定 = UTC) を再現する。
+	process.env.TZ = 'UTC';
+	ledger = [];
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	process.env.TZ = ORIGINAL_TZ;
+});
+
+describe('#4020 AC3 — 全達成ボーナスは JST の当日で判定される', () => {
+	it('[B0] sentinel: この test は実効 UTC で走っている', () => {
+		// env 文字列ではなく Date の実挙動で確認する (#4020 AC2 規約)。
+		expect(new Date('2026-07-26T21:00:00Z').getTimezoneOffset()).toBe(0);
+	});
+
+	it('[B2] 対照: fixture は 07-26 と 07-27 を区別する (この test が空振りでないこと)', async () => {
+		// UTC 側の日付では 1 件も logged にならない = 旧実装が見ていた世界。
+		const utcSide = await findMustActivitiesWithToday(asChildId(CHILD_ID), '2026-07-26');
+		expect(utcSide.logged).toBe(0);
+		expect(utcSide.total).toBe(2);
+		// JST 側の日付では全達成。
+		const jstSide = await findMustActivitiesWithToday(asChildId(CHILD_ID), '2026-07-27');
+		expect(jstSide.logged).toBe(2);
+		expect(jstSide.total).toBe(2);
+	});
+
+	// **ここが #4020 の顧客被害そのもの。** 旧実装ではこの時刻で logged=0 になり、
+	// ボーナスが付与も演出もされなかった。
+	it('[B1] UTC 日曜 15:00 (JST 月曜 00:00) — 当日で集計し、ボーナスが付与される', async () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+
+		const data = await runLoad();
+
+		// load → service に渡った日付が JST の当日であること
+		expect(findMustActivitiesWithToday).toHaveBeenCalledWith(expect.anything(), '2026-07-27');
+		expect(findMustActivitiesWithToday).not.toHaveBeenCalledWith(expect.anything(), '2026-07-26');
+
+		// 顧客に見える結果: 全達成 → 付与 (preschool = 5pt)
+		expect(data.mustStatus).not.toBeNull();
+		expect(data.mustStatus.total).toBe(2);
+		expect(data.mustStatus.logged).toBe(2);
+		expect(data.mustStatus.allComplete).toBe(true);
+		expect(data.mustStatus.granted).toBe(true);
+		expect(data.mustStatus.points).toBe(5);
+
+		// point_ledger に当日の 1 行が入っていること
+		expect(ledger).toHaveLength(1);
+		expect(ledger[0].type).toBe(MUST_COMPLETION_BONUS_TYPE);
+		expect(ledger[0].amount).toBe(5);
+		expect(ledger[0].recordedDate).toBe('2026-07-27');
+		expect(ledger[0].description).toContain('2026-07-27');
+	});
+
+	it('[B3] 窓の内側で 2 回 load しても付与は 1 回だけ (冪等 / 演出 1 回限り)', async () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+
+		const first = await runLoad();
+		expect(first.mustStatus.granted).toBe(true);
+
+		const second = await runLoad();
+		expect(second.mustStatus.allComplete).toBe(true);
+		expect(second.mustStatus.granted).toBe(false);
+		expect(second.mustStatus.points).toBe(0);
+
+		expect(ledger).toHaveLength(1);
+	});
+
+	it('[B4] 窓の終端 UTC 23:59 (JST 08:59) でも同じ当日を見る', async () => {
+		freezeUtc('2026-07-26T23:59:00Z');
+
+		const data = await runLoad();
+
+		expect(findMustActivitiesWithToday).toHaveBeenCalledWith(expect.anything(), '2026-07-27');
+		expect(data.mustStatus.granted).toBe(true);
+	});
+
+	it('[B4b] 窓を抜けた UTC 月曜 00:00 (JST 09:00) でも当日は変わらない', async () => {
+		freezeUtc('2026-07-27T00:00:00Z');
+
+		const data = await runLoad();
+
+		expect(findMustActivitiesWithToday).toHaveBeenCalledWith(expect.anything(), '2026-07-27');
+		expect(data.mustStatus.granted).toBe(true);
+	});
+
+	// #4020 AC1 は「呼び出し 3 箇所すべてが JST を見る」ことを求めている。
+	// ボーナス経路以外の 2 本も同じ日付であることをここで固定する。
+	it('[B5] checklist / おすすめ活動も同じ JST 当日を受け取る (#4020 AC1 の 3 呼び出し)', async () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+
+		await runLoad();
+
+		expect(getChecklistsForChild).toHaveBeenCalledWith(
+			expect.anything(),
+			'2026-07-27',
+			'test-tenant',
+		);
+		expect(selectRecommendations).toHaveBeenCalledWith(expect.anything(), '2026-07-27');
+	});
+
+	it('[B6] baby は全達成でもボーナス対象外 (ADR-0011) — 早期 return で mustStatus=null', async () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+
+		const data = await runLoad('baby');
+
+		expect(data.mustStatus).toBeNull();
+		expect(ledger).toHaveLength(0);
+	});
+});

--- a/tests/unit/services/child-challenge-service.test.ts
+++ b/tests/unit/services/child-challenge-service.test.ts
@@ -66,7 +66,13 @@ vi.mock('$lib/server/db/child-repo', () => ({
 	findAllChildren: (...a: unknown[]) => mockFindAllChildren(...a),
 }));
 
-vi.mock('$lib/domain/date-utils', () => ({
+// #4003: `todayDateJST` だけを固定し、他は実装を通す部分 mock にする。
+// 全 export を差し替える形だと、date-utils に関数が増えたとき
+// 「No "xxx" export is defined on the mock」で**この test file 全体が落ちる**
+// (weekStartJST 追加時に実際に 10 件落ちた)。テストが固定したいのは「今日」だけなので、
+// 曜日計算 (weekStartJST) は実物を使う — mock で置き換えると検証対象が消える。
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
 	todayDateJST: () => '2026-05-25',
 }));
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全年齢モードの子ども（記録する側）と、その保護者

**解決する課題**: 「書き込みは JST、読み出しはローカル TZ」で基準が食い違い、**本番 Lambda（TZ 未設定 = UTC）で毎日・毎週 9 時間だけ子どもの画面が壊れていた**。

- **#4003（critical）**: 週次チャレンジのバッジが **毎週 9 時間、全カテゴリで消える**
- **#4020（critical）**: 子供ホームの「今日」が前日のままになり、**記録したのに今日のおやくそくが埋まらない / チェックリストの進捗が戻る**

いずれも「子どもががんばりを記録する」という本プロダクトの中核体験が、**毎日決まった時間帯に静かに壊れる**類のものです。

**期待される効果**: JST 00:00〜09:00 に使う家庭でも、記録が正しく「今日」に入り、チャレンジバッジが表示される。

## 関連 Issue

closes #4003
closes #4020

- #4015 — 同 root class の一般化（ローカル TZ 日付 getter 112 箇所 / 47 file）。本 PR は実欠陥 2 件のみを扱い、棚卸しと lint 化は #4015 に委ねる
- `sibling-ranking-service.ts:30` に同型の独自 `getWeekStart()` が**未修正で残存**（#4015 の分類対象。本 PR のスコープ外）

## AC 検証マップ (ADR-0004)

**Issue の AC 番号と 1:1 で対応させています** (QA 指摘 BLOCK-3 対応、2026-07-29)。#4003 / #4020 は AC 番号が独立に振られているため、Issue を明記して分けています。

### #4003 — 週次チャレンジのバッジが毎週 9 時間消える

| AC | AC 内容 (Issue 原文の要約) | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC1** | 本番相当環境でホームに `challenge-target-badge` が実際に描画されるかを確認する | **統合 PR (`release/* → main`) の重量レーン** | **本 PR では検証できません。** 軽量レーン (feature → develop) は `e2e-test` / `a11y` を発火させない設計 (`branch-strategy.md` レーン分離) のため、原理的にここでは実行されません。**検証の場所が統合 PR であり、不足ではありません** |
| **AC2** | 落ちている 3 test の原因を「時間依存」か否かで確定させる (推論で断定しない) | 固定時刻を注入した unit + 失敗 run の時刻突合 | **PASS**。`weekStartJST()` に UTC 日曜 14:59 / 15:00 を注入して red/green が切り替わることを実測 (`[W1]` `[W2]`)。失敗 2 run の `createdAt` = `2026-07-26T21:21:59Z` / `T22:10:32Z` = JST 月曜 06:21 / 07:10 で窓の内側 |
| **AC3** | 恒久対処を入れる (期待値を緩めて緑にすることは禁止 — ADR-0005) | 実装 diff | **PASS**。e2e の期待は 1 文字も変えず、`getWeekStart()` を `weekStartJST()` へ委譲する本体修正で対処 |
| **AC4** | 同 class の時間依存を他の e2e / unit に走査し Issue に記録する | **PO 側で実施済み** | **PASS**。[issuecomment-5112497086](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4003#issuecomment-5112497086) に全文。副産物として #4051 (fixture と SUT が同じ `getWeekStart()` を呼ぶため構造的に検出できない 2 件) が起票済み |
| **AC5** | 3 test が実行週に関わらず green。統合レーンの `e2e-test` 3 shard + `a11y` が CI 実測で緑 | **統合 PR の重量レーン** | **本 PR では検証できません** (AC1 と同じ理由)。統合 PR の CI が緑になった時点で充足し、その merge が main へ届いて #4003 が close されるため `closes #4003` は正当です |

### #4020 — 子供ホームだけ「今日」がローカル TZ

| AC | AC 内容 (Issue 原文の要約) | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC1** | ローカル定義 `todayDate()` (`:62-65`) を**削除**し `todayDateJST()` へ差し替える。呼び出し 3 箇所すべてが JST を見る | 実装 diff + test `[B5]` | **PASS (2026-07-29 に修正)**。当初は `function todayDate() { return todayDateJST(); }` の **wrapper で名前を残していた**が、QA 指摘 (BLOCK-2) を受けて削除。`:165` checklist / `:204` recommendation / `:237` bonus の 3 箇所が `todayDateJST()` を直接呼ぶ |
| **AC2** | TZ 固定 + sentinel + 固定時刻で「修正前は前日 / 修正後は当日」を示す。修正前 commit で fail する実行ログを証跡とする | `tests/unit/routes/child-home-must-bonus-jst.test.ts` `[B0]` `[B2]` `[B5]` + mutation 実行 | **PASS**。sentinel は `expect(new Date('2026-07-26T21:00:00Z').getTimezoneOffset()).toBe(0)` (`process.env.TZ` の文字列は見ない)。mutation 実測は下記「追記 (2026-07-29): QA BLOCK 対応」参照 |
| **AC3** | **全達成ボーナスの窓を test で閉じる。** UTC 15:00〜24:00 で「当日分の must を全達成 → 付与される」ことを示す | 同 file `[B1]` `[B3]` `[B4]` | **PASS (2026-07-29 に追加)**。`[B1]` = UTC 日曜 15:00 で `granted=true` / `points=5` / ledger 1 行 (`recorded_date=2026-07-27`)。`[B3]` = 2 回 load しても付与 1 回 |
| **AC4** | `validation/activity.ts:314` の `export { todayDateJST as todayDate }` を残すか寄せるかを**判断し、判断と根拠を PR 本文に記載する** | 下記「#4020 AC4 — `todayDate` 別名 re-export の判断」 | **PASS (2026-07-29 に追記)**。**別名を残す**判断。根拠は同節に記載 |
| **AC5** | 修正後に `(child)` 配下のページ間で「今日」の解釈が一致していることを確認する | `grep` | **PASS**。`grep -rn "getFullYear\|getMonth\|getDate" "src/routes/(child)"` = **0 件**。`home` / `checklist` とも `todayDateJST()` 経由 |

### 本 PR 固有の確認 (Issue の AC ではない)

| 項目 | 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| 回帰なし | 既存テストを壊していない | `npx vitest run tests/unit/routes/ tests/unit/services/child-challenge-service.test.ts tests/unit/domain/` | **PASS — 111 files / 1468 tests passed** |
| BLOCK 対応後 | 追加 test + 近傍 suite | `npx vitest run child-home-must-bonus-jst / week-start-jst / home-cookie-guard / home-form-field-guard / activity-service / child-challenge-service` | **PASS — 6 files / 115 tests passed** (exit 0) |
| Ready gate | `npm run pre-ready -- --pr 4031` 全 Step PASS | 下記「テスト & 安全装置セルフチェック」参照 | — |

### なぜ e2e ではなく unit で固定したか

失敗している e2e（`child-challenge-card-badge.spec.ts:52/65/80`）は **この 9 時間の窓に入った時だけ落ちます**。つまり実行時刻次第で緑にも赤にもなり、**回帰検出手段として信頼できません**（#4003 が「日曜 UTC 夜に回した run だけ落ちた」形で表面化したのがまさにそれ）。時刻を固定できる層で境界そのものを assert します。

**e2e の期待を緩める案は採りません** — ADR-0005 違反であり、本番で毎週 9 時間バッジが消える顧客影響を隠すためです。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## ADR-0002 Critical 修正 5 要件チェック（必須）

### 要件 1: 回帰テストを同一 PR 内で追加

| AC | テストファイル | テスト内容 |
|---|---|---|
| AC2 (#4003) | `tests/unit/domain/week-start-jst.test.ts` | `[W1]`-`[W4]` UTC 日曜 14:59 / 15:00 / 23:59・月曜 00:00 の窓境界で週頭が正しく切り替わる |
| AC2 (#4003) | 同上 | `[W5]` 窓の内側で `weekStart <= todayDateJST <= weekEnd`（**active 判定の前提そのもの**） |
| AC2 (#4003) | 同上 | `[W6]`-`[W8]` 各曜日 / 月またぎ / 年またぎ / 引数指定 |
| **AC3 (#4020)** | `tests/unit/routes/child-home-must-bonus-jst.test.ts` | **新規 8 件** (2026-07-29 追加)。`load` を実際に呼び、**load → service → repo に渡る日付**を通しで固定する |
| AC3 (#4020) | 同上 | `[B1]` UTC 日曜 15:00 (JST 月曜 00:00) で当日集計 → `granted=true` / `+5pt` / ledger 1 行 |
| AC3 (#4020) | 同上 | `[B3]` 窓の内側で 2 回 load しても付与は 1 回 (冪等・演出 1 回限り) |
| AC2 (#4020) | 同上 | `[B0]` sentinel (`getTimezoneOffset()`) / `[B2]` fixture が 07-26 と 07-27 を区別することの対照 |
| AC1 (#4020) | 同上 | `[B5]` checklist / おすすめ活動も同じ JST 当日を受け取る (呼び出し 3 箇所すべて) |

**e2e を追加していない理由**は上記「なぜ e2e ではなく unit で固定したか」のとおり。既存 e2e 3 件は本修正で緑になる想定（実行時刻の窓に依存しなくなる）。

### 要件 2: AC 全項目完了（部分実装で closes 禁止）

- [ ] Issue の全 AC が本 PR で完了している（未実装の残件なし）

**チェックを外しています (QA 指摘 BLOCK-3、2026-07-29)。** 実装はすべて本 PR に入っていますが、**#4003 AC1 / AC5 の 2 件は軽量レーンでは原理的に検証できません**。

| AC | 状態 | 検証が行われる場所 |
|---|---|---|
| #4003 AC1 (本番相当で描画確認) | **未検証** | 統合 PR (`release/* → main`) の `e2e-test` 3 shard |
| #4003 AC5 (統合レーンの重量 job が緑) | **未検証** | 同上 + `a11y` |

重量 job は統合 PR でしか発火しません (`branch-strategy.md` の軽量 / 重量レーン分離)。これは**不足ではなく検証の場所が違う**もので、統合 PR の CI が緑になった時点で充足します。その merge が main へ届いて #4003 / #4020 が auto-close されるため、`closes` の紐付けは正当です。**「実行されなかった検証」と「実行されて通った検証」を同じ green として扱わない**ため、ここは `[x]` にしません (#4007 の root class)。

**加えて #4003 本文が挙げる「同 class の横展開」は本 PR に含めません。** `sibling-ranking-service.ts:30` の同型 `getWeekStart()` は未修正で残っており、これは #4015（112 箇所の棚卸し）の担当です。#4003 / #4020 の AC 自体には含まれていません。

### 要件 3: 提案全実装

- [x] Issue 本文の対応案を実装した
- 採用: **案A（`getWeekStart()` を JST 基準に変更）** + **案B（境界時刻を固定した unit 回帰）**
- **不採用: 案C（ローカル TZ 日付 getter を禁止する lint / fitness function）** — 47 file / 112 箇所の棚卸しを伴い critical 修正の scope を膨らませます。#4015 が既にその一般化 Issue として存在するため委譲します（Issue 本文も「案C は #4015 に委譲するのが妥当」としています）

### 要件 4: 全 5 年齢モードで実機検証 + スクリーンショット

**N/A（UI 非影響）+ 根拠**:

本 PR は**日付文字列の算出基準のみ**を変更しており、描画コード（`.svelte`）・スタイル・レイアウト・文言のいずれにも変更がありません（変更は `.ts` 3 file + テスト 2 file のみ）。年齢モードによる分岐にも触れていません（`home/+page.server.ts` の `baby` 早期 return は変更前後で不変）。

**ただし「表示が変わらない」わけではありません** — それが本修正の目的です。JST 00:00〜09:00 に限り、これまで消えていたバッジが出る / これまで埋まらなかったおやくそくが埋まる、という**正しい表示に戻ります**。この差分は 9 時間の窓の内側でしか観測できないため、SS ではなく `[W1]`-`[W5]` の境界テストで固定しています。

### 要件 5: 直近 30 日の同一ファイル変更 PR チェック

| ファイル | 直近 30 日の変更 | 本 PR との関係 |
|---|---|---|
| `src/lib/domain/date-utils.ts` | **該当なし** | — |
| `src/lib/server/services/child-challenge-service.ts` | `a220dc5a`（2026-07-15、#3284/#3342/#3356 ポイント台帳の原子化）/ `967e0a08`（2026-07-09、#3607 カテゴリ SSOT） | **関連なし**。いずれも日付算出に触れていない |
| `src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts` | `e047193f`（2026-07-17、#3799/#3800 opaque id guard）/ `cbb9d325`（2026-07-17、#3805 analytics 撤去）/ `70944029`（2026-07-16、#3581 trust 境界） | **関連なし**。いずれも日付算出に触れていない |

`getWeekStart()` の最終変更は 2026-07-01 (`84675c94`) で 30 日を超えており、**同一箇所の再修正ではありません**。

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`) — `child-challenge-service.ts` の `getWeekStart()`
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`) — `(child)/[uiMode]/home/+page.server.ts` の `todayDate()`
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`) — `date-utils.ts` に `weekStartJST()` を追加
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI

**影響を受ける画面・機能**: 子供ホーム（週次チャレンジバッジ / 今日のおやくそくバー / チェックリスト進捗 / おすすめ活動 / 全達成ボーナス）。**JST 00:00〜09:00 の時間帯のみ挙動が変わり、それ以外の 15 時間は完全に不変**

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/domain/week-start-jst.test.ts` — **新規 8 件**。`vi.setSystemTime` で窓の内外を固定
  - `tests/unit/services/child-challenge-service.test.ts` — `date-utils` の mock を `importOriginal` の**部分 mock** に変更（下記）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: 上記 5 要件を全て記載

### 副次的に直したもの — mock が全 export 差し替えで壊れやすかった

`weekStartJST` を追加したところ `child-challenge-service.test.ts` が **10 件まとめて落ちました**。

```
Error: [vitest] No "weekStartJST" export is defined on the "$lib/domain/date-utils" mock.
```

mock が `vi.mock(path, () => ({ todayDateJST }))` の**全 export 差し替え**だったため、date-utils に関数が 1 つ増えるだけで test file が全滅する構造でした。落ちた 10 件のうち 6 件は生成 / 冪等 / rescue 判定など**日付と無関係な test** です。

`importOriginal` の部分 mock に変更し、固定したい `todayDateJST` だけを差し替え、**曜日計算は実物を通す**ようにしました（mock で置き換えると検証対象そのものが消えるため）。

## スクリーンショット / ビジュアルデモ

**該当なし（UI 非影響）**。理由は「ADR-0002 要件 4」に記載。`.svelte` / `.css` / `site/` の変更ゼロ。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 日付算出の実装を `date-utils.ts`（SSOT）に置き、`getWeekStart()` は委譲のみ。callsite の署名は不変
- [x] **DRY**: `getLastWeekStart()` と同じ「文字列 → `Date.UTC` → `getUTC*`」の形に揃えた
- [x] **YAGNI**: lint / fitness function（案C）は本 PR に含めない（#4015 へ委譲）
- [x] **Security（OSS 公開前提）**: N/A
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: `Date` 生成 1 回。呼び出し頻度・計算量とも変化なし

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [x] **全年齢モード 5 種に横展開** — `home/+page.server.ts` は 5 モード共通の load。`baby` の早期 return は不変
- [ ] ナビゲーション 3 種に反映
- [x] E2E / ユニットシード + チュートリアルを同期 — e2e は `child_challenges` を seed せず当週自動生成に依存する設計のため、seed 変更は不要
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — **`docs/design/44-チャレンジ設計書.md` に §3.4a を新設した** (2026-07-29 追記)。当初は「`date-utils.ts` 冒頭の日時管理方針 (#966) が既に SSOT を宣言しているので不要」と判断したが、CI の `design-doc-check` が fail する。コード内コメントは設計書ではないため、週頭 (`weekStartJST`) / 今日 (`todayDateJST`) の SSOT と `Date` ローカル日付 getter の禁止を設計書側にも残した
- [x] 並行 PR overlap 確認 (#1200) — open PR #4028 / #4021 / #4019 / #4016 / #4010 / #3989 と変更ファイル重複なし

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [ ] このPRに破壊的変更は**含まれない**
- [x] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**既存 `child_challenges` 行との整合（未検証）**:

`start_date` の算出基準が変わるため、**移行週に UTC 週頭と JST 週頭が異なる行が既に存在する場合**、`idx_child_challenges_auto_weekly_unique(child_id, start_date)` 上で新規行が 1 本増える可能性があります。**DB を触っていないため未検証です。**

影響は「その週だけチャレンジが 2 本見える」で、データ破壊ではありません。ただし**確認せずに本番へ入れるべきではない**と考えており、レビューで判断を仰ぎたい点です。

**レビュー依頼事項・QA**:

1. **上記の既存行との整合**（移行週に auto:weekly が二重生成されないか）。staging で `child_challenges` を確認できると確実です
2. **要件 4 を「N/A（UI 非影響）」とした判断**。描画コードは触っていませんが、**表示結果は 9 時間の窓の内側で変わります**（それが修正の目的）。SS で示せない性質のため境界テストで代替しています
3. `sibling-ranking-service.ts:30` の同型未修正を本 PR に含めない判断（#4015 へ委譲）
4. ~~pg / DSQL 側 `child-challenge-repo` の active 判定が sqlite 版と同一条件かは未読です~~ → **PO が実読して closed (2026-07-29)**。`sqlite/child-challenge-repo.ts:53-65` と `dsql/child-challenge-repo.ts:144-145` は完全に一致し、`findActiveOrUnclaimed` も結果集合が同一。別 Issue は不要

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A（UI 非影響、根拠は要件 4）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)


## 追記 (2026-07-29): `design-doc-check` の赤を是正

必須 check `design-doc-check` が fail していた。

```console
##[error]❌ src/routes/ に変更がありますが、docs/design/ の更新がありません (ADR-0003)。
```

本 PR は `src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts` の「今日」の基準を変える。ユーザーに見える挙動が変わる (JST 00:00〜09:00 の 9 時間で表示が正しくなる) ため `refactor:internal-no-doc-impact` label の要件 (機能仕様変化なし) は満たさない。

`docs/design/44-チャレンジ設計書.md` に **§3.4a「日付境界の基準は JST SSOT に統一する」** を新設し、次を固定した:

- 週頭 = `weekStartJST(date?)` / 今日 = `todayDateJST()` を SSOT とする表
- `Date` のローカル日付 getter (`getFullYear` / `getMonth` / `getDate` / `getDay`) の使用禁止と、その理由 (本番 Lambda / CI runner は TZ 未設定 = UTC)
- 読み書きで基準がずれたときの実害 2 件 (#4003 週次チャレンジバッジの消失 / #4020 今日のおやくそく未反映)
- 回帰 test (`tests/unit/domain/week-start-jst.test.ts`) の位置づけ

**mutation で「doc を外すと fail する」ことを実測してから PASS と書いている:**

```console
$ PR_FILES="$(gh pr diff 4031 --name-only)
docs/design/44-チャレンジ設計書.md" PR_LABELS="..." node scripts/check-design-doc-sync.mjs
[pass] docs/design/ の同期更新あり     DESIGN_EXIT=0
$ (docs/design 行を外して同じコマンド)
[fail] src/routes/ に変更がありますが、docs/design/ の更新がありません (ADR-0003)。
```

`node scripts/check-doc-code-references.mjs` も exit 0 (baseline 内、新規違反なし)。


## 追記 (2026-07-29): QA BLOCK 対応 (BLOCK-1 / BLOCK-2 / BLOCK-3)

[QA 指摘](https://github.com/Takenori-Kusaka/ganbari-quest/pull/4031#issuecomment-5112454975) の 3 件と、PO の [案 A 採用 + BLOCK-2 格上げ](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4020#issuecomment-5112497230) を受けた対応です。

### BLOCK-1 (#4020 AC3) — 全達成ボーナスの窓を test で閉じた

**指摘は正確でした。** 直前の回帰 test (`week-start-jst.test.ts`) は週頭の算出だけを守っており、#4020 が挙げた顧客被害の筆頭 (**全達成ボーナスが付与されない = ポイントの欠損**) の経路を 1 行も守っていませんでした。

**なぜ service 単体の test では閉じないか**: `tryGrantMustCompletionBonus(childId, today, uiMode, tenantId)` は `today` を**引数で受け取るだけ**で、内部に TZ 依存を 1 つも持ちません (`activity-service.ts:444-491`)。欠陥は 100% 呼び出し側 (`home/+page.server.ts`) にあるため、service の unit を何本足しても窓は閉じません。

そこで **`load` を実際に呼び、load → service → repo に渡る日付を通しで固定する** test を追加しました。

`tests/unit/routes/child-home-must-bonus-jst.test.ts` (新規 8 件)

| test | 内容 |
|---|---|
| `[B0]` | sentinel: `expect(new Date('2026-07-26T21:00:00Z').getTimezoneOffset()).toBe(0)` で**実効 UTC** を確認。`expect(process.env.TZ).toBe('UTC')` は使わない (#4020 AC2 規約) |
| `[B2]` | **対照**: fixture が `2026-07-26` と `2026-07-27` を区別することを直接 assert (test が空振りでないことの証明) |
| `[B1]` | **UTC 日曜 15:00 (JST 月曜 00:00)** — `findMustActivitiesWithToday` に `2026-07-27` が渡り、`granted=true` / `points=5` / point_ledger 1 行 (`recorded_date=2026-07-27`)。`2026-07-26` で呼ばれていないことも assert |
| `[B3]` | 窓の内側で 2 回 load しても付与は 1 回 (冪等・演出 1 回限り) |
| `[B4]` / `[B4b]` | 窓の終端 (UTC 23:59 = JST 08:59) と窓の外 (UTC 月曜 00:00 = JST 09:00) |
| `[B5]` | checklist / おすすめ活動も同じ JST 当日を受け取る (**#4020 AC1 の 3 呼び出し全部**) |
| `[B6]` | baby は早期 return で `mustStatus=null` (ADR-0011) |

**fixture の作り方** — repo 層 (`$lib/server/db/activity-repo`) だけを日付キーの fake に差し替え、**service と `load` は実物**を使っています。fake の述語は実 backend を写しています。

- `findMustActivitiesWithToday` = `recorded_date = today AND cancelled = 0` (`sqlite/activity-repo.ts:294-303`)
- `insertPointLedger` の `recorded_date` = `todayDateJST()` (`dsql/point-write.ts:71` — 本番 backend の実装そのもの)
- `countPointLedgerEntriesByTypeAndDate` = `recorded_date = date` (`dsql/activity-repo.ts:513-519`)

**guard が guard として効くことの実測** (`dev-session.md`「QA 指摘の再発防止台帳」3 の観点)。修正を一時的に旧ローカル TZ 実装へ戻して実行しました。

```console
# 修正を旧実装 (new Date() のローカル日付要素) へ差し戻した状態
$ npx vitest run tests/unit/routes/child-home-must-bonus-jst.test.ts; echo "EXIT=$?"
     × [B1] UTC 日曜 15:00 (JST 月曜 00:00) — 当日で集計し、ボーナスが付与される
     × [B3] 窓の内側で 2 回 load しても付与は 1 回だけ (冪等 / 演出 1 回限り)
     × [B4] 窓の終端 UTC 23:59 (JST 08:59) でも同じ当日を見る
     × [B5] checklist / おすすめ活動も同じ JST 当日を受け取る (#4020 AC1 の 3 呼び出し)
 Test Files  1 failed (1)
      Tests  4 failed | 4 passed (8)
EXIT=1

# 修正を復元
$ npx vitest run tests/unit/routes/child-home-must-bonus-jst.test.ts; echo "EXIT=$?"
 Test Files  1 passed (1)
      Tests  8 passed (8)
EXIT=0
```

落ちたのは**窓に依存する 4 本だけ**で、窓の外の `[B4b]`・sentinel・対照・baby は通ったままです。差し戻しは検証後に復元済み (`git status` 差分ゼロを確認)。

### BLOCK-2 (#4020 AC1) — wrapper として残していた `todayDate` を削除した

**PO の格上げ判断に従い、BLOCK 条件として対応しました。** 直前の実装は `function todayDate() { return todayDateJST(); }` という wrapper で、**中身だけ JST に差し替えて名前を残していました**。

`validation/activity.ts:314` に `export { todayDateJST as todayDate }` という**同名の JST 別名**が存在するため、ローカル関数が同名で居る限り呼び出し側の見た目は JST 版と完全に一致し、grep でも目視でも区別できません。これは #4020 の 5 Whys の 4 (**名前による隠蔽** = 5 か月間検出されなかった直接の機構) そのものです。**挙動が等価でも、ここでの体裁は再発防止の本体**という PO の判断に同意します。

wrapper を削除し、3 箇所が `todayDateJST()` を直接呼ぶ形にしました (`:165` checklist / `:204` recommendation / `:237` bonus)。削除理由は同 file の doc comment にも残しています。

### BLOCK-3 — `[x] 全 AC 完了` を外し、AC 検証マップを Issue の AC 番号に 1:1 で揃えた

上記「AC 検証マップ」を #4003 AC1-AC5 / #4020 AC1-AC5 の 10 行に張り替え、「ADR-0002 要件 2」のチェックを外しました。**#4003 AC1 / AC5 は「未達」ではなく「軽量レーンでは原理的に検証できない」**もので、検証の場所は統合 PR の重量レーンです。その旨を要件 2 に明記しています。

`#4003 AC4` (同 class の時間依存走査) は **PO 側で実施済み**のため充足として扱っています ([issuecomment-5112497086](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4003#issuecomment-5112497086))。

## #4020 AC4 — `todayDate` 別名 re-export の判断

**判断: `src/lib/domain/validation/activity.ts:314` の `export { todayDateJST as todayDate }` は残します。**

根拠は 3 点です。

1. **本 PR で消したかった隠蔽機構は「同名のローカル定義が別 TZ 実装を持っていたこと」であり、別名 re-export 単体ではありません。** ローカル定義を削除した時点で「同じ名前が 2 つの意味を持つ」状態は解消しています。残った `todayDate` は**どこから呼んでも JST** です
2. **本 PR は critical 修正であり、scope を広げると回帰面が増えます。** `todayDate` の呼び出し側を機械的に数えると本体コードだけで複数 file にまたがり、リネームは「日付が 1 日ずれる」class の変更と同じ経路を触ります。ADR-0002 §4 (critical でも品質ゲート省略禁止) の趣旨からも、**別 PR で単独に検証すべき変更**です
3. **名前の統一そのものは #4015 の軸に乗ります。** #4015 は「ローカル TZ 日付 getter 112 箇所 / 47 file」の棚卸しと lint 化を扱っており、`todayDate` → `todayDateJST` への寄せはその一般化の一部として扱うのが自然です

**呼び出し側の変更は本 PR では 0 件**です (別名を残したため影響範囲なし)。

> **混同回避**: BLOCK-2 で削除したのは `home/+page.server.ts` のローカル関数であり、本節が扱う `validation/activity.ts:314` の別名 re-export とは**別の場所**です。PO も 7/27 に「本 PR では残す」と判断済みです。

## 副次の発見 (本 PR のスコープ外・regression ではありません)

`[B3]` の冪等 test を書く過程で、**全達成ボーナスの冪等判定が backend 間で非対称**であることを実読で確認しました。**本 PR が持ち込んだものではなく、本 PR で挙動が変わるものでもありません。**

| backend | 冪等 lookup の述語 | 比較対象 |
|---|---|---|
| **dsql** (cognito / 本番) | `recorded_date = ${date}` (`dsql/activity-repo.ts:513-519`) | `recorded_date` は書込時に `todayDateJST()` で導出 (`dsql/point-write.ts:71`) → **JST 同士で一致** |
| **sqlite** (NUC / local / test) | `date(created_at) = ${date}` (`sqlite/activity-repo.ts:752`) | `created_at` の default は `CURRENT_TIMESTAMP` = **UTC** (`schema.ts:188`) → `today` (JST) と**食い違う** |

sqlite backend では、JST 00:00〜09:00 の間に全達成した場合 `date(created_at)` が前日を返すため冪等判定が 0 件となり、**ホームを開き直すたびにボーナスが再加算されうる**という読みです。

- **本 PR の前後で NUC の挙動は不変です。** NUC は `docker-compose.yml:29` で `TZ=Asia/Tokyo` のため、修正前のローカル日付も修正後の `todayDateJST()` も**同じ JST 日付**を返します。したがって本 PR は NUC 側の入力を 1 文字も変えていません
- 既存 test (`tests/unit/services/activity-service.test.ts:566-574`) のコメントは、この非対称を**「テスト側の flake」として**記述しており、production の挙動としては扱われていません
- **[未確認]**: NUC 実機での再現は行っていません (コード実読のみ)

**起票は PO 判断に委ねます。** 本 PR には含めません (#4020 / #4003 の AC 外であり、critical 修正の scope を広げないため)。
