### PR TITLE
fix: #3978 #3953 gate の適用範囲を広げる (readdir 世代判定の機械 gate 化 + journal gate の全 dialect 化 + pre-commit 導線)

### DIFF
--- a/.claude/skills/db-migration/SKILL.md
+++ b/.claude/skills/db-migration/SKILL.md
@@ -51,13 +51,14 @@ ADR-0031 (既存データ互換) と**対**で必須。migration は「既存 st
 
 ### 5. journal `when` を手で書き換えない（#3946 本番 500 / #3948 class-lock）
 
-`drizzle/pglite/meta/_journal.json` の `when` は **drizzle-kit が入れた `Date.now()` をそのまま使う**。手で書き換えてはならない。
+`drizzle/<dialect>/meta/_journal.json` の `when` は **drizzle-kit が入れた `Date.now()` をそのまま使う**。手で書き換えてはならない。
 
 drizzle-orm の migrator（pg-core dialect）は `適用済み最大 created_at < folderMillis` の migration だけを適用する。つまり **実時刻より未来の `when` を一度でも本番 DB へ適用すると、以降 drizzle-kit が生成する全 migration（`when` は実時刻）が既存 DB で永久に skip される**。#3946 はこれで NUC 本番の `/preschool/home` が 500 になった（0002 の手書き丸め値 1784500000000 が未来 → 0003/0004 が永久 skip → `login_streaks` 未作成）。
 
 - [ ] `when` は `npx drizzle-kit generate` の出力のまま（丸め値・連番・未来値にしない）
 - [ ] 既存 migration の `when` を後から編集しない（既に本番 `__drizzle_migrations.created_at` に記録済のため、編集は「適用済みだが journal 上は未適用」の不整合になる）
-- [ ] 機械 gate: `scripts/lib/db/drizzle-journal-gate.mjs`（`tests/unit/db/pglite-journal-when-range-3948.test.ts` が CI で hard-fail）
+- [ ] 機械 gate: `scripts/lib/db/drizzle-journal-gate.mjs`（判定 SSOT）。発火点は 2 つ — commit 時 = `.husky/pre-commit`（`drizzle/*/meta/_journal.json` が staged のときだけ `node scripts/check-drizzle-journal.mjs` を実行、#3953）/ CI = `tests/unit/db/pglite-journal-when-range-3948.test.ts`
+- [ ] 走査は **`drizzle/*/meta/_journal.json` の glob**（PGlite 固定ではない）。新しい dialect の journal を足しても自動で gate 対象になる。0 件マッチも fail する（#3953）
 
 **grandfather 例外**: `1784500000000` / `1784500000001` / `1784500000002`（0002 / 0003 / 0004）は値そのものを修正せず gate の例外として固定している。実生成時刻へ書き戻すと、**#3947 以前の backup から restore した DB（適用済み最大 `created_at` = 1784500000000）で 0003/0004 が永久 skip され #3946 が再発する**ため（`[WR7]` が実 migrator で固定）。**新規にこの例外を増やさないこと**（根拠と一覧の SSOT は `scripts/lib/db/drizzle-journal-gate.mjs` 冒頭コメント）。
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,13 @@ jobs:
         # (本 Issue の対応時に必須 gate 6 job が実際に同時 fail した)。列挙の閉包を機械検証する。
         run: node scripts/check-workflow-sparse-checkout-closure.mjs
 
