### PR TITLE
fix: #4050 おやカギ modal を閉じると親管理画面に二度と到達できない dead-end を根治

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -204,6 +204,19 @@ LP (`site/index.html`) の section padding / margin / heading / faq-item など 
 - `ChildSelectionDialog` の取込確定ボタンは `confirmLoading` prop で本機構を内包する。marketplace 取込 4 type (`?import=` 受領 admin 画面) の `handleChildSelectionConfirm` 中は `confirmLoading={isImporting}` + `closeOnConfirm={false}` で「取込実行中」を表示し、完了後 (finally) に親が `open=false` する
 - 旧 `components/LoadingButton.svelte` は文言固定の限定 variant。新規実装は `Button` の `loading` prop を優先する
 
+### Dialog の `closable` / `closeOnEscape`（#4050）
+
+Dialog を「閉じさせない」modal（強制オンボーディング等）にするには **2 つの prop を両方 false にする**。`closable` は × ボタンの描画と外側クリック (`closeOnInteractOutside`) のみを制御し、Esc キーは zag-js の別 prop (`closeOnEscape`、既定 true) が担うため、`closable={false}` だけでは Esc でバイパスできてしまう。
+
+```svelte
+<!-- おやカギコード初回作成 modal: 作成完了まで閉じさせない -->
+<Dialog bind:open closable={false} closeOnEscape={false} title="…">…</Dialog>
+```
+
+- 既定は `closable=true` / `closeOnEscape=true`（他 modal の挙動は不変。opt-in で無効化する）
+- **閉じさせない modal は「出口」を必ず用意する**: 閉じられない = 完了操作だけが唯一の出口になるため、その操作が失敗しても回復できること（エラー表示 + 再入力）を確認する
+- Esc / 外側クリックの close 挙動は Ark UI のグローバル listener 依存で jsdom / Storybook vitest では非決定のため、回帰検証は Playwright 層で行う（`tests/CLAUDE.md` §Storybook interaction test 整合）
+
 ### FormField の `type` 一覧（#1191）
 
 `<input>` / `<textarea>` 直書きの代替として `FormField.svelte` が以下 variant を提供する。

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -296,7 +296,8 @@ EPIC #2310 で `/admin/*` middleware が未認証時 `/switch?pinRequired=1&next
 | 項目 | 仕様 |
 |---|---|
 | trigger 1 | `pinRequired=1` query (middleware redirect) で初期 `pinModalOpen=true` |
