### PR TITLE
fix(billing): #4026 #4055 契約状態の書き換えを単一強制点に集約し、§10.5 の担保欄を実装の実態に合わせる

### DIFF
--- a/docs/design/billing-redesign/contract-state-matrix.md
+++ b/docs/design/billing-redesign/contract-state-matrix.md
@@ -64,7 +64,7 @@
 
 | # | 組み合わせ | なぜ不正か | 現に起きるか |
 |---|---|---|---|
-| **X1** | `sub` なし + `plan` あり | 契約が無いのにプランだけ残る。`licenseStatus=none` なのに `plan` を表示する経路が生まれる | **起きる**（§5 D1） |
+| **X1** | `sub` なし + `plan` あり | 契約が無いのにプランだけ残る。`licenseStatus=none` なのに `plan` を表示する経路が生まれる | 起きない（W5 が 4 列を網羅的にクリアし、後着 event は単一強制点の突合で弾かれる。#3982 / #4026） |
 | **X2** | `sub` あり + `plan` なし | 課金しているのにプラン不明。`planTier` が `standard` に丸められ、premium 契約者が standard 扱いになる | 起きうる（checkout の `metadata.planId` が未知のとき。alert は出る） |
 | **X3** | `status=active` + `exp` あり | `active` に期限は無い。dunning / 解約の残骸 | **起きる**（§5 D2） |
 | **X4** | `status=grace_period` + `sub` なし | 猶予の対象となる契約が存在しない | 起きうる |
@@ -77,11 +77,11 @@
 
 | # | トリガ | 実装 | 書く内容 | 遷移 |
 |---|---|---|---|---|
-| W1 | `checkout.session.completed` | `stripe-service.ts:284` | `sub` / `plan` / `status=active` / `trialUsedAt` | S1 → S2 |
-| W2 | `invoice.paid` | `stripe-service.ts:321` | `status=active` + `plan`（未解決なら**保持**） | S3 → S2 / S2 → S2 |
-| W3 | `invoice.payment_failed` | `stripe-service.ts:347` | `status=grace_period` / `exp = now + 7d` | S2 → S3 |
-| W4 | `customer.subscription.updated` | `stripe-service.ts:378` | `plan`（未解決なら保持）+ `status`（Stripe status を正規化） | S2 ⇄ S3 / → S4 |
-| W5 | `customer.subscription.deleted` | `stripe-service.ts:401` | `status=suspended`（+ `sub` / `plan` のクリアを**意図**） | S2/S3/S4 → **S5 のはず** |
+| W1 | `checkout.session.completed` | `stripe-service.ts` `handleCheckoutCompleted` | `sub` / `plan` / `status=active` / `trialUsedAt` | S1 → S2 |
+| W2 | `invoice.paid` | `stripe-service.ts` `handleInvoicePaid` | `status=active` + `plan`（未解決なら**保持**） | S3 → S2 / S2 → S2 |
+| W3 | `invoice.payment_failed` | `stripe-service.ts` `handlePaymentFailed` | `status=grace_period` / `exp = now + 7d` | S2 → S3 |
+| W4 | `customer.subscription.updated` | `stripe-service.ts` `handleSubscriptionUpdated` | 非終端: `plan`（未解決なら保持）+ `status`（Stripe status を正規化） / 終端: W5 と同じ 4 列 | S2 ⇄ S3 / → S4 / → S5 |
+| W5 | `customer.subscription.deleted` | `stripe-service.ts` `handleSubscriptionDeleted` | `sub=NULL` / `plan=NULL` / `exp=NULL` / `status=suspended`（`TERMINAL_CONTRACT_STATE` の 4 列を網羅、#4026） | S2/S3/S4 → S5 |
 | W6 | アプリ内解約 | `tenant/cancel/+server.ts:79` | `status=grace_period` / `exp = now + 30d` | S2 → S3 |
 | W7 | 解約取り消し | `tenant/reactivate/+server.ts:63` | `status=active` / `exp=undefined` | S3 → S2 |
 | W8 | 退会猶予満了バッチ | `tenant-cleanup/+server.ts:64` | `status=terminated` | → S6 |
@@ -91,13 +91,12 @@
 
 | ID | ズレ | 実装の事実 | Issue |
 |---|---|---|---|
-| **D1** | W5 が S5 に到達しない | `stripeSubscriptionId: undefined` / `plan: undefined` を渡しているが、`updateTenantStripe` は `undefined` を「**その列を更新しない**」として扱う。よって `sub` も `plan` も**残る** = **X1 を作る** | #3982（PR #3992） |
 | **D2** | W6 と W3 が同じ `grace_period` に書く | 「支払い失敗の猶予」と「解約申請の猶予」が同一値。しかも W6 は 30 日固定、W3 は 7 日で**日数も規約と不一致** | #3986 → #3991 に統合 |
 | **D3** | S6 (`terminated`) の書き手が W8 のみ | しかも W8 は cron 未登録（`CRON_JOBS` に `tenant-cleanup` 無し）+ `dryRun` 既定 true。**実質書き手ゼロ**でチャーン KPI が恒常 0 になりうる | #3987 |
 | **D4** | S4 に実効果が無い | `authorization.ts:171-173` は `suspended` でも `allowed: true` を返す。「読み取り専用」というコメントと実装が不一致 | #3982 / #3993 |
 | **D5** | W3 が退会向け機構を誤発火させる | `grace_period` は `hooks.server.ts:430` の**読み取り専用ロック**と `tenant-cleanup` の**物理削除対象**のトリガでもある。支払い失敗しただけで子どもが記録できなくなる | **#3993（critical）** |
 
-**この 5 件は、機能軸の文書を個別に読んでいる限り見えない。** 本表のように「誰が」「どの列に」「何を書くか」を 1 枚に並べた時点で、W3 と W6 が同じセルに書いていること（D2）、W5 の意図と効果が違うこと（D1）、S6 に書き手がいないこと（D3）が同時に見える。
+**これらは、機能軸の文書を個別に読んでいる限り見えない。** 本表のように「誰が」「どの列に」「何を書くか」を 1 枚に並べた時点で、W3 と W6 が同じセルに書いていること（D2）、S6 に書き手がいないこと（D3）が同時に見える。
 
 ---
 
@@ -122,7 +121,7 @@
 | 案 | 判定 | 理由 |
 |---|---|---|
 | CHECK 制約 | **不採用** | 4 列の組み合わせ CHECK は後から張る必要があるが、DSQL は ALTER 後付けに制約があり（schema コメント §10-5「CHECK 固定だと ALTER 後付け不可で新プラン投入が表再構築になる」）、`plan` に CHECK を張らない既存判断と整合しない。**不正状態を書き込む経路（W1-W9）を塞ぐのが先**であり、DB 側で弾いても書き手のバグは残る |
-| gate スクリプト | **不採用（単独では）** | 静的解析で「どの組み合わせが書かれるか」を導出するのは、`updateTenantStripe` の部分更新セマンティクス（`undefined` = 保持）があるため不可能に近い。D1 がまさに「静的に読むと正しく見えるが効果が違う」例 |
+| gate スクリプト | **不採用（単独では）** | 静的解析で「どの組み合わせが書かれるか」を導出するのは、`updateTenantStripe` の部分更新セマンティクス（`undefined` = 保持）があるため不可能に近い（「静的に読むと正しく見えるが効果が違う」形になる）。ただし「書き込み経路が単一関数を通ること」自体は静的に強制できる（`stripe-contract-write-single-enforcement.test.ts`、#4026） |
 | **判定関数 + 定期監査** | **採用** | 許容集合をドメイン層の SSOT にし、(a) 書き手の unit test が「書いた結果が許容集合に入る」ことを assert できる、(b) 運用側が本番行を突合できる、の両方に使える |
 
 ### 実装方針（本 Issue のスコープ外、follow-up）
@@ -131,16 +130,16 @@
 
 <!-- doc-code-refs: ignore-line -->
 1. ドメイン層（`src/lib/domain/` 配下、新規ファイル）に許容集合（S1-S6）と分類関数 `classifyContractState()` を置く
-2. 各 webhook handler の unit test で「handler 適用後の行が S1-S6 のいずれかに分類される」ことを assert する。**D1 のような「意図と効果の乖離」はこの assert で落ちる**（#3982 の契約テストが先例）
+2. 各 webhook handler の unit test で「handler 適用後の行が S1-S6 のいずれかに分類される」ことを assert する。**「意図と効果の乖離」はこの assert で落ちる**（#3982 / #4026 の契約テストが先例）
 3. 定期監査（`/ops` or cron）で本番行を分類し、X1-X4 に該当する行を報告する
 
-**先に #3982 / #3991 / #3993 を入れる。** 現状は X1 / X3 を作る書き手が現役なので、判定関数を先に入れると本番で恒常的に不正を報告し続ける（狼少年になる）。
+**先に #3991 / #3993 を入れる。** X1 を作る書き手は #3982 / #4026 で塞いだが、X3 を作る書き手が現役なので、判定関数を先に入れると本番で恒常的に不正を報告し続ける（狼少年になる）。
 
 ---
 
 ## 8. 関連
 
-- #3982（D1 / D4）/ #3986 → #3991（D2）/ #3987（D3）/ **#3993 critical（D5）**
+- #3982 / #4026（W5 の終端 4 列 + 単一強制点）/ #3982（D4）/ #3986 → #3991（D2）/ #3987（D3）/ **#3993 critical（D5）**
 - `phase1-cancellation-requirements.md` FR-1 / NFR-2（期末解約）
 - `phase1-dunning-requirements.md` FR-1 / NFR-3 / US-1 / US-4（支払い失敗で子供の体験を止めない）
 - `docs/design/08-データベース設計書.md`（`families` 列定義）

--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -616,14 +616,17 @@ Customer Portal 経由のみ。Portal 内の「プラン変更」UI から切り
 > で設計確定済だが **実装は未着手**（同 doc のステータス欄「コード変更は Phase 7」）。
 > 順序ガード（本節）と dedup（#2641 設計）は別の防御であり、片方では他方を代替できない。
 
-#### 10.5.1 収束の 2 原則
+#### 10.5.1 収束の 3 原則
 
 | # | 原則 | 実装 |
 |---|------|------|
-| **P1** | **可変な属性は「event の payload」ではなく「Stripe 上の現行 subscription」から解決する** | `handleInvoicePaid` は `invoice.lines` を読まず `subscriptions.retrieve()` の現行 price を SSOT にする（#3960）。retrieve は常に最新を返すため、後着 event でも古い値を書かない |
-| **P2** | **終端状態 (`canceled` / `incomplete_expired`) を検出した handler は、契約ありきの状態を書き戻さない** | `isSubscriptionTerminal()`（`stripe-service.ts`）。この 2 status は Stripe 上で他の status に戻らないため、「契約はもう存在しない」ことの確定印として使える（#3982） |
+| **P1** | **可変な属性は「event の payload」ではなく「Stripe 上の現行 subscription」から解決する** | `handleInvoicePaid` のみ。`invoice.lines` を読まず `subscriptions.retrieve()` の現行 price を SSOT にする（#3960）。**`handleSubscriptionUpdated` は P1 の対象外** — payload の subscription から plan を解決する（`metadata.tenantId` が無いときに通る `resolveSubscriptionContext()` の retrieve は tenant 特定にのみ使う） |
+| **P2** | **終端状態 (`canceled` / `incomplete_expired`) を検出した handler は、契約ありきの状態を書き戻さない** | `isSubscriptionTerminal()`（`stripe-service.ts`）。この 2 status は Stripe 上で他の status に戻らないため、「契約はもう存在しない」ことの確定印として使える（#3982）。判定対象は **payload の status** なので、終端の後に非終端 event が後着するケースは P3 が担う |
+| **P3** | **契約状態の書き換えは「event 対象 = tenant の現行契約」のときだけ適用する。終端状態は列の集合として 1 箇所で定義し全列を書く** | `applyTenantContractState()` が唯一の書き込み経路（#4026）。`tenant.stripeSubscriptionId` と event の subscription が一致しなければ適用しない（不一致は warn、別 subscription を指す場合は `stripe-contract-target-mismatch` alert）。終端は `TERMINAL_CONTRACT_STATE` = `stripe_subscription_id` / `plan` / `plan_expires_at` を null + `status=suspended`。迂回は `tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts` が禁止する |
 
 `paused` / `unpaid` / `incomplete` は復帰し得るため終端に含めない（含めると復帰経路を殺す）。
