### PR TITLE
fix(ci): #4030 A-1 orphan repo guard の母数を実 FS 由来にし、現役 dsql/pglite を検査対象に入れる

### DIFF
--- a/scripts/check-orphan-repos.mjs
+++ b/scripts/check-orphan-repos.mjs
@@ -37,6 +37,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { escapeRegExp } from './lib/ci/escape-regexp.mjs';
 import {
 	loadBaseline,
 	parseArgs,
@@ -151,15 +152,19 @@ function main() {
 			const locations = [];
 			const layer = path.basename(path.dirname(repoFile));
 			const importNeedle = `${layer}/${base}`;
+			// #4030: 素の includes() だと `sqlite/activity-repo` が
+			// `sqlite/activity-repo-archive` の import にも一致し、結線が切れているのに
+			// 「結線済」と誤判定する。末尾に単語文字 / ハイフンが続かないことを要求する。
+			const needleRe = new RegExp(`${escapeRegExp(importNeedle)}(\\.js)?(?![\\w-])`);
 			for (const src of callerSources) {
 				// 自分自身は除く
 				if (src.file === repoFile) continue;
-				if (!src.text.includes(importNeedle)) continue;
+				if (!needleRe.test(src.text)) continue;
 				const lines = src.text.split(/\r?\n/);
 				for (let i = 0; i < lines.length; i++) {
 					const line = lines[i];
 					if (!/\b(import|from|require)\b/.test(line)) continue;
-					if (line.includes(importNeedle)) {
+					if (needleRe.test(line)) {
 						found = true;
 						locations.push(`${path.relative(REPO_ROOT, src.file).replace(/\\/g, '/')}:${i + 1}`);
 					}

--- a/scripts/check-orphan-repos.mjs
+++ b/scripts/check-orphan-repos.mjs
@@ -2,13 +2,21 @@
 /**
  * scripts/check-orphan-repos.mjs (EPIC #2362 follow-up)
  *
- * src/lib/server/db/{sqlite,demo,dynamodb}/ 配下の repo 実装ファイルについて、
+ * src/lib/server/db/ 配下の各 backend layer の repo 実装ファイルについて、
  * facade (`src/lib/server/db/<name>.ts`) または factory (`src/lib/server/db/factory.ts`)
  * のいずれからも参照されていないものを検出する。
  *
  * 構造的予防の目的:
- *   - 3 layer (sqlite / demo / dynamodb) の追加忘れ / 削除忘れを可視化
+ *   - backend layer の追加忘れ / 削除忘れを可視化
  *   - 機能撤去で実装ファイルだけ残った dead repo を block
+ *
+ * #4030 A-1: layer の母数は **実 FS から導出**する。旧実装は
+ * `const REPO_LAYER_DIRS = ['sqlite', 'demo', 'dynamodb']` の literal 固定で、
+ * `dynamodb` は #3438 で撤去済 (dir 不在) の一方、現行アーキの中心である `dsql/`
+ * (repo 34 本) と `pglite/` が**一度も検査されていなかった**。
+ * 「3 layer の追加忘れ / 削除忘れを可視化する」と自称しながら、layer の増減自体に
+ * 追随できていない状態だったため、母数の導出を FS に変え、repo layer でない dir は
+ * 理由付きで明示除外する (no-silent-gap)。
  *
  * 使用法:
  *   node scripts/check-orphan-repos.mjs              # CI mode
@@ -39,9 +47,39 @@ import {
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const DB_DIR = path.join(REPO_ROOT, 'src', 'lib', 'server', 'db');
-const REPO_LAYER_DIRS = ['sqlite', 'demo', 'dynamodb'];
+
+/**
+ * `src/lib/server/db/` 直下にあるが backend repo layer **ではない** dir と、その理由 (#4030 A-1)。
+ *
+ * ここに無い dir は自動的に repo layer として検査対象になる。新しい dir を足したのに
+ * 検査したくない場合、**理由を書かないと母数から外せない**。理由の非空は
+ * `tests/unit/scripts/check-orphan-repos-population.test.ts` が assert する。
+ *
+ * @type {Record<string, string>}
+ */
+export const NON_REPO_LAYER_DIRS = {
+	interfaces:
+		'repo が実装する interface 定義。実装ではなく caller 側として扱う (下の callerSources に含めている)',
+	types: 'backend 非依存の型定義のみ。repo 実装を持たない',
+	migration: 'schema migration の runner / pipeline / transformer。backend 別の repo 層ではない',
+};
+
+/**
+ * repo layer dir を実 FS から導出する (#4030 A-1)。
+ *
+ * @returns {string[]} layer dir 名 (辞書順)
+ */
+export function resolveRepoLayerDirs(dbDir = DB_DIR) {
+	return fs
+		.readdirSync(dbDir, { withFileTypes: true })
+		.filter((e) => e.isDirectory())
+		.map((e) => e.name)
+		.filter((name) => !(name in NON_REPO_LAYER_DIRS))
+		.sort();
+}
 
 function main() {
+	const REPO_LAYER_DIRS = resolveRepoLayerDirs();
 	const args = parseArgs(process.argv);
 	const mode = args.updateBaseline ? 'update-baseline' : args.report ? 'report' : 'check';
 	const baseline = loadBaseline('repos');
@@ -72,10 +110,41 @@ function main() {
 		}
 	}
 
+	// tier 2 の caller 候補: repo 全体 (#4030 A-1)。
+	// layer 配下には repo 本体 (*-repo.ts) 以外に helper が同居しており (occ-retry / pg-uuid /
+	// dsql-errors 等)、これらは兄弟 repo から import されるのが正常で **facade から呼ばれない**。
+	// facade 到達性を helper にも要求すると 22 件の偽陽性が出て guard が使い物にならなくなるため、
+	// helper には「repo のどこからも import されていない = dead」だけを要求する。
+	// tier 1 (*-repo.ts の facade 到達性) は従来と同じ強さのまま維持する。
+	const repoWideSources = [];
+	for (const root of ['src', 'tests', 'scripts', 'infra']) {
+		const rootDir = path.join(REPO_ROOT, root);
+		if (!fs.existsSync(rootDir)) continue;
+		for (const f of walkDir(rootDir, { extensions: ['.ts', '.mjs', '.js', '.cjs'] })) {
+			repoWideSources.push({ file: f, text: fs.readFileSync(f, 'utf8') });
+		}
+	}
+
 	const findings = repoFiles
 		.map((repoFile) => {
 			const rel = path.relative(REPO_ROOT, repoFile).replace(/\\/g, '/');
 			const base = path.basename(repoFile, '.ts');
+
+			// tier 2: repo 本体でない helper は「どこからも import されていない」だけを検出する
+			if (!base.endsWith('-repo')) {
+				const importers = repoWideSources.filter(
+					(s) =>
+						s.file !== repoFile &&
+						new RegExp(`from\\s+['"][^'"]*\\b${base}(\\.js)?['"]`).test(s.text),
+				);
+				if (importers.length > 0) return null;
+				return {
+					name: rel,
+					reason: `layer helper "${rel}" は repo 全体 (src / tests / scripts / infra) のどこからも import されていません (dead code の疑い)。`,
+					locations: [],
+					allowlisted: baseline.allowed.includes(rel),
+				};
+			}
 			// import path として現れる形式: `./sqlite/<base>` `./dynamodb/<base>` `./demo/<base>`
 			// または `from './sqlite/<base>'` の boundary 一致
 			let found = false;

--- a/scripts/lib/ci/orphan-utils.mjs
+++ b/scripts/lib/ci/orphan-utils.mjs
@@ -128,6 +128,26 @@ export function walkDir(dir, options = {}) {
 export const escapeRegex = escapeRegExp;
 
 /**
+ * baseline の entry のうち、**実在しないファイルを指しているもの**を返す (#4030)。
+ *
+ * 免除 entry は「実在する違反を意図的に許す」記録なので、対象ファイルが消えたら記録も消す。
+ * entry が path でない category (env / labels / routes 等は識別子を入れる) を誤検出しないよう、
+ * 「拡張子を持ち、かつ `/` を含む」= repo 相対 path とみなせるものだけを対象にする。
+ *
+ * @param {{ allowed: string[] }} baseline
+ * @returns {string[]} 実在しない entry
+ */
+export function staleBaselineEntries(baseline) {
+	return (baseline.allowed ?? []).filter(
+		(entry) =>
+			typeof entry === 'string' &&
+			entry.includes('/') &&
+			/\.[a-z]+$/.test(entry) &&
+			!fs.existsSync(path.join(REPO_ROOT, entry)),
+	);
+}
+
+/**
  * 結果 print + exit。
  *  - clean (新規 orphan 0): exit 0
  *  - new orphan あり: exit 1 (CI 用)
@@ -190,6 +210,24 @@ export function reportFindings(category, findings, options) {
 	}
 
 	// check mode (default)
+	//
+	// #4030: baseline に「実在しないファイル」の entry が残っていても、従来は誰も気づけなかった。
+	// 実際 repos.json には #3438 で撤去済の `dynamodb/` 配下 2 件が残り続けていた。
+	// 免除は「実在する違反を意図的に許す」ための記録なので、対象が消えたら記録も消す
+	// (放置すると baseline が「かつて何かがあった跡」の墓場になり、reason の信頼性が落ちる)。
+	const stale = staleBaselineEntries(baseline);
+	if (stale.length > 0) {
+		process.stderr.write(
+			`[check-orphan-${category}] NG — baseline に実在しないファイルの entry が ${stale.length} 件あります:\n`,
+		);
+		for (const s of stale) process.stderr.write(`  - ${s}\n`);
+		process.stderr.write(
+			`\n対応: scripts/orphan-baselines/${category}.json の "allowed" / "reasons" から該当 entry を削除する\n` +
+				'  (対象が消えている以上、その entry は何も免除していない)。\n',
+		);
+		return 1;
+	}
+
 	if (newOrphans.length === 0) {
 		process.stdout.write(
 			`[check-orphan-${category}] OK — ${findings.length} known orphan(s) all in baseline\n`,

--- a/scripts/orphan-baselines/repos.json
+++ b/scripts/orphan-baselines/repos.json
@@ -1,15 +1,17 @@
 {
 	"allowed": [
 		"src/lib/server/db/demo/webhook-event-repo.ts",
-		"src/lib/server/db/dynamodb/client.ts",
-		"src/lib/server/db/dynamodb/keys.ts",
+		"src/lib/server/db/dsql/grant-optional-points.ts",
+		"src/lib/server/db/dsql/invite-accept.ts",
+		"src/lib/server/db/dsql/webhook-event-repo.ts",
 		"src/lib/server/db/sqlite/run-in-transaction.ts"
 	],
 	"reasons": {
-		"src/lib/server/db/dynamodb/client.ts": "DynamoDB client 初期化 helper。#3438 で repo 層撤去後も residual DynamoDB アクセス (migration hydrate writeback.ts / probe.ts / analytics provider) が参照。table 撤去は Phase 3。",
-		"src/lib/server/db/dynamodb/keys.ts": "DynamoDB partition/sort key 構築 helper。#3438 で repo 層撤去後も migration hydrate / probe / backup-entity-registry test が参照。table 撤去は Phase 3。",
 		"src/lib/server/db/demo/webhook-event-repo.ts": "Phase 7 PR-1 expand 段階で配備 (in-memory webhook event repo for demo backend)。facade (`db/webhook-events.ts`) / factory (`factory.ts` `createWebhookEventRepo`) からの import は Phase 7 PR-4a (webhook handler 統合 + sqlite repo 実装と同時) で追加。expand-then-contract pattern 整合 (Phase 6 子 5 #2678 SSOT)。本 PR では in-memory 実装 + unit test (tests/unit/db/webhook-event-repo.test.ts) のみ配備し、PR-4a 着手時に本 entry を baseline から削除する。",
-		"src/lib/server/db/sqlite/run-in-transaction.ts": "EPIC #3424 Phase A cycle-1 (#3531)。runInTransaction / withOccRetry の SQLite 実装 port + unit test のみ本 PR で配備し、既存 write path からの facade/factory 結線は後続サイクルで行う (expand-then-contract pattern、Phase 6 子 5 #2678 SSOT 整合)。結線完了時に本 entry を baseline から削除する。"
+		"src/lib/server/db/sqlite/run-in-transaction.ts": "EPIC #3424 Phase A cycle-1 (#3531)。runInTransaction / withOccRetry の SQLite 実装 port + unit test のみ本 PR で配備し、既存 write path からの facade/factory 結線は後続サイクルで行う (expand-then-contract pattern、Phase 6 子 5 #2678 SSOT 整合)。結線完了時に本 entry を baseline から削除する。",
+		"src/lib/server/db/dsql/webhook-event-repo.ts": "EPIC #3424 M4-E PR8c で DSQL backend 実装 + unit test のみ配備。facade (`db/webhook-events.ts`) / factory 結線は #3985 (webhook event.id dedup が設計・DB・repo・テストまで揃って未配線) で行う。expand-then-contract pattern 整合で、同 layer の demo 実装 (本 baseline の既存 entry) と同じ段階にある。結線時に両 entry を削除する。",
+		"src/lib/server/db/dsql/grant-optional-points.ts": "EPIC #3424 / #3541 (#N4-2 Phase C cycle 2) で配備した optional point 付与プリミティブ。#4030 A-1 で母数を実 FS 由来に変えた結果、repo 全体のどこからも import されていないことが初めて可視化された。結線するか撤去するかの判断は #4039 で行う (guard の母数是正と、それで見つかった違反の是正は別物 — #4030 AC2)。",
+		"src/lib/server/db/dsql/invite-accept.ts": "EPIC #3424 / #3528 (#N2-1 Phase B cycle (b)) で配備した invite 受諾 txn。#4030 A-1 で母数を実 FS 由来に変えた結果、repo 全体のどこからも import されていないことが初めて可視化された。判断は #4039 (#4030 AC2 に従い本 PR では是正しない)。"
 	},
 	"version": "1.0.0",
 	"generated": "2026-07-02T04:27:39.813Z"

--- a/tests/unit/scripts/check-orphan-repos-population.test.ts
+++ b/tests/unit/scripts/check-orphan-repos-population.test.ts
@@ -1,0 +1,119 @@
+/**
+ * tests/unit/scripts/check-orphan-repos-population.test.ts (#4030 A-1)
+ *
+ * ## 何が壊れていたか
+ *
+ * `check-orphan-repos.mjs` の検査対象 layer は literal 固定だった:
+ *
+ * ```js
+ * const REPO_LAYER_DIRS = ['sqlite', 'demo', 'dynamodb'];
+ * ```
+ *
+ * `dynamodb` は #3438 で撤去済で dir すら存在しない。一方、現行アーキの中心である
+ * `dsql/` (repo 34 本) と `pglite/` は**一度も検査対象に入っていなかった**。
+ * 「layer の追加忘れ / 削除忘れを可視化する」と自称する guard が、**layer の増減自体に
+ * 追随できていなかった**。
+ *
+ * ## 本 test が固定すること
+ *
+ * 母数が実 FS から導出されること、および除外が理由付きで明示されること。
+ * 「dsql を literal に足す」だけの修正では [O2] が通らない (同じ腐り方を再現するため)。
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '../../../..');
+const scriptUrl = pathToFileURL(resolve(repoRoot, 'scripts/check-orphan-repos.mjs')).href;
+const utilsUrl = pathToFileURL(resolve(repoRoot, 'scripts/lib/ci/orphan-utils.mjs')).href;
+
+/** .mjs の named export を子プロセスで評価して JSON で受け取る (svelte-check の型 program に載せない)。 */
+function evalInScript<T>(url: string, expr: string): T {
+	const code = `const m = await import(${JSON.stringify(url)});
+process.stdout.write(JSON.stringify(${expr}));`;
+	return JSON.parse(
+		execFileSync(process.execPath, ['--input-type=module', '-e', code], { encoding: 'utf8' }),
+	) as T;
+}
+
+const dbDirs = readdirSync(resolve(repoRoot, 'src/lib/server/db'), { withFileTypes: true })
+	.filter((e) => e.isDirectory())
+	.map((e) => e.name);
+
+describe('#4030 A-1 repo layer の母数は実 FS 由来である', () => {
+	it('[O1] db/ 直下の全 dir は「検査対象」か「理由付き除外」のどちらかに分類される', () => {
+		const layers = evalInScript<string[]>(scriptUrl, 'm.resolveRepoLayerDirs()');
+		const excluded = Object.keys(evalInScript<object>(scriptUrl, 'm.NON_REPO_LAYER_DIRS'));
+		const unclassified = dbDirs.filter((d) => !layers.includes(d) && !excluded.includes(d));
+		expect(unclassified).toEqual([]);
+	});
+
+	// 現行アーキの中心。ここが母数から漏れていたのが本 Issue の実害。
+	it('[O2] 実在する backend layer (dsql / pglite / sqlite / demo) が全て検査対象に入る', () => {
+		const layers = evalInScript<string[]>(scriptUrl, 'm.resolveRepoLayerDirs()');
+		for (const expected of ['dsql', 'pglite', 'sqlite', 'demo']) {
+			expect(layers).toContain(expected);
+		}
+	});
+
+	it('[O3] 除外 dir は実在し、かつ理由が非空である', () => {
+		const excluded = evalInScript<Record<string, string>>(scriptUrl, 'm.NON_REPO_LAYER_DIRS');
+		for (const [name, reason] of Object.entries(excluded)) {
+			// 消えた dir の除外を残さない (母数が腐る方向)
+			expect(dbDirs, `除外 dir "${name}" が実在しない`).toContain(name);
+			expect(reason.trim().length, `除外 dir "${name}" の理由が空`).toBeGreaterThan(0);
+		}
+	});
+
+	// literal 固定に戻す修正を検出する。source 文字列検査なのは、
+	// 「FS から導出しているか」は戻り値だけでは区別できないため
+	// (literal に dsql / pglite を足しても [O1] [O2] は通ってしまう)。
+	it('[O4] layer 一覧を literal 配列で持ち直していない', () => {
+		const src = readFileSync(resolve(repoRoot, 'scripts/check-orphan-repos.mjs'), 'utf8');
+		expect(src).toMatch(/readdirSync\(dbDir/);
+		// 旧実装を引用している doc コメントは対象外 (実コード行だけを見る)
+		const codeOnly = src
+			.split('\n')
+			.filter((l) => {
+				const t = l.trimStart();
+				return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*');
+			})
+			.join('\n');
+		expect(codeOnly).not.toMatch(/REPO_LAYER_DIRS\s*=\s*\[/);
+	});
+});
+
+describe('#4030 baseline に実在しないファイルの entry を残さない', () => {
+	it('[O5] staleBaselineEntries が実在しない entry を検出する', () => {
+		const stale = evalInScript<string[]>(
+			utilsUrl,
+			"m.staleBaselineEntries({ allowed: ['src/lib/server/db/dynamodb/client.ts', 'package.json'] })",
+		);
+		expect(stale).toEqual(['src/lib/server/db/dynamodb/client.ts']);
+	});
+
+	it('[O6] path でない entry (識別子 baseline) を誤検出しない', () => {
+		const stale = evalInScript<string[]>(
+			utilsUrl,
+			"m.staleBaselineEntries({ allowed: ['SOME_ENV_NAME', 'someLabelKey'] })",
+		);
+		expect(stale).toEqual([]);
+	});
+
+	it('[O7] 全 orphan baseline に実在しない entry が無い', () => {
+		const baselineDir = resolve(repoRoot, 'scripts/orphan-baselines');
+		const offenders: string[] = [];
+		for (const file of readdirSync(baselineDir).filter((f) => f.endsWith('.json'))) {
+			const baseline = JSON.parse(readFileSync(resolve(baselineDir, file), 'utf8'));
+			const stale = evalInScript<string[]>(
+				utilsUrl,
+				`m.staleBaselineEntries(${JSON.stringify({ allowed: baseline.allowed ?? [] })})`,
+			);
+			for (const s of stale) offenders.push(`${file}: ${s}`);
+		}
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: この repo を触る開発者（間接的には、DB 層の dead code / 未結線がユーザー影響のあるバグとして現れるのを防ぐ）

**解決する課題**: `check-orphan-repos.mjs` は「backend layer の追加忘れ / 削除忘れを可視化する」と自称しながら、検査対象の layer が literal 固定だった。

```js
// scripts/check-orphan-repos.mjs:42（修正前）
const REPO_LAYER_DIRS = ['sqlite', 'demo', 'dynamodb'];
```

`dynamodb` は #3438 で撤去済で **dir すら存在しない**。一方、現行アーキの中心である `dsql/`（repo 34 本）と `pglite/` は**一度も検査されていなかった**。**layer の増減を可視化する guard が、layer の増減自体に追随できていなかった。**

**期待される効果**: 現役の 34 repo が orphan 検査下に入る。実際、母数を直した時点で**未結線が 3 件見つかった**（下記）。

## 関連 Issue

<!-- no-issue-close: 本 PR は #4030 の A-1 (check-orphan-repos.mjs の母数) のみを実装する。A-2 / A-3 (DSQL 系 fitness の再帰化) と class B (reason 非空 assertion) が未着手のため #4030 は閉じない。#4039 は本 PR が可視化した未結線の triage 先で、本 PR では解決しない。 -->

- #4030 — 本 PR は **A-1（`check-orphan-repos.mjs` の母数）のみ**。Issue 本文が「実害 5 件は守っている不変条件の重さが異なるため 3 つに分ける」と明記しており、A-2 / A-3（DSQL 系 fitness の再帰化）と class B（reason 非空 assertion）は本 PR に含めない
- **#4039** — 本 PR の母数是正で新たに可視化された未結線 2 件の triage（AC2 に従い切り出し）
- #3985 — `dsql/webhook-event-repo.ts` の結線（3 件目はここに帰属）
- #3438 — `dynamodb` layer 撤去。literal 母数が陳腐化した原因
- #4025 / #3658 / #3171 / #3134 — no-silent-gap パターンの系譜

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `REPO_LAYER_DIRS` を実 FS 由来に変える（非 repo dir は理由付きで明示除外、literal のまま `dsql` を足すだけにしない） | `resolveRepoLayerDirs()` + `[O1]`〜`[O4]` | **PASS** — `readdirSync` 由来。`interfaces` / `types` / `migration` を理由付きで除外。`[O4]` が literal 配列への差し戻しを検出する |
| AC2 | 新規検出された orphan の是正は本 Issue に含めず切り出す | #4039 起票 + baseline に追跡先付きで記録 | **PASS** — 3 件を baseline へ。うち 1 件は既存の #3985、残り 2 件は #4039 |
| AC3 | DSQL 系 3 guard の再帰化 | — | **本 PR 対象外**（Issue の分割方針 2 番目） |
| AC4 | AC3 で `migration/` 配下が検出された場合の allowlist 判断 | — | **本 PR 対象外**（AC3 に従属） |
| AC5 | class B（reason 非空 assertion） | — | **本 PR 対象外**（Issue の分割方針 3 番目。AC6 の判断が先） |
| AC6 | `--update-baseline` の自動投入理由をどう扱うか決める | — | **本 PR 対象外**（class B と同じ PR で扱う） |
| AC7 | 各修正に mutation 実出力を添える | 下記 5 種 | **PASS** |
| AC8 | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4040`（exit 0） | **PASS** — 適用対象の 12 step 全て PASS。残り 5 step は LP / UI 非変更による適用対象外（`--skip` 指定なし、下記注記参照） |

### mutation 検証（dev-session §QA 指摘台帳 観点 3）

- **M1** 母数を literal 配列に戻す（`dsql` / `pglite` を含めた「一見正しい」literal でも） → `[O4]` fail（1 failed / 6 passed）
- **M2** 除外理由を空文字にする → `[O3]` fail（1 failed / 6 passed）
- **M3** baseline に実在しない entry を戻す → `[O7]` fail + `check-orphan-repos.mjs` が exit 1
- **M4 (非弱体化確認)** `factory.ts` から `activity-repo` の import 行を全削除 → **6 件検出**（`demo/` `dsql/` `sqlite/` の activity-repo 系）。**修正前は `dsql/activity-repo.ts` が母数に無く検出できなかった**ので、これが本 PR の実効性そのもの
- **M5** `'./sqlite/activity-repo'` → `'./sqlite/activity-repo-archive'` に書き換え（rename して結線が切れた状況） → **1 件検出**。修正前は `includes()` の部分一致で「結線済」と誤判定していた

**テスト設計の要点**: `[O1]` `[O2]`（実 layer が母数に入る）だけだと、**literal 配列に `dsql` を足すだけ**の修正でも緑になり、次に layer が増減したときに同じ腐り方をする。`[O4]` でソース側の導出方法まで固定している。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI — `scripts/check-orphan-repos.mjs` / `scripts/lib/ci/orphan-utils.mjs` / `scripts/orphan-baselines/repos.json`

**影響を受ける画面・機能**: なし（アプリコードは 1 行も変えていない）

## 設計・実装方針

### 母数を FS 由来にすると偽陽性が 22 件出る問題

`dsql/` を母数に入れると、旧来の「facade / factory / interfaces から import されていなければ orphan」規則では **22 件**が orphan として報告された。中身を確認すると、その大半は layer 配下に同居する helper（`occ-retry` / `pg-uuid` / `dsql-errors` / `schema` / `migration/*` 等）で、**兄弟 repo から import されるのが正常であり facade からは呼ばれない**。

これを全部 baseline に流し込むと、それは silent cap そのものになる。かといって facade 到達性を捨てると `*-repo.ts` に対する既存の不変条件が弱まる（ADR-0006）。そこで **2 tier に分けた**。

- **tier 1（`*-repo.ts`）**: facade / factory / interfaces から到達できること。**従来と同じ強さ**
- **tier 2（helper）**: repo 全体（`src` / `tests` / `scripts` / `infra`）のどこからも import されていない = dead

結果、報告は 22 件 → **3 件**になり、その 3 件はいずれも本物だった。

### 新たに可視化された 3 件

- `dsql/webhook-event-repo.ts` — **#3985**（webhook event.id dedup が設計・DB・repo・テストまで揃って未配線）が扱う既知の expand 段階。同 layer の demo 実装は既に同じ理由で baseline にある
- `dsql/grant-optional-points.ts` / `dsql/invite-accept.ts` — repo 全体のどこからも import されていない。結線か撤去かの判断が要るため **#4039** に切り出した

**是正を本 PR に含めていないのは AC2 の指示どおり**（guard の母数是正と、それで見つかった違反の是正は別物）。baseline entry には**追跡先の Issue 番号を書いてある**ので、`--update-baseline` の自動文言で埋めた entry は 1 件も無い。

### baseline に実在しないファイルの entry が残る問題（横展開）

`repos.json` には撤去済 `dynamodb/` 配下の 2 件が残っていた。免除は「実在する違反を意図的に許す」記録なので、**対象が消えたら記録も消す**べきで、残ると baseline が「かつて何かがあった跡」の墓場になり reason の信頼性が落ちる。共有の `orphan-utils.mjs` に検出を追加した。

全 11 baseline を調べたところ、stale entry があるのは `repos.json` の 2 件だけだった（`env` / `labels` / `routes` 等は path でない識別子を入れるため、判定は「拡張子を持ち `/` を含む」entry に限定している。`[O6]` で誤検出しないことを固定）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）

> **summary 表示についての注記**: exit 0 で適用対象の 12 step は全て PASS。ただし summary は `PARTIAL PASS — 5 step が --skip 指定で未実行です (lp-dimensions, lp-fallback, lp-labels, ss-embed-gate, capture)` と表示される。**`--skip` は 1 つも指定していない**。5 step は LP / labels.ts / UI を触っていないことによる適用対象外の自動 skip で、`pre-ready` がこの 2 種を区別せず表示するのが原因（#4018、PR #4037 で修正済）。本 PR の変更は CI script と baseline のみで LP / UI 差分は無い。

- [x] 追加・変更したテストの概要: `tests/unit/scripts/check-orphan-repos-population.test.ts`（新規 7 件、`[O1]`〜`[O7]`）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:high`）

## スクリーンショット / ビジュアルデモ

**該当なし（UI 非影響）**。`.svelte` / `.css` / `site/` の変更ゼロ。CI script とその baseline のみ

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 母数導出（`resolveRepoLayerDirs`）/ 除外宣言（`NON_REPO_LAYER_DIRS`）/ 検出（`main`）を分けた
- [x] **DRY**: stale 検出は共有 `orphan-utils.mjs` に置き、11 category 全てに効く。regex escape は既存の `escapeRegExp` を再利用（3 変種目を作らない、#3766）
- [x] **YAGNI**: tier は 2 段のみ。helper の「誰から呼ばれているか」の分類はしていない
- [x] **Security（OSS 公開前提）**: 秘密情報なし。**guard を緩める変更を含む**（helper の判定基準）ため、`[O4]` `M4` `M5` で「tier 1 が従来どおり検出すること」を明示的に確認した
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: tier 2 で `src` / `tests` / `scripts` / `infra` を 1 度走査する。ローカル実行で 1 秒未満

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — 本 script を参照する設計書記述は無し（`node scripts/check-doc-code-references.mjs` で確認）
- [x] 並行 PR overlap 確認 (#1200) — `scripts/check-orphan-repos.mjs` / `orphan-utils.mjs` を触る open PR は他に無い

**同じ class の横展開**: stale baseline 検出は共有 `orphan-utils.mjs` に入れたので **11 category 全てに効く**。#4030 が挙げる残りの実害（A-2 / A-3 の再帰化、class B の reason 非空）は Issue の分割方針どおり別 PR で扱う

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational | 備考 |
|------------|---------------|----------------------|------|
| N/A | N/A | N/A | LP 非変更 |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビューで見てほしい点**:

1. **tier 2 の判定基準（repo 全体からの import 有無）が緩すぎないか**。helper に facade 到達性を求めるのは誤りだと考えているが、「兄弟 repo からしか呼ばれない helper」と「test からしか呼ばれない helper」を区別していない。後者は dead に近いが、本 PR では区別していない
2. **`migration` を非 repo layer として除外した判断**。`src/lib/server/db/migration/` は runner / pipeline で backend 別実装ではないと読んだ。なお `dsql/migration/` は `dsql` layer 配下なので tier 2 で検査される

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りのまま残っている AC がない）
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付

> AC3〜AC6 は Issue #4030 自身の分割方針に従って別 PR に回している。「全 AC が実装済み」は**本 PR のスコープ（A-1）に対して**の意味であり、`closes #4030` は付けていない。
> チェックリスト 3 項目目は `.github/PULL_REQUEST_TEMPLATE.md` の原文が `check-pr-body.mjs` の禁止語を含むため言い換えている（#4022 / PR #4036 で修正中）。
> UI / 認証画面の 2 項目は本 PR に該当がない（`.svelte` 差分ゼロ）。

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

