### PR TITLE
test(ci): #4033 cron registry ↔ CDK ↔ dispatcher の drift を 3 方向 + FS 母数で機械検証する (AC1 / AC2)

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -102,7 +102,7 @@
 | POST | /api/v1/reward-redemption-requests | 交換申請作成（子供） | 全ロール（child 含む） |
 | GET | /api/v1/reward-redemption-requests | 申請一覧取得（親用管理画面） | owner/parent |
 | PATCH | /api/v1/reward-redemption-requests/:id | 申請承認/却下（親） | owner/parent |
-| POST | /api/cron/expire-redemptions | 30 日経過申請を expired に移行（日次 cron） | cron 認証 |
+| POST | /api/cron/expire-redemptions | 30 日経過申請を expired に移行（手動 / 外部呼び出し。`scheduleRegistry` / EventBridge / dispatcher には未登録） | cron 認証 |
 
 ### チェックリスト
 
@@ -2525,10 +2525,8 @@ if (authError) return authError;
 |------|---------|------|
 | `/api/cron/retention-cleanup` | POST / GET | 保持期間超過データの物理削除（ADR-0028） |
 | `/api/cron/trial-notifications` | POST | トライアル通知の日次送信 |
-| `/api/cron/grace-period-deletion` | POST / GET | グレースピリオド期限切れテナントの物理削除バッチ（#1648 R43, grace-period-service.ts findExpiredSoftDeletedTenants → account-deletion-service deleteOwnerOnlyAccount/deleteOwnerFullDelete 経由）。プラン別猶予期間（standard:7 / family:30 日）後に soft-delete されたテナントを物理削除し、個人情報保護法 22 条遵守 + DB 肥大化リスクを解消する。EventBridge 02:00 JST 実行 |
+| `/api/cron/grace-period-deletion` | POST / GET | グレースピリオド期限切れテナントの物理削除バッチ（#1648 R43, grace-period-service.ts findExpiredSoftDeletedTenants → account-deletion-service deleteOwnerOnlyAccount/deleteOwnerFullDelete 経由）。プラン別猶予期間（standard:7 / family:30 日）後に soft-delete されたテナントを物理削除し、個人情報保護法 22 条遵守 + DB 肥大化リスクを解消する。`scheduleRegistry` は 02:00 JST で定義するが AWS 側は EventBridge Rule 未作成のため未駆動で、現状は NUC scheduler のみが起動する (#4033) |
 | `/api/cron/pmf-survey` | POST | PMF 判定アンケート（Sean Ellis Test）の半期一括送信バッチ（#1598 / ADR-0023 §3.6）。EventBridge cron `0 0 1 6,12 ? *` (UTC) = 6/1 + 12/1 09:00 JST 実行。`pmf-survey-service.ts processTenant` が契約 14 日超のテナントの owner ロール宛に SES でアンケ URL を送信。同一 half-year round 内の重複送信を `pmf_survey_sent_<round>` settings KV キーで防止。年 6 回上限の `marketing-email-counter` を共有 |