+
+P3 の突合は tenant 同定の経路（`metadata.tenantId` / customer 逆引き）が「その tenant が今どの subscription を持つか」と独立であることから必要になる。`checkout.session.completed` だけは契約を**新規に割り当てる** event なので突合対象を持たない（`assign-contract`）。
 
 #### 10.5.2 ユースケース × 到着順 収束表
 
@@ -631,17 +634,20 @@ Customer Portal 経由のみ。Portal 内の「プラン変更」UI から切り
 
 | # | ユースケース | 発火 event | 到着順 | 最終状態 | 担保 |
 |---|---|---|---|---|---|
-| U1 | 新規購入 | `checkout.session.completed`, `customer.subscription.updated`(active) | どちらでも | `id=sub_x` / `plan=購入プラン` / `active` | P1（updated は現行 price を書く） |
+| U1 | 新規購入 | `checkout.session.completed`, `customer.subscription.updated`(active) | どちらでも | `id=sub_x` / `plan=購入プラン` / `active` | `checkout` が契約を割り当てる。`updated` は payload の price から plan を解決するが、新規購入では payload の price と現行 price が一致するため結果が正しい（P1 ではない）。`updated` が先着した場合は割り当て前なので P3 が適用を見送り、後着の `checkout` が確定させる |
 | U2 | プラン変更（standard → premium） | `customer.subscription.updated`(active), `invoice.paid` | どちらでも | `plan=premium` | P1（#3960。旧実装は `invoice.lines.data[0]` = 変更前 price を書いて巻き戻していた） |
 | U3 | 支払い失敗 | `invoice.payment_failed` | — | `grace_period` / `planExpiresAt=+7d` | — |
 | U4 | 支払い失敗 → 更新して復帰 | `invoice.payment_failed`, `invoice.paid` | 実時系列どおり | `active` | Stripe が時系列に発火（同時発火ではない） |
-| U5 | **解約** | `customer.subscription.updated`(canceled), `customer.subscription.deleted` | **どちらでも** | `id=NULL` / `plan=NULL` / `suspended` | **P2**（updated 側も終端収束させる。P2 がないと updated 後着で `id=NULL` かつ `plan≠NULL` という DB 上ありえない組合せが残る） |
+| U5 | **解約** | `customer.subscription.updated`(canceled), `customer.subscription.deleted` | **どちらでも** | `id=NULL` / `plan=NULL` / `exp=NULL` / `suspended` | **P2 + P3**（先着が終端 4 列を書き、後着は割り当てが消えているため適用されない。P2 がないと updated 後着で `id=NULL` かつ `plan≠NULL`、P3 がないと **非終端** の updated 後着で同じ組合せが残る = U9） |
 | U6 | **解約後に当期分請求が後着** | `customer.subscription.deleted`, `invoice.paid` | **どちらでも** | `id=NULL` / `plan=NULL` / `suspended` | **P2**（P2 がないと `invoice.paid` が `status=active` を書き戻し、**解約済みテナントが課金中として復活**する） |
 | U7 | **解約後に payment_failed が後着** | `customer.subscription.deleted`, `invoice.payment_failed` | **どちらでも** | 同上 | **P2**（P2 がないと `grace_period` へ巻き戻る） |
-| U8 | 解約 → 再購読 | `...deleted`, `checkout.session.completed`(新 sub) | 実時系列どおり | `id=sub_new` / `plan=新プラン` / `active` | `stripeCustomerId` を残すこと。かつ U5/U6/U7 の収束が効いていること（`id` が残っていると `createCheckoutSession` が `ALREADY_SUBSCRIBED` で弾き、そもそも U8 に入れない = #3982 の実害） |
+| U8 | 解約 → 再購読 | `...deleted`, `checkout.session.completed`(新 sub) | **どちらでも** | `id=sub_new` / `plan=新プラン` / `active` | `stripeCustomerId` を残すこと + U5/U6/U7 の収束（`id` が残っていると `createCheckoutSession` が `ALREADY_SUBSCRIBED` で弾き、そもそも U8 に入れない = #3982 の実害）+ **P3**（旧 sub の event が後着しても現行契約 `sub_new` を指さないため適用されない。P3 がないと新契約の `id` が NULL 化し、ALREADY_SUBSCRIBED ガードが外れて二重課金が成立し得る） |
+| U9 | **解約後に非終端の `updated` が後着** | `customer.subscription.deleted`, `customer.subscription.updated`(active) | **どちらでも** | `id=NULL` / `plan=NULL` / `exp=NULL` / `suspended` | **P3**（P2 は payload の status を見るため、この `updated` は終端分岐に入らない。割り当てが消えているため P3 が適用を見送る。P3 がないと `id=NULL` + `plan≠NULL` + `status=active` が残る） |
+| U10 | **アプリ内解約 → 即時 cancel → `deleted` 後着** | `/api/v1/admin/tenant/cancel`（`grace_period` + `exp=+30d` を書く）, `customer.subscription.deleted` | **どちらでも** | `id=NULL` / `plan=NULL` / `exp=NULL` / `suspended` | **P3**（終端は列の集合として定義され `plan_expires_at` も null で書く。P3 がないと契約が無いのに期限だけ残り、`SaasLicensePanel` が有効期限を表示し `lifecycle-email-service` が期限判断に使う = X3） |
 
 回帰テスト: `tests/unit/services/stripe-service.test.ts`
-（U2 = `#3960 — ... の順で` 2 本 / U5・U6・U7 = `#3982 — ...` 4 本 + 終端でない `past_due` の対照 1 本）。
+（U2 = `#3960 — ... の順で` 2 本 / U5・U6・U7 = `#3982 — ...` 4 本 + 終端でない `past_due` の対照 1 本 / U8・U9・U10 = `#4026 — ...` 3 本 + `#4055 — ...` 1 本）。
+単一強制点の迂回禁止は `tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts`。
 
 #### 10.5.3 未カバー（既知の残課題）
 

--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -68,7 +68,7 @@
 
 1. `session.metadata.tenantId` を取得（Checkout 作成時に埋め込み済み）
 2. `session.metadata.planId` を取得し `Tenant['plan']` にキャスト
-3. `repos.auth.updateTenantStripe()` で以下を更新:
+3. `applyTenantContractState()`（契約を**新規割り当て**するため突合対象を持たない `assign-contract`、§10.5.1 P3）で以下を更新:
    - `stripeCustomerId`
    - `stripeSubscriptionId`
    - `plan` = 新プラン
