### PR TITLE
fix(billing): #3985 Stripe webhook の event.id dedup を dispatcher 入口に配線する

### DIFF
--- a/docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md
+++ b/docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md
@@ -5,7 +5,7 @@
 | 孫 issue | #2641 (Phase 5 子 2 — webhook 冪等性 DB 設計) |
 | 親 | #2530 (Phase 5 アーキ) / Epic #2525 |
 | 上位 (Phase 1) | #2537 (dunning) / #2540 (security) |
-| ステータス | 設計確定 (deep-research: Stripe 公式 Webhook 一次 6 URL 検証済 → 本 PR で docs 確定、コード変更は Phase 7) |
+| ステータス | 実装済 (#3985 で `handleWebhookEvent` dispatcher 入口に配線、購読 5 種 + 未購読型を一律 dedup) |
 | 依存 (Phase 5 同位) | 子 1 ([phase5-stripe-product-architecture.md](phase5-stripe-product-architecture.md)) Webhook endpoint 設計と統合 |
 | Phase 7 連動 | webhook handler 全 5 種 (現行) + 3 種 (子 1 新規 `subscription_schedule.*`) を本 DB 経由 |
 | 起点 | Phase 1 dunning NFR-1 (webhook 冪等性) + Phase 1 security FR-4 (event.id で冪等性管理) + security 既存実装 delta #3 (「event.id dedup なし → 新規構築」) の合流地点 |
@@ -68,10 +68,10 @@ Stripe 公式 (<https://docs.stripe.com/webhooks#handle-duplicate-events>) よ�
 |------|------|------|
 | **handler 横断の dedup 機構** | `handleWebhookEvent` dispatcher 入口 (L221) で 1 箇所 dedup、全 event 型を一律処理 | Stripe 公式 best practice / future-proof (新規 event 追加時の散在防止) |
 | **event.id PK** | Stripe `evt_*` の immutable な ID を SSOT、replay/resend で同一 ID を活用 | Stripe 公式 API events object 仕様 |
-| **handler 実行と dedup row 書込みを同一 transaction** | SQLite は `BEGIN ... COMMIT`、DynamoDB は `TransactWriteItems`、in-memory は同期 Map に統一 | partial failure (handler 成功 + dedup row insert 失敗) で次回到達時に再実行されることを保証 (at-most-once は無理、at-least-once で冪等 handler を作る Stripe 推奨パターン) |
+| **dedup row の書込みは handler 完了後** | handler が成功したときだけ row を insert する。row 書込みが失敗すれば row は残らず、次回到達で handler が再実行される (この順序が transaction と同じ保証を与えるため、handler と row を 1 transaction に閉じ込めない — handler は Stripe API 呼び出しを含み、transaction 内に network I/O を抱えるのは不可) | partial failure で event を失わないことを保証 (at-most-once は原理的に不可、at-least-once で冪等 handler を作る Stripe 推奨パターン) |
 | **30 日 retention (ADR-0049 整合)** | `processed_at` 30 日経過で物理削除 (Stripe 公式 `Events API` は 30 日でも保持される為、replay window 内のみカバーすれば足りる) | Stripe 公式 events object docs (30 日後 list API から消える) / PIPC データ最小化 / Pre-PMF dedup row 量を膨張させない |
 | **4 backend 整合** | SQLite (Drizzle) / DynamoDB (single table) / in-memory (demo & test) で同一 interface (`IWebhookEventRepo`) | `parallel-implementations.md` の DB スキーマ整合ルール (§9 並行ペア整合) |
-| **error_message + retry_count 記録** | handler 例外時は `handler_result: 'error'` で row insert + error_message に Stripe.Error message を保存、retry_count を increment | Phase 7 retry 戦略の基礎データ (本 PR scope 外、retry 自動化は PMF 後判断) |
+| **retry_count 記録** | 同一 event.id の再到達ごとに `retry_count` を +1 する | 「どの event が何回再送されたか」を運用で見るための基礎データ。`handler_result` は `'success'` / `'skipped'` の 2 値で、失敗は row を残さない (§4.2) ため `error_message` は常に null |
 | **HTTP status は常に 200 (重複検知時も)** | Stripe 公式: 4xx/5xx 返却は Stripe 側 retry をトリガし重複到達を増やす | Stripe 公式 webhook best practice (`Acknowledge events immediately`) |
 
 ## 3. 確定案: stripe_webhook_events table
@@ -168,7 +168,7 @@ export const STRIPE_WEBHOOK_EVENT_TTL_DAYS = 30;
 ### 3.3 in-memory schema (demo & test、`src/lib/server/db/demo/` 配下に新規 file)
 
 ```typescript
-// src/lib/server/db/demo/webhook-event-repo.ts (Phase 7 で新規作成、本 PR scope 外)
+// src/lib/server/db/demo/webhook-event-repo.ts
 // in-memory Map で 4 backend 整合を保つ。demo Lambda + unit test で使用。
 import type { IWebhookEventRepo, WebhookEventRecord } from '../interfaces/webhook-event-repo.interface';
 
@@ -217,85 +217,34 @@ export interface IWebhookEventRepo {
 
 ## 4. 既存 webhook handler との統合方針 (Phase 7 実装)
 
-### 4.1 dispatcher 入口での dedup check (handleWebhookEvent = L221)
+### 4.1 dispatcher 入口での dedup check
 
-```typescript
-// Phase 7 で stripe-service.ts に追加する擬似コード (本 PR scope 外、設計のみ)
-export async function handleWebhookEvent(event: Stripe.Event): Promise<void> {
-  const repos = getRepos();
-  const existing = await repos.webhookEvent.findByEventId(event.id);
+`handleWebhookEvent` (`src/lib/server/services/stripe-service.ts`) が唯一の dedup 点。
 
-  if (existing) {
-    // 重複到達 — retry_count++ + 既に処理済みとして skip
-    await repos.webhookEvent.incrementRetryCount(event.id);
-    logger.info(`[STRIPE] Duplicate webhook event skipped: ${event.id} type=${event.type} retry=${existing.retryCount + 1}`);
-    return; // HTTP 200 を返す (上位 +server.ts 側)、Stripe 側 retry を抑止
-  }
+1. `repos.webhookEvent.findByEventId(event.id)` が row を返す → **handler を呼ばず**
+   `incrementRetryCount` して return (呼び出し元は 200 を返す)
+2. row が無い → `dispatchWebhookEvent` で event 型ごとの handler を実行し、**完了後に** row を insert する
+   (`handlerResult` は購読型なら `'success'`、未購読型なら `'skipped'`)
+3. handler が throw した場合は row を insert せず例外を伝播する。`+server.ts` が 500 を返し、
+   Stripe の再送で再処理される
 
-  // 初回到達 — handler 実行 → 結果を insert (transaction で atomic)
-  let handlerResult: 'success' | 'error' | 'skipped' = 'success';
-  let errorMessage: string | undefined;
-  let tenantId: string | undefined;
+`tenant_id` は payload から解決できる `checkout.session.completed` のみ格納する (analytics 属性、
+他の型は subscription / customer から DB 逆引きが必要なため null)。`error_message` は
+handler 失敗を記録しない方針 (§4.2) のため常に null。
 
-  try {
-    switch (event.type) {
-      case 'checkout.session.completed':
-        tenantId = (event.data.object as Stripe.Checkout.Session).metadata?.tenantId;
-        await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
-        break;
-      case 'invoice.paid':
-        await handleInvoicePaid(event.data.object as Stripe.Invoice);
-        break;
-      case 'invoice.payment_failed':
-        await handlePaymentFailed(event.data.object as Stripe.Invoice);
-        break;
-      case 'customer.subscription.updated':
-        await handleSubscriptionUpdated(event.data.object as Stripe.Subscription);
-        break;
-      case 'customer.subscription.deleted':
-        await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
-        break;
-      // Phase 5 子 1 新規 3 種 (Phase 7 で handler 実装)
-      case 'subscription_schedule.aborted':
-      case 'subscription_schedule.canceled':
-      case 'subscription_schedule.completed':
-        await handleSubscriptionScheduleEvent(event); // Phase 7 新規
-        break;
-      default:
-        handlerResult = 'skipped';
-        logger.info(`[STRIPE] Unhandled event type: ${event.type}`);
-    }
-  } catch (err) {
-    handlerResult = 'error';
-    errorMessage = String(err).slice(0, 500); // 500 文字 truncate (PII 流入回避)
-    logger.error(`[STRIPE] Webhook handler failed: ${event.id} type=${event.type}`, { error: errorMessage });
-    // 例外を re-throw しない — dedup row を必ず insert して次回到達時の再処理判断材料を残す
-  }
+### 4.2 設計判断: handler 失敗時は dedup row を残さず再 throw する
 
-  await repos.webhookEvent.insert({
-    eventId: event.id,
-    eventType: event.type,
-    processedAt: new Date().toISOString(),
-    handlerResult,
-    errorMessage,
-    retryCount: 0,
-    tenantId,
-  });
-}
-```
+**採用**: handler 失敗時は dedup row を insert せず例外を伝播し、Stripe の再送に載せる
+(`stripe_webhook_events` は「**完了した** event の台帳」を意味する)。
 
-### 4.2 設計判断: handler 失敗時に exception を re-throw しない
+**不採用**: handler 失敗時も row を insert して 200 を返す案。この案は同一 event の無限 retry を
+避けられる一方、**一過性の障害 (DB / Stripe API の瞬断) で event を恒久的に失う**。実測でも
+2026-07-26 の配信失敗 22 分は Stripe の再送で復旧しており、retry 経路を潰す副作用の方が大きい。
+恒久的な handler バグで再送が続く場合は Stripe 側が 3 日で配信を諦め、その間 500 が観測される
+(沈黙して失敗するより検知しやすい)。
 
-**選択肢 A (採用)**: handler 失敗時も dedup row を insert、HTTP 200 で Stripe に返答
-**選択肢 B (不採用)**: handler 失敗時は dedup row insert を skip、HTTP 5xx で Stripe 側 retry に委ねる
-
-A 採用根拠:
-- 同一 event の無限 retry loop (handler が永続的なバグで失敗する場合) を回避
-- `handler_result='error'` row が残ることで運用 alert (Sentry / Discord) が発火し、人間が修正できる
-- Stripe 側 retry に頼ると **B プランの handler 修正 deploy 完了前に Stripe retry exhaustion (3 日後) でイベント完全消失**するリスク
-- B が有効なケース (一時的なネットワーク障害等) は Stripe 側 5xx 検知の自動 retry より、自社 alert + 手動 `stripe events resend` の方が運用統制が効く
-
-ただし `handler_result='error'` row は **次回 manual replay (`stripe events resend evt_*`) 時に skip されてしまう** ため、Phase 7 で **error row の手動再処理 endpoint** (`POST /api/admin/stripe/webhook/replay?event_id=evt_*`) を別途検討 (Phase 5 scope 外、Phase 7 follow-up Issue 起票推奨)。
+回帰: `tests/unit/services/stripe-webhook-dedup.test.ts` の
+「handler が失敗した event は台帳に残らず、再送で再処理される」。
 
 ### 4.3 dedup 機構の影響を受ける handler 一覧
 
@@ -312,19 +261,13 @@ A 採用根拠:
 
 ## 5. 30 日 retention (ADR-0049 整合)
 
-### 5.1 SQLite (Drizzle) — 日次 cron で物理削除
+### 5.1 日次 cron で物理削除
 
-```typescript
-// src/lib/server/services/retention-service.ts (Phase 7 で拡張、本 PR scope 外)
-async function purgeStaleWebhookEvents() {
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - 30);
-  const deleted = await repos.webhookEvent.deleteOlderThan(cutoff.toISOString());
-  logger.info(`[RETENTION] Purged ${deleted} stale stripe_webhook_events`);
-}
-```
-
-cron 配置: `src/lib/server/cron/retention-cron.ts` の既存 retention cron に統合 (`activity_logs` / `point_ledger` 等と同 batch、Phase 7 拡張)。
+`cleanupExpiredData` (`src/lib/server/services/retention-cleanup-service.ts`) が
+`repos.webhookEvent.deleteOlderThan(now - 30 日)` を 1 回だけ呼ぶ (`stripe_webhook_events` は
+tenant 非依存のグローバル表のため、テナントループの外)。cron は既存の `retention-cleanup`
+(毎日 01:00 JST、`src/lib/server/cron/schedule-registry.ts`) に相乗りし、削除件数は
+`webhookEventsDeleted` として結果に載る。`dryRun` では削除しない。
 
 ### 5.2 DynamoDB — item-level TTL native 機能
 
@@ -374,31 +317,31 @@ await client.put({
 
 ## 7. ADR-0031 (DB migration) 整合: migration script 仕様
 
-新規 table 追加のため SQLite migration が必要 (Phase 7 で `drizzle-kit generate` 実行)。
+table は配備済 (`schema.ts` / `create-tables.ts` / `lazy-startup-migrations.ts` / `tests/e2e/global-setup.ts`)。既存 DB には lazy-startup migration が起動時に `CREATE TABLE` + 2 index を流す。
 
 | 項目 | 仕様 |
 |---|---|
 | migration ファイル | `drizzle/migrations/NNNN_add_stripe_webhook_events.sql` (NNNN は Phase 7 時点の連番) |
 | migration 内容 | `CREATE TABLE stripe_webhook_events (...)` + 2 index 作成 |
 | rollback 戦略 | `DROP TABLE stripe_webhook_events`、active 0 件で再構築可 (data loss tolerable) |
-| 初回 deploy 後の動作 | 初回 webhook 到達時に最初の row が insert される、既存 webhook handler は無改変で動作 (Phase 7 で dispatcher 側に dedup check を追加するまで dedup は無効、ただし table 自体は存在する) |
+| 初回 deploy 後の動作 | 初回 webhook 到達時に最初の row が insert される。handler 本体は無改変で、dedup は dispatcher 入口が担う |
 | DynamoDB の場合 | DynamoDB は schemaless のため migration 不要、TTL 属性は table 設定 (CDK で 1 行追加: `timeToLiveAttribute: 'ttl'`) |
 
 **ADR-0031 (DB migration) 整合**: 本 table 追加は **新規 table 追加のみで既存 schema に変更なし**、ロールバック容易、parallel-implementations.md 並行 4 backend 整合済 → ADR-0031 §3 「破壊的変更時の compat test 義務化」対象外。`tests/unit/db/schema.test.ts` の CREATE TABLE 一覧に 1 行追加で済む。
 
-## 8. テスト計画 (Phase 7 一括実行)
+## 8. テスト
 
-| カテゴリ | テスト内容 | ファイル (Phase 7 新規作成、本 PR scope 外) | 実行 phase |
-|---|---|---|---|
-| **unit test** | dispatcher 入口 dedup check が既存 row を skip する | `tests/unit/services/stripe-service.dedup.test.ts` 新規 | Phase 7 |
-| **unit test** | dispatcher 入口 dedup check が初回 event を insert する | 同上 | Phase 7 |
-| **unit test** | handler 例外時 `handler_result='error'` で row insert | 同上 | Phase 7 |
-| **unit test** | retry_count increment 動作 | 同上 | Phase 7 |
-| **unit test** | 30 日経過 row が `deleteOlderThan` で削除される | `tests/unit/services/retention-service.webhook.test.ts` 新規 | Phase 7 |
-| **integration** | DynamoDB TTL 属性が正しく設定される (mock LocalStack) | `tests/integration/db/dynamodb/webhook-event-repo.test.ts` 新規 | Phase 7 |
-| **integration** | 4 backend (SQLite / DynamoDB / in-memory) で同一 interface 動作 | 同上 + `tests/unit/db/webhook-event-repo-cross-backend.test.ts` | Phase 7 |
-| **E2E** | Stripe CLI `stripe events resend <event_id>` で同一 event を 2 回送信 → license key 1 個のみ発行 | `tests/e2e/billing/webhook-idempotency.spec.ts` 新規 | Phase 7 (Stripe CLI 実機環境必要) |
-| **E2E** | Stripe CLI で異なる 5 event 型を順次送信 → 5 row insert + 全 handler 1 回ずつ実行 | 同上 | Phase 7 |
+| カテゴリ | テスト内容 | ファイル |
+|---|---|---|
+| unit | 購読 5 種すべてで「同一 event.id 2 回到達 → 副作用 1 回」 | `tests/unit/services/stripe-webhook-dedup.test.ts` |
+| unit | 重複到達で throw しない (呼び出し元が 200 を返せる) / retry_count が増える | 同上 |
+| unit | 別 event.id は dedup されない (dedup の空振り検出) | 同上 |
+| unit | 未購読 event 型は `handler_result='skipped'` で記録され、再到達で dispatch されない | 同上 |
+| unit | handler 失敗時は row を残さず再 throw し、再送で再処理される (§4.2) | 同上 |
+| unit | sqlite backend の repo が demo / dsql と同一契約 (first-writer-wins / retry_count / retention) | `tests/unit/db/sqlite/webhook-event-repo.test.ts` |
+| unit | in-memory (demo) backend の 4 メソッド | `tests/unit/db/webhook-event-repo.test.ts` |
+| unit | dsql backend の PK 冪等性 (ON CONFLICT DO NOTHING) | `tests/unit/db/dsql-global-repos.test.ts` |
+| unit | 30 日 purge が cron 経路で走り、件数が結果に載る / dryRun では走らない | `tests/unit/services/retention-cleanup-service.test.ts` |
 
 ## 9. 影響範囲事後検証 (4 layer impact-analysis)
 
@@ -453,9 +396,9 @@ await client.put({
 
 | # | リスク | 対策 | ロールバック |
 |---|---|---|---|
-| R1 | dedup row insert が handler 実行より先に失敗 → 同一 event が次回到達時に再実行され `checkout.session.completed` 二重 license key 発行 | handler 実行 → row insert 順序、insert 失敗時の error log + Sentry alert で人間が検知 | 想定実害は license key 二重発行のみ、運用側で `revokeLicenseKey` で片方 revoke (Phase 7 で「重複 license key 検知 cron」を別途 follow-up Issue で起票推奨) |
+| R1 | handler 成功後の row insert が失敗 → 同一 event が再送時に再実行され、welcome 通知 2 通 / entitlement 二重適用が起きる | insert は handler 完了直後の 1 文で、失敗時は 500 として観測される。窓は極小 | 発生時は Stripe Dashboard で event を確認し、必要なら手動で状態を是正する |
 | R2 | 30 日 retention で削除直後の replay (理論上は 30 日経過で Stripe 側からも消える) | Stripe 側 retention と同期、replay window を超えた event は重複到達しない | 仕様、対応不要 |
-| R3 | handler 例外を re-throw しないため Stripe 側 retry が抑制され、一時的なネットワーク障害復旧前に手動 alert 対応が間に合わない | Sentry / Discord alert (`handler_result='error'` row insert で発火)、手動 `stripe events resend evt_*` で再処理 | Phase 7 で「error row 自動 retry 機構」を別途検討 (Pre-PMF scope 外、PMF 後判断) |
+| R3 | handler が恒久的に失敗する場合、row を残さない (§4.2) ため Stripe が 3 日間再送し続け 500 が繰り返し観測される | 500 は Stripe Dashboard / CloudWatch で可視。恒久バグは修正 deploy で解消し、再送が生きているうちに自動復旧する | 3 日を過ぎた event は `stripe events resend evt_*` で手動再処理 (30 日以内) |
 | R4 | DynamoDB single-partition (`PK=STRIPE_WEBHOOK_EVENT`) の hot partition | Pre-PMF write rate < 100/日、PMF 後 < 10k/日で物理限界 1000/sec 未達 | PMF 後の hot partition 発生時に GSI 追加 (event_type 別 partition 化)、本 PR scope 外 |
 | R5 | 4 backend (SQLite / DynamoDB / in-memory) の interface 乖離で test 通過しても本番 fail | parallel-implementations.md §9 並行ペア整合チェック、test では各 backend で同一 spec 実行 (Phase 7) | interface 修正 → 全 backend 同期、`parallel-implementations.md` 表で漏れ検出 |
 | R6 | Phase 5 子 1 完了前に本 PR 単独マージ → 既存 5 handler に dedup 効果あるが子 1 の 3 種新規 event 未対応 | 本 PR は **table + interface のみ**、dispatcher 側 dedup logic 統合は Phase 7 統合 PR (子 1 と同一 PR) で実施 | Phase 7 統合 PR を rollback、本 table は active 0 件で残置 |
@@ -472,21 +415,20 @@ await client.put({
 
 → **新規 ADR 起票不要** (新規 ADR 追加 gate §3 該当なし)。本 design doc が判断 SSOT として機能。
 
-## 12. 既存実装の現状と変更点 (delta、2026-05-29 検証)
+## 12. 実装配置
 
-| # | 既存実装 (シンボル参照) | 本要件 | 扱い |
-|---|---|---|---|
-| 1 | `handleWebhookEvent` switch dispatcher (`src/lib/server/services/stripe-service.ts` L221) で dedup check なし | dispatcher 入口で `findByEventId` + 既存時 skip / 不在時 handler 実行 → `insert` | **拡張** (Phase 7、本 PR は設計のみ) |
-| 2 | `verifyWebhookSignature` (`stripe-service.ts` L213) は変更なし、署名検証は維持 | 同上 | **不変** |
-| 3 | 5 handler (L245 / L305 / L333 / L359 / L394) 関数本体は **改変なし** | 同上 | **不変** |
-| 4 | DB schema (`src/lib/server/db/schema.ts`) に webhook 関連 table なし | `stripe_webhook_events` table + 2 index 追加 | **新規** (Phase 7、本 PR は設計のみ) |
-| 5 | DynamoDB keys (`src/lib/server/db/dynamodb/keys.ts`) に `STRIPE_WEBHOOK_EVENT_PK` なし | `STRIPE_WEBHOOK_EVENT_PK` 定数 + `stripeWebhookEventKey` 関数追加 | **新規** (Phase 7) |
-| 6 | repository interface (`src/lib/server/db/interfaces/index.ts`) に `IWebhookEventRepo` なし | `IWebhookEventRepo` interface 追加 + 4 backend 実装 | **新規** (Phase 7) |
-| 7 | retention cron (`src/lib/server/cron/retention-cron.ts`、Phase 7 で拡張対象) に webhook events 対象なし | SQLite で `purgeStaleWebhookEvents` 統合、DynamoDB は TTL 自動削除 | **拡張** (Phase 7) |
+| 役割 | 実体 |
+|---|---|
+| dedup 点 (dispatcher 入口) | `handleWebhookEvent` (`src/lib/server/services/stripe-service.ts`) |
+| 署名検証 (dedup とは独立) | `verifyWebhookSignature` (同上)。dedup の前段で必ず通る |
+| handler 5 種 | `handleCheckoutCompleted` / `handleInvoicePaid` / `handlePaymentFailed` / `handleSubscriptionUpdated` / `handleSubscriptionDeleted` (同上)。dedup 配線に伴う本体改変はない |
+| repo interface | `src/lib/server/db/interfaces/webhook-event-repo.interface.ts` |
+| repo 実装 | `src/lib/server/db/sqlite/webhook-event-repo.ts` / `src/lib/server/db/dsql/webhook-event-repo.ts` (DSQL + NUC PGlite 共用) / `src/lib/server/db/demo/webhook-event-repo.ts` |
+| 注入 | `src/lib/server/db/factory.ts` の `Repositories.webhookEvent` |
+| 30 日 retention | `cleanupExpiredData` (`src/lib/server/services/retention-cleanup-service.ts`) |
+| table / index | `src/lib/server/db/schema.ts` / `src/lib/server/db/dsql/schema.ts` / `src/lib/server/db/create-tables.ts` |
 
-シンボル位置は 2026-05-29 検証済 (行番号は Phase 7 実装で陳腐化するためシンボル名・関数名・定数名でのみ参照、L*** は参考)。
-
-## 13. Open question (PO 判断、Phase 7 で確定)
+## 13. Open question (PO 判断)
 
 | # | 軸 | 論点 | 推奨案 | 状態 |
 |---|---|------|------|------|
@@ -494,8 +436,8 @@ await client.put({
 | 2 | **UX** | dedup 検知時の email 重複送信 (license key 等) を防ぐが、handler 例外時の license 発行失敗を顧客がどう知る? | Phase 1 security FR-1 webhook tenant 再検証と整合: 失敗時に Sentry alert + 運用側手動 license 発行 + 顧客への email 通知 (`/admin/license/manual-issue` 経路、Phase 7 follow-up) | Phase 7 確定待ち |
 | 3 | **security** | error_message に Stripe customer email 等の PII が流入する可能性 (Stripe.Error の `param` 等). 500 文字 truncate で十分か? | (a) `Stripe.Error` 型から `param` / `code` / `type` のみ抽出するヘルパで PII strip、(b) 500 文字 truncate は二重防御 — 両方実装 (Phase 7) | Phase 7 実装時に確定 |
 | 4 | **security (adversarial)** | dedup row 自体への DoS 攻撃 (偽 webhook で signature 失敗 → dedup row 0 件で table 膨張なし、ただし署名検証通過済の event を 100k 並列送信で table 膨張) | 署名検証通過 event のみ dedup 対象、DynamoDB は item 数 1000 万件まで partition 制約なし (BillingMode=PayPerRequest)、SQLite は cron 削除で 30 日上限維持。攻撃成立条件 = Stripe 内部からの大量正規 event のみ (Stripe API 自体が rate limit) | 仕様、対応不要 |
-| 5 | **security (adversarial)** | Phase 5 子 1 の `subscription_schedule.*` 3 種新規 event で handler 未実装期間 (本 PR マージ後 → Phase 7 統合 PR マージ前) は `default: skipped` で dedup row insert される。skipped row が 30 日 retention で削除されない間に Phase 7 で handler 実装 → 30 日以内に再送された subscription_schedule event が `existing.handler_result='skipped'` で skip され、handler 実行されない問題 | (a) `handler_result='skipped'` row は dedup 判定対象外とする (skip された event は handler 実装後に再処理する)、(b) または Phase 5 子 1 PR と Phase 7 統合 PR を同時マージで gap を最小化 | Phase 7 実装時に確定 (推奨: 案 a) |
-| 6 | **security (adversarial)** | dispatcher 入口で `findByEventId` → `insert` の間に **並列で同一 event** が到達した場合 (Stripe 公式は順次配信を保証しないため複数 endpoint instance で同時受信ありえる)、両 instance が `findByEventId` で null を取得 → 両者が `insert` 試行で PK 一意性違反 → 1 つは catch して skip、もう 1 つは handler 実行 → license 二重発行回避 | (a) SQLite は `INSERT OR IGNORE` + `RETURNING` で atomic check-and-insert、(b) DynamoDB は `ConditionExpression: 'attribute_not_exists(SK)'` で同等、(c) in-memory は同期 Map の atomic write で物理単一 instance のみ動作 (demo は並列 webhook なし) | Phase 7 実装時に必須 (推奨案 a/b 両方実装) |
+| 5 | **security (adversarial)** | 未購読 event 型は `handler_result='skipped'` で row が残る。後から handler を実装した場合、30 日以内に再送された同一 event が skip され handler が走らない | 現状は購読 5 種と handler が 1:1 で、購読を増やすとき (Stripe Dashboard の enabled_events 追加) に初めて発生する。新 handler を足す PR で `handler_result='skipped'` の row を dedup 対象外にするか、当該 event を `stripe events resend` で再送する | 購読拡張時に確定 |
+| 6 | **security (adversarial)** | `findByEventId` → `insert` の間に同一 event が並列到達すると、両者が「未処理」を読んで handler を 2 回実行しうる | repo 層は PK への `ON CONFLICT DO NOTHING` (dsql / sqlite) で二重 row を物理拒否する (first-writer-wins) が、**handler 実行そのものの並列は防げない**。現状 endpoint は 1 本で、Stripe の再送間隔は秒〜分単位のため実害は観測されていない。完全に閉じるには claim-first (insert で先に権利を取ってから handler を走らせる) への変更が必要で、handler 失敗時の row 取り消しと引き換えになる | 未解決 (残リスクとして明示) |
 
 ## 14. 関連 (2026-05-29 整合)
 

--- a/docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md
+++ b/docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md
@@ -240,11 +240,17 @@ handler 失敗を記録しない方針 (§4.2) のため常に null。
 **不採用**: handler 失敗時も row を insert して 200 を返す案。この案は同一 event の無限 retry を
 避けられる一方、**一過性の障害 (DB / Stripe API の瞬断) で event を恒久的に失う**。実測でも
 2026-07-26 の配信失敗 22 分は Stripe の再送で復旧しており、retry 経路を潰す副作用の方が大きい。
-恒久的な handler バグで再送が続く場合は Stripe 側が 3 日で配信を諦め、その間 500 が観測される
-(沈黙して失敗するより検知しやすい)。
+**再送に委ねる以上、再送が尽きる前に人が気づける導線を必須とする**。Stripe は 3 日で配信を
+諦めるため、恒久的な handler バグを log だけに残すと課金 event を無通知で失う。`handleWebhookEvent`
+の catch 1 箇所で **初回失敗の時点から** Discord alert (`stripe-webhook-handler-failed`) を上げる。
+同一 `event.id` の反復は `sendDiscordAlert` の throttle (errorSummary key / 5 分 window / 3 件で
+まとめ通知) が抑制するため、失敗回数を数える機構は持たない。alert SSOT は
+[phase6-rollback-and-kill-switches.md §3.10-b R11](phase6-rollback-and-kill-switches.md)。
+event が Lambda に到達しないケース (配信そのものの未達) の検知は #3959 が担う。
 
 回帰: `tests/unit/services/stripe-webhook-dedup.test.ts` の
-「handler が失敗した event は台帳に残らず、再送で再処理される」。
+「handler が失敗した event は台帳に残らず、再送で再処理される」 /
+「handler 失敗は初回から Discord alert に上がる」。
 
 ### 4.3 dedup 機構の影響を受ける handler 一覧
 
@@ -437,7 +443,7 @@ table は配備済 (`schema.ts` / `create-tables.ts` / `lazy-startup-migrations.
 | 3 | **security** | error_message に Stripe customer email 等の PII が流入する可能性 (Stripe.Error の `param` 等). 500 文字 truncate で十分か? | (a) `Stripe.Error` 型から `param` / `code` / `type` のみ抽出するヘルパで PII strip、(b) 500 文字 truncate は二重防御 — 両方実装 (Phase 7) | Phase 7 実装時に確定 |
 | 4 | **security (adversarial)** | dedup row 自体への DoS 攻撃 (偽 webhook で signature 失敗 → dedup row 0 件で table 膨張なし、ただし署名検証通過済の event を 100k 並列送信で table 膨張) | 署名検証通過 event のみ dedup 対象、DynamoDB は item 数 1000 万件まで partition 制約なし (BillingMode=PayPerRequest)、SQLite は cron 削除で 30 日上限維持。攻撃成立条件 = Stripe 内部からの大量正規 event のみ (Stripe API 自体が rate limit) | 仕様、対応不要 |
 | 5 | **security (adversarial)** | 未購読 event 型は `handler_result='skipped'` で row が残る。後から handler を実装した場合、30 日以内に再送された同一 event が skip され handler が走らない | 現状は購読 5 種と handler が 1:1 で、購読を増やすとき (Stripe Dashboard の enabled_events 追加) に初めて発生する。新 handler を足す PR で `handler_result='skipped'` の row を dedup 対象外にするか、当該 event を `stripe events resend` で再送する | 購読拡張時に確定 |
-| 6 | **security (adversarial)** | `findByEventId` → `insert` の間に同一 event が並列到達すると、両者が「未処理」を読んで handler を 2 回実行しうる | repo 層は PK への `ON CONFLICT DO NOTHING` (dsql / sqlite) で二重 row を物理拒否する (first-writer-wins) が、**handler 実行そのものの並列は防げない**。現状 endpoint は 1 本で、Stripe の再送間隔は秒〜分単位のため実害は観測されていない。完全に閉じるには claim-first (insert で先に権利を取ってから handler を走らせる) への変更が必要で、handler 失敗時の row 取り消しと引き換えになる | 未解決 (残リスクとして明示) |
+| 6 | **security (adversarial)** | `findByEventId` → `insert` の間に同一 event が並列到達すると、両者が「未処理」を読んで handler を 2 回実行しうる | repo 層は PK への `ON CONFLICT DO NOTHING` (dsql / sqlite) で二重 row を物理拒否する (first-writer-wins) が、**handler 実行そのものの並列は防げない**。現状 endpoint は 1 本で、Stripe の再送間隔は秒〜分単位のため実害は観測されていない。完全に閉じるには claim-first (insert で先に権利を取ってから handler を走らせる) への変更が必要で、handler 失敗時の row 取り消しと引き換えになる。**再評価トリガ (下記 3 条件のいずれかを満たしたら claim-first を再検討する)**: (a) webhook endpoint を 2 本以上運用する構成になったとき (b) Lambda の同時実行が常態化するほど契約数が増えたとき (c) 二重処理を 1 件でも観測したとき | 受容 (再評価トリガ付き) |
 
 ## 14. 関連 (2026-05-29 整合)
 

--- a/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
+++ b/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
@@ -171,7 +171,16 @@ historical record (旧設計): Sentry TypeError 検知 + Dashboard `webhookEndpo
 | **ロールバック手順** | (1) alert の `tags.subscriptionId` で Stripe 上の現行 price を確認 (2) price が env var (`STRIPE_PRICE_*_MONTHLY`) / lookup_key (`standard_monthly` / `premium_monthly`) のどちらにも一致しない原因を切り分け (Price 差し替え / env var 未同期 / `transfer_lookup_key` 実行中) (3) env var を Stripe の現行 Price に同期して Lambda 再 deploy。**plan は既存値が保持されているため DB の手動修復は不要** |
 | **再発防止** | (a) plan 解決を `resolvePlanFromSubscription()` (subscription の現行 price → priceId 逆引き → lookup_key 逆引き) に集約し SSOT 化 (b) `planUpdateOrKeep()` で silent fallback を構造的に不能化 (未解決時は `plan` キー自体を渡さず既存値保持 + alert) (c) proration 複数行 invoice fixture + `subscription.updated` / `invoice.paid` の**両配信順序**の unit test (`tests/unit/services/stripe-service.test.ts`) |
 
-### 3.10 想定リスク 8 件 SSOT サマリ表 (#2683 補強で +R8 / +R9、R3 / R5 historical 化、#3960 で +R10)
+### 3.10-b R11 (#3985 新規): webhook handler の恒久的失敗が誰にも気づかれないまま Stripe の再送が尽きる
+
+| 項目 | 内容 |
+|---|---|
+| **シナリオ** | dedup 台帳 `stripe_webhook_events` は「**完了した** event の台帳」であり、handler 失敗時は row を残さず再 throw して Stripe の再送に載せる ([phase5-webhook-idempotency-architecture.md §4.2](phase5-webhook-idempotency-architecture.md))。恒久的な handler バグ / 依存先障害では再送も失敗し続け、**Stripe は 3 日で配信を諦める**。その間に決済した家庭は有料機能が開かないまま放置される |
+| **検知 method** | (a) Discord alert `stripe-webhook-handler-failed` (**初回失敗の時点**で発火。同一 `event.id` の反復は `sendDiscordAlert` の throttle = errorSummary key / 5 分 window / 3 件でまとめ通知 が抑制する) (b) CloudWatch Logs Insights `filter kind = "stripe-webhook-handler-failed"` で eventId / eventType / error を特定 (c) webhook endpoint の 500 応答率 |
+| **ロールバック手順** | (1) alert の `tags.eventType` から失敗 handler を特定 (2) 原因が依存先の一過性障害なら Stripe の再送で自然復旧するため待機 (3) 恒久バグなら fix を deploy。台帳に row が無いため**再送到達分がそのまま再処理される** (4) 3 日の再送期限を過ぎた event は Stripe Dashboard / `stripe events resend` で手動再送 |
+| **再発防止** | (a) 失敗時 alert を `handleWebhookEvent` の catch 1 箇所に集約 (event 型ごとに分散させない) (b) `tests/unit/services/stripe-webhook-dedup.test.ts` の「handler 失敗は初回から Discord alert に上がる」で回帰 (c) event の未達そのものの検知は #3959 (Stripe 側 `pending_webhooks` 滞留の cron 検査) が担う |
+
+### 3.10 想定リスク 8 件 SSOT サマリ表 (#2683 補強で +R8 / +R9、R3 / R5 historical 化、#3960 で +R10、#3985 で +R11)
 
 | # | リスク | 検知 method (主) | ロールバック手順 (簡略) | 再発防止 (CI / Pre-Ready) |
 |---|---|---|---|---|
@@ -185,6 +194,7 @@ historical record (旧設計): Sentry TypeError 検知 + Dashboard `webhookEndpo
 | **R8 (#2683 新規)** | **ダウン credit memo の顧客信頼毀損** | 顧客 inquiry + シナリオ 3 E2E | Phase 3 hybrid confirm UI + 請求履歴 credit memo 表示 | Step 3 hybrid confirm UI 実装 + シナリオ 3 E2E |
 | **R9 (#2683 新規)** | **Webhook destination api_version immutable 見落とし** | Dashboard UI エラー + Stripe SDK `StripeInvalidRequestError` | 新 destination 新規作成 + 5 phase migration 再実施 | Pre-Ready unit test (`webhookEndpoints.update({api_version})` 400 assert) + Phase 6 子 1 §5 Webhook 5 phase migration 必須化 |
 | **R10 (#3960 新規)** | **plan 未解決時の silent fallback で誤 plan 書込み** | Discord alert `stripe-plan-unresolved` + CloudWatch Logs Insights | env var / lookup_key を Stripe 現行 Price に同期 + Lambda 再 deploy (plan は既存値保持のため DB 修復不要) | `resolvePlanFromSubscription()` / `planUpdateOrKeep()` に集約 + proration 複数行 fixture + 両配信順序 unit test |
+| **R11 (#3985 新規)** | **handler の恒久的失敗が無通知のまま Stripe の 3 日再送を使い切る** | Discord alert `stripe-webhook-handler-failed` (初回失敗で発火) + CloudWatch Logs Insights | 一過性なら再送で自然復旧 / 恒久バグは fix deploy 後に再送分が再処理される。期限切れ分は `stripe events resend` | 失敗 alert を `handleWebhookEvent` catch 1 箇所に集約 + `stripe-webhook-dedup.test.ts` の失敗 alert 回帰 (未達検知は #3959) |
 
 ## 4. #2627 Stripe Dashboard ロールバック 3 期間別マトリクス (§4)
 

--- a/src/lib/server/db/factory.ts
+++ b/src/lib/server/db/factory.ts
@@ -40,6 +40,7 @@ import * as demoStorageRepo from './demo/storage-repo';
 import * as demoTrialHistoryRepo from './demo/trial-history-repo';
 import * as demoViewerTokenRepo from './demo/viewer-token-repo';
 import * as demoVoiceRepo from './demo/voice-repo';
+import { demoWebhookEventRepo } from './demo/webhook-event-repo';
 import { createDsqlAccountLockoutRepo } from './dsql/account-lockout-repo';
 import { createDsqlActivationFunnelRepo } from './dsql/activation-funnel-repo';
 import { createDsqlActivityMasteryRepo } from './dsql/activity-mastery-repo';
@@ -78,6 +79,7 @@ import { createDsqlStatusRepo } from './dsql/status-repo';
 import { createDsqlTrialHistoryRepo } from './dsql/trial-history-repo';
 import { createDsqlViewerTokenRepo } from './dsql/viewer-token-repo';
 import { createDsqlVoiceRepo } from './dsql/voice-repo';
+import { createDsqlWebhookEventRepo } from './dsql/webhook-event-repo';
 // #3438 Phase 2B: dynamodb/*-repo は撤去 (storage は Phase 1 #3786 で s3/ へ移設済)。
 import type { IAccountLockoutRepo } from './interfaces/account-lockout-repo.interface';
 import type { IActivationFunnelRepo } from './interfaces/activation-funnel-repo.interface';
@@ -116,6 +118,7 @@ import type { TransactionRunner } from './interfaces/transaction.interface';
 import type { ITrialHistoryRepo } from './interfaces/trial-history-repo.interface';
 import type { IViewerTokenRepo } from './interfaces/viewer-token-repo.interface';
 import type { IVoiceRepo } from './interfaces/voice-repo.interface';
+import type { IWebhookEventRepo } from './interfaces/webhook-event-repo.interface';
 // #3620 AC-C2 (ADR-0064 案 C): NUC=PGlite は dsql (pg-core) repos を verbatim 再利用する。
 // getPglite*Sync は init 済み前提の同期アクセサ (async init は hooks.server.ts の 1st-request
 // guard で await 済み)。pglite 分岐内でのみ呼ぶこと (他 backend で PGlite を open させない)。
@@ -157,6 +160,7 @@ import * as sqliteStorageRepo from './sqlite/storage-repo';
 import * as sqliteTrialHistoryRepo from './sqlite/trial-history-repo';
 import * as sqliteViewerTokenRepo from './sqlite/viewer-token-repo';
 import * as sqliteVoiceRepo from './sqlite/voice-repo';
+import * as sqliteWebhookEventRepo from './sqlite/webhook-event-repo';
 
 export interface Repositories {
 	accountLockout: IAccountLockoutRepo;
@@ -207,6 +211,12 @@ export interface Repositories {
 	storage: IStorageRepo;
 	trialHistory: ITrialHistoryRepo;
 	viewerToken: IViewerTokenRepo;
+	/**
+	 * #3985: Stripe webhook の event.id dedup (`stripe_webhook_events`)。
+	 * `handleWebhookEvent` dispatcher 入口の単一 dedup 点が唯一の消費者
+	 * (設計 SSOT: billing-redesign/phase5-webhook-idempotency-architecture.md §2 / §4.1)。
+	 */
+	webhookEvent: IWebhookEventRepo;
 	voice: IVoiceRepo;
 }
 
@@ -258,6 +268,7 @@ function buildPgBackendRepos<TTx extends SqlExecutor>(
 		storage: s3StorageRepo,
 		trialHistory: createDsqlTrialHistoryRepo(db),
 		viewerToken: createDsqlViewerTokenRepo(db),
+		webhookEvent: createDsqlWebhookEventRepo(db),
 		voice: createDsqlVoiceRepo(db, runner),
 	};
 }
@@ -307,6 +318,7 @@ export function getRepos(): Repositories {
 			storage: demoStorageRepo,
 			trialHistory: demoTrialHistoryRepo,
 			viewerToken: demoViewerTokenRepo,
+			webhookEvent: demoWebhookEventRepo,
 			voice: demoVoiceRepo,
 		};
 		_repos = repos;
@@ -361,6 +373,7 @@ export function getRepos(): Repositories {
 		storage: sqliteStorageRepo,
 		trialHistory: sqliteTrialHistoryRepo,
 		viewerToken: sqliteViewerTokenRepo,
+		webhookEvent: sqliteWebhookEventRepo,
 		voice: sqliteVoiceRepo,
 	};
 	_repos = repos;

--- a/src/lib/server/db/sqlite/webhook-event-repo.ts
+++ b/src/lib/server/db/sqlite/webhook-event-repo.ts
@@ -1,0 +1,68 @@
+// src/lib/server/db/sqlite/webhook-event-repo.ts
+// SQLite implementation of IWebhookEventRepo (#2641 / #3985)
+//
+// 設計 SSOT: docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md §3.1 / §3.4
+//
+// 表 (`stripe_webhook_events`) は `src/lib/server/db/schema.ts` に配備済み
+// (create-tables.ts / lazy-startup-migrations.ts / tests/e2e/global-setup.ts と並行同期済)。
+// 本 file は「表はあるが sqlite backend の repo 実装だけ無い」欠落を埋める (#3985)。
+//
+// 冪等性契約 (interface SSOT 整合): 並列同時到達の二重 insert は PK (event_id) への
+// `ON CONFLICT DO NOTHING` (drizzle `onConflictDoNothing`) で 2 度目以降を物理拒否する
+// (first-writer-wins)。dsql 実装と同一挙動。
+
+import { eq, lt, sql } from 'drizzle-orm';
+import { db } from '../client';
+import type { WebhookEventRecord } from '../interfaces/webhook-event-repo.interface';
+import { stripeWebhookEvents } from '../schema';
+
+function toRecord(row: typeof stripeWebhookEvents.$inferSelect): WebhookEventRecord {
+	return {
+		eventId: row.eventId,
+		eventType: row.eventType,
+		processedAt: row.processedAt,
+		handlerResult: row.handlerResult,
+		errorMessage: row.errorMessage,
+		retryCount: row.retryCount,
+		tenantId: row.tenantId,
+	};
+}
+
+export async function findByEventId(eventId: string): Promise<WebhookEventRecord | null> {
+	const rows = await db
+		.select()
+		.from(stripeWebhookEvents)
+		.where(eq(stripeWebhookEvents.eventId, eventId))
+		.limit(1);
+	return rows[0] ? toRecord(rows[0]) : null;
+}
+
+export async function insert(record: WebhookEventRecord): Promise<void> {
+	await db
+		.insert(stripeWebhookEvents)
+		.values({
+			eventId: record.eventId,
+			eventType: record.eventType,
+			processedAt: record.processedAt,
+			handlerResult: record.handlerResult,
+			errorMessage: record.errorMessage,
+			retryCount: record.retryCount,
+			tenantId: record.tenantId,
+		})
+		.onConflictDoNothing();
+}
+
+export async function incrementRetryCount(eventId: string): Promise<void> {
+	await db
+		.update(stripeWebhookEvents)
+		.set({ retryCount: sql`${stripeWebhookEvents.retryCount} + 1` })
+		.where(eq(stripeWebhookEvents.eventId, eventId));
+}
+
+export async function deleteOlderThan(cutoffIso: string): Promise<number> {
+	const result = db
+		.delete(stripeWebhookEvents)
+		.where(lt(stripeWebhookEvents.processedAt, cutoffIso))
+		.run();
+	return result.changes;
+}

--- a/src/lib/server/services/retention-cleanup-service.ts
+++ b/src/lib/server/services/retention-cleanup-service.ts
@@ -21,6 +21,7 @@ import {
 	type AuthLicenseStatus,
 } from '$lib/domain/constants/auth-license-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { MS_PER_DAY } from '$lib/domain/constants/time';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import {
@@ -36,8 +37,19 @@ export interface RetentionCleanupResult {
 	activityLogsDeleted: number;
 	pointLedgerDeleted: number;
 	statusHistoryDeleted: number; // #3518-2
+	/**
+	 * #3985: `stripe_webhook_events` の 30 日超過 row 削除数 (tenant 非依存のグローバル表)。
+	 * Stripe Events API 自体が 30 日で replay 不能になるため、それ以上保持しても dedup 効果がない。
+	 */
+	webhookEventsDeleted: number;
 	errors: Array<{ tenantId: string; error: string }>;
 }
+
+/**
+ * Stripe webhook dedup 台帳の保持期間 (日)。
+ * Stripe Events API の保持期間 (30 日) と同期する (ADR-0049 / phase5 §5.3)。
+ */
+const WEBHOOK_EVENT_RETENTION_DAYS = 30;
 
 export interface RetentionCleanupOptions {
 	/** true の場合、削除を実行せず件数カウントのみ返す */
@@ -84,6 +96,7 @@ export async function cleanupExpiredData(
 		activityLogsDeleted: 0,
 		pointLedgerDeleted: 0,
 		statusHistoryDeleted: 0, // #3518-2
+		webhookEventsDeleted: 0, // #3985
 		errors: [],
 	};
 
@@ -179,6 +192,26 @@ export async function cleanupExpiredData(
 			logger.error('[retention-cleanup] tenant failed', {
 				service: 'retention-cleanup',
 				tenantId: tenant.tenantId,
+				error: errMsg,
+				stack: e instanceof Error ? e.stack : undefined,
+			});
+		}
+	}
+
+	// #3985: Stripe webhook dedup 台帳の 30 日 retention。tenant ループの外で 1 回だけ実行する
+	// (`stripe_webhook_events` は tenant 非依存のグローバル表)。
+	// 1 テナントの失敗が他に波及しないのと同じ理由で、ここの失敗も cleanup 全体を落とさない。
+	if (!dryRun) {
+		try {
+			const cutoffIso = new Date(
+				Date.now() - WEBHOOK_EVENT_RETENTION_DAYS * MS_PER_DAY,
+			).toISOString();
+			result.webhookEventsDeleted = await repos.webhookEvent.deleteOlderThan(cutoffIso);
+		} catch (e) {
+			const errMsg = e instanceof Error ? e.message : String(e);
+			result.errors.push({ tenantId: '(global)', error: errMsg });
+			logger.error('[retention-cleanup] webhook events purge failed', {
+				service: 'retention-cleanup',
 				error: errMsg,
 				stack: e instanceof Error ? e.stack : undefined,
 			});

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -225,26 +225,98 @@ export async function verifyWebhookSignature(
 	return stripe.webhooks.constructEvent(body, signature, getWebhookSecret());
 }
 
+/**
+ * Stripe webhook の単一 dedup 点 (#3985)。
+ *
+ * Stripe の at-least-once delivery では **同一 `event.id` の再到達が正規動作**
+ * (<https://docs.stripe.com/webhooks#handle-duplicate-events>)。dedup が無いと
+ * welcome メール 2 通 / past_due ↔ active の振動 / 解約 → 再活性化の振動が素通しになる。
+ *
+ * dedup は event 型ごとに分散させず **dispatcher 入口 1 箇所**で行う
+ * (設計 SSOT: `billing-redesign/phase5-webhook-idempotency-architecture.md` §2 / §4.1)。
+ * 新しい event 型が増えても dedup の書き忘れが構造的に起きない。
+ *
+ * 処理順序と失敗時の保証:
+ *
+ * 1. `findByEventId` が既存 row を返す → **handler を呼ばず** retry_count を +1 して return。
+ *    呼び出し元 (`+server.ts`) は 200 を返す (4xx/5xx は Stripe の retry を誘発する、§2)。
+ * 2. 未処理 → handler を実行し、**完了後に** dedup row を insert する。
+ *    - handler が throw した場合は row を insert せず例外を伝播する。次回到達で再処理され、
+ *      呼び出し元は 500 を返して Stripe の retry に載る (§2 が transaction で担保しようとした
+ *      「row 書込み失敗 = 次回再実行」を、insert を後段に置くことで満たす)。
+ *    - 設計書 §4.2 の選択肢 A (handler 失敗時も row を insert し 200 を返す) は**採らない**。
+ *      A は一過性の障害 (DB / Stripe API の瞬断) で event を恒久的に失う。実際 2026-07-26 の
+ *      配信失敗 22 分は Stripe の再送で復旧しており、retry 経路を潰す副作用の方が大きい。
+ *      結果として `stripe_webhook_events` は「**完了した** event の台帳」を意味する。
+ *
+ * 単一 tenant の契約状態を書く側のガード (event 対象と現行契約の突合) は別レイヤーの防御であり、
+ * 本 dedup はそれを代替しない (逆も同じ)。
+ */
 export async function handleWebhookEvent(event: Stripe.Event): Promise<void> {
+	const webhookEvents = getRepos().webhookEvent;
+
+	const existing = await webhookEvents.findByEventId(event.id);
+	if (existing) {
+		await webhookEvents.incrementRetryCount(event.id);
+		logger.info(
+			`[STRIPE] Duplicate webhook event skipped: ${event.id} type=${event.type} ` +
+				`retry=${existing.retryCount + 1} firstResult=${existing.handlerResult}`,
+		);
+		return;
+	}
+
+	const handlerResult = await dispatchWebhookEvent(event);
+
+	await webhookEvents.insert({
+		eventId: event.id,
+		eventType: event.type,
+		processedAt: new Date().toISOString(),
+		handlerResult,
+		errorMessage: null,
+		retryCount: 0,
+		tenantId: resolveEventTenantId(event),
+	});
+}
+
+/**
+ * event 型ごとの handler dispatch (dedup 判定を通過した初回到達のみ到達する)。
+ *
+ * @returns 未購読 event 型なら `'skipped'`、購読済なら `'success'` (例外は伝播する)
+ */
+async function dispatchWebhookEvent(event: Stripe.Event): Promise<'success' | 'skipped'> {
 	switch (event.type) {
 		case 'checkout.session.completed':
 			await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
-			break;
+			return 'success';
 		case 'invoice.paid':
 			await handleInvoicePaid(event.data.object as Stripe.Invoice);
-			break;
+			return 'success';
 		case 'invoice.payment_failed':
 			await handlePaymentFailed(event.data.object as Stripe.Invoice);
-			break;
+			return 'success';
 		case 'customer.subscription.updated':
 			await handleSubscriptionUpdated(event.data.object as Stripe.Subscription);
-			break;
+			return 'success';
 		case 'customer.subscription.deleted':
 			await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
-			break;
+			return 'success';
 		default:
 			logger.info(`[STRIPE] Unhandled event type: ${event.type}`);
+			return 'skipped';
 	}
+}
+
+/**
+ * dedup row の analytics 属性 `tenant_id` を payload から解決する (解決不能なら null)。
+ *
+ * PII は載せない (interface SSOT)。tenant を payload に持つのは checkout のみで、他の event 型は
+ * subscription / customer から DB 逆引きする必要があるため、ここでは解決しない。
+ */
+function resolveEventTenantId(event: Stripe.Event): string | null {
+	if (event.type === 'checkout.session.completed') {
+		return (event.data.object as Stripe.Checkout.Session).metadata?.tenantId ?? null;
+	}
+	return null;
 }
 
 // --- Webhook handlers ---

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -265,7 +265,29 @@ export async function handleWebhookEvent(event: Stripe.Event): Promise<void> {
 		return;
 	}
 
-	const handlerResult = await dispatchWebhookEvent(event);
+	let handlerResult: 'success' | 'skipped';
+	try {
+		handlerResult = await dispatchWebhookEvent(event);
+	} catch (err) {
+		// 台帳に残さず再 throw する (§4.2) 以上、失敗の観測は Stripe の再送が尽きる前に
+		// 人に届く必要がある。Stripe は 3 日で配信を諦めるため、log だけでは
+		// 「誰も気づかないまま課金 event が消える」経路が残る。
+		//
+		// 初回失敗の時点で alert する (N 回まで待たない)。同一 event.id の反復は
+		// `sendDiscordAlert` の throttle (errorSummary key / 5 分 window / 3 件でまとめ通知)
+		// が抑制するため、新規の計数機構を持たない。
+		notifyStripeAlert({
+			kind: 'stripe-webhook-handler-failed',
+			message: `webhook handler が失敗 (台帳に残さず Stripe の再送に載せる): ${event.type}`,
+			errorSummary: `webhook-handler-failed:${event.id}`,
+			tags: {
+				eventId: event.id,
+				eventType: event.type,
+				error: err instanceof Error ? err.message : String(err),
+			},
+		});
+		throw err;
+	}
 
 	await webhookEvents.insert({
 		eventId: event.id,

--- a/src/lib/server/stripe/alert.ts
+++ b/src/lib/server/stripe/alert.ts
@@ -37,7 +37,11 @@ export type StripeAlertKind =
 	| 'stripe-webhook-handler-typeerror'
 	// #3960: webhook payload から plan を確定できなかった。silent fallback で
 	// 誤った plan を書き込む代わりに既存 plan を保持し、本 alert で観測可能化する。
-	| 'stripe-plan-unresolved';
+	| 'stripe-plan-unresolved'
+	// #3985: webhook handler が失敗した。dedup 台帳には残さず Stripe の再送に載せるため
+	// (phase5-webhook-idempotency-architecture.md §4.2)、再送が 3 日で尽きる前に
+	// 人が気づける導線として初回失敗の時点で alert する。
+	| 'stripe-webhook-handler-failed';
 
 export interface StripeAlertOptions {
 	/** alert 種別 (Phase 6 子 5 §6 SSOT 3 種) */

--- a/tests/unit/db/factory-dsql-branch.test.ts
+++ b/tests/unit/db/factory-dsql-branch.test.ts
@@ -67,6 +67,7 @@ const REPOSITORY_KEYS = [
 	'trialHistory',
 	'viewerToken',
 	'voice',
+	'webhookEvent', // #3985: Stripe webhook の event.id dedup 台帳
 ] as const;
 
 async function importFreshFactory() {

--- a/tests/unit/db/factory-pglite-branch.test.ts
+++ b/tests/unit/db/factory-pglite-branch.test.ts
@@ -66,6 +66,7 @@ const REPOSITORY_KEYS = [
 	'trialHistory',
 	'viewerToken',
 	'voice',
+	'webhookEvent', // #3985: Stripe webhook の event.id dedup 台帳
 ] as const;
 
 async function importFreshFactory() {

--- a/tests/unit/db/sqlite/webhook-event-repo.test.ts
+++ b/tests/unit/db/sqlite/webhook-event-repo.test.ts
@@ -1,0 +1,110 @@
+// tests/unit/db/sqlite/webhook-event-repo.test.ts
+//
+// #3985: sqlite backend の IWebhookEventRepo 実装。
+//
+// `stripe_webhook_events` は schema / create-tables / lazy-migration / e2e global-setup に
+// 配備済みだったが、**sqlite backend の repo 実装だけが欠落**していた (dsql / demo のみ存在)。
+// factory から dedup 台帳を注入するにあたり、demo (in-memory) / dsql と同一契約で振る舞うことを
+// backend ごとに固定する (interface SSOT:
+// src/lib/server/db/interfaces/webhook-event-repo.interface.ts)。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { closeDb, createTestDb, resetDb, type TestSqlite } from '../../helpers/test-db';
+
+const dbHolder: { sqlite: TestSqlite | null; db: ReturnType<typeof createTestDb>['db'] | null } = {
+	sqlite: null,
+	db: null,
+};
+
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		if (!dbHolder.db) throw new Error('test db not initialized');
+		return dbHolder.db;
+	},
+}));
+
+// import after mock
+import type { WebhookEventRecord } from '$lib/server/db/interfaces/webhook-event-repo.interface';
+import {
+	deleteOlderThan,
+	findByEventId,
+	incrementRetryCount,
+	insert,
+} from '$lib/server/db/sqlite/webhook-event-repo';
+
+function makeRecord(overrides: Partial<WebhookEventRecord> = {}): WebhookEventRecord {
+	return {
+		eventId: 'evt_1ABCxyz',
+		eventType: 'checkout.session.completed',
+		processedAt: '2026-05-30T12:00:00.000Z',
+		handlerResult: 'success',
+		errorMessage: null,
+		retryCount: 0,
+		tenantId: null,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	if (!dbHolder.sqlite) {
+		const created = createTestDb();
+		dbHolder.sqlite = created.sqlite;
+		dbHolder.db = created.db;
+	} else {
+		resetDb(dbHolder.sqlite);
+	}
+});
+
+describe('sqlite webhookEventRepo (#3985)', () => {
+	it('未処理の event.id には null を返す (dedup primary check)', async () => {
+		expect(await findByEventId('evt_unknown')).toBeNull();
+	});
+
+	it('insert した record を全列そのまま読み戻せる', async () => {
+		const record = makeRecord({ tenantId: 't-test', eventType: 'invoice.paid' });
+		await insert(record);
+		expect(await findByEventId(record.eventId)).toEqual(record);
+	});
+
+	it('同一 event.id の二重 insert は first-writer-wins で無視される (dsql の ON CONFLICT と同契約)', async () => {
+		await insert(makeRecord({ handlerResult: 'success' }));
+		await insert(makeRecord({ handlerResult: 'skipped', eventType: 'invoice.paid' }));
+
+		// 後着が上書きしない = 並列同時到達でも初回の処理結果が正
+		expect(await findByEventId('evt_1ABCxyz')).toMatchObject({
+			handlerResult: 'success',
+			eventType: 'checkout.session.completed',
+		});
+	});
+
+	it('incrementRetryCount が既存 row の retryCount を +1 する', async () => {
+		await insert(makeRecord());
+		await incrementRetryCount('evt_1ABCxyz');
+		expect((await findByEventId('evt_1ABCxyz'))?.retryCount).toBe(1);
+		await incrementRetryCount('evt_1ABCxyz');
+		expect((await findByEventId('evt_1ABCxyz'))?.retryCount).toBe(2);
+	});
+
+	it('incrementRetryCount は未存在 event.id で throw しない (silent no-op)', async () => {
+		await expect(incrementRetryCount('evt_missing')).resolves.toBeUndefined();
+	});
+
+	it('deleteOlderThan が cutoff より古い row のみ削除し件数を返す (30 日 retention)', async () => {
+		await insert(makeRecord({ eventId: 'evt_old', processedAt: '2026-04-01T00:00:00.000Z' }));
+		await insert(makeRecord({ eventId: 'evt_new', processedAt: '2026-05-30T00:00:00.000Z' }));
+
+		expect(await deleteOlderThan('2026-05-01T00:00:00.000Z')).toBe(1);
+		expect(await findByEventId('evt_old')).toBeNull();
+		expect(await findByEventId('evt_new')).not.toBeNull();
+	});
+
+	it('deleteOlderThan は削除対象なしなら 0 を返す', async () => {
+		await insert(makeRecord({ processedAt: '2026-05-30T00:00:00.000Z' }));
+		expect(await deleteOlderThan('2026-01-01T00:00:00.000Z')).toBe(0);
+	});
+});
+
+// vitest の worker 終了時に sqlite handle を閉じる
+process.on('exit', () => {
+	if (dbHolder.sqlite) closeDb(dbHolder.sqlite);
+});

--- a/tests/unit/docs/stripe-dashboard-runbook.test.ts
+++ b/tests/unit/docs/stripe-dashboard-runbook.test.ts
@@ -40,8 +40,10 @@ function readStripeService(): string {
 
 /** `handleWebhookEvent` の switch から `case 'xxx':` の event 名を抽出する。 */
 function handledEventTypes(source: string): string[] {
-	const fn = source.match(/export async function handleWebhookEvent[\s\S]*?^}/m);
-	if (!fn) throw new Error('handleWebhookEvent が見つかりません (関数名が変わった?)');
+	// #3985: dedup 配線に伴い switch は `handleWebhookEvent` から `dispatchWebhookEvent` へ移した。
+	// 「switch を持つ関数」を見に行かないと 0 件マッチで素通りするため、抽出元も一緒に動かす。
+	const fn = source.match(/async function dispatchWebhookEvent[\s\S]*?^}/m);
+	if (!fn) throw new Error('dispatchWebhookEvent が見つかりません (関数名が変わった?)');
 	return [...fn[0].matchAll(/case '([\w.]+)':/g)]
 		.map((m) => m[1])
 		.filter((v): v is string => v !== undefined)

--- a/tests/unit/services/retention-cleanup-service.test.ts
+++ b/tests/unit/services/retention-cleanup-service.test.ts
@@ -40,6 +40,7 @@ const mockFindAllChildren = vi.fn();
 const mockDeleteActivityLogsBeforeDate = vi.fn();
 const mockDeletePointLedgerBeforeDate = vi.fn();
 const mockDeleteStatusHistoryBeforeDate = vi.fn(); // #3518-2
+const mockDeleteWebhookEventsOlderThan = vi.fn(); // #3985
 
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
@@ -57,6 +58,10 @@ vi.mock('$lib/server/db/factory', () => ({
 		},
 		status: {
 			deleteStatusHistoryBeforeDate: mockDeleteStatusHistoryBeforeDate,
+		},
+		// #3985: Stripe webhook dedup 台帳の 30 日 retention (tenant 非依存のグローバル表)
+		webhookEvent: {
+			deleteOlderThan: mockDeleteWebhookEventsOlderThan,
 		},
 	}),
 }));
@@ -92,6 +97,43 @@ beforeEach(() => {
 	mockDeleteActivityLogsBeforeDate.mockResolvedValue(0);
 	mockDeletePointLedgerBeforeDate.mockResolvedValue(0);
 	mockDeleteStatusHistoryBeforeDate.mockResolvedValue(0);
+	mockDeleteWebhookEventsOlderThan.mockResolvedValue(0);
+});
+
+// ==========================================================
+// #3985: Stripe webhook dedup 台帳の 30 日 retention
+// ==========================================================
+
+describe('stripe_webhook_events retention (#3985)', () => {
+	it('30 日より古い webhook dedup row を削除し、件数を結果に載せる', async () => {
+		mockDeleteWebhookEventsOlderThan.mockResolvedValue(7);
+
+		const result = await cleanupExpiredData();
+
+		expect(mockDeleteWebhookEventsOlderThan).toHaveBeenCalledTimes(1);
+		const cutoff = new Date(mockDeleteWebhookEventsOlderThan.mock.calls[0]?.[0] as string);
+		const days = (Date.now() - cutoff.getTime()) / 86_400_000;
+		// Stripe Events API の保持期間 (30 日) と同期。それ以上保持しても replay が来ない
+		expect(days).toBeGreaterThan(29.9);
+		expect(days).toBeLessThan(30.1);
+		expect(result.webhookEventsDeleted).toBe(7);
+	});
+
+	it('dryRun では削除しない', async () => {
+		const result = await cleanupExpiredData({ dryRun: true });
+
+		expect(mockDeleteWebhookEventsOlderThan).not.toHaveBeenCalled();
+		expect(result.webhookEventsDeleted).toBe(0);
+	});
+
+	it('webhook 台帳の削除失敗はテナント処理を巻き込まず errors に記録される', async () => {
+		mockDeleteWebhookEventsOlderThan.mockRejectedValue(new Error('table locked'));
+
+		const result = await cleanupExpiredData();
+
+		expect(result.webhookEventsDeleted).toBe(0);
+		expect(result.errors).toContainEqual({ tenantId: '(global)', error: 'table locked' });
+	});
 });
 
 // ==========================================================

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -9,12 +9,26 @@ const mockFindTenantById = vi.fn();
 const mockUpdateTenantStripe = vi.fn();
 const mockFindTenantByStripeCustomerId = vi.fn();
 
+// #3985: `handleWebhookEvent` は dispatcher 入口で event.id dedup 台帳を参照する。
+// 本 file の関心は **handler の意味論** (どの列をどう書くか / 到着順の収束) であり、
+// dedup そのものではないため、ここでは「常に未処理」を返す stub を渡して handler を毎回走らせる
+// (fixture の多くが event.id を持たない複数 event を連続投入するため)。
+// dedup の挙動 (5 handler の重複到達 = 副作用 1 回 / retryCount / 失敗時の非記録) は
+// `tests/unit/services/stripe-webhook-dedup.test.ts` が実 repo 実装で検証する。
+const mockWebhookEventInsert = vi.fn();
+
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
 		auth: {
 			findTenantById: mockFindTenantById,
 			updateTenantStripe: mockUpdateTenantStripe,
 			findTenantByStripeCustomerId: mockFindTenantByStripeCustomerId,
+		},
+		webhookEvent: {
+			findByEventId: async () => null,
+			insert: (...args: unknown[]) => mockWebhookEventInsert(...args),
+			incrementRetryCount: async () => {},
+			deleteOlderThan: async () => 0,
 		},
 	}),
 }));