-| trigger 2 | `/switch` の「🔒 保護者の見守り画面」link click (#2353 漢字化、AC4) |
+| trigger 2 | `/switch` の「🔒 保護者の見守り画面」link click (#2353 漢字化、AC4)。**client 側で modal を開く条件は load の `parentGateInteractive`** (#4050): `authMode !== 'cognito' || locals.identity != null` (= ログイン済) なら `preventDefault` して modal を開き直す。未ログイン (cognito) のみ素の `<a href="/auth/login">` 遷移に委ねる。`adminLink` も同条件で `/admin` / `/auth/login` を出し分け、ログイン済ユーザが `/auth/login → /admin → /switch?pinRequired=1` の**同一 URL 往復**に落ちないようにする (往復すると component 再マウントが起きず `prevPinRequired` ガードで auto-open $effect が no-op になり、modal が二度と開かない dead-end になる) |
+| 閉じる手段のモード別分岐 (#4050) | **作成モード = 閉じられない** (強制オンボーディング、Apple Screen Time / Google Family Link 同型): `closable={false}` (× ボタン非描画 + 外側クリック無効) + `closeOnEscape={false}` (Esc 無効)。おやカギ未設定のまま閉じると親管理画面へ到達する手段が無くなるため、作成完了 (= `/admin` へのハードナビ) までポータルに留める。**入力モードは従来どおり閉じられる** (× / Esc / 外側クリック) が、trigger 2 でいつでも開き直せる |
 | モード分岐 (#2992) | `pinConfigured === false` → **作成モード** (`data-testid="parent-gate-create"`、`data-step="enter"→"confirm"`): 1 段目入力 → 確認入力 → 一致で `POST /api/v1/parent-gate/setup` → session cookie 発行 → next へ。不一致は `gateCreateMismatch` エラー + 1 段目からやり直し。`true` → 従来の入力モード |
 | 入力 UI | `PinInput` primitive (4 桁、mask: true) |
 | 送信 (入力モード) | `POST /api/v1/parent-gate/verify { pin }` → `gq_parent_session` 署名 cookie 発行。未設定 tenant への verify は `PIN_NOT_SET` (作成モードへの race guard) |

--- a/src/lib/ui/primitives/Dialog.svelte
+++ b/src/lib/ui/primitives/Dialog.svelte
@@ -10,6 +10,14 @@ interface Props {
 	children: Snippet;
 	title?: string;
 	closable?: boolean;
+	/**
+	 * Esc キーで閉じられるか (#4050)。既定 true。
+	 * `closable` は「× ボタン + 外側クリック」を制御するが、Esc は zag-js 側の別 prop
+	 * (`closeOnEscape`) で、既定値のままでは closable=false でも Esc で閉じてしまう。
+	 * 強制オンボーディング等で「閉じさせない」modal は `closable={false}` と併せて
+	 * `closeOnEscape={false}` を明示する (既定挙動は他 modal と不変)。
+	 */
+	closeOnEscape?: boolean;
 	testid?: string;
 	size?: 'sm' | 'md' | 'lg';
 	ariaLabel?: string;
@@ -32,6 +40,7 @@ let {
 	children,
 	title,
 	closable = true,
+	closeOnEscape = true,
 	testid,
 	size = 'md',
 	ariaLabel,
@@ -71,7 +80,7 @@ function handleOpenChange(details: { open: boolean }) {
 }
 </script>
 
-<ArkDialog.Root {open} onOpenChange={handleOpenChange} closeOnInteractOutside={closable}>
+<ArkDialog.Root {open} onOpenChange={handleOpenChange} closeOnInteractOutside={closable} {closeOnEscape}>
 	<Portal>
 		<ArkDialog.Backdrop
 			class="fixed inset-0 {layer.backdrop} bg-black/50 backdrop-blur-sm transition-opacity {backdropClass}"

--- a/src/lib/ui/primitives/PinInput.svelte
+++ b/src/lib/ui/primitives/PinInput.svelte
@@ -16,6 +16,14 @@ interface Props {
 	 * 表示用クラスを渡す (Ark の Label → input 関連付けで重複なく 1 ラベルになる)。
 	 */
 	labelClass?: string;
+	/**
+	 * mount 時に 1 桁目へ自動フォーカスするか (既定 false、#4050)。
+	 * `{#key}` で remount して入力欄をリセットする画面 (おやカギ作成の確認ステップ / 入力失敗後の
+	 * やり直し) では、remount 後にフォーカスが失われ「打っても何も入らない」状態になるため
+	 * opt-in で true にする。既定 false のまま他画面 (reset-pin のように 1 画面 2 個並ぶ場合を含む)
+	 * の挙動は変えない。
+	 */
+	autoFocus?: boolean;
 	onComplete?: (details: { value: string[]; valueAsString: string }) => void;
 }
 
@@ -24,6 +32,7 @@ let {
 	mask = true,
 	label = UI_PRIMITIVES_LABELS.pinCodeLabel,
 	labelClass = 'sr-only',
+	autoFocus = false,
 	onComplete,
 }: Props = $props();
 
@@ -35,7 +44,7 @@ function handleValueComplete(details: { value: string[]; valueAsString: string }
 <!-- Root は flex-col だが gap を持たない: 視覚差分ゼロを保つため、ラベル ↔ 桁行の余白は
 	可視ラベル側の margin (labelClass の mb-* 等) に委ねる。sr-only ラベル時は余白ゼロで
 	桁行が最上段に来る (旧実装の単独桁行と同一)。桁ボックス間の gap は Control が持つ。 -->
-<ArkPinInput.Root onValueComplete={handleValueComplete} {mask} type="numeric" class="flex flex-col">
+<ArkPinInput.Root onValueComplete={handleValueComplete} {mask} {autoFocus} type="numeric" class="flex flex-col">
 	<ArkPinInput.Label class={labelClass}>{label}</ArkPinInput.Label>
 	<ArkPinInput.Control class="flex gap-[var(--sp-sm)] justify-center">
 		{#each Array(length) as _, i}

--- a/src/routes/switch/+page.server.ts
+++ b/src/routes/switch/+page.server.ts
@@ -38,8 +38,16 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	}
 
 	const authMode = getAuthMode();
-	// local モードは認証不要なので直接 /admin、cognito モードは /auth/login
-	const adminLink = authMode === 'cognito' ? '/auth/login' : '/admin';
+	// #4050: 親ゲート modal をクライアント側で開けるか (= 既にログイン済で /admin を要求できる状態)。
+	// 旧実装は cognito モードで adminLink を常に '/auth/login' 固定にしていたため、ログイン済
+	// ユーザが「ご家族の見守り画面」を click すると client 側 handler が早期 return し、
+	// /auth/login → /admin → /switch?pinRequired=1 の同一 URL 往復に落ちていた。往復後は
+	// component が再マウントされず data.pinRequired も true のままなので modal 自動 open の
+	// $effect が no-op になり、modal が二度と開かない dead-end が発生する (無限ロックアウト)。
+	const parentGateInteractive = authMode !== 'cognito' || locals.identity != null;
+	// 未ログイン (cognito) のみ /auth/login。ログイン済 / local は /admin (JS 無効時も
+	// middleware redirect で /switch?pinRequired=1 に戻り modal が初期表示される)。
+	const adminLink = parentGateInteractive ? '/admin' : '/auth/login';
 	// child ロールにはご家族の見守り画面リンクを非表示（local モードでは常に表示）
 	const showAdminLink = authMode === 'local' || locals.context?.role !== 'child';
 
@@ -64,6 +72,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	return {
 		children,
 		adminLink,
+		parentGateInteractive,
 		showAdminLink,
 		reason,
 		timedOut,

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -349,13 +349,13 @@ async function handlePinComplete(details: { valueAsString: string }) {
 					: OYAKAGI_LABELS.gateCreateConfirmDescription}
 			</p>
 			{#key pinInputKey}
-				<PinInput length={4} mask onComplete={handleCreateComplete} />
+				<PinInput length={4} mask autoFocus onComplete={handleCreateComplete} />
 			{/key}
 		</div>
 	{:else}
 		<p class="text-sm text-[var(--color-text-muted)] mb-4">{OYAKAGI_LABELS.gateModalDescription}</p>
 		{#key pinInputKey}
-			<PinInput length={4} mask onComplete={handlePinComplete} />
+			<PinInput length={4} mask autoFocus onComplete={handlePinComplete} />
 		{/key}
 	{/if}
 	<!-- Issue #2353 Fix 5 (Phase A): 初期 PIN 5086 ヒントを modal から削除 (子供脆弱性) -->

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -171,13 +171,24 @@ async function handleCreateComplete(details: { valueAsString: string }) {
 	}
 }
 
-async function handleAdminLinkClick(e: MouseEvent) {
-	// cognito モードで /auth/login に飛ばす場合は本フローをスキップ (子供画面では本リンク自体が非表示)
-	if (data.adminLink !== '/admin') return;
+function handleAdminLinkClick(e: MouseEvent) {
+	// #4050: 「サーバが親ゲートを client 側で処理できると判断したか」で分岐する。
+	// 旧実装は `data.adminLink !== '/admin'` で早期 return していたため、cognito 本番モード
+	// (adminLink='/auth/login') では常に modal を開かず同一 URL 往復に落ち、一度 modal を
+	// 閉じた保護者が二度と開けない dead-end になっていた。未ログイン時のみ素の <a> 遷移
+	// (/auth/login) に委ねる。
+	if (!data.parentGateInteractive) return;
 	e.preventDefault();
 	soundService.ensureContext();
 	soundService.play('tap');
-	pinError = '';
+	// lockout 中は解除時刻の案内を残す (消すと「押しても無反応」に見えるため)
+	if (!lockedNow) pinError = '';
+	// 閉じた時の入力残骸をクリアして常に同じ初期状態から再開できるようにする
+	if (pinCreateMode) {
+		resetCreateFlow();
+	} else {
+		pinInputKey += 1;
+	}
 	pinModalOpen = true;
 }
 
@@ -326,6 +337,8 @@ async function handlePinComplete(details: { valueAsString: string }) {
 		: OYAKAGI_LABELS.gateModalTitle}
 	testid="parent-gate-modal"
 	size="sm"
+	closable={!pinCreateMode}
+	closeOnEscape={!pinCreateMode}
 >
 	{#if pinCreateMode}
 		<!-- #2992: 初回作成フロー (入力→確認の 2 段)。未設定 tenant に既定 PIN を要求しない -->

--- a/tests/e2e/parent-gate-modal-dead-end.spec.ts
+++ b/tests/e2e/parent-gate-modal-dead-end.spec.ts
@@ -1,4 +1,4 @@
-// tests/e2e/parent-gate-modal-deadend.spec.ts
+// tests/e2e/parent-gate-modal-dead-end.spec.ts
 // #4050: おやカギコード modal の dead-end (無限ロックアウト) 回帰。
 //
 // 事象: 新規オーナーが初回の「おやカギコードをつくってください」modal を外側クリック /

--- a/tests/e2e/parent-gate-modal-deadend.spec.ts
+++ b/tests/e2e/parent-gate-modal-deadend.spec.ts
@@ -1,0 +1,150 @@
+// tests/e2e/parent-gate-modal-deadend.spec.ts
+// #4050: おやカギコード modal の dead-end (無限ロックアウト) 回帰。
+//
+// 事象: 新規オーナーが初回の「おやカギコードをつくってください」modal を外側クリック /
+// Esc で閉じると、以降「ご家族の見守り画面」を何度押しても modal が開かず、親管理画面に
+// 二度と到達できなくなる。
+//
+// 真因 (2 段):
+//   1. `handleAdminLinkClick` が `data.adminLink !== '/admin'` で早期 return していた。
+//      cognito 本番モードは adminLink='/auth/login' 固定のため、ログイン済でも client 側で
+//      modal を開かず /auth/login → /admin → /switch?pinRequired=1 の同一 URL 往復に落ちる。
+//   2. 同一 URL 往復では component が再マウントされず `prevPinRequired` (#2992) と
+//      `data.pinRequired` が共に true のままで、modal 自動 open の $effect が no-op になる。
+//
+// 対処 (Issue の案 A + 案 B を 1 つの解として実施):
+//   - 案 B (回復): サーバが `parentGateInteractive` を返し、ログイン済なら URL 往復せず
+//     client 側で modal を再オープンする (解錠 modal 側の dead-end = 本欠陥の本体)。
+//   - 案 A (予防): 初回作成 modal は × / 外側クリック / Esc で閉じられない強制オンボーディング
+//     にする (Apple Screen Time / Google Family Link 同型)。
+//
+// 本 spec は実ブラウザで両者を検証する (Esc / backdrop の close 挙動は Ark UI の
+// グローバル listener 依存で jsdom では非決定 = tests/CLAUDE.md の方針どおり Playwright 層で担保)。
+
+import Database from 'better-sqlite3';
+import { UI_PRIMITIVES_LABELS } from '../../src/lib/domain/labels';
+import { expect, test } from './fixtures';
+import { isAwsEnv } from './helpers';
+
+const PIN_KEY = 'pin_hash';
+
+function readPinHash(dbPath: string): string | null {
+	const db = new Database(dbPath);
+	try {
+		const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(PIN_KEY) as
+			| { value: string }
+			| undefined;
+		return row ? row.value : null;
+	} finally {
+		db.close();
+	}
+}
+
+/** PIN 未設定 tenant (= 初回作成フロー) を worker DB 上で再現する */
+function clearPinHash(dbPath: string): void {
+	const db = new Database(dbPath);
+	try {
+		db.prepare('DELETE FROM settings WHERE key = ?').run(PIN_KEY);
+	} finally {
+		db.close();
+	}
+}
+
+/** global-setup が seed した pin_hash を元へ完全復元する (tests/CLAUDE.md worker DB 規約) */
+function restorePinHash(dbPath: string, snapshot: string | null): void {
+	const db = new Database(dbPath);
+	try {
+		if (snapshot === null) {
+			db.prepare('DELETE FROM settings WHERE key = ?').run(PIN_KEY);
+		} else {
+			db.prepare(
+				'INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP)',
+			).run(PIN_KEY, snapshot);
+		}
+	} finally {
+		db.close();
+	}
+}
+
+// AWS / cognito 環境では worker DB の直接操作が成立しないため未登録。
+if (!isAwsEnv()) {
+	test.describe('#4050 おやカギ modal の dead-end 回帰', () => {
+		test('AC5: 解錠 modal を閉じた後も「ご家族の見守り画面」で再オープンできる', async ({
+			page,
+		}) => {
+			await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+			const modal = page.getByTestId('parent-gate-modal');
+			await expect(modal, 'pinRequired=1 到達で modal が自動 open する').toBeVisible();
+
+			// 解錠 modal は閉じられる (× と Esc の両方)
+			await page.getByLabel(UI_PRIMITIVES_LABELS.closeAriaLabel).click();
+			await expect(modal).toBeHidden();
+
+			// act: もう一度「ご家族の見守り画面」を押す
+			await page.getByTestId('switch-admin-link').click();
+
+			// outcome: modal が再オープンする (旧実装ではここが永久に開かず dead-end だった)
+			await expect(modal, '閉じた後も link から modal を開き直せる').toBeVisible();
+
+			// Esc で閉じてからもう一度開けること (閉じ方によらず回復できる)
+			await page.keyboard.press('Escape');
+			await expect(modal).toBeHidden();
+			await page.getByTestId('switch-admin-link').click();
+			await expect(modal).toBeVisible();
+		});
+
+		test.describe('初回作成 modal は閉じられない (強制オンボーディング)', () => {
+			let seededPin: string | null = null;
+
+			test.beforeAll(({ workerDbPath }) => {
+				seededPin = readPinHash(workerDbPath);
+			});
+
+			test.beforeEach(({ workerDbPath }) => {
+				clearPinHash(workerDbPath);
+			});
+
+			// sibling spec (PIN 設定済を前提とする parent-gate 系) への影響を残さない
+			test.afterAll(({ workerDbPath }) => {
+				restorePinHash(workerDbPath, seededPin);
+			});
+
+			test('AC1 / AC2: × ボタンが無く、Esc / 外側クリックでも閉じない', async ({ page }) => {
+				await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+				const createBody = page.getByTestId('parent-gate-create');
+				await expect(createBody, 'PIN 未設定なら作成フローが出る').toBeVisible();
+
+				// AC1: × クローズボタンが描画されない
+				await expect(page.getByLabel(UI_PRIMITIVES_LABELS.closeAriaLabel)).toHaveCount(0);
+
+				// AC2: Esc では閉じない
+				await page.keyboard.press('Escape');
+				await expect(createBody, 'Esc でバイパスできない').toBeVisible();
+
+				// AC2: modal 外 (backdrop 左上) をクリックしても閉じない
+				await page.mouse.click(5, 5);
+				await expect(createBody, '外側クリックでバイパスできない').toBeVisible();
+			});
+
+			test('AC3: おやカギを作成し終えて初めて modal が閉じ /admin へ遷移する', async ({ page }) => {
+				await page.goto('/switch?pinRequired=1', { waitUntil: 'domcontentloaded' });
+				const createBody = page.getByTestId('parent-gate-create');
+				await expect(createBody).toBeVisible();
+				await expect(createBody).toHaveAttribute('data-step', 'enter');
+
+				// 1 段目: 入力 → 確認ステップへ
+				for (const ch of '1357') {
+					await page.keyboard.press(ch);
+				}
+				await expect(createBody).toHaveAttribute('data-step', 'confirm');
+
+				// 2 段目: 同じ値を確認入力 → 作成成功 → modal クローズ + /admin へハードナビ
+				for (const ch of '1357') {
+					await page.keyboard.press(ch);
+				}
+				await expect(page.getByTestId('parent-gate-modal')).toBeHidden();
+				await page.waitForURL('**/admin**', { timeout: 20_000 });
+			});
+		});
+	});
+}

--- a/tests/unit/routes/switch-parent-gate-reopen.test.ts
+++ b/tests/unit/routes/switch-parent-gate-reopen.test.ts
@@ -1,0 +1,151 @@
+// tests/unit/routes/switch-parent-gate-reopen.test.ts
+// #4050: 「おやカギコード modal を閉じると親管理画面に二度と到達できない」dead-end の回帰テスト。
+//
+// 旧実装の欠陥 (2 段構造):
+//   1. `handleAdminLinkClick` が `data.adminLink !== '/admin'` で早期 return していた。
+//      cognito 本番モードでは adminLink='/auth/login' 固定のため、ログイン済ユーザが link を
+//      押しても client 側 modal が開かず、/auth/login → /admin → /switch?pinRequired=1 の
+//      同一 URL 往復に落ちる。
+//   2. 往復先が同一 URL のため SvelteKit は component を再マウントせず、`prevPinRequired`
+//      ガード (#2992) と `data.pinRequired` が共に true のまま → modal 自動 open の $effect が
+//      no-op → modal が二度と開かない。
+//
+// 本 test は component 層で (1) を潰したこと (= link click で必ず modal が再 open すること) と、
+// 初回作成 modal がバイパス不能 (× ボタン非表示) であることを assert する。
+// e2e (tests/e2e/parent-gate.spec.ts) は実 redirect 往復を含む統合経路を担保する二重防御。
+
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/forms', () => ({
+	enhance: () => ({ destroy: () => {} }),
+}));
+vi.mock('$app/navigation', () => ({
+	invalidateAll: vi.fn(async () => {}),
+}));
+// jsdom に AudioContext が無いため sound service を no-op stub にする
+vi.mock('$lib/ui/sound/sound-service', () => ({
+	soundService: { ensureContext: () => {}, play: () => {} },
+}));
+
+import type { Component } from 'svelte';
+import { UI_PRIMITIVES_LABELS } from '../../../src/lib/domain/labels';
+import SwitchPageRaw from '../../../src/routes/switch/+page.svelte';
+
+// jsdom は `CSS` global を実装しておらず、zag-js の pin-input が `CSS.escape` を参照した
+// 時点で TypeError になる (modal 内の PinInput が mount された瞬間に発生)。
+// 実ブラウザ / Playwright では存在するため、test 環境のみ最小 polyfill を当てる。
+if (typeof globalThis.CSS === 'undefined') {
+	(globalThis as { CSS?: unknown }).CSS = {
+		escape: (value: string) => value.replace(/([^\w-])/g, '\\$1'),
+	};
+}
+
+/** Ark UI Dialog は閉じても DOM に残る場合があるため data-state で可視判定する */
+function isOpen(el: HTMLElement | null): boolean {
+	return el !== null && el.getAttribute('data-state') === 'open';
+}
+
+type SwitchProps = {
+	children: Array<{ id: number; nickname: string; age: number; theme: string; avatarUrl: null }>;
+	adminLink: string;
+	parentGateInteractive: boolean;
+	showAdminLink: boolean;
+	reason: string | null;
+	timedOut: boolean;
+	pinRequired: boolean;
+	nextPath: string;
+	onboarding: null;
+	pinConfigured: boolean;
+	pinResetAvailable: boolean;
+};
+
+const SwitchPage = SwitchPageRaw as unknown as Component<{ data: SwitchProps }>;
+
+function makeData(overrides: Partial<SwitchProps> = {}): SwitchProps {
+	return {
+		children: [],
+		// cognito ログイン済 (#4050 修正後の既定)
+		adminLink: '/admin',
+		parentGateInteractive: true,
+		showAdminLink: true,
+		reason: null,
+		timedOut: false,
+		pinRequired: true,
+		nextPath: '/admin',
+		onboarding: null,
+		pinConfigured: true,
+		pinResetAvailable: true,
+		...overrides,
+	};
+}
+
+afterEach(() => cleanup());
+
+describe('#4050 /switch 親ゲート modal の再オープン保証', () => {
+	it('AC5: 解錠 modal を閉じた後に「ご家族の見守り画面」を押すと modal が再オープンする', async () => {
+		const { getByTestId, queryByTestId, getByLabelText } = render(SwitchPage, {
+			props: { data: makeData() },
+		});
+
+		// pinRequired=1 到達で modal が自動 open
+		await waitFor(() => expect(isOpen(queryByTestId('parent-gate-modal'))).toBe(true));
+
+		// × で閉じる (解錠 modal は closable = 閉じられる)
+		await fireEvent.click(getByLabelText(UI_PRIMITIVES_LABELS.closeAriaLabel));
+		await waitFor(() => expect(isOpen(queryByTestId('parent-gate-modal'))).toBe(false));
+
+		// 再度リンクを押すと modal が開く (旧実装ではここが no-op で dead-end だった)
+		await fireEvent.click(getByTestId('switch-admin-link'));
+		await waitFor(() => expect(isOpen(queryByTestId('parent-gate-modal'))).toBe(true));
+	});
+
+	it('AC5: link click は既定遷移を抑止して client 側 modal で処理する', async () => {
+		const { getByTestId } = render(SwitchPage, { props: { data: makeData() } });
+		const link = getByTestId('switch-admin-link');
+
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+		await fireEvent(link, event);
+
+		expect(event.defaultPrevented).toBe(true);
+	});
+
+	it('未ログイン (parentGateInteractive=false) では素の /auth/login 遷移に委ねる', async () => {
+		const { getByTestId, queryByTestId } = render(SwitchPage, {
+			props: {
+				data: makeData({
+					adminLink: '/auth/login',
+					parentGateInteractive: false,
+					pinRequired: false,
+				}),
+			},
+		});
+		const link = getByTestId('switch-admin-link');
+		expect(link.getAttribute('href')).toBe('/auth/login');
+
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+		await fireEvent(link, event);
+
+		// preventDefault せず、modal も開かない (ログイン画面へ遷移させる)
+		expect(event.defaultPrevented).toBe(false);
+		expect(isOpen(queryByTestId('parent-gate-modal'))).toBe(false);
+	});
+
+	it('AC1: 初回作成 modal (pinConfigured=false) には × クローズボタンが無い', async () => {
+		const { getByTestId, queryByLabelText } = render(SwitchPage, {
+			props: { data: makeData({ pinConfigured: false }) },
+		});
+
+		await waitFor(() => expect(getByTestId('parent-gate-create')).toBeTruthy());
+		expect(queryByLabelText(UI_PRIMITIVES_LABELS.closeAriaLabel)).toBeNull();
+	});
+
+	it('AC1 対比: 解錠 modal (pinConfigured=true) には × クローズボタンがある', async () => {
+		const { getByTestId, getByLabelText } = render(SwitchPage, {
+			props: { data: makeData() },
+		});
+
+		await waitFor(() => expect(getByTestId('parent-gate-modal')).toBeTruthy());
+		expect(getByLabelText(UI_PRIMITIVES_LABELS.closeAriaLabel)).toBeTruthy();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 新規オーナーが最初に出る「おやカギコードをつくってください」ダイアログを外側クリック / Esc で閉じると、以降「ご家族の見守り画面」を何度押してもダイアログが開かず、**おやカギの設定も親管理画面へのアクセスも永久にできなくなる**（無限ロックアウト）。cognito 本番モード限定で、獲得した新規オーナーが親機能に一度も到達できないまま離脱する。

**期待される効果**: 初回作成ダイアログは作成完了まで閉じられない強制オンボーディングになり（バイパス不能）、解錠ダイアログ側は閉じても「ご家族の見守り画面」からいつでも開き直せる（回復可能）。どちらの経路でも親管理画面に到達できなくなる状態が構造的に発生しない。

## 関連 Issue

closes #4050

関連: #2992（初回は作る・既存は入るの作成フロー / `prevPinRequired` ガード導入元）/ #2353（PIN gate modal 設計欠陥 6 点）/ ADR-0050（Parent-Gate）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `pinConfigured === false`（おやカギ未設定）の作成モーダル表示中、ダイアログ右上のクローズ用（×）ボタンが非表示になっていること。 | `npx vitest run tests/unit/routes/switch-parent-gate-reopen.test.ts`（「AC1: 初回作成 modal (pinConfigured=false) には × クローズボタンが無い」）+ `npx playwright test tests/e2e/parent-gate-modal-dead-end.spec.ts`（AC1 / AC2 ケース）+ SS 修正前後比較 | PASS（unit 5 件 green / 実装 = `closable={!pinCreateMode}`、SS 修正後に × が消えていること） |
| AC2 | モーダル外のオーバーレイ領域をクリックしたり、エスケープキーを押したりしても、作成モーダルが閉じないこと（強制的な初回作成フローの維持）。 | `npx playwright test tests/e2e/parent-gate-modal-dead-end.spec.ts -g "AC1 / AC2"`（実ブラウザで Esc 押下 → visible / backdrop クリック → visible） | PASS（実装 = `closable={false}` + 新規 `closeOnEscape={false}`。Esc は zag-js の別 prop のため `closable` だけでは閉じてしまう点を Dialog primitive で opt-in 化） |
| AC3 | おやカギコード（4〜6桁の数字）を入力・確認一致させ、正しく設定完了した時点で初めてモーダルが閉じ、全画面ローディング（`/admin` への安全なハードナビ）が起動すること。 | `npx playwright test tests/e2e/parent-gate-modal-dead-end.spec.ts -g "AC3"`（入力 → `data-step=confirm` → 一致入力 → modal hidden → `/admin` へ URL 遷移） | PASS（既存の `triggerAdminNavigation()` 経路を維持。作成完了だけが唯一の出口になる。**副次修正**: 確認ステップは `{#key pinInputKey}` の remount でフォーカスが失われ「打っても入らない」状態だったため、`PinInput` に `autoFocus` prop（既定 false、opt-in）を追加し `/switch` の 2 箇所で有効化した。閉じられない modal で入力できなければ真の dead-end になるため本 Issue の scope 内として同時修正） |
| AC4 | ログイン済み owner で `/switch` に到達した際、おやカギが設定されていない場合はモーダルが 100% 自動オープンし、バイパス不能であることをE2Eテストで検証すること。 | `npx playwright test tests/e2e/parent-gate-modal-dead-end.spec.ts`（PIN 未設定 worker DB で `/switch?pinRequired=1` 到達 → 作成 modal visible → Esc / 外側クリックでバイパス不能） | PASS（**scope 注記**: 自動オープンの発火条件は従来どおり「親ゲート要求時（`pinRequired` 到達）＋ 見守り画面 link click」。おやカギ未設定なら `/switch` を開いただけで無条件に閉じられない modal を出す実装は採らない — `/switch` は子供が自分のプロフィールを選ぶ画面でもあり、子供が閉じられない PIN 作成 modal に閉じ込められるため。「親ゲートに到達したら 100% 開く + バイパス不能」で AC の趣旨を満たしている） |
| AC5（PO 追加） | `pinConfigured === true`（解錠モーダル）でも、モーダルを閉じたあと「ご家族の見守り画面」を再クリックするとモーダルが再オープンすること。 | `npx vitest run tests/unit/routes/switch-parent-gate-reopen.test.ts` + `npx playwright test tests/e2e/parent-gate-modal-dead-end.spec.ts -g "AC5"`（× で閉じる → 再クリックで再表示、Esc で閉じる → 再クリックで再表示） | PASS（本欠陥の本体。`handleAdminLinkClick` の早期 return 条件を `adminLink !== '/admin'` → `!data.parentGateInteractive` に変更し URL 往復自体を発生させない） |
| AC6（PO 追加） | `prevPinRequired` を単純撤去しないこと（#2992 の `effect_update_depth_exceeded` 再発は不可）。 | `git diff origin/develop -- src/routes/switch/+page.svelte` で `let prevPinRequired = false;` + `$effect` ガードが無傷であることを確認 | PASS（ガードは 1 行も変更していない。URL 往復自体を発生させないことで $effect の no-op 問題を回避に頼らず消した） |
| AC7（PO 追加） | Esc 無効化は `closable` の既定値と他モーダルの挙動を変えず、switch 側だけが opt-in する形にすること。 | `git diff origin/develop -- src/lib/ui/primitives/Dialog.svelte`（`closeOnEscape = true` 既定で追加）+ `grep -rn "closable" --include=*.svelte src/`（他 12 コンポーネントの呼び出しは無変更） | PASS（既定 `closeOnEscape=true` のため既存 modal の挙動は不変。`/switch` の作成モードのみ `closeOnEscape={false}` を明示） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: `/switch`（子供選択ポータル）のおやカギコード modal（作成モード / 解錠モード）と「🔒 保護者の見守り画面」導線。`Dialog` primitive は prop 追加のみで既定挙動は不変。

### 真因（対症療法ではないことの説明）

1. **回復不能の真因**: `handleAdminLinkClick` が `data.adminLink !== '/admin'` で早期 return していた。cognito 本番では `adminLink='/auth/login'` 固定のため、ログイン済でも client 側 modal が開かず `/auth/login → /admin → /switch?pinRequired=1` の**同一 URL 往復**に落ちる。
2. **再オープン不能の真因**: 同一 URL 往復では SvelteKit が component を再マウントせず、`prevPinRequired`（#2992）と `data.pinRequired` が共に `true` のままで modal 自動 open の `$effect` が no-op になる。

対処は Issue の**案 A + 案 B を 1 つの解**として実施（PO 判断どおり A/B の択一にしない）。案 B = 往復自体を発生させない（回復）、案 A = 初回は閉じさせない（予防）。

### 横展開確認（同 class の欠陥が他にないか）

- `grep -rn "let prev[A-Z]" --include=*.svelte src/` → **`switch/+page.svelte` の 1 件のみ**（同 class の「前回値ガード × 同一 URL 再ロード」は他画面に存在しない）
- `grep -rn "adminLink" --include=*.svelte --include=*.ts src/` → 判定を持つのは `switch` の 1 経路のみ
- `grep -rn "closable" --include=*.svelte src/` → `closable={false}` は 12 箇所あるが、いずれも祝福 / 結果 / 確認 overlay で「Esc で閉じられて困る」ものではない（強制オンボーディングは本 modal のみ）。既定 `closeOnEscape=true` のため挙動変更なし
- `grep -rn "PinInput" --include=*.svelte src/` → remount フォーカス喪失の同 class は `/auth/reset-pin` にもあるが、同一画面に PinInput が 2 個並ぶ（OTP + 新 PIN）ため自動フォーカス先が一意に決まらない。既定 `autoFocus=false` のまま**変更しない**（本 PR では `/switch` の単一 PinInput 画面のみ opt-in）

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）

<!-- 検証証跡 (Dev 本体が再実行、2026-07-29) -->
> **pre-ready 実測** (worktree `agent-a092e894ea9e9a5c6`、PR #4064 番号指定で再実行):
> - 適用対象の **1 step すべて PASS** — 1 biome / 1b cspell / 2 型検査 / 3 vitest / 4 hardcoded-strings / 7 plan-literals / 7b license-key-leak / 7c cli-entry-guard / 7d sparse-checkout / 9 Readiness gate / 10 doc-code-references / 11 terminology-coherence / 11b SS embed gate / 12 capture
> - 自動 skip (適用対象外) — 5 lp-dimensions / 6 lp-fallback / 8 lp-labels (いずれも site/**・labels.ts・terms.ts・age-tier.ts を 1 file も変更していないため)
> - 末尾サマリの `PARTIAL PASS ... --skip 指定で未実行` は **#4018 の既知欠陥** (条件による自動 skip を `--skip` 指定と誤表示)。本実行で `--skip` は一切指定していない。修正は PR #4037 が対応中

- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/routes/switch-parent-gate-reopen.test.ts`（新規 5 件）: 解錠 modal を閉じた後の link click で再オープン / link click が `preventDefault` される / 未ログイン時は素の `/auth/login` 遷移に委ねる / 作成モードは × 非描画 / 解錠モードは × あり
  - `tests/e2e/parent-gate-modal-dead-end.spec.ts`（新規 3 件）: AC5 再オープン（× / Esc の両方から回復）/ AC1・AC2 作成 modal のバイパス不能（× 非描画・Esc・外側クリック）/ AC3 作成完了で初めて閉じて `/admin` へ遷移。PIN 未設定状態は worker DB の `pin_hash` を snapshot → 削除 → `afterAll` で完全復元（`tests/CLAUDE.md` worker DB 規約準拠）
  - Esc / backdrop の close 挙動は Ark UI のグローバル listener 依存で jsdom では発火しないため（`tests/CLAUDE.md` §Storybook interaction test の既存方針）、AC2 の検証は Playwright 層に置いた
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: 5 要件確認済み（① E2E 回帰を同一 PR で追加 ② AC 全項目完了 ③ Issue の提案 A/B を両方実装 ④ 年齢モード差分なし（`/switch` は年齢モード非依存の共通ポータル、SS で mobile / desktop を確認）⑤ 直近 30 日の同一ファイル変更 PR = #3089 / #2992 系の navigating overlay・作成フローを確認し、いずれも本修正で挙動を壊していないことを既存 E2E で確認）

## スクリーンショット / ビジュアルデモ

**4 スロット添付**（#1740）:

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![修正前 before-create-modal-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4064/before-create-modal-mobile.png) | ![修正前 before-create-modal-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4064/before-create-modal-desktop.png) |
| **修正後** | ![修正後 after-create-modal-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4064/after-create-modal-mobile.png) | ![修正後 after-create-modal-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4064/after-create-modal-desktop.png) |

DOM スナップショット（SS と同一プロセス・同一 page で取得、#1766）:
[before-create-modal-mobile.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4064/before-create-modal-mobile.dom.html) /
[before-create-modal-desktop.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4064/before-create-modal-desktop.dom.html) /
[after-create-modal-mobile.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4064/after-create-modal-mobile.dom.html) /
[after-create-modal-desktop.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4064/after-create-modal-desktop.dom.html)

**インタラクティブ状態**: 初回作成 modal（`pinConfigured=false`）を `/switch?pinRequired=1` で表示した状態（`npm run dev` を local backend で起動し、`settings.pin_hash` を一時削除して PIN 未設定 tenant を再現。撮影後に復元済）。**修正前は modal 右上に × クローズボタンがあり**（＝押すと dead-end に入る入口）、**修正後は × が消え**、Esc / 外側クリックでも閉じず作成完了だけが出口になる。sha256 は before / after で相違を確認済（mobile `464093ec…` → `26913a87…` / desktop `36c159ff…` → `2c05d52c…`）。

DESIGN.md §9 禁忌 6 点の自己判定: hex 直書きなし / primitive 再実装なし（`Dialog` + `PinInput` を使用）/ 内部コード露出なし / 用語は `OYAKAGI_LABELS` 経由 / インラインスタイルなし / `<style>` 追加なし。

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 「親ゲートを client で処理できるか」の判定をサーバー load（`parentGateInteractive`）に集約し、component は表示に専念
- [x] **DRY**: Esc 無効化は Dialog primitive の prop として 1 箇所に実装（呼び出し側で個別 keydown ハンドラを書かない）
- [x] **YAGNI**: 新規抽象なし。prop 1 つ + load field 1 つの追加のみ
- [x] **Security（OSS 公開前提）**: 秘密情報なし。おやカギ未設定 tenant のみ `setup` API を許可する既存の制約（`ALREADY_CONFIGURED` 403）は不変
- [x] **アクセシビリティ**: 作成モードは Esc / × を意図的に無効化するが、`role="dialog"` + focus trap は Ark UI 既定のまま。出口（作成完了）とエラー時の再入力導線が残るため恒久トラップにならない
- [x] **パフォーマンス**: 追加のネットワーク往復を**減らす**変更（`/auth/login → /admin → /switch` の 3 往復を削除）

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001)
- [x] 並行 PR overlap 確認 (#1200)
- [ ] N/A — 並行実装の影響範囲外

設計書同期: `docs/design/06-UI設計書.md §4.6.1`（trigger 2 の発火条件 = `parentGateInteractive` / 閉じる手段のモード別分岐）+ `docs/DESIGN.md §5`（Dialog の `closable` / `closeOnEscape` 2 prop 併用ルール）。`/switch` は年齢モード非依存の共通ポータルのため 5 モード横展開の対象外。

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | | |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:
- AC4 の scope 解釈（`/switch` 到達だけで無条件に閉じられない modal を出すのではなく、親ゲート到達時に 100% 開く + バイパス不能とした理由）を AC 検証マップに明記しています。子供のプロフィール選択を塞がないための判断です。
- cognito 本番モード固有の経路（`locals.identity != null` 判定）は local backend では再現できないため（`docs/CLAUDE.md` §local 検証不可）、cognito 分岐は unit（`parentGateInteractive=false` ケース）で、共通機構は E2E（local lane）で二重に押さえています。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付
- [x] QA 承認・動作確認が完了している

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
