### PR TITLE
fix(ci): #4029 #4022 未置換プレースホルダを body 全体で検出し、PR テンプレートの gate 矛盾 2 件を解消する

### DIFF
--- a/.claude/skills/dev-open-pr/ready-gate-checklist.md
+++ b/.claude/skills/dev-open-pr/ready-gate-checklist.md
@@ -118,7 +118,6 @@ node scripts/check-pr-template-sections-sync.mjs
 **条件**: `## Ready for Review チェックリスト` の項目を**実機検証してから** `[x]` に変更。虚偽チェック禁止。
 
 ```markdown
-- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
 - [x] セルフレビュー済み（不要な差分・デバッグコードなし）
 - [x] 全 AC が実装済み
 - [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認

--- a/.claude/skills/dev-open-pr/templates/pr-body-critical-fix.md
+++ b/.claude/skills/dev-open-pr/templates/pr-body-critical-fix.md
@@ -46,7 +46,7 @@ closes #{{ISSUE_NUMBER}}
 
 ### 要件 2: AC 全項目完了（部分実装で closes 禁止）
 
-- [ ] Issue の全 AC が本 PR で完了している（残存 TODO / 「予定」なし）
+- [ ] Issue の全 AC が本 PR で完了している（未実装・先送りのまま残っている AC がない）
 
 ### 要件 3: 提案全実装
 
@@ -139,7 +139,8 @@ UI 変更なしの場合: 「**該当なし（バックエンド修正のみ）*
 
 ## Ready for Review チェックリスト
 
-- [ ] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
+<!-- pre-ready の実行証跡はチェック項目にしない（本リストの未チェックを check-pr-body が block し、その check-pr-body を pre-ready 自身が呼ぶため自己参照 deadlock、#4022）。ログのパスと結果を PR body 本文に記載する。 -->
+
 - [ ] **ADR-0002 5 要件全て満たした**（再掲、自己確認）
 - [ ] セルフレビュー済み
 - [ ] 全 AC が実装済み

--- a/.claude/skills/dev-open-pr/templates/pr-body-default.md
+++ b/.claude/skills/dev-open-pr/templates/pr-body-default.md
@@ -112,7 +112,8 @@ UI 変更を含まない PR は本セクションに「**該当なし（理由�
 
 ## Ready for Review チェックリスト
 
-- [ ] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
+<!-- pre-ready の実行証跡はチェック項目にしない（本リストの未チェックを check-pr-body が block し、その check-pr-body を pre-ready 自身が呼ぶため自己参照 deadlock、#4022）。ログのパスと結果を PR body 本文に記載する。 -->
+
 - [ ] セルフレビュー済み（不要な差分・デバッグコードなし）
 - [ ] 全 AC が実装済み
 - [ ] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認

--- a/.claude/skills/dev-open-pr/templates/pr-body-lp.md
+++ b/.claude/skills/dev-open-pr/templates/pr-body-lp.md
@@ -108,7 +108,8 @@ closes #{{ISSUE_NUMBER}}
 
 ## Ready for Review チェックリスト
 
-- [ ] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
+<!-- pre-ready の実行証跡はチェック項目にしない（本リストの未チェックを check-pr-body が block し、その check-pr-body を pre-ready 自身が呼ぶため自己参照 deadlock、#4022）。ログのパスと結果を PR body 本文に記載する。 -->
+
 - [ ] LP メトリクス全指標 PASS をローカル確認した（`measure-lp-dimensions.mjs`）
 - [ ] セルフレビュー済み
 - [ ] 全 AC が実装済み

--- a/.claude/skills/dev-open-pr/templates/pr-body-refactor-ssot.md
+++ b/.claude/skills/dev-open-pr/templates/pr-body-refactor-ssot.md
@@ -115,7 +115,8 @@ UI 描画が変わる場合: 4 スロット必須。
 
 ## Ready for Review チェックリスト
 
-- [ ] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
+<!-- pre-ready の実行証跡はチェック項目にしない（本リストの未チェックを check-pr-body が block し、その check-pr-body を pre-ready 自身が呼ぶため自己参照 deadlock、#4022）。ログのパスと結果を PR body 本文に記載する。 -->
+
 - [ ] 移動先対応マップが全件埋まっている（旧 path 参照 0 件確認済み）
 - [ ] セルフレビュー済み
 - [ ] 全 AC が実装済み

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -163,11 +163,12 @@ UI 変更を含まない PR (refactor / docs / infra のみ) は本セクショ�
 
 ## Ready for Review チェックリスト
 
-<!-- Draft → Ready 前に確認。CI 全緑は GitHub Status Checks 側で別途検証されるため本リストには含めない（#1775 自己言及循環の解消） -->
+<!-- Draft → Ready 前に確認。CI 全緑は GitHub Status Checks 側で別途検証されるため本リストには含めない（#1775 自己言及循環の解消）
+     pre-ready の実行証跡もチェック項目にしない（本リストの未チェックを check-pr-body が block し、その check-pr-body を
+     pre-ready 自身が呼ぶため自己参照 deadlock になる、#4022）。実行証跡はログのパスと結果を PR body 本文に記載する。 -->
 
-- [ ] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
 - [ ] セルフレビュー済み（不要な差分・デバッグコードなし）
-- [ ] 全 AC が実装済み（TODO / 「予定」のまま残っている AC がない）
+- [ ] 全 AC が実装済み（未実装・先送りのまま残っている AC がない）
 - [ ] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み
 - [ ] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認
 - [ ] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -483,6 +483,178 @@ export function checkPoDecisionBrief(body, labels) {
 }
 
 // ---------------------------------------------------------------------------
+// 未置換プレースホルダ検出 (body 全体、code fence 内を含む) — #4029
+// ---------------------------------------------------------------------------
+
+/**
+ * 「置換されていないテンプレート断片」を示すトークン SSOT (#4029)。
+ *
+ * 発生経緯: PR #4002 の body L208 が `PRE_READY_LOG_PLACEHOLDER` のまま残り、その block を
+ * 根拠に 2 箇所が `- [x]` を立てていた (成果物のない `[x]`)。当時の未置換検出は
+ * `___` を PO 決裁セクション内でのみ見ていたため、**code fence 内の別表記**は素通りした。
+ * fence を除外すると今回の実例をそのまま逃すので、**fence 内も対象**にする。
+ *
+ * HTML コメントだけは除外する (template 由来の記入ガイドが `<!-- 例: ___ -->` の形で
+ * 残るのは正常であり、開発者が書いた本文ではないため)。除外は行番号を保つマスクで行う。
+ *
+ * 各 pattern の狭め方 (誤検出との境界、#4029):
+ *   - `PLACEHOLDER` は**大文字のみ**。英文中の "placeholder" という単語を拾わない
+ *   - `XXX` は `#XXX` (Issue 番号の伏せ字引用) / URL path (`/XXX`) / 語中 (`XXXY`) を除外
+ *   - `___` は 3 連続以上のアンダースコア。Markdown の水平線 (`---`) とは別字
+ */
+export const PLACEHOLDER_PATTERNS = [
+	{
+		id: 'underscore-blank',
+		label: '___ (template の空欄)',
+		re: /_{3,}/g,
+	},
+	{
+		id: 'placeholder-token',
+		label: 'PLACEHOLDER / *_PLACEHOLDER',
+		// `PRE_READY_LOG_PLACEHOLDER` のように接頭辞が付く形を確実に拾うため `\b` は使わない
+		// (`_` は word 文字なので接頭辞境界に `\b` が立たず、#4002 の実例を取り逃がす)。
+		re: /[A-Z0-9_]*PLACEHOLDER[A-Z0-9_]*/g,
+	},
+	{
+		id: 'tbd',
+		label: 'TBD',
+		re: /\bTBD\b/g,
+	},
+	{
+		id: 'xxx',
+		label: 'XXX',
+		re: /(?<![#/\w-])XXX(?![\w-])/g,
+	},
+	{
+		id: 'japanese-angle-slot',
+		label: '<ここに…> 型スロット',
+		re: /<ここに[^>\n]*>/g,
+	},
+];
+
+/**
+ * 誤検出時の唯一の逃げ道 (#4029)。
+ *
+ * 本 gate 自身を直す PR / template を編集する PR は、プレースホルダ文字列を
+ * 正当に本文へ書く。label による一括 skip は fail-open (label を付けるだけで gate が
+ * 消える) なので採らず、**PR body に理由付きの宣言を 1 行書いた場合のみ**通す。
+ */
+export const PLACEHOLDER_SCAN_SKIP_RE = /<!--\s*placeholder-scan-skip:\s*([^>]*?)\s*-->/;
+
+/** 宣言の理由に求める最小文字数 (「-」等の空宣言で gate を消させない)。 */
+const PLACEHOLDER_SKIP_REASON_MIN_LENGTH = 10;
+
+/**
+ * HTML コメントを**行番号を保ったまま**空白化する (#4029)。
+ * `stripMarkdownComments` は行ごと消えるため、検出行番号を PR body の実行番号と
+ * 一致させたい本 gate では使えない。
+ *
+ * @param {string} body
+ * @returns {string}
+ */
+export function maskMarkdownComments(body) {
+	return body.replace(/<!--[\s\S]*?-->/g, (m) => m.replace(/[^\n]/g, ' '));
+}
+
+/**
+ * 未置換プレースホルダを PR body 全体 (code fence 内を含む) からスキャンする (#4029)。
+ *
+ * @param {string} body
+ * @returns {{ id: string; token: string; line: string; lineNo: number }[]}
+ */
+export function scanPlaceholders(body) {
+	const masked = maskMarkdownComments(body);
+	const lines = masked.split('\n');
+	const rawLines = body.split('\n');
+	const violations = [];
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? '';
+		for (const pattern of PLACEHOLDER_PATTERNS) {
+			const re = new RegExp(pattern.re.source, pattern.re.flags);
+			let m = re.exec(line);
+			while (m !== null) {
+				violations.push({
+					id: pattern.id,
+					token: m[0],
+					line: (rawLines[i] ?? '').trim(),
+					lineNo: i + 1,
+				});
+				m = re.exec(line);
+			}
+		}
+	}
+	return violations;
+}
+
+/**
+ * `<!-- placeholder-scan-skip: 理由 -->` 宣言を解釈する (#4029)。
+ *
+ * @param {string} body
+ * @returns {{ declared: boolean; reason: string }}
+ */
+export function parsePlaceholderScanSkip(body) {
+	const m = body.match(PLACEHOLDER_SCAN_SKIP_RE);
+	if (!m) return { declared: false, reason: '' };
+	return { declared: true, reason: (m[1] ?? '').trim() };
+}
+
+/**
+ * 未置換プレースホルダ gate 本体 (#4029)。
+ *
+ * 宣言がある場合は「何を見逃したか」を violation ではなく notes として返す
+ * (#3962 と同じ方針 — 見分けのつかない pass を作らない)。
+ *
+ * @param {string} body
+ * @returns {{ violation: { id: string; message: string } | null; notes: string[] }}
+ */
+export function checkPlaceholders(body) {
+	const found = scanPlaceholders(body);
+	const skip = parsePlaceholderScanSkip(body);
+
+	if (skip.declared) {
+		if (skip.reason.length < PLACEHOLDER_SKIP_REASON_MIN_LENGTH) {
+			return {
+				violation: {
+					id: 'placeholder-scan-skip-reason-missing',
+					message:
+						`\`<!-- placeholder-scan-skip: 理由 -->\` の理由が ${PLACEHOLDER_SKIP_REASON_MIN_LENGTH} 文字未満です ` +
+						`(実際: ${JSON.stringify(skip.reason)})。\n` +
+						'  対応: 「なぜこの PR が正当にプレースホルダ文字列を本文へ書くのか」を具体的に書く ' +
+						'(例: 本 gate の検出対象トークンを PR body 内で説明するため)。',
+				},
+				notes: [],
+			};
+		}
+		return {
+			violation: null,
+			notes: [
+				`[check-pr-body] SKIPPED — 未置換プレースホルダ検査 (#4029) を宣言により skip しました (検出 ${found.length} 件)`,
+				`  理由: ${skip.reason}`,
+			],
+		};
+	}
+
+	if (found.length === 0) return { violation: null, notes: [] };
+
+	const sample = found
+		.slice(0, 6)
+		.map((v) => `  - L${v.lineNo} 「${v.token}」(${v.id}): ${v.line.slice(0, 80)}`)
+		.join('\n');
+	return {
+		violation: {
+			id: 'unreplaced-placeholder',
+			message:
+				`PR body に未置換プレースホルダが ${found.length} 件あります ` +
+				`(code fence 内も対象、#4002 の実例がまさに fence 内でした):\n${sample}\n` +
+				'対応 1: 実際の内容 (実行ログ / パス / 結果) に置換する。埋められないなら、それを根拠にした `[x]` を外す。\n' +
+				'対応 2: 本 gate や template を直す PR で正当にプレースホルダ文字列を書く場合のみ、\n' +
+				'        `<!-- placeholder-scan-skip: 理由 -->` を PR body に 1 行書く (label では通らない)。',
+		},
+		notes: [],
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 文字化け検出 (BOM / heuristic) — #2562 / #2576
 // ---------------------------------------------------------------------------
 
@@ -925,6 +1097,8 @@ Detected violations:
   6. hotfix label PR (${HOTFIX_LABELS.join(' / ')}) で ADR-0006 配布証跡欄が空 (#2343)
   7. PR body の文字化け (BOM / \`??\` 5 件以上) — heredoc 由来 cp932 mojibake (#2562 / #2576)
   8. 変更タイプ checkbox 未選択 (\`- [x]\` 1 つ以上必須、CI gate「変更タイプの選択」と同一 SSOT、#3846)
+  9. 未置換プレースホルダ (${PLACEHOLDER_PATTERNS.map((p) => p.label).join(' / ')}) が body のどこかに残存 (code fence 内も対象、#4002 / #4029)
+     正当にプレースホルダ文字列を書く PR は \`<!-- placeholder-scan-skip: 理由 -->\` を body に 1 行書く (label では通らない)
 
 Exit codes:
   0 = OK
@@ -970,9 +1144,10 @@ function loadPrBody(args) {
  * @param {string[]} requiredSections
  * @param {string} template `.github/PULL_REQUEST_TEMPLATE.md` の内容 (#3846 変更タイプ検証で使用)
  * @param {{ pr: string | null; skipMergeable: boolean; labels?: string[] }} args
+ * @param {string[]} notes skip 等の「検査しなかったこと」を呼び出し側で出力するための追記先 (#4029)
  * @returns {{ id: string; issue: string; message: string }[]}
  */
-function collectViolations(body, requiredSections, template, args) {
+function collectViolations(body, requiredSections, template, args, notes = []) {
 	const violations = [];
 	const labels = args.labels ?? [];
 
@@ -1030,6 +1205,11 @@ function collectViolations(body, requiredSections, template, args) {
 	const hotfixEnvCheck = checkEnvDistributionForHotfix(body, labels);
 	if (hotfixEnvCheck) violations.push({ ...hotfixEnvCheck, issue: '#2343' });
 
+	// #4029: 未置換プレースホルダ検出 (body 全体 / code fence 内も対象)
+	const placeholders = checkPlaceholders(body);
+	notes.push(...placeholders.notes);
+	if (placeholders.violation) violations.push({ ...placeholders.violation, issue: '#4002/#4029' });
+
 	// #2562 / #2576: PR body 文字化け検出 (BOM / `??` heuristic)
 	const mojibake = detectMojibake(body);
 	for (const m of mojibake) {
@@ -1086,7 +1266,16 @@ export async function main(argv = process.argv.slice(2)) {
 		for (const line of formatSkippedLabelGates()) console.log(line);
 	}
 
-	const violations = collectViolations(body, requiredSections, template, { ...args, labels });
+	/** @type {string[]} */
+	const notes = [];
+	const violations = collectViolations(
+		body,
+		requiredSections,
+		template,
+		{ ...args, labels },
+		notes,
+	);
+	for (const line of notes) console.log(line);
 
 	if (violations.length === 0) {
 		console.log(

--- a/tests/unit/github/pr-body-template-integrity.test.ts
+++ b/tests/unit/github/pr-body-template-integrity.test.ts
@@ -1,0 +1,125 @@
+/**
+ * tests/unit/github/pr-body-template-integrity.test.ts (#4022)
+ *
+ * PR body の「供給元テンプレート」が、その body を検査する gate 自身と矛盾しないことを固定する。
+ *
+ * 背景: `.github/PULL_REQUEST_TEMPLATE.md` をそのまま貼ると `check-pr-body.mjs` が必ず落ちる
+ * 状態が 2 種類あった。
+ *   1. 禁止語 (`TODO` / `予定`) を素の本文行に含む → `forbidden-terms` が立つ
+ *   2. `pre-ready 全 Step PASS` を Ready チェックリスト項目に持つ → 未チェックだと
+ *      `unchecked-ready-checklist` が立つが、そのチェックを外すには pre-ready の実測が要る
+ *      という自己参照 deadlock (#4021 で実測)
+ *
+ * 判定入力は **fixture 文字列ではなく実ファイル**。fixture に対して 0 件を確認するだけの
+ * テストは、実 template が将来行を戻しても緑のままになり、守りたい対象を守らない。
+ * 加えて body 生成経路は `.github/` の 1 本ではなく skill 側 4 template + back-merge 生成器の
+ * 計 7 入力あるため、全経路に同じ assertion をかける。
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { renderBackMergePrBody } from '../../../scripts/back-merge-pr-body.mjs';
+import { scanForbiddenTerms, stripMarkdownComments } from '../../../scripts/check-pr-body.mjs';
+
+const repoRoot = resolve(__dirname, '../../..');
+
+/** PR body の供給元となる実テンプレートファイル (#4022 AC11: 1-5 番目の入力)。 */
+const TEMPLATE_FILES = [
+	'.github/PULL_REQUEST_TEMPLATE.md',
+	'.claude/skills/dev-open-pr/templates/pr-body-default.md',
+	'.claude/skills/dev-open-pr/templates/pr-body-critical-fix.md',
+	'.claude/skills/dev-open-pr/templates/pr-body-lp.md',
+	'.claude/skills/dev-open-pr/templates/pr-body-refactor-ssot.md',
+] as const;
+
+const READY_SECTION_HEADING = '## Ready for Review チェックリスト';
+
+function readTemplate(relPath: string): string {
+	return readFileSync(resolve(repoRoot, relPath), 'utf-8');
+}
+
+/** `## Ready for Review チェックリスト` セクション本文を切り出す (次の `## ` まで)。 */
+function extractReadySection(body: string): string {
+	const startIdx = body.indexOf(READY_SECTION_HEADING);
+	if (startIdx === -1) return '';
+	const remaining = body.slice(startIdx + READY_SECTION_HEADING.length);
+	const nextSectionIdx = remaining.search(/^## /m);
+	return nextSectionIdx === -1 ? remaining : remaining.slice(0, nextSectionIdx);
+}
+
+/** Ready セクション内の「未チェックかつ pre-ready に言及する」項目行を返す。 */
+function findPreReadyUncheckedItems(body: string): string[] {
+	return extractReadySection(body)
+		.split('\n')
+		.map((l) => l.trim())
+		.filter((l) => /^- \[ \]/.test(l) && l.includes('pre-ready'));
+}
+
+describe('PR body テンプレートは forbidden-terms gate と矛盾しない (#4022 AC1/AC3/AC4)', () => {
+	it.each(TEMPLATE_FILES)('%s の禁止語が 0 件', (relPath) => {
+		const violations = scanForbiddenTerms(stripMarkdownComments(readTemplate(relPath)));
+		expect(
+			violations.map((v) => `L${v.lineNo} 「${v.term}」: ${v.line}`),
+			`${relPath} を貼っただけで check-pr-body が落ちる状態になっている`,
+		).toEqual([]);
+	});
+
+	it('HTML コメント内の禁止語は許容する (AC4 境界 — 既存コメントを壊さない)', () => {
+		// gate 本体が `<!-- -->` を除外する仕様なので、テンプレ側の解説コメントは対象外。
+		const withComment = '<!-- CI 全緑は別途検証される -->\n本文には禁止語なし\n';
+		expect(scanForbiddenTerms(stripMarkdownComments(withComment))).toEqual([]);
+	});
+
+	it('検査が本当に効いている (禁止語を混ぜたら検出される)', () => {
+		const mutated = `${readTemplate('.github/PULL_REQUEST_TEMPLATE.md')}\n- [ ] 残りは TODO\n`;
+		expect(scanForbiddenTerms(stripMarkdownComments(mutated)).length).toBeGreaterThan(0);
+	});
+});
+
+describe('Ready チェックリストに pre-ready 自己参照項目が無い (#4022 AC6/AC8/AC10/AC11)', () => {
+	it.each(TEMPLATE_FILES)('%s の Ready セクションに pre-ready 未チェック項目が 0 件', (relPath) => {
+		const body = readTemplate(relPath);
+		expect(extractReadySection(body), `${relPath} に Ready セクションが無い`).not.toBe('');
+		expect(
+			findPreReadyUncheckedItems(body),
+			`${relPath}: この項目は check-pr-body → pre-ready → check-pr-body の自己参照 deadlock を作る`,
+		).toEqual([]);
+	});
+
+	it.each([
+		false,
+		true,
+	])('back-merge 生成器 (isConflict=%s) の Ready セクションにも同項目が無い (AC11 6-7 番目の入力)', (isConflict) => {
+		const body = renderBackMergePrBody({
+			hotfixPr: 1234,
+			hotfixHead: 'fix/1234-example',
+			mergeSha: 'abcdef1234567890',
+			branch: 'develop',
+			isConflict,
+		});
+		expect(findPreReadyUncheckedItems(body)).toEqual([]);
+	});
+
+	it('検査が本当に効いている (項目を戻したら検出される)', () => {
+		const mutated = [
+			READY_SECTION_HEADING,
+			'',
+			'- [ ] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した',
+			'',
+			'## 次のセクション',
+		].join('\n');
+		expect(findPreReadyUncheckedItems(mutated)).toHaveLength(1);
+	});
+
+	it('`## テスト & 安全装置セルフチェック` 側の集約申告は残す (AC7 境界)', () => {
+		// 当該セクションは findUncheckedReadyChecklist の対象外なので deadlock 経路に無い。
+		const template = readTemplate('.github/PULL_REQUEST_TEMPLATE.md');
+		expect(template).toContain('## テスト & 安全装置セルフチェック');
+		const selfCheckIdx = template.indexOf('## テスト & 安全装置セルフチェック');
+		const readyIdx = template.indexOf(READY_SECTION_HEADING);
+		const selfCheckSection = template.slice(selfCheckIdx, readyIdx);
+		expect(selfCheckSection).toContain('pre-ready');
+	});
+});

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -13,6 +13,7 @@ import {
 	checkAcMap,
 	checkChangeTypeSelection,
 	checkEnvDistributionForHotfix,
+	checkPlaceholders,
 	checkPoDecisionBrief,
 	checkSelfReviewEvidence,
 	detectMojibake,
@@ -29,9 +30,12 @@ import {
 	hasHotfixLabel,
 	hasPoDecisionLabel,
 	LABEL_CONDITIONAL_GATES,
+	PLACEHOLDER_PATTERNS,
 	PO_DECISION_LABEL,
+	parsePlaceholderScanSkip,
 	resolveLabels,
 	scanForbiddenTerms,
+	scanPlaceholders,
 	stripCodeBlocks,
 	stripMarkdownComments,
 } from '../../../scripts/check-pr-body.mjs';
@@ -954,5 +958,119 @@ describe('extractLabelNames — shell 引用に依存せず label を取り出�
 		expect(fetched).toBeNull();
 		const r = resolveLabels({ pr: '3965', labels: null, noLabels: false }, fetched);
 		expect('labels' in r).toBe(false);
+	});
+});
+
+describe('未置換プレースホルダ検出 (#4002 / #4029)', () => {
+	// #4002 の body 断片。`[x]` の根拠が code fence 内の未置換トークンだけ、という実例。
+	const PR4002_FRAGMENT = [
+		'## テスト & 安全装置セルフチェック',
+		'',
+		'- [x] **`npm run pre-ready` 全 Step PASS** — ログは下記',
+		'',
+		'```console',
+		'PRE_READY_LOG_PLACEHOLDER',
+		'```',
+		'',
+	].join('\n');
+
+	it('[PH1] fence 内の *_PLACEHOLDER を検出する — 本 Issue の実例', () => {
+		const found = scanPlaceholders(PR4002_FRAGMENT);
+		expect(found).toHaveLength(1);
+		expect(found[0]?.token).toBe('PRE_READY_LOG_PLACEHOLDER');
+		expect(found[0]?.id).toBe('placeholder-token');
+		// 行番号は raw body の行番号と一致する (HTML コメント除去で行がずれない)
+		expect(found[0]?.lineNo).toBe(6);
+	});
+
+	it('[PH2] 置換すれば pass する (mutation の裏返し)', () => {
+		const replaced = PR4002_FRAGMENT.replace(
+			'PRE_READY_LOG_PLACEHOLDER',
+			'Step 1/12 biome check ... PASS',
+		);
+		expect(scanPlaceholders(replaced)).toEqual([]);
+		expect(checkPlaceholders(replaced).violation).toBeNull();
+	});
+
+	it('[PH3] checkPlaceholders は違反として返す (gate として繋がっている)', () => {
+		const result = checkPlaceholders(PR4002_FRAGMENT);
+		expect(result.violation?.id).toBe('unreplaced-placeholder');
+		expect(result.violation?.message).toContain('PRE_READY_LOG_PLACEHOLDER');
+	});
+
+	it('[PH4] 各トークン種別を body のどこにあっても検出する', () => {
+		const body = [
+			'普通の本文 ___',
+			'結果: TBD',
+			'担当: XXX',
+			'| AC1 | <ここに AC 内容> | grep | OK |',
+			'```',
+			'PLACEHOLDER',
+			'```',
+		].join('\n');
+		const ids = new Set(scanPlaceholders(body).map((v) => v.id));
+		expect([...ids].sort()).toEqual(
+			['japanese-angle-slot', 'placeholder-token', 'tbd', 'underscore-blank', 'xxx'].sort(),
+		);
+	});
+
+	it('[PH5] HTML コメント内の記入ガイドは対象外 (template 由来で開発者の本文ではない)', () => {
+		expect(scanPlaceholders('<!-- 例: ___ を実際の値に置換する / TBD 禁止 -->\n本文\n')).toEqual(
+			[],
+		);
+	});
+
+	it('[PH6] XXX は #XXX / URL path / 語中を拾わない (誤検出の狭め、#4029)', () => {
+		const body = [
+			'関連 Issue の書式は #XXX のように書く',
+			'https://example.com/XXX/detail',
+			'識別子 XXXY は語中なので対象外',
+		].join('\n');
+		expect(scanPlaceholders(body).filter((v) => v.id === 'xxx')).toEqual([]);
+	});
+
+	it('[PH7] 小文字の placeholder という英単語は拾わない', () => {
+		expect(scanPlaceholders('this is a placeholder image for the LP')).toEqual([]);
+	});
+
+	it('[PH8] 宣言があるときだけ skip され、理由が短ければ違反になる', () => {
+		const skipped = `${PR4002_FRAGMENT}\n<!-- placeholder-scan-skip: 本 gate の検出トークンを body 内で説明するため -->\n`;
+		const r1 = checkPlaceholders(skipped);
+		expect(r1.violation).toBeNull();
+		expect(r1.notes.join('\n')).toContain('SKIPPED');
+
+		const emptyReason = `${PR4002_FRAGMENT}\n<!-- placeholder-scan-skip: - -->\n`;
+		expect(checkPlaceholders(emptyReason).violation?.id).toBe(
+			'placeholder-scan-skip-reason-missing',
+		);
+	});
+
+	it('[PH9] label 相当の文字列を body に書いても skip されない (fail-open にしない)', () => {
+		const labelish = `${PR4002_FRAGMENT}\nlabels: placeholder-allowed\n`;
+		expect(checkPlaceholders(labelish).violation?.id).toBe('unreplaced-placeholder');
+		expect(parsePlaceholderScanSkip(labelish).declared).toBe(false);
+	});
+
+	it('[PH10] PO 決裁セクションの ___ 検出は従来どおり動く (回帰なし)', () => {
+		const body = [
+			'## PO 決裁ブリーフ',
+			'',
+			'```mermaid',
+			'flowchart TD',
+			'  A --> B',
+			'```',
+			'',
+			'- 影響: ___',
+		].join('\n');
+		const r = checkPoDecisionBrief(body, [PO_DECISION_LABEL]);
+		expect(r?.id).toBe('po-decision-brief-unfilled-placeholder');
+	});
+
+	it('[PH11] パターン定義はヘルプ表示用の label を全件持つ', () => {
+		expect(PLACEHOLDER_PATTERNS.length).toBeGreaterThanOrEqual(5);
+		for (const p of PLACEHOLDER_PATTERNS) {
+			expect(p.id).toBeTruthy();
+			expect(p.label).toBeTruthy();
+		}
 	});
 });

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -3,7 +3,13 @@
  *
  * scripts/check-pr-body.mjs の純粋関数（検出ロジック）の unit test。
  * GitHub API 呼び出し (gh pr view) は本テストでは触れない（--body-file 経路でテスト可能）。
+ *
+ * 検出器の負例 fixture には「検出されない側」を示すためのわざとらしい綴りが含まれる
+ * (`XXXY` = 語境界を持たないので XXX として検出されない / `labelish` = PLACEHOLDER 等の
+ * token に見えるが該当しない語)。これらは typo ではなく検査対象そのものなので、
+ * .cspell.json の辞書 (= 本物の語彙) には入れず file-scoped ignore で閉じる。
  */
+// cspell:ignore XXXY labelish
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';


### PR DESCRIPTION
<!-- placeholder-scan-skip: 本 PR 自体が未置換プレースホルダ検出 gate の実装であり、検出対象トークンを PR 本文で説明・列挙する必要があるため -->

## 顧客価値・目的

**誰の**: ganbari-quest に PR を出す全ての開発者 / レビューする QM
**どんな状況で**: 手順書 (PR テンプレート) どおりに body を書いたとき / 証跡が埋まっていない body をレビューするとき
**何を得るか**: (1) 手順書どおりに書けば gate を通る状態、(2) 「埋めていない証跡ブロックを根拠にした `[x]`」を人の目でなく機械が止める状態

現状は逆で、テンプレートを貼ると gate が必ず落ちるため全員が黙って手順書から逸脱しており、その結果「gate の指摘は本当の欠陥か手順書のせいか」が判別できなくなっていた。同時に、証跡ブロックが未置換のまま Ready 化された PR (#4002) は QM の目視でしか止まらなかった。

## 関連 Issue

Closes #4029
Closes #4022

- PR #4002 — #4029 の発見元 (証跡ブロックが未置換のまま Ready 化)
- #4021 — #4022 の deadlock を実測で踏んだ PR
- ADR-0061 (人の注意依存を機械強制へ) / ADR-0060 (完了宣言の検証義務)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| #4029 AC1 | 未置換トークンが body のどこにあっても (code fence 内を含む) 検出され fail する | `npx vitest run tests/unit/scripts/check-pr-body.test.ts` の `[PH1]` `[PH3]` `[PH4]` | PASS。`[PH1]` は #4002 の body 断片 (fence 内) を fixture にして 1 件検出、行番号 6 まで一致 |
| #4029 AC2 | PO 決裁セクションの空欄検出が従来どおり動く (回帰なし) | 同ファイル `[PH10]` + 既存 `checkPoDecisionBrief` テスト群 | PASS。`po-decision-brief-unfilled-placeholder` が従来どおり返る。既存 100 テスト green |
| #4029 AC3 | 除外宣言を書いた場合のみ通過し、label 単独では通過しない | 同ファイル `[PH8]` `[PH9]` | PASS。宣言時のみ skip + SKIPPED 行出力、理由 10 文字未満は違反。label 風文字列 (`labels: placeholder-allowed`) では通らない |
| #4029 AC4 | #4002 の body 断片を fixture とした unit test があり、gate を外すと fail する | mutation C (`PLACEHOLDER_PATTERNS` を空配列に置換) | `exit=1` で 5 テスト fail (95 passed)。復元後は 229 passed。ログは下記「テスト実行結果」 |
| #4029 AC5 | `npm run pre-ready` Step 9 経由でも同じ検出が働く | Step 9 の実体が `check-pr-body.mjs` であることと、検出が `collectViolations` に組み込まれている点 (`node scripts/check-pr-body.mjs --help` の 9 番目に掲載) | PASS。`main()` → `collectViolations()` の 1 経路のみで、`--pr` / `--body-file` 双方に適用される |
| #4022 AC1 | テンプレートの禁止語が 0 件 | `node -e` で `scanForbiddenTerms(stripMarkdownComments(...))` を 5 テンプレートに実行 | 5 ファイルすべて 0 件。ログは下記「テスト実行結果」 |
| #4022 AC2 | 書き換え後もチェック項目として残っている (削除で 0 件にしていない) | `.github/PULL_REQUEST_TEMPLATE.md` の当該行 | 「全 AC が実装済み（未実装・先送りのまま残っている AC がない）」として存置。意味は不変 |
| #4022 AC3 | 実ファイルを読み `scanForbiddenTerms` が 0 件を返すテストが 1 本ある | `tests/unit/github/pr-body-template-integrity.test.ts` の 1 つ目の describe | PASS。fixture 文字列ではなく `readFileSync` で実ファイルを読む |
| #4022 AC4 | HTML コメント内の禁止語は現行どおり許容 | 同ファイル「HTML コメント内の禁止語は許容する」 | PASS。テンプレート 67 行目 / 166 行目のコメントは無傷 |
| #4022 AC5 | テンプレートの `## ` 見出しを変更しない | `git diff origin/develop -- .github/PULL_REQUEST_TEMPLATE.md` に見出し差分なし | PASS。差分は本文 2 行とコメント 1 箇所のみ。必須セクション 13 件は不変 |
| #4022 AC6 | Ready セクションから自己参照項目を削除し、コメントに証跡の書き方を追記 | `.github/PULL_REQUEST_TEMPLATE.md` の 164-171 行 | PASS。削除 + コメントに「実行証跡はログのパスと結果を本文に記載する」を追記 |
| #4022 AC7 | `## テスト & 安全装置セルフチェック` 側の集約申告は残す | 同テストファイル「集約申告は残す (AC7 境界)」 | PASS。当該セクションは `findUncheckedReadyChecklist` の対象外で deadlock 経路にない |
| #4022 AC8 | 実ファイルを読み、Ready セクション内に該当未チェック項目が 0 件であることを固定 | 同ファイル 2 つ目の describe (`it.each`) | PASS。mutation で 5 ファイルそれぞれ個別に fail することを実測 |
| #4022 AC9 | `.github/PR_TEMPLATE_SECTIONS.json` を変更しない | `git diff --name-only origin/develop` | PASS。同 JSON は変更ファイル一覧に含まれない。同期スクリプトも実行していない |
| #4022 AC10 | skill 側 4 テンプレートからも同じ項目を削除し同じコメントを入れる | `git diff origin/develop -- .claude/skills/dev-open-pr/templates/` | PASS。default / critical-fix / lp / refactor-ssot の 4 ファイルすべて |
| #4022 AC11 | 判定入力を 7 つにする (実ファイル 5 + `renderBackMergePrBody` の 2 分岐) | 同テストファイルの `it.each(TEMPLATE_FILES)` + `it.each([false, true])` | PASS。5 ファイルそれぞれ 1 行ずつ戻す mutation を個別実行し全件 fail を実測 |
| #4022 AC12 | `ready-gate-checklist.md` の当該行を例示から外す | `git diff origin/develop -- .claude/skills/dev-open-pr/ready-gate-checklist.md` | PASS。118 行目の「実機検証してから `[x]`」という規律は残置 |
| #4022 AC13 | `scripts/back-merge-pr-body.mjs` のコードは変更しない | `git diff --name-only origin/develop` | PASS。同ファイルは変更ファイル一覧になく、テストは export 済み関数を呼ぶだけ |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・変更コンポーネント

- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 顧客向け画面への影響なし。PR 提出フロー (テンプレート + `check-pr-body.mjs` + `pre-ready` Step 9 + `.husky/pre-push`) のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）

> **実行結果**: exit 0、適用対象の 12 step 全て PASS。summary は `PARTIAL PASS — 5 step が --skip 指定で未実行です (lp-dimensions, lp-fallback, lp-labels, ss-embed-gate, capture)` と表示されるが、**`--skip` は 1 つも指定していない**。5 step は LP / labels.ts / UI を触っていないことによる適用対象外の自動 skip で、`pre-ready` がこの 2 種を区別せず表示するのが原因（#4018、PR #4037 で修正済）。
>
> 初回実行では Step 1b (cspell) が本 PR の負例 fixture (`XXXY` / `labelish`) で fail した。これらは typo ではなく検出器の負例そのものなので、`.cspell.json` の辞書（= 本物の語彙）には入れず file-scoped `// cspell:ignore` で当該ファイルに閉じた。
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/github/pr-body-template-integrity.test.ts` (新規、16 テスト) — 実テンプレート 5 ファイル + `renderBackMergePrBody` 2 分岐の計 7 入力に対し「禁止語 0 件」「Ready セクションに自己参照項目 0 件」を固定
  - `tests/unit/scripts/check-pr-body.test.ts` (追記、`[PH1]`〜`[PH11]` の 11 テスト) — #4002 の body 断片を fixture にした検出 / 除外宣言 / 誤検出の境界 / 既存の空欄検出の回帰なし
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 新規 env / secret の追加なし
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — `priority:critical` ラベルなし

### 本 PR で実行した検証コマンドと結果

実装中は他セッションと CPU が競合するため `npm run pre-ready` を回さず、以下を個別実行して検証した。Ready 化の直前に `npm run pre-ready -- --pr 4036` を通してある（結果は上記）。

```console
$ npx biome check .
Checked 2053 files in 9s. No fixes applied.  (errors 0)

$ npx vitest run tests/unit/scripts/check-pr-body.test.ts tests/unit/github/pr-body-template-integrity.test.ts
 Test Files  2 passed (2)
      Tests  116 passed (116)

$ node scripts/check-pr-body.mjs --help
  9. 未置換プレースホルダ (___ (template の空欄) / PLACEHOLDER / *_PLACEHOLDER / TBD / XXX / <ここに…> 型スロット) が body のどこかに残存 (code fence 内も対象、#4002 / #4029)
```

### mutation 検証 (テストが本当に効いていることの実測)

`git checkout -- .` で毎回復元しながら、5 テンプレートに 1 行ずつ戻す / 禁止語を混ぜる / gate 本体を無効化する の 7 通りを個別に実行した。

```console
=== BASELINE (no mutation) ===
Test Files  11 passed (11)
Tests  229 passed (229)

=== MUTATION A: restore pre-ready item into .github/PULL_REQUEST_TEMPLATE.md ===
exit=1  Tests  1 failed | 15 passed (16)
=== MUTATION A: ... pr-body-default.md ===        exit=1  Tests  1 failed | 15 passed (16)
=== MUTATION A: ... pr-body-critical-fix.md ===   exit=1  Tests  1 failed | 15 passed (16)
=== MUTATION A: ... pr-body-lp.md ===             exit=1  Tests  1 failed | 15 passed (16)
=== MUTATION A: ... pr-body-refactor-ssot.md ===  exit=1  Tests  1 failed | 15 passed (16)

=== MUTATION B: inject forbidden term into .github/PULL_REQUEST_TEMPLATE.md ===
exit=1  Tests  1 failed | 15 passed (16)
FAIL  tests/unit/github/pr-body-template-integrity.test.ts > .github/PULL_REQUEST_TEMPLATE.md の禁止語が 0 件

=== MUTATION C: revert #4029 gate (empty PLACEHOLDER_PATTERNS) ===
exit=1  Tests  5 failed | 95 passed (100)
FAIL  [PH1] / [PH3] / [PH4] / [PH9] / [PH11]

=== AFTER RESTORE (all mutations reverted) ===
Test Files  11 passed (11)
Tests  229 passed (229)
git status: (clean)
```

### 誤検出調査 (open PR 12 件に対する実測)

新しい検出を現時点の open PR 全 12 件の body にかけた結果。誤検出 0 件、真の検出 1 件。

| PR | 検出件数 | 検出トークン | 判定 |
|---|---|---|---|
| #4034 / #4032 / #4031 / #4028 | 0 | なし | 誤検出なし |
| #4021 / #4019 / #4016 / #4010 | 0 | なし | 誤検出なし |
| #4002 | 1 (L208) | `PRE_READY_LOG_PLACEHOLDER` | **真の検出**。#4029 の発見元そのもの |
| #3995 / #3992 / #3989 | 0 | なし | 誤検出なし |

**狭めた点**: (1) `XXX` は `#XXX` (Issue 番号の伏せ字引用) / URL パス (`/XXX`) / 語中 (`XXXY`) を除外する `(?<![#/\w-])XXX(?![\w-])` に限定した。(2) `PLACEHOLDER` は大文字のみとし、英文中の小文字 `placeholder` は拾わない。(3) HTML コメント内は対象外 (テンプレート由来の記入ガイドであり開発者の本文ではない)。行番号がずれないよう、コメントは削除ではなく空白マスクで処理している。

## スクリーンショット / ビジュアルデモ

N/A — 顧客向け画面の変更なし (CI スクリプトと PR テンプレートのみ)。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検出ロジックは `scanPlaceholders` (検出) / `parsePlaceholderScanSkip` (宣言解釈) / `checkPlaceholders` (判定) に分離。既存の `scanForbiddenTerms` と同じ関数形に揃えた
- [x] **DRY**: 専用スクリプトを新設せず `check-pr-body.mjs` を拡張 (#1442)。`grep -rn "PLACEHOLDER" scripts/` で他に同種の検出実装がないことを確認済
- [x] **YAGNI**: 除外機構は inline 宣言 1 つのみ。設定ファイル / 環境変数 / label による抜け道は作っていない
- [x] **Security（OSS 公開前提）**: N/A — 入力は自分の PR body のみ、秘密情報の扱いなし。正規表現は入力長に対して線形で catastrophic backtracking を持たない
- [x] **アクセシビリティ**: N/A — UI 変更なし
- [x] **パフォーマンス**: 走査は body の行数 × パターン 5 の線形。既存の走査と同オーダー

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外
- [x] **並行 PR overlap** (#1200): `scripts/check-pr-body.mjs` / PR テンプレートを同時に触る open PR がないことを確認 (`gh pr list` の 12 件を確認済)
- [x] **設計書同期** (ADR-0001): `docs/design/` 側に本 gate の仕様記述はなく、`node scripts/check-pr-body.mjs --help` が SSOT。ヘルプに 9 番目の検出として追記済

**横展開して発見した同型欠陥**: `.claude/skills/dev-open-pr/templates/pr-body-critical-fix.md` の 39 行目にも同じ禁止語 2 語が入っていたため、同じ書き換えを適用した (`.github/` 側だけ直しても、そのテンプレートを選んだ PR で再発するため)。

## レビュー依頼事項・破壊的変更

- [x] このPRに破壊的変更は**含まれない**

**レビューしていただきたい点**:

1. **gate を弱めていないこと**の確認 — テンプレート由来の行を除外する例外は `check-pr-body.mjs` に一切足していない (それを足すとテンプレートの行をコピーすれば禁止語を持ち込めるため)。修正したのは手順書側のみ
2. **除外宣言の設計** — `<!-- placeholder-scan-skip: 理由 -->` は理由 10 文字以上を要求し、skip した場合は「何件を見逃したか」を SKIPPED 行として出力する (無言 pass を作らない、#3962 と同方針)。本 PR 自身がこの宣言を使っている
3. **Ready チェックリストから項目を 1 つ減らしたこと** — 自動で `[x]` を書き戻す案は採らなかった (機械が人の代わりに自己申告することになるため)

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りのまま残っている AC がない）
- [x] Phase 分割した場合: N/A — 分割していない
- [x] UI 変更時: N/A — UI 変更なし
- [x] 認証画面変更時: N/A — 認証画面の変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