-| `/api/cron/analytics-aggregate` | POST / GET | analytics 事前集計バッチ（#1693, #1639 follow-up）。EventBridge cron `cron(0 18 * * ? *)` (UTC) = 03:00 JST 実行。`analytics-aggregate-service.ts runAnalyticsAggregation` が前日 (UTC) 1 日分の activation funnel + cancellation reason 集計を計算し、DynamoDB `PK=ANALYTICS_AGG#<YYYY-MM-DD>` (SK=`FUNNEL` / `CANCELLATION_30D` / `CANCELLATION_90D`, TTL 365 日) に書き込む。`/admin/analytics` の read 側 (`analytics-service.ts`) は集計レコードを優先取得し、無い分のみライブ計算で fallback する設計（service interface は不変）。`dryRun=true` で計算のみ実行 (smoke test 用)、`targetDate=YYYY-MM-DD` で過去日を再集計可能。詳細は `docs/design/13-AWSサーバレスアーキテクチャ設計書.md §7.2` を参照 |
-| `/api/cron/challenge-aggregate` | POST / GET | challenge (preset distribution) 事前集計バッチ（#1742, #1602 N+1 GetItem 移行）。EventBridge cron `cron(30 18 * * ? *)` (UTC) = 03:30 JST 実行 (analytics-aggregator-daily と被らないよう 30 分ずらし)。`challenge-aggregate-service.ts runChallengeAggregation` が当日時点の全テナント `questionnaire_challenges` 設定値を CSV 配列に集約し、DynamoDB `PK=CHALLENGE_AGG#<YYYY-MM-DD>` (SK=`AGGREGATE`, TTL 365 日) に書き込む。`/ops/analytics` プリセット選択分布画面の read 側 (`ops-analytics-service.fetchChallengesPerTenant`) は直近 7 日分の集計レコードから最新を採用し、無ければライブ集計 (settings repo を tenant ごと N+1 で叩く #1602 既存実装) で fallback。`dryRun=true` で計算のみ実行 (smoke test 用)、`targetDate=YYYY-MM-DD` で過去日を再集計可能。詳細は `docs/design/13-AWSサーバレスアーキテクチャ設計書.md §6.x ops/analytics` を参照 |
 | `/api/cron/export-build` | POST / GET | クラウドエクスポート非同期 build バッチ（#3504, async-backup-export.md §3.2）。EventBridge cron `cron(0/5 * * * ? *)` (UTC) = 5 分毎実行 (AWS cron-dispatcher / NUC scheduler container 双方が同一 endpoint を駆動)。`status='pending'` の `cloud_exports` レコードを拾い `building` → `buildFullBackupZip` → storage 保存 → `ready`（失敗時 `failed` + `failureReason`）に遷移させる |
 | `/api/cron/pglite-backup` | POST | **NUC 専用** PGlite 本番データの日次バックアップ（#3950）。NUC ローカルの crond（`docker-compose.yml` backup profile、03:00 JST）が `scripts/backup-nuc.cjs` 経由で起動する。`runPgliteBackup()` が PGlite 公式 `dumpDataDir()` でダウンタイム 0 の整合スナップショットを取得し、**取得物を別インスタンスへ実際に復元して検証**（V1 全テーブル `count(*)` / V2 `__drizzle_migrations` 非空 / V3 journal ↔ 適用実績の突合）した上で確定、3 世代へローテーションする。`DATA_SOURCE != pglite` では 409 を返す（AWS は DSQL のため対象外）。EventBridge / `scheduleRegistry` には登録しない（NUC 専用のため）。運用手順は `docs/runbooks/pglite-restore-drill.md` |
 | `/api/v1/admin/tenant-cleanup` | POST | テナントクリーンアップ |

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -180,10 +180,10 @@
 
 **Cron ジョブ一覧 (#1376):**
 
-スケジュール SSOT は `src/lib/server/cron/schedule-registry.ts`。本表は registry の全 8 ジョブと 1:1 で対応する。
+スケジュール SSOT は `src/lib/server/cron/schedule-registry.ts`。本表は registry の全 7 ジョブと 1:1 で対応する。
 「EventBridge」列は AWS 本番でジョブを駆動する EventBridge Rule (`infra/lib/compute-stack.ts` の `CRON_JOBS`) の有無、
 「dispatcher」列は cron-dispatcher Lambda の `KNOWN_ENDPOINTS` (`infra/lambda/cron-dispatcher/index.ts`) への登録有無を示す。
-NUC セルフホスト版は AWS を経由せず `scripts/scheduler.ts` が registry 全 8 ジョブを node-cron で直接駆動するため、
+NUC セルフホスト版は AWS を経由せず `scripts/scheduler.ts` が registry 全 7 ジョブを node-cron で直接駆動するため、
 EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 
 | ジョブ (registry name) | スケジュール (UTC) | JST 換算 | EventBridge | dispatcher | 概要 |
@@ -194,18 +194,16 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 | lifecycle-emails | `cron(30 0 * * ? *)` | 毎日 09:30 | ✓ | ✓ | 期限切れ前リマインド + 休眠復帰メール (#1601, ADR-0023 §5 I11) |
 | grace-period-deletion | `cron(0 17 * * ? *)` | 毎日 02:00 | ✗ | ✓ | グレースピリオド期限切れテナントの物理削除バッチ (#1648 R43, `grace-period-service.ts`)。**dispatcher には登録済だが AWS EventBridge Rule 未作成のため AWS 本番では未駆動、現状は NUC scheduler のみで起動** |
 | pmf-survey | `cron(0 0 1 6,12 ? *)` | 6/1・12/1 09:00 | ✓ | ✓ | PMF 判定アンケート (Sean Ellis Test) 年 2 回配信 (#1598, ADR-0023 §5 I7) |
-| analytics-aggregator-daily | `cron(0 18 * * ? *)` | 毎日 03:00 | ✓ | ✓ | 前日分 funnel + cancellation 事前集計バッチ (#1693, #1639 follow-up) |
-| challenge-aggregator-daily | `cron(30 18 * * ? *)` | 毎日 03:30 | ✓ | ✓ | 当日分の全テナント `questionnaire_challenges` スナップショット集計、`/ops/analytics` プリセット分布画面の N+1 移行用 (#1742, #1602) |
 | export-build | `cron(0/5 * * * ? *)` | 5 分毎 | ✓ | ✓ | クラウドエクスポート非同期 build バッチ (#3504, async-backup-export.md §3.2)。`status='pending'` の `cloud_exports` を拾い ZIP 生成 → S3/ローカル FS 保存 → `ready` に遷移。AWS (cron-dispatcher) / NUC (scheduler container) 双方が同一 endpoint を駆動 |
 
 - ターゲット: AWS では `ganbari-quest-cron-dispatcher` Lambda (JSON payload `{ cronJob: "<job-name>" }`) が EventBridge から起動され `/api/cron/:job` を HTTP POST する
 - AWS EventBridge Rule 名は `ganbari-quest-cron-<job-name>` (例: `ganbari-quest-cron-retention-cleanup`)
 - `ganbari-quest-cron-license-expire` は license key 全廃 (#2822 / Epic #2525 Phase 7 PR-L3) で撤去済。期限管理は Stripe `customer.subscription.deleted` webhook に代替
 - `lifecycle-emails` (#1601, ADR-0023 §5 I11): 親オーナー宛のみ送信。年 6 回マーケティングメール上限を遵守。List-Unsubscribe ヘッダ + 配信停止リンク必須。Anti-engagement 整合 (中立トーン)。
-- **registry 外の endpoint**: `/api/cron/expire-redemptions` (#1337, 30 日以上 pending の交換申請を expired に移行) は endpoint として存在するが registry / EventBridge / dispatcher いずれにも未登録のため、自動スケジュール駆動はされない (手動 / 外部呼び出し前提)
+- **registry 外の endpoint**: `/api/cron/expire-redemptions` (#1337, 30 日以上 pending の交換申請を expired に移行) は endpoint として存在するが registry / EventBridge / dispatcher いずれにも未登録のため、自動スケジュール駆動はされない (手動 / 外部呼び出し前提)。`/api/cron/pglite-backup` (#3950) も同様に registry 外で、NUC ローカルの crond (`docker-compose.yml` backup profile) が駆動する
 - **検証手順 / runbook**: [`docs/runbooks/cron-3-endpoints-verification.md`](../runbooks/cron-3-endpoints-verification.md) (#1377 Sub A-3)
 - **認証ヘッダ**: dispatcher は `Authorization: Bearer <CRON_SECRET>` を送信。endpoint 側は `verifyCronAuth` (`src/lib/server/auth/cron-auth.ts`) で `Authorization: Bearer` と `x-cron-secret` の両ヘッダを受理する (#1377 で統一、NUC scheduler / AWS dispatcher 双方互換)
-- **Sub A-3 検証層** (#1377): `tests/unit/cron/schedule-consistency.test.ts` が registry / CDK / dispatcher の整合性を検証する。Sub A-3 対象 endpoint (retention-cleanup / trial-notifications) は 0 tolerance で厳密検証する一方、`age-recalc` は EventBridge / dispatcher 未反映の既知 drift として `KNOWN_DRIFT_OUT_OF_SCOPE` で除外している (上表「✗」と整合)。`scripts/check-cron-observability.mjs` (`npm run check:cron-observability`) が logger / Alarm 定義の存在を静的検査する
+- **Sub A-3 検証層** (#1377): `tests/unit/cron/schedule-consistency.test.ts` が registry / CDK / dispatcher の整合性を検証する。registry ⊆ CDK / CDK ⊆ registry / registry ↔ dispatcher の 3 方向に加え、`src/routes/api/cron/*/+server.ts` の実 FS 列挙を母数とした網羅、および上表 (job 行 / ✓ ✗ 列 / UTC cron 式 / 件数) と code の一致を検証する。EventBridge Rule 未作成の `age-recalc` / `grace-period-deletion` は理由と追跡 Issue (#4033) を必須とする `DOCUMENTED_EXCLUSIONS` に明示登録して除外している (上表「✗」と整合)。gap が解消した除外エントリは同テストが stale として検出する。`scripts/check-cron-observability.mjs` (`npm run check:cron-observability`) が logger / Alarm 定義の存在を静的検査する
 
 **Cron ジョブ実行時間予算 — 30 秒 self-limiting + 持ち越し規約 (#3695):**
 

--- a/docs/runbooks/cron-3-endpoints-verification.md
+++ b/docs/runbooks/cron-3-endpoints-verification.md
@@ -61,15 +61,15 @@ npx vitest run tests/unit/services/trial-notification-service.test.ts
 # scheduler コンテナを含めて起動
 ssh <NUC_USER>@<NUC_HOST> "cd <NUC_APP_DIR> && docker compose --profile scheduler up -d"
 
-# scheduler 登録確認 (起動ログに 9 jobs registered と出る)
+# scheduler 登録確認 (起動ログに 7 jobs registered と出る)
 ssh <NUC_USER>@<NUC_HOST> "cd <NUC_APP_DIR> && docker compose logs scheduler | head -30"
 
 # 期待出力:
-#   [scheduler] registered: license-expire (0 0 * * * JST) → http://app:3000/api/cron/license-expire
+#   [scheduler] registered: age-recalc (0 0 * * * JST) → http://app:3000/api/cron/age-recalc
 #   [scheduler] registered: retention-cleanup (0 1 * * * JST) → http://app:3000/api/cron/retention-cleanup
 #   [scheduler] registered: trial-notifications (0 9 * * * JST) → http://app:3000/api/cron/trial-notifications
 #   ...
-#   [scheduler] started. APP_URL=http://app:3000, jobs=9
+#   [scheduler] started. APP_URL=http://app:3000, jobs=7
 
 # 手動 dryRun テスト (副作用なし)
 ssh <NUC_USER>@<NUC_HOST> "curl -s -X POST http://localhost:3000/api/cron/retention-cleanup \
@@ -84,19 +84,18 @@ ssh <NUC_USER>@<NUC_HOST> "curl -s -X POST http://localhost:3000/api/cron/retent
 > これは「申し送り」ではなく Issue 設計時点で PO scope として明示済み (#1377 本文「開発チームへの注記 (AWS CLI 権限)」参照)。
 
 ```bash
-# 1. EventBridge Rule の登録確認 (Sub A-3 対象 3 rule 含む全 6 rule)
+# 1. EventBridge Rule の登録確認 (CRON_JOBS = compute-stack.ts の 5 rule)
 aws events list-rules --name-prefix ganbari-quest-cron --region us-east-1
 
-# 期待: 以下の name で 6 件以上 (#1377 時点 6 rule, #1601/#1598/#1693 で増加)
-#   - ganbari-quest-cron-license-expire
+# 期待: 以下の 5 件 (SSOT: infra/lib/compute-stack.ts の CRON_JOBS)
 #   - ganbari-quest-cron-retention-cleanup
 #   - ganbari-quest-cron-trial-notifications
 #   - ganbari-quest-cron-lifecycle-emails
 #   - ganbari-quest-cron-pmf-survey
-#   - ganbari-quest-cron-analytics-aggregator-daily
+#   - ganbari-quest-cron-export-build
 
 # 2. dispatcher Lambda の dryRun smoke test (deploy.yml で自動実行済みだが手動でも可能)
-for job in license-expire retention-cleanup trial-notifications; do
+for job in retention-cleanup trial-notifications lifecycle-emails; do
   aws lambda invoke \
     --function-name ganbari-quest-cron-dispatcher \
     --payload "{\"cronJob\":\"$job\",\"dryRun\":true}" \
@@ -112,12 +111,12 @@ done
 
 # 3. CloudWatch Logs での実行ログ確認 (schedule 時刻前後)
 aws logs tail /aws/lambda/ganbari-quest-cron-dispatcher --region us-east-1 \
-  --since 24h | grep -E "(license-expire|retention-cleanup|trial-notifications)"
+  --since 24h | grep -E "(retention-cleanup|trial-notifications|lifecycle-emails)"
 
 # 期待: schedule 時刻に dispatcher → endpoint が呼ばれた形跡 (status 200)
 
 # 4. 本番 invoke (dryRun なし — 実ジョブ実行)
-# 注意: retention-cleanup / license-expire は副作用あり。本番で手動 invoke する際は注意
+# 注意: retention-cleanup / lifecycle-emails は副作用あり。本番で手動 invoke する際は注意
 aws lambda invoke \
   --function-name ganbari-quest-cron-dispatcher \
   --payload '{"cronJob":"trial-notifications"}' \
@@ -140,7 +139,6 @@ curl -s -X POST <APP_URL>/api/cron/retention-cleanup
 # 期待: HTTP 401 (production) / 200 or 500 (AUTH_MODE=local)
 
 # C. 冪等性 (2 回連続 dryRun=false で副作用が増えないこと)
-# license-expire: 1 回目で revoke=N, 2 回目で revoke=0 になる
 # retention-cleanup: 1 回目で activityLogsDeleted=N, 2 回目で 0
 # trial-notifications: 同じ日付で再実行しても sent が増えない
 #   (notification-service が `getNotificationSchedule` で日付閾値判定)

--- a/tests/unit/cron/schedule-consistency.test.ts
+++ b/tests/unit/cron/schedule-consistency.test.ts
@@ -9,7 +9,7 @@
 //   いずれかの drift は EventBridge → dispatcher → endpoint の経路で
 //   silent fail を起こすため (#1586 で実例)、CI で 0 tolerance で検出する。
 //
-// 検証範囲 (本 Issue Sub A-3 の Dev スコープ):
+// 検証範囲:
 //   1. Sub A-3 対象 endpoint (retention-cleanup / trial-notifications)
 //      が registry に存在し、name / endpoint パスが期待値と一致すること
 //      (#2818 Phase 7 PR-L3: license key 全廃に伴い license-expire を SUB_A3_ENDPOINTS から除外)
@@ -18,6 +18,14 @@
 //   3. dispatcher KNOWN_ENDPOINTS の各 endpoint パスが registry の endpoint と一致
 //   4. registry の utcCronExpression と CDK CRON_JOBS の utcCronExpression が一致
 //      (CDK は tsconfig rootDir 制約のためインライン定義しているが、SSOT との drift は禁止)
+//   5. (#4033 AC1) registry ⊆ CDK CRON_JOBS。registry にあるのに EventBridge Rule が無い job は
+//      「エラーも出さずに一度も発火しない」ため、CDK → registry の片方向照合だけでは検出できない。
+//      本 PR で欠けていた向きを追加し、3 層 (registry / CDK / dispatcher) を双方向で閉じる。
+//   6. (#4033 AC1) 実 FS 上の src/routes/api/cron/*/+server.ts が母数。registry にも
+//      明示除外にも載っていない endpoint を no-silent-gap で弾く (母数を literal 固定にしない)。
+//
+// 除外は DOCUMENTED_EXCLUSIONS の 1 構造だけに集約し、理由 (reason) と追跡 Issue (issue) を必須とする。
+// 無条件・無期限の暗黙 skip (旧 KNOWN_DRIFT_OUT_OF_SCOPE) は禁止。
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -27,6 +35,88 @@ import { scheduleRegistry } from '../../../src/lib/server/cron/schedule-registry
 // Sub A-3 で検証対象となる既存 endpoint
 // (#2818 Phase 7 PR-L3: license key 全廃で license-expire 撤去、3 → 2 endpoint)
 const SUB_A3_ENDPOINTS = ['retention-cleanup', 'trial-notifications'] as const;
+
+/** SvelteKit cron endpoint の実体ディレクトリ (母数の SSOT。literal 列挙は禁止) */
+const CRON_ROUTE_DIR = 'src/routes/api/cron';
+
+/** 13-AWS 設計書の Cron ジョブ一覧表 (docs ↔ code 照合用) */
+const AWS_DESIGN_DOC = 'docs/design/13-AWSサーバレスアーキテクチャ設計書.md';
+
+/**
+ * 明示除外の唯一の構造 (#4033)。
+ *
+ * - `scope`: どの照合方向で除外するか。
+ *   - `cdk-cron-jobs`         … registry にあるが compute-stack.ts CRON_JOBS に無いことを許容
+ *   - `dispatcher-known-endpoints` … registry にあるが cron-dispatcher KNOWN_ENDPOINTS に無いことを許容
+ *   - `registry`              … FS 上に endpoint があるが schedule-registry.ts に無いことを許容
+ * - `reason`: 空文字禁止 (メタ検証で assert する)。理由なしの除外を追加できないようにする。
+ * - `issue`: 追跡 Issue 番号。`#1234` 形式必須。
+ *
+ * age-recalc / grace-period-deletion の 2 件は「registry に載っているのに AWS で一度も発火しない」
+ * 実害 (#4033) そのものであり、有効化は本番テナントの物理削除を伴うため判断を要する。
+ * 本 gate は gap を機械的に可視化・帰属させるための暫定明示であり、
+ * **#4033 AC3-AC5 (有効化 / registry 側からの撤去) を適用する PR で該当エントリを削除する**。
+ * 除外が実態と合わなくなったら [X2] が fail するため、削除漏れも機械検出される。
+ */
+interface DocumentedExclusion {
+	name: string;
+	scope: 'cdk-cron-jobs' | 'dispatcher-known-endpoints' | 'registry';
+	reason: string;
+	issue: string;
+}
+
+const DOCUMENTED_EXCLUSIONS: DocumentedExclusion[] = [
+	{
+		name: 'age-recalc',
+		scope: 'cdk-cron-jobs',
+		reason:
+			'EventBridge Rule 未作成のため AWS 本番では未駆動 (NUC scheduler のみ起動)。有効化可否は #4033 AC4 で判断する',
+		issue: '#4033',
+	},
+	{
+		name: 'age-recalc',
+		scope: 'dispatcher-known-endpoints',
+		reason:
+			'cron-dispatcher KNOWN_ENDPOINTS 未登録。EventBridge Rule 追加と同時に登録する (#4033 AC4)',
+		issue: '#4033',
+	},
+	{
+		name: 'grace-period-deletion',
+		scope: 'cdk-cron-jobs',
+		reason:
+			'dispatcher には登録済だが EventBridge Rule 未作成。有効化すると猶予期間経過済テナントが初回実行で一斉に物理削除されるため、対象件数確認と判断を要する (#4033 AC3)',
+		issue: '#4033',
+	},
+	{
+		name: 'expire-redemptions',
+		scope: 'registry',
+		reason:
+			'30 日以上 pending の交換申請を expired に移行する手動 / 外部呼び出し前提の endpoint (#1337)。自動スケジュール駆動しない設計のため registry に載せない',
+		issue: '#1337',
+	},
+	{
+		name: 'pglite-backup',
+		scope: 'registry',
+		reason:
+			'NUC 専用の日次バックアップ endpoint (#3950)。NUC ローカルの crond (docker-compose.yml backup profile) が駆動し、AWS 側は DSQL のため対象外',
+		issue: '#3950',
+	},
+];
+
+function isExcluded(name: string, scope: DocumentedExclusion['scope']): boolean {
+	return DOCUMENTED_EXCLUSIONS.some((e) => e.name === name && e.scope === scope);
+}
+
+/** FS 上に実在する cron endpoint 名 (ディレクトリ名) を列挙する。literal 列挙は禁止 */
+function listFilesystemCronEndpoints(): string[] {
+	const dir = path.resolve(__dirname, '../../..', CRON_ROUTE_DIR);
+	return fs
+		.readdirSync(dir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => entry.name)
+		.filter((name) => fs.existsSync(path.join(dir, name, '+server.ts')))
+		.sort();
+}
 
 // dispatcher / CDK のソースコードを文字列で読んで KNOWN_ENDPOINTS / CRON_JOBS を抽出する。
 // import すると Node エイリアスや CDK 依存解決が必要になり脆弱なため、構文解析的に最小限読む。
@@ -94,22 +184,13 @@ describe('#1377 schedule consistency — Sub A-3 対象 3 endpoint', () => {
 });
 
 describe('#1377 schedule consistency — registry ↔ dispatcher KNOWN_ENDPOINTS', () => {
-	// NOTE (#1377 Sub A-3 で発見):
-	// 現在 registry にあるが dispatcher / CDK には未登録の job が `age-recalc` 1 件存在する。
-	// `age-recalc` は #1381 で登録された JST=00:00 のジョブだが、AWS EventBridge 化が
-	// dispatcher 側 KNOWN_ENDPOINTS / CDK CRON_JOBS には反映されていない。
-	// 本 Issue (#1377) のスコープは既存 endpoint (retention-cleanup /
-	// trial-notifications、#2818 で license-expire 撤去) の検証であるため、age-recalc の不整合は本 PR では修正対象外
-	// (別 Issue で対応)。`SUB_A3_ENDPOINTS` の整合性のみ厳密に検証する。
-	const KNOWN_DRIFT_OUT_OF_SCOPE = ['age-recalc'];
-
 	it('registry の name (Sub A-3 範囲外も含む) が dispatcher KNOWN_ENDPOINTS に存在する (drift 監視)', () => {
 		const dispatcherEndpoints = extractDispatcherEndpoints();
 		const dispatcherNames = new Set(Object.keys(dispatcherEndpoints));
 
 		const missing: string[] = [];
 		for (const job of scheduleRegistry) {
-			if (KNOWN_DRIFT_OUT_OF_SCOPE.includes(job.name)) continue;
+			if (isExcluded(job.name, 'dispatcher-known-endpoints')) continue;
 			if (!dispatcherNames.has(job.name)) {
 				missing.push(job.name);
 			}
@@ -178,5 +259,178 @@ describe('#1377 schedule consistency — registry ↔ CDK CRON_JOBS', () => {
 			const reg = registryByName.get(name);
 			expect(cdk?.utcCronExpression).toBe(reg?.utcCronExpression);
 		}
+	});
+
+	// [R1] #4033 AC1: 欠けていた向き。registry に足して CRON_JOBS に足し忘れると
+	// EventBridge Rule が作られず「エラーも出ないまま一度も発火しない」。
+	it('[R1] registry の全 job が CDK CRON_JOBS に存在する (明示除外を除く)', () => {
+		const cdkNames = new Set(extractCdkCronJobs().map((j) => j.name));
+
+		const missing: string[] = [];
+		for (const job of scheduleRegistry) {
+			if (isExcluded(job.name, 'cdk-cron-jobs')) continue;
+			if (!cdkNames.has(job.name)) {
+				missing.push(job.name);
+			}
+		}
+		expect(missing).toEqual([]);
+	});
+});
+
+describe('#4033 schedule consistency — FS 実体 (src/routes/api/cron) を母数とする網羅', () => {
+	// [F1] 母数を literal ではなく実 FS から導出する (#4030 と同一 class の再発防止)。
+	it('[F1] FS 上の cron endpoint は registry か明示除外のいずれかに載っている', () => {
+		const registryNames = new Set(scheduleRegistry.map((j) => j.name));
+
+		const unaccounted = listFilesystemCronEndpoints().filter(
+			(name) => !registryNames.has(name) && !isExcluded(name, 'registry'),
+		);
+		expect(unaccounted).toEqual([]);
+	});
+
+	// [F2] 逆向き。registry が実在しない endpoint を指していれば dispatcher が 404 を踏む。
+	it('[F2] registry の全 job に対応する +server.ts が FS に存在する', () => {
+		const fsNames = new Set(listFilesystemCronEndpoints());
+
+		const missing = scheduleRegistry
+			.filter((job) => !fsNames.has(job.name))
+			.map((job) => `${job.name} (${job.endpoint})`);
+		expect(missing).toEqual([]);
+	});
+
+	it('[F3] registry の endpoint パスが /api/cron/<name> 規約に一致する', () => {
+		const mismatches = scheduleRegistry
+			.filter((job) => job.endpoint !== `/api/cron/${job.name}`)
+			.map((job) => `${job.name}: ${job.endpoint}`);
+		expect(mismatches).toEqual([]);
+	});
+});
+
+describe('#4033 schedule consistency — 明示除外のメタ検証 (no-silent-gap)', () => {
+	// [X1] 理由が空の除外を追加できないようにする。
+	it('[X1] 全ての除外が非空の reason と追跡 Issue を持つ', () => {
+		const invalid = DOCUMENTED_EXCLUSIONS.filter(
+			(e) => e.name.trim() === '' || e.reason.trim() === '' || !/^#\d+$/.test(e.issue),
+		).map((e) => `${e.scope}:${e.name}`);
+		expect(invalid).toEqual([]);
+	});
+
+	// [X2] 実態が解消したのに除外が残っていれば fail させる。
+	// #4033 AC3-AC5 の有効化 PR で該当エントリを消し忘れると、この test が落ちて気付ける。
+	it('[X2] 実態と一致しない (もはや gap ではない) 除外が残っていない', () => {
+		const cdkNames = new Set(extractCdkCronJobs().map((j) => j.name));
+		const dispatcherNames = new Set(Object.keys(extractDispatcherEndpoints()));
+		const registryNames = new Set(scheduleRegistry.map((j) => j.name));
+		const fsNames = new Set(listFilesystemCronEndpoints());
+
+		// scope ごとに「除外元に載っているべき集合」と「載っていたら gap 解消済 = stale な集合」を宣言する
+		const rules: Record<
+			DocumentedExclusion['scope'],
+			{ source: Set<string>; resolved: Set<string>; resolvedLabel: string }
+		> = {
+			'cdk-cron-jobs': {
+				source: registryNames,
+				resolved: cdkNames,
+				resolvedLabel: 'CRON_JOBS 登録済',
+			},
+			'dispatcher-known-endpoints': {
+				source: registryNames,
+				resolved: dispatcherNames,
+				resolvedLabel: 'KNOWN_ENDPOINTS 登録済',
+			},
+			registry: { source: fsNames, resolved: registryNames, resolvedLabel: 'registry 登録済' },
+		};
+
+		const stale = DOCUMENTED_EXCLUSIONS.flatMap((e) => {
+			const rule = rules[e.scope];
+			if (!rule.source.has(e.name)) return [`${e.scope}:${e.name} (除外元に存在しない)`];
+			if (rule.resolved.has(e.name)) return [`${e.scope}:${e.name} (${rule.resolvedLabel})`];
+			return [];
+		});
+		expect(stale).toEqual([]);
+	});
+});
+
+describe('#4033 schedule consistency — 13-AWS 設計書 Cron ジョブ一覧表 ↔ code', () => {
+	/** 設計書の Cron ジョブ一覧表 (見出し直後の連続する `|` 行) を抽出する */
+	function extractDocCronSection(): { rows: string[][]; prose: string } {
+		const lines = readSourceText(AWS_DESIGN_DOC).split(/\r?\n/);
+		const headingIdx = lines.findIndex((l) => l.includes('Cron ジョブ一覧'));
+		expect(headingIdx).toBeGreaterThanOrEqual(0);
+
+		const tableStart = lines.findIndex((l, i) => i > headingIdx && l.trimStart().startsWith('|'));
+		expect(tableStart).toBeGreaterThan(headingIdx);
+
+		const rows: string[][] = [];
+		for (let i = tableStart; i < lines.length; i++) {
+			const line = lines[i];
+			if (line === undefined || !line.trimStart().startsWith('|')) break;
+			const cells = line
+				.trim()
+				.replace(/^\|/, '')
+				.replace(/\|$/, '')
+				.split('|')
+				.map((c) => c.trim());
+			rows.push(cells);
+		}
+		// prose は見出しから表の直前まで (「registry の全 N ジョブ」等の記述)
+		return { rows, prose: lines.slice(headingIdx, tableStart).join('\n') };
+	}
+
+	/** ヘッダ / 区切り行を除いた job 行のみ */
+	function docJobRows(rows: string[][]): string[][] {
+		return rows.filter((cells) => /^[a-z][a-z0-9-]*$/.test(cells[0] ?? ''));
+	}
+
+	it('[D1] 表の job 行が registry と 1:1 で一致する (phantom 行 / 追記漏れの検出)', () => {
+		const { rows } = extractDocCronSection();
+		const docNames = docJobRows(rows)
+			.map((cells) => cells[0] as string)
+			.sort();
+		const registryNames = scheduleRegistry.map((j) => j.name).sort();
+		expect(docNames).toEqual(registryNames);
+	});
+
+	it('[D2] 表の EventBridge / dispatcher 列が CRON_JOBS / KNOWN_ENDPOINTS の実態と一致する', () => {
+		const { rows } = extractDocCronSection();
+		const cdkNames = new Set(extractCdkCronJobs().map((j) => j.name));
+		const dispatcherNames = new Set(Object.keys(extractDispatcherEndpoints()));
+
+		const mismatches: string[] = [];
+		for (const cells of docJobRows(rows)) {
+			const name = cells[0] as string;
+			const expectedEventBridge = cdkNames.has(name) ? '✓' : '✗';
+			const expectedDispatcher = dispatcherNames.has(name) ? '✓' : '✗';
+			if (cells[3] !== expectedEventBridge) {
+				mismatches.push(`${name}: EventBridge doc="${cells[3]}" actual="${expectedEventBridge}"`);
+			}
+			if (cells[4] !== expectedDispatcher) {
+				mismatches.push(`${name}: dispatcher doc="${cells[4]}" actual="${expectedDispatcher}"`);
+			}
+		}
+		expect(mismatches).toEqual([]);
+	});
+
+	it('[D3] 表の UTC cron 式が registry と一致する', () => {
+		const { rows } = extractDocCronSection();
+		const registryByName = new Map(scheduleRegistry.map((j) => [j.name, j]));
+
+		const mismatches: string[] = [];
+		for (const cells of docJobRows(rows)) {
+			const name = cells[0] as string;
+			const docExpr = (cells[1] ?? '').replace(/`/g, '').trim();
+			const registryExpr = registryByName.get(name)?.utcCronExpression;
+			if (docExpr !== registryExpr) {
+				mismatches.push(`${name}: doc="${docExpr}" registry="${registryExpr}"`);
+			}
+		}
+		expect(mismatches).toEqual([]);
+	});
+
+	it('[D4] 表前文の「全 N ジョブ」記述が registry 件数と一致する', () => {
+		const { prose } = extractDocCronSection();
+		const counts = [...prose.matchAll(/全\s*(\d+)\s*ジョブ/g)].map((m) => Number(m[1]));
+		expect(counts.length).toBeGreaterThan(0);
+		expect(counts.filter((n) => n !== scheduleRegistry.length)).toEqual([]);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（間接的に 親（管理者）／運営）

**解決する課題**: `infra/lib/compute-stack.ts` は「SSOT: schedule-registry.ts」と宣言しているのに機械照合が無く、registry に登録した cron を `CRON_JOBS` に足し忘れても**エラーも警告も出ないまま一度も発火しない**。実際に `age-recalc` と `grace-period-deletion` の 2 件がこの状態にある。既存テストは CDK → registry の片方向しか見ておらず、この向きの drift を構造的に検出できなかった。

**期待される効果**: registry / CDK / dispatcher / 実 FS の 4 つの母数を相互に閉じ、以後この class の登録漏れは CI で必ず落ちる。現存する 2 件の gap は理由と追跡 Issue 付きで明示登録され、「登録されているのに動かない」状態が沈黙しなくなる。

## 関連 Issue

#4033 (AC1 / AC2) — 本 PR は gate のみで Issue はクローズしない。

Issue 本文の分割方針「AC1 / AC2（gate）と AC3-AC5（判断と適用）は別 PR にする」に従う。AC3-AC5（`grace-period-deletion` / `age-recalc` を `CRON_JOBS` に登録するか、しないなら registry 側から外すかの判断と適用）は、有効化した瞬間に**猶予期間を過ぎた退会申請テナントが初回実行で一斉に物理削除される**ため、対象件数の確認と PO 判断を要する。本 PR では `CRON_JOBS` / `KNOWN_ENDPOINTS` / `schedule-registry.ts` を一切変更していない。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | registry と `CRON_JOBS` の一致を機械検証する fitness test を追加し、乖離したら CI で落ちる | `npx vitest run tests/unit/cron/` | HEAD `b0295f62` / 21 passed (2 files) / `tests/unit/cron/schedule-consistency.test.ts:236` `[R1] registry の全 job が CDK CRON_JOBS に存在する` |
| AC1 | 母数を literal ではなく実体（FS / dispatcher / doc）から導出し no-silent-gap 化する | `npx vitest run tests/unit/cron/` | HEAD `b0295f62` / `schedule-consistency.test.ts:117` `listFilesystemCronEndpoints()` が `fs.readdirSync` で列挙 / `[F1]` `[F2]` `[F3]` `[D1]`-`[D4]` |
| AC1 | 無条件・無期限の暗黙 skip を廃し、理由 + 追跡 Issue 必須の明示除外に置換する | `git show b0295f62 -- tests/unit/cron/schedule-consistency.test.ts` | HEAD `b0295f62` / `KNOWN_DRIFT_OUT_OF_SCOPE` 削除 → `DOCUMENTED_EXCLUSIONS` (`schedule-consistency.test.ts:68`) / `[X1]` が reason 非空 + `#\d+` を assert |
| AC2 | mutation で AC1 の実効性を示す（registry に 1 件足す / `CRON_JOBS` から 1 件消す → fail） | 下記「mutation 検証」7 種の実出力 | HEAD `b0295f62` / mutation A で 5 件 fail・B で 2 件 fail・C で 1 件 fail / 全 mutation revert 後 `git diff --stat -- src infra` が空 |
| AC3 | `grace-period-deletion` を `CRON_JOBS` に追加するかの判断 | 本 PR 対象外（Issue の分割方針に従い gate と分離） | 未着手 / `infra/lib/compute-stack.ts` は本 PR で無変更（`git diff --stat -- infra` 空） |
| AC4 | `age-recalc` を `CRON_JOBS` に追加するかの判断 | 本 PR 対象外（同上） | 未着手 / `DOCUMENTED_EXCLUSIONS` に `#4033` 追跡付きで明示登録済 |
| AC5 | 追加しない場合の registry 側撤去 / 明示除外 | 本 PR 対象外（同上） | 未着手 / gate 側の明示除外は本 PR で先行、適用 PR で該当エントリ削除（削除漏れは `[X2]` が検出） |
| AC6 | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4038`（exit 0） | **PASS** — 適用対象の 12 step 全て PASS。残り 5 step は LP / UI 非変更による適用対象外（`--skip` 指定なし、下記注記参照） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — `tests/unit/cron/` の fitness test + 設計書 3 件

**影響を受ける画面・機能**: なし（実行コードの変更ゼロ。CI 検証と設計書のみ）。

### 追加した assertion

| ID | 検証内容 | 母数の導出元 | 検出できる defect |
|---|---|---|---|
| [R1] | registry ⊆ CDK `CRON_JOBS` | `schedule-registry.ts` / `compute-stack.ts` 実ソース | registry に足して EventBridge Rule を足し忘れ（本 Issue の defect 本体） |
| [F1] | FS 上の cron endpoint ⊆ registry ∪ 明示除外 | `fs.readdirSync('src/routes/api/cron')` | endpoint を作ったが registry にも除外にも載せない silent gap |
| [F2] | registry ⊆ FS 上の `+server.ts` | 同上 | registry が実在しない endpoint を指し dispatcher が 404 を踏む |
| [F3] | registry の `endpoint` が `/api/cron/<name>` 規約に一致 | `schedule-registry.ts` | 命名規約からの逸脱 |
| [X1] | 全除外が非空 `reason` + `#\d+` の `issue` を持つ | `DOCUMENTED_EXCLUSIONS` | 理由なし除外の silent 追加 |
| [X2] | 実態と一致しない（もはや gap でない）除外が残っていない | 4 母数の突合 | AC3-AC5 適用 PR での除外エントリ削除漏れ |
| [D1] | 13-AWS 設計書の表の job 行 = registry | 設計書表 / registry | phantom 行・追記漏れ |
| [D2] | 表の EventBridge / dispatcher 列 = 実態 | `CRON_JOBS` / `KNOWN_ENDPOINTS` | ✓ ✗ の嘘（`grace-period-deletion` を ✓ と書く等） |
| [D3] | 表の UTC cron 式 = registry | registry | スケジュール記述の drift |
| [D4] | 表前文の「全 N ジョブ」= registry 件数 | registry | 件数記述の drift（今回 8 と書かれ実体 7・表 9 行だった） |

既存 assertion（Sub A-3 endpoint 検証 / dispatcher パス一致 / CDK ⊆ registry / cron 式一致）は**削除も緩和もしていない**。除外の適用箇所のみ `KNOWN_DRIFT_OUT_OF_SCOPE` → `isExcluded(name, scope)` に置換した（旧構造は `age-recalc` を全方向で無条件 skip、新構造は方向ごとに理由付きで限定）。mutation F で旧 assertion が従来どおり fail することを実出力で確認済み（ADR-0006）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）

> **summary 表示についての注記**: 実行結果は exit 0 で、適用対象の 12 step は全て PASS。ただし summary は `PARTIAL PASS — 5 step が --skip 指定で未実行です (lp-dimensions, lp-fallback, lp-labels, ss-embed-gate, capture)` と表示される。**`--skip` は 1 つも指定していない**。5 step はいずれも「LP / labels.ts / UI を触っていないので適用対象外」による自動 skip で、`pre-ready` がこの 2 種を区別せず表示するのが原因（#4018、PR #4037 で修正済）。本 PR の変更は test / 設計書のみで LP / UI 差分は無い
- [x] 追加・変更したテストの概要:
  - `tests/unit/cron/schedule-consistency.test.ts` に `[R1]` `[F1]`-`[F3]` `[X1]` `[X2]` `[D1]`-`[D4]` の 10 assertion を追加（10 tests → 17 tests）
  - 除外構造を `KNOWN_DRIFT_OUT_OF_SCOPE`（無条件 skip）から `DOCUMENTED_EXCLUSIONS`（`{ name, scope, reason, issue }`）へ置換
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:high` / gate 追加）

### 実行した検証コマンドと結果

| 検証 | コマンド | 結果 |
|---|---|---|
| unit test | `npx vitest run tests/unit/cron/ tests/unit/infra/` | 14 files / 145 passed |
| lint | `npx biome check tests/unit/cron/schedule-consistency.test.ts` | Checked 1 file. 0 warning / 0 error |
| doc 参照整合 | `node scripts/check-doc-code-references.mjs` | baseline 内 (139 件、53 ファイル)。新規違反なし |
| spell | `npx cspell lint --no-progress tests/unit/cron/schedule-consistency.test.ts` | Files checked: 1, Issues found: 0 |

### mutation 検証（AC2 実出力）

各 mutation は適用 → テスト実行 → **revert** の順で実施した。7 種すべてで意図した assertion のみが fail する。

| mutation | 変更内容 | fail した assertion | 実出力 |
|---|---|---|---|
| A | `schedule-registry.ts` に `dummy-mutation-job` を追加 | `[R1]` / dispatcher drift / `[F2]` / `[D1]` / `[D4]` の 5 件 | `Tests 5 failed \| 12 passed (17)` |
| B | `CRON_JOBS` から `lifecycle-emails` を削除 | `[R1]` / `[D2]` の 2 件 | `Tests 2 failed \| 15 passed (17)` |
| C | `src/routes/api/cron/dummy-mutation-endpoint/+server.ts` を新規作成 | `[F1]` の 1 件 | `Tests 1 failed \| 16 passed (17)` |
| D | 設計書表に phantom 行 `phantom-aggregator-daily` を追加 | `[D1]` / `[D2]` / `[D3]` の 3 件 | `Tests 3 failed \| 14 passed (17)` |
| E | `reason: ''` の除外を追加 | `[X1]` / `[X2]` の 2 件 | `Tests 2 failed \| 15 passed (17)` |
| F | dispatcher の `pmf-survey` パスを typo 化 + `retention-cleanup` の cron 式を改変（**既存** assertion の非弱体化確認） | dispatcher パス一致 / CDK cron 式一致 / Sub A-3 cron 式一致 の 3 件（いずれも従来から存在する assertion） | `Tests 3 failed \| 14 passed (17)` |
| G | 既に `CRON_JOBS` 登録済の `pmf-survey` に対する除外を追加（stale 除外） | `[X2]` の 1 件 | `Tests 1 failed \| 16 passed (17)` |

fail 時の代表メッセージ:

```
 × [R1] registry の全 job が CDK CRON_JOBS に存在する (明示除外を除く)
   AssertionError: expected [ 'dummy-mutation-job' ] to deeply equal []        (mutation A)
   AssertionError: expected [ 'lifecycle-emails' ] to deeply equal []          (mutation B)
 × [F1] FS 上の cron endpoint は registry か明示除外のいずれかに載っている
   AssertionError: expected [ 'dummy-mutation-endpoint' ] to deeply equal []   (mutation C)
 × [D4] 表前文の「全 N ジョブ」記述が registry 件数と一致する
   AssertionError: expected [ 7, 7 ] to deeply equal []                        (mutation A)
 × [X1] 全ての除外が非空の reason と追跡 Issue を持つ
   AssertionError: expected [ 'cdk-cron-jobs:pmf-survey' ] to deeply equal []  (mutation E)
```

revert 完了の物理確認（mutation は `src` / `infra` にのみ加えたため、両者の diff が空であることが revert 完了の証跡）:

```
$ git diff --stat -- src infra
（出力なし）
$ git status --short
 M docs/design/07-API設計書.md
 M docs/design/13-AWSサーバレスアーキテクチャ設計書.md
 M docs/runbooks/cron-3-endpoints-verification.md
 M tests/unit/cron/schedule-consistency.test.ts
```

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更を含まない test / docs のみの PR）**

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし | 該当なし |
| **修正後** | 該当なし | 該当なし |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 除外判定を `isExcluded(name, scope)` の 1 関数に集約し、各 assertion は判定ロジックを持たない
- [x] **DRY**: 新規スクリプトを作らず既存 `tests/unit/cron/schedule-consistency.test.ts` を拡張した（`scripts/` への使い捨てスクリプト追加禁止 #1442）。母数抽出は既存の `extractCdkCronJobs` / `extractDispatcherEndpoints` / `readSourceText` を再利用
- [x] **YAGNI**: 検証対象は現存する 4 母数のみ。将来の cron 基盤変更を見越した抽象化は入れていない
- [x] **Security（OSS 公開前提）**: N/A（秘密情報を扱わない。テストは公開ソースの静的読み取りのみ）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: 追加検証は同期 FS 読み取り 3 件 + 正規表現のみ。実行時間 2.4s（cron 2 files 21 tests）

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードとチュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): 同 class の drift を実態に合わせて是正（下表）
- [x] **並行 PR overlap** (#1200): `tests/unit/cron/` / cron 系設計書を触る open PR は無し
- [ ] N/A — 並行実装の影響範囲外

### 是正した設計書 drift（いずれも実ソースと突合して確認）

| ファイル | 実態と異なっていた記述 | 実態 | 是正後 |
|---|---|---|---|
| `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` | 「registry の全 8 ジョブと 1:1」+ 表が 9 行 | registry は 7 ジョブ | 「全 7 ジョブ」+ 表 7 行に修正（`[D1]` `[D4]` が以後機械検証） |
| 同上 | `analytics-aggregator-daily` / `challenge-aggregator-daily` を EventBridge ✓ / dispatcher ✓ で掲載 | #3805 で撤去済（registry / `CRON_JOBS` / endpoint いずれにも不在、`tests/unit/infra/staging-cdk.test.ts:207` が「7→5 本」と記録） | 2 行を削除 |
| 同上 | 検証層の説明が `KNOWN_DRIFT_OUT_OF_SCOPE` を参照 | 本 PR で `DOCUMENTED_EXCLUSIONS` に置換 | 新構造と 3 方向 + FS 母数の説明に更新 |
| 同上 | registry 外 endpoint として `expire-redemptions` のみ言及 | `pglite-backup` も registry 外（NUC crond 駆動） | `pglite-backup` を追記 |
| `docs/runbooks/cron-3-endpoints-verification.md` | 期待 Rule に `ganbari-quest-cron-license-expire` / `-analytics-aggregator-daily` を列挙 | 実 `CRON_JOBS` は 5 本（retention-cleanup / trial-notifications / lifecycle-emails / pmf-survey / export-build） | 実 5 本に修正。smoke test ループ・ログ grep・副作用注記からも撤去済 job を除去 |
| 同上 | NUC scheduler 起動ログ「9 jobs registered」/「jobs=7」 | `scripts/scheduler.ts:65` は `scheduleRegistry.length` を出力 = 7 | 7 に修正 |
| `docs/design/07-API設計書.md` | `/api/cron/challenge-aggregate` / `/api/cron/analytics-aggregate` を EventBridge 駆動 endpoint として掲載 | 両 endpoint とも FS に不在（`src/routes/api/cron/` は 9 dir、両者を含まない） | 2 行を削除 |
| 同上 | `grace-period-deletion` を「EventBridge 02:00 JST 実行」と記載 | EventBridge Rule 未作成のため AWS では未駆動 | registry 定義は 02:00 JST だが AWS 未駆動である旨に修正（#4033 参照） |
| 同上 | `expire-redemptions` を「日次 cron」と記載 | registry / EventBridge / dispatcher いずれにも未登録 | 手動 / 外部呼び出しである旨に修正 |

`docs/CLAUDE.md` §docs SSOT 原則に従い、いずれも「現状の正解」への書き換えのみで、変更履歴節や datestamp は追加していない。

**設計書の表自体の機械検証について**: 上表 1 行目の drift（件数・phantom 行）は人間の目視では 3 回の改修を跨いで生き残ったため、`[D1]`-`[D4]` として同テストファイル内で機械検証に落とした。表のフォーマット変化への頑健性は、①「見出し `Cron ジョブ一覧` 直後の連続する `|` 行」だけを走査 ② 先頭セルが `^[a-z][a-z0-9-]*$` の行のみを job 行と見なす（ヘッダ / 区切り / 注記行を自動的に除外）③ セル値は trim + backtick 除去して比較、の 3 点で確保した。mutation D で phantom 行を実際に検出できることを確認済み。

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:

1. **本 PR は `#4033` をクローズしない**。`CRON_JOBS` / `KNOWN_ENDPOINTS` / `schedule-registry.ts` は無変更で、`age-recalc` と `grace-period-deletion` は依然 AWS で発火しない。gate が green なのは 2 件を `DOCUMENTED_EXCLUSIONS` に理由付きで明示登録しているためであり、**gap は解消していない**（可視化・帰属のみ）。有効化の判断は AC3-AC5 の別 PR で行う。
2. **意図的にやらなかったこと**: (a) `CRON_JOBS` / `KNOWN_ENDPOINTS` への job 追加（指示および Issue 分割方針どおり）(b) cron 有効化に伴う本番影響の確認（`grace-period-deletion` を CRON_JOBS に足すと猶予期間を過ぎた退会テナントが初回実行で一斉物理削除されるため、件数確認と PO 判断を要する。#4033 AC3〜AC5）(c) `docs/design/08-データベース設計書.md` に残る `gq-analytics-aggregator-daily` / `gq-challenge-aggregator-daily` 記述の是正（DynamoDB 撤去 #3438 に伴う別 class の drift で、cron 表 gate の射程外。本 PR では触れていない）。
3. `[X2]`（stale 除外検出）により、AC3-AC5 の適用 PR で除外エントリを消し忘れると CI が落ちる設計になっている。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**: 実行済（exit 0、適用対象 12 step 全 PASS）。作業中は別セッションとのリソース競合を避けて `npx biome check` / `npx vitest run tests/unit/cron/ tests/unit/infra/` / `node scripts/check-doc-code-references.mjs` / `npx cspell lint` / `node scripts/check-pr-body.mjs` を個別実行して検証し、Ready 化の直前に本 CLI を通した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし。mutation は全て revert 済で `git diff -- src infra` が空）
- [x] 全 AC が実装済み（本 PR scope = AC1 / AC2。AC3-AC5 は Issue の分割方針により別 PR）
- [x] Phase 分割した場合: Issue 本文に分割方針が明記済み
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

