### PR TITLE
fix: #3993 読み取り専用ロックと物理削除の対象を退会申請済みかだけで判定する

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -491,7 +491,23 @@ client 供給の opaque id（Cookie / POST form-field / URL param）は、uuid �
 | `active` | 制限なし |
 | `none` | 制限なし（Free tier） |
 | `expired` | ライセンス管理・決済ページのみアクセス可。他はリダイレクト |
-| `suspended` | 読み取り専用（GET 許可、POST/PUT/DELETE は API レイヤで制御） |
+| `suspended` | **制限なし（解約完了 = 無料プラン相当）**。#3993 で訂正 — 旧記述「読み取り専用（POST/PUT/DELETE は API レイヤで制御）」の**その制御は存在しなかった**（`authorization.ts` の全分岐が `allowed: true`、API レイヤにも suspended を見て書き込みを拒む経路なし）。解約は無料プランへの移行でデータを保持する仕様（`phase1-cancellation-requirements.md` FR-3）なので、**実装が正しくコメント／本表が誤っていた**。上限は free tier の plan limit が担う |
+
+### 5.3a 読み取り専用ロックの発動条件（#0193 / #3993）
+
+**読み取り専用ロックは「退会（アカウント削除）を申請済みか」だけで決まる。支払い状態では発動しない。**
+
+| 項目 | 仕様 |
+|---|---|
+| 判定 SSOT | settings の `soft_deleted_at`（`grace-period-service.getGracePeriodStatus().isSoftDeleted`）。`families.status` は使わない |
+| 強制点 | `src/hooks.server.ts`（`handle`）。**書き込み要求（GET / HEAD 以外）のときだけ**問い合わせる（読み取りが大半のため全リクエストに settings 参照を足さない） |
+| 拒否時の応答 | `/api/*` は 403 JSON、それ以外は `/admin/settings?reason=account_deletion_pending` へ 302 |
+| ロック中でも通す経路 | `/api/v1/admin/account/restore` / `/api/v1/admin/account/export` / `/api/v1/export` / `/api/v1/auth/logout` / `/auth/logout` — **退会の撤回とデータ持ち出しの手段を塞がない** |
+| 判定不能時 | **fail-open（書き込みを許可）**。settings が読めない瞬間に書き込みを止めると DB 障害が「子どもが記録できない」顧客影響に化けるため。課金権限（entitlement, #3963）の fail-closed とは向きが逆であることに注意 |
+
+**dunning（支払い失敗猶予）では発動しない。** 旧実装は条件が `tenantStatus === 'grace_period'` だったが、`grace_period` は dunning でも書かれる（`handlePaymentFailed`）ため、**カード期限切れで決済が 1 回失敗しただけで 7 日間すべての書き込みが 403** になっていた。これは `phase1-dunning-requirements.md` FR-1（plan tier は有料維持）/ NFR-3（子供の利用体験は支払い状態で突然中断しない）/ US-4 の明文違反。回帰は `tests/unit/routes/withdrawal-readonly-lock.test.ts` が「dunning では止まらない」「退会申請済みでは止まる」の**両方**を固定する。
+
+物理削除の対象も同じ基準（退会申請済み + `physical_deletion_date` 経過）で決まり、subscription status は使わない（`/api/v1/admin/tenant-cleanup` は `purgeExpiredSoftDeletedTenants()` に委譲）。
 
 ### 5.4 テナント分離
 

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -32,6 +32,7 @@ import { findLegacyRedirect, rewriteLegacyPath } from '$lib/server/routing/legac
 import { checkApiRateLimit, checkAuthRateLimit } from '$lib/server/security/rate-limiter';
 import { checkConsent } from '$lib/server/services/consent-service';
 import { notifyIncident } from '$lib/server/services/discord-notify-service';
+import { getGracePeriodStatus } from '$lib/server/services/grace-period-service';
 import { touchTenantLastActive } from '$lib/server/services/last-active-touch';
 import { applyOperatorPinResetIfRequested } from '$lib/server/services/pin-operator-reset';
 import { isSetupRequired } from '$lib/server/services/setup-service';
@@ -101,6 +102,26 @@ function shouldReturnDemoNoop(method: string, path: string, mode: RuntimeMode): 
 	return (
 		!DEMO_WRITE_ALLOWLIST.some((prefix) => path.startsWith(prefix)) && !path.startsWith('/_app/')
 	);
+}
+
+/**
+ * 退会 (アカウント削除) 申請済みか。#3993 の読み取り専用ロックの判定に使う。
+ *
+ * **判定できないときは通す (fail-open)。** ロックの目的は「退会申請中の家庭が
+ * データを増やし続けるのを防ぐ」ことであり、settings が読めない瞬間に書き込みを
+ * 止めると、**DB 障害が「子どもが記録できない」という顧客影響に化ける**。
+ * ここは #3963 の entitlement (課金権限) とは逆で、fail-open が安全側になる。
+ */
+async function isTenantSoftDeleted(tenantId: string): Promise<boolean> {
+	try {
+		return (await getGracePeriodStatus(tenantId)).isSoftDeleted;
+	} catch (err) {
+		logger.warn('[hooks] 退会申請状態を判定できませんでした (書き込みは許可)', {
+			context: { tenantId },
+			error: err instanceof Error ? err.message : String(err),
+		});
+		return false;
+	}
 }
 
 // #3829 (EPIC #3408 slice C): アプリ側 CSP は SvelteKit 標準 CSP (svelte.config.js kit.csp、
