### PR TITLE
fix(ci): #3984 CRLF shebang import を vite 設定で根治 + #3983 --labels 経路の fail-closed 化

### DIFF
--- a/.claude/skills/dev-open-pr/ready-gate-checklist.md
+++ b/.claude/skills/dev-open-pr/ready-gate-checklist.md
@@ -23,8 +23,11 @@ Wave 1 (#1969 / #1970 等) で 4 Agent 連続して同じ 4 種類の CI gate �
 
 ```bash
 # 1. PR body 全体 (必須セクション 13 件 / AC マップ / 禁止語 / hotfix 配布証跡欄強化チェック)
-node scripts/check-pr-body.mjs --body-file tmp/pr-bodies/<num>-<slug>.md \
-  --labels "priority:critical,hotfix" --skip-mergeable
+#    Ready 化前 = PR は既に存在するので --pr を渡し、label は PR の実値を使う (#3983)。
+#    --labels は「手で主張した label」なので、間違っていても検出できない。
+#    実 label に po-decision:required が付いていれば PO 決裁ブリーフ gate もここで発火する。
+node scripts/check-pr-body.mjs --pr <num> --body-file tmp/pr-bodies/<num>-<slug>.md \
+  --skip-mergeable
 
 # 2. 設計書同期 (src/routes/ 変更時に docs/design/ 同期 or refactor:internal-no-doc-impact label exempt)
 PR_FILES="$(gh pr diff <num> --name-only)" \
@@ -37,6 +40,13 @@ node scripts/check-no-direct-env-access.mjs
 # 4. 新規 env 配布証跡 (ADR-0006)
 node scripts/check-new-required-env.mjs
 ```
+
+> **PR 作成前に先出しで検証したい場合 (#3983)**: `--pr` が使えないので
+> `--labels "priority:critical,hotfix"` を渡す。このとき **発火しなかった label 条件付き gate は
+> `[check-pr-body] SKIPPED — …` 行に列挙される**ので、その行を読んで「まだ検査していない gate」を
+> 把握すること (`OK — 違反なし` だけ見て全 gate 通過と誤読しない)。
+> label が 1 件も付かない見込みなら `--labels ""` ではなく **`--no-labels`** を使う
+> (空の `--labels` は沈黙 fail-open のため exit 2 で中断する)。
 
 詳細 narrative + 4 PR root cause: `docs/rationale/08-hotfix-pr-ci-fail-prevention.md` / `docs/sessions/dev-session.md` §hotfix PR runbook
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -15,3 +15,9 @@
 *.ttf binary
 *.eot binary
 *.db binary
+
+# #3984: CRLF 回帰テストの fixture のみ、意図的に CRLF で checkout させる。
+# 「CRLF の shebang 付き .mjs を import しても壊れない」ことを全環境 (CI Linux 含む) で
+# 決定的に検証するため、上の `* text=auto eol=lf` を本 1 行で上書きする。
+# 検証: tests/unit/scripts/crlf-shebang-import.test.ts / 対処: vite.config.ts stripShebangPlugin
+tests/fixtures/crlf/*.mjs text eol=crlf

--- a/biome.json
+++ b/biome.json
@@ -149,6 +149,7 @@
 			"!**/.tmp-screenshots",
 			"!**/drizzle",
 			"!tests/fixtures/restore-real-scale-backup.json",
+			"!tests/fixtures/crlf",
 			"!**/.dependency-cruiser-known-violations.json",
 			"!**/eslint-suppressions.json"
 		]

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -923,33 +923,61 @@ export function extractLabelNames(raw) {
  * 見分けがつかない pass は本 Issue が塞ごうとしている失敗 class そのものなので、
  * skip した gate 名を件数付きで出すための一覧をここに固定する。
  *
- * @type {ReadonlyArray<{ name: string; issue: string; label: string }>}
+ * `triggers` は発火 label の実値、`label` は表示用の文字列。
+ *
+ * @type {ReadonlyArray<{ name: string; issue: string; label: string; triggers: string[] }>}
  */
 export const LABEL_CONDITIONAL_GATES = [
 	{
 		name: 'hotfix env 配布証跡 (ADR-0006)',
 		issue: '#2343',
 		label: HOTFIX_LABELS.join(' / '),
+		triggers: [...HOTFIX_LABELS],
 	},
 	{
 		name: 'PO 決裁ブリーフ',
 		issue: '#3962',
 		label: PO_DECISION_LABEL,
+		triggers: [PO_DECISION_LABEL],
 	},
 ];
 
 /**
- * `--no-labels` 指定時に「検査しなかった gate」を明示する出力行を組み立てる (#3962 QA 指摘)。
+ * 与えた label 一覧で **発火しなかった** label 条件付き gate を返す (#3983)。
  *
- * 呼び出し側が `console.log` するだけで済むよう、行配列で返す。
+ * `--no-labels` (labels = []) は全件が未発火になるので、全件 skip の特殊ケースになる。
+ *
+ * @param {string[]} labels
+ * @returns {ReadonlyArray<{ name: string; issue: string; label: string; triggers: string[] }>}
+ */
+export function selectSkippedLabelGates(labels) {
+	const normalized = labels.map((l) => l.trim().toLowerCase());
+	return LABEL_CONDITIONAL_GATES.filter((g) => !g.triggers.some((t) => normalized.includes(t)));
+}
+
+/**
+ * 「検査しなかった gate」を明示する出力行を組み立てる (#3962 QA 指摘 / #3983)。
+ *
+ * #3962 は `--no-labels` にだけ本出力を入れたため、`--labels <csv>` で
+ * 発火しなかった gate は **通常 pass と見分けがつかない**まま残っていた (#3983)。
+ * 「label をこちらが手で主張した」経路 (`--no-labels` / `--labels`) は、その主張が
+ * 誤っていても検出できない以上、どちらも「検査していない」と表示する。
+ * `--pr <N>` の実 label は PR の事実そのものなので「発火しなかった = 正しい判定」であり
+ * 本出力の対象外 (毎回の pre-ready を無意味な SKIPPED 行で埋めない)。
+ *
+ * 呼び出し側が `console.log` するだけで済むよう、行配列で返す。skip 0 件なら空配列。
  * 将来メッセージを整理した拍子に無言化しないよう、gate 名の出現を test で固定している ([LB7])。
  *
+ * @param {string[]} labels 検査に使う label 一覧
+ * @param {string} source 経路の表示名 (`--no-labels` / `--labels`)
  * @returns {string[]}
  */
-export function formatSkippedLabelGates() {
+export function formatSkippedLabelGates(labels, source) {
+	const skipped = selectSkippedLabelGates(labels);
+	if (skipped.length === 0) return [];
 	return [
-		`[check-pr-body] SKIPPED — label 条件付き gate ${LABEL_CONDITIONAL_GATES.length} 件は検査していません (--no-labels)`,
-		...LABEL_CONDITIONAL_GATES.map((g) => `  - ${g.name} (${g.issue}) — 発火 label: ${g.label}`),
+		`[check-pr-body] SKIPPED — label 条件付き gate ${skipped.length} 件は検査していません (${source})`,
+		...skipped.map((g) => `  - ${g.name} (${g.issue}) — 発火 label: ${g.label}`),
 		`  ※ label が付いた後に --pr <N> で再実行しないと、上記 gate は一度も動きません`,
 	];
 }
@@ -969,12 +997,24 @@ export function formatSkippedLabelGates() {
 export function resolveLabels(args, fetched) {
 	if (args.noLabels) return { labels: [] };
 	if (args.labels !== null) {
-		return {
-			labels: args.labels
-				.split(',')
-				.map((s) => s.trim())
-				.filter(Boolean),
-		};
+		const parsed = args.labels
+			.split(',')
+			.map((s) => s.trim())
+			.filter(Boolean);
+		// #3983: `--labels ""` / `--labels " , "` は「label 0 件の明示」ではなく、
+		// `--labels "$LABELS"` で変数が空だった事故の形。#3965 が消した
+		// `catch { return [] }` と同じ沈黙 fail-open になるので受理しない。
+		// 「label が 0 件」を主張する引数は `--no-labels` が既にある。
+		if (parsed.length === 0) {
+			return {
+				error:
+					`--labels に有効な label がありません (受け取った値: ${JSON.stringify(args.labels)})。\n` +
+					`  label 条件付き検査 (hotfix #2343 / po-decision #3962) が黙って全 skip されるのを防ぐため、\n` +
+					`  空の --labels は受理しません (--labels "$VAR" で変数が空だった場合を含む)。\n` +
+					`  対応: label 0 件を明示したいなら --no-labels を使ってください。`,
+			};
+		}
+		return { labels: parsed };
 	}
 	if (fetched !== null) return { labels: fetched };
 	if (args.pr) {
@@ -1240,13 +1280,15 @@ Usage:
 label の解決方法 (#3962):
   label 条件付き gate (hotfix env 配布証跡 #2343 / PO 決裁ブリーフ #3962) が黙って
   skip されるのを防ぐため、label が解決できない呼び出しは exit 2 で中断する (fail-closed)。
-  PR 番号が取れるなら --pr を渡すこと。--no-labels は PR 作成前の dry-run 専用で、
-  指定すると「検査しなかった gate」が SKIPPED 行として出力される。
+  PR 番号が取れるなら --pr を渡すこと。--no-labels / --labels は PR 作成前の dry-run 専用で、
+  どちらも「発火しなかった label 条件付き gate」を SKIPPED 行として出力する (#3983)。
+  空の --labels ("" / " , ") は沈黙 fail-open になるため exit 2 で中断する (#3983)。
 
 Options:
   --pr <num>          GitHub PR 番号 (gh pr view で body 取得 + label 自動検出)
   --body-file <path>  ローカルファイルから body を読む（PR 未作成時の dry-run 用）
   --labels <csv>      PR ラベルをカンマ区切りで明示指定（--body-file 時の hotfix 検出用、#2343）
+                      空文字は不可 — label 0 件の明示は --no-labels を使う (#3983)
   --no-labels         label が 1 件も無いことを明示（--body-file dry-run 用、#3962）
   --draft             Draft 相当として検査（--body-file dry-run 専用、#3997）
                       --pr 指定時は gh pr view --json isDraft の実状態が優先され本フラグは無視される
@@ -1431,10 +1473,15 @@ export async function main(argv = process.argv.slice(2)) {
 	}
 	const labels = resolved.labels;
 
-	// #3962 (QA 指摘): skip した gate を通常 pass と見分けられる形で先に出す。
-	if (args.noLabels) {
-		for (const line of formatSkippedLabelGates()) console.log(line);
-	}
+	// #3962 (QA 指摘) / #3983: skip した gate を通常 pass と見分けられる形で先に出す。
+	// 対象は「label を手で主張した」経路 (--no-labels / --labels) の未発火 gate。
+	const skippedLines = args.noLabels
+		? formatSkippedLabelGates(labels, '--no-labels')
+		: args.labels !== null
+			? formatSkippedLabelGates(labels, '--labels')
+			: [];
+	for (const line of skippedLines) console.log(line);
+	const skippedCount = skippedLines.length === 0 ? 0 : selectSkippedLabelGates(labels).length;
 
 	/** @type {string[]} */
 	const notes = [];
@@ -1462,8 +1509,8 @@ export async function main(argv = process.argv.slice(2)) {
 			? ` (Draft のため Ready 化要件 ${READY_ONLY_GATES.length} 件は deferred)`
 			: '';
 		console.log(
-			args.noLabels
-				? `[check-pr-body] OK (label 条件付き gate ${LABEL_CONDITIONAL_GATES.length} 件は未検査)${draftNote} — 違反なし`
+			skippedCount > 0
+				? `[check-pr-body] OK (label 条件付き gate ${skippedCount} 件は未検査)${draftNote} — 違反なし`
 				: `[check-pr-body] OK${draftNote} — 違反なし`,
 		);
 		return 0;

--- a/tests/fixtures/crlf/crlf-shebang-module.mjs
+++ b/tests/fixtures/crlf/crlf-shebang-module.mjs
@@ -17,6 +17,5 @@ import { basename } from 'node:path';
 
 export const MARKER = 'crlf-shebang-ok';
 
-export function baseOf(p) {
-	return basename(p);
-}
+// module 評価時に hoist 済み import を実際に使う (transform が壊れていれば評価できない)
+export const BASE_OF_SAMPLE = basename('/tmp/foo/bar.mjs');

--- a/tests/fixtures/crlf/crlf-shebang-module.mjs
+++ b/tests/fixtures/crlf/crlf-shebang-module.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * tests/fixtures/crlf/crlf-shebang-module.mjs (#3984)
+ *
+ * CRLF 改行 + shebang + import 文を併せ持つ最小 fixture。
+ * import 文があることが必須 — vite ssr transform が import を先頭行へ hoist した結果、
+ * 除去し損ねた shebang と同一行で衝突する、というのが #3984 の再現条件。
+ *
+ * .gitattributes の `tests/fixtures/crlf/*.mjs text eol=crlf` で全 checkout 環境で
+ * CRLF に固定される (repo 既定の eol=lf を意図的に上書き)。
+ * 改行を LF に直さないこと — CRLF であること自体が検証対象。
+ *
+ * 検証: tests/unit/scripts/crlf-shebang-import.test.ts
+ */
+
+import { basename } from 'node:path';
+
+export const MARKER = 'crlf-shebang-ok';
+
+export function baseOf(p) {
+	return basename(p);
+}

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -42,6 +42,7 @@ import {
 	resolveLabels,
 	scanForbiddenTerms,
 	scanPlaceholders,
+	selectSkippedLabelGates,
 	stripCodeBlocks,
 	stripMarkdownComments,
 } from '../../../scripts/check-pr-body.mjs';
@@ -876,6 +877,16 @@ describe('resolveLabels — label 未解決は fail-closed (#3962 QA BLOCK 1)', 
 		expect(r).toEqual({ labels: [PO_DECISION_LABEL, 'hotfix'] });
 	});
 
+	it('[LB5b] --labels が trim 後に空リストになったら error にする (#3983 沈黙 fail-open)', () => {
+		// `--labels "$LABELS"` で変数が空だった事故の形。label 条件付き gate 2 件が
+		// 全 skip されるのに出力は通常 pass と同じ、という #3965 の残穴。
+		for (const raw of ['', ' ', ',', ' , ', ',,']) {
+			const r = resolveLabels({ ...noLabelArgs, labels: raw }, null);
+			expect('labels' in r).toBe(false);
+			expect('error' in r && r.error).toContain('--no-labels');
+		}
+	});
+
 	it('[LB6] 未解決と label 無しが同じ結果にならない — 同一 body で検査が消えないことの回帰', () => {
 		// QA の再現 (PR #3956 の実 body 相当: po-decision:required 付きだがブリーフ無し)
 		const bodyWithoutBrief = '## 顧客価値・目的\n\n本文\n';
@@ -904,7 +915,7 @@ describe('resolveLabels — label 未解決は fail-closed (#3962 QA BLOCK 1)', 
  */
 describe('formatSkippedLabelGates — --no-labels は何を検査しなかったかを出す (#3962)', () => {
 	it('[LB7] skip した label 条件付き gate の名前と件数が出力に含まれる', () => {
-		const out = formatSkippedLabelGates().join('\n');
+		const out = formatSkippedLabelGates([], '--no-labels').join('\n');
 
 		// 件数が LABEL_CONDITIONAL_GATES と一致する (gate を足したのに文言が古い、を防ぐ)
 		expect(out).toContain(`label 条件付き gate ${LABEL_CONDITIONAL_GATES.length} 件`);
@@ -925,6 +936,47 @@ describe('formatSkippedLabelGates — --no-labels は何を検査しなかった
 		expect(LABEL_CONDITIONAL_GATES.map((g) => g.issue)).toEqual(['#2343', '#3962']);
 		expect(hasPoDecisionLabel([PO_DECISION_LABEL])).toBe(true);
 		expect(hasHotfixLabel(HOTFIX_LABELS.slice(0, 1))).toBe(true);
+	});
+});
+
+/**
+ * #3983: #3962 が塞いだ失敗 class (「検査していない gate が通常 pass に見える」) が
+ * `--labels <csv>` 経路にだけ残っていた。`--labels "priority:critical,hotfix"`
+ * (ready-gate-checklist.md の hotfix 手順そのまま) は po-decision gate を落とすが、
+ * 出力は `OK — 違反なし` で完全な pass と区別がつかなかった。
+ *
+ * 「発火しなかった gate だけ」を SKIPPED として出す形に変え、誤表示 (発火した gate まで
+ * SKIPPED に出す) の回帰も同時に固定する。
+ */
+describe('selectSkippedLabelGates / formatSkippedLabelGates — --labels でも未検査を可視化 (#3983)', () => {
+	it('[LB9] --labels "priority:critical,hotfix" で po-decision gate が SKIPPED に出る', () => {
+		const labels = ['priority:critical', 'hotfix'];
+		const out = formatSkippedLabelGates(labels, '--labels').join('\n');
+
+		expect(out).toContain('SKIPPED');
+		expect(out).toContain('--labels');
+		expect(out).toContain('PO 決裁ブリーフ');
+		expect(out).toContain(PO_DECISION_LABEL);
+		expect(out).toContain('label 条件付き gate 1 件');
+		// 発火した hotfix gate は「検査していない」ではないので出さない
+		expect(out).not.toContain('hotfix env 配布証跡');
+	});
+
+	it('[LB10] 発火した gate は SKIPPED に出ない — 誤表示の回帰', () => {
+		const labels = ['priority:critical', 'hotfix', PO_DECISION_LABEL];
+		expect(selectSkippedLabelGates(labels)).toEqual([]);
+		// 全 gate 発火なら SKIPPED 行そのものを出さない (空配列)
+		expect(formatSkippedLabelGates(labels, '--labels')).toEqual([]);
+	});
+
+	it('[LB11] label 0 件 (--no-labels) は全 gate が skip 対象になる特殊ケース', () => {
+		expect(selectSkippedLabelGates([])).toHaveLength(LABEL_CONDITIONAL_GATES.length);
+	});
+
+	it('[LB12] 大文字 / 前後空白の label でも発火判定される (skip 誤表示の回帰)', () => {
+		expect(selectSkippedLabelGates([' PO-Decision:Required '])).toEqual([
+			LABEL_CONDITIONAL_GATES[0],
+		]);
 	});
 });
 

--- a/tests/unit/scripts/crlf-shebang-import.test.ts
+++ b/tests/unit/scripts/crlf-shebang-import.test.ts
@@ -23,12 +23,9 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // この import 自体が回帰の本体 — plugin が無いと本 file 全体が読み込めず fail する
-import { MARKER, baseOf } from '../../fixtures/crlf/crlf-shebang-module.mjs';
+import { baseOf, MARKER } from '../../fixtures/crlf/crlf-shebang-module.mjs';
 
-const fixturePath = path.resolve(
-	process.cwd(),
-	'tests/fixtures/crlf/crlf-shebang-module.mjs',
-);
+const fixturePath = path.resolve(process.cwd(), 'tests/fixtures/crlf/crlf-shebang-module.mjs');
 
 describe('CRLF shebang module import (#3984)', () => {
 	it('fixture は CRLF 改行 + shebang で保存されている (前提条件の固定)', () => {

--- a/tests/unit/scripts/crlf-shebang-import.test.ts
+++ b/tests/unit/scripts/crlf-shebang-import.test.ts
@@ -1,0 +1,51 @@
+/**
+ * tests/unit/scripts/crlf-shebang-import.test.ts (#3984)
+ *
+ * 回帰テスト: **CRLF の shebang 付き `.mjs` を import しても壊れない**。
+ *
+ * 背景 (#3984): vite 本体の shebang 除去 RE は `/^#!.*\n/` (`getFileStartIndex`)。
+ * JS の `.` は行終端子にマッチしないため CRLF (`#!...\r\n`) では**マッチせず**、
+ * shebang が残ったまま ssr transform が import 文を先頭行へ hoist する。結果
+ * `const x = __vite__cjsImport0_...;#!/usr/bin/env node` という 1 行が生まれ、
+ * rolldown が `Invalid Character \`!\`` で parse 失敗し **test file 自体が読めなくなる**
+ * (`Tests no tests`)。エラー文言から改行コードに辿り着けず flake と誤判定された。
+ *
+ * 対処 (`vite.config.ts` の `stripShebangPlugin`): ssr transform より前に、改行種別に
+ * 依らず shebang 行を除去する。
+ *
+ * fixture (`tests/fixtures/crlf/crlf-shebang-module.mjs`) は `.gitattributes` の
+ * `eol=crlf` で **全 checkout 環境 (CI Linux 含む) で CRLF に固定**される。fixture の
+ * 改行が CRLF であること自体も本 test で assert し、eol 指定が外れたら気付けるようにする。
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// この import 自体が回帰の本体 — plugin が無いと本 file 全体が読み込めず fail する
+import { MARKER, baseOf } from '../../fixtures/crlf/crlf-shebang-module.mjs';
+
+const fixturePath = path.resolve(
+	process.cwd(),
+	'tests/fixtures/crlf/crlf-shebang-module.mjs',
+);
+
+describe('CRLF shebang module import (#3984)', () => {
+	it('fixture は CRLF 改行 + shebang で保存されている (前提条件の固定)', () => {
+		const raw = readFileSync(fixturePath, 'utf8');
+		expect(raw.startsWith('#!')).toBe(true);
+		expect(raw).toContain('\r\n');
+		// LF 単独行が混ざっていない (CRLF に正規化されている)
+		expect(raw.replace(/\r\n/g, '')).not.toContain('\n');
+	});
+
+	it('CRLF shebang 付き .mjs を import しても export が読める', () => {
+		expect(MARKER).toBe('crlf-shebang-ok');
+	});
+
+	it('import 文を持つ module でも transform が壊れない (hoist 済み import との衝突回帰)', () => {
+		// baseOf() は fixture が import した `node:path` の basename を呼ぶ。
+		// import 文が先頭行へ hoist されるため #3984 の衝突条件を満たす。
+		expect(baseOf('/tmp/foo/bar.mjs')).toBe('bar.mjs');
+	});
+});

--- a/tests/unit/scripts/crlf-shebang-import.test.ts
+++ b/tests/unit/scripts/crlf-shebang-import.test.ts
@@ -23,7 +23,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 // この import 自体が回帰の本体 — plugin が無いと本 file 全体が読み込めず fail する
-import { baseOf, MARKER } from '../../fixtures/crlf/crlf-shebang-module.mjs';
+import { BASE_OF_SAMPLE, MARKER } from '../../fixtures/crlf/crlf-shebang-module.mjs';
 
 const fixturePath = path.resolve(process.cwd(), 'tests/fixtures/crlf/crlf-shebang-module.mjs');
 
@@ -41,8 +41,8 @@ describe('CRLF shebang module import (#3984)', () => {
 	});
 
 	it('import 文を持つ module でも transform が壊れない (hoist 済み import との衝突回帰)', () => {
-		// baseOf() は fixture が import した `node:path` の basename を呼ぶ。
+		// BASE_OF_SAMPLE は fixture が module 評価時に `node:path` の basename を呼んだ結果。
 		// import 文が先頭行へ hoist されるため #3984 の衝突条件を満たす。
-		expect(baseOf('/tmp/foo/bar.mjs')).toBe('bar.mjs');
+		expect(BASE_OF_SAMPLE).toBe('bar.mjs');
 	});
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,8 +11,37 @@ import { defineConfig } from 'vitest/config';
 const dirname =
 	typeof __dirname !== 'undefined' ? __dirname : path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * #3984: CRLF の shebang 付き `.mjs` を import すると vite ssr transform が壊れる問題の根本対処。
+ *
+ * vite 本体の shebang 除去は `hashbangRE = /^#!.*\n/`
+ * (`node_modules/vite/dist/node/chunks/node.js` の `getFileStartIndex`) で実装されている。
+ * JS の `.` は行終端子 (LF / CR / U+2028 / U+2029) にマッチしないため、`#!/usr/bin/env node` + CRLF
+ * では `.*` が `\r` の手前で止まり、続く `\n` を要求する本 RE が **マッチしない**。
+ * 結果 shebang が除去されないまま ssr transform が import 文を先頭へ hoist し、
+ * hoist された `const x = __vite__cjsImport0_...;` の直後 (同一行) に `#!` が残る。
+ * rolldown が `!` を不正文字として parse に失敗し、`Invalid Character \`!\`` で
+ * **test file 自体が読み込めない** (`Tests no tests`) 状態になる。
+ *
+ * 対処: ssr transform より前 (`enforce: 'pre'`) に、CRLF / LF / CR いずれの改行でも
+ * shebang 行を除去する。行数を保つため空行に置換する (source map / stack trace 整合)。
+ * 回帰テスト: `tests/unit/scripts/crlf-shebang-import.test.ts`
+ * (`tests/fixtures/crlf/crlf-shebang-module.mjs` は `.gitattributes` で `eol=crlf` 固定)。
+ */
+const stripShebangPlugin = {
+	name: 'ganbari-strip-shebang',
+	enforce: 'pre' as const,
+	transform(code: string, id: string) {
+		if (!/\.(?:mjs|js|cjs|ts|mts|cts)(?:\?|$)/.test(id)) return null;
+		if (!code.startsWith('#!')) return null;
+		// shebang 行を「改行を残したまま」空に置換する (LF / CRLF / CR いずれにも対応)
+		const transformed = code.replace(/^#![^\r\n]*/, '');
+		return { code: transformed, map: null };
+	},
+};
+
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit()],
+	plugins: [stripShebangPlugin, tailwindcss(), sveltekit()],
 	server: {
 		fs: {
 			// git worktree (`tmp/wt-XXXX/` または `.claude/worktrees/<name>/`) で起動した時、


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発・CI 品質ゲート）

**解決する課題**: CI / test 基盤に残っていた 2 つの fail-open 穴を塞ぐ。
(1) #3984 — `init-pr-body.test.ts` の間欠 fail は flake ではなく **CRLF のとき決定的に落ちる**。落ち方が `RolldownError: Parse failure: Invalid Character \`!\`` + `Tests no tests` で、エラーから改行コードに辿り着けないため flake として処理されかけた。原因不明の間欠 fail を flake と名付けると本物の fail が紛れる。
(2) #3983 — `check-pr-body.mjs` の `--labels` 経路は、発火しなかった label 条件付き gate を **SKIPPED 表示なしで通常 pass と同じ出力**にしていた。`--labels ""` に至っては沈黙して全 gate を skip する（#3965 が消した `catch { return [] }` と同型の fail-open）。

**期待される効果**: (1) 改行コードに依らず shebang 付き `.mjs` を import できるようになり、「読めない test file」由来の偽 flake が構造的に消える。(2) 「検査していない gate がある pass」が出力上つねに `SKIPPED` として可視化され、空 `--labels` は exit 2 で中断する。最も手順を飛ばされやすい hotfix 手順（#2343 の前提）で沈黙 pass が出なくなる。

## 関連 Issue

closes #3984
closes #3983

- PR #3965 (#3962) — 本 2 件はいずれもその QM Re-Review 由来。#3983 は #3965 の residual R1
- ADR-0006 / #2343 — hotfix env 配布証跡 gate（label 条件付き gate の 1 件目）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 3984-AC1 | 案 A / 案 B のいずれか (または両方) を選び、根拠を Issue にコメントで残す | Issue #3984 コメント + 本 PR body §「#3984 の直し方と根拠」 | PASS — **案 A / 案 B を退け、vite 設定（ssr transform 前の shebang 除去 plugin）で根治**。根拠を Issue #3984 にコメント済み |
| 3984-AC2 | 案 A: 対象 `.mjs` を CRLF 化した状態で gate が fail し、メッセージから原因に辿り着けることを PR に貼る | — | N/A（案 A 不採用）。**根治により「CRLF だと壊れる」事象自体が消える**ため、CRLF を fail させる gate は逆に誤検出になる。根拠は §「#3984 の直し方と根拠」 |
| 3984-AC3 | CRLF 化しても `npx vitest run tests/unit/scripts/` が全 PASS することを PR に貼る | 対象 2 file を CRLF 化 → `npx vitest run tests/unit/scripts/init-pr-body.test.ts tests/unit/scripts/check-pr-body.test.ts` | PASS — `Test Files 2 passed (2) / Tests 106 passed (106)`（§証跡 1-C）。案 B の shebang 削除なしで達成 |
| 3984-AC4 | 回帰テスト（CRLF shebang script を import しても壊れない） | `npx vitest run tests/unit/scripts/crlf-shebang-import.test.ts` | PASS — 3 tests passed（§証跡 1-B）。fixture は `.gitattributes` `eol=crlf` で全環境 CRLF 固定 |
| 3983-AC1 | `--labels "priority:critical,hotfix"` で po-decision gate が発火しなかったとき SKIPPED 行にその gate 名が出る | `[LB9]` + CLI 実行 A' | PASS — §証跡 2-A' / `[LB9]` |
| 3983-AC2 | `--labels "priority:critical,hotfix,po-decision:required"` では SKIPPED 行に po-decision が**出ない**（誤表示の回帰） | `[LB10]` + CLI 実行 B | PASS — §証跡 2-B / `[LB10]` |
| 3983-AC3 | `--labels ""` / `--labels " , "` は exit 2 で中断し `--no-labels` を案内する | `[LB5b]` + CLI 実行 C | PASS — exit 2 + `--no-labels` 案内（§証跡 2-C） |
| 3983-AC4 | mutation: SKIPPED 出力のフィルタを消す（= 常に全件出す）と AC2 の test が落ちること | `selectSkippedLabelGates` の filter 述語を反転して vitest 実行 | PASS — `[LB9]` / `[LB10]` が fail（§証跡 3） |
| 3983-AC5 | `ready-gate-checklist.md` の hotfix 手順を新仕様に合わせて更新する | `.claude/skills/dev-open-pr/ready-gate-checklist.md` diff | PASS — `--labels` 固定値 → `--pr <num>`（実 label）に是正 + PR 未作成時の SKIPPED 読み方を追記 |
| 共通-AC | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4063` | **PASS** — 適用対象 12 step 全て PASS (下記「検証証跡」)。旧記載は存在しない PR 番号 (`--pr 4059`) を根拠にしていたため差し替え |

> **pre-ready 実測** (worktree `agent-ae876294c8c0a2e71`、PR #4063 番号指定、他の重い検証プロセス 0 件の単独実行):
> - 適用対象の **12 step すべて PASS** — 9 Readiness gate / 1 biome / 1b cspell / 4 hardcoded-strings / 7 plan-literals / 7b license-key-leak / 7c cli-entry-guard / 7d sparse-checkout / 10 doc-code-references / 11 terminology-coherence / 2 型検査 / 3 vitest
> - 自動 skip (適用対象外) — 5 lp-dimensions / 6 lp-fallback / 8 lp-labels / 11b SS embed / 12 capture (LP・labels.ts・UI をいずれも変更していないため)
> - 1 回目の実行では `page-guide-coverage` / `ci-unit-test-path-filter-closure [PC2]` の 2 件が 5s timeout で落ちたが、**同 2 file を単独実行すると 3.28s / 21 passed** で通り、本 PR の変更 (CRLF shebang import / `--labels` fail-closed) とは無関係な**負荷依存の timeout** と確認した。この class は **#4085** として起票済 (同 class 4 例目、区分宣言の gate 化を提案)

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし（アプリの実行時挙動は不変）。影響先は build/test 基盤（`vite.config.ts` の transform）と PR 品質ゲート CLI（`scripts/check-pr-body.mjs`）。

### #3984 の直し方と根拠（`.gitattributes` / vite 設定 / shebang のどれで直すか）

**根本原因（実測で特定）**: vite 本体の shebang 除去は `hashbangRE = /^#!.*\n/`（`node_modules/vite/dist/node/chunks/node.js:3119` の `getFileStartIndex`）。JS の `.` は行終端子（LF / CR / U+2028 / U+2029）にマッチしないため、`#!/usr/bin/env node\r\n` では `.*` が `\r` の手前で止まり、続く `\n` を要求する本 RE が**マッチしない**。shebang が残ったまま ssr transform が import 文を先頭行へ hoist し、`const fileURLToPath = __vite__cjsImport0_node_url["fileURLToPath"];#!/usr/bin/env node` という 1 行が生まれ、rolldown が `!` を不正文字として parse に失敗 → **test file 自体が読めない**（`Tests no tests`）。

**選定**: **vite 設定**（`vite.config.ts` に `enforce: 'pre'` の shebang 除去 plugin を追加）。

| 案 | 判定 | 理由 |
|---|---|---|
| `.gitattributes` | 不採用（現状維持） | 既に `* text=auto eol=lf` があり **checkout は LF**。壊れるのは「何かが working tree に CRLF を書き戻した瞬間」であり、`.gitattributes` は working tree への後発書き込みを防げない。原因を潰せない |
| shebang 削除（Issue 案 B） | 不採用 | 現在 vitest が import する 2 file を直しても、**shebang 付き `.mjs` は repo に 100 file 以上ある**（`grep -rln '^#!' --include=*.mjs scripts/ .claude/`）。将来どれかが import 対象になれば同じ穴が再発する。範囲が狭く再発を防げない |
| CRLF 検出 gate（Issue 案 A） | 不採用 | 早期に分かるエラーにする案。**根治すると「CRLF だと壊れる」事象自体が消える**ため、CRLF を hard-fail させる gate は実害のない改行に対する誤検出になる（本 PR が意図的に CRLF で固定する回帰 fixture が最初の誤検出対象になる）。新規 `scripts/` の使い捨て追加も CLAUDE.md 禁忌 |
| **vite 設定（採用）** | 採用 | ssr transform の**前**に改行種別非依存で shebang を除去する。LF / CRLF / CR すべてに効き、`.mjs` / `.js` / `.ts` 系すべてに効くため「改行コードで壊れる」class を発生源で消す。差分は plugin 10 行、依存追加ゼロ（ADR-0010 Bucket A） |

**回帰の固定方法**: `tests/fixtures/crlf/crlf-shebang-module.mjs`（shebang + `import` 文を持つ最小 module）を `.gitattributes` の `tests/fixtures/crlf/*.mjs text eol=crlf` で **全 checkout 環境（CI Linux 含む）で CRLF に固定**し、`tests/unit/scripts/crlf-shebang-import.test.ts` が import する。fixture が実際に CRLF であることも同 test で assert しているため、`eol=crlf` 指定が外れたら気付ける。

### #3983 の設計判断（SKIPPED をどの経路で出すか）

`--no-labels` / `--labels` は **こちらが手で主張した label** であり、その主張が誤っていても検出できない。よってどちらも「検査していない」として SKIPPED を出す。一方 `--pr <N>` の実 label は PR の事実そのものなので「発火しなかった = 正しい判定」であり SKIPPED の対象外にした（毎回の `pre-ready` を無意味な SKIPPED 行で埋めないため）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/scripts/crlf-shebang-import.test.ts`（新規 3 件）— CRLF shebang module の import 回帰 + fixture が CRLF であることの前提固定
  - `tests/unit/scripts/check-pr-body.test.ts` — `[LB5b]`（空 `--labels` の fail-closed）/ `[LB9]`〜`[LB12]`（`--labels` 経路の SKIPPED 可視化・誤表示回帰・normalize）を追加、`[LB7]` を新シグネチャに追従
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（priority:medium）

## スクリーンショット / ビジュアルデモ

**該当なし（CI / test のみ。UI 変更を含まない）**

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし | 該当なし |
| **修正後** | 該当なし | 該当なし |

**インタラクティブ状態**: N/A

### 証跡 1: #3984

**1-A. 修正前（再現）** — CRLF + shebang + import を持つ module を vitest から import すると test file ごと読めない:

```
FAIL  |0| tests/unit/scripts/__tmp-repro.test.ts
RolldownError: Parse failure: Parse failed with 1 error:
Invalid Character `!`
1: const fileURLToPath = __vite__cjsImport0_node_url["fileURLToPath"];#!/usr/bin/env node
                                                                       ^
 ❯ ssrTransformScript node_modules/vite/dist/node/chunks/node.js:11882:9
 Test Files  1 failed (1)
      Tests  no tests
```

**1-B. 修正後（回帰テスト）**:

```
$ npx vitest run tests/unit/scripts/crlf-shebang-import.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

**1-C. 実 script を CRLF 化した状態（Issue の再現手順そのもの）**:

```
$ node -e "for (const p of ['.claude/skills/dev-open-pr/scripts/init-pr-body.mjs','scripts/check-pr-body.mjs']) { ... LF->CRLF ... }"
$ npx vitest run tests/unit/scripts/init-pr-body.test.ts tests/unit/scripts/check-pr-body.test.ts
 Test Files  2 passed (2)
      Tests  106 passed (106)
```

（実行後 `git checkout --` で両 file を LF に復帰済み）

### 証跡 2: #3983 CLI 実測（Issue の A/B/C/D 表と同じ形）

本 PR body 自身を `--body-file` に渡して実測（`node scripts/check-pr-body.mjs --body-file <本 body> <label 指定> --skip-mergeable`）。

**A'（Issue の A 相当 / `--labels "priority:critical,hotfix"`）** — hotfix gate は発火して PASS、**po-decision gate は SKIPPED として名指しされる**（旧: 完全な pass と区別不能）:

```
[check-pr-body] SKIPPED — label 条件付き gate 1 件は検査していません (--labels)
  - PO 決裁ブリーフ (#3962) — 発火 label: po-decision:required
  ※ label が付いた後に --pr <N> で再実行しないと、上記 gate は一度も動きません
[check-pr-body] OK (label 条件付き gate 1 件は未検査) — 違反なし
exit=0
```

**B（`--labels "priority:critical,hotfix,po-decision:required"`）** — 2 gate とも発火するので SKIPPED 行は 1 行も出ない（誤表示の回帰）。本 body には PO 決裁ブリーフが無いため gate が正しく落ちる:

```
[check-pr-body] FAIL — 1 件の違反:

✗ [po-decision-brief-missing-section] (#3944/#3956/#3962)
  `po-decision:required` label が付いていますが、PR body に `## PO 決裁ブリーフ` セクションがありません
exit=1
```

**C（`--labels ""`）** — 旧: 沈黙して全 gate skip + `OK — 違反なし` / 新: exit 2 で中断し `--no-labels` を案内:

```
[check-pr-body] ERROR: --labels に有効な label がありません (受け取った値: "")。
  label 条件付き検査 (hotfix #2343 / po-decision #3962) が黙って全 skip されるのを防ぐため、
  空の --labels は受理しません (--labels "$VAR" で変数が空だった場合を含む)。
  対応: label 0 件を明示したいなら --no-labels を使ってください。
exit=2
```

**C2（`--labels " , "`）** — 同じく exit 2（受け取った値: `" , "`）。

**D（`--no-labels`、#3965 で改善済の経路）** — 従来どおり全 2 件を SKIPPED 列挙（回帰なし）:

```
[check-pr-body] SKIPPED — label 条件付き gate 2 件は検査していません (--no-labels)
  - hotfix env 配布証跡 (ADR-0006) (#2343) — 発火 label: priority:critical / hotfix
  - PO 決裁ブリーフ (#3962) — 発火 label: po-decision:required
[check-pr-body] OK (label 条件付き gate 2 件は未検査) — 違反なし
exit=0
```

**A' と D が同じ「検査していない pass」として同型の出力になった** — Issue #3983 が指摘した非対称が解消。

### 証跡 3: #3983 mutation（gate を外すと落ちるか）

「gate を外すと fail するか」を実行して確認（#3956 教訓）。**2 件とも実際に mutation を適用 → 実行 → `git checkout --` で復帰**（commit 済みの実装に対して行ったので、証跡が静かに嘘にならない）。

**mutation 1（#3983 AC4）** — `selectSkippedLabelGates` の filter を消して常に全件返すようにする:

```diff
- return LABEL_CONDITIONAL_GATES.filter((g) => !g.triggers.some((t) => normalized.includes(t)));
+ return LABEL_CONDITIONAL_GATES; // MUTATION: filter を消す (#3983 AC4)
```

```
$ npx vitest run tests/unit/scripts/check-pr-body.test.ts
 × [LB9] --labels "priority:critical,hotfix" で po-decision gate が SKIPPED に出る
 × [LB10] 発火した gate は SKIPPED に出ない — 誤表示の回帰
 × [LB12] 大文字 / 前後空白の label でも発火判定される (skip 誤表示の回帰)
 Test Files  1 failed (1)
      Tests  3 failed | 91 passed (94)
```

**mutation 2（#3984 の回帰テストが本当に効いているか）** — `vite.config.ts` の plugins から `stripShebangPlugin` を外す:

```
$ npx vitest run tests/unit/scripts/crlf-shebang-import.test.ts
 ❯ ssrTransformScript node_modules/vite/dist/node/chunks/node.js:11882:9
 Test Files  1 failed (1)
      Tests  no tests
```

（`Tests no tests` = #3984 と同じ「test file ごと読めない」失敗形。plugin を戻すと 3 passed に復帰）

**mutation 復帰後の再確認**:

```
$ npx vitest run tests/unit/scripts/check-pr-body.test.ts tests/unit/scripts/crlf-shebang-import.test.ts
 Test Files  2 passed (2)
      Tests  97 passed (97)
```

### 証跡 4: pre-ready

<!-- EVIDENCE_4_PLACEHOLDER -->

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: `selectSkippedLabelGates`（どの gate が未発火か）と `formatSkippedLabelGates`（表示）を分離。vite plugin は shebang 除去の単一責任
- [x] **DRY**: 発火 label を `LABEL_CONDITIONAL_GATES[].triggers` に集約し、`HOTFIX_LABELS` / `PO_DECISION_LABEL` から導出（gate 一覧の二重管理を増やさない）
- [x] **YAGNI**: `--pr` 経路への SKIPPED 出力・CRLF 検出 gate はいずれも不採用（上記根拠）。新規 script 追加ゼロ
- [x] **Security（OSS 公開前提）**: 秘密情報なし。変更方向は fail-open → fail-closed
- [x] **アクセシビリティ**: N/A（CLI / build 設定）
- [x] **パフォーマンス**: plugin は `code.startsWith('#!')` で即 return する早期脱出付き。transform 実測 65〜81ms で従前と同等

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [ ] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200)
- [x] N/A — 並行実装の影響範囲外（UI / ドメイン非変更）

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [ ] このPRに破壊的変更は**含まれない**
- [x] 含まれる → 影響範囲・マイグレーション手順を以下に記載

`check-pr-body.mjs` の CLI 契約が 1 点厳しくなる: **`--labels ""`（空文字）は exit 2 で中断**するようになる。repo 内に `--labels ""` を渡す呼び出しは 0 件であることを確認済み（`--labels` の使用は `ready-gate-checklist.md` のリテラル 1 箇所のみで、本 PR で `--pr` に置換）。手元スクリプトで `--labels "$VAR"` を使っている場合は `--no-labels` に置き換える（エラーメッセージがその案内を出す）。

エクスポート API も変更: `formatSkippedLabelGates()` が `(labels, source)` を取る。呼び出し元は `scripts/check-pr-body.mjs` の `main()` と unit test のみ。

**レビュー依頼事項・QA**:
- #3984 の選定（vite 設定での根治、案 A / 案 B いずれも不採用）が妥当か。特に「案 A の CRLF gate は根治後は誤検出になる」という判断
- #3983 で `--pr` 経路に SKIPPED を出さない線引き（実 label = 事実 / 手で主張した label = 未検査）が妥当か

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