+      - name: readdir rotation guard — 緩い一致で世代を数える class の禁止 (#3978)
+        # readdir の戻りを prefix / suffix の緩い一致で絞り込み、その結果を削除対象にすると、
+        # 命名規則から外れた同居物 (手動退避 / 旧命名の残骸 / ディレクトリ) が「世代」として
+        # 数えられ保持枠を食う。同じ指摘を #3956 (PGlite 側) / #3978 (SQLite 側) と 2 度受けたため、
+        # 3 度目を待たず機械 gate 化した (ADR-0061 same-class-N → guard)。
+        run: node scripts/check-readdir-rotation-guard.mjs
+
       - name: License key re-introduction guard (#2836 / Epic #2525 Phase 7 PR-L4)
         # license key 全廃 (Phase 1 補強 3 #2788) の再導入防止。allowlist 外のコード行に
         # ライセンスキー / licenseKey / license-key / LICENSE_KEY 参照を検出したら fail。

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -49,3 +49,26 @@ if echo "$STAGED" | grep -qE "(src/lib/domain/labels\.ts|src/lib/domain/terms\.t
 
   echo "[pre-commit] SSOT companion 整合検査 OK"
 fi
+
+# ---------------------------------------------------------------------------
+# drizzle journal (`drizzle/<dialect>/meta/_journal.json`) の `when` 値域検査 (#3953)
+#
+# #3946 は「journal の `when` を手で書き換えた」ことで本番 500 になった class。#3948 で gate を
+# 入れたが発火点が CI (vitest) のみで、手編集した開発者が気づくのは push 後だった。
+# 上の labels.ts / terms.ts と同じ「staged path 限定検査」の形で commit 時点に前倒しする。
+#
+# 判定ロジックは scripts/lib/db/drizzle-journal-gate.mjs (SSOT) の再利用のみ (複製しない)。
+# ---------------------------------------------------------------------------
+if echo "$STAGED" | grep -qE "^drizzle/[^/]+/meta/_journal\.json$"; then
+  echo "[pre-commit] drizzle journal 変更検出 — \`when\` 値域検査を実行"
+
+  node scripts/check-drizzle-journal.mjs || {
+    echo "[pre-commit] check-drizzle-journal FAILED"
+    echo "  → drizzle-kit が生成した \`when\` を手で書き換えないでください。書き換えを戻すか、"
+    echo "    \`npx drizzle-kit generate\` をやり直して実時刻を入れ直してください"
+    echo "    (手順 SSOT: .claude/skills/db-migration/SKILL.md)"
+    exit 1
+  }
+
+  echo "[pre-commit] drizzle journal 検査 OK"
+fi

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -141,7 +141,7 @@ server side gate (`.github/workflows/pr-author-guard.yml`) で違反 PR が即�
 | # | 指摘 class | 発生 PR | 現在の防御 |
 |---|-----------|---------|-----------|
 | 1 | `po-decision:required` label 付きなのに PO 決裁ブリーフが PR body にない | #3944 / #3956 | **機械 gate**: `scripts/check-pr-body.mjs` の `checkPoDecisionBrief`（pre-ready Readiness gate step に内蔵）。見出し欠落 / mermaid 欠落 / 未置換 `___` を fail させる |
-| 2 | 構造化識別子を `startsWith` / `endsWith` の緩い一致で判定した | #3956 | レビュー観点（下記） |
+| 2 | 構造化識別子を `startsWith` / `endsWith` の緩い一致で判定した | #3956 / #3978 | **機械 gate**: `scripts/check-readdir-rotation-guard.mjs`（pre-ready Step 7e + CI `lint-and-test`）。`readdir` の緩い一致 × 近接する破壊的操作を検出。別 class なら `rotation-gate-ok: <理由>` で明示的に opt-out する + レビュー観点（下記） |
 | 3 | guard の fixture が「規則に従うデータ」だけで、規則から外れた実在物を含まない | #3956 | レビュー観点（下記） |
 
 **2 の観点 — 命名規則のあるファイル名・ID・key を判定するときは、prefix/suffix 一致ではなく正規表現の完全一致で書く。** 生成側にも同じパターンの assert を置き、命名変更時に silent に壊れないようにする。#3956 では `pglite-` prefix + `.tgz` suffix 一致にしたため、同居する手動スナップショット `pglite-snapshot-*.tgz` が「世代」として数えられ、実保持が 3 → 2 世代に減っていた。

--- a/scripts/backup-db.cjs
+++ b/scripts/backup-db.cjs
@@ -137,9 +137,10 @@ async function main() {
 	try {
 		const bdb = new Database(backupPath, { readonly: true });
 		try {
-			const tableCount = bdb
-				.prepare("SELECT COUNT(*) as cnt FROM sqlite_master WHERE type='table'")
-				.get().cnt;
+			const tableCountRow = /** @type {{ cnt: number }} */ (
+				bdb.prepare("SELECT COUNT(*) as cnt FROM sqlite_master WHERE type='table'").get()
+			);
+			const tableCount = tableCountRow.cnt;
 
 			const integrity = bdb.pragma('integrity_check');
 			const integrityOk =
@@ -148,7 +149,7 @@ async function main() {
 				throw new Error(`integrity_check failed: ${JSON.stringify(integrity)}`);
 			}
 
-			const fkViolations = bdb.pragma('foreign_key_check');
+			const fkViolations = /** @type {unknown[]} */ (bdb.pragma('foreign_key_check'));
 			if (!Array.isArray(fkViolations) || fkViolations.length > 0) {
 				throw new Error(
 					`foreign_key_check found ${fkViolations.length} violation(s): ${JSON.stringify(fkViolations.slice(0, 5))}`,
@@ -207,7 +208,7 @@ async function main() {
 			}
 		} catch (err) {
 			console.warn(
-				`[backup-db] WARNING: BACKUP_POST_HOOK failed: ${err.message}, backup itself succeeded`,
+				`[backup-db] WARNING: BACKUP_POST_HOOK failed: ${err instanceof Error ? err.message : String(err)}, backup itself succeeded`,
 			);
 			// Hook failure is non-fatal - local backup is already saved
 		}

--- a/scripts/backup-db.cjs
+++ b/scripts/backup-db.cjs
@@ -42,6 +42,63 @@ const BACKUP_DIR = process.env.BACKUP_DIR
 const MAX_BACKUPS = Number(process.env.BACKUP_RETENTION) || 7;
 const POST_HOOK = process.env.BACKUP_POST_HOOK || '';
 
+/** バックアップファイル名の prefix。 */
+const SQLITE_BACKUP_PREFIX = 'ganbari-quest-';
+/** バックアップファイルの拡張子。 */
+const SQLITE_BACKUP_EXT = '.db';
+/**
+ * 「日次バックアップの世代」として数えてよいファイル名の厳密形 (`ganbari-quest-<YYYYMMDDHHMMSS>.db`)。
+ *
+ * ⚠️ prefix + 拡張子の緩い一致 (`startsWith('ganbari-quest-') && endsWith('.db')`) で世代を
+ * 数えてはいけない。同じ BACKUP_DIR には運用中に置かれる **命名規則外のファイル**が同居し得る:
+ *
+ *   - 手動退避 (`ganbari-quest-manual-pre-hotfix.db`) — 辞書順で `'m'` > 数字のため
+ *     `.sort().reverse()` の先頭 (= 最新世代扱い) に恒久的に居座り、保持枠を 1 つ食う。
+ *     結果として実バックアップの最古 1 世代が本来より 1 日早く消える。
+ *   - 旧命名の残骸 (`ganbari-quest-2026-07-26.db`) — 同じく prefix / 拡張子に一致してしまう。
+ *   - 世代を退避したディレクトリ (`ganbari-quest-archive.db`) — 名前だけでは file と区別できず、
+ *     削除対象に入ると `unlinkSync` が EISDIR / EPERM で落ちてローテーション自体が停止する。
+ *
+ * これは PGlite 側 (`src/lib/server/db/pglite/backup.ts` の `PGLITE_BACKUP_FILENAME_PATTERN`)
+ * で #3956 の QA 指摘により是正済みの class と同一 (辞書順の向きが違うだけ)。SQLite 側も
+ * **本パターンの完全一致 + Dirent の isFile()** の 2 段で世代を決める (#3978)。
+ */
+const SQLITE_BACKUP_FILENAME_PATTERN = /^ganbari-quest-\d{14}\.db$/;
+
+/**
+ * `ganbari-quest-<YYYYMMDDHHMMSS>.db` 形式のファイル名を作る (UTC、辞書順 = 時系列順)。
+ *
+ * 命名を変えたのに世代判定パターンを追従し忘れると、生成物がローテーション対象から外れて
+ * 世代が無限に増える (or 新世代が「世代 0 件」に見える) 形で silent に壊れる。生成側で固定する。
+ *
+ * @param {Date} now
+ * @returns {string}
+ */
+function buildBackupFilename(now) {
+	const ts = now
+		.toISOString()
+		.replace(/[-:T.Z]/g, '')
+		.slice(0, 14);
+	const filename = `${SQLITE_BACKUP_PREFIX}${ts}${SQLITE_BACKUP_EXT}`;
+	if (!SQLITE_BACKUP_FILENAME_PATTERN.test(filename)) {
+		throw new Error(`[backup-db] 生成したファイル名が世代判定パターンに一致しません: ${filename}`);
+	}
+	return filename;
+}
+
+/**
+ * ディレクトリ内の **日次バックアップ世代のみ**を新しい順 (辞書順降順 = 新しい順) に返す。
+ *
+ * @param {string[]} filenames 通常ファイルの名前のみ (ディレクトリは呼び出し側で除外済)
+ * @returns {string[]}
+ */
+function selectBackupGenerations(filenames) {
+	return filenames
+		.filter((f) => SQLITE_BACKUP_FILENAME_PATTERN.test(f))
+		.sort()
+		.reverse();
+}
+
 async function main() {
 	console.log('=== Ganbari Quest Backup ===');
 	console.log(`Time: ${new Date().toISOString()}`);
@@ -59,12 +116,7 @@ async function main() {
 	}
 
 	// Create backup
-	const now = new Date();
-	const ts = now
-		.toISOString()
-		.replace(/[-:T.Z]/g, '')
-		.slice(0, 14);
-	const backupFilename = `ganbari-quest-${ts}.db`;
+	const backupFilename = buildBackupFilename(new Date());
 	const backupPath = path.join(BACKUP_DIR, backupFilename);
 
 	const db = new Database(DB_PATH);
@@ -115,11 +167,14 @@ async function main() {
 	}
 
 	// Rotate old backups
-	const files = fs
-		.readdirSync(BACKUP_DIR)
-		.filter((f) => f.startsWith('ganbari-quest-') && f.endsWith('.db'))
-		.sort()
-		.reverse();
+	// 世代判定は「命名パターンの完全一致」+「通常ファイルであること」の 2 段 (#3978)。
+	// 手動退避 / 旧命名の残骸 / 退避ディレクトリを世代に数えないことで、保持世代数と削除対象が
+	// 同居物に左右されないようにする。
+	const regularFileNames = fs
+		.readdirSync(BACKUP_DIR, { withFileTypes: true })
+		.filter((entry) => entry.isFile())
+		.map((entry) => entry.name);
+	const files = selectBackupGenerations(regularFileNames);
 	if (files.length > MAX_BACKUPS) {
 		for (const old of files.slice(MAX_BACKUPS)) {
 			fs.unlinkSync(path.join(BACKUP_DIR, old));
@@ -161,7 +216,17 @@ async function main() {
 	console.log('=== Backup complete ===');
 }
 
-main().catch((err) => {
-	console.error('Fatal error:', err);
-	process.exit(1);
-});
+module.exports = {
+	SQLITE_BACKUP_FILENAME_PATTERN,
+	buildBackupFilename,
+	selectBackupGenerations,
+};
+
+// CJS の直接実行判定。require.main / module はいずれも realpath 解決済みのため
+// symlink / junction 経由で起動しても一致する (ESM 側の判定 SSOT は scripts/lib/is-main.mjs)。
+if (require.main === module) {
+	main().catch((err) => {
+		console.error('Fatal error:', err);
+		process.exit(1);
+	});
+}

--- a/scripts/check-drizzle-journal.mjs
+++ b/scripts/check-drizzle-journal.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-drizzle-journal.mjs
+ *
+ * #3953: drizzle journal (`drizzle/<dialect>/meta/_journal.json`) の `when` 値域 gate を
+ * **commit 時点で**踏めるようにする薄い CLI 入口。
+ *
+ * ## なぜ CLI が要るのか (#3951 監査 accepted-residual 対象 2)
+ *
+ * #3948 の gate は `tests/unit/db/pglite-journal-when-range-3948.test.ts` (vitest) からしか
+ * 発火しない = 気づくのは push 後 (CI)。journal を手で書き換えた開発者に対する予防導線は
+ * `.claude/skills/db-migration/SKILL.md` (agent 向け) だけで、**人間の手編集には何も無かった**。
+ *
+ * `.husky/pre-commit` (#2086) には「特定パスが staged のときだけ検査を走らせる」前例があるので、
+ * 同じ形で `drizzle/<dialect>/meta/_journal.json` が staged のときだけ本 CLI を走らせる。全 commit を
+ * 重くしないため、ADR-0030 (pre-push hook 非採用 / DX 重視) の趣旨とも矛盾しない。
+ *
+ * ## 判定ロジックは複製しない
+ *
+ * 値域ルール (R1-R4) / grandfather / glob 走査はすべて `scripts/lib/db/drizzle-journal-gate.mjs`
+ * (SSOT) 側にある。本 file は「実行して結果を印字し exit code を決める」だけ。
+ *
+ * ## 使い方
+ *
+ *   node scripts/check-drizzle-journal.mjs          # 違反があれば exit 1
+ *   node scripts/check-drizzle-journal.mjs --help
+ *
+ * ## 関連
+ *   - scripts/lib/db/drizzle-journal-gate.mjs (判定 SSOT)
+ *   - tests/unit/db/pglite-journal-when-range-3948.test.ts (CI 側の発火点)
+ *   - .husky/pre-commit (#2086 staged path 限定検査の前例)
+ *   - Issue #3946 / #3948 / #3953
+ */
+
+import {
+	checkAllJournals,
+	formatAllJournalViolations,
+	JOURNAL_GLOB,
+} from './lib/db/drizzle-journal-gate.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
+
+function printHelp() {
+	console.log(`check-drizzle-journal.mjs — drizzle journal の \`when\` 値域 gate (Issue #3948 / #3953)
+
+走査対象: ${JOURNAL_GLOB} (発見した全 journal に適用。0 件マッチも fail)
+検証ルール:
+  R1 when が未来でない / R2 手書きの丸め値・連番でない
+  R3 プロジェクト開始より過去でない / R4 idx 連番 + when 狭義単調増加
+  R0 journal が 1 本も無い / JSON として読めない
+
+判定 SSOT: scripts/lib/db/drizzle-journal-gate.mjs
+使い方   : node scripts/check-drizzle-journal.mjs`);
+}
+
+function main() {
+	if (process.argv.includes('--help') || process.argv.includes('-h')) {
+		printHelp();
+		return 0;
+	}
+	const { files, violations } = checkAllJournals(process.cwd());
+
+	if (violations.length === 0) {
+		console.log(
+			`[check-drizzle-journal] OK: ${files.length} 件の journal が全ルールを満たしています (${files.join(', ')})`,
+		);
+		return 0;
+	}
+
+	console.error(`[check-drizzle-journal] FAIL: ${violations.length} 件の違反`);
+	console.error(formatAllJournalViolations(violations));
+	console.error(
+		'\n  → drizzle-kit が生成した `when` を手で書き換えないでください (手順 SSOT: .claude/skills/db-migration/SKILL.md)。',
+	);
+	return 1;
+}
+
+if (isMainModule(import.meta.url)) {
+	process.exit(main());
+}

--- a/scripts/check-readdir-rotation-guard.mjs
+++ b/scripts/check-readdir-rotation-guard.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-readdir-rotation-guard.mjs
+ *
+ * #3978: 「`readdir` の戻りを緩い一致で絞り込み、その結果を破壊的操作の対象にする」class を
+ * 機械的に検出する gate。
+ *
+ * ## 背景 — なぜ 2 回目で gate 化するのか
+ *
+ * PR #3956 で QM から「`readdir` の戻りを `startsWith` + `endsWith` の緩い一致で世代として
+ * 数えており、命名規則から外れたファイルが世代枠を食う」という BLOCK を受けた。#3956 では
+ * PGlite 側 (`PGLITE_BACKUP_FILENAME_PATTERN`) を正規表現の完全一致に直して閉じたが、
+ * **同じ class が `scripts/backup-db.cjs` に残存していた** (#3978 の一次調査で発見)。
+ *
+ * 手動退避 `ganbari-quest-manual-pre-hotfix.db` を 1 本置くだけで、辞書順で `'m'` は数字より
+ * 後ろなので降順ソートの先頭 (= 最新扱い) に居座り、保持枠を恒久的に 1 つ食う。結果として
+ * 実バックアップの最古 1 世代が本来より 1 日早く `unlinkSync` される。
+ *
+ * 「3 回目で linter rule 化では遅い。2 回目で機械化を試み、代わりに機械化の水準を下げる」
+ * という PO / QM 判断 (docs/sessions/dev-session.md §「QA 指摘の再発防止台帳」#2/#3) に従い、
+ * 本 gate は **意図的に精度を落とした行ベース検査**として実装している。
+ *
+ * ## 検出条件 (3 つすべてを満たす箇所)
+ *
+ *   1. `readdir` / `readdirSync` の呼び出しがある
+ *   2. その直後の chain 内 (CHAIN_WINDOW 行) の `.filter(...)` が `startsWith(` / `endsWith(` を
+ *      直接使っており、`*_PATTERN` 名の const (正規表現) を経由していない
+ *   3. 同一ファイル内の近接 (±PROXIMITY_WINDOW 行) に破壊的操作
+ *      (`unlinkSync` / `rm(` / `rmSync(` / `rename(` / `renameSync(` / `unlink(`) がある
+ *
+ * ## 意図的に下げた水準 (false positive を許容する)
+ *
+ * 静的解析で「同一関数内」を厳密に取るのは重いので、初版は **同一ファイル内の近接 (±20 行)**
+ * で判定する。false positive は許容し、`rotation-gate-ok: <理由>` の inline 抑制コメントで
+ * 明示的に除外できるようにしている。
+ *
+ * **抑制コメントを書かせること自体が「この絞り込みは削除に使われる」という宣言になる**ので、
+ * gate の目的 (書き手にその接続を意識させる) は達成される。理由が空のマーカーは opt-out として
+ * 認めない (無言の抑止を防ぐ)。
+ *
+ * ## 使い方
+ *
+ *   node scripts/check-readdir-rotation-guard.mjs          # 違反があれば exit 1
+ *   node scripts/check-readdir-rotation-guard.mjs --help
+ *
+ * ## 関連
+ *   - src/lib/server/db/pglite/backup.ts (目標形: PGLITE_BACKUP_FILENAME_PATTERN 完全一致)
+ *   - scripts/backup-db.cjs (#3978 で是正した同 class の実在箇所)
+ *   - tests/unit/scripts/check-readdir-rotation-guard.test.ts
+ *   - ADR-0061 (same-class-N → guard 化)
+ *   - Issue #3956 / #3978
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { isMain as isMainModule } from './lib/is-main.mjs';
+
+/** 走査対象ルート (repo 相対)。 */
+export const SCAN_ROOTS = ['src', 'scripts'];
+/** 走査対象拡張子。 */
+export const SCAN_EXTS = ['.ts', '.js', '.mjs', '.cjs'];
+/** 走査から外すディレクトリ名 (worktrees は他ブランチ実体を重複走査しないため必須)。 */
+const SKIP_DIRS = new Set([
+	'node_modules',
+	'.svelte-kit',
+	'cdk.out',
+	'dist',
+	'build',
+	'__snapshots__',
+	'worktrees',
+]);
+
+/**
+ * `readdir` 行から下方向に何行を「同一 chain」と見なすか。
+ * `.readdirSync(dir)` → 改行 → `.filter(...)` → `.sort()` … の整形済みチェーンを拾える幅。
+ */
+export const CHAIN_WINDOW = 8;
+/**
+ * 破壊的操作を探す近接幅 (readdir 行の ±)。#3978 の指定値。
+ * 「同一関数内」の厳密判定を避けた代替であり、false positive は抑制コメントで処理する。
+ */
+export const PROXIMITY_WINDOW = 20;
+
+/** 破壊的操作。これが近接に無ければ「列挙だけ」なので対象外 (走査 script 等の false positive を除く)。 */
+const DESTRUCTIVE_RE = /\b(unlinkSync|unlink|rmSync|rm|renameSync|rename)\s*\(/;
+/** 緩い一致による絞り込み。 */
+const LOOSE_MATCH_RE = /\.(startsWith|endsWith)\s*\(/;
+/** 命名済みパターン const (正規表現) 経由の判定。これがあれば緩い一致があっても対象外。 */
+const NAMED_PATTERN_RE = /[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*_PATTERN\b/;
+/** readdir 呼び出し。 */
+const READDIR_RE = /\breaddir(Sync)?\s*\(/;
+/** 抑制マーカー (理由必須)。 */
+const SUPPRESS_RE = /rotation-gate-ok:\s*\S/;
+
+/**
+ * 行がコメントのみか判定する (block comment の内側行 / 行頭 `//` / shebang)。
+ *
+ * 完全な字句解析はしない。gate の目的は「実行されるコード」の検出であり、
+ * 解説コメント中の記述例 (本 file 冒頭の説明など) を violation にしないための最小限の除外。
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+export function isCommentLine(line) {
+	const t = line.trim();
+	return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') || t.startsWith('#!');
+}
+
+/**
+ * 対象行、またはその直前に連続するコメント行の中に抑制マーカーがあるか。
+ *
+ * @param {readonly string[]} lines
+ * @param {number} index 対象行の 0-based index
+ * @returns {boolean}
+ */
+function hasSuppression(lines, index) {
+	if (SUPPRESS_RE.test(lines[index] ?? '')) return true;
+	for (let j = index - 1; j >= 0; j--) {
+		const line = lines[j] ?? '';
+		if (line.trim() === '') break;
+		if (!isCommentLine(line)) break;
+		if (SUPPRESS_RE.test(line)) return true;
+	}
+	return false;
+}
+
+/**
+ * 1 ファイルを走査して violation を返す (純粋関数、unit test 対象)。
+ *
+ * @param {string} relPath repo 相対パス (区切りは OS 依存でよい)
+ * @param {string} source ファイル内容
+ * @returns {Array<{ file: string, line: number, text: string }>}
+ */
+export function scanSource(relPath, source) {
+	const normalized = relPath.split(sep).join('/');
+	const lines = source.split(/\r?\n/);
+	/** @type {Array<{ file: string, line: number, text: string }>} */
+	const violations = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? '';
+		if (isCommentLine(line)) continue;
+		if (!READDIR_RE.test(line)) continue;
+
+		// (2) chain 内の絞り込みが「緩い一致」かつ「命名済みパターン非経由」か。
+		const chain = lines
+			.slice(i, i + CHAIN_WINDOW + 1)
+			.filter((l) => !isCommentLine(l))
+			.join('\n');
+		if (!chain.includes('.filter(')) continue;
+		if (!LOOSE_MATCH_RE.test(chain)) continue;
+		if (NAMED_PATTERN_RE.test(chain)) continue;
+
+		// (3) 近接に破壊的操作があるか (= 絞り込み結果が削除 / 移動の対象集合になり得る)。
+		const near = lines
+			.slice(Math.max(0, i - PROXIMITY_WINDOW), i + PROXIMITY_WINDOW + 1)
+			.filter((l) => !isCommentLine(l))
+			.join('\n');
+		if (!DESTRUCTIVE_RE.test(near)) continue;
+
+		if (hasSuppression(lines, i)) continue;
+
+		violations.push({ file: normalized, line: i + 1, text: line.trim() });
+	}
+
+	return violations;
+}
+
+/**
+ * dir 配下を再帰走査して対象拡張子のファイルを集める。テストファイルは対象外。
+ *
+ * @param {string} dir
+ * @param {string[]} [acc]
+ * @returns {string[]}
+ */
+function collectFiles(dir, acc = []) {
+	let entries;
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return acc;
+	}
+	for (const e of entries) {
+		const full = join(dir, e.name);
+		if (e.isDirectory()) {
+			if (SKIP_DIRS.has(e.name) || e.name.startsWith('.')) continue;
+			collectFiles(full, acc);
+			continue;
+		}
+		if (!e.isFile()) continue;
+		if (/\.(test|spec)\./.test(e.name)) continue;
+		if (SCAN_EXTS.some((ext) => e.name.endsWith(ext))) acc.push(full);
+	}
+	return acc;
+}
+
+/**
+ * repoRoot 配下の SCAN_ROOTS を走査し、全違反と走査件数を返す。
+ *
+ * @param {string} repoRoot
+ * @returns {{ violations: Array<{ file: string, line: number, text: string }>, scanned: string[], fileCount: number }}
+ */
+export function findAllViolations(repoRoot) {
+	/** @type {Array<{ file: string, line: number, text: string }>} */
+	const violations = [];
+	/** @type {string[]} */
+	const scanned = [];
+	let fileCount = 0;
+
+	for (const scanRoot of SCAN_ROOTS) {
+		const abs = join(repoRoot, scanRoot);
+		try {
+			if (!statSync(abs).isDirectory()) {
+				scanned.push(`${scanRoot}=対象外`);
+				continue;
+			}
+		} catch {
+			scanned.push(`${scanRoot}=未検出`);
+			continue;
+		}
+		const files = collectFiles(abs);
+		scanned.push(`${scanRoot}=${files.length}`);
+		fileCount += files.length;
+		for (const file of files) {
+			violations.push(...scanSource(relative(repoRoot, file), readFileSync(file, 'utf8')));
+		}
+	}
+
+	return { violations, scanned, fileCount };
+}
+
+function printHelp() {
+	console.log(`check-readdir-rotation-guard.mjs — readdir の緩い一致 × 破壊的操作を禁止する gate (Issue #3978)
+
+走査対象: ${SCAN_ROOTS.join(' / ')} 配下の ${SCAN_EXTS.join(' / ')} (*.test.* / *.spec.* は除外)
+検出条件: readdir の chain 内 (${CHAIN_WINDOW} 行) の .filter が startsWith / endsWith を直接使い、
+          *_PATTERN 経由でなく、同一ファイルの ±${PROXIMITY_WINDOW} 行に破壊的操作がある
+opt-out : 当該行または直前のコメント行に \`rotation-gate-ok: <理由>\` (理由必須)
+使い方  : node scripts/check-readdir-rotation-guard.mjs`);
+}
+
+function main() {
+	if (process.argv.includes('--help') || process.argv.includes('-h')) {
+		printHelp();
+		return 0;
+	}
+	const repoRoot = process.cwd();
+	const { violations, scanned, fileCount } = findAllViolations(repoRoot);
+
+	// 走査件数を必ず出す。0 件走査と 0 件違反が同じ文言の exit 0 になると、
+	// 「gate が壊れて何も見ていない」状態を PASS と読み違える (本 gate が塞ぐ class と同型)。
+	if (fileCount === 0) {
+		console.error(
+			`[check-readdir-rotation-guard] FAIL: 1 ファイルも走査していません (走査 ${scanned.join(' / ')})`,
+		);
+		console.error(
+			'  → cwd が repo root か、SCAN_ROOTS が checkout に含まれているか確認してください。',
+		);
+		return 1;
+	}
+
+	if (violations.length === 0) {
+		console.log(
+			`[check-readdir-rotation-guard] OK: 緩い一致 × 破壊的操作は 0 件 (走査 ${scanned.join(' / ')})`,
+		);
+		return 0;
+	}
+
+	console.error(`[check-readdir-rotation-guard] FAIL: ${violations.length} 件の違反`);
+	for (const v of violations) {
+		console.error(`  ${v.file}:${v.line} ${v.text}`);
+	}
+	console.error('\n  背景: readdir の戻りを prefix / suffix の緩い一致で絞り込むと、命名規則から');
+	console.error('        外れた同居物 (手動退避 / 旧命名の残骸 / ディレクトリ) が「世代」として');
+	console.error('        数えられ、保持枠を食う or 削除対象に混ざる (#3956 / #3978)。');
+	console.error('  → 修正: 命名規則を `*_PATTERN` 名の正規表現 const として定義し、その完全一致');
+	console.error(
+		'          (`PATTERN.test(name)`) で絞り込む。生成側にも同じパターンの assert を置く。',
+	);
+	console.error(
+		'  → opt-out: 別 class だと判断した場合のみ、当該行/直前行に `rotation-gate-ok: <理由>`',
+	);
+	return 1;
+}
+
+if (isMainModule(import.meta.url)) {
+	process.exit(main());
+}

--- a/scripts/lib/db/drizzle-journal-gate.mjs
+++ b/scripts/lib/db/drizzle-journal-gate.mjs
@@ -111,9 +111,8 @@ export function findJournalWhenViolations(entries, options = {}) {
 				rule: 'R4-idx',
 				tag,
 				when,
-				message:
-					`idx が配列順と一致しない (idx=${idx}, 期待=${i})。
-` + `    → entries の並べ替え・手編集を戻し、drizzle-kit が生成した idx 連番へ戻してください。`,
+				message: `idx が配列順と一致しない (idx=${idx}, 期待=${i})。
+    → entries の並べ替え・手編集を戻し、drizzle-kit が生成した idx 連番へ戻してください。`,
 			});
 		}
 

--- a/scripts/lib/db/drizzle-journal-gate.mjs
+++ b/scripts/lib/db/drizzle-journal-gate.mjs
@@ -55,6 +55,9 @@
 // **新規 migration でこの例外を増やしてはならない**。`npx drizzle-kit generate` が入れた `when` を
 // 手で書き換えないこと (手順 SSOT: `.claude/skills/db-migration/SKILL.md`)。
 
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 /** 0002_evaluations_week_unique の手書き `when` — #3946 の原因値。 */
 export const HANDWRITTEN_WHEN_0002 = 1784500000000;
 /** 0003_login_streaks_counter の手書き `when` — #3947 で 0002 を上回らせるために採番した連番。 */
@@ -184,4 +187,119 @@ export function findJournalWhenViolations(entries, options = {}) {
  */
 export function formatJournalWhenViolations(violations) {
 	return violations.map((v) => `  [${v.rule}] ${v.tag}: ${v.message}`).join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// 全 dialect 走査 (#3953 — #3951 監査 accepted-residual 対象 1)
+//
+// #3948 初版は journal を **PGlite 固定パス** (`drizzle/pglite/meta/_journal.json`) で読んでいた。
+// 現時点で journal はリポジトリ全体で 1 本しかないため実害はなかったが、将来 drizzle の別 dialect
+// 用 journal (例: `drizzle/dsql/meta/_journal.json`) が増えたとき **gate に一切かからないまま通る**。
+// #3946 は「journal を手で触れる」ことに起因する class なので、新しい journal が増えた瞬間に
+// 同じ窓が開く。走査を glob 化しておけば追加コストなしで塞げる。
+//
+// glob 化で新たに生まれる silent skip (「0 件マッチ = 素通り」) は R0-no-journal で fail させる。
+// ---------------------------------------------------------------------------
+
+/** journal を探すルート (repoRoot 相対)。`<root>/<dialect>/meta/_journal.json` を走査する。 */
+export const JOURNAL_ROOT_DIR = 'drizzle';
+/** 走査パターンの人間向け表現 (エラーメッセージ / --help 用)。 */
+export const JOURNAL_GLOB = 'drizzle/*/meta/_journal.json';
+
+/**
+ * `drizzle/<dialect>/meta/_journal.json` を全て見つけて repo 相対パス (POSIX 区切り) で返す。
+ *
+ * @param {string} repoRoot
+ * @returns {string[]} 発見順 (dialect ディレクトリ名の昇順)
+ */
+export function findJournalFiles(repoRoot) {
+	const root = join(repoRoot, JOURNAL_ROOT_DIR);
+	if (!existsSync(root)) return [];
+	/** @type {string[]} */
+	const found = [];
+	for (const entry of readdirSync(root, { withFileTypes: true }).sort((a, b) =>
+		a.name.localeCompare(b.name),
+	)) {
+		if (!entry.isDirectory()) continue;
+		const rel = `${JOURNAL_ROOT_DIR}/${entry.name}/meta/_journal.json`;
+		if (existsSync(join(repoRoot, rel))) found.push(rel);
+	}
+	return found;
+}
+
+/**
+ * 発見した **全 journal** に `findJournalWhenViolations` を適用する。
+ *
+ * 判定ロジックは `findJournalWhenViolations` の 1 本のみ (複製しない)。本関数は
+ * 「どの journal に適用するか」と「1 本も見つからない = gate が空振り」の検出だけを担う。
+ *
+ * @param {string} repoRoot
+ * @param {{ now?: number, grandfathered?: readonly number[] }} [options]
+ * @returns {{ files: string[], violations: Array<{ file: string, rule: string, tag: string, when: number, message: string }> }}
+ */
+export function checkAllJournals(repoRoot, options = {}) {
+	const files = findJournalFiles(repoRoot);
+	/** @type {Array<{ file: string, rule: string, tag: string, when: number, message: string }>} */
+	const violations = [];
+
+	// glob 化の副作用で「対象 0 件だから PASS」という新しい silent skip を作らない (#3953 AC2)。
+	if (files.length === 0) {
+		violations.push({
+			file: JOURNAL_GLOB,
+			rule: 'R0-no-journal',
+			tag: '(none)',
+			when: 0,
+			message:
+				`${JOURNAL_GLOB} に一致する journal が 1 本も見つかりません。gate が何も検査せず ` +
+				'PASS している状態です。\n' +
+				'    → repo root で実行しているか、drizzle/ が checkout に含まれているかを確認してください。',
+		});
+		return { files, violations };
+	}
+
+	for (const file of files) {
+		let entries;
+		try {
+			const parsed = JSON.parse(readFileSync(join(repoRoot, file), 'utf-8'));
+			entries = parsed.entries;
+		} catch (err) {
+			violations.push({
+				file,
+				rule: 'R0-parse',
+				tag: '(file)',
+				when: 0,
+				message:
+					`journal を JSON として読めません: ${err instanceof Error ? err.message : String(err)}\n` +
+					'    → 手編集した JSON の構文を戻してください。',
+			});
+			continue;
+		}
+		if (!Array.isArray(entries) || entries.length === 0) {
+			violations.push({
+				file,
+				rule: 'R0-parse',
+				tag: '(file)',
+				when: 0,
+				message:
+					'journal に entries がありません (空 journal は migration 消失と区別できない)。\n' +
+					'    → drizzle-kit が生成した journal へ戻してください。',
+			});
+			continue;
+		}
+		for (const v of findJournalWhenViolations(entries, options)) {
+			violations.push({ file, ...v });
+		}
+	}
+
+	return { files, violations };
+}
+
+/**
+ * `checkAllJournals` の結果を人間可読な 1 本のメッセージへ整形する (file 名付き)。
+ *
+ * @param {Array<{ file: string, rule: string, tag: string, when: number, message: string }>} violations
+ * @returns {string}
+ */
+export function formatAllJournalViolations(violations) {
+	return violations.map((v) => `  ${v.file} [${v.rule}] ${v.tag}: ${v.message}`).join('\n');
 }

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -887,7 +887,10 @@ export function buildSteps(args, changedFiles) {
 			label: readdirRotationScriptExists
 				? 'Step 7e/12: check-readdir-rotation-guard.mjs (#3978)'
 				: 'Step 7e/12: check-readdir-rotation-guard.mjs (script 未配備 — skip)',
-			skip: args.skipReaddirRotationGuard || !readdirRotationScriptExists,
+			...skipStateOf({
+				byFlag: args.skipReaddirRotationGuard,
+				scriptMissing: !readdirRotationScriptExists,
+			}),
 			runner: () =>
 				run('check-readdir-rotation-guard', ['node', 'scripts/check-readdir-rotation-guard.mjs']),
 			fixHint:

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -68,6 +68,7 @@ const SKIP_FLAGS = {
 	'--skip-license-key-leak': 'skipLicenseKeyLeak',
 	'--skip-cli-entry-guard': 'skipCliEntryGuard',
 	'--skip-sparse-checkout-closure': 'skipSparseCheckoutClosure',
+	'--skip-readdir-rotation-guard': 'skipReaddirRotationGuard',
 	'--skip-lp-labels': 'skipLpLabels',
 	'--skip-pr-body': 'skipPrBody',
 	'--skip-doc-code-references': 'skipDocCodeReferences',
@@ -89,6 +90,7 @@ function parseArgs(argv) {
 		skipLicenseKeyLeak: false,
 		skipCliEntryGuard: false,
 		skipSparseCheckoutClosure: false,
+		skipReaddirRotationGuard: false,
 		skipLpLabels: false,
 		skipPrBody: false,
 		skipDocCodeReferences: false,
@@ -133,6 +135,7 @@ Options:
   --skip-license-key-leak Step 7b license key 再導入防止検査をスキップ (#2836 / Phase 7 PR-L4)
   --skip-cli-entry-guard Step 7c 自前の CLI 直接実行判定 / 手組み file:// URL 検査をスキップ (#3969)
   --skip-sparse-checkout-closure Step 7d workflow sparse-checkout の import 閉包検査をスキップ (#3969)
+  --skip-readdir-rotation-guard Step 7e readdir の緩い一致 × 破壊的操作の検査をスキップ (#3978)
   --skip-lp-labels       Step 8 LP labels 同期検査をスキップ (labels.ts / terms.ts / age-tier.ts 変更時のみ自動実行、Phase 1 B1)
   --skip-pr-body         Step 9 PR body 検査をスキップ
   --skip-doc-code-references Step 10 デッドリンク検査をスキップ
@@ -152,6 +155,7 @@ Steps:
   7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972 / Phase 5 F1 / #1918)
   7c. check-cli-entry-guard.mjs  — 自前の CLI 直接実行判定 / 手組み file:// URL 禁止 (#3969)
   7d. check-workflow-sparse-checkout-closure.mjs — workflow sparse-checkout の import 閉包検査 (#3969)
+  7e. check-readdir-rotation-guard.mjs — readdir の緩い一致で世代を数える class の検出 (#3978)
   8.  generate-lp-labels --check  — site/shared-labels.js 同期検査 (labels.ts / terms.ts / age-tier.ts 変更時のみ、Phase 1 B1 / #1917)
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
   10. check-doc-code-references.mjs — ドキュメントのデッドリンク検知 (#2577)
@@ -517,6 +521,9 @@ export function buildSteps(args, changedFiles) {
 		'scripts/check-workflow-sparse-checkout-closure.mjs',
 	);
 	const sparseClosureScriptExists = existsSync(sparseClosureScript);
+	// #3978: readdir の緩い一致で世代を数え、その結果を破壊的操作の対象にする class の検出
+	const readdirRotationScript = resolve(repoRoot, 'scripts/check-readdir-rotation-guard.mjs');
+	const readdirRotationScriptExists = existsSync(readdirRotationScript);
 
 	return [
 		{
@@ -662,6 +669,24 @@ export function buildSteps(args, changedFiles) {
 				'  workflow の sparse-checkout に import 先の列挙漏れがあります (#3969)。\n' +
 				'  - 修正: 出力された不足パスを当該 sparse-checkout ブロックに追加する\n' +
 				'  - 放置すると当該 job が ERR_MODULE_NOT_FOUND で落ちる (無言 PASS ではなく hard fail)',
+		},
+		// Step 7e: check-readdir-rotation-guard (#3978)
+		// readdir の戻りを prefix / suffix の緩い一致で絞り込み、その結果を削除対象にする class。
+		// 同じ指摘を #3956 / #3978 と 2 度受けたため、3 度目を待たず機械 gate 化した
+		// (docs/sessions/dev-session.md §「QA 指摘の再発防止台帳」#2 / ADR-0061)。
+		{
+			name: 'readdir-rotation-guard',
+			label: readdirRotationScriptExists
+				? 'Step 7e/12: check-readdir-rotation-guard.mjs (#3978)'
+				: 'Step 7e/12: check-readdir-rotation-guard.mjs (script 未配備 — skip)',
+			skip: args.skipReaddirRotationGuard || !readdirRotationScriptExists,
+			runner: () =>
+				run('check-readdir-rotation-guard', ['node', 'scripts/check-readdir-rotation-guard.mjs']),
+			fixHint:
+				'  readdir の緩い一致 (startsWith / endsWith) の結果を破壊的操作の対象にしています (#3978)。\n' +
+				'  - 修正: 命名規則を `*_PATTERN` 名の正規表現 const にし、その完全一致で絞り込む\n' +
+				'  - 生成側にも同じパターンの assert を置く (命名変更で silent に壊れないようにする)\n' +
+				'  - 別 class だと判断した場合のみ `rotation-gate-ok: <理由>` を当該行/直前行に置く',
 		},
 		// Step 8: generate-lp-labels --check (Phase 1 B1 / #1917)
 		// Issue #1920 graceful degradation: 検査 script が未配備なら skip + warning。

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -473,6 +473,7 @@ export const STEP_COST_CLASS_BY_NAME = {
 	'license-key-leak': 'static',
 	'cli-entry-guard': 'static',
 	'sparse-checkout-closure': 'static',
+	'readdir-rotation-guard': 'static',
 	'lp-labels': 'static',
 	'doc-code-references': 'static',
 	'terminology-coherence': 'static',

--- a/src/lib/server/db/sqlite/storage-repo.ts
+++ b/src/lib/server/db/sqlite/storage-repo.ts
@@ -128,6 +128,11 @@ export const listFiles: IStorageRepo['listFiles'] = async (prefix) => {
 	const dir = join(baseDir, dirname(prefix));
 	if (!existsSync(dir)) return [];
 	const baseName = prefix.split('/').pop() ?? '';
+	// rotation-gate-ok: ここの startsWith は「プレフィックス検索」という API 仕様そのものであり、
+	// 命名規則のあるファイル名から**世代を数える** class (#3956 / #3978) ではない。
+	// ただし deleteByPrefix がこの戻りを無条件に全件 unlinkSync するため、`prefix="avatars/child1"`
+	// が `avatars/child10.png` まで巻き込む **プレフィックス境界の欠落**という別 class の欠陥は
+	// 残っている (#3978 の調査で記録済み、本 Issue の対象外)。境界を入れる修正は別 Issue で扱う。
 	return readdirSync(dir)
 		.filter((f) => {
 			const full = join(dir, f);

--- a/tests/unit/db/pglite-journal-when-range-3948.test.ts
+++ b/tests/unit/db/pglite-journal-when-range-3948.test.ts
@@ -6,12 +6,15 @@
 // 生成する全 migration が本番既存 DB で永久 skip される (#3946 と完全に同型の本番 500)。
 // 本テストはその穴を塞ぐ gate (scripts/lib/db/drizzle-journal-gate.mjs) を CI で hard-fail させる。
 //
-//   [WR1] 実 journal (drizzle/pglite/meta/_journal.json) が gate の全ルールを満たす
+//   [WR1] 実 journal (drizzle/<dialect>/meta/_journal.json、glob で発見した全件) が gate の全ルールを満たす
 //   [WR2] gate 自体の実効性: 未来値 / 手書き丸め値 / 逆転 / 過去すぎる値 の fixture で fail する
 //   [WR3] grandfather は既存 3 値限定 — 同型の新規丸め値は grandfather されず fail する
 //   [WR4] DSQL provision は `when` を参照しない (idx 順 + tag 冪等) ことの固定
 //   [WR7] grandfather 3 値を「実生成時刻へ直す」と pre-hotfix backup の restore で #3946 が再発する
 //         (grandfather が必要である理由そのものを実 migrator + 実 migration で固定する)
+//   [WR8] gate の適用先が全 dialect (#3953 — 走査の glob 化が実際に効いていることの検証)
+//         - 0 件マッチ = fail (glob 化で「素通り」という新しい silent skip を作らない)
+//         - 複数 journal がある状態で **2 本目に違反があれば fail する**
 //
 // [WR2] は「gate を書いたが実は何も落とせていない」を防ぐ実効性検証 (#3072 と同型の考え方)。
 
@@ -23,8 +26,10 @@ import { drizzle } from 'drizzle-orm/pglite';
 import { migrate } from 'drizzle-orm/pglite/migrator';
 import { afterAll, describe, expect, it } from 'vitest';
 import {
+	checkAllJournals,
+	findJournalFiles,
 	findJournalWhenViolations,
-	formatJournalWhenViolations,
+	formatAllJournalViolations,
 	GRANDFATHERED_WHEN,
 	HANDWRITTEN_WHEN_0002,
 	MIN_PLAUSIBLE_WHEN,
@@ -97,22 +102,26 @@ async function tableExists(client: PGlite, table: string): Promise<boolean> {
 }
 
 describe('drizzle journal `when` 値域 gate (#3948)', () => {
-	it('[WR1] 実 journal (drizzle/pglite) が gate の全ルールを満たす', () => {
-		const entries = loadRealJournal();
-		expect(entries.length).toBeGreaterThan(0);
-		const violations = findJournalWhenViolations(entries);
+	it('[WR1] 実 journal (glob で発見した全 dialect) が gate の全ルールを満たす', () => {
+		// #3953 AC1: PGlite 固定パスではなく drizzle/*/meta/_journal.json の glob 走査。
+		// 将来 drizzle/dsql/meta/_journal.json 等が増えたら、追加作業なしでこの assert の対象になる。
+		const { files, violations } = checkAllJournals(process.cwd());
+		expect(files.length, 'journal が 1 本も見つからない').toBeGreaterThan(0);
+		expect(files, 'PGlite journal が走査対象に含まれていない').toContain(
+			'drizzle/pglite/meta/_journal.json',
+		);
 		expect(
 			violations,
-			`journal 違反あり:\n${formatJournalWhenViolations(violations)}`,
+			`journal 違反あり:\n${formatAllJournalViolations(violations)}`,
 		).toStrictEqual([]);
 	});
 
 	it('[WR1b] 実 journal の grandfather 例外は既知 3 値のみ (新規追加が混ざっていない)', () => {
-		const entries = loadRealJournal();
 		// grandfather を無効化すると、既知 3 値 **だけ** が R2 で落ちる = 例外が増えていない。
-		const withoutGrandfather = findJournalWhenViolations(entries, { grandfathered: [] });
-		expect(withoutGrandfather.every((v) => v.rule === 'R2-handwritten')).toBe(true);
-		expect(withoutGrandfather.map((v) => v.when).sort((a, b) => a - b)).toStrictEqual([
+		// #3953 AC1: 判定対象は glob で発見した全 journal。
+		const { violations } = checkAllJournals(process.cwd(), { grandfathered: [] });
+		expect(violations.every((v) => v.rule === 'R2-handwritten')).toBe(true);
+		expect(violations.map((v) => v.when).sort((a, b) => a - b)).toStrictEqual([
 			...GRANDFATHERED_WHEN,
 		]);
 	});
@@ -297,6 +306,86 @@ describe('drizzle journal `when` 値域 gate (#3948)', () => {
 			await healthy.close();
 		}
 	}, 120_000);
+
+	// -------------------------------------------------------------------------
+	// [WR8] gate の適用先が全 dialect であることの検証 (#3953 AC1-AC3)
+	//
+	// 「glob にした」と書くだけでは、実際に 2 本目以降へ適用されている保証がない。
+	// 複数 journal を持つ fake repo root を作り、**2 本目にだけ違反を置いて** fail することを固定する。
+	// -------------------------------------------------------------------------
+
+	/** `<root>/drizzle/<dialect>/meta/_journal.json` を持つ fake repo root を作る。 */
+	function makeFakeRepoRoot(journals: Record<string, JournalEntry[]>): string {
+		const root = join(tmpdir(), `journal-glob-3953-${process.pid}-${tempDirs.length}`);
+		tempDirs.push(root);
+		for (const [dialect, entries] of Object.entries(journals)) {
+			const metaDir = join(root, 'drizzle', dialect, 'meta');
+			mkdirSync(metaDir, { recursive: true });
+			writeFileSync(
+				join(metaDir, '_journal.json'),
+				JSON.stringify({ version: '7', dialect: 'postgresql', entries }),
+			);
+		}
+		return root;
+	}
+
+	it('[WR8a] journal が 1 本も無ければ fail する (glob 化で「0 件マッチ = 素通り」を作らない)', () => {
+		const emptyRoot = join(tmpdir(), `journal-glob-3953-empty-${process.pid}`);
+		tempDirs.push(emptyRoot);
+		mkdirSync(emptyRoot, { recursive: true });
+
+		const { files, violations } = checkAllJournals(emptyRoot);
+		expect(files).toStrictEqual([]);
+		expect(violations.map((v) => v.rule)).toStrictEqual(['R0-no-journal']);
+		// 踏んだ人が次に何をすればいいか分かること (既存 gate と同じ「→」始まりの次アクション行)。
+		expect(violations[0]?.message).toContain('→');
+	});
+
+	it('[WR8b] 複数 journal のうち 2 本目に違反があれば fail する (glob が実際に効いている)', () => {
+		const now = 1_785_000_000_000;
+		const root = makeFakeRepoRoot({
+			// 1 本目は健全。固定パス実装ならここだけを見て PASS してしまう。
+			pglite: healthyEntries(),
+			// 2 本目に #3946 と同型の未来値。glob 化していなければ検査対象にすらならない。
+			// 丸め値 (R2) ではなく **未来値 (R1) だけ**で落ちる値にして、検出理由を一意にする。
+			dsql: [
+				...healthyEntries(),
+				{ idx: 3, when: 1_900_000_123_456, tag: '0003_far_future_on_second_journal' },
+			],
+		});
+
+		const { files, violations } = checkAllJournals(root, { now });
+		expect(files).toStrictEqual([
+			'drizzle/dsql/meta/_journal.json',
+			'drizzle/pglite/meta/_journal.json',
+		]);
+		expect(violations.map((v) => v.rule)).toStrictEqual(['R1-future']);
+		expect(violations[0]?.file).toBe('drizzle/dsql/meta/_journal.json');
+		expect(violations[0]?.tag).toBe('0003_far_future_on_second_journal');
+		// 出力に file 名が出ること (どの journal を直せばいいか分かる)。
+		expect(formatAllJournalViolations(violations)).toContain('drizzle/dsql/meta/_journal.json');
+	});
+
+	it('[WR8c] 複数 journal がすべて健全なら違反 0 件 (false positive を出さない)', () => {
+		const root = makeFakeRepoRoot({ pglite: healthyEntries(), dsql: healthyEntries() });
+		const { files, violations } = checkAllJournals(root, { now: 1_785_000_000_000 });
+		expect(files).toHaveLength(2);
+		expect(violations).toStrictEqual([]);
+	});
+
+	it('[WR8d] findJournalFiles は dialect ディレクトリのみを拾う (meta 無しは無視)', () => {
+		const root = makeFakeRepoRoot({ pglite: healthyEntries() });
+		// journal を持たない dialect ディレクトリ (SQL だけ置いた作業中ディレクトリ等) は対象外。
+		mkdirSync(join(root, 'drizzle', 'work-in-progress'), { recursive: true });
+		expect(findJournalFiles(root)).toStrictEqual(['drizzle/pglite/meta/_journal.json']);
+	});
+
+	it('[WR8e] JSON として壊れた journal は R0-parse で fail する', () => {
+		const root = makeFakeRepoRoot({ pglite: healthyEntries() });
+		writeFileSync(join(root, 'drizzle', 'pglite', 'meta', '_journal.json'), '{ broken');
+		const { violations } = checkAllJournals(root);
+		expect(violations.map((v) => v.rule)).toStrictEqual(['R0-parse']);
+	});
 
 	it('[WR4] DSQL provision は `when` を参照しない (idx 順 + tag 冪等) — 影響波及なしの固定', () => {
 		// `when` を意図的に逆転させても、DSQL の loadMigrationFiles は idx 順で読む。

--- a/tests/unit/scripts/backup-db.test.ts
+++ b/tests/unit/scripts/backup-db.test.ts
@@ -4,6 +4,11 @@ import os from 'node:os';
 import path from 'node:path';
 import Database from 'better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	buildBackupFilename,
+	SQLITE_BACKUP_FILENAME_PATTERN,
+	selectBackupGenerations,
+} from '../../../scripts/backup-db.cjs';
 
 describe('backup-db.cjs (#2781 graceful fallback)', () => {
 	let tmpDir: string;
@@ -25,12 +30,13 @@ describe('backup-db.cjs (#2781 graceful fallback)', () => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
 	});
 
-	function runBackup(hookEnv: string) {
+	function runBackup(hookEnv: string, extraEnv: Record<string, string> = {}) {
 		const env = {
 			...process.env,
 			DATABASE_URL: dbPath,
 			BACKUP_DIR: backupDir,
 			BACKUP_POST_HOOK: hookEnv,
+			...extraEnv,
 		};
 		// We execute the script directly in a child process
 		// 2>&1 redirects stderr to stdout so we can capture console.warn
@@ -63,5 +69,125 @@ describe('backup-db.cjs (#2781 graceful fallback)', () => {
 		expect(out).toContain('hook ran successfully');
 		expect(out).toContain('[Hook] OK');
 		expect(out).toContain('=== Backup complete ===');
+	});
+
+	// -----------------------------------------------------------------------
+	// ローテーションの世代判定 (#3978)
+	//
+	// 旧実装は `f.startsWith('ganbari-quest-') && f.endsWith('.db')` の緩い一致で世代を数え、
+	// その結果を `.sort().reverse().slice(MAX_BACKUPS)` して unlinkSync していた。
+	// BACKUP_DIR には運用中に命名規則外のファイルが同居するため、それらが世代枠を食って
+	// 実バックアップの最古世代が本来より早く消える (#3956 で PGlite 側について受けた指摘と同 class)。
+	//
+	// fixture には **規則に従わないが実在するもの**を実名で混ぜる (dev-session.md §台帳 #3)。
+	// -----------------------------------------------------------------------
+
+	/** 命名規則に従う世代 (`ganbari-quest-<YYYYMMDDHHMMSS>.db`)。古い順。 */
+	const VALID_GENERATIONS = [
+		'ganbari-quest-20260101000000.db',
+		'ganbari-quest-20260102000000.db',
+		'ganbari-quest-20260103000000.db',
+		'ganbari-quest-20260104000000.db',
+	];
+
+	/**
+	 * 命名規則から外れているが BACKUP_DIR に実在し得るファイル群。
+	 * 先頭 2 件は旧実装の緩い一致に **一致してしまう** (= 世代枠を食う) もの。
+	 */
+	const NON_CONFORMING_FILES = [
+		// 手動退避。辞書順で 'm' > 数字のため降順ソートの先頭 (最新扱い) に恒久的に居座る。
+		'ganbari-quest-manual-pre-hotfix.db',
+		// 旧命名の残骸 (ハイフン区切り)。prefix / 拡張子とも一致する。
+		'ganbari-quest-2026-07-26.db',
+		// 中断した採取の残骸。
+		'ganbari-quest-20260105000000.db.tmp',
+		// SQLite WAL sidecar。
+		'ganbari-quest-20260104000000.db-wal',
+		// PGlite 側の手動スナップショット (#3950 一次証跡の実名)。同じ dir に置かれ得る。
+		'pglite-snapshot-20260726-0738-pre-pr3947.tgz',
+	];
+
+	function seedBackupDir(files: string[]) {
+		fs.mkdirSync(backupDir, { recursive: true });
+		for (const f of files) fs.writeFileSync(path.join(backupDir, f), 'x');
+	}
+
+	function listBackupDir(): string[] {
+		return fs.readdirSync(backupDir).sort();
+	}
+
+	function listGenerations(): string[] {
+		return listBackupDir().filter((f) => /^ganbari-quest-\d{14}\.db$/.test(f));
+	}
+
+	it('[BK-R1] 命名規則外ファイルが同居しても保持世代数・削除対象が変わらない', () => {
+		seedBackupDir([...VALID_GENERATIONS, ...NON_CONFORMING_FILES]);
+
+		const out = runBackup('', { BACKUP_RETENTION: '3' });
+		expect(out).toContain('=== Backup complete ===');
+
+		// 新規採取 1 本を含めて 5 世代 → 新しい順に 3 世代だけ残る。
+		const generations = listGenerations();
+		expect(generations).toHaveLength(3);
+		// 残るのは「新規採取 + 20260104 + 20260103」。同居物に枠を食われていない。
+		expect(generations).toContain('ganbari-quest-20260104000000.db');
+		expect(generations).toContain('ganbari-quest-20260103000000.db');
+		expect(generations).not.toContain('ganbari-quest-20260102000000.db');
+		expect(generations).not.toContain('ganbari-quest-20260101000000.db');
+		expect(out).toContain('[Backup] Total: 3 backups');
+
+		// 命名規則外のファイルは 1 件も削除されていない (世代でもゴミでもなく、運用者の持ち物)。
+		const remaining = listBackupDir();
+		for (const f of NON_CONFORMING_FILES) {
+			expect(remaining, `${f} が削除された`).toContain(f);
+		}
+	});
+
+	it('[BK-R2] prefix に一致するディレクトリを世代として数えない', () => {
+		// 運用者が古い世代を退避したディレクトリ。名前だけでは file と区別できず、
+		// 世代に数えると保持枠を食い、削除対象に入れば unlinkSync が EISDIR で落ちる。
+		seedBackupDir(VALID_GENERATIONS.slice(0, 2));
+		fs.mkdirSync(path.join(backupDir, 'ganbari-quest-archive.db'));
+
+		const out = runBackup('', { BACKUP_RETENTION: '2' });
+		expect(out).toContain('=== Backup complete ===');
+		expect(out).toContain('[Backup] Total: 2 backups');
+
+		expect(listGenerations()).toHaveLength(2);
+		expect(fs.statSync(path.join(backupDir, 'ganbari-quest-archive.db')).isDirectory()).toBe(true);
+	});
+
+	it('[BK-R3] 生成したファイル名は世代判定パターンに完全一致する (命名変更で silent に壊れない)', () => {
+		seedBackupDir([]);
+		const out = runBackup('', { BACKUP_RETENTION: '7' });
+		expect(out).toContain('=== Backup complete ===');
+
+		const generations = listGenerations();
+		expect(generations).toHaveLength(1);
+		// 生成側の assert (buildBackupFilename 内) が効いていること = 生成名と判定パターンが同期。
+		expect(generations[0]).toMatch(SQLITE_BACKUP_FILENAME_PATTERN);
+	});
+
+	it('[BK-R4] selectBackupGenerations は完全一致した世代のみを新しい順で返す', () => {
+		expect(selectBackupGenerations([...VALID_GENERATIONS, ...NON_CONFORMING_FILES])).toStrictEqual([
+			'ganbari-quest-20260104000000.db',
+			'ganbari-quest-20260103000000.db',
+			'ganbari-quest-20260102000000.db',
+			'ganbari-quest-20260101000000.db',
+		]);
+	});
+
+	it('[BK-R5] buildBackupFilename は UTC の 14 桁タイムスタンプを使う (辞書順 = 時系列順)', () => {
+		expect(buildBackupFilename(new Date('2026-07-26T07:38:09.123Z'))).toBe(
+			'ganbari-quest-20260726073809.db',
+		);
+		expect(buildBackupFilename(new Date('2026-07-26T07:38:09.123Z'))).toMatch(
+			SQLITE_BACKUP_FILENAME_PATTERN,
+		);
+		// 辞書順が時系列順であること (降順ソート = 新しい順、が成立する前提)。
+		expect(
+			buildBackupFilename(new Date('2026-01-01T00:00:00Z')) <
+				buildBackupFilename(new Date('2026-12-31T23:59:59Z')),
+		).toBe(true);
 	});
 });

--- a/tests/unit/scripts/check-readdir-rotation-guard.test.ts
+++ b/tests/unit/scripts/check-readdir-rotation-guard.test.ts
@@ -1,0 +1,150 @@
+// tests/unit/scripts/check-readdir-rotation-guard.test.ts
+// #3978 — 「readdir の緩い一致 × 破壊的操作」gate の実効性テスト。
+//
+// gate を書いても「実は何も落とせていない」ことがある (#3072 と同型)。本テストは
+//   [RG1] #3978 修正**前**の scripts/backup-db.cjs を検出できる    ← gate の実効性
+//   [RG2] 修正**後**の実ファイルは検出されない                      ← 修正が gate 基準を満たす
+//   [RG3] 抑制コメントが効く / 理由が空なら効かない
+//   [RG4] false positive を出さない条件 (破壊的操作なし / *_PATTERN 経由)
+//   [RG5] repo 全体を走査して違反 0 件 (走査件数 > 0 も併せて固定)
+//   [RG6] storage-repo.ts の抑制コメントに理由が書かれている (#3978 AC4)
+// を固定する。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	findAllViolations,
+	PROXIMITY_WINDOW,
+	scanSource,
+} from '../../../scripts/check-readdir-rotation-guard.mjs';
+
+const REPO_ROOT = process.cwd();
+
+/**
+ * #3978 修正前の scripts/backup-db.cjs のローテーション部 (実物のコピー)。
+ * gate がこの形を落とせなければ、gate は本 Issue の目的を果たしていない。
+ */
+const PRE_FIX_BACKUP_DB = `
+	// Rotate old backups
+	const files = fs
+		.readdirSync(BACKUP_DIR)
+		.filter((f) => f.startsWith('ganbari-quest-') && f.endsWith('.db'))
+		.sort()
+		.reverse();
+	if (files.length > MAX_BACKUPS) {
+		for (const old of files.slice(MAX_BACKUPS)) {
+			fs.unlinkSync(path.join(BACKUP_DIR, old));
+			console.log(\`[Rotate] Removed: \${old}\`);
+		}
+	}
+`;
+
+describe('check-readdir-rotation-guard (#3978)', () => {
+	it('[RG1] 修正前の backup-db.cjs ローテーションを検出する (gate の実効性)', () => {
+		const violations = scanSource('scripts/backup-db.cjs', PRE_FIX_BACKUP_DB);
+		expect(violations).toHaveLength(1);
+		expect(violations[0]?.text).toContain('readdirSync');
+		expect(violations[0]?.file).toBe('scripts/backup-db.cjs');
+	});
+
+	it('[RG2] 修正後の実 scripts/backup-db.cjs は検出されない', () => {
+		const rel = 'scripts/backup-db.cjs';
+		const source = readFileSync(join(REPO_ROOT, rel), 'utf8');
+		// 修正が「gate を黙らせただけ」でないこと: 命名済みパターンの完全一致を実際に使っている。
+		expect(source).toContain('SQLITE_BACKUP_FILENAME_PATTERN');
+		expect(source).toMatch(/SQLITE_BACKUP_FILENAME_PATTERN\s*=\s*\/\^ganbari-quest-/);
+		expect(scanSource(rel, source)).toStrictEqual([]);
+	});
+
+	it('[RG3] 抑制コメントは理由付きのときだけ効く', () => {
+		const withReason = `
+	// rotation-gate-ok: プレフィックス検索という API 仕様そのもので、世代を数える class ではない
+	const files = readdirSync(dir).filter((f) => f.startsWith(base));
+	for (const f of files) unlinkSync(join(dir, f));
+`;
+		expect(scanSource('src/x.ts', withReason)).toStrictEqual([]);
+
+		// 理由が空のマーカーは opt-out として認めない (無言の抑止を防ぐ)。
+		const withoutReason = withReason.replace(
+			'rotation-gate-ok: プレフィックス検索という API 仕様そのもので、世代を数える class ではない',
+			'rotation-gate-ok:',
+		);
+		expect(scanSource('src/x.ts', withoutReason)).toHaveLength(1);
+
+		// 同一行に書いた場合も効く。
+		const inline = `
+	const files = readdirSync(dir).filter((f) => f.startsWith(base)); // rotation-gate-ok: 別 class
+	for (const f of files) unlinkSync(join(dir, f));
+`;
+		expect(scanSource('src/x.ts', inline)).toStrictEqual([]);
+	});
+
+	it('[RG4] 破壊的操作がなければ検出しない (列挙だけの走査 script を巻き込まない)', () => {
+		const enumerateOnly = `
+	const files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+	for (const f of files) console.log(f);
+`;
+		expect(scanSource('scripts/audit/x.mjs', enumerateOnly)).toStrictEqual([]);
+	});
+
+	it('[RG4b] *_PATTERN の完全一致を経由していれば検出しない (目標形)', () => {
+		const namedPattern = `
+	const BACKUP_FILENAME_PATTERN = /^snap-\\d{14}\\.tgz$/;
+	const files = readdirSync(dir).filter((f) => BACKUP_FILENAME_PATTERN.test(f)).sort().reverse();
+	for (const old of files.slice(3)) unlinkSync(join(dir, old));
+`;
+		expect(scanSource('src/x.ts', namedPattern)).toStrictEqual([]);
+
+		// 緩い一致と *_PATTERN が同居する形 (段階的な移行途中) も、パターン経由と見なして通す。
+		// gate の水準を意図的に下げている箇所であり、ここは書き手の宣言に委ねる。
+		const mixed = `
+	const NAME_PATTERN = /^snap-\\d+$/;
+	const files = readdirSync(dir).filter((f) => NAME_PATTERN.test(f) && f.endsWith('.tgz'));
+	for (const old of files) unlinkSync(join(dir, old));
+`;
+		expect(scanSource('src/x.ts', mixed)).toStrictEqual([]);
+	});
+
+	it('[RG4c] 破壊的操作が近接窓の外なら検出しない (窓幅が効いている)', () => {
+		const far = [
+			"const files = readdirSync(dir).filter((f) => f.startsWith('x'));",
+			...Array.from({ length: PROXIMITY_WINDOW + 2 }, (_, i) => `const pad${i} = ${i};`),
+			'unlinkSync(join(dir, files[0]));',
+		].join('\n');
+		expect(scanSource('src/x.ts', far)).toStrictEqual([]);
+
+		// 窓の内側なら検出する (境界の両側を固定する)。
+		const near = [
+			"const files = readdirSync(dir).filter((f) => f.startsWith('x'));",
+			...Array.from({ length: PROXIMITY_WINDOW - 2 }, (_, i) => `const pad${i} = ${i};`),
+			'unlinkSync(join(dir, files[0]));',
+		].join('\n');
+		expect(scanSource('src/x.ts', near)).toHaveLength(1);
+	});
+
+	it('[RG5] repo 全体に違反 0 件、かつ 1 件以上のファイルを実際に走査している', () => {
+		const { violations, fileCount } = findAllViolations(REPO_ROOT);
+		expect(
+			violations,
+			`違反:\n${violations.map((v) => `  ${v.file}:${v.line} ${v.text}`).join('\n')}`,
+		).toStrictEqual([]);
+		// 「0 件走査だから 0 件違反」= 無言の PASS を弾く (本 gate が塞ぐ class と同型)。
+		expect(fileCount).toBeGreaterThan(100);
+	});
+
+	it('[RG6] storage-repo.ts の抑制コメントに別 class である理由が書かれている (#3978 AC4)', () => {
+		const source = readFileSync(
+			join(REPO_ROOT, 'src/lib/server/db/sqlite/storage-repo.ts'),
+			'utf8',
+		);
+		const marker = source
+			.split(/\r?\n/)
+			.find((l) => l.includes('rotation-gate-ok:'))
+			?.trim();
+		expect(marker, 'storage-repo.ts に抑制コメントがない').toBeDefined();
+		// 理由が「別 class である」ことを述べていること (無言の抑止・空マーカーを防ぐ)。
+		expect(marker).toContain('プレフィックス検索');
+		expect(source).toContain('プレフィックス境界の欠落');
+	});
+});

--- a/tests/unit/scripts/check-readdir-rotation-guard.test.ts
+++ b/tests/unit/scripts/check-readdir-rotation-guard.test.ts
@@ -127,19 +127,15 @@ describe('check-readdir-rotation-guard (#3978)', () => {
 	// 既定 testTimeout (5s、vite.config.ts) では並列実行の負荷次第で timeout する
 	// (#3972 / #4005 と同 class)。assertion を弱めるのではなく、本 test の性質に見合う
 	// 明示 timeout を与える (cli-entry-guard.test.ts の spawn 系 test と同じ扱い)。
-	it(
-		'[RG5] repo 全体に違反 0 件、かつ 1 件以上のファイルを実際に走査している',
-		() => {
-			const { violations, fileCount } = findAllViolations(REPO_ROOT);
-			expect(
-				violations,
-				`違反:\n${violations.map((v) => `  ${v.file}:${v.line} ${v.text}`).join('\n')}`,
-			).toStrictEqual([]);
-			// 「0 件走査だから 0 件違反」= 無言の PASS を弾く (本 gate が塞ぐ class と同型)。
-			expect(fileCount).toBeGreaterThan(100);
-		},
-		60_000,
-	);
+	it('[RG5] repo 全体に違反 0 件、かつ 1 件以上のファイルを実際に走査している', () => {
+		const { violations, fileCount } = findAllViolations(REPO_ROOT);
+		expect(
+			violations,
+			`違反:\n${violations.map((v) => `  ${v.file}:${v.line} ${v.text}`).join('\n')}`,
+		).toStrictEqual([]);
+		// 「0 件走査だから 0 件違反」= 無言の PASS を弾く (本 gate が塞ぐ class と同型)。
+		expect(fileCount).toBeGreaterThan(100);
+	}, 60_000);
 
 	it('[RG6] storage-repo.ts の抑制コメントに別 class である理由が書かれている (#3978 AC4)', () => {
 		const source = readFileSync(

--- a/tests/unit/scripts/check-readdir-rotation-guard.test.ts
+++ b/tests/unit/scripts/check-readdir-rotation-guard.test.ts
@@ -123,15 +123,23 @@ describe('check-readdir-rotation-guard (#3978)', () => {
 		expect(scanSource('src/x.ts', near)).toHaveLength(1);
 	});
 
-	it('[RG5] repo 全体に違反 0 件、かつ 1 件以上のファイルを実際に走査している', () => {
-		const { violations, fileCount } = findAllViolations(REPO_ROOT);
-		expect(
-			violations,
-			`違反:\n${violations.map((v) => `  ${v.file}:${v.line} ${v.text}`).join('\n')}`,
-		).toStrictEqual([]);
-		// 「0 件走査だから 0 件違反」= 無言の PASS を弾く (本 gate が塞ぐ class と同型)。
-		expect(fileCount).toBeGreaterThan(100);
-	});
+	// 本 test は src/ + scripts/ の 900+ ファイルを実際に読む I/O bound な fitness で、
+	// 既定 testTimeout (5s、vite.config.ts) では並列実行の負荷次第で timeout する
+	// (#3972 / #4005 と同 class)。assertion を弱めるのではなく、本 test の性質に見合う
+	// 明示 timeout を与える (cli-entry-guard.test.ts の spawn 系 test と同じ扱い)。
+	it(
+		'[RG5] repo 全体に違反 0 件、かつ 1 件以上のファイルを実際に走査している',
+		() => {
+			const { violations, fileCount } = findAllViolations(REPO_ROOT);
+			expect(
+				violations,
+				`違反:\n${violations.map((v) => `  ${v.file}:${v.line} ${v.text}`).join('\n')}`,
+			).toStrictEqual([]);
+			// 「0 件走査だから 0 件違反」= 無言の PASS を弾く (本 gate が塞ぐ class と同型)。
+			expect(fileCount).toBeGreaterThan(100);
+		},
+		60_000,
+	);
 
 	it('[RG6] storage-repo.ts の抑制コメントに別 class である理由が書かれている (#3978 AC4)', () => {
 		const source = readFileSync(


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（運用者 / 開発者）

**解決する課題**: 「gate を作ったのに、適用範囲が狭くて同 class を取り逃す」という同型の欠陥が 2 件同時に残っていた。

- **#3978**: `readdir` の戻りを `startsWith` + `endsWith` の緩い一致で「バックアップ世代」として数える class。PR #3956 で PGlite 側は正規表現の完全一致に直したが、**`scripts/backup-db.cjs` に同じ欠陥が実在**したまま残っていた（同じ指摘を 2 度受けた）。手動退避 `ganbari-quest-manual-pre-hotfix.db` を 1 本置くだけで、辞書順で `'m'` が数字より後ろのため降順ソートの先頭（＝最新扱い）に居座り、保持枠を恒久的に 1 つ食う。結果、**実バックアップの最古 1 世代が本来より 1 日早く `unlinkSync` される**。
- **#3953**: drizzle journal `when` 値域 gate（#3948）の適用先が **PGlite 固定パス**で、将来 dialect が増えたとき新しい journal が無検査で通る。また発火点が CI (vitest) のみで、journal を手編集した人が気づくのは push 後だった。

**期待される効果**:

- バックアップ保持世代が「同居する運用者の持ち物」に食われなくなり、災害復旧時に**約束した世代数が実際に手元にある**。
- 同 class の再発を人の注意力ではなく機械 gate（`check-readdir-rotation-guard.mjs`）が止める。3 回目を待たず 2 回目で機械化した（`docs/sessions/dev-session.md` §「QA 指摘の再発防止台帳」#2 / ADR-0061 same-class-N → guard）。
- journal gate が全 dialect に自動追従し、手編集は **commit 時点**で止まる。

## 関連 Issue

closes #3978
closes #3953

## AC 検証マップ (ADR-0004)

HEAD = `02706bf3`

### #3978

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 3978-AC1 | `scripts/backup-db.cjs` のローテーションが命名済み `*_PATTERN` の完全一致を経由している | `scripts/backup-db.cjs:66` / `:95-100` / `:173-177` を読む | PASS — `SQLITE_BACKUP_FILENAME_PATTERN = /^ganbari-quest-\d{14}\.db$/` (backup-db.cjs:66) を `selectBackupGenerations()` (:95-100) の完全一致で適用。呼び出し側 (:173-177) は `readdirSync(..., { withFileTypes: true })` で `isFile()` 済みの名前だけを渡す 2 段構え |
| 3978-AC2 | 命名規則外ファイル同居下でも保持世代数・削除対象が変わらない unit test が存在し、旧実装に戻すと落ちる（mutation 証跡） | `npx vitest run tests/unit/scripts/backup-db.test.ts` + 旧実装への mutation 再実行 | PASS — 修正後 `Tests 8 passed (8)`。旧実装（`startsWith`+`endsWith`）へ戻すと `[BK-R1]`（`expected […(2)] to have a length of 3`）と `[BK-R2]`（`expected [ 'ganbari-quest-20260729044754.db' ] to have a length of 2`）の **2 件が fail**（下記「mutation 証跡」）。fixture は手動退避 / 旧命名の残骸 / `.tmp` / WAL sidecar / `pglite-snapshot-20260726-0738-pre-pr3947.tgz` / 退避ディレクトリを**実名で**含む (backup-db.test.ts:85-108, :146-158) |
| 3978-AC3 | 新 gate が `backup-db.cjs` の**修正前**コードを検出でき、修正後は検出しないことを test で固定 | `npx vitest run tests/unit/scripts/check-readdir-rotation-guard.test.ts` | PASS — `Tests 8 passed (8)`。`[RG1]` が修正前コード（実物のコピー、test:29-43）を 1 件検出、`[RG2]` が実ファイル 0 件 + `SQLITE_BACKUP_FILENAME_PATTERN` の実使用を assert（「gate を黙らせただけ」でないことの確認） |
| 3978-AC4 | `storage-repo.ts` の `readdir` filter が gate で検出された場合、抑制コメントで理由が明記されている（別 class である旨） | `node scripts/check-readdir-rotation-guard.mjs` 初回実行 + `[RG6]` | PASS — 初回実行で `src/lib/server/db/sqlite/storage-repo.ts:131` を検出 → `rotation-gate-ok:` に「プレフィックス検索という API 仕様そのもの」「`deleteByPrefix` の**プレフィックス境界の欠落**は別 class で本 Issue 対象外」と明記 (storage-repo.ts:131-136)。理由の実在は `[RG6]` が機械検証 |
| 3978-AC5 | `npm run pre-ready -- --help` の step 一覧に新 gate が載っている | `node scripts/pre-ready.mjs --help` | PASS — `7e. check-readdir-rotation-guard.mjs — readdir の緩い一致で世代を数える class の検出 (#3978)` / Options に `--skip-readdir-rotation-guard` |
| 3978-AC6 | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4033` | 未実施（Dev 本体が本ブランチで実行し、結果を下記「検証証跡」に記載する） |

### #3953

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 3953-AC1 | `[WR1]` / `[WR1b]` を `drizzle/*/meta/_journal.json` の glob 走査に変更し、発見した全 journal に gate を適用 | `npx vitest run tests/unit/db/pglite-journal-when-range-3948.test.ts` | PASS — `Tests 16 passed (16)`。`[WR1]` / `[WR1b]` は `checkAllJournals(process.cwd())` 経由（test:106-128）。走査 SSOT は `findJournalFiles()` (drizzle-journal-gate.mjs) |
| 3953-AC2 | journal が 1 本も見つからない場合は fail（「0 件マッチ = 素通り」を作らない） | `[WR8a]` + 実 demo 実行 | PASS — `[WR8a]` が `R0-no-journal` を assert（test:339-350）。実行証跡: `NEW (0 件マッチ) rules = R0-no-journal`（下記「mutation 証跡」） |
| 3953-AC3 | 複数 journal がある状態を fixture で再現し、2 本目に違反があれば fail する | `[WR8b]` / `[WR8c]` / `[WR8d]` / `[WR8e]` | PASS — `[WR8b]` は pglite（健全）+ dsql（未来値）の 2 本 fixture で `R1-future` を dsql 側にのみ検出。旧実装（PGlite 固定パス）は同 fixture で **violations = 0（素通り）**（下記「mutation 証跡」） |
| 3953-AC4 | `.husky/pre-commit` に、`drizzle/*/meta/_journal.json` が staged のときだけ gate を実行する step を追加。失敗メッセージは `→` 始まりの次アクション行を含む | 実 hook 実行（journal を未来値に書き換えて staged → `sh .husky/pre-commit`） | PASS — hook exit=1、出力に `→ 手書きした値を戻し、drizzle-kit が生成した実時刻をそのまま使ってください` / `→ drizzle-kit が生成した when を手で書き換えないでください` を含む。journal 非 staged 時は exit=0 で何も走らない（下記「実行証跡」） |
| 3953-AC5 | pre-commit から呼べる CLI 入口を用意する。判定ロジックは複製せず既存 SSOT を再利用 | `node scripts/check-drizzle-journal.mjs` / `--help` | PASS — `scripts/check-drizzle-journal.mjs` は `checkAllJournals` / `formatAllJournalViolations` を import するだけの薄い入口（判定ルール R1-R4 / grandfather / glob はすべて `scripts/lib/db/drizzle-journal-gate.mjs` 側、複製ゼロ）。実行結果: `[check-drizzle-journal] OK: 1 件の journal が全ルールを満たしています (drizzle/pglite/meta/_journal.json)` |
| 3953-AC6 | 既存 11 本のテスト（`[WR1]`-`[WR7]`）が引き続き PASS | `npx vitest run tests/unit/db/pglite-journal-when-range-3948.test.ts` | PASS — 既存 11 本 + 新規 `[WR8a-e]` 5 本 = `16 passed`（削除・skip ゼロ） |

### mutation 証跡（gate を外すと落ちるか）

**#3978 — ローテーションを旧実装（緩い一致）へ戻した状態**

```
$ node scripts/check-readdir-rotation-guard.mjs
[check-readdir-rotation-guard] FAIL: 1 件の違反
  scripts/backup-db.cjs:174 .readdirSync(BACKUP_DIR)
gate exit=1

$ npx vitest run tests/unit/scripts/backup-db.test.ts
 × [BK-R1] 命名規則外ファイルが同居しても保持世代数・削除対象が変わらない 225ms
 × [BK-R2] prefix に一致するディレクトリを世代として数えない 232ms
AssertionError: expected [ …(2) ] to have a length of 3 but got 2
AssertionError: expected [ 'ganbari-quest-20260729044754.db' ] to have a length of 2 but got 1
      Tests  2 failed | 6 passed (8)
```

（修正を戻した状態では `[BK-R1]` で保持世代が 3 → 2 に減っている＝**実バックアップが 1 世代余計に消えている**ことがそのまま数値で出る。）

**#3953 — 走査を旧実装（PGlite 固定パス）に戻した状態**

pglite（健全）と dsql（末尾に手書きの未来値 `1900000123456`）の 2 本 journal を持つ fixture に対して:

```
OLD (PGlite 固定パス)  violations = 0 → 素通り
NEW (glob 全 dialect)  files = drizzle/dsql/meta/_journal.json, drizzle/pglite/meta/_journal.json
NEW                    violations = drizzle/dsql/meta/_journal.json [R1-future] 0002_hand_edited_future
NEW (0 件マッチ)       rules = R0-no-journal
```

### 実行証跡（pre-commit hook、#3953 AC4）

journal の末尾 `when` を `1900000123456`（未来値）に書き換えて staged にした状態:

```
$ git diff --cached --name-only
drizzle/pglite/meta/_journal.json

$ sh .husky/pre-commit
[pre-commit] drizzle journal 変更検出 — `when` 値域検査を実行
[check-drizzle-journal] FAIL: 1 件の違反
  drizzle/pglite/meta/_journal.json [R1-future] 0004_drop_login_bonuses: when=1900000123456 が現在時刻 (1785300603801) より未来。…
    → 手書きした値を戻し、drizzle-kit が生成した実時刻をそのまま使ってください。
  → drizzle-kit が生成した `when` を手で書き換えないでください (手順 SSOT: .claude/skills/db-migration/SKILL.md)。
[pre-commit] check-drizzle-journal FAILED
  → …`npx drizzle-kit generate` をやり直して実時刻を入れ直してください
hook exit=1

（journal を staged にしない通常 commit では hook exit=0、何も実行されない）
```

> 注: 本 worktree の `core.hooksPath` はメインクローンの `.husky/_` を指すため、worktree 内 `git commit` では本ブランチの hook が起動しない。上記はブランチの hook 本体を直接実行して検証した。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: UI 変更なし。影響は NUC SQLite バックアップのローテーション（`scripts/backup-db.cjs`）と、CI / pre-ready / pre-commit の gate 構成。`src/lib/server/db/sqlite/storage-repo.ts` はコメント追加のみで挙動不変。

**変更ファイル**:

| ファイル | 内容 |
|---|---|
| `scripts/backup-db.cjs` | 世代判定を `SQLITE_BACKUP_FILENAME_PATTERN` の完全一致 + `isFile()` の 2 段へ。生成側 assert (`buildBackupFilename`)。`require.main === module` で直接実行時のみ main 実行 + 純関数を export（test から import 可能に）。JSDoc 型注釈追加（svelte-check の対象に入るため） |
| `scripts/check-readdir-rotation-guard.mjs` | **新規** gate。`readdir` chain の緩い一致 × 近接する破壊的操作を検出。`rotation-gate-ok: <理由>` で opt-out（理由必須） |
| `scripts/check-drizzle-journal.mjs` | **新規** CLI。journal gate SSOT を呼ぶだけの薄い入口 |
| `scripts/lib/db/drizzle-journal-gate.mjs` | `findJournalFiles` / `checkAllJournals` / `formatAllJournalViolations` を追加（glob 走査 + 0 件 fail）。判定ルール本体 `findJournalWhenViolations` は無改変 |
| `scripts/pre-ready.mjs` | Step 7e + `--skip-readdir-rotation-guard` |
| `.github/workflows/ci.yml` | `lint-and-test` に readdir rotation guard step |
| `.husky/pre-commit` | journal staged 時のみ `check-drizzle-journal.mjs` |
| `src/lib/server/db/sqlite/storage-repo.ts` | 抑制コメント（別 class である理由 + 残存欠陥の記録）のみ |
| `tests/unit/scripts/backup-db.test.ts` | `[BK-R1]`〜`[BK-R5]` 追加 |
| `tests/unit/scripts/check-readdir-rotation-guard.test.ts` | **新規** `[RG1]`〜`[RG6]` |
| `tests/unit/db/pglite-journal-when-range-3948.test.ts` | `[WR1]`/`[WR1b]` を glob 化、`[WR8a-e]` 追加 |
| `docs/sessions/dev-session.md` | 再発防止台帳 #2 の「現在の防御」をレビュー観点 → 機械 gate に更新 |
| `.claude/skills/db-migration/SKILL.md` | 発火点 2 つ（pre-commit / CI）と glob 走査を明記 |

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）

<!-- 検証証跡 (Dev 本体が再実行、2026-07-29) -->
> **pre-ready 実測** (worktree `agent-a9308f1c97499540c`、PR #4066 番号指定で再実行):
> - 適用対象の **1 step すべて PASS** — 1 biome / 1b cspell / 2 型検査 / 3 vitest / 4 hardcoded-strings / 7 plan-literals / 7b license-key-leak / 7c cli-entry-guard / 7d sparse-checkout / 7e readdir-rotation-guard (本 PR の新 gate) / 9 Readiness gate / 10 doc-code-references / 11 terminology-coherence
> - 自動 skip (適用対象外) — 5 lp-dimensions / 6 lp-fallback / 8 lp-labels / 11b SS embed / 12 capture (LP・labels.ts・UI をいずれも変更していないため)
> - 末尾サマリの `PARTIAL PASS ... --skip 指定で未実行` は **#4018 の既知欠陥** (条件による自動 skip を `--skip` 指定と誤表示)。本実行で `--skip` は一切指定していない。修正は PR #4037 が対応中

- [x] 追加・変更したテストの概要:
  - `tests/unit/scripts/check-readdir-rotation-guard.test.ts`（新規 8 本）— 修正前コード検出 / 修正後 0 件 / 抑制コメント（理由必須）/ 破壊的操作なしは非検出 / `*_PATTERN` 経由は非検出 / 近接窓の境界両側 / repo 全体 0 件 + 走査件数 > 0 / storage-repo 抑制理由の実在
  - `tests/unit/scripts/backup-db.test.ts`（`[BK-R1]`〜`[BK-R5]` 追加）— 命名規則外ファイル同居下の世代数・削除対象 / ディレクトリ非計上 / 生成名とパターンの同期 / 純関数の並び順 / UTC 14 桁
  - `tests/unit/db/pglite-journal-when-range-3948.test.ts`（`[WR8a]`〜`[WR8e]` 追加、`[WR1]`/`[WR1b]` を glob 化）— 0 件マッチ fail / 2 本目違反の検出 / 全健全時 false positive なし / dialect ディレクトリ判定 / JSON 破損
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:medium` / `priority:low`）

## スクリーンショット / ビジュアルデモ

**該当なし（script / test / CI 設定のみで UI 変更を含まないため）**

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし | 該当なし |
| **修正後** | 該当なし | 該当なし |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 判定（`findJournalWhenViolations` / `scanSource`）と入出力（CLI / hook / pre-ready）を分離。CLI は SSOT を呼ぶだけで判定を持たない
- [x] **DRY**: journal 判定ロジックの複製ゼロ（#3953 AC5）。`grep -rn "startsWith('ganbari-quest-'\|_journal.json" src/ scripts/ tests/` で残存箇所を確認し、`storage-repo.ts` の 1 件は別 class として抑制コメントで明示
- [x] **YAGNI**: gate は行ベースの静的検査に留め、AST 解析はしない（迂回形が実際に混入したらその時点で AST 化する旨を script 冒頭に明記）。false positive は抑制コメントで処理する設計
- [x] **Security（OSS 公開前提）**: 秘密情報なし。バックアップ削除対象の絞り込みを厳格化する変更で、誤削除の面を**狭める**方向のみ
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: gate は 937 ファイルの行走査のみ（実測 1 秒未満）。CI / pre-ready への追加負荷は無視できる

## 横展開・影響波及チェック

- [ ] 本番アプリ + デモ版を同期
- [ ] **LP ↔ アプリ双方向整合**（#1481 / ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシードと チュートリアルを同期
- [ ] **labels SSOT** (ADR-0009)
- [x] **設計書同期** (ADR-0001): `docs/sessions/dev-session.md`（再発防止台帳の「現在の防御」を機械 gate に更新）+ `.claude/skills/db-migration/SKILL.md`（journal gate の発火点 2 つと glob 走査）を同 PR で更新
- [x] **並行 PR overlap** (#1200): 変更ファイルを同時期に触る open PR なし
- [ ] N/A — 並行実装の影響範囲外

**同 class の横展開調査**（#3978 の一次調査を本 PR で機械化）:

| 箇所 | 判定 | 対応 |
|---|---|---|
| `scripts/backup-db.cjs` | 同 class の実在欠陥 | 本 PR で是正 |
| `src/lib/server/db/pglite/backup.ts` | 是正済（#3956、目標形） | 変更なし |
| `src/lib/server/db/sqlite/storage-repo.ts` | **別 class**（プレフィックス境界の欠落。`prefix="avatars/child1"` が `avatars/child10.png` を巻き込む） | 抑制コメントで理由と残存欠陥を明記。境界修正は別 Issue |
| `scripts/audit/*` / `check-*.mjs` の拡張子 filter | 列挙のみ（破壊的操作なし） | gate が近接条件で非検出（`[RG4]` で固定） |

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる

**レビュー依頼事項・QA**:

1. **gate の水準を意図的に下げている点**（#3978 の指定どおり）: 「同一関数内」の厳密判定はせず、`readdir` 行から下 8 行の chain と ±20 行の近接で判定する。false positive は `rotation-gate-ok: <理由>` で除外する設計で、**抑制コメントを書かせること自体が「この絞り込みは削除に使われる」という宣言**になる、という前提で組んでいます。この線引きで妥当かご確認ください。
2. **`storage-repo.ts` を本 PR で直さない判断**: `deleteByPrefix` のプレフィックス境界欠落（`child1` が `child10.png` を巻き込む）は実在の欠陥ですが #3978 の class とは別なので、抑制コメントに記録して別 Issue 送りにしています（Issue 本文の指示どおり）。起票が必要なら PO 判断をお願いします。
3. **`backup-db.cjs` の `require.main === module` 化**: test から純関数を import するために必要でした。ESM 側の判定 SSOT (`scripts/lib/is-main.mjs`) は CJS から import できないため CJS 標準イディオムを使っています（`check-cli-entry-guard` の 2 ルールには抵触せず、`require.main` / `module` はいずれも realpath 解決済みで symlink 経由でも一致）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS** をローカル確認した
- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未完了のまま残っている AC はない）
- [x] Phase 分割した場合: 該当なし（1 PR で 2 Issue を完遂）
- [x] UI 変更時: 該当なし（script / test / CI のみ）
- [x] 認証画面変更時: 該当なし
- [x] QA 承認・動作確認が完了している（Dev 側の完遂宣言）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
