### PR TITLE
docs: #4014 staging 実機検証 runbook を追加 — cognito + DSQL 経路の手順を固定する

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -146,6 +146,8 @@ npm run dev:cognito-signup  # signup ページは COGNITO_DEV_MODE 無しが必�
 | `DATA_SOURCE=demo` | `createInvite` が非永続 stub (一覧に出ず受諾不可) |
 | `DATA_SOURCE=pglite` | `DEV_USERS` の tenant id が非 UUID のため uuid 型 column で 22P02 (全 admin ページ 500) |
 
+cognito + DSQL 経路 (招待 / メンバー / 課金状態の解決) を staging で実機検証する手順は [runbooks/staging-live-verification.md](runbooks/staging-live-verification.md) が SSOT。
+
 ## 巨大 docs refactor PR 分割ガイドライン (#2225)
 
 #2223 (Epic 2 / 142 file) / #2224 (Epic 3 / 146 file) で連続発生した「docs/sessions/ SSOT 削除 + 60+ ファイル参照未更新 + 機械生成ツール暴走」(両 PR BLOCK / Close) の構造的再発防止。

--- a/docs/runbooks/staging-live-verification.md
+++ b/docs/runbooks/staging-live-verification.md
@@ -77,6 +77,7 @@ aws logs tail /aws/lambda/ganbari-quest-staging-app --region us-east-1 --since 1
 - **`DEV_USERS`（`src/lib/server/auth/providers/cognito-dev.ts`）は staging に存在しない**。あれは `COGNITO_DEV_MODE` 前提のローカル専用定義で、staging Lambda env に `COGNITO_DEV_MODE` は入っていない。
 - **staging DSQL には seed 配線が無い**（`docs/design/staging-synthetic-seed.md` §5「AWS staging: 構造準備済 / 配線は #2873」）。検証対象の家族データは、sign-up して自分で作ったものになる。
 - サインアップ確認メールは Cognito default email 送信（SES 非構成）。届かない場合は §6 の gap に従いオーナーに依頼する。
+- **検証が終わったら作成した Cognito ユーザーを削除する**（`aws cognito-idp admin-delete-user --user-pool-id <staging pool id> --username <検証用ユーザー>`）。放置すると staging に検証者の実メールアドレスが残り続ける。削除権限が無い場合はオーナーに依頼する。
 
 ## 6. Step 4 — DSQL の対象行を書き換える / 戻す
 
@@ -96,11 +97,13 @@ aws dsql generate-db-connect-admin-auth-token --hostname "$DSQL_ENDPOINT" \
   --region us-east-1 --expires-in 3600
 ```
 
+> **トークンの取扱い**: 有効期限は 3600 秒（`--expires-in` の値）。**PR body / Issue / チャットに貼らない**、シェル履歴に残さない（変数へ代入するか `HISTCONTROL=ignorespace` 下で先頭スペース付き実行）、検証完了後は変数を破棄（`unset`）してターミナルを閉じる。`aws dsql` は AWS CLI v2 の新しめのバージョンでのみ提供されるサブコマンド。`aws dsql help` が引けない場合は CLI を最新に更新してから再実行する（リポジトリ内の DSQL 経路は SDK 実装で CLI の前例が無いため、初回実行者は先に疎通を確認すること）。
+
 > **リポジトリに任意 SQL を流す汎用 CLI は無い**（`dsql:migrate` は migration 適用、`dsql:grant` は role 付与の専用ツール）。上記トークンを外部 PostgreSQL クライアント（psql 等）のパスワードとして渡して接続する。この接続方式は `docs/research/dsql-poc-phase1-results-2026-07-05.md` の実クラスタ PoC で確認されているが、**staging cluster で本 runbook 作成時に再実行はしていない**（§8 参照）。
 
 ### 6.2 書き換え手順（必ず 5 段で行う）
 
-`families.plan` の値は `src/lib/domain/constants/subscription-plan.ts`（`monthly` / `yearly` / `family-monthly` / `family-yearly` / `lifetime`）、`families.status` は `src/lib/domain/constants/subscription-status.ts`（`active` / `grace_period` / `suspended` / `terminated`）が SSOT。SSOT 外の値を入れると `families_status_ck` で拒否される。
+`families.plan` の値は `src/lib/domain/constants/subscription-plan.ts`（`monthly` / `yearly` / `family-monthly` / `family-yearly` / `lifetime`）、`families.status` は `src/lib/domain/constants/subscription-status.ts`（`active` / `grace_period` / `suspended` / `terminated`）が SSOT。**DB が拒否するのは `status` だけ**（`families_status_ck`）で、**`plan` には CHECK が無い**（`src/lib/server/db/dsql/schema.ts` の `families` 定義コメント: plans lookup 表参照のため CHECK を張らない）。SSOT 外の plan を書いても DB は黙って受理するので、投入前に値を目視確認すること（typo を「拒否されなかった = 正しい値」と誤認すると §7 の観測結果がバグか typo か切り分けられなくなる）。
 
 ```sql
 -- (1) 変更前の値を控える（この出力を PR body に貼る）