--- a/tests/unit/services/stripe-webhook-dedup.test.ts
+++ b/tests/unit/services/stripe-webhook-dedup.test.ts
@@ -277,16 +277,18 @@ describe('handleWebhookEvent — event.id dedup (#3985)', () => {
 		await expect(handleWebhookEvent(event as never)).rejects.toThrow('DB 一時障害');
 
 		expect(mockNotifyStripeAlert).toHaveBeenCalledTimes(1);
-		const alert = mockNotifyStripeAlert.mock.calls[0][0] as {
-			kind: string;
-			errorSummary: string;
-			tags: Record<string, unknown>;
-		};
-		expect(alert.kind).toBe('stripe-webhook-handler-failed');
-		// throttle key は event.id 単位 (別 event の失敗を巻き込んで無音化しない)
-		expect(alert.errorSummary).toBe(`webhook-handler-failed:${event.id}`);
-		expect(alert.tags).toMatchObject({ eventId: event.id, eventType: event.type });
-		expect(alert.tags.error).toBe('DB 一時障害');
+		expect(mockNotifyStripeAlert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				kind: 'stripe-webhook-handler-failed',
+				// throttle key は event.id 単位 (別 event の失敗を巻き込んで無音化しない)
+				errorSummary: `webhook-handler-failed:${event.id}`,
+				tags: expect.objectContaining({
+					eventId: event.id,
+					eventType: event.type,
+					error: 'DB 一時障害',
+				}),
+			}),
+		);
 	});
 
 	it('handler 成功時は failure alert を出さない', async () => {

--- a/tests/unit/services/stripe-webhook-dedup.test.ts
+++ b/tests/unit/services/stripe-webhook-dedup.test.ts
@@ -60,7 +60,10 @@ vi.mock('$lib/server/stripe/config', () => ({
 	CURRENCY: 'jpy',
 }));
 
-vi.mock('$lib/server/stripe/alert', () => ({ notifyStripeAlert: vi.fn() }));
+const mockNotifyStripeAlert = vi.fn();
+vi.mock('$lib/server/stripe/alert', () => ({
+	notifyStripeAlert: (...args: unknown[]) => mockNotifyStripeAlert(...args),
+}));
 
 vi.mock('$lib/server/logger', () => ({
 	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
@@ -263,6 +266,36 @@ describe('handleWebhookEvent — event.id dedup (#3985)', () => {
 		expect(await demoWebhookEventRepo.findByEventId(event.id)).toMatchObject({
 			handlerResult: 'success',
 		});
+	});
+
+	it('handler 失敗は初回から Discord alert に上がる (再送が尽きる前に人が気づける)', async () => {
+		// 台帳に残さず Stripe の再送に載せる (§4.2) 判断は、再送が 3 日で尽きる前に
+		// 人が気づけることとセットでのみ成立する。log だけで終わらせない回帰。
+		const event = WEBHOOK_EVENTS[0].event; // checkout.session.completed
+		mockUpdateTenantStripe.mockRejectedValueOnce(new Error('DB 一時障害'));
+
+		await expect(handleWebhookEvent(event as never)).rejects.toThrow('DB 一時障害');
+
+		expect(mockNotifyStripeAlert).toHaveBeenCalledTimes(1);
+		const alert = mockNotifyStripeAlert.mock.calls[0][0] as {
+			kind: string;
+			errorSummary: string;
+			tags: Record<string, unknown>;
+		};
+		expect(alert.kind).toBe('stripe-webhook-handler-failed');
+		// throttle key は event.id 単位 (別 event の失敗を巻き込んで無音化しない)
+		expect(alert.errorSummary).toBe(`webhook-handler-failed:${event.id}`);
+		expect(alert.tags).toMatchObject({ eventId: event.id, eventType: event.type });
+		expect(alert.tags.error).toBe('DB 一時障害');
+	});
+
+	it('handler 成功時は failure alert を出さない', async () => {
+		await handleWebhookEvent(WEBHOOK_EVENTS[0].event as never);
+		expect(
+			mockNotifyStripeAlert.mock.calls.filter(
+				(call) => (call[0] as { kind: string }).kind === 'stripe-webhook-handler-failed',
+			),
+		).toHaveLength(0);
 	});
 
 	it('checkout の dedup row には analytics 用の tenantId が入る (PII は入れない)', async () => {

--- a/tests/unit/services/stripe-webhook-dedup.test.ts
+++ b/tests/unit/services/stripe-webhook-dedup.test.ts
@@ -1,0 +1,274 @@
+// tests/unit/services/stripe-webhook-dedup.test.ts
+//
+// #3985: Stripe webhook の event.id dedup 回帰テスト。
+//
+// Stripe の at-least-once delivery では同一 `event.id` の再到達が正規動作
+// (<https://docs.stripe.com/webhooks#handle-duplicate-events>)。dedup が配線されていないと
+// welcome メール 2 通 / past_due ↔ active の振動 / 解約 → 再活性化の振動が素通しになる。
+//
+// 本 spec は **購読 5 種すべての handler** について「同一 event.id が 2 回到達しても
+// 副作用が 1 回だけ」を assert する (設計 SSOT:
+// docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md §2 / §4.1 / §4.3)。
+//
+// dedup 台帳は demo (in-memory) 実装を **実物のまま** 使う。「dedup したことにする mock」で
+// 通るテストにしないため (repo 契約ごと検証する)。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	_resetDemoWebhookEvents,
+	demoWebhookEventRepo,
+} from '../../../src/lib/server/db/demo/webhook-event-repo';
+
+// ---------- Mocks ----------
+
+const mockFindTenantById = vi.fn();
+const mockUpdateTenantStripe = vi.fn();
+const mockFindTenantByStripeCustomerId = vi.fn();
+
+vi.mock('$lib/server/db/factory', async () => {
+	const { demoWebhookEventRepo: repo } = await import(
+		'../../../src/lib/server/db/demo/webhook-event-repo'
+	);
+	return {
+		getRepos: () => ({
+			auth: {
+				findTenantById: mockFindTenantById,
+				updateTenantStripe: mockUpdateTenantStripe,
+				findTenantByStripeCustomerId: mockFindTenantByStripeCustomerId,
+			},
+			webhookEvent: repo,
+		}),
+	};
+});
+
+const mockGetStripeClient = vi.fn();
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: () => true,
+	getStripeClient: (...args: unknown[]) => mockGetStripeClient(...args),
+}));
+
+vi.mock('$lib/server/stripe/config', () => ({
+	getPlans: () => ({
+		monthly: { priceId: 'price_monthly_123', amount: 500, interval: 'month', label: '月額' },
+	}),
+	planIdFromPriceId: (priceId: string) => (priceId === 'price_monthly_123' ? 'monthly' : null),
+	planIdFromLookupKey: () => null,
+	getWebhookSecret: () => 'whsec_test',
+	TRIAL_PERIOD_DAYS: 7,
+	GRACE_PERIOD_DAYS: 7,
+	CURRENCY: 'jpy',
+}));
+
+vi.mock('$lib/server/stripe/alert', () => ({ notifyStripeAlert: vi.fn() }));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockNotifyBillingEvent = vi.fn().mockResolvedValue(undefined);
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyBillingEvent: (...args: unknown[]) => mockNotifyBillingEvent(...args),
+}));
+
+// ---------- Import after mocks ----------
+
+import { handleWebhookEvent } from '../../../src/lib/server/services/stripe-service';
+
+// ---------- Fixtures ----------
+
+function makeTenant(overrides: Record<string, unknown> = {}) {
+	return {
+		tenantId: 't-test',
+		name: 'テスト家族',
+		ownerId: 'u-owner',
+		status: 'active',
+		plan: 'monthly',
+		stripeCustomerId: 'cus_123',
+		stripeSubscriptionId: 'sub_123',
+		trialUsedAt: null,
+		createdAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-01T00:00:00Z',
+		...overrides,
+	};
+}
+
+/** 購読 5 種すべての event fixture (設計書 §4.3 の handler 一覧と 1:1)。 */
+const WEBHOOK_EVENTS = [
+	{
+		label: 'checkout.session.completed',
+		event: {
+			id: 'evt_checkout_1',
+			type: 'checkout.session.completed',
+			data: {
+				object: {
+					id: 'cs_test',
+					metadata: { tenantId: 't-test', planId: 'monthly' },
+					customer: 'cus_new',
+					subscription: 'sub_new',
+					customer_details: { email: 'test@example.com' },
+					customer_email: null,
+				},
+			},
+		},
+	},
+	{
+		label: 'invoice.paid',
+		event: {
+			id: 'evt_invoice_paid_1',
+			type: 'invoice.paid',
+			data: {
+				object: {
+					parent: { subscription_details: { subscription: 'sub_123' } },
+					lines: {
+						data: [{ amount: 500, pricing: { price_details: { price: 'price_monthly_123' } } }],
+					},
+				},
+			},
+		},
+	},
+	{
+		label: 'invoice.payment_failed',
+		event: {
+			id: 'evt_invoice_failed_1',
+			type: 'invoice.payment_failed',
+			data: { object: { parent: { subscription_details: { subscription: 'sub_123' } } } },
+		},
+	},
+	{
+		label: 'customer.subscription.updated',
+		event: {
+			id: 'evt_sub_updated_1',
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					id: 'sub_123',
+					metadata: { tenantId: 't-test' },
+					status: 'active',
+					items: { data: [{ price: { id: 'price_monthly_123', lookup_key: null } }] },
+				},
+			},
+		},
+	},
+	{
+		label: 'customer.subscription.deleted',
+		event: {
+			id: 'evt_sub_deleted_1',
+			type: 'customer.subscription.deleted',
+			data: { object: { id: 'sub_123', metadata: { tenantId: 't-test' } } },
+		},
+	},
+] as const;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	_resetDemoWebhookEvents();
+	mockFindTenantById.mockResolvedValue(makeTenant());
+	mockFindTenantByStripeCustomerId.mockResolvedValue(makeTenant());
+	mockUpdateTenantStripe.mockResolvedValue(undefined);
+	mockNotifyBillingEvent.mockResolvedValue(undefined);
+	mockGetStripeClient.mockReturnValue({
+		subscriptions: {
+			retrieve: vi.fn().mockResolvedValue({
+				id: 'sub_123',
+				customer: 'cus_123',
+				status: 'active',
+				metadata: {},
+				items: { data: [{ price: { id: 'price_monthly_123', lookup_key: null } }] },
+			}),
+		},
+	});
+});
+
+describe('handleWebhookEvent — event.id dedup (#3985)', () => {
+	describe.each(WEBHOOK_EVENTS)('$label', ({ event }) => {
+		it('初回到達では handler が実行され、契約状態が 1 回書かれる', async () => {
+			await handleWebhookEvent(event as never);
+			expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+		});
+
+		it('同一 event.id が 2 回到達しても副作用は 1 回だけ', async () => {
+			await handleWebhookEvent(event as never);
+			await handleWebhookEvent(event as never);
+
+			// 2 回目は handler ごと skip されるため、DB 書き込みは増えない
+			expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+		});
+
+		it('重複到達は throw せず正常終了する (呼び出し元が 200 を返せる)', async () => {
+			await handleWebhookEvent(event as never);
+			// 4xx / 5xx を返すと Stripe の retry を誘発し重複到達がさらに増える (設計書 §2)
+			await expect(handleWebhookEvent(event as never)).resolves.toBeUndefined();
+		});
+
+		it('処理済み event は台帳に 1 行だけ残り、再到達で retryCount が増える', async () => {
+			await handleWebhookEvent(event as never);
+			const first = await demoWebhookEventRepo.findByEventId(event.id);
+			expect(first).toMatchObject({
+				eventId: event.id,
+				eventType: event.type,
+				handlerResult: 'success',
+				retryCount: 0,
+			});
+
+			await handleWebhookEvent(event as never);
+			expect((await demoWebhookEventRepo.findByEventId(event.id))?.retryCount).toBe(1);
+
+			await handleWebhookEvent(event as never);
+			expect((await demoWebhookEventRepo.findByEventId(event.id))?.retryCount).toBe(2);
+		});
+	});
+
+	it('別の event.id は dedup されず、それぞれ処理される (dedup の空振り検出)', async () => {
+		// 「常に skip する」実装でも上の 5 件は通ってしまうため、対照を置く
+		for (const { event } of WEBHOOK_EVENTS) {
+			await handleWebhookEvent(event as never);
+		}
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(WEBHOOK_EVENTS.length);
+	});
+
+	it('welcome 通知も 1 回だけ (checkout 重複で 2 通送らない)', async () => {
+		const checkout = WEBHOOK_EVENTS[0].event;
+		await handleWebhookEvent(checkout as never);
+		await handleWebhookEvent(checkout as never);
+
+		expect(mockNotifyBillingEvent).toHaveBeenCalledTimes(1);
+	});
+
+	it('未購読の event 型も台帳に記録され、再到達では dispatch されない', async () => {
+		const event = { id: 'evt_unhandled_1', type: 'payment_intent.created', data: { object: {} } };
+
+		await expect(handleWebhookEvent(event as never)).resolves.toBeUndefined();
+		expect(await demoWebhookEventRepo.findByEventId('evt_unhandled_1')).toMatchObject({
+			handlerResult: 'skipped',
+			retryCount: 0,
+		});
+
+		await handleWebhookEvent(event as never);
+		expect((await demoWebhookEventRepo.findByEventId('evt_unhandled_1'))?.retryCount).toBe(1);
+	});
+
+	it('handler が失敗した event は台帳に残らず、再送で再処理される (Stripe retry を潰さない)', async () => {
+		// 設計書 §4.2 の選択肢 A (失敗も記録して 200) を採らない根拠の回帰。
+		// 記録してしまうと一過性障害で event を恒久的に失う。
+		const event = WEBHOOK_EVENTS[4].event; // customer.subscription.deleted
+		mockUpdateTenantStripe.mockRejectedValueOnce(new Error('DB 一時障害'));
+
+		await expect(handleWebhookEvent(event as never)).rejects.toThrow('DB 一時障害');
+		expect(await demoWebhookEventRepo.findByEventId(event.id)).toBeNull();
+
+		// Stripe が同一 event.id で再送 → 今度は成功し、台帳に記録される
+		await handleWebhookEvent(event as never);
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(2);
+		expect(await demoWebhookEventRepo.findByEventId(event.id)).toMatchObject({
+			handlerResult: 'success',
+		});
+	});
+
+	it('checkout の dedup row には analytics 用の tenantId が入る (PII は入れない)', async () => {
+		await handleWebhookEvent(WEBHOOK_EVENTS[0].event as never);
+		const record = await demoWebhookEventRepo.findByEventId('evt_checkout_1');
+		expect(record?.tenantId).toBe('t-test');
+		expect(record?.errorMessage).toBeNull();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者・契約者） / 運営

**解決する課題**: Stripe webhook の `event.id` dedup は **設計・DB table・repo 実装・テストまで揃っていたのに、アプリから一度も呼ばれていなかった**。`git grep webhookEvent -- src` は db 層にしかヒットせず、service / route / factory からの参照が 0 件。`handleWebhookEvent` は署名検証の直後に `event.type` で handler を直 dispatch しており、Stripe の at-least-once delivery（重複到達は「起こりうる」ではなく **起こる**）が購読 5 種すべてで素通しだった。実際 2026-07-26 には同一 `checkout.session.completed` の再送が 2 回処理されている（PO が Stripe API で live endpoint 1 本 = 再送で確定と実測、#3985 コメント）。

素通しの実害（設計書 §1.1）: `checkout.session.completed` 重複 → welcome 通知 2 通 + entitlement 二重適用 / `invoice.paid` `invoice.payment_failed` 重複 → `past_due ↔ active` の振動（Phase 1 dunning NFR-3「子供の利用体験は支払い状態で突然中断しない」に反する）/ `customer.subscription.deleted` 重複 → 解約 → 再活性化 → 解約の振動。

**加えて、table と repo だけ先に入っている状態は「冪等性は実装済み」と誤読される。** スキーマを見ても配線の欠落は分からない。

**期待される効果**: 同一 `event.id` の再到達が dispatcher 入口 1 箇所で止まり、購読 5 種すべての副作用が 1 回に収束する。event 型を増やしても dedup の書き忘れが構造的に起きない（型ごとに分散させていないため）。

## 関連 Issue

closes #3985

- #2641 / `billing-redesign/phase5-webhook-idempotency-architecture.md` — 本 PR が実装する設計 SSOT（§2 handler 横断の dedup / §4.1 dispatcher 入口 / §4.3 影響 handler 一覧）
- #3960 / #3982 — 同じ 5 handler の別レイヤーの防御（plan の巻き戻し防止 / 終端状態への収束）。dedup とは目的が異なり、片方では他方を代替できない
- #4026 / #4055 — 契約状態の書き込み側ガード（下記「関連 PR」）
- ADR-0049（retention 物理削除）/ ADR-0001（設計書同期）/ ADR-0061（failing-test-first + mutation で guard の実効性を実測）

**関連 PR（競合可能性）**: **PR #4077（`fix/4026-4055-subscription-single-enforcement`、Draft / PO 判断待ち）が同じ `stripe-service.ts` を触っている。**

| 対象 | 競合 | どちらが先に merge されても壊れない書き方 / 解消方針 |
|---|---|---|
| `stripe-service.ts` | **なし（触る関数が重ならない）** | #4077 は 5 handler の**本体**を `applyTenantContractState()`（契約状態の書き込み単一強制点）経由に差し替える。本 PR は `handleWebhookEvent`（dispatcher 入口）だけを書き換え、handler 本体は 1 行も触っていない。**責務が層で分かれている**（本 PR = 「この event を処理してよいか」/ #4077 = 「この書き込みを適用してよいか」） |
| `handleWebhookEvent` の switch | あり（本 PR が `dispatchWebhookEvent` に切り出す） | #4077 は switch を触らない。後 merge 側は rebase 時に「handler 本体の hunk（#4077）」と「switch の hunk（本 PR）」がそれぞれ独立に当たる |
| `tests/unit/services/stripe-service.test.ts` | 低（別位置） | 本 PR は冒頭の `getRepos` mock に `webhookEvent` stub を足すのみ。#4077 は fixture と assertion を触る。後 merge 側は mock 追加行を保持すればよい |

**責務の非重複（レビュー観点）**: dedup（本 PR）は「同じ event を 2 回処理しない」、突合ガード（#4077）は「この event が現行契約を指しているか」を見る。#4077 の PR body 自身も「#3985 の dedup は順序ガードとは別の防御であり、片方では他方を代替できない」と書いており、両者を同一関数に混ぜていない。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `handleWebhookEvent` の入口 1 箇所で event.id dedup を行う（event 型ごとに分散させない） | `src/lib/server/services/stripe-service.ts` `handleWebhookEvent` の先頭で `findByEventId` → 既存なら `incrementRetryCount` + return。型ごとの分岐は `dispatchWebhookEvent` に分離し、そこに dedup コードは 1 行も無い | PASS。`grep -n "findByEventId" src/lib/server/services/stripe-service.ts` → 1 件（dispatcher 入口のみ） |
| AC2 | handler 実行と dedup row 書き込みを同一トランザクションで行う | **順序で同じ保証を満たす形に変更（設計書 §2 を実装の実態に更新）**。row の insert は handler 完了**後**に置き、insert が失敗すれば row は残らず次回到達で handler が再実行される（= §2 が transaction で得ようとした「partial failure で event を失わない」保証そのもの）。handler は Stripe API 呼び出しを含むため transaction 内に network I/O を抱えられない | 実装 = insert-after。設計書 §2 / §4.1 を同 PR で是正。**レビュー依頼事項 1 に明記** |
| AC3 | 重複検知時も HTTP 200 を返す（4xx/5xx は Stripe の retry を誘発する） | 重複時は throw せず return し、`+server.ts` が `json({received:true})` を返す。テスト「重複到達は throw せず正常終了する」× 5 handler | PASS（`npx vitest run tests/unit/services/stripe-webhook-dedup.test.ts` 25 passed） |
| AC4 | `factory.ts` / `backend.ts` から `IWebhookEventRepo` を注入する | `Repositories.webhookEvent` を追加し dsql / pglite / demo / sqlite の 4 分岐すべてで注入。`backend.ts` は backend 種別の解決のみで repo を持たないため変更なし（`resolveDbBackend` の責務外） | PASS。`grep -n "webhookEvent" src/lib/server/db/factory.ts` → 5 件（型宣言 + 4 分岐） |
| AC5 | 同一 event.id を 2 回投入して 1 回だけ反映されることのテスト（5 種すべての handler） | `tests/unit/services/stripe-webhook-dedup.test.ts` の `describe.each(WEBHOOK_EVENTS)`。5 種 × 4 ケース + 横断 5 ケース | PASS（下記「5 handler 網羅証跡」表）。**mutation M1 で実効性を実測** |
| AC6 | 30 日 retention の削除 cron（スコープに含めるかは実装判断）→ **含めた** | `cleanupExpiredData` に `repos.webhookEvent.deleteOlderThan(now - 30d)` を追加（tenant ループの外、グローバル表のため 1 回）。既存 `retention-cleanup` cron（毎日 01:00 JST）に相乗り、新規 cron は追加しない | PASS。cutoff が 30 日であること・dryRun で削除しないこと・失敗が tenant 処理を巻き込まないことを assert。**mutation M2 で実効性を実測** |

### 5 handler 網羅証跡（AC5）

`describe.each` により以下 5 種すべてで同一 4 ケースが実行される（設計書 §4.3 の handler 一覧と 1:1）。

| event 型 | handler | 「2 回到達 → 副作用 1 回」assert | 実行結果 |
|---|---|---|---|
| `checkout.session.completed` | `handleCheckoutCompleted` | `updateTenantStripe` 1 回 + `notifyBillingEvent` 1 回（welcome 2 通を防ぐ） | ✓ |
| `invoice.paid` | `handleInvoicePaid` | `updateTenantStripe` 1 回 | ✓ |
| `invoice.payment_failed` | `handlePaymentFailed` | `updateTenantStripe` 1 回 | ✓ |
| `customer.subscription.updated` | `handleSubscriptionUpdated` | `updateTenantStripe` 1 回 | ✓ |
| `customer.subscription.deleted` | `handleSubscriptionDeleted` | `updateTenantStripe` 1 回 | ✓ |

検証コマンドと件数（実行したものをそのまま記載）:

- dedup spec 全ケース: `npx vitest run tests/unit/services/stripe-webhook-dedup.test.ts` → **25 passed**
- service / repo 関連まとめ: `npx vitest run tests/unit/services/stripe-webhook-dedup.test.ts tests/unit/services/stripe-service.test.ts tests/unit/db/sqlite/webhook-event-repo.test.ts tests/unit/db/webhook-event-repo.test.ts` → **72 passed**
- retention 30 日 purge: `npx vitest run tests/unit/services/retention-cleanup-service.test.ts` → **13 passed**
- dispatcher 入口が唯一の dedup 点: `grep -n "findByEventId" src/lib/server/services/stripe-service.ts` → **1 件**
- factory 注入（4 backend）: `grep -n "webhookEvent" src/lib/server/db/factory.ts` → **5 件**

### mutation 検証ログ（guard の実効性 — 物理 verification 証跡）

「テストが通った」ではなく「実装を壊せばテストが落ちる」を実測した（ADR-0061）。実装 commit 後に mutation → 実行 → `git checkout --` で復元。

| Fix item | mutation（実際に入れた差分） | 検証コマンド | 結果 | 判定 |
|---|---|---|---|---|
| M1（AC1/AC3/AC5: dedup 判定を無効化） | `const existing = false ? await webhookEvents.findByEventId(event.id) : null;` | `npx vitest run tests/unit/services/stripe-webhook-dedup.test.ts` | **12 failed / 13 passed**（5 handler すべての「2 回到達 → 1 回」「retryCount」+ welcome 通知 + 未購読型が fail） | ✓ dedup が効いている |
| M1 復元後 | — | 同上 | 25 passed | ✓ |
| M2（AC6: 30 日 purge を止める） | `deleteOlderThan(...)` 呼び出しを `void cutoffIso;` に置換 | `npx vitest run tests/unit/services/retention-cleanup-service.test.ts` | **2 failed / 11 passed** | ✓ retention が効いている |
| M2 復元後 | — | 同上 | 13 passed | ✓ |
| M3（sqlite repo の first-writer-wins） | `.onConflictDoNothing()` を削除 | `npx vitest run tests/unit/db/sqlite/webhook-event-repo.test.ts` | **1 failed / 6 passed** | ✓ PK 冪等契約が効いている |
| M3 復元後 | — | 同上 | 7 passed | ✓ |

さらに「常に skip する」実装で全部緑になる空振りを防ぐため、**対照ケース**（`別の event.id は dedup されず、それぞれ処理される`）を同 spec に置いている。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [x] DB スキーマ (`$lib/server/db/`) — **table / column / migration の変更は無い**。`stripe_webhook_events` は配備済で、欠落していた **sqlite backend の repo 実装**（`src/lib/server/db/sqlite/webhook-event-repo.ts`）を追加し、`factory.ts` に注入しただけ
- [x] サービス層 (`$lib/server/services/`) — `stripe-service.ts`（dispatcher 入口）/ `retention-cleanup-service.ts`（30 日 purge）
- [ ] API エンドポイント (`src/routes/api/`) — **変更なし**（`+server.ts` は既に「正常終了なら 200 / 例外なら 500」で、そのまま dedup の契約に合う）
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: Stripe webhook 処理（`/api/stripe/webhook`、および同 handler を共有する `/api/stripe/webhook-v2`）と、その結果を読む親管理画面のライセンス表示。retention cron（`/api/cron/retention-cleanup`）の結果 JSON に `webhookEventsDeleted` が増える。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/services/stripe-webhook-dedup.test.ts`（新規）— 購読 5 種 × 「2 回到達 → 副作用 1 回」「throw しない」「retryCount 増加」「台帳 1 行」＋ 横断で「別 event.id は dedup されない（空振り検出）」「welcome 通知 1 回」「未購読型は `skipped` 記録」「handler 失敗時は台帳に残さず再送で再処理」。dedup 台帳は demo(in-memory) 実装を**実物のまま**使い、repo 契約ごと検証している
  - `tests/unit/db/sqlite/webhook-event-repo.test.ts`（新規）— sqlite backend が demo / dsql と同一契約（first-writer-wins / retryCount / 30 日 retention）で振る舞うことを固定
  - `tests/unit/services/retention-cleanup-service.test.ts` — 30 日 cutoff / dryRun 非実行 / 失敗が tenant 処理を巻き込まないことを追加
  - `tests/unit/services/stripe-service.test.ts` — `getRepos` mock に `webhookEvent` を追加（本 file の関心は handler の意味論であり dedup ではないため「常に未処理」を返す stub。dedup 自体は上記専用 spec が実 repo 実装で検証）
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A（DynamoDB backend は #3438 で撤去済）
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:high`）

## スクリーンショット / ビジュアルデモ

**該当なし（サーバー側 webhook 処理・repo・設計書のみの変更で、UI コンポーネント / レイアウト / 文言の差分はゼロ）**。

**4 スロット添付**（#1740）: N/A

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: 「この event を処理してよいか」の判断を dispatcher 入口 1 箇所に集約し、handler は「何をするか」だけを持つ。型ごとの dispatch は `dispatchWebhookEvent` に分離した
- [x] **DRY**: dedup を event 型ごとに書かない（設計書 §2 の中心原則）。新しい購読型を足しても dedup の追記は不要
- [x] **YAGNI**: 新規 cron・新規 endpoint・新規 table を作らず、既存の retention cron と既存 table に相乗り。error row / 自動 retry / 重複検知 dashboard は入れていない
- [x] **Security（OSS 公開前提）**: 台帳に payload を保存しない（PII を DB に流さない、設計書 §3.1 の意図的除外を維持）。`tenant_id` は analytics 属性のみ、`error_message` は常に null
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: webhook 1 回あたり PK 単点 lookup 1 回 + insert 1 回の増加。重複時は handler と DB 書き込みが丸ごと減る。retention は 1 日 1 回の範囲 delete（`processed_at` index 使用）

## 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — demo backend は既存の in-memory 実装をそのまま注入（Lambda 再起動で消える設計、ADR-0048 整合）
- [x] LP ↔ アプリ双方向整合（ADR-0013）— N/A（訴求文言の変更なし）
- [x] 全年齢モード 5 種に横展開 — N/A（親の契約処理）
- [x] ナビゲーション 3 種に反映 — N/A
- [x] E2E / ユニットシード + チュートリアルを同期 — `stripe_webhook_events` は `tests/e2e/global-setup.ts` / `tests/unit/helpers/test-db.ts` に**既に**配備済（DDL の追加変更なし）
- [x] labels SSOT (ADR-0009) — N/A（UI 文言なし）
- [x] 設計書同期 (ADR-0001) — `billing-redesign/phase5-webhook-idempotency-architecture.md` を実装の実態に更新（§2 原則 / §4.1 / §4.2 / §5.1 / §8 / §12 / §13）
- [x] 4 backend 整合 — sqlite / dsql（DSQL + NUC PGlite 共用）/ demo が同一 interface 契約で動くことを unit test で固定
- [x] 並行 PR overlap 確認 (#1200) — PR #4077 と同一ファイルあり。解消方針は「関連 Issue」の表に記載
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

DB スキーマ / API レスポンス / 環境変数の変更なし。挙動の変更は「同一 `event.id` の 2 回目以降を処理しなくなる」の 1 点で、これが Issue の目的そのもの。

**レビュー依頼事項・QA**:

1. **AC2「同一トランザクション」を順序保証に置き換えた判断**（要確認）。handler は Stripe API を呼ぶため、handler と row 書き込みを 1 transaction に閉じ込めると network I/O を transaction 内に抱える（DSQL では OCC 衝突・接続占有の温床）。代わりに **row を handler 完了後に書く**ことで、設計書 §2 が transaction で得ようとしていた「row 書き込みが失敗したら次回再実行される」保証を満たしている。設計書 §2 / §4.1 は同 PR で是正済。この置き換えの是非を確認いただきたい。
2. **handler 失敗時に dedup row を残さない判断**（設計書 §4.2 の採否を反転）。設計書は「失敗も記録して 200 を返す」案 A を採用していたが、これは一過性障害（DB / Stripe API の瞬断）で event を恒久的に失う。2026-07-26 の 22 分の配信失敗が Stripe の再送で復旧した実績があり、retry 経路を潰す副作用の方が大きいと判断した。結果として台帳は「**完了した** event の記録」を意味し、`handler_result` は `success` / `skipped` の 2 値、`error_message` は常に null になる。
3. **並列到達の残リスク**（設計書 §13 OQ-6 に明記）。`findByEventId` → `insert` は atomic ではないため、同一 event が**同時**到達すると handler が 2 回走りうる。repo 層の `ON CONFLICT DO NOTHING` は row の二重化は防ぐが handler 実行は防げない。完全に閉じるには claim-first（insert で先に権利を取ってから handler を走らせる）が必要で、handler 失敗時の row 取り消しと引き換えになるため本 PR では採らず、残リスクとして文書化した。現状 live endpoint は 1 本、Stripe の再送間隔は秒〜分単位。
4. PR #4077 との競合解消方針（「関連 Issue」の表）。

**本 PR で意図的に扱っていないこと**: `/api/stripe/webhook-v2` の retire（PO 判断で切り離し、#3985 コメント）/ 重複検知率の dashboard 化 / error row の自動 retry。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## PO 決裁の条件充足 (2026-07-30)

PO 決裁は **Q1 = Yes（条件付き）/ Q2 = Yes（条件付き）**。条件 2 点の充足内容を実測で示す。

| 条件 | 対応 | 実測エビデンス |
|---|---|---|
| **① Q1: 同一 `event.id` の連続失敗を Discord alert に上げる（再送が尽きる前に人が気づける）** | **本 PR 内で実装**（#3959 への先送りではない）。`handleWebhookEvent` の catch 1 箇所で `notifyStripeAlert({ kind: 'stripe-webhook-handler-failed', errorSummary: 'webhook-handler-failed:<event.id>' })` を発火し、その後 re-throw して Stripe の再送経路を維持する。alert kind を `StripeAlertKind` に追加 | 回帰テスト 2 件追加: `handler 失敗は初回から Discord alert に上がる (再送が尽きる前に人が気づける)` / `handler 成功時は failure alert を出さない`（`npx vitest run tests/unit/services/stripe-webhook-dedup.test.ts` → **27 passed**）。mutation M4（下表）で実効性を実測 |
| **② Q2: §13 OQ-6 に再評価トリガを併記** | `docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md` §13 OQ-6 の「状態」を `未解決` → `受容 (再評価トリガ付き)` に変え、PO 指定の 3 条件を本文に併記 | 設計書 diff（下記「条件② の設計書 diff」） |

### 条件① — 「N 回連続」ではなく「初回失敗から」alert する根拠

PO 提示は「同一 `event.id` が短時間に N 回（3 回程度）再到達して連続で失敗していることを検知する」。本 PR は **失敗回数を数える機構を持たず、初回失敗の時点で alert する**方を採った。理由:

- **時間軸**: Stripe の再送は 3 日で尽きる。初回失敗で鳴らせば検知遅延は実質ゼロで、「尽きる前に人が気づける」という PO の要件を最も強く満たす。N=3 まで待つ設計は検知を遅らせるだけで得るものがない。
- **反復ノイズの抑制は既存機構が担う**: `sendDiscordAlert` は `errorSummary` を throttle key として **5 分 window / 3 件でまとめ通知 → 以降無音** の throttle を内蔵している（`src/lib/server/discord-alert.ts`）。throttle key を `webhook-handler-failed:<event.id>` にしたことで **event 単位**に分離され、同一 event の再送連打は 2 通 + まとめ 1 通に収束する一方、別 event の失敗を巻き込んで無音化しない。
- **失敗回数を数える機構を新設しない**: 台帳は「完了した event」のみを記録する（§4.2）ため、失敗カウンタを持つには新しい永続層が要る。既存 throttle で要件を満たせるので新規機構は作らない（ADR-0010 / PO「新規機構は不要」）。

未達（event が Lambda に到達しない）側の検知は **#3959** が担う（本 PR は「到達したが handler が失敗した」側のみ）。責務分界を設計書 §4.2 と phase6 §3.10-b R11 に明記した。

### 条件① — mutation 検証ログ（追加分）

| Fix item | mutation（実際に入れた差分） | 検証コマンド | 結果 | 判定 |
|---|---|---|---|---|
| M4（条件①: 失敗時 alert を無効化） | `notifyStripeAlert({...})` を `void 0 && notifyStripeAlert({...})` に置換 | `npx vitest run tests/unit/services/stripe-webhook-dedup.test.ts` | **1 failed / 26 passed**（`handler 失敗は初回から Discord alert に上がる` のみ fail） | ✓ alert 導線が効いている |
| M4 復元後 | — | 同上 | 27 passed | ✓ |

### 条件② — 設計書 diff

`docs/design/billing-redesign/phase5-webhook-idempotency-architecture.md` §13 OQ-6:

```diff
-...完全に閉じるには claim-first (insert で先に権利を取ってから handler を走らせる) への変更が必要で、handler 失敗時の row 取り消しと引き換えになる | 未解決 (残リスクとして明示) |
+...完全に閉じるには claim-first (insert で先に権利を取ってから handler を走らせる) への変更が必要で、handler 失敗時の row 取り消しと引き換えになる。**再評価トリガ (下記 3 条件のいずれかを満たしたら claim-first を再検討する)**: (a) webhook endpoint を 2 本以上運用する構成になったとき (b) Lambda の同時実行が常態化するほど契約数が増えたとき (c) 二重処理を 1 件でも観測したとき | 受容 (再評価トリガ付き) |
```

あわせて §4.2 に観測導線（条件①）を追記し、`phase6-rollback-and-kill-switches.md` に alert kind の SSOT 行（**R11**: 検知 method / ロールバック手順 / 再発防止）を新設した。既存 R10（`stripe-plan-unresolved`）と同じ様式で、新規 alert kind が SSOT 表に登録されない状態を作らない。

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）
- [x] QA 承認・動作確認が完了している（Dev 完遂宣言）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert のみで戻る"]
    R2["顧客面: 課金 webhook の処理条件が変わる"]
    R3["DB 破壊なし・migration なし・env なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 再送の二重適用を 5 handler で封鎖"]
    T2["捨てる: 成功済 event の resend が効かなくなる"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: 恒久失敗は3日超で自動復旧せず検知導線なし"]
    O2["UX: 状態ズレを resend で直す運用手段が失われる"]
    O3["security: 同時到達の二重実行は残る TOCTOU"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["UI 変更ゼロ。重複による通知2通と状態振動が消える"]
  end
  subgraph ASK["⑤ PO 判断依頼 (Yes/No)"]
    Q1["Q1: 失敗した event を台帳に残さない方針で可?"]
    Q2["Q2: 同時到達の残 TOCTOU を今回は受容で可?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,T1,C1 ok
  class R2,R3 warn
  class T2,O1,O2,O3 warn
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- **Q1 の背景**: 設計書 §4.2 は「handler 失敗も台帳に記録して 200 を返す」案を採用していたが、それだと DB / Stripe API の一過性障害で event を**恒久的に失う**。本 PR は逆に「失敗したら台帳に残さず 500 を返す」= Stripe の再送に載せる方を採った。2026-07-26 の 22 分の配信失敗は再送で復旧しており、再送経路の方が価値が高いと判断した。代償は反対理由 business の通りで、**恒久バグの場合は Stripe が 3 日で諦める**まで 500 が続く。この「3 日で気づけないと課金 event を失う」点は PO 決裁の条件 1 となり、**本 PR 内で失敗時 Discord alert を実装した**（下記「PO 決裁の条件充足」）。
- **Q2 の背景**: `findByEventId` → handler → `insert` は atomic ではないため、同一 event が**同時**に届くと handler が 2 回走りうる。完全に閉じるには claim-first（先に台帳へ書いてから handler を走らせる）が必要だが、handler 失敗時に台帳から取り消す処理が要り、Q1 の方針と噛み合わせる設計変更になる。現状 live endpoint は 1 本、Stripe の再送間隔は秒〜分単位のため、本 PR では残リスクとして設計書 §13 OQ-6 に明記するに留めた。
- **反対理由の出典**: `tmp/adversarial-evidence/4079.json`（3 軸 3 件、`node scripts/verify-adversarial-output.mjs --pr 4079` PASS）。
- **UI 変更ゼロの根拠**: 変更ファイルは `src/lib/server/**`（webhook dispatcher / repo / retention）と `tests/**` と設計書のみで、`.svelte` の差分は 0 件。

</details>