@@ -305,7 +305,7 @@ DynamoDB: PK=`GRADUATION_CONSENT`, SK=`<isoTs>#<uuid>` (single global partition�
 | 操作 | Webhook | DB 反映 |
 |------|---------|---------|
 | プラン変更（standard ↔ family、月 ↔ 年） | `customer.subscription.updated` | `plan` を `planIdFromPriceId(item.price.id)` で更新、`status='active'` |
-| サブスク解約（即時 or 期末） | `customer.subscription.deleted` | `stripeSubscriptionId=undefined, plan=undefined, status='suspended'` |
+| サブスク解約（即時 or 期末） | `customer.subscription.deleted` | `stripeSubscriptionId=null, plan=null, planExpiresAt=null, status='suspended'`（終端 4 列、§10.5.1 P3） |
 | 支払い方法更新 | （Stripe 側のみ） | DB 変更なし |
 | 請求書履歴閲覧 | （Stripe 側のみ） | DB 変更なし |
 
@@ -329,28 +329,31 @@ DynamoDB: PK=`GRADUATION_CONSENT`, SK=`<isoTs>#<uuid>` (single global partition�
    | `past_due` | `'grace_period'` |
    | `unpaid` / `paused` / `incomplete` | `'suspended'` |
    | `canceled` / `incomplete_expired` | 終端収束（手順 2 で処理済、§10.5） |
-5. `repos.auth.updateTenantStripe()` で `plan, status` を保存
+5. `applyTenantContractState()`（契約状態を書き換える唯一の経路、§10.5.1 P3）で `plan, status` を保存。
+   **event 対象の subscription が tenant の現行契約でなければ適用しない**（#4026）
 6. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_updated', 'status=..., plan=...')`
 
 ### 3.4 Webhook 処理 — `customer.subscription.deleted`
 
-`stripe-service.ts:handleSubscriptionDeleted()` → `clearSubscriptionAssignment()`
+`stripe-service.ts:handleSubscriptionDeleted()` → `applyTenantContractState()` + `TERMINAL_CONTRACT_STATE`
 
 1. テナント特定（同上）
-2. `repos.auth.updateTenantStripe()` で:
+2. event 対象が tenant の現行契約であることを突合（§10.5.1 P3）。不一致なら適用しない（#4026）
+3. 終端状態（`TERMINAL_CONTRACT_STATE`、契約に紐づく列を網羅）を書く:
    - `stripeSubscriptionId` = **`null`**（= SQL で `NULL` を書く）
    - `plan` = **`null`**（同上）
+   - `planExpiresAt` = **`null`**（契約が無いのに期限だけ残る孤児を作らない、#4026）
    - `status` = `'suspended'`
    - `stripeCustomerId` は**意図的に残す**（再購読時の Stripe customer 再利用 + 後続 webhook の逆引き鍵）
-3. **`undefined` ではなく `null` である理由 (#3982)**: `updateTenantStripe` は部分更新 API で、
+4. **`undefined` ではなく `null` である理由 (#3982)**: `updateTenantStripe` は部分更新 API で、
    `undefined` = 「その列を更新しない」、`null` = 「NULL でクリアする」という 2 値セマンティクス
    （契約は `IAuthRepo.updateTenantStripe` の JSDoc が SSOT）。
    旧実装は `undefined` を渡しており **クリアが丸ごと no-op** だった。その結果
    `stripe_subscription_id` が解約後も残り、`createCheckoutSession()` の
    `if (tenant.stripeSubscriptionId) return { error: 'ALREADY_SUBSCRIBED' }` が発火して
    **解約済みユーザーの再購読導線が塞がっていた**
-4. **重要**: テナント・子供データ・活動履歴は削除しない（解約と削除は別概念。アカウント削除は `/admin/settings` 経由 → `account-deletion-flow.md` 参照）
-5. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_deleted')`
+5. **重要**: テナント・子供データ・活動履歴は削除しない（解約と削除は別概念。アカウント削除は `/admin/settings` 経由 → `account-deletion-flow.md` 参照）
+6. Discord 通知: `notifyBillingEvent(tenantId, 'subscription_deleted')`
 
 ---
 
@@ -367,7 +370,7 @@ DynamoDB: PK=`GRADUATION_CONSENT`, SK=`<isoTs>#<uuid>` (single global partition�
    ```ts
    const graceExpires = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
    ```
-3. `repos.auth.updateTenantStripe()` で:
+3. `applyTenantContractState()`（§10.5.1 P3、event 対象が現行契約のときのみ適用）で:
    - `status` = `'grace_period'`
    - `planExpiresAt` = `graceExpires`
 4. Discord 通知: `notifyBillingEvent(tenantId, 'payment_failed', '猶予期間: ...')`

--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -625,7 +625,7 @@ Customer Portal 経由のみ。Portal 内の「プラン変更」UI から切り
 |---|------|------|
 | **P1** | **可変な属性は「event の payload」ではなく「Stripe 上の現行 subscription」から解決する** | `handleInvoicePaid` のみ。`invoice.lines` を読まず `subscriptions.retrieve()` の現行 price を SSOT にする（#3960）。**`handleSubscriptionUpdated` は P1 の対象外** — payload の subscription から plan を解決する（`metadata.tenantId` が無いときに通る `resolveSubscriptionContext()` の retrieve は tenant 特定にのみ使う） |
 | **P2** | **終端状態 (`canceled` / `incomplete_expired`) を検出した handler は、契約ありきの状態を書き戻さない** | `isSubscriptionTerminal()`（`stripe-service.ts`）。この 2 status は Stripe 上で他の status に戻らないため、「契約はもう存在しない」ことの確定印として使える（#3982）。判定対象は **payload の status** なので、終端の後に非終端 event が後着するケースは P3 が担う |
-| **P3** | **契約状態の書き換えは「event 対象 = tenant の現行契約」のときだけ適用する。終端状態は列の集合として 1 箇所で定義し全列を書く** | `applyTenantContractState()` が唯一の書き込み経路（#4026）。`tenant.stripeSubscriptionId` と event の subscription が一致しなければ適用しない（不一致は warn、別 subscription を指す場合は `stripe-contract-target-mismatch` alert）。終端は `TERMINAL_CONTRACT_STATE` = `stripe_subscription_id` / `plan` / `plan_expires_at` を null + `status=suspended`。迂回は `tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts` が禁止する |
+| **P3** | **契約状態の書き換えは「event 対象 = tenant の現行契約」のときだけ適用する。終端状態は列の集合として 1 箇所で定義し全列を書く** | `applyTenantContractState()` が唯一の書き込み経路（#4026）。`tenant.stripeSubscriptionId` と event の subscription が一致しなければ適用しない。不一致の観測レベルは 3 分岐（`tags.mismatchKind`）: 割り当てなし × 終端 event = warn のみ（解約済みへの正常な後着）/ 割り当てなし × **非終端** event = `stripe-contract-target-mismatch` alert（`tenant-unassigned-live-subscription`。Stripe 上は課金中なのに DB に紐付いておらず「払っているのに機能が開かない」ため人の介入が要る）/ 別 subscription = 同 alert（`other-subscription`）。終端は `TERMINAL_CONTRACT_STATE` = `stripe_subscription_id` / `plan` / `plan_expires_at` を null + `status=suspended`。迂回は `tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts` が禁止する |
 
 `paused` / `unpaid` / `incomplete` は復帰し得るため終端に含めない（含めると復帰経路を殺す）。
 
@@ -659,6 +659,7 @@ P3 の突合は tenant 同定の経路（`metadata.tenantId` / customer 逆引�
 | 同一 `event.id` の重複到達（dedup） | 設計確定・**実装未着手**（#2641 / phase5-webhook-idempotency-architecture.md） |
 | 同一 tenant への webhook 並行処理（handler 間の競合） | 未設計。Lambda 並行実行下では U1〜U8 の順序ガードも read-modify-write の間に割り込まれ得る |
 | DB ↔ Stripe の定期 reconcile | 未実装（#823、§10.4） |
+| 解約後の猶予期限の顧客向け表示 | 終端クリア（U10）で `plan_expires_at` が null になるため、解約後は画面（`SaasLicensePanel` の「有効期限」行）から期限が消える。顧客への期限告知は解約完了メール（`sendCancellationEmail` の `graceEndDate`）が担う（暫定）。表示の担い手は #3991 で決める |
 
 ---
 

--- a/src/lib/server/db/interfaces/auth-repo.interface.ts
+++ b/src/lib/server/db/interfaces/auth-repo.interface.ts
@@ -72,7 +72,9 @@ export interface IAuthRepo {
 	 *   `handleInvoicePaid` / `handleSubscriptionUpdated` が plan を解決できなかったとき、
 	 *   既存 plan を壊さないためにこの意味論に依存している (#3960)。
 	 * - `null` = **その列を NULL でクリアする**。`customer.subscription.deleted` で
-	 *   subscription 参照を解消する用途 (null を渡せるのは nullable 列のみ)。
+	 *   subscription 参照 / plan / 期限を解消する用途 (null を渡せるのは nullable 列のみ)。
+	 *   終端状態は `stripeSubscriptionId` / `plan` / `planExpiresAt` を**同時に** null で
+	 *   クリアする (片方だけ残すと contract-state-matrix の X1 / X3 を作る、#4026)。
 	 *
 	 * 実装は「渡されたキーだけ SET 句を積む」方式であり、全フィールド `undefined`
 	 * (= SET 句 0 件) の場合は UPDATE 自体を発行しない。
@@ -83,7 +85,7 @@ export interface IAuthRepo {
 			stripeCustomerId?: string;
 			stripeSubscriptionId?: string | null;
 			plan?: Tenant['plan'] | null;
-			planExpiresAt?: string;
+			planExpiresAt?: string | null;
 			trialUsedAt?: string;
 			status?: Tenant['status'];
 		},

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -337,7 +337,8 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 
 	const applied = await applyTenantContractState(
 		tenant,
-		{ mode: 'current-contract', subscriptionId: subscription.id },
+		// ここに到達する時点で終端でないことは上で確定済 (#4077 観測レベルの出し分けに使う)
+		{ mode: 'current-contract', subscriptionId: subscription.id, subscriptionTerminal: false },
 		'invoice.paid',
 		() => ({
 			status: SUBSCRIPTION_STATUS.ACTIVE,
@@ -379,7 +380,8 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
 	const graceExpires = new Date(Date.now() + GRACE_PERIOD_DAYS * MS_PER_DAY).toISOString();
 	const applied = await applyTenantContractState(
 		tenant,
-		{ mode: 'current-contract', subscriptionId: subscription.id },
+		// 同上: 終端は上で早期 return 済
+		{ mode: 'current-contract', subscriptionId: subscription.id, subscriptionTerminal: false },
 		'invoice.payment_failed',
 		() => ({
 			status: SUBSCRIPTION_STATUS.GRACE_PERIOD,
@@ -407,9 +409,14 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 	// 書き戻すと「subscription 参照なし・plan あり」という DB 上ありえない組み合わせが残る。
 	// canceled は Stripe 上 revert しない終端状態なので、**deleted と同じ終端状態へ収束**させる。
 	// これで deleted→updated / updated→deleted のどちらの順序でも最終状態が一致する。
-	const target = { mode: 'current-contract', subscriptionId: subscription.id } as const;
+	const terminal = isSubscriptionTerminal(subscription);
+	const target = {
+		mode: 'current-contract',
+		subscriptionId: subscription.id,
+		subscriptionTerminal: terminal,
+	} as const;
 
-	if (isSubscriptionTerminal(subscription)) {
+	if (terminal) {
 		const cleared = await applyTenantContractState(
 			tenant,
 			target,
@@ -473,7 +480,8 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription): Pro
 
 	const applied = await applyTenantContractState(
 		tenant,
-		{ mode: 'current-contract', subscriptionId: subscription.id },
+		// deleted は契約消滅の確定通知なので、payload の status に依らず終端として扱う (#4077)
+		{ mode: 'current-contract', subscriptionId: subscription.id, subscriptionTerminal: true },
 		'customer.subscription.deleted',
 		() => TERMINAL_CONTRACT_STATE,
 	);
@@ -548,9 +556,12 @@ const TERMINAL_CONTRACT_STATE = {
  *   `createCheckoutSession()` の ALREADY_SUBSCRIBED ガードが外れて二重課金が成立し得る)。
  * - `assign-contract`: `checkout.session.completed` のみ。契約を**新規に割り当てる** event なので
  *   突合対象がまだ存在しない (突合すると新規購入が永久に適用されなくなる)。
+ *
+ * `subscriptionTerminal` は「その event が指す subscription が Stripe 上でもう生きていないか」
+ * (#4077)。突合しなかったときの**観測レベルの出し分け**にだけ使う (適用可否は変えない)。
  */
 type ContractEventTarget =
-	| { mode: 'current-contract'; subscriptionId: string }
+	| { mode: 'current-contract'; subscriptionId: string; subscriptionTerminal: boolean }
 	| { mode: 'assign-contract' };
 
 /**
@@ -576,7 +587,7 @@ async function applyTenantContractState(
 	if (target.mode === 'current-contract') {
 		const current = tenant.stripeSubscriptionId ?? null;
 		if (current !== target.subscriptionId) {
-			notifyContractTargetMismatch(tenant, target.subscriptionId, eventType, current);
+			notifyContractTargetMismatch(tenant, target, eventType, current);
 			return false;
 		}
 	}
@@ -586,35 +597,44 @@ async function applyTenantContractState(
 }
 
 /**
- * event 対象が現行契約でなかったことを観測可能にする (#4026)。
+ * event 対象が現行契約でなかったことを観測可能にする (#4026 / #4077)。
  *
- * 2 つの事実を区別する。潰すと「解約済みに後着した正常な event」で alert が鳴り続け、
- * 本当に危険な「別契約の event」が埋もれる:
- * - 割り当て無し (`null`) = 契約未確立 (checkout 前) or 解約済み。**正常な skip** なので warn のみ
+ * 3 つの事実を区別する。潰すと「解約済みに後着した正常な event」で alert が鳴り続け、
+ * 本当に危険な mismatch が埋もれる:
+ * - 割り当て無し (`null`) × 終端 event = 解約済み契約への正常な後着。**正常な skip** なので warn のみ
+ * - 割り当て無し (`null`) × 非終端 event = **Stripe 上は生きている契約なのに DB に紐付いていない**。
+ *   親は課金明細だけ増え、有料機能は開かないまま顧客からは原因が見えない。必ず人が介入するので alert
+ *   (#4077 PO 決裁 Q1 条件。checkout webhook の恒久失敗 / Dashboard 手動作成が代表的な発生源)
  * - 別 subscription = 旧契約の後着 or tenant 同定ミス。**現行契約を壊しかけた**ので alert
  */
 function notifyContractTargetMismatch(
 	tenant: Pick<Tenant, 'tenantId'>,
-	eventSubscriptionId: string,
+	target: Extract<ContractEventTarget, { mode: 'current-contract' }>,
 	eventType: string,
 	currentSubscriptionId: string | null,
 ): void {
+	const eventSubscriptionId = target.subscriptionId;
 	logger.warn(
 		`[STRIPE] ${eventType} — event 対象が tenant の現行契約ではないため状態を更新しません: ` +
 			`tenant=${tenant.tenantId} eventSubscription=${eventSubscriptionId} ` +
 			`currentSubscription=${currentSubscriptionId ?? 'none'}`,
 	);
-	if (currentSubscriptionId === null) return;
+	// 終端 event が割り当て無しの tenant に後着するのは解約済みの正常系。鳴らさない。
+	if (currentSubscriptionId === null && target.subscriptionTerminal) return;
 
+	const unassigned = currentSubscriptionId === null;
 	notifyStripeAlert({
 		kind: 'stripe-contract-target-mismatch',
-		message: `${eventType} が tenant の現行契約とは別の subscription を指しています (適用せず skip)`,
+		message: unassigned
+			? `${eventType} の subscription は Stripe 上で継続中ですが tenant に割り当てられていません (課金済み未紐付けの可能性、適用せず skip)`
+			: `${eventType} が tenant の現行契約とは別の subscription を指しています (適用せず skip)`,
 		errorSummary: `contract_target_mismatch:${eventType}:${eventSubscriptionId}`,
 		tags: {
 			tenantId: tenant.tenantId,
 			event: eventType,
 			eventSubscriptionId,
-			currentSubscriptionId,
+			currentSubscriptionId: currentSubscriptionId ?? 'none',
+			mismatchKind: unassigned ? 'tenant-unassigned-live-subscription' : 'other-subscription',
 		},
 	});
 }

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -280,14 +280,19 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
 			tags: { tenantId, event: 'checkout.session.completed', receivedPlanId: String(planId) },
 		});
 	}
-	const repos = getRepos();
-	await repos.auth.updateTenantStripe(tenantId, {
-		stripeCustomerId: customerId ?? undefined,
-		stripeSubscriptionId: subscriptionId ?? undefined,
-		plan: plan ?? undefined,
-		status: SUBSCRIPTION_STATUS.ACTIVE,
-		trialUsedAt: new Date().toISOString(),
-	});
+	// checkout は契約を**新規割り当て**する event なので突合対象がまだ存在しない (#4026)。
+	await applyTenantContractState(
+		{ tenantId, stripeSubscriptionId: undefined },
+		{ mode: 'assign-contract' },
+		'checkout.session.completed',
+		() => ({
+			stripeCustomerId: customerId ?? undefined,
+			stripeSubscriptionId: subscriptionId ?? undefined,
+			plan: plan ?? undefined,
+			status: SUBSCRIPTION_STATUS.ACTIVE,
+			trialUsedAt: new Date().toISOString(),
+		}),
+	);
 
 	logger.info(
 		`[STRIPE] Checkout completed: tenant=${tenantId} customer=${customerId} subscription=${subscriptionId}`,
@@ -330,13 +335,18 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 	// subscription を SSOT にすれば、どちらの順序でも最終状態は現行 price に収束する。
 	const plan = resolvePlanFromSubscription(subscription);
 
-	const repos = getRepos();
-	await repos.auth.updateTenantStripe(tenant.tenantId, {
-		status: SUBSCRIPTION_STATUS.ACTIVE,
-		// #3960: plan 未解決時は silent fallback せず **既存 plan を保持** する
-		// (`plan: undefined` は repo 実装で「更新しない」として扱われる)。
-		...planUpdateOrKeep(plan, tenant, 'invoice.paid', subscription.id),
-	});
+	const applied = await applyTenantContractState(
+		tenant,
+		{ mode: 'current-contract', subscriptionId: subscription.id },
+		'invoice.paid',
+		() => ({
+			status: SUBSCRIPTION_STATUS.ACTIVE,
+			// #3960: plan 未解決時は silent fallback せず **既存 plan を保持** する
+			// (`plan: undefined` は repo 実装で「更新しない」として扱われる)。
+			...planUpdateOrKeep(plan, tenant, 'invoice.paid', subscription.id),
+		}),
+	);
+	if (!applied) return;
 
 	logger.info(`[STRIPE] Invoice paid: tenant=${tenant.tenantId} plan=${plan ?? 'unresolved'}`);
 
@@ -366,12 +376,17 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
 		return;
 	}
 
-	const repos = getRepos();
 	const graceExpires = new Date(Date.now() + GRACE_PERIOD_DAYS * MS_PER_DAY).toISOString();
-	await repos.auth.updateTenantStripe(tenant.tenantId, {
-		status: SUBSCRIPTION_STATUS.GRACE_PERIOD,
-		planExpiresAt: graceExpires,
-	});
+	const applied = await applyTenantContractState(
+		tenant,
+		{ mode: 'current-contract', subscriptionId: subscription.id },
+		'invoice.payment_failed',
+		() => ({
+			status: SUBSCRIPTION_STATUS.GRACE_PERIOD,
+			planExpiresAt: graceExpires,
+		}),
+	);
+	if (!applied) return;
 
 	logger.warn(`[STRIPE] Payment failed: tenant=${tenant.tenantId}, grace until ${graceExpires}`);
 
@@ -392,8 +407,16 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 	// 書き戻すと「subscription 参照なし・plan あり」という DB 上ありえない組み合わせが残る。
 	// canceled は Stripe 上 revert しない終端状態なので、**deleted と同じ終端状態へ収束**させる。
 	// これで deleted→updated / updated→deleted のどちらの順序でも最終状態が一致する。
+	const target = { mode: 'current-contract', subscriptionId: subscription.id } as const;
+
 	if (isSubscriptionTerminal(subscription)) {
-		await clearSubscriptionAssignment(tenant.tenantId);
+		const cleared = await applyTenantContractState(
+			tenant,
+			target,
+			'customer.subscription.updated',
+			() => TERMINAL_CONTRACT_STATE,
+		);
+		if (!cleared) return;
 		logger.info(
 			`[STRIPE] Subscription updated (terminal=${subscription.status}): ` +
 				`tenant=${tenant.tenantId} — subscription 参照と plan をクリアし suspended へ収束`,
@@ -408,7 +431,6 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 
 	const plan = resolvePlanFromSubscription(subscription);
 
-	const repos = getRepos();
 	// Stripe SDK 側の subscription.status ('active'|'trialing'|'past_due'|…) を
 	// アプリ内部の SUBSCRIPTION_STATUS に正規化する。
 	const status: Tenant['status'] =
@@ -418,11 +440,20 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 				? SUBSCRIPTION_STATUS.GRACE_PERIOD
 				: SUBSCRIPTION_STATUS.SUSPENDED;
 
-	await repos.auth.updateTenantStripe(tenant.tenantId, {
-		// #3960: silent fallback (`?? MONTHLY`) 廃止。未解決時は既存 plan を保持 + alert。
-		...planUpdateOrKeep(plan, tenant, 'customer.subscription.updated', subscription.id),
-		status,
-	});
+	// #4055: 終端判定は payload の status を見るため、`deleted` の後に非終端の `updated`
+	// (例 status=active) が後着すると、この分岐に入る。突合 (#4026) が
+	// 「割り当て済みの契約でない」として弾くので、終端状態が巻き戻らない。
+	const applied = await applyTenantContractState(
+		tenant,
+		target,
+		'customer.subscription.updated',
+		() => ({
+			// #3960: silent fallback (`?? MONTHLY`) 廃止。未解決時は既存 plan を保持 + alert。
+			...planUpdateOrKeep(plan, tenant, 'customer.subscription.updated', subscription.id),
+			status,
+		}),
+	);
+	if (!applied) return;
 
 	logger.info(`[STRIPE] Subscription updated: tenant=${tenant.tenantId} status=${status}`);
 
@@ -440,7 +471,13 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription): Pro
 		: (await resolveSubscriptionContext(subscription.id))?.tenant;
 	if (!tenant) return;
 
-	await clearSubscriptionAssignment(tenant.tenantId);
+	const applied = await applyTenantContractState(
+		tenant,
+		{ mode: 'current-contract', subscriptionId: subscription.id },
+		'customer.subscription.deleted',
+		() => TERMINAL_CONTRACT_STATE,
+	);
+	if (!applied) return;
 
 	logger.info(`[STRIPE] Subscription deleted: tenant=${tenant.tenantId}`);
 
@@ -473,24 +510,112 @@ function isSubscriptionTerminal(subscription: Stripe.Subscription): boolean {
 	return (TERMINAL_SUBSCRIPTION_STATUSES as readonly string[]).includes(subscription.status);
 }
 
+// ============================================================
+// 契約状態の単一強制点 (#4026)
+// ============================================================
+
+/** 契約状態 (families の status / plan / stripe_subscription_id / plan_expires_at) の更新差分 */
+type TenantContractStatePatch = Parameters<
+	ReturnType<typeof getRepos>['auth']['updateTenantStripe']
+>[1];
+
 /**
- * subscription 参照と plan を解除し、テナントを解約済み終端状態にする (#3982)。
+ * 解約が確定した契約の**終端状態** (contract-state-matrix.md S5、#4026)。
  *
- * 旧 `handleSubscriptionDeleted` は `undefined` を渡していたが、`updateTenantStripe` の
- * 部分更新セマンティクス (undefined = その列を更新しない) により **両方とも no-op** だった。
- * 結果 `stripe_subscription_id` が解約後も残り、`createCheckoutSession()` の
- * `if (tenant.stripeSubscriptionId)` ガードが ALREADY_SUBSCRIBED を返して
- * **再購読導線が塞がっていた**。クリアは `null` (= NULL を書く) で表現する。
+ * 「終端」を handler ごとに列挙すると、書き忘れた列が孤児として残る。実際に
+ * `/api/v1/admin/tenant/cancel` が `status=grace_period` + `planExpiresAt=+30d` を書いた直後の
+ * `deleted` は `planExpiresAt` を書かず、**契約が無いのに期限だけ残る** (X3) 状態を作っていた。
+ * 終端状態は列の集合として 1 箇所で定義し、全列を網羅的に書く。
  *
  * `stripeCustomerId` は意図的に残す: 同一顧客の再購読で Stripe customer を再利用するため
  * (`resolveSubscriptionContext` の customer 逆引きの鍵でもあり、消すと後続 webhook が
  * tenant を解決できなくなる)。
  */
-async function clearSubscriptionAssignment(tenantId: string): Promise<void> {
-	await getRepos().auth.updateTenantStripe(tenantId, {
-		stripeSubscriptionId: null,
-		plan: null,
-		status: SUBSCRIPTION_STATUS.SUSPENDED,
+const TERMINAL_CONTRACT_STATE = {
+	stripeSubscriptionId: null,
+	plan: null,
+	status: SUBSCRIPTION_STATUS.SUSPENDED,
+	planExpiresAt: null,
+} as const satisfies TenantContractStatePatch;
+
+/**
+ * 契約状態の書き換えが「どの契約に対する event か」(#4026)。
+ *
+ * - `current-contract`: 既存契約に対する後続 event。**tenant の現行 subscription と一致する
+ *   ときだけ適用する**。Stripe は配信順序を保証せず、tenant の同定も
+ *   `metadata.tenantId` / customer 逆引きで行うため、突合しないと旧 subscription の後着 event が
+ *   現行契約を壊す (解約 → 再購読済み tenant の subscription 参照が NULL 化し、
+ *   `createCheckoutSession()` の ALREADY_SUBSCRIBED ガードが外れて二重課金が成立し得る)。
+ * - `assign-contract`: `checkout.session.completed` のみ。契約を**新規に割り当てる** event なので
+ *   突合対象がまだ存在しない (突合すると新規購入が永久に適用されなくなる)。
+ */
+type ContractEventTarget =
+	| { mode: 'current-contract'; subscriptionId: string }
+	| { mode: 'assign-contract' };
+
+/**
+ * **契約状態を書き換える唯一の経路** (#4026)。
+ *
+ * `stripe-service.ts` から `updateTenantStripe` を直接呼ぶことは
+ * `tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts` が禁止する。
+ * これにより、新しい handler が増えても「event 対象と現行契約の突合」を迂回できない
+ * (ADR-0061 fitness function — 再発防止を人の注意に依存させない)。
+ *
+ * `buildPatch` は**突合を通過したときだけ**評価する。差分の組み立て自体が観測を伴う
+ * (`planUpdateOrKeep` は plan 未解決 alert を上げる) ため、適用しない event で
+ * alert を鳴らさないための順序である。
+ *
+ * @returns 適用したら true、現行契約でないため skip したら false
+ */
+async function applyTenantContractState(
+	tenant: Pick<Tenant, 'tenantId' | 'stripeSubscriptionId'>,
+	target: ContractEventTarget,
+	eventType: string,
+	buildPatch: () => TenantContractStatePatch,
+): Promise<boolean> {
+	if (target.mode === 'current-contract') {
+		const current = tenant.stripeSubscriptionId ?? null;
+		if (current !== target.subscriptionId) {
+			notifyContractTargetMismatch(tenant, target.subscriptionId, eventType, current);
+			return false;
+		}
+	}
+
+	await getRepos().auth.updateTenantStripe(tenant.tenantId, buildPatch());
+	return true;
+}
+
+/**
+ * event 対象が現行契約でなかったことを観測可能にする (#4026)。
+ *
+ * 2 つの事実を区別する。潰すと「解約済みに後着した正常な event」で alert が鳴り続け、
+ * 本当に危険な「別契約の event」が埋もれる:
+ * - 割り当て無し (`null`) = 契約未確立 (checkout 前) or 解約済み。**正常な skip** なので warn のみ
+ * - 別 subscription = 旧契約の後着 or tenant 同定ミス。**現行契約を壊しかけた**ので alert
+ */
+function notifyContractTargetMismatch(
+	tenant: Pick<Tenant, 'tenantId'>,
+	eventSubscriptionId: string,
+	eventType: string,
+	currentSubscriptionId: string | null,
+): void {
+	logger.warn(
+		`[STRIPE] ${eventType} — event 対象が tenant の現行契約ではないため状態を更新しません: ` +
+			`tenant=${tenant.tenantId} eventSubscription=${eventSubscriptionId} ` +
+			`currentSubscription=${currentSubscriptionId ?? 'none'}`,
+	);
+	if (currentSubscriptionId === null) return;
+
+	notifyStripeAlert({
+		kind: 'stripe-contract-target-mismatch',
+		message: `${eventType} が tenant の現行契約とは別の subscription を指しています (適用せず skip)`,
+		errorSummary: `contract_target_mismatch:${eventType}:${eventSubscriptionId}`,
+		tags: {
+			tenantId: tenant.tenantId,
+			event: eventType,
+			eventSubscriptionId,
+			currentSubscriptionId,
+		},
 	});
 }
 

--- a/src/lib/server/stripe/alert.ts
+++ b/src/lib/server/stripe/alert.ts
@@ -33,6 +33,9 @@ import { redactPii, redactPiiInTags } from '$lib/server/stripe/pii-redaction';
  */
 export type StripeAlertKind =
 	| 'stripe-lookup-failed'
+	// #4026: 契約状態を書き換える event が、tenant の**現行契約とは別の** subscription を
+	// 指していた。適用せず skip したうえで観測する (旧契約の後着 or tenant 同定ミス)。
+	| 'stripe-contract-target-mismatch'
 	| 'stripe-webhook-unknown-type'
 	| 'stripe-webhook-handler-typeerror'
 	// #3960: webhook payload から plan を確定できなかった。silent fallback で

--- a/tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts
+++ b/tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts
@@ -1,0 +1,92 @@
+// tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts
+// #4026 — 契約状態の書き換えは単一強制点を通る (ADR-0061 fitness function)
+//
+// 契約状態 (`families` の status / plan / stripe_subscription_id / plan_expires_at) を
+// 各 webhook handler が個別に書いていたため、
+//   (1)「この event は tenant の現行契約を指しているか」の突合が handler の任意になり
+//   (2)「終端状態とはどの列がどうあることか」が定義されず書き忘れた列が孤児化した
+// (#3982 / #4055 は同じ根から出た再発)。
+//
+// 局所修正では「新しい handler が増えれば同じ抜けが再発する」構造が残るため、
+// **`stripe-service.ts` から `updateTenantStripe` を呼べるのは単一強制点 1 箇所だけ**を
+// 機械強制する。route-db-boundary.test.ts (#3152) と同型の Architecture Fitness Function で、
+// 検出器は TypeScript compiler API (既存 devDependency、新規ツールゼロ)。
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const STRIPE_SERVICE = resolve(REPO_ROOT, 'src/lib/server/services/stripe-service.ts');
+
+/** 契約状態を書き換える唯一の関数 (この関数の中だけが `updateTenantStripe` を呼べる) */
+const ENFORCEMENT_POINT = 'applyTenantContractState';
+
+/** `updateTenantStripe(...)` 呼び出しを含む「最も内側の関数」の名前を全件返す。 */
+function findUpdateTenantStripeCallers(source: string, fileName: string): string[] {
+	const sf = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true);
+	const callers: string[] = [];
+
+	const enclosingFunctionName = (node: ts.Node): string => {
+		for (let cur: ts.Node | undefined = node.parent; cur; cur = cur.parent) {
+			if (ts.isFunctionDeclaration(cur) || ts.isMethodDeclaration(cur)) {
+				return cur.name?.getText() ?? '<anonymous>';
+			}
+			// `const f = () => {}` / `const f = function () {}`
+			if (
+				(ts.isArrowFunction(cur) || ts.isFunctionExpression(cur)) &&
+				cur.parent &&
+				ts.isVariableDeclaration(cur.parent)
+			) {
+				return cur.parent.name.getText();
+			}
+		}
+		return '<module-scope>';
+	};
+
+	const visit = (node: ts.Node): void => {
+		if (
+			ts.isCallExpression(node) &&
+			ts.isPropertyAccessExpression(node.expression) &&
+			node.expression.name.text === 'updateTenantStripe'
+		) {
+			callers.push(enclosingFunctionName(node));
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+	return callers;
+}
+
+describe('#4026 契約状態の書き換え単一強制点 (fitness function)', () => {
+	it('stripe-service.ts は単一強制点からしか updateTenantStripe を呼ばない', () => {
+		const callers = findUpdateTenantStripeCallers(
+			readFileSync(STRIPE_SERVICE, 'utf-8'),
+			STRIPE_SERVICE,
+		);
+
+		// 呼び出しが消えていたら (= 検出器が空振りしていたら) それ自体が異常
+		expect(callers.length).toBeGreaterThan(0);
+		expect(callers).toEqual(callers.map(() => ENFORCEMENT_POINT));
+	});
+
+	it('検出器は強制点を迂回した handler を検出する (非トートロジー証明)', () => {
+		// 単一強制点を迂回して直接 repo を叩く新規 handler を意図的に書いた fixture。
+		// これが検出されないなら上のテストは常に緑になる (gate が空振りする)。
+		const bypassing = `
+			async function handleSomethingNew(subscription: { id: string }): Promise<void> {
+				await getRepos().auth.updateTenantStripe('t-1', { status: 'active' });
+			}
+			async function ${ENFORCEMENT_POINT}(): Promise<void> {
+				await getRepos().auth.updateTenantStripe('t-1', { status: 'suspended' });
+			}
+		`;
+
+		const callers = findUpdateTenantStripeCallers(bypassing, 'fixture.ts');
+
+		expect(callers).toContain('handleSomethingNew');
+		expect(callers).not.toEqual(callers.map(() => ENFORCEMENT_POINT));
+	});
+});

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -426,7 +426,7 @@ describe('handleWebhookEvent', () => {
 		mockGetStripeClient.mockReturnValue({
 			subscriptions: { retrieve: mockSubscriptionsRetrieve },
 		});
-		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant());
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant());
 
 		const event = {
 			type: 'invoice.paid',
@@ -473,7 +473,7 @@ describe('handleWebhookEvent', () => {
 		mockGetStripeClient.mockReturnValue({
 			subscriptions: { retrieve: mockSubscriptionsRetrieve },
 		});
-		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant({ plan: 'monthly' }));
 
 		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
 
@@ -495,7 +495,7 @@ describe('handleWebhookEvent', () => {
 		mockGetStripeClient.mockReturnValue({
 			subscriptions: { retrieve: mockSubscriptionsRetrieve },
 		});
-		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant({ plan: 'monthly' }));
 
 		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
 
@@ -514,7 +514,9 @@ describe('handleWebhookEvent', () => {
 		mockGetStripeClient.mockReturnValue({
 			subscriptions: { retrieve: mockSubscriptionsRetrieve },
 		});
-		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'family-monthly' }));
+		mockFindTenantByStripeCustomerId.mockResolvedValue(
+			makeSubscribedTenant({ plan: 'family-monthly' }),
+		);
 
 		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
 
@@ -530,8 +532,8 @@ describe('handleWebhookEvent', () => {
 		mockGetStripeClient.mockReturnValue({
 			subscriptions: { retrieve: vi.fn().mockResolvedValue(subscription) },
 		});
-		mockFindTenantById.mockResolvedValue(makeTenant({ plan: 'monthly' }));
-		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant({ plan: 'monthly' }));
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant({ plan: 'monthly' }));
 
 		await handleWebhookEvent({
 			type: 'customer.subscription.updated',
@@ -551,8 +553,8 @@ describe('handleWebhookEvent', () => {
 		mockGetStripeClient.mockReturnValue({
 			subscriptions: { retrieve: vi.fn().mockResolvedValue(subscription) },
 		});
-		mockFindTenantById.mockResolvedValue(makeTenant({ plan: 'monthly' }));
-		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant({ plan: 'monthly' }));
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant({ plan: 'monthly' }));
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant({ plan: 'monthly' }));
 
 		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
 		await handleWebhookEvent({
@@ -566,7 +568,7 @@ describe('handleWebhookEvent', () => {
 	});
 
 	it('customer.subscription.updated — plan 未解決なら plan を上書きせず alert を上げる (#3960)', async () => {
-		mockFindTenantById.mockResolvedValue(makeTenant({ plan: 'family-monthly' }));
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant({ plan: 'family-monthly' }));
 
 		await handleWebhookEvent({
 			type: 'customer.subscription.updated',
@@ -610,12 +612,16 @@ describe('handleWebhookEvent', () => {
 
 	it('invoice.payment_failed → grace_period に変更', async () => {
 		const mockSubscriptionsRetrieve = vi.fn().mockResolvedValue({
+			// 実 Stripe subscription は必ず id / status を持つ。id は「この event が
+			// tenant の現行契約を指すか」の突合に使われる (#4026)
+			id: 'sub_123',
 			customer: 'cus_123',
+			status: 'past_due',
 		});
 		mockGetStripeClient.mockReturnValue({
 			subscriptions: { retrieve: mockSubscriptionsRetrieve },
 		});
-		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant());
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant());
 
 		const event = {
 			type: 'invoice.payment_failed',
@@ -638,7 +644,7 @@ describe('handleWebhookEvent', () => {
 	});
 
 	it('customer.subscription.updated → ステータス反映', async () => {
-		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
 
 		const event = {
 			type: 'customer.subscription.updated',
@@ -665,7 +671,7 @@ describe('handleWebhookEvent', () => {
 	});
 
 	it('customer.subscription.updated — past_due → grace_period', async () => {
-		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
 
 		const event = {
 			type: 'customer.subscription.updated',
@@ -694,7 +700,7 @@ describe('handleWebhookEvent', () => {
 	// **no-op をそのまま追認していた** (updateTenantStripe は undefined = 更新しない)。
 	// クリアの意図を DB まで届かせるには null でなければならないため、null を固定する。
 	it('customer.subscription.deleted → suspended + subscriptionId/plan を null でクリア (#3982)', async () => {
-		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
 
 		const event = {
 			type: 'customer.subscription.deleted',
@@ -711,6 +717,8 @@ describe('handleWebhookEvent', () => {
 			status: 'suspended',
 			stripeSubscriptionId: null,
 			plan: null,
+			// #4026: 終端状態は契約に紐づく列を網羅的に書く (期限だけ残る孤児を作らない)
+			planExpiresAt: null,
 		});
 		// stripeCustomerId は再購読時の customer 再利用 + webhook 逆引きの鍵なので消さない
 		expect(mockUpdateTenantStripe.mock.calls[0]?.[1]).not.toHaveProperty('stripeCustomerId');
@@ -733,7 +741,12 @@ describe('handleWebhookEvent', () => {
 		return makeTenant({ stripeSubscriptionId: undefined, plan: undefined, status: 'suspended' });
 	}
 
-	const TERMINAL_STATE = { status: 'suspended', stripeSubscriptionId: null, plan: null };
+	const TERMINAL_STATE = {
+		status: 'suspended',
+		stripeSubscriptionId: null,
+		plan: null,
+		planExpiresAt: null,
+	};
 
 	function deletedEvent(subscriptionId = 'sub_123') {
 		return {
@@ -755,28 +768,31 @@ describe('handleWebhookEvent', () => {
 	}
 
 	it('#3982 — deleted → updated(canceled) の順でも plan が復活せず終端状態に収束する', async () => {
-		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
 
 		await handleWebhookEvent(deletedEvent() as never);
 		// deleted 適用後の tenant を読む (id / plan はクリア済み)
 		mockFindTenantById.mockResolvedValue(makeCancelledTenant());
 		await handleWebhookEvent(cancelledUpdatedEvent() as never);
 
-		// 2 event とも同じ終端状態を書く = 到着順に依らず収束する
-		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(2);
+		// 書き込まれた状態は全て終端 = 到着順に依らず収束する。
+		// #4026 以降、2 通目は「割り当ての無い tenant への event」として適用されない
+		// (先着が既に終端へ収束させているので、最終状態は変わらない)。
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
 		for (const call of mockUpdateTenantStripe.mock.calls) {
 			expect(call[1]).toEqual(TERMINAL_STATE);
 		}
 	});
 
 	it('#3982 — updated(canceled) → deleted の逆順でも最終状態が一致する', async () => {
-		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
 
 		await handleWebhookEvent(cancelledUpdatedEvent() as never);
 		mockFindTenantById.mockResolvedValue(makeCancelledTenant());
 		await handleWebhookEvent(deletedEvent() as never);
 
-		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(2);
+		// 逆順でも同じ: 先着が終端へ収束させ、後着は現行契約を指さないため適用されない
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
 		for (const call of mockUpdateTenantStripe.mock.calls) {
 			expect(call[1]).toEqual(TERMINAL_STATE);
 		}
@@ -791,7 +807,7 @@ describe('handleWebhookEvent', () => {
 					.mockResolvedValue(makeSubscription('price_monthly_123', { status: 'canceled' })),
 			},
 		});
-		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
 		mockFindTenantByStripeCustomerId.mockResolvedValue(makeCancelledTenant());
 
 		await handleWebhookEvent(deletedEvent() as never);
@@ -810,7 +826,7 @@ describe('handleWebhookEvent', () => {
 					.mockResolvedValue(makeSubscription('price_monthly_123', { status: 'canceled' })),
 			},
 		});
-		mockFindTenantById.mockResolvedValue(makeTenant());
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
 		mockFindTenantByStripeCustomerId.mockResolvedValue(makeCancelledTenant());
 
 		await handleWebhookEvent(deletedEvent() as never);
@@ -832,7 +848,7 @@ describe('handleWebhookEvent', () => {
 					.mockResolvedValue(makeSubscription('price_monthly_123', { status: 'past_due' })),
 			},
 		});
-		mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant());
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant());
 
 		await handleWebhookEvent({
 			type: 'invoice.payment_failed',

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -102,6 +102,19 @@ function makeTenant(overrides: Record<string, unknown> = {}) {
 }
 
 /**
+ * **現行契約を持つ** tenant の mock (#4026)。
+ *
+ * 契約状態を書き換える webhook (`invoice.paid` / `invoice.payment_failed` /
+ * `customer.subscription.updated` / `...deleted`) は、event 対象の subscription が
+ * tenant の現行契約であるときだけ適用される。したがって「その webhook が適用される」
+ * ことを検証する fixture は、tenant 側にも同じ subscription が割り当たっている必要がある
+ * (割り当てが無い tenant = 契約未確立 or 解約済み)。
+ */
+function makeSubscribedTenant(overrides: Record<string, unknown> = {}) {
+	return makeTenant({ stripeSubscriptionId: 'sub_123', ...overrides });
+}
+
+/**
  * Stripe subscription の mock (#3960)。
  *
  * `handleInvoicePaid` は plan を invoice の line item ではなく **subscription の現行 price**
@@ -830,6 +843,95 @@ describe('handleWebhookEvent', () => {
 			't-test',
 			expect.objectContaining({ status: 'grace_period' }),
 		);
+	});
+
+	// ======================================================
+	// #4026 / #4055: 契約状態の書き換えは「event 対象 = tenant の現行契約」のときだけ
+	//
+	// tenant の同定は `subscription.metadata.tenantId` (無ければ customer 逆引き) で行うため、
+	// **その tenant が今どの subscription を持っているか**とは独立に handler へ到達する。
+	// 突合が無いと (a) 旧 subscription の後着 event が現行契約を壊し
+	// (b) 解約済み (割り当て NULL) の tenant に非終端 event が plan / ACTIVE を書き戻す。
+	// ======================================================
+
+	function updatedEvent(
+		subscriptionId: string,
+		status = 'active',
+		priceId = 'price_family_monthly_789',
+	) {
+		return {
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					...makeSubscription(priceId, { status, id: subscriptionId }),
+					metadata: { tenantId: 't-test' },
+				},
+			},
+		};
+	}
+
+	it('#4026 — 旧 sub の deleted が後着しても、再購読済み tenant の現行契約を壊さない', async () => {
+		// 解約 → 再購読を通った tenant。現行契約は sub_new (課金中)。
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: 'sub_new', plan: 'family-monthly', status: 'active' }),
+		);
+
+		await handleWebhookEvent(deletedEvent('sub_old') as never);
+
+		// 旧契約の event で現行契約の列を 1 つも書かない
+		// (書くと id=NULL → createCheckoutSession の ALREADY_SUBSCRIBED ガードが外れ二重課金し得る)
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+		expect(mockNotifyStripeAlert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				kind: 'stripe-contract-target-mismatch',
+				tags: expect.objectContaining({
+					tenantId: 't-test',
+					eventSubscriptionId: 'sub_old',
+					currentSubscriptionId: 'sub_new',
+				}),
+			}),
+		);
+	});
+
+	it('#4026 — 旧 sub の updated(active) が後着しても、再購読済み tenant の plan を巻き戻さない', async () => {
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: 'sub_new', plan: 'family-monthly', status: 'active' }),
+		);
+
+		await handleWebhookEvent(updatedEvent('sub_old', 'active', 'price_monthly_123') as never);
+
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
+	it('#4026 — 終端状態は planExpiresAt も含めて網羅的に書く (孤児列を残さない)', async () => {
+		// アプリ内解約 (`/api/v1/admin/tenant/cancel`) は grace_period + planExpiresAt を書いてから
+		// Stripe を即時キャンセルする。直後の deleted が planExpiresAt を書かないと、
+		// 契約が無いのに期限だけ残る (SaasLicensePanel / lifecycle-email-service が読む)。
+		mockFindTenantById.mockResolvedValue(
+			makeSubscribedTenant({ status: 'grace_period', planExpiresAt: '2026-08-28T00:00:00Z' }),
+		);
+
+		await handleWebhookEvent(deletedEvent() as never);
+
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith('t-test', {
+			status: 'suspended',
+			stripeSubscriptionId: null,
+			plan: null,
+			planExpiresAt: null,
+		});
+	});
+
+	it('#4055 — deleted の後に非終端 updated(active) が後着しても終端状態を維持する', async () => {
+		mockFindTenantById.mockResolvedValueOnce(makeSubscribedTenant());
+		await handleWebhookEvent(deletedEvent() as never);
+
+		// deleted 適用後の tenant を読む (割り当てはクリア済み)
+		mockFindTenantById.mockResolvedValue(makeCancelledTenant());
+		await handleWebhookEvent(updatedEvent('sub_123', 'active') as never);
+
+		// 2 通目は「現行契約でない」として適用されない = plan / ACTIVE が復活しない
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+		expect(mockUpdateTenantStripe.mock.calls[0]?.[1]).toEqual(TERMINAL_STATE);
 	});
 
 	it('未対応のイベント型 → エラーなし', async () => {

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -950,6 +950,49 @@ describe('handleWebhookEvent', () => {
 		expect(mockUpdateTenantStripe.mock.calls[0]?.[1]).toEqual(TERMINAL_STATE);
 	});
 
+	// ======================================================
+	// #4077 (PO 決裁 Q1 条件): 割り当て NULL の tenant への mismatch は
+	// 「event の subscription が生きているか」で沈黙させ方を変える。
+	//
+	// 「Stripe 上は課金中なのに DB に割り当てが無い」= 親は請求だけ増え、子供側の機能は
+	// 開かない最悪クラスの失敗モードで、しかも顧客からは原因が見えない。warn (誰も見ない)
+	// では問い合わせが来るまで発見されないため alert を上げる。
+	// 逆に解約済み契約への後着 (終端) は正常な skip なので鳴らさない (alert 疲れの回避)。
+	// ======================================================
+
+	it('#4077 — 割り当て NULL の tenant に非終端 event が来たら alert を上げる', async () => {
+		// checkout webhook の恒久失敗 / Dashboard 手動作成で生じる「課金済み未紐付け」tenant。
+		mockFindTenantById.mockResolvedValue(makeCancelledTenant());
+
+		await handleWebhookEvent(updatedEvent('sub_live', 'active') as never);
+
+		// 適用しない判断は #4026 のまま (割り当て前の event を書き込む方が危険)
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+		expect(mockNotifyStripeAlert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				kind: 'stripe-contract-target-mismatch',
+				tags: expect.objectContaining({
+					tenantId: 't-test',
+					event: 'customer.subscription.updated',
+					eventSubscriptionId: 'sub_live',
+					currentSubscriptionId: 'none',
+					mismatchKind: 'tenant-unassigned-live-subscription',
+				}),
+			}),
+		);
+	});
+
+	it('#4077 — 割り当て NULL の tenant への終端 event は alert を上げない (正常な後着)', async () => {
+		mockFindTenantById.mockResolvedValue(makeCancelledTenant());
+
+		// deleted (= 契約消滅) と updated(canceled) の両方が終端扱い
+		await handleWebhookEvent(deletedEvent('sub_gone') as never);
+		await handleWebhookEvent(cancelledUpdatedEvent() as never);
+
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+		expect(mockNotifyStripeAlert).not.toHaveBeenCalled();
+	});
+
 	it('未対応のイベント型 → エラーなし', async () => {
 		const event = {
 			type: 'payment_intent.created',


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 運営

**解決する課題**: 契約状態（`families` の `status` / `plan` / `stripe_subscription_id` / `plan_expires_at`）を書き換える経路が単一強制点を持たず、各 webhook handler が「自分が知っている列だけ」を個別に書いていた。そのため (1)「この event が tenant の現行契約を指しているか」の突合が handler の任意になり、旧 subscription の後着 event が**再購読済み tenant の現行契約を壊す**（`stripe_subscription_id` が NULL 化 → `createCheckoutSession()` の `ALREADY_SUBSCRIBED` ガードが外れ二重課金が成立し得る）(2) 終端状態が列の集合として定義されておらず、アプリ内解約（`/api/v1/admin/tenant/cancel`）が書いた `plan_expires_at` が `deleted` 後も**孤児として残り**、`SaasLicensePanel` の「有効期限」行に契約が無いのに期限が表示される。

あわせて `plan-change-flow.md` §10.5（webhook 到着順序の SSOT）が**実装より強い保証を名乗っていた**問題を是正する。U1 の担保欄は未実装の原則（P1）を根拠にし、U5 が「DB 上ありえない」とした組合せは「終端の後に**非終端**の `updated` が後着する」経路で実際に到達可能だった。SSOT が過大な保証を名乗ると、次に同じ穴を踏む人が「doc で確認済み」として素通りする。

**期待される効果**: 契約状態の書き換えが 1 関数を通り、突合と列網羅を**迂回できない**構造になる（新しい handler が増えても同じ抜けが再発しない）。設計書 §10.5 の担保欄が、実装が実際に持っている保証と一致する。

## 関連 Issue

closes #4026
closes #4055

- #3982 / PR #3992 — 本 PR の発見元。`deleted` の no-op 修正 + §10.5 新設。本 PR はその構造化と担保欄の是正
- #3960 — plan の巻き戻し（P1 の出典）
- #3988 / `billing-redesign/contract-state-matrix.md` — 契約状態 4 列の許容組み合わせ SSOT。X1 / X3 の書き手を塞ぐ側の変更
- #3985 / #2641 — event dedup（未実装）。順序ガード（本 PR）とは別の防御であり、片方では他方を代替できない
- ADR-0061（fitness function で人の注意依存を機械強制）/ ADR-0001（設計書同期）

**関連 PR（競合可能性）**: **PR #4061（`fix/3980-3981-stripe-plan-resolution`）が同じ `stripe-service.ts` / `alert.ts` / `stripe-service.test.ts` を触っている。**

| 対象 | 競合 | どちらが先に merge されても壊れない書き方 / 解消方針 |
|---|---|---|
| `stripe-service.ts` | なし（触る関数が異なる） | #4061 は `resolveSubscriptionContext` / `resolvePlanFromSubscription`、本 PR は `handleCheckoutCompleted` / `handleInvoicePaid` / `handlePaymentFailed` / `handleSubscriptionUpdated` / `handleSubscriptionDeleted` + 新規の強制点。行が重ならない |
| `alert.ts` の `StripeAlertKind` | 低（union の別位置） | #4061 は末尾（`stripe-plan-unresolved` の後）に 2 件追加、本 PR は先頭側（`stripe-lookup-failed` の直後）に 1 件追加。**意図的に挿入位置をずらしてある**ため hunk が重ならない |
| `tests/unit/services/stripe-service.test.ts` | **あり（1 箇所、意味的）** | #4061 の `#3980 — subscription item が複数なら alert を上げる` は tenant fixture（`stripeSubscriptionId: null`）に対し `sub_multi` の event を流し `updateTenantStripe` 呼び出しを assert する。本 PR 以後、契約状態の書き換えは「event 対象 = tenant の現行契約」でなければ適用されないため、**後 merge 側が fixture を `makeSubscribedTenant({ stripeSubscriptionId: 'sub_multi', plan: 'monthly' })` に 1 行変更する**（`makeSubscribedTenant` は本 PR で追加。alert の assert 自体は影響を受けない） |

本 PR の diff は #4061 の変更行を含まない（rebase 時に上書きしない）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #4026 AC1 | 契約状態を書き換える経路が単一関数に集約され、event 対象と現行契約の突合が迂回不能になっている | `src/lib/server/services/stripe-service.ts` `applyTenantContractState()` を全 5 handler が経由 / `npx vitest run tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts` | PASS（2 passed）。`updateTenantStripe` の呼び出し元は `applyTenantContractState` のみ |
| #4026 AC2 | 終端状態が型として定義され、`planExpiresAt` を含む全列を網羅的に書く（孤児列が残らない） | `TERMINAL_CONTRACT_STATE`（`satisfies TenantContractStatePatch`、4 列）/ test `#4026 — 終端状態は planExpiresAt も含めて網羅的に書く (孤児列を残さない)` | PASS。`{stripeSubscriptionId:null, plan:null, status:'suspended', planExpiresAt:null}` を assert |
| #4026 AC3 | 単一強制点以外からの `updateTenantStripe` 直呼びを検出する fitness function があり、意図的に迂回した diff で fail することを確認済み | mutation 実測（下記「mutation 検証ログ」M2）+ 非トートロジー fixture test | PASS。`handleSubscriptionDeleted` から直呼びに変えると `expected [ 'handleSubscriptionDeleted', …(1) ] to deeply equal [ 'applyTenantContractState', …(1) ]` で fail |
| #4026 AC4 | `plan-change-flow.md` §10.5.1 / §10.5.2 が上記 3 点と整合（U8 の順序前提の是正 + アプリ内解約経路の行追加） | `docs/design/plan-change-flow.md` §10.5.1（P3 追加）/ §10.5.2（U8 を「どちらでも」に是正 + U10 = アプリ内解約経路を追加） | PASS |
| #4026 AC5 | 「旧 sub の deleted が新 sub 契約中の tenant に後着しても現行契約を壊さない」unit test が存在する | test `#4026 — 旧 sub の deleted が後着しても、再購読済み tenant の現行契約を壊さない`（+ updated 版 1 本） | PASS。`updateTenantStripe` が 1 度も呼ばれないこと + `stripe-contract-target-mismatch` alert を assert |
| #4055 AC1 | §10.5.2 U1 の担保欄から「P1（updated は現行 price を書く）」を外し、payload から解決している事実と結果が正しい理由を書く | `plan-change-flow.md` §10.5.2 U1 行 | PASS。「`updated` は payload の price から plan を解決するが、新規購入では payload の price と現行 price が一致するため結果が正しい（P1 ではない）」 |
| #4055 AC2 | §10.5.1 P1 の実装欄に `handleSubscriptionUpdated` が P1 の対象外であることを明記 | `plan-change-flow.md` §10.5.1 P1 行 | PASS。「`handleInvoicePaid` のみ」+「`handleSubscriptionUpdated` は P1 の対象外」を明記 |
| #4055 AC3 | `handleSubscriptionUpdated` に、tenant 側が既に解約済み（`stripeSubscriptionId` が NULL、または `subscription.id` と不一致）なら plan / status を書き戻さないガードを追加 | `applyTenantContractState()` の `current !== target.subscriptionId` 突合（`handleSubscriptionUpdated` の終端 / 非終端の両分岐が経由） | PASS。局所ガードではなく単一強制点として実装（#4026 と同一箇所） |
| #4055 AC4 | 回帰テスト追加 — `deleted` → 非終端 `updated`(active) で最終状態が `id=NULL / plan=NULL / suspended` のまま | test `#4055 — deleted の後に非終端 updated(active) が後着しても終端状態を維持する`（`#3982 —` 4 本と同形式） | PASS。書き込みは 1 回のみ + 終端 4 列一致を assert |
| #4055 AC5 | mutation で AC4 が効いていることを実測 | 下記「mutation 検証ログ」M1 | PASS。ガード無効化で 5 本 fail、復元で 37 本 pass |
| #4055 AC6 | §10.5.2 に U9 の行を追加（解約後に非終端 `updated` が後着 / `id=NULL` `plan=NULL` `suspended` / 担保 = AC3 のガード） | `plan-change-flow.md` §10.5.2 U9 行 | PASS |
| #4055 AC7（境界） | `isSubscriptionTerminal()` の判定対象 status（`canceled` / `incomplete_expired`）を変更しない | `git diff origin/develop -- src/lib/server/services/stripe-service.ts` に `TERMINAL_SUBSCRIPTION_STATUSES` の差分なし | PASS（未変更） |
| #4055 AC8（境界） | `handleInvoicePaid` の P1 実装（`subscriptions.retrieve()` を SSOT）を変更しない | 同上。`resolveSubscriptionContext` / `resolvePlanFromSubscription` は未変更、`handleInvoicePaid` の変更は書き込み経路の差し替えのみ | PASS |
| #4055 AC9 | `AuthContext.plan`（`cognito.ts:171`）が解約済みプラン名を載せたまま**画面に出る経路があるか**を確認し結果を記録 | 下記「AC9 調査結果」 | **画面には出ない**（プラン名表示は `planTier` 経由で `licenseStatus` にゲートされる）。ただし**別経路で `plan_expires_at` は画面に出ていた**（`SaasLicensePanel` の「有効期限」行）— 本 PR の終端 4 列クリアで解消 |

### AC9 調査結果（`AuthContext.plan` の画面露出、実読）

`locals.context?.plan` の全消費箇所を追跡した（`grep -rn "context?\.plan\|context\.plan" src/`）:

- 全消費が `resolveFullPlanTier(tenantId, licenseStatus, planId)` / `softDeleteTenant(...)` への入力。`plan-limit-service.ts:107-109` が `licenseStatus === ACTIVE` のときだけ `plan` を tier に反映し、解約後は `licenseStatus = none` → `free` に落ちる（`cognito.ts:159-164`）
- プラン名を描画する `SaasLicensePanel.svelte` は `license.plan` ではなく **`data.planTier`（`resolveFullPlanTier` 経由）** をラベル化する（同 component 冒頭コメント「planTier SSOT 統一」）。したがって解約済みプラン名が画面に出る経路は**無い**
- 一方で**同 panel の「有効期限」行は `license.planExpiresAt`（`tenant.plan_expires_at` の生値）を直接描画**しており、孤児化した期限は**画面に出ていた**。これは #4026 の終端列網羅（`planExpiresAt: null`）で解消する

### mutation 検証ログ（物理 verification 証跡）

| Fix item | 検証コマンド（実行したものをそのまま） | output 件数 | 判定 |
|---|---|---|---|
| M1（突合ガードを無効化: `if (false && current !== target.subscriptionId)`） | `npx vitest run tests/unit/services/stripe-service.test.ts` | 5 failed / 32 passed（`#4026 —` 2 本 / `#4055 —` 1 本 / `#3982 —` 2 本が fail） | ✓ ガードが効いている |
| M1 復元後 | 同上 | 37 passed | ✓ |
| M2（強制点を迂回: `handleSubscriptionDeleted` から `updateTenantStripe` 直呼び） | `npx vitest run tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts` | 1 failed / 1 passed（`expected [ 'handleSubscriptionDeleted', …(1) ]`） | ✓ fitness が効いている |
| M2 復元後 | 同上 | 2 passed | ✓ |
| 単一強制点の網羅（`updateTenantStripe` 直呼び 0 件） | `grep -n "updateTenantStripe" src/lib/server/services/stripe-service.ts` | 呼び出しは 1 件（`applyTenantContractState` 内）+ JSDoc 言及のみ | ✓ |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — repo **interface の型のみ**（`planExpiresAt?: string | null`）。列定義・マイグレーションの変更なし（`plan_expires_at` は既に nullable）
- [x] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: Stripe webhook 処理（`checkout.session.completed` / `invoice.paid` / `invoice.payment_failed` / `customer.subscription.updated` / `customer.subscription.deleted`）と、その結果を読む親管理画面のライセンスパネル（プラン / 状態 / 有効期限表示）。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/architecture/stripe-contract-write-single-enforcement.test.ts`（新規）— `stripe-service.ts` から `updateTenantStripe` を呼べるのは単一強制点のみ（TypeScript compiler API で AST 走査、非トートロジー fixture 付き）
  - `tests/unit/services/stripe-service.test.ts` — `#4026` 3 本 / `#4055` 1 本を追加。webhook fixture を `makeSubscribedTenant()`（現行契約を持つ tenant）に是正し、`invoice.payment_failed` の retrieve mock に実 Stripe と同じ `id` / `status` を補完。`#3982` 順序 2 本は「後着は適用されず終端状態が維持される」に更新（呼び出し回数の期待は 2 → 1、assertion は据え置きで終端 4 列一致を全件検査）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（DynamoDB backend は #3438 で撤去済）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:high` / `type:fix`）

## スクリーンショット / ビジュアルデモ

**該当なし（サーバー側 webhook 処理と設計書のみの変更で、UI コンポーネント・レイアウト・文言の差分はゼロ）**。

**4 スロット添付**（#1740）: N/A

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 契約状態の書き換えという単一の責務を 1 関数に集約。handler は「何を書くか」だけを持ち、「書いてよいか」の判定は強制点が持つ
- [x] **DRY**: 終端状態の列集合を `TERMINAL_CONTRACT_STATE` 1 箇所に集約（従来は `clearSubscriptionAssignment` と handler 側に分散し `planExpiresAt` が欠落していた）
- [x] **YAGNI**: 突合の 2 モード（`current-contract` / `assign-contract`）は実在する 2 種類の event に対応する最小分岐。dedup / 楽観ロック（#3985）は本 PR に含めない
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。alert の tags は subscription id / tenant id のみで PII を含まない
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: DB / Stripe API の呼び出し回数は不変。突合は既に取得済みの `tenant` のフィールド比較のみ（skip 時は UPDATE が 1 回減る）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — demo repo の `updateTenantStripe` は no-op stub（`db/demo/auth-repo.ts`）で契約状態を持たないため影響なし
- [x] LP ↔ アプリ双方向整合（ADR-0013）— N/A（訴求文言の変更なし）
- [x] 全年齢モード 5 種に横展開 — N/A（親管理側の契約状態）
- [x] ナビゲーション 3 種に反映 — N/A
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A（`families` の列定義は不変）
- [x] labels SSOT (ADR-0009) — N/A（UI 文言なし）
- [x] 設計書同期 (ADR-0001) — `plan-change-flow.md` §10.5.1 / §10.5.2 + `billing-redesign/contract-state-matrix.md`（W1-W5 の書き手 / X1 / D1 / §7）
- [x] 並行 PR overlap 確認 (#1200) — PR #4061 と重複ファイルあり。解消方針は「関連 Issue」の表に記載
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

DB スキーマ / API レスポンス / 環境変数の変更なし。挙動の変更は「現行契約を指さない webhook を適用しなくなる」「終端時に `plan_expires_at` も NULL にする」の 2 点で、いずれも不正状態（contract-state-matrix の X1 / X3）を作らない方向。

**レビュー依頼事項・QA**:

1. **突合の厳格さの妥当性** — `tenant.stripeSubscriptionId` が NULL の tenant に届いた webhook は適用されない。U1（`checkout` より `updated` が先着）でも収束することを §10.5.2 に明記したが、「割り当て前の event を捨てる」判断の是非を確認いただきたい（捨てても後着の `checkout` が確定させるため最終状態は一致する）
2. **alert のノイズ設計** — PO 決裁 Q1 条件を受け 3 分岐にした（下記「PO 決裁の条件充足」①）。割り当て無し × 終端 = warn のみ / 割り当て無し × **非終端** = alert / 別 subscription = alert。終端後着（正常系）で鳴らさずに「課金済み未紐付け」だけを鳴らす
3. PR #4061 との競合解消方針（「関連 Issue」の表）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言）

## PO 決裁の条件充足 (2026-07-30)

PO 決裁は Q1 / Q2 とも **Yes（条件付き）**。両条件を本 PR 内で充足した。

### ① Q1 条件 — 割り当て NULL × 非終端 event は warn ではなく alert に上げる

`ContractEventTarget` に `subscriptionTerminal` を持たせ、突合失敗時の**観測レベルのみ** 3 分岐にした（適用可否は #4026 のまま不変 = 割り当て前の event は書き込まない）。alert kind は既存 `stripe-contract-target-mismatch` を維持し `tags.mismatchKind` で区別する（PR #4061 の `alert.ts` union と hunk が衝突しないため）。

| 不一致の種類 | 観測 | `tags.mismatchKind` | 根拠 |
|---|---|---|---|
| 割り当て無し × 終端 event（canceled / incomplete_expired / deleted） | warn のみ | — | 解約済み契約への正常な後着。鳴らすと alert 疲れで本当の事象が埋もれる |
| 割り当て無し × **非終端** event（active / trialing / past_due …） | **alert** | `tenant-unassigned-live-subscription` | Stripe 上は課金中なのに DB に紐付いていない = 親は請求だけ増え機能が開かない。必ず人が介入する |
| 別 subscription | alert | `other-subscription` | 旧契約の後着 or tenant 同定ミス（従来どおり） |

**回帰テスト**（`tests/unit/services/stripe-service.test.ts`）:

| テスト名 | 検証内容 |
|---|---|
| `#4077 — 割り当て NULL の tenant に非終端 event が来たら alert を上げる` | 未割当 tenant + `updated`(active) → `updateTenantStripe` 未呼出（適用しない）かつ `mismatchKind=tenant-unassigned-live-subscription` の alert 発火 |
| `#4077 — 割り当て NULL の tenant への終端 event は alert を上げない (正常な後着)` | 未割当 tenant + `deleted` / `updated`(canceled) → 適用せず alert も 0 件 |

failing-test-first で追加（実装前 run: 1 failed / 38 passed → 実装後 41 passed）。実装後の mutation 検証:

| mutation | 落ちたテスト |
|---|---|
| 終端条件を外し `currentSubscriptionId === null` だけで return（= 従来の warn のみ） | 非終端 alert テストが fail |
| 早期 return を削除（= 常に alert） | 終端 alert 非発火テストが fail |

### ② Q2 条件 — 猶予期限表示の担い手を #3991 で決める + 設計書に暫定を 1 行

| 条件 | 実施内容 |
|---|---|
| #3991 に AC 追加 | https://github.com/Takenori-Kusaka/ganbari-quest/issues/3991 の AC に「**解約後の猶予期限を顧客が画面で確認する手段をどのモデルが担うかを決める**」を追加（終端クリアで `plan_expires_at` が NULL になり `SaasLicensePanel` の「有効期限」行が消えること／案 A では「請求期間終了日」が Stripe 側 SSOT になるため、その値を画面に出す担い手を決めること、を明記） |
| #3991 を priority:high | **既に付与済みであることを確認**（`gh issue view 3991 --json labels` → `type:fix` / `priority:high` / `area:billing`）。既存 label は変更していない |
| 設計書に残課題 1 行 | `docs/design/plan-change-flow.md` §10.5.3「未カバー（既知の残課題）」に 1 行追加: 終端クリアで解約後は画面から期限が消え、期限告知は解約完了メール（`sendCancellationEmail` の `graceEndDate`）が担う（暫定）／表示の担い手は #3991 で決定 |

あわせて §10.5.1 P3 の記述を①の 3 分岐仕様に同期した（docs SSOT 原則に従い「現状の正解」のみを記述し、経緯は本 PR / commit に置く）。

### 補足（PO 記録事項への応答）

- security 軸 TOCTOU（dedup 未実装で突合が atomic でない）は §10.5 冒頭の「順序ガードと dedup は別の防御であり片方では他方を代替できない」注記を維持（受容判断は PR #4079 / #3985 側）
- PR #4061 との fixture 競合解消方針は「関連 Issue」の表のとおりで変更なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert のみで戻る"]
    R2["顧客面: 課金状態の書込条件が変わる"]
    R3["DB 破壊なし・migration なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 二重課金経路と孤児期限を構造的に封鎖"]
    T2["捨てる: 割当NULL tenant の webhook は適用しない"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: 課金中だが割当NULLの tenant を取りこぼす"]
    O2["UX: 解約直後に有効期限の表示が消える"]
    O3["security: 同定ミスがNULL側だとalert無・TOCTOU残"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["UI 変更なし。解約後の有効期限行が消えるのみ"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 割当NULL tenant への webhook を捨てる方針で可?"]
    Q2["Q2: 解約後に有効期限表示が消えるのは許容?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,C1,T1 ok
  class R2,R3 warn
  class T2,O1,O2,O3 warn
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- **Q1 の背景**: 本 PR 以後、契約状態を書き換える webhook は `tenant.stripe_subscription_id` と event の subscription が一致するときだけ適用される。一致しない典型は (a) 旧 subscription の後着（**捨てるのが正しい** = #4026 の目的）(b) tenant 側が NULL（解約済み or checkout 前）。(b) のうち「Stripe では課金中なのに DB 側の割り当てが NULL」という状態が存在すると、`invoice.paid` が適用されず有料機能が開かないまま放置される。現状この状態を作る経路は checkout webhook の恒久的失敗 / Dashboard 手動作成 / 移行残に限られ、alert ではなく warn のみで記録する設計にしている（解約済み tenant への正常な後着で alert が鳴り続けるのを避けるため）。
- **Q2 の背景**: `plan_expires_at` を終端でクリアするのは contract-state-matrix の不正状態 X3（契約が無いのに期限が残る）の解消。副作用として `SaasLicensePanel` の「有効期限」行が解約後に表示されなくなる。「解約したのに期限が出続ける」と「解約したら期限が消える」のどちらが顧客にとって正しいかは、#3991（grace_period の多重定義: 支払い失敗の猶予 7 日 と 解約申請の猶予 30 日 が同じ列を共有）の整理と接続する。
- **反対理由の出典**: `tmp/adversarial-evidence/4077.json`（3 軸 3 件、`node scripts/verify-adversarial-output.mjs --pr 4077` PASS）。
- **security 軸の残課題**: event dedup（#3985 / #2641）と tenant 単位の楽観ロックは未実装のため、突合は atomic ではない（読み取り後に別 event が割り込む TOCTOU が残る）。本 PR は順序ガードのみを担い、dedup を代替しない（§10.5 冒頭の注記どおり）。

</details>