@@ -138,7 +141,7 @@ WHERE family_id = '<検証対象の family uuid>';
 
 再ログインせずに反映されるかを見る検証では、**書き換え後にログアウトしない**こと（Cookie を作り直すと「毎リクエスト DB から解決しているか」を確認できなくなる）。
 
-証跡は「(1) の SELECT 出力 → (2) の UPDATE → 観測結果（スクリーンショット / ログ）→ (5) の SELECT 出力」の順に PR body へ貼る。
+証跡は「(1) の SELECT 出力 → (2) の UPDATE → 観測結果（スクリーンショット / ログ）→ (5) の SELECT 出力」の順に PR body へ貼る。**本リポジトリは OSS 公開前提のため、貼付時に `family_id`（UUID）とメールアドレスをマスクする**（`family_id=<masked>` に置換するか、出力を貼らず「(1) と (5) の plan / status / plan_expires_at が一致することを確認した」と記す）。スクリーンショットに課金状態以外の識別情報が写り込んでいないかも貼る前に確認する。
 
 ## 8. 本 runbook が保証できない点
 

--- a/docs/runbooks/staging-live-verification.md
+++ b/docs/runbooks/staging-live-verification.md
@@ -3,6 +3,14 @@
 > **対象**: ローカルのどの backend でも実行されない `AUTH_MODE=cognito` + DSQL 経路（課金状態の解決 / entitlement / parent-gate / 招待・メンバー）を、AWS staging（`ganbari-quest-staging-app`）で 1 回通して観測するための手順。
 > **実行主体**: リリース発火 = GQ-Audit / 検証実行と証跡提出 = GQ-Dev / 秘匿値・権限の配置 = オーナー。
 