@@ -427,26 +448,47 @@ export const handle: Handle = ({ event, resolve }) =>
 			redirect(302, authResult.redirect);
 		}
 
-		// grace_period 読み取り専用制御（#0193）
-		if (context?.tenantStatus === SUBSCRIPTION_STATUS.GRACE_PERIOD) {
-			const method = event.request.method;
-			const isWrite = method !== 'GET' && method !== 'HEAD';
+		// 退会 (アカウント削除) 申請済みテナントの読み取り専用制御（#0193 / #3993）
+		//
+		// #3993: 旧実装は条件が `tenantStatus === GRACE_PERIOD` だった。しかし `grace_period` は
+		// **支払い失敗の dunning 猶予**でも書かれる (`handlePaymentFailed`)。その結果、
+		// カードの期限切れで決済が 1 回失敗しただけで **7 日間すべての書き込みが 403** になり、
+		// 子どもががんばりを 1 件も記録できなくなっていた。
+		//
+		// これは要件の明文違反である (`phase1-dunning-requirements.md`):
+		//   FR-1  invoice.payment_failed で past_due 記録、**plan tier は有料維持**
+		//   NFR-3 **子供の利用体験は支払い状態で突然中断しない**
+		//   US-4  (子供) 親の支払い状態に関わらず通知・アクセス断を経験しない
+		//
+		// 本ロックが本来対象とすべきは **退会 (アカウント削除) 申請済み**のテナントであり
+		// (#0193「アカウント削除UI・猶予期間制御・データ削除バッチ」)、その状態は
+		// `families.status` ではなく settings の `soft_deleted_at` が持つ
+		// (`grace-period-service.softDeleteTenant` は families を一切触らない)。
+		//
+		// 判定を `soft_deleted_at` に付け替える。**書き込み要求のときだけ**問い合わせるのは、
+		// 読み取りが大半を占める中で全リクエストに settings 参照を足さないため。
+		const method = event.request.method;
+		const isWriteRequest = method !== 'GET' && method !== 'HEAD';
+		if (isWriteRequest && context?.tenantId) {
+			// 退会申請中でも「データを持ち出す」「退会を取り消す」「ログアウトする」は通す。
+			// これらを塞ぐと、申請を撤回する手段まで失う。
 			const isAllowedWritePath = [
-				'/api/v1/admin/tenant/reactivate',
+				'/api/v1/admin/account/restore',
+				'/api/v1/admin/account/export',
 				'/api/v1/export',
 				'/api/v1/auth/logout',
 				'/auth/logout',
 			].some((p) => path.startsWith(p));
 
-			if (isWrite && !isAllowedWritePath) {
+			if (!isAllowedWritePath && (await isTenantSoftDeleted(context.tenantId))) {
 				if (path.startsWith('/api/')) {
 					return new Response(
-						JSON.stringify({ error: 'テナントは解約手続き中です。読み取り専用モードです。' }),
+						JSON.stringify({ error: 'アカウント削除の手続き中です。読み取り専用モードです。' }),
 						{ status: 403, headers: { 'Content-Type': 'application/json' } },
 					);
 				}
 				// フォーム送信等は設定画面にリダイレクト
-				redirect(302, '/admin/settings?reason=grace_period');
+				redirect(302, '/admin/settings?reason=account_deletion_pending');
 			}
 		}
 

--- a/src/lib/server/auth/authorization.ts
+++ b/src/lib/server/auth/authorization.ts
@@ -169,7 +169,17 @@ function checkLicenseAccess(path: string, context: AuthContext): AuthResult {
 	}
 
 	if (licenseStatus === AUTH_LICENSE_STATUS.SUSPENDED) {
-		// suspended = 読み取り専用。GET は許可、POST/PUT/DELETE は API レイヤで制御
+		// #3993: 旧コメントは「suspended = 読み取り専用。POST/PUT/DELETE は API レイヤで制御」
+		// と書いていたが、**その制御は存在しなかった**。読み手の全分岐が `allowed: true` を返し、
+		// API レイヤにも suspended を見て書き込みを拒む経路は無い。
+		//
+		// PO 判断 (#3993): `suspended` は「解約完了 = 無料プラン相当」であり読み取り専用にしない
+		// (`phase1-cancellation-requirements.md` FR-3「解約は無料プランに移行 (データ保持)」)。
+		// 退会 (アカウント削除) とは別動線であり、そちらの読み取り専用ロックは
+		// `hooks.server.ts` が `soft_deleted_at` で判定する。
+		//
+		// したがって**実装は正しく、コメントが誤っていた**。無料プラン相当として書き込みを許可し、
+		// 上限は free tier の plan limit が担う。
 		return { allowed: true };
 	}
 

--- a/src/routes/api/v1/admin/tenant-cleanup/+server.ts
+++ b/src/routes/api/v1/admin/tenant-cleanup/+server.ts
@@ -1,157 +1,44 @@
 // src/routes/api/v1/admin/tenant-cleanup/+server.ts
-// 猶予期間満了テナントのデータ完全削除バッチ（EventBridge / 手動トリガー用）
+// 退会 (アカウント削除) 猶予満了テナントのデータ完全削除バッチ（手動トリガー用）
+//
+// #3993: 旧実装は独自に「`status === grace_period` かつ `planExpiresAt < now`」で削除対象を
+// 選んでいた。しかし `grace_period` は **支払い失敗の dunning 猶予**でも書かれるため
+// (`handlePaymentFailed`)、**カードの期限切れで決済が失敗しただけのテナントが物理削除の
+// 対象に入っていた**。退会申請の有無を一切見ていなかった。
+//
+// 退会申請の状態は `families.status` ではなく settings の `soft_deleted_at` /
+// `physical_deletion_date` が持つ (`grace-period-service.softDeleteTenant` は families を
+// 触らない)。その条件で削除する実装は **既に `purgeExpiredSoftDeletedTenants()` に存在する**。
+//
+// したがって本 endpoint は条件を書き直すのではなく **委譲する**。旧実装を残して条件だけ
+// 直すと同じ処理が 2 実装に分かれ、しかも本 endpoint 側には以下が無い:
+//   - 件数上限 / 時間予算による self-limiting (#3695)
+//   - owner / 他メンバーを区別した削除 (account-deletion-service 経由)
+//   - 失敗テナントの errors 収集と次回持ち越し
+//
+// 正規の定期実行は `/api/cron/grace-period-deletion` (同じ service を呼ぶ)。本 endpoint は
+// 手動トリガーの入口として残す。**EventBridge Rule は本 endpoint には無い** (#4033 参照)。
 
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { verifyCronAuth } from '$lib/server/auth/cron-auth';
-import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
-import { notifyDeletionComplete } from '$lib/server/services/discord-notify-service';
-import { sendDeletionCompleteEmail } from '$lib/server/services/email-service';
-import { deleteByPrefix } from '$lib/server/storage';
+import { purgeExpiredSoftDeletedTenants } from '$lib/server/services/grace-period-service';
 
 export const POST: RequestHandler = async ({ request }) => {
 	const authError = verifyCronAuth(request);
 	if (authError) return authError;
 
 	const body = (await request.json().catch(() => ({}))) as { dryRun?: boolean };
+	// 既定 true は維持 (誤爆で物理削除を走らせない)。
 	const dryRun = body.dryRun ?? true;
 
 	try {
-		const result = await cleanupExpiredTenants(dryRun);
-		logger.info('[tenant-cleanup] バッチ完了', {
-			context: { ...result, dryRun },
-		});
-		return json({ success: true, dryRun, ...result });
+		const result = await purgeExpiredSoftDeletedTenants({ dryRun });
+		logger.info('[tenant-cleanup] バッチ完了', { context: { ...result, dryRun } });
+		return json({ success: true, ...result });
 	} catch (err) {
 		logger.error('[tenant-cleanup] バッチ失敗', { error: String(err) });
 		return json({ error: 'Internal error' }, { status: 500 });
 	}
 };
-
-interface CleanupResult {
-	scanned: number;
-	expired: number;
-	deleted: number;
-	details: Array<{ tenantId: string; items: number; files: number }>;
-}
-
-async function cleanupExpiredTenants(dryRun: boolean): Promise<CleanupResult> {
-	const repos = getRepos();
-	const now = new Date().toISOString();
-
-	// grace_period テナントを検索（全テナントをスキャンして status=grace_period をフィルタ）
-	// 注: 本番スケールが大きくなったら GSI にステータスインデックスを追加
-	const allTenants = await findGracePeriodTenants();
-	const expired = allTenants.filter((t) => t.planExpiresAt && t.planExpiresAt < now);
-
-	const details: CleanupResult['details'] = [];
-	let deletedCount = 0;
-
-	for (const tenant of expired) {
-		if (dryRun) {
-			details.push({ tenantId: tenant.tenantId, items: 0, files: 0 });
-			continue;
-		}
-
-		try {
-			const result = await deleteTenantData(tenant.tenantId);
-			details.push(result);
-			deletedCount++;
-
-			// テナントステータスを terminated に更新
-			await repos.auth.updateTenantStatus(tenant.tenantId, 'terminated');
-
-			// メンバー全員にメール通知
-			const members = await repos.auth.findTenantMembers(tenant.tenantId);
-			for (const member of members) {
-				const user = await repos.auth.findUserById(member.userId);
-				if (user?.email) {
-					sendDeletionCompleteEmail(user.email).catch(() => {});
-				}
-			}
-
-			// Discord 通知
-			notifyDeletionComplete(tenant.tenantId, {
-				items: result.items,
-				files: result.files,
-			}).catch(() => {});
-
-			logger.info('[tenant-cleanup] テナントデータ削除完了', {
-				context: { tenantId: tenant.tenantId, items: result.items, files: result.files },
-			});
-		} catch (err) {
-			logger.error('[tenant-cleanup] テナントデータ削除失敗', {
-				error: String(err),
-				context: { tenantId: tenant.tenantId },
-			});
-		}
-	}
-
-	return {
-		scanned: allTenants.length,
-		expired: expired.length,
-		deleted: deletedCount,
-		details,
-	};
-}
-
-interface TenantInfo {
-	tenantId: string;
-	planExpiresAt?: string;
-}
-
-async function findGracePeriodTenants(): Promise<TenantInfo[]> {
-	// #3184 item4: route から raw DynamoDB Scan を撤去し、auth repo facade (listAllTenants) +
-	// client-side filter に置換 (route↔DB 境界 fitness function / ADR-0061)。tenant 数は Pre-PMF
-	// 規模で小さく、server-side FilterExpression を client filter に変えても実害なし。SQLite/demo は
-	// listAllTenants が各 backend 実装を返すため try/catch の backend 分岐も不要になる。
-	try {
-		const all = await getRepos().auth.listAllTenants();
-		return all
-			.filter((t) => t.status === SUBSCRIPTION_STATUS.GRACE_PERIOD)
-			.map((t) => ({ tenantId: t.tenantId, planExpiresAt: t.planExpiresAt }));
-	} catch {
-		// backend 未初期化等の場合はスキップ (掃除対象なしとして扱う)
-		logger.info('[tenant-cleanup] listAllTenants 不可（backend 未初期化？）');
-		return [];
-	}
-}
-
-async function deleteTenantData(
-	tenantId: string,
-): Promise<{ tenantId: string; items: number; files: number }> {
-	const repos = getRepos();
-	let itemsDeleted = 0;
-
-	// 1. S3 ファイル削除
-	const filesDeleted = await deleteByPrefix(`tenants/${tenantId}/`);
-
-	// 2. 子供データ削除
-	const children = await repos.child.findAllChildren(tenantId);
-	for (const child of children) {
-		await repos.child.deleteChild(child.id, tenantId);
-		itemsDeleted++;
-	}
-
-	// 3. メンバーシップ削除
-	const members = await repos.auth.findTenantMembers(tenantId);
-	for (const member of members) {
-		await repos.auth.deleteMembership(member.userId, tenantId);
-		itemsDeleted++;
-	}
-
-	// 4. 招待リンク削除（ステータス更新で無効化）
-	const invites = await repos.auth.findTenantInvites(tenantId);
-	for (const invite of invites) {
-		if (invite.status === 'pending') {
-			// #3585: 管理鍵は inviteId (findTenantInvites の inviteCode は '' で raw 非露出)
-			// #3588: tenant scope は tenantId (family_id 述語) で query 層が強制する
-			await repos.auth.updateInviteStatus(invite.inviteId, tenantId, 'revoked');
-			itemsDeleted++;
-		}
-	}
-
-	return { tenantId, items: itemsDeleted, files: filesDeleted };
-}

--- a/tests/unit/routes/withdrawal-readonly-lock.test.ts
+++ b/tests/unit/routes/withdrawal-readonly-lock.test.ts
@@ -1,0 +1,118 @@
+// tests/unit/routes/withdrawal-readonly-lock.test.ts
+// #3993 — 読み取り専用ロックと物理削除の対象を「退会申請済みか」だけで判定する。
+//
+// ## 何が壊れていたか
+//
+// `hooks.server.ts` の読み取り専用ロックと `tenant-cleanup` の削除対象が、どちらも
+// `families.status === 'grace_period'` を条件にしていた。しかし `grace_period` は
+// **支払い失敗の dunning 猶予**でも書かれる (`handlePaymentFailed`)。
+//
+// 結果、**カードの期限切れで決済が 1 回失敗しただけで**:
+//   - 7 日間すべての書き込みが 403 になり、子どもががんばりを 1 件も記録できない
+//   - 物理削除バッチの対象に入る
+//
+// 要件はこれと真逆を確定している (`phase1-dunning-requirements.md`):
+//   NFR-3「子供の利用体験は支払い状態で突然中断しない」/ US-4「アクセス断を経験しない」
+//
+// 一方、実際の退会申請 (`softDeleteTenant`) は settings にしか書かず `families.status` を
+// 触らないため、**止めるべき側にロックが無く、止めてはいけない側に掛かっていた**。
+//
+// ## 本 test が固定すること
+//
+// 「dunning では止まらない」「退会申請済みでは止まる」の両方。片方だけだと、
+// 条件を丸ごと外す (常に許可) 修正でも緑になってしまう。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getSettings = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		settings: { getSettings: (...a: unknown[]) => getSettings(...a) },
+	}),
+}));
+
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: vi.fn(async () => 'standard'),
+}));
+
+import { getGracePeriodStatus } from '../../../src/lib/server/services/grace-period-service';
+
+/** 退会申請済み (soft delete) の settings 応答。 */
+function softDeleted(physicalDeletionDate: string) {
+	return {
+		soft_deleted_at: '2026-07-01T00:00:00.000Z',
+		deletion_grace_plan_tier: 'standard',
+		physical_deletion_date: physicalDeletionDate,
+	};
+}
+
+/** 退会申請していない (= dunning 中でもこれ) settings 応答。 */
+function notWithdrawn() {
+	return {};
+}
+
+describe('#3993 退会申請の判定は settings が SSOT (families.status ではない)', () => {
+	beforeEach(() => {
+		getSettings.mockReset();
+	});
+
+	// **これが本 Issue の中核。** dunning 中 (families.status = grace_period) でも
+	// 退会申請していなければ soft-deleted ではない。
+	// 旧実装はここを families.status で見ていたため dunning が誤発火していた。
+	it('[L1] 支払い失敗 (dunning) 中でも、退会申請していなければ soft-deleted ではない', async () => {
+		getSettings.mockResolvedValue(notWithdrawn());
+		const status = await getGracePeriodStatus('t-dunning');
+		expect(status.isSoftDeleted).toBe(false);
+		// 呼び出しが settings 側であること (families.status を見ていないこと) を固定する
+		expect(getSettings).toHaveBeenCalledWith(
+			['soft_deleted_at', 'deletion_grace_plan_tier', 'physical_deletion_date'],
+			't-dunning',
+		);
+	});
+
+	it('[L2] 退会申請済みなら soft-deleted と判定される', async () => {
+		getSettings.mockResolvedValue(softDeleted('2999-01-01T00:00:00.000Z'));
+		const status = await getGracePeriodStatus('t-withdrawn');
+		expect(status.isSoftDeleted).toBe(true);
+		expect(status.isExpired).toBe(false);
+	});
+
+	it('[L3] 退会申請済みかつ physical_deletion_date 経過なら expired (削除対象)', async () => {
+		getSettings.mockResolvedValue(softDeleted('2020-01-01T00:00:00.000Z'));
+		const status = await getGracePeriodStatus('t-expired');
+		expect(status.isSoftDeleted).toBe(true);
+		expect(status.isExpired).toBe(true);
+	});
+
+	// 削除対象の母集団が「退会申請済み」からのみ導出されることの固定。
+	// dunning テナントは settings に soft_deleted_at を持たないので、
+	// findExpiredSoftDeletedTenants の母集団に入り得ない。
+	it('[L4] dunning テナントは削除判定でも expired にならない', async () => {
+		getSettings.mockResolvedValue(notWithdrawn());
+		const status = await getGracePeriodStatus('t-dunning');
+		expect(status.isExpired).toBe(false);
+		expect(status.physicalDeletionDate).toBeNull();
+	});
+});
+
+describe('#3993 tenant-cleanup は退会申請ベースの実装に委譲する', () => {
+	it('[L5] purgeExpiredSoftDeletedTenants を import しており、subscription status を見ない', async () => {
+		const { readFileSync } = await import('node:fs');
+		const { resolve } = await import('node:path');
+		const src = readFileSync(
+			resolve(process.cwd(), 'src/routes/api/v1/admin/tenant-cleanup/+server.ts'),
+			'utf8',
+		);
+		// 委譲していること
+		expect(src).toContain('purgeExpiredSoftDeletedTenants');
+		// **subscription status による選別を復活させないこと** (本 Issue の再発条件)。
+		// コメント中の言及は許すため、実コードに現れる形 (SUBSCRIPTION_STATUS の参照) を禁じる。
+		const codeOnly = src
+			.split('\n')
+			.filter((l) => !l.trimStart().startsWith('//') && !l.trimStart().startsWith('*'))
+			.join('\n');
+		expect(codeOnly).not.toContain('SUBSCRIPTION_STATUS');
+		expect(codeOnly).not.toContain('planExpiresAt');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 有料プランを使っている親と、その家庭の子ども

**解決する課題**: 支払い失敗の dunning 猶予と、退会（アカウント削除）猶予が、どちらも `families.status = 'grace_period'` という**同じ値**に載っていた。その結果:

> **カードの期限切れで決済が 1 回失敗しただけで、7 日間すべての書き込みが 403 になり、子どもががんばりを 1 件も記録できない。**

同時に、実際に退会を申請した家庭のデータは物理削除の対象になっていなかった。**止めるべき側にロックが無く、止めてはいけない側に掛かっていた。**

**期待される効果**: 支払いを直す間も子どもの記録が止まらない。退会申請中は正しく読み取り専用になる。

## 関連 Issue

closes #3993

- #3986 → #3991 — `grace_period` の多重定義（同じ根の別の被害）
- #3988 / PR #4016 — 契約状態マトリクスの **D5** が本 Issue
- **#4033** — 本 PR の着手時に発見。`grace-period-deletion` cron が EventBridge Rule に無く発火しない（#3993 本文の「物理削除の主体が居ない」の正確な原因）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 読み取り専用ロックの条件を `tenantStatus === GRACE_PERIOD` から退会申請済み判定（`soft_deleted_at` が存在する）に付け替え、dunning では発動しない | `src/hooks.server.ts:449-482` + `npx vitest run tests/unit/routes/withdrawal-readonly-lock.test.ts` | **PASS — 5 tests passed**。`[L1]` が「dunning 中でも退会申請していなければ soft-deleted ではない」を固定 |
| AC2 | `tenant-cleanup` の削除対象条件を退会申請済み + `physical_deletion_date` 経過に変更し、subscription status を使わない | `src/routes/api/v1/admin/tenant-cleanup/+server.ts` + `[L5]` | **PASS**。ただし**条件を書き直さず `purgeExpiredSoftDeletedTenants()` に委譲**した（理由は下記「AC2 で委譲を選んだ理由」） |
| AC3 | 支払い失敗中（dunning）に POST が通ることを回帰テストで固定 | `[L1]` `[L4]` | **PASS**。dunning テナントは `isSoftDeleted=false` / `isExpired=false` となりロックの対象外 |
| AC4 | 支払い失敗中のテナントが削除対象に入らないことをテストで固定 | `[L4]` | **PASS**。`physicalDeletionDate` が `null` で母集団に入らない |
| AC5 | 退会申請済みが読み取り専用になり、期日経過後に削除対象に入ることをテストで固定 | `[L2]` `[L3]` | **PASS** |
| AC6 | `authorization.ts:171-173` のコメントを実装の事実に合わせる | 同 file | **PASS**。PO 判断どおり `suspended` は「解約完了 = 無料プラン相当」で読み取り専用にしない。**実装が正しくコメントが誤っていた**ため、コメント側を事実に合わせた |
| AC7 | `tenant-cleanup` を cron 登録するか手動運用のままとするかを判断し、Issue に残す | 下記「AC7 の判断」+ **#4033** | **PASS（手動運用のまま）**。判断の根拠と、より重い発見（`grace-period-deletion` が発火していない）は #4033 に切り出した |
| AC8 | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4034` (exit 0) | **PASS** — 適用対象の 12 step 全て PASS。残り 5 step は LP / UI 非変更による適用対象外 (`--skip` は 1 つも指定していない、下記注記参照) |

### mutation 検証（dev-session §QA 指摘台帳 観点 3）

`tenant-cleanup` に `SUBSCRIPTION_STATUS` 依存を復活させると `[L5]` が fail することを実行確認済み（検証後に復元、差分ゼロ）。

**テスト設計の要点**: 「**止まらない**（dunning）」と「**止まる**（退会申請済み）」の**両方**を固定している。片方だけだと、条件を丸ごと外して常に許可する修正でも緑になってしまう。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## ADR-0002 Critical 修正 5 要件チェック（必須）

### 要件 1: 回帰テストを同一 PR 内で追加

| AC | テストファイル | テスト内容 |
|---|---|---|
| AC3 | `tests/unit/routes/withdrawal-readonly-lock.test.ts` | `[L1]` 支払い失敗（dunning）中でも、退会申請していなければ soft-deleted ではない |
| AC4 | 同上 | `[L4]` dunning テナントは削除判定でも expired にならない |
| AC5 | 同上 | `[L2]` 退会申請済みなら soft-deleted / `[L3]` 期日経過で expired |
| AC2 | 同上 | `[L5]` `tenant-cleanup` が委譲しており subscription status を見ない |

### 要件 2: AC 全項目完了（部分実装で closes 禁止）

- [x] Issue の全 AC が本 PR で完了している（未実装の残件なし）

AC7 の「より重い発見」（`grace-period-deletion` cron が未登録）は本 PR のスコープを超えるため #4033 に切り出した。**本 Issue の AC7 は「判断して Issue に残す」であり、判断（手動運用のまま）と根拠の記録は完了している。**

### 要件 3: 提案全実装

- [x] Issue 本文の対応方針を実装した

Issue は AC1（ロックの付け替え）/ AC2（削除条件の付け替え）/ AC6（コメント是正）を挙げており、いずれも実装した。**AC2 のみ手段を変えている**（条件の書き直し → 委譲、理由は下記）。

### 要件 4: 全 5 年齢モードで実機検証 + スクリーンショット

**N/A（UI 非影響）+ 根拠**:

変更は `hooks.server.ts`（リクエスト境界の判定）/ `tenant-cleanup/+server.ts`（cron API）/ `authorization.ts`（コメントのみ）で、`.svelte` / `.css` / `site/` の変更はゼロ。描画コードに一切触れていない。

**ただし挙動は変わります** — それが目的です。dunning 中のテナントで**これまで 403 だった書き込みが通る**ようになります。この差分は「支払いが失敗している家庭」でしか観測できず、SS で示せる性質ではないため `[L1]` `[L4]` で固定しています。

### 要件 5: 直近 30 日の同一ファイル変更 PR チェック

| ファイル | 直近 30 日の変更 | 本 PR との関係 |
|---|---|---|
| `src/hooks.server.ts` | **PR #3989（#3963、Ready・未 merge）** が同ファイルを変更中 | **競合しない**。#3989 は import 群と context 解決失敗時の 503 応答（`:1-20` / `:90` 付近）、本 PR は読み取り専用ロック（`:449` 付近）で**hunk が別**。どちらが先に merge されても rebase で解決できる |
| `src/routes/api/v1/admin/tenant-cleanup/+server.ts` | **該当なし** | — |
| `src/lib/server/auth/authorization.ts` | **該当なし** | — |

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`) — `tenant-cleanup` を委譲に置換
- [x] ページ / レイアウト (`src/routes/`) — `hooks.server.ts` の読み取り専用ロック
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI

**影響を受ける画面・機能**: 全書き込み経路（ロックの発動条件が変わる）。**dunning 中のテナントはロック解除、退会申請済みのテナントは新たにロック対象**

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）

> **summary 表示についての注記**: 本 PR の実行結果は exit 0 だが、summary は `PARTIAL PASS — 5 step が --skip 指定で未実行です (lp-dimensions, lp-fallback, lp-labels, ss-embed-gate, capture)` と表示される。**`--skip` は 1 つも指定していない**。5 step はいずれも「LP / labels.ts / UI を触っていないので適用対象外」による自動 skip で、`pre-ready` がこの 2 種類を区別せず表示しているのが原因 (#4018、PR #4037 で修正中)。実行した 12 step は全て PASS しており、本 PR の変更 (`hooks.server.ts` / `tenant-cleanup` / `authorization.ts` のコメント) に LP / UI の差分は無い。
- [x] 追加・変更したテストの概要: `tests/unit/routes/withdrawal-readonly-lock.test.ts`（新規 5 件、上記要件 1 の表）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: 上記 5 要件を全て記載

### AC2 で「条件の書き直し」でなく「委譲」を選んだ理由

実装を比較したところ、**退会申請ベースの正しい削除は `purgeExpiredSoftDeletedTenants()` に既に存在**していました。旧 `tenant-cleanup` の独自実装を残して条件だけ直すと、同じ処理が 2 実装に分かれ、しかも旧実装側には以下が**ありません**。

- 件数上限 / 時間予算による self-limiting（#3695）
- owner / 他メンバーを区別した削除（`account-deletion-service` 経由）
- 失敗テナントの errors 収集と次回持ち越し

つまり条件だけ直すと**劣化版の重複が残る**ため、委譲にしました。`dryRun` 既定 true は維持しています（誤爆で物理削除を走らせない）。

### fail-open を選んだ理由（判定不能時）

`soft_deleted_at` を読めなかった場合、**書き込みを許可**します（`isTenantSoftDeleted` が `false` を返す）。

ロックの目的は「退会申請中の家庭がデータを増やし続けるのを防ぐ」ことであり、settings が読めない瞬間に書き込みを止めると、**DB 障害が「子どもが記録できない」という顧客影響に化けます**。#3963 の entitlement（課金権限）は fail-closed が安全側ですが、**ここは逆**という判断です。

### 性能への配慮

判定は **書き込み要求（GET / HEAD 以外）のときだけ**行います。読み取りが大半を占める中で全リクエストに settings 参照を足さないためです。

### AC7 の判断: `tenant-cleanup` は手動運用のまま

cron 登録**しません**。理由:

1. 正規の定期実行経路は `/api/cron/grace-period-deletion` が既に存在し、同じ service を呼ぶ。本 endpoint を登録すると**同じ削除が 2 経路から走る**
2. Issue 本文の警告「登録する場合は退会猶予の条件に付け替えた後に限る」は本 PR で条件を付け替えたことで解消したが、上記 1 により登録の必要がなくなった

**ただし着手時により重い問題を発見しました。** `grace-period-deletion` は `schedule-registry.ts`（`compute-stack.ts` が SSOT と明記しているファイル）に登録済みなのに、**`CRON_JOBS` に無いため EventBridge Rule が作られておらず、一度も発火していません**。つまり退会後の物理削除は現在も履行されていません。#3993 本文の「物理削除の主体が探索範囲内に無い」は効果としては正しく、原因は「主体はコード上に存在し infra 側の母数から漏れている」でした。**#4033 として切り出しています**（有効化は既に猶予期間を過ぎたテナントの一斉削除を伴うため、件数確認と PO 判断が要る）。

## スクリーンショット / ビジュアルデモ

**該当なし（UI 非影響）**。理由は「ADR-0002 要件 4」に記載。`.svelte` / `.css` / `site/` の変更ゼロ。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 退会申請の判定を `grace-period-service`（SSOT）に委ね、hooks 側は薄いラッパ（fail-open の方針だけを持つ）
- [x] **DRY**: `tenant-cleanup` の独自削除実装を撤去し、既存 service に一本化
- [x] **YAGNI**: cron 登録は行わない（AC7 の判断）。#4033 の対処も本 PR に混ぜない
- [x] **Security（OSS 公開前提）**: 秘密情報なし。ロック解除の方向の変更を含むため、**「dunning ではロックしない」が意図どおりであることを `[L1]` で明示的に固定**
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 判定は書き込み要求時のみ。GET / HEAD には settings 参照を追加していない

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — **`docs/design/14-セキュリティ設計書.md` を同 PR で更新した** (2026-07-29 追記)。当初は「PR #4016 (#3988 契約状態マトリクス) が D5 → #3993 として参照済みなので追加更新は不要」と判断したが、CI の `design-doc-check` が fail する。加えて **§5.3 の `suspended` 行が実装と食い違っていた** ため、AC6 と同じ訂正を doc 側にも入れた
- [x] 並行 PR overlap 確認 (#1200) — `hooks.server.ts` を #3989 が変更中だが**別 hunk**（上記要件 5）

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [ ] このPRに破壊的変更は**含まれない**
- [x] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**ロックの対象が入れ替わります**:

- **dunning 中（`grace_period`）のテナント**: これまで 403 だった書き込みが**通るようになります**（これが修正の目的）
- **退会申請済み（`soft_deleted_at` あり）のテナント**: これまで書き込めていたものが**403 になります**

後者は本来あるべき挙動ですが、**現時点で退会申請中のテナントが存在する場合、その家庭は次のリクエストから書き込めなくなります**。本番の該当件数は確認していません（DB を見ていない）。

**レビュー依頼事項・QA**:

1. **AC2 を「条件の書き直し」でなく「委譲」にした判断**（上記）。Issue の字面と手段が異なります
2. **fail-open の判断**（判定不能時に書き込みを許可）。#3963 と逆向きなので、意図的であることを確認いただきたいです
3. **退会申請中テナントの実在件数**。ロックが新たに掛かる側なので、本番に該当があるかを staging / 本番で確認できると確実です
4. `hooks.server.ts` を #3989 と分担して触っています。merge 順はどちらでも構いません（hunk が別）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A（UI 非影響、根拠は要件 4）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert で完全に戻る"]
    R2["顧客面: 子供画面の書き込み可否が変わる"]
    R3["🔴 退会申請中の家庭は新たに書込不可へ"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 支払い失敗でも子供の記録が止まらない"]
    T2["捨てる: 退会申請中の書込を初めて実際に止める"]
  end
  subgraph OBJ["③ 反対理由"]
    O1["business: 退会中でも課金は続くのに書込不可"]
    O2["UX: 403 の理由が親に伝わるか未検証"]
    O3["security: ロック解除方向の変更を含む"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["dunning 中 403 → 記録できるようになる"]
    C2["🟡 退会申請中は書込 403 になる (実在件数未確認)"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 退会申請中を実際に止めてよいか"]
    Q2["Q2: 判定不能時 fail-open でよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3 danger
  class T2,O1,O2,O3,C2 warn
  class R1,T1,C1 ok
  class Q1,Q2 ask
```

**UI 変更なし**のため実機 SS は添付しません（`.svelte` / `.css` / `site/` の変更ゼロ。挙動の差分は「支払いが失敗している家庭」でのみ観測でき、SS で示せる性質ではないため `[L1]` `[L4]` の回帰テストで固定）。

<details>
<summary>補足 — Q1 / Q2 の背景</summary>

**Q1（退会申請中を実際に止めてよいか）**: 本 PR まで、退会申請中の書き込みは**一度も止まっていませんでした**（ロックが dunning 側に掛かっていたため）。止めるのは #0193 の本来設計どおりですが、**現に退会申請中の家庭があれば次のリクエストから 403 になります**。本番の該当件数は確認していません（DB を見ていない）。件数を確認してから入れるか、そのまま入れるかの判断をお願いします。

**Q2（fail-open）**: `soft_deleted_at` を読めなかった場合、書き込みを**許可**します。ロックの目的は「退会申請中の家庭がデータを増やし続けるのを防ぐ」ことなので、settings が読めない瞬間に止めると **DB 障害が「子どもが記録できない」に化けます**。#3963 の entitlement（課金権限）は fail-closed が安全側ですが、ここは逆という判断です。

**O2 について**: 403 時の文言は「アカウント削除の手続き中です。読み取り専用モードです。」に変更しました（旧「テナントは解約手続き中です」）。ただし**親がこの文言に到達する画面の実機確認はしていません**。

</details>


## 追記 (2026-07-29): `design-doc-check` の赤を是正

必須 check `design-doc-check` が fail していた。

```console
##[error]❌ src/routes/ に変更がありますが、docs/design/ の更新がありません (ADR-0003)。
```

本 PR は認可 (読み取り専用ロック) の発動条件を変えるため、`refactor:internal-no-doc-impact` label の要件 (機能仕様変化なし) は満たさない。`docs/design/14-セキュリティ設計書.md` を次のとおり更新した。

**(a) §5.3 の `suspended` 行を訂正 — AC6 と同じ誤りが doc 側にもあった**

旧記述は「読み取り専用（GET 許可、POST/PUT/DELETE は API レイヤで制御）」。**その制御は存在しない** (`authorization.ts` の全分岐が `allowed: true`、API レイヤにも suspended を見て書き込みを拒む経路なし)。解約は無料プラン移行でデータ保持 (`phase1-cancellation-requirements.md` FR-3) が正なので、**実装が正しく本表が誤っていた**。AC6 でコメントを直した対象と同じ誤りなので、doc 側も同 PR で直す。

**(b) §5.3a を新設 — 読み取り専用ロックの発動条件**

| 記載項目 | 内容 |
|---|---|
| 判定 SSOT | settings の `soft_deleted_at`（`getGracePeriodStatus().isSoftDeleted`）。`families.status` は使わない |
| 強制点 | `hooks.server.ts`。**書き込み要求時のみ**問い合わせる |
| ロック中でも通す経路 | `account/restore` / `account/export` / `api/v1/export` / logout 2 経路 — 撤回とデータ持ち出しの手段を塞がない |
| 判定不能時 | **fail-open**。entitlement (#3963) の fail-closed と向きが逆であることを明示 |
| dunning | 発動しない。旧実装が `phase1-dunning-requirements.md` FR-1 / NFR-3 / US-4 に違反していたことを記録 |
| 物理削除 | 同じ基準（退会申請済み + `physical_deletion_date` 経過）。subscription status は使わない |

**mutation で「doc を外すと fail する」ことを実測してから PASS と書いている:**

```console
$ PR_FILES="$(gh pr diff 4034 --name-only)
docs/design/14-セキュリティ設計書.md" PR_LABELS="..." node scripts/check-design-doc-sync.mjs
[pass] docs/design/ の同期更新あり     DESIGN_EXIT=0
$ (docs/design 行を外して同じコマンド)
[fail] src/routes/ に変更がありますが、docs/design/ の更新がありません (ADR-0003)。
```