+## ⚠️ ステータス: 未実証（2026-07 時点）
+
+**本 runbook は通しで実行されていない。** 初回実行は Issue [#4099](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4099) で行う（検証主体 = オーナー（AWS SSO 対話ログインが必須）+ GQ-Audit（staging リリース発火））。
+
+未実証の 4 項目は [§8 本 runbook が保証できない点](#8-本-runbook-が保証できない点) を参照 — psql 接続と UPDATE / staging sign-up の確認コード到達性 / staging DSQL の初期データ / Stripe 経路の不在。
+
+初回実行で手順との齟齬が出た場合は、**本 runbook を是正してから**証跡とする。是正の結果として本ステータス見出しを撤去できることが #4099 の close 判定。
+
 ## 1. 適用範囲
 
 ### 本 runbook で検証する
@@ -147,4 +155,4 @@ WHERE family_id = '<検証対象の family uuid>';
 - [docs/design/staging-synthetic-seed.md](../design/staging-synthetic-seed.md) — PII-free 合成 seed の設計と配線状況
 - [docs/runbooks/dsql-restore.md](dsql-restore.md) — DSQL の backup / 復元
 - `.github/workflows/deploy-aws-staging.yml` / `infra/lib/compute-stack.ts` / `infra/lib/auth-stack.ts` / `infra/lib/env-config.ts`
-- Issue #2873（AWS staging stack）/ #3732（invite / members の local 検証不可）
+- Issue #2873（AWS staging stack）/ #3732（invite / members の local 検証不可）/ #4099（本 runbook の初回実行と gap 4 項目の確定）

--- a/docs/runbooks/staging-live-verification.md
+++ b/docs/runbooks/staging-live-verification.md
@@ -1,0 +1,150 @@
+# Runbook: staging 実機検証（cognito + DSQL 経路）
+
+> **対象**: ローカルのどの backend でも実行されない `AUTH_MODE=cognito` + DSQL 経路（課金状態の解決 / entitlement / parent-gate / 招待・メンバー）を、AWS staging（`ganbari-quest-staging-app`）で 1 回通して観測するための手順。
+> **実行主体**: リリース発火 = GQ-Audit / 検証実行と証跡提出 = GQ-Dev / 秘匿値・権限の配置 = オーナー。
+
+## 1. 適用範囲
+
+### 本 runbook で検証する
+
+| 対象 | ローカルで実行されない理由 | staging で通る経路 |
+|---|---|---|
+| cognito provider（`src/lib/server/auth/providers/cognito.ts`） | `npm run dev` は `local.ts` / `dev:cognito` は `cognito-dev.ts` / demo は `anonymous.ts` を使い、`cognito.ts` を通らない | staging Lambda env `AUTH_MODE=cognito`（`infra/lib/compute-stack.ts` の `stagingEnvironment`） |
+| DSQL `families` 行を読む課金・権限解決 | ローカルは sqlite / PGlite / demo stub で `families` の DSQL 行を読まない | staging Lambda env `DATA_SOURCE=dsql` + `DSQL_USER=app_user` |
+| 招待 / メンバー（invites / memberships） | sqlite / demo / PGlite の 3 backend すべてで検証不可（`docs/CLAUDE.md` §「local 検証不可: invite / members (auth repo) 系 (#3732)」） | 同上 |
+
+### 本 runbook で検証しない（staging に存在しない）
+
+| 対象 | 根拠 |
+|---|---|
+| Stripe webhook / checkout の実イベント | `.github/workflows/deploy-aws-staging.yml` 冒頭「外部サービス副作用ゼロ: Stripe / Discord / Gemini / SES 系 secret は一切渡さない」。`compute-stack.ts` の `stagingEnvironment` にも Stripe 系 env は無い |
+| cron / 定期ジョブ | staging は cron-dispatcher を構築しない（`compute-stack.ts`、`enableCronDispatcher=false`） |
+| demo Lambda / log archiving | staging は構築しない（`infra/lib/env-config.ts` の staging 設定） |
+| SES 経由のメール送信 | `infra/lib/auth-stack.ts` は非 prod で SES を構成せず Cognito default email に fallback する |
+
+Stripe 実イベントが必要な検証は staging では原理的に再現できない。その場合は本 runbook を使わず、本番反映後の実測を証跡とする判断をオーナーに仰ぐ。
+
+## 2. 役割分担
+
+| 工程 | 担当 | 実行内容 | 前提 |
+|---|---|---|---|
+| リリース発火 | GQ-Audit | `deploy-aws-staging.yml` を `workflow_dispatch` + `dsqlEnabled=true` で起動 | 検証対象コミットが `develop` に入っていること（§3） |
+| 検証実行・証跡提出 | GQ-Dev | DSQL 対象行の書き換え → 観測 → 原状復帰 → PR body へ貼付 | AWS credential（§6 の gap 参照） |
+| 秘匿値・権限の配置 | オーナー | 検証用 Cognito アカウント / AWS 権限の可否判断 | — |
+
+## 3. Step 1 — リリース発火（GQ-Audit）
+
+`workflow_dispatch` の checkout ref は `develop` 固定（`deploy-aws-staging.yml` Step 1）。**検証したい修正が `develop` に merge されていなければ、staging には反映されない**。未 merge の修正を検証したい場合は、統合 PR（develop → main）を立てれば `pull_request` trigger 側で当該 PR HEAD が deploy される（この経路では DSQL lane が常時 ON）。
+
+```bash
+gh workflow run deploy-aws-staging.yml -f dsqlEnabled=true
+gh run list --workflow=deploy-aws-staging.yml --limit 1
+gh run watch <run-id>
+```
+
+- **actor guard**: job は `Takenori-Kusaka` / `ganbariquestsupport-lab` の 2 アカウントでのみ実行される。他アカウントで dispatch すると job 自体が skip される。
+- **concurrency**: group `deploy-aws-staging` / `cancel-in-progress: true`。同時に走らせると前の run が cancel されるため、検証中は他の統合 PR と重ならない時間帯を選ぶ。
+- DSQL lane では cluster deploy → `npm run dsql:migrate`（schema provisioning）→ staging 3 stack deploy → `npm run dsql:grant`（Lambda 実行 role への app_user 付与）→ health / smoke → 実 DSQL 並行検証 test の順に実行される。
+
+## 4. Step 2 — deploy 完了確認
+
+workflow run が緑であれば health（`/api/health`、5 回 retry）と smoke（`/` と `/switch` が 200 か 302）は既に PASS している。手元で再確認する場合:
+
+```bash
+BASE=$(aws lambda get-function-url-config --function-name ganbari-quest-staging-app \
+  --region us-east-1 --query 'FunctionUrl' --output text)
+BASE="${BASE%/}"
+curl -s -o /dev/null -w "%{http_code}\n" "$BASE/api/health"   # 200
+```
+
+Lambda のログは `/aws/lambda/ganbari-quest-staging-app`（`compute-stack.ts` の `AppLogGroup`）:
+
+```bash
+aws logs tail /aws/lambda/ganbari-quest-staging-app --region us-east-1 --since 10m --follow
+```
+
+## 5. Step 3 — 検証用アカウント
+
+- staging の Cognito user pool は `ganbari-quest-staging-users-v2`（`infra/lib/auth-stack.ts` の `UserPoolV2` + `env-config.ts` の `resourcePrefix`）。`selfSignUpEnabled: true` / email 検証あり / パスワードは 8 文字以上・大小英字・数字を含むこと。
+- **`DEV_USERS`（`src/lib/server/auth/providers/cognito-dev.ts`）は staging に存在しない**。あれは `COGNITO_DEV_MODE` 前提のローカル専用定義で、staging Lambda env に `COGNITO_DEV_MODE` は入っていない。
+- **staging DSQL には seed 配線が無い**（`docs/design/staging-synthetic-seed.md` §5「AWS staging: 構造準備済 / 配線は #2873」）。検証対象の家族データは、sign-up して自分で作ったものになる。
+- サインアップ確認メールは Cognito default email 送信（SES 非構成）。届かない場合は §6 の gap に従いオーナーに依頼する。
+
+## 6. Step 4 — DSQL の対象行を書き換える / 戻す
+
+`families` 行（`src/lib/server/db/dsql/schema.ts` の `families`）を検証用の状態に変え、アプリがそれを読むかを観測する。
+
+### 6.1 接続情報
+
+```bash
+DSQL_ENDPOINT=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsqlStaging \
+  --region us-east-1 --query "Stacks[0].Outputs[?OutputKey=='ClusterEndpoint'].OutputValue" --output text)
+```
+
+接続パラメータはリポジトリ内の DSQL CLI（`scripts/dsql-migrate.ts` / `scripts/dsql-grant.ts`）と同一: user = `admin`（`DbConnectAdmin` 経路、アプリ実行時の `app_user` とは分離）/ database = `postgres` / TLS 必須。パスワードには IAM 認証トークンを投入する:
+
+```bash
+aws dsql generate-db-connect-admin-auth-token --hostname "$DSQL_ENDPOINT" \
+  --region us-east-1 --expires-in 3600
+```
+
+> **リポジトリに任意 SQL を流す汎用 CLI は無い**（`dsql:migrate` は migration 適用、`dsql:grant` は role 付与の専用ツール）。上記トークンを外部 PostgreSQL クライアント（psql 等）のパスワードとして渡して接続する。この接続方式は `docs/research/dsql-poc-phase1-results-2026-07-05.md` の実クラスタ PoC で確認されているが、**staging cluster で本 runbook 作成時に再実行はしていない**（§8 参照）。
+
+### 6.2 書き換え手順（必ず 5 段で行う）
+
+`families.plan` の値は `src/lib/domain/constants/subscription-plan.ts`（`monthly` / `yearly` / `family-monthly` / `family-yearly` / `lifetime`）、`families.status` は `src/lib/domain/constants/subscription-status.ts`（`active` / `grace_period` / `suspended` / `terminated`）が SSOT。SSOT 外の値を入れると `families_status_ck` で拒否される。
+
+```sql
+-- (1) 変更前の値を控える（この出力を PR body に貼る）
+SELECT family_id, plan, status, plan_expires_at, updated_at
+FROM families WHERE family_id = '<検証対象の family uuid>';
+
+-- (2) 検証したい状態に書き換える
+UPDATE families
+SET plan = 'family-monthly', status = 'active', updated_at = now()
+WHERE family_id = '<検証対象の family uuid>';
+
+-- (3) → §7 の観測を実施
+
+-- (4) 控えた値へ戻す（NULL だった列は NULL に戻す）
+UPDATE families
+SET plan = <控えた plan>, status = '<控えた status>', updated_at = now()
+WHERE family_id = '<検証対象の family uuid>';
+
+-- (5) 復旧確認（(1) と plan / status / plan_expires_at が一致すること）
+SELECT family_id, plan, status, plan_expires_at FROM families
+WHERE family_id = '<検証対象の family uuid>';
+```
+
+- 書き換えるのは**自分が sign-up して作った family の行だけ**。他の行に触らない。
+- `updated_at` は復旧後も (1) とは異なる値になる。差分ゼロを確認するのは `plan` / `status` / `plan_expires_at`。
+- (4) を実行せずに終わらない。次の検証者が汚れた行を掴む。
+
+## 7. Step 5 — 観測
+
+| 観測点 | 手順 | AC 充足と言える状態 |
+|---|---|---|
+| プラン表示 | staging の Function URL でログイン → `/admin/subscription`（parent-gate PIN を通す） | 表示プラン / 上限が §6.2 (2) で書き込んだ値と一致する |
+| 権限（entitlement） | 当該プランでのみ使える機能を 1 つ操作する | プランに応じて許可 / 拒否が切り替わる |
+| サーバ側の解決 | `aws logs tail /aws/lambda/ganbari-quest-staging-app --since 10m` | 例外・fail-closed による 5xx が出ていない |
+
+再ログインせずに反映されるかを見る検証では、**書き換え後にログアウトしない**こと（Cookie を作り直すと「毎リクエスト DB から解決しているか」を確認できなくなる）。
+
+証跡は「(1) の SELECT 出力 → (2) の UPDATE → 観測結果（スクリーンショット / ログ）→ (5) の SELECT 出力」の順に PR body へ貼る。
+
+## 8. 本 runbook が保証できない点
+
+| 項目 | 状態 | 対処 |
+|---|---|---|
+| §6 の psql 接続と UPDATE の実行 | AWS credential（`DbConnectAdmin` 相当）が必要で、リポジトリ内からは検証できない | 実行者が初回実行時に結果を PR に記録し、齟齬があれば本 runbook を修正する |
+| staging Cognito でのサインアップ完了 | SES 非構成のため確認コードの到達性が未確認 | 届かない場合はオーナーに Cognito 側でのユーザー作成を依頼する（admin 権限が必要） |
+| staging DSQL の初期データ | seed 配線が未実施（`docs/design/staging-synthetic-seed.md` §5） | 検証者が sign-up してデータを作る |
+| Stripe 経路 | staging に存在しない（§1） | 本番実測での代替可否をオーナーに確認する |
+
+## 9. 関連
+
+- [docs/runbooks/staging-gate-required-checks.md](staging-gate-required-checks.md) — staging deploy gate の required 化手順
+- [docs/design/staging-synthetic-seed.md](../design/staging-synthetic-seed.md) — PII-free 合成 seed の設計と配線状況
+- [docs/runbooks/dsql-restore.md](dsql-restore.md) — DSQL の backup / 復元
+- `.github/workflows/deploy-aws-staging.yml` / `infra/lib/compute-stack.ts` / `infra/lib/auth-stack.ts` / `infra/lib/env-config.ts`
+- Issue #2873（AWS staging stack）/ #3732（invite / members の local 検証不可）

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -336,9 +336,13 @@ node scripts/check-new-required-env.mjs
 ### 本番デプロイ動作確認（critical / 監査 / 認可 / 課金）
 
 PR 本文 Test plan に以下 3 点を明記:
-- [ ] `DATA_SOURCE=dynamodb` 相当（staging）で実機動作確認
-- [ ] DynamoDB コンソールで当該テーブルに書込み確認
+- [ ] staging（`AUTH_MODE=cognito` + `DATA_SOURCE=dsql`）で実機動作確認
+- [ ] 対象テーブルの行が想定どおり更新されたことを確認
 - [ ] Lambda CloudWatch Logs に想定イベント出現確認
+
+staging での実機確認手順（deploy 発火 / DSQL 行の書き換えと復旧 / 観測 / 役割分担）は
+[docs/runbooks/staging-live-verification.md](../runbooks/staging-live-verification.md) を参照する。
+ローカルのどの backend でも通らない cognito + DSQL 経路（課金状態の解決 / 招待・メンバー）は本 runbook が唯一の検証手順。
 
 follow-up に逃がせるのは「本番に存在しなくても顧客に気付かれない」場合のみ。顧客提供価値（不正検知 / 監査 / 保証）に直結する機能は同一 PR 完結必須。
 


### PR DESCRIPTION
## PO 決裁の条件充足（2026-07-30）

PO 決裁「Q1: AC2 を別 Issue に切り出し、本 PR は Ready → merge してよい = **Yes（条件付き）**」に対する充足状況。

| 条件 | 充足内容 |
|---|---|
| **条件 1: runbook 冒頭に「未実証」ステータス見出しを置く**（必須） | `docs/runbooks/staging-live-verification.md` の **§1 の直前**に見出し `## ⚠️ ステータス: 未実証（2026-07 時点）` を追加。本文 4 行で (a)「本 runbook は通しで実行されていない」(b) 初回実行の追跡先 = #4099（検証主体 = オーナー（AWS SSO 対話ログイン必須）+ GQ-Audit）(c) 未実証 4 項目への §8 アンカーリンク (d) 齟齬が出た場合は本 runbook を是正してから証跡とする、を明記 |
| **条件 2: 切り出し先 Issue（AC1〜AC6）** | **#4099** を起票（https://github.com/Takenori-Kusaka/ganbari-quest/issues/4099）。PO 提示のタイトル案・AC1〜AC6 を原文どおり反映。`priority:high` 維持（`critical` に上げない）。検証主体は「オーナー（AWS SSO 対話ログイン必須）+ GQ-Audit（staging リリース発火）」を専用の表で明示し、「Dev セッション単独では close できない」と本文に記載 |
| **条件 3: ガード条項 G1〜G3** | #4099 本文の §「ガード条項（PO 決裁 2026-07-30 の条件 3）」に G1（「runbook のとおり staging で検証した」と書かない）/ G2（未実証部分を他 runbook・設計書へコピーして横展開しない）/ G3（本 runbook を根拠に staging を CI required check へ昇格しない、#2874 Phase 2 の判断は初回実行後）を記載。#4099 の AC6 が本条項の遵守を完了条件に含む |
| **条件 4: merge 前に残っている実務** | `npm run pre-ready -- --pr 4035` **完走・ALL PASS（2026-07-30 12:50〜13:13、exit code 0）**。下記「テスト & 安全装置セルフチェック」に実測を記載。`docs/sessions/dev-session.md` の checklist 2 行の是正は PO 判断どおり scope 内として維持 |

**本 PR で AC2 を充足していないこと**（未実証の runbook を merge すること）は上記 PO 決裁 Q2 相当の判断に基づく。false assurance は条件 1 の冒頭見出し + #4099 の G1〜G3 で封じる。

## 顧客価値・目的

**対象ユーザー**: 運営 / 有料顧客

**解決する課題**: `AUTH_MODE=cognito` + DSQL 経路（課金状態の解決 / entitlement / parent-gate / 招待・メンバー）は、ローカルのどの backend でも Playwright E2E でも 1 行も実行されない。この経路の修正は「検証手段が無い」状態で本番に出るしかなく、直近の課金 incident では顧客画面が誤ったプラン表示のまま固定された。staging（`ganbari-quest-staging-app`）自体は存在し当該経路も通るのに、誰が deploy を発火し / DSQL の行をどう書き換え / 何を観測すれば充足かの手順書が無かった。

**期待される効果**: staging 実機検証の手順が固定され、課金・認証経路の修正を Draft のまま止めずに実経路で 1 度観測できる。同じ調査を毎回やり直す時間がゼロになる。

## 関連 Issue

closes #4014

- **related** #4099 — 本 PR から切り出した「runbook の初回実行（#4014 の旧 AC2）」。PO 決裁 2026-07-30 の条件 2 / 条件 3（ガード条項 G1〜G3）を含む

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `docs/runbooks/` に staging 実機検証 runbook を追加 | `ls docs/runbooks/staging-live-verification.md` | 追加済 / `docs/runbooks/staging-live-verification.md`（既存 `staging-gate-required-checks.md` と同じ書式・同ディレクトリ） |
| AC1-a | `deploy-aws-staging.yml` を `workflow_dispatch` + `dsqlEnabled=true` で起動する手順（誰が発火するかを含む） | runbook §3 と `.github/workflows/deploy-aws-staging.yml` の突合 | §3 に `gh workflow run deploy-aws-staging.yml -f dsqlEnabled=true` を記載。actor guard 2 アカウント（workflow L80）/ checkout ref = `develop` 固定（L85）/ concurrency cancel-in-progress（L57-59）を明記 |
| AC1-b | deploy 完了の確認方法（Function URL / health） | runbook §4 と workflow Step 13-15 の突合 | §4 に `aws lambda get-function-url-config --function-name ganbari-quest-staging-app` + `curl $BASE/api/health` を記載。endpoint 実在: `src/routes/api/health/+server.ts`。log group `/aws/lambda/ganbari-quest-staging-app` は `infra/lib/compute-stack.ts` の `AppLogGroup` |
| AC1-c | DSQL の対象行を検証用に書き換える手順と、検証後に戻す手順 | runbook §6 と `src/lib/server/db/dsql/schema.ts` の列名突合 | §6 に SELECT（値の控え）→ UPDATE →観測→復旧 UPDATE →復旧確認 SELECT の 5 段手順。列名 `family_id` / `plan` / `status` / `plan_expires_at` は schema.ts `families` と一致。値域は `src/lib/domain/constants/subscription-plan.ts` / `subscription-status.ts` を SSOT として参照 |
| AC1-d | 観測方法（どの画面 / どの API 応答を見れば充足か） | runbook §7 と `src/routes/(parent)/admin/subscription/+page.server.ts` の突合 | §7 に観測表 3 行（`/admin/subscription` の表示プラン / entitlement 操作 / CloudWatch Logs）。subscription ページの load が DB からプラン・上限を解決していることを確認 |
| AC1-e | Stripe 経路が現状の staging に存在しないことの明記 | runbook §1 と `.github/workflows/deploy-aws-staging.yml` L12 の突合 | §1「本 runbook で検証しない」表の先頭行で L12「外部サービス副作用ゼロ: Stripe / Discord / Gemini / SES 系 secret は一切渡さない」を引用。`infra/lib/compute-stack.ts` の `stagingEnvironment` にも Stripe 系 env が無いことを併記 |
| AC1-f | 役割分担（Audit = リリース発火 / Dev = 検証実行 / オーナー = 秘匿値・権限）の明記 | runbook §2 | §2 の 4 列表に 3 行を記載 |
| AC2 | 上記手順を実際に 1 回通した証跡 | — | **本 PR のスコープ外（#4099 へ切り出し、PO 決裁 2026-07-30）**。実行には AWS SSO 対話ログイン（`DbConnectAdmin` 相当）と GQ-Audit による staging リリース発火が必要で、Dev セッション単独では完遂不能。未実証の 4 項目（psql 接続と UPDATE / staging sign-up の確認コード到達 / staging DSQL の初期データ / Stripe 経路）は runbook §8 に表で明示し、**runbook 冒頭に「未実証」ステータス見出し**を置いて #4099 へ誘導した（PO 決裁の条件 1）。初回実行と本見出しの撤去可否は #4099 の close 判定 |
| AC3 | `docs/sessions/dev-session.md` から本 runbook への参照が 1 行ある | `grep -n staging-live-verification docs/sessions/dev-session.md` | §「本番デプロイ動作確認（critical / 監査 / 認可 / 課金）」に参照 2 行を追加（同節の checklist が撤去済 backend を指していたため 2 行を現行構成に是正） |
| AC4 | 秘匿値（鍵 / トークン / 接続文字列）が runbook 本文に含まれていない | `grep -nE "secret\|token\|password" docs/runbooks/staging-live-verification.md` の目視確認 | 秘匿値の実体はゼロ。取得コマンド（`aws dsql generate-db-connect-admin-auth-token`）と `<検証対象の family uuid>` 等の placeholder のみ |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（ドキュメントのみ。コード / 設定の変更ゼロ）

**並行実装ペア**:

- [ ] 本番アプリ (`src/routes/(child)/`, `src/routes/(parent)/`) + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）— LP 記載なし
- [ ] 全年齢モード 5 種（baby/preschool/elementary/junior/senior）に横展開
- [ ] ナビゲーション 3 種（`AdminLayout` + `AdminMobileNav` + `BottomNav`）に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): 新規 runbook への参照を `docs/CLAUDE.md`（local 検証不可 §の直後）と `docs/sessions/dev-session.md` に同 PR で追加
- [x] **重量 e2e 敏感領域**: N/A（ドキュメントのみでコード変更ゼロ）
- [x] **並行 PR overlap** (#1200): bot が報告するとおり `docs/CLAUDE.md` / `docs/sessions/dev-session.md` は #3995 とファイル重複する。ただし #3995 は head=`develop` / base=`main` の統合 PR であり、本 PR（base=`develop`）が merge されれば同 PR に取り込まれる関係。並行作業による内容衝突ではない。それ以外の open PR との重複はなし
- [ ] N/A — 並行実装の影響範囲外

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4035` | PASS（2026-07-30、exit code 0） |
| 追加・変更テスト | N/A（ドキュメントのみ） | N/A |

- [x] **`npm run pre-ready -- --pr 4035` 全 Step PASS**（#1775 / ADR-0030）— **2026-07-30 に完走、exit code 0**。`[pre-ready] ALL PASS — Ready for Review に進めます。` を確認。Step 3 (vitest run) = `Test Files 571 passed | 4 skipped (575)` / `Tests 8817 passed | 13 skipped (8830)` / Duration 1157.92s、失敗 0 件。適用対象外 5 step は変更内容が検査対象を含まないため未実行（lp-fallback / lp-labels / lp-dimensions / ss-embed-gate / capture、#4018）。Step 5 / 11b / 12 は LP 変更なし・UI 変更なしで skip
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  N/A（ドキュメントのみ）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **SOLID / DRY / YAGNI**: SOLID は N/A（コード変更なし）。DRY = `docs/runbooks/` 既存 13 ファイルと `docs/design/billing-redesign/phase7-staging-validation-protocol.md` を確認し、staging の実行手順を扱う既存文書が無いことを確認（後者は特定 PR の検証期間 SLA で手順書ではない）。YAGNI = 手順書のみで CI 化 / 新規スクリプトは追加しない（Issue の設計方針どおり）
- [x] **Security（OSS 公開前提）**: 秘匿値・内部 URL の hardcode なし。DSQL トークンは取得コマンドのみ記載し値を書かない。加えて QM 指摘を受け、証跡貼付時の `family_id` マスク・トークンの取扱い（有効期限 / 履歴・PR body に残さない / 使用後破棄）・検証後の Cognito ユーザー削除を runbook に明記した
- [x] **A11y・パフォーマンス**: N/A（UI / クエリ変更なし）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

## スクリーンショット / ビジュアルデモ

**該当なし（ドキュメントのみの変更で UI 差分ゼロ）**

**インタラクティブ状態**: N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:

1. **AC2（1 回通した証跡）は #4099 へ切り出し済**（PO 決裁 2026-07-30）。本 PR は手順書と、リポジトリから確認できない箇所の明示（runbook §8 + 冒頭「未実証」ステータス見出し）までを含む。初回実行（発火 = GQ-Audit / AWS SSO 対話ログイン保持者 = オーナー）と、その結果に応じた runbook 是正・見出し撤去は #4099 で行う。
2. 記載した手順のうち、リポジトリから裏取りできたのは workflow の入力・actor guard・checkout ref・Lambda 関数名 / log group・health と smoke の判定・staging Lambda env（`AUTH_MODE=cognito` / `DATA_SOURCE=dsql` / Stripe 系 env 不在）・Cognito pool 名とパスワードポリシー・`families` の列名と値域・`/admin/subscription` の load。裏取りできなかったのは psql での接続と UPDATE の実行、staging sign-up の確認コード到達性で、両方 §8 に明記した（もっともらしいコマンドを書かずに gap として残す方針）。
3. `docs/sessions/dev-session.md` の checklist 2 行は撤去済み backend（DynamoDB）を指していたため、参照追加と同時に現行構成へ是正した。この 2 行の是正が scope 外と判断される場合は戻す。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した — **2026-07-30 に完走し ALL PASS（exit code 0）**。前回（同日午前）は他セッションの重い検証と並走して vitest が終わらず打ち切っていたが、今回は heavy lock を単独保持した状態で再実行し、vitest 8817 passed / 失敗 0 件で全 step PASS を確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 本 PR スコープの全 AC（AC1 / AC1-a〜f / AC3 / AC4）が実装済み — **AC2 は本 PR のスコープ外（#4099 へ切り出し、PO 決裁 2026-07-30）。未検証のため本 PR では充足を主張しない**
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み（N/A — Phase 分割なし）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)




