### PR TITLE
fix(date): #4015 ローカル TZ 日付 getter 120 箇所を全数分類し、顧客影響 75 箇所を JST SSOT へ是正する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,13 @@ jobs:
         # instance 修正をやめ、追加時に区分の判断を必ず発生させる gate にした (ADR-0061)。
         run: node scripts/check-repo-scan-test-declaration.mjs
 
+      - name: Local TZ date getter guard (#4015 / ADR-0061 same-class-N)
+        # 実時刻から `getFullYear()` / `getMonth()` / `getDate()` / `getDay()` で暦要素を取り出すと、
+        # Lambda (UTC) と NUC (JST) で同じコードが違う日付を返す。#4003 ではこれで週次チャレンジが
+        # 毎週 9 時間消えた (3 例目)。日付計算は date-utils.ts の JST SSOT 経由に統一し、
+        # TZ 非依存と言える箇所のみ理由付き allowlist で pin する (理由が空だと gate 自身が fail)。
+        run: node scripts/check-local-tz-date-getters.mjs
+
       - name: License key re-introduction guard (#2836 / Epic #2525 Phase 7 PR-L4)
         # license key 全廃 (Phase 1 補強 3 #2788) の再導入防止。allowlist 外のコード行に
         # ライセンスキー / licenseKey / license-key / LICENSE_KEY 参照を検出したら fail。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,11 @@ Ready 化前は依然として `npm run pre-ready -- --pr <num>` 全 step PASS �
 
 ### Ready 化前チェック（必須）
 
-`npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #1920 / #2918 で SSOT 検証 step 拡張)。全 19 step (Step 1〜12 + 1b / 7b / 7c / 7d / 7e / 7f / 11b) を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`** (#2929 で同期):
+`npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #1920 / #2918 で SSOT 検証 step 拡張)。全 20 step (Step 1〜12 + 1b / 7b / 7c / 7d / 7e / 7f / 7g / 11b) を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`** (#2929 で同期):
 
-1. biome check / 1b. cspell (#3649, CI 同一コマンド) / 2. svelte-check / 3. vitest run / 4. check-hardcoded-strings (#1452) / 5. measure-lp-dimensions (#1163, LP 変更時のみ) / 6. sync-lp-fallback --check (#1945, LP / labels.ts 変更時のみ) / 7. check-no-plan-literals (#972) / 7b. check-license-key-leak (#2836) / 7c. check-cli-entry-guard (#3969) / 7d. check-workflow-sparse-checkout-closure (#3969) / 7e. check-readdir-rotation-guard (#3978) / 7f. check-repo-scan-test-declaration (#4085) / 8. generate-lp-labels --check (#1917, labels.ts / terms.ts / age-tier.ts 変更時のみ) / 9. Readiness gate = check-pr-body (PR 番号必須) / 10. check-doc-code-references (#2577) / 11. check-terminology-coherence (#2555) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail) / 12. capture (UI 変更時のみガイダンス)
+1. biome check / 1b. cspell (#3649, CI 同一コマンド) / 2. svelte-check / 3. vitest run / 4. check-hardcoded-strings (#1452) / 5. measure-lp-dimensions (#1163, LP 変更時のみ) / 6. sync-lp-fallback --check (#1945, LP / labels.ts 変更時のみ) / 7. check-no-plan-literals (#972) / 7b. check-license-key-leak (#2836) / 7c. check-cli-entry-guard (#3969) / 7d. check-workflow-sparse-checkout-closure (#3969) / 7e. check-readdir-rotation-guard (#3978) / 7f. check-repo-scan-test-declaration (#4085) / 7g. check-local-tz-date-getters (#4015, ローカル TZ 日付 getter 禁止 / JST SSOT 強制) / 8. generate-lp-labels --check (#1917, labels.ts / terms.ts / age-tier.ts 変更時のみ) / 9. Readiness gate = check-pr-body (PR 番号必須) / 10. check-doc-code-references (#2577) / 11. check-terminology-coherence (#2555) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail) / 12. capture (UI 変更時のみガイダンス)
 
-**Step 番号は表示上の識別子であり実行順ではない (#4048)**。実行は cheap-fail-first — PR body だけを見る検査 (Step 9) → 静的テキスト検査 (1 / 1b / 4 / 6 / 7 / 7b / 7c / 7d / 8 / 10 / 11) → 型検査 (2) → テスト (3) → ブラウザ実測 (5) → SS 系 (11b / 12) の順。検査の集合・合否条件は番号順実行時と同一。
+**Step 番号は表示上の識別子であり実行順ではない (#4048)**。実行は cheap-fail-first — PR body だけを見る検査 (Step 9) → 静的テキスト検査 (1 / 1b / 4 / 6 / 7 / 7b / 7c / 7d / 7e / 7f / 7g / 8 / 10 / 11) → 型検査 (2) → テスト (3) → ブラウザ実測 (5) → SS 系 (11b / 12) の順。検査の集合・合否条件は番号順実行時と同一。
 
 E2E / Storybook は別途 (`npx playwright test` / `npm run test:storybook`)。任意: `npx eslint "src/**/*.ts"` (#977) / `npm run type-coverage` / `npm run knip` (#970)。CI 自動拒否は `.github/workflows/ci.yml` 参照。
 

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -137,7 +137,7 @@
 | `npm run dev` | 開発サーバー (port 5173、local モード) |
 | `npm run dev:cognito` | Cognito 認証画面 (#1026、認証画面 PR Ready 前必須) |
 | `npm run build` | SvelteKit production build |
-| `npm run pre-ready -- --pr <num>` | Ready 化前 全 19 step 検証 (ADR-0030 / #1920 / #2918。一覧 SSOT は `--help`。実行順は cheap-fail-first で Step 番号順ではない、#4048) |
+| `npm run pre-ready -- --pr <num>` | Ready 化前 全 20 step 検証 (ADR-0030 / #1920 / #2918 / #4015。一覧 SSOT は `--help`。実行順は cheap-fail-first で Step 番号順ではない、#4048) |
 | `npx biome check .` | Biome lint (Tier T1) |
 | `npx svelte-check` | Svelte 型チェック |
 | `npx vitest run` | unit / integration テスト |

--- a/docs/design/44-チャレンジ設計書.md
+++ b/docs/design/44-チャレンジ設計書.md
@@ -110,23 +110,32 @@
 
 multi-armed bandit / Thompson sampling、BirdBrain 型 ML 難度調整、DDA、曜日×カテゴリ×年齢の多変量 rule table は **MAU・学習データ前提で Pre-PMF 未到達**のため不採用（[ADR-0010](../decisions/0010-pre-pmf-scope-judgment.md) / YAGNI）。「3分岐＋2連続未達特例」を超えたら設計を止めて PO に戻す。
 
-### 3.4a 日付境界の基準は JST SSOT に統一する（#4003 / #4020）
+### 3.4a 日付境界の基準は JST SSOT に統一する（#4003 / #4020 / #4015）
 
-**週次チャレンジの「週頭」と、子供ホームの「今日」は、いずれも `src/lib/domain/date-utils.ts` の JST 関数を SSOT とする。**
+**「実時刻の瞬間から暦要素（年 / 月 / 日 / 曜日）を取り出す」計算は、アプリ全体で `src/lib/domain/date-utils.ts` の JST 関数群を SSOT とする。** 対象は週次チャレンジの「週頭」・子供ホームの「今日」に限らず、月次集計・週次集計・年齢計算など日付境界を扱う全箇所。
 
-| 用途 | SSOT | 使用箇所 |
+| 用途 | SSOT | 代表使用箇所 |
 |---|---|---|
-| その週の月曜 | `weekStartJST(date?)` | `child-challenge-service.ts`（生成時の `startDate` / `endDate`） |
 | 今日 | `todayDateJST()` | 子供ホーム `(child)/[uiMode]/home/+page.server.ts` / 活動記録の書き込み側 |
+| その週の月曜 / 日曜 | `weekStartJST(date?)` / `weekEndJST(date?)` | `child-challenge-service.ts`（生成時の `startDate` / `endDate`） |
+| 曜日番号 (0=日〜6=土) | `jstDayOfWeek(date?)` | 曜日別集計 |
+| 年 / 月 | `jstYearMonth(date?)` | 年齢計算・期間表示 |
+| 月キー (YYYY-MM) | `monthKeyJST(date?)` | 月次集計のバケット key |
+| 月キーを N ヶ月ずらす | `shiftMonthKey(monthKey, delta)` | 直近 N ヶ月の集計列挙 |
+| その月の月初 / 月末 | `monthStartJST(date?)` / `monthEndJST(date?)` / `monthEndOfKey(monthKey)` | 期間の境界値算出 |
+| ISO タイムスタンプが指定月キーに属するか | `isInJstMonth(isoTimestamp, monthKey)` | `createdAt` 等 UTC 文字列の月次集計判定 |
+| 日付文字列の N 日後 | `addDaysJST(dateStr, days)` | 期限計算 |
 
-**禁止**: 週頭・今日の算出に `Date` のローカル日付 getter（`getFullYear` / `getMonth` / `getDate` / `getDay`）を使うこと。本番 Lambda と CI runner は TZ 未設定（= UTC）で動くため、**JST 00:00〜09:00 の 9 時間だけ前日/前週として扱われる**。
+**禁止**: 上記用途に `Date` のローカル日付 getter（`getFullYear` / `getMonth` / `getDate` / `getDay`）を直接使うこと。本番 Lambda と CI runner は TZ 未設定（= UTC）で動くため、**JST 00:00〜09:00 の 9 時間だけ前日/前週/前月として扱われる**。機械強制: `scripts/check-local-tz-date-getters.mjs`（`npm run pre-ready` Step 7g）が新規のローカル TZ getter 使用を検出し、allowlist（理由必須）外は CI で fail する。
 
 読み書きで基準がずれると次の実害が出る（いずれも実際に発生した）:
 
 - **週次チャレンジのバッジが毎週 9 時間まるごと消える**（#4003）— 書き込み側が UTC 基準で `endDate = その日曜` を入れる一方、読み出し側の `todayDateJST()` は既に翌週月曜を返すため `endDate >= today` が false になる
 - **「記録したのに今日のおやくそくが埋まらない」「チェックリストの進捗が戻る」**（#4020）— 書き込み側は `todayDateJST()`、読み出し側はローカル日付、と基準が食い違う
 
-実装方針は「JST の暦日を文字列にしてから UTC 深夜として再解釈し、以降の曜日算術を UTC 系で閉じる」。回帰は `tests/unit/domain/week-start-jst.test.ts` が UTC / JST 双方の TZ で固定する。
+実装方針は「JST の暦日を文字列にしてから UTC 深夜として再解釈し、以降の曜日算術を UTC 系で閉じる」。回帰は `tests/unit/domain/week-start-jst.test.ts` / `tests/unit/domain/jst-date-ssot.test.ts` / `tests/unit/services/jst-boundary-regression.test.ts` が UTC / JST 双方の TZ で固定する。
+
+**意図的に UTC を採る例外**: `ops-analytics-service.getMonthKey()` は tenant の月次集計キーを `tenant.createdAt`（ISO UTC 文字列）から直接生成するため、JST ではなく UTC を月境界に固定している。これは `cohort-analysis-service`（#3449）が同じ理由から UTC を月境界 SSOT に選んだ決定に揃えるためで、両者の月バケットが食い違うと `/ops` 上で retention / acquisition 集計が不整合になる。
 
 ### 3.5 関連実装
 

--- a/scripts/check-local-tz-date-getters.mjs
+++ b/scripts/check-local-tz-date-getters.mjs
@@ -1,0 +1,380 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-local-tz-date-getters.mjs (#4015 / ADR-0061 same-class-N → guard)
+ *
+ * ローカル TZ 日付 getter (`getFullYear()` / `getMonth()` / `getDate()` / `getDay()`) の
+ * 無秩序な使用を止める CI ガード。
+ *
+ * ## なぜ必要か
+ *
+ * 本番 runtime は 2 種類あり、プロセス TZ が一致しない。
+ *
+ *   - AWS Lambda / CI runner : UTC → JST 00:00〜09:00 の 9 時間、暦日が 1 日前になる
+ *   - NUC セルフホスト        : JST → JST と一致する
+ *
+ * つまりローカル getter は「同じコードが環境ごとに違う日付を返す」。#4003 ではこれで
+ * 子供ホームの週次チャレンジが毎週 9 時間まるごと消えた (3 例目)。日付計算の SSOT は
+ * `src/lib/domain/date-utils.ts` (JST 基準) 側に既に存在していたが、**違反を検知する手段が
+ * 無かったため新規コードに同じ形が入り続けた**。本 gate がその検知手段。
+ *
+ * ## 検査ルール
+ *
+ * 1. `SEARCH_ROOTS` 配下の `.ts` / `.svelte` を走査し、コメント行以外のローカル getter を数える
+ *    (`getUTCFullYear()` 等の UTC getter は TZ 非依存なので対象外)
+ * 2. **no-silent-gap**: 検出のあった file が `ALLOWLIST` に無ければ fail
+ *    (新規 file で黙って増えることを防ぐ)
+ * 3. **ratchet**: allowlist entry の `max` を超えた occurrence 数は fail
+ *    (allowlist 済 file の中で新規に増えることも防ぐ)
+ * 4. **理由の強制**: `reason` が空 / 未設定の entry があれば、違反 0 件でも fail
+ *    (「除外はしたが理由が無い」= #3956 で観測した形骸化を作らない)
+ *
+ * allowlist に載っているのは #4015 の全数棚卸で **(b) 安全** と判定した箇所のみ。分類基準:
+ *
+ *   - b1: `YYYY-MM-DD` を `T00:00:00Z` (UTC 深夜) でパースし、そこから加減算する
+ *         (UTC+0 以上の TZ では暦要素が一致するため UTC / JST 両 runtime で同結果)
+ *   - b2: `YYYY-MM-DD` を `T00:00:00` (ローカル深夜) でパースし、ローカル getter で読む
+ *         (パースと読み出しが同じ TZ 系で閉じている)
+ *   - b3: `setDate(getDate() + N)` が「N 日後の絶対時刻 (期限)」生成で、暦要素を外に出さない
+ *
+ * **新しく (a) 相当 (= 実時刻の瞬間からローカル getter で暦要素を取り出す) を書かないこと。**
+ * その用途は `date-utils.ts` の `todayDateJST` / `toJSTDateString` / `weekStartJST` /
+ * `weekEndJST` / `addDaysJST` / `jstDayOfWeek` / `jstYearMonth` / `monthKeyJST` /
+ * `shiftMonthKey` / `monthStartJST` / `monthEndJST` / `isInJstMonth` が担う。
+ *
+ * 使用法: node scripts/check-local-tz-date-getters.mjs
+ * CI: 検出時は exit 1。
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from './lib/is-main.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+/** 走査ルート (REPO_ROOT 相対)。tests/ は意図的な時刻固定が多いため対象外 (#4015 No-gos)。 */
+export const SEARCH_ROOTS = ['src'];
+
+/** 走査対象拡張子 */
+export const EXTENSIONS = ['.ts', '.svelte'];
+
+/**
+ * ローカル TZ 日付 getter。`getUTC*` は先頭の `.` で自然に除外される
+ * (`.getDate(` は `.getUTCDate(` に一致しない)。
+ */
+export const LOCAL_TZ_GETTER = /\.(getFullYear|getMonth|getDate|getDay)\s*\(\s*\)/;
+
+/**
+ * allowlist — #4015 の全数棚卸で (b) 安全と判定した箇所のみ。
+ *
+ * `file`: REPO_ROOT 相対 path (`/` 区切り) / `max`: 許容 occurrence 数 (ratchet 上限)
+ * `reason`: **必須**。空文字なら本 script 自身が fail する。
+ */
+export const ALLOWLIST = [
+	{
+		file: 'src/lib/domain/labels.ts',
+		max: 0,
+		reason:
+			'(SSOT 化済) 週次チャート曜日は jstDayOfWeek() 経由に置換済。将来の再混入を 0 で pin する',
+	},
+	{
+		file: 'src/lib/server/services/birthday-bonus-service.ts',
+		max: 6,
+		reason:
+			'(b2) 誕生日 / 基準日とも YYYY-MM-DD + T00:00:00 のローカル深夜パースで、ローカル getter による読み出しと同じ TZ 系で閉じている (年齢差分・年判定とも TZ 非依存)',
+	},
+	{
+		file: 'src/lib/server/services/report-service.ts',
+		max: 3,
+		reason:
+			'(b1) `new Date(startDate)` = YYYY-MM-DD の UTC 深夜パースに対する日次ループの ±1 日加算。暦要素の文字列化は toJSTDateString() に委譲済',
+	},
+	{
+		file: 'src/lib/server/services/plan-limit-service.ts',
+		max: 2,
+		reason:
+			'(b1) 保持期間 cutoff (JST 基準の YYYY-MM-DD) を UTC 深夜でパースしてからの -1 日。UTC+0 以上の runtime で同一文字列になる',
+	},
+	{
+		file: 'src/lib/server/services/daily-mission-service.ts',
+		max: 2,
+		reason:
+			'(b2) JST 日付文字列をローカル深夜でパースし、ローカル getter で日数を戻す。パースと読み出しが同じ TZ 系',
+	},
+	{
+		file: 'src/lib/server/services/usage-log-service.ts',
+		max: 4,
+		reason:
+			'(b3) 検索範囲の上下端 / 日次バケット offset として「±N 日後の絶対時刻」を作るのみで、暦要素をローカル getter で外に出していない',
+	},
+	{
+		file: 'src/lib/server/services/child-challenge-service.ts',
+		max: 1,
+		reason: '(b3) 集計入力の「14 日前の絶対時刻」生成のみ。暦要素の露出なし',
+	},
+	{
+		file: 'src/lib/server/services/activity-pin-service.ts',
+		max: 1,
+		reason: '(b3) 使用頻度集計の「N 日前の絶対時刻」生成のみ。暦要素の露出なし',
+	},
+	{
+		file: 'src/lib/server/services/grace-period-service.ts',
+		max: 1,
+		reason: '(b3) 物理削除猶予期限 = N 日後の絶対時刻を作り ISO で保存するのみ',
+	},
+	{
+		file: 'src/lib/server/services/cloud-export-service.ts',
+		max: 1,
+		reason: '(b3) エクスポート PIN の有効期限 = N 日後の絶対時刻を作り ISO で保存するのみ',
+	},
+	{
+		file: 'src/lib/server/services/viewer-token-service.ts',
+		max: 1,
+		reason: '(b3) 閲覧トークン失効時刻 = N 日後の絶対時刻を作り ISO で保存するのみ',
+	},
+	{
+		file: 'src/lib/server/db/demo/daily-mission-repo.ts',
+		max: 1,
+		reason: '(b1) missionDate (YYYY-MM-DD) の UTC 深夜パースからの -1 日',
+	},
+	{
+		file: 'src/lib/server/demo/demo-data.ts',
+		max: 2,
+		reason: '(b1) 固定日付 / 固定瞬間を起点とした -N 日。デモ fixture であり実時刻起点でない',
+	},
+	{
+		file: 'src/lib/server/debug-plan.ts',
+		max: 1,
+		reason:
+			'(b3) DEBUG_TRIAL の擬似終了日を「7 日後の絶対時刻」で作り、暦日化は toJSTDateString() に委譲 (dev 専用、本番ビルド無効)',
+	},
+	{
+		file: 'src/routes/api/v1/admin/tenant/cancel/+server.ts',
+		max: 1,
+		reason: '(b3) 解約猶予期限 = N 日後の絶対時刻を作り ISO で保存するのみ',
+	},
+	{
+		file: 'src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.server.ts',
+		max: 2,
+		reason: '(b3) 履歴取得範囲の「N 日前の絶対時刻」生成のみ。暦日化は toJSTDateString() に委譲済',
+	},
+	{
+		file: 'src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.svelte',
+		max: 3,
+		reason:
+			'(b2) recordedAt 由来の YYYY-MM-DD をローカル深夜パースし、ローカル getter で表示用の月 / 日 / 曜日にする。パースと読み出しが同じ TZ 系',
+	},
+	{
+		file: 'src/routes/(parent)/admin/reports/+page.svelte',
+		max: 1,
+		reason:
+			'(b2) 選択中の月キー文字列からローカルコンストラクタで構築した Date をローカル getter で読む。実時刻由来でない',
+	},
+	{
+		file: 'src/lib/features/admin/components/ChildListCard.svelte',
+		max: 1,
+		reason:
+			'(b1) 誕生日 (YYYY-MM-DD) の UTC 深夜パースを月 / 日の表示に使う。UTC+0 以上の TZ で暦要素が一致',
+	},
+	{
+		file: 'src/lib/features/child-home/BabyHomePage.stories.svelte',
+		max: 4,
+		reason:
+			'(dev) Storybook の fixture 生成 (「N ヶ月前生まれ」等の相対誕生日)。本番ビルドに含まれず顧客に見える値を作らない',
+	},
+	{
+		file: 'src/lib/ui/primitives/BirthdayInput.svelte',
+		max: 1,
+		reason:
+			'(b2) 月の日数算出 `new Date(y, m, 0).getDate()` はローカルコンストラクタ + ローカル getter で閉じており、返る日数は TZ 非依存',
+	},
+];
+
+/**
+ * relPath (`/` 区切り) の allowlist entry を返す
+ * @param {string} relPath
+ * @returns {{file: string, max: number, reason: string} | undefined}
+ */
+export function findAllowlistEntry(relPath) {
+	const normalized = relPath.replace(/\\/g, '/');
+	return ALLOWLIST.find((e) => e.file === normalized);
+}
+
+/**
+ * allowlist 自体の健全性検査。`reason` が空 / 空白のみの entry を返す。
+ * 「除外したが理由が無い」形骸化を構造的に禁じる (#3956 の教訓)。
+ * @returns {Array<{file: string, max: number, reason: string}>}
+ */
+export function findAllowlistEntriesWithoutReason() {
+	return ALLOWLIST.filter((e) => typeof e.reason !== 'string' || e.reason.trim() === '');
+}
+
+/**
+ * line がコメント行なら true (経緯記述・SSOT 説明は許容する)
+ * @param {string} line
+ * @returns {boolean}
+ */
+export function isCommentLine(line) {
+	const trimmed = line.trimStart();
+	return (
+		trimmed.startsWith('//') ||
+		trimmed.startsWith('*') ||
+		trimmed.startsWith('/*') ||
+		trimmed.startsWith('<!--')
+	);
+}
+
+/**
+ * 1 ファイル分の content からローカル TZ getter 行を抽出する (純関数)。
+ * @param {string} relPath REPO_ROOT 相対 path
+ * @param {string} content ファイル内容
+ * @returns {Array<{file: string, line: number, snippet: string}>}
+ */
+export function findOccurrencesInContent(relPath, content) {
+	/** @type {Array<{file: string, line: number, snippet: string}>} */
+	const out = [];
+	content.split(/\r?\n/).forEach((line, idx) => {
+		if (!LOCAL_TZ_GETTER.test(line)) return;
+		if (isCommentLine(line)) return;
+		out.push({
+			file: relPath.replace(/\\/g, '/'),
+			line: idx + 1,
+			snippet: line.trim().slice(0, 120),
+		});
+	});
+	return out;
+}
+
+/**
+ * occurrence 群を allowlist と突き合わせ、違反 (no-silent-gap / ratchet 超過) を返す。
+ * @param {Array<{file: string, line: number, snippet: string}>} occurrences
+ * @returns {Array<{kind: 'not-allowlisted'|'over-max', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string}>}>}
+ */
+export function evaluateOccurrences(occurrences) {
+	/** @type {Map<string, Array<{file: string, line: number, snippet: string}>>} */
+	const byFile = new Map();
+	for (const o of occurrences) {
+		const list = byFile.get(o.file) ?? [];
+		list.push(o);
+		byFile.set(o.file, list);
+	}
+	/** @type {Array<{kind: 'not-allowlisted'|'over-max', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string}>}>} */
+	const violations = [];
+	for (const [file, list] of byFile) {
+		const entry = findAllowlistEntry(file);
+		if (!entry) {
+			violations.push({
+				kind: 'not-allowlisted',
+				file,
+				count: list.length,
+				max: 0,
+				samples: list.slice(0, 5),
+			});
+			continue;
+		}
+		if (list.length > entry.max) {
+			violations.push({
+				kind: 'over-max',
+				file,
+				count: list.length,
+				max: entry.max,
+				samples: list.slice(0, 5),
+			});
+		}
+	}
+	return violations;
+}
+
+/**
+ * @param {string} dir
+ * @param {string[]} out
+ * @returns {string[]}
+ */
+function walk(dir, out = []) {
+	if (!fs.existsSync(dir)) return out;
+	for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === 'node_modules') continue;
+			walk(full, out);
+		} else if (entry.isFile() && EXTENSIONS.some((ext) => entry.name.endsWith(ext))) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+/**
+ * REPO_ROOT 配下の SEARCH_ROOTS を走査し全 occurrence を返す
+ * @param {string} [repoRoot]
+ * @returns {Array<{file: string, line: number, snippet: string}>}
+ */
+export function findAllOccurrences(repoRoot = REPO_ROOT) {
+	/** @type {Array<{file: string, line: number, snippet: string}>} */
+	const occurrences = [];
+	for (const root of SEARCH_ROOTS) {
+		for (const file of walk(path.join(repoRoot, root))) {
+			const rel = path.relative(repoRoot, file);
+			occurrences.push(...findOccurrencesInContent(rel, fs.readFileSync(file, 'utf8')));
+		}
+	}
+	return occurrences;
+}
+
+function main() {
+	const noReason = findAllowlistEntriesWithoutReason();
+	if (noReason.length > 0) {
+		console.error(
+			`[check-local-tz-date-getters] ✗ allowlist に理由 (reason) の無い entry が ${noReason.length} 件あります:\n`,
+		);
+		for (const e of noReason) console.error(`  ${e.file}`);
+		console.error(
+			'\n  除外は必ず「なぜ TZ 非依存と言えるか」を reason に書いてください (#4015 / #3956)。',
+		);
+		process.exit(1);
+	}
+
+	const violations = evaluateOccurrences(findAllOccurrences());
+	if (violations.length === 0) {
+		console.log(
+			`[check-local-tz-date-getters] OK — allowlist (${ALLOWLIST.length} file、全件 reason 付き) 外のローカル TZ 日付 getter なし`,
+		);
+		process.exit(0);
+	}
+
+	console.error(
+		`[check-local-tz-date-getters] ✗ ローカル TZ 日付 getter の違反を ${violations.length} file で検出しました (#4015):\n`,
+	);
+	for (const v of violations) {
+		const head =
+			v.kind === 'not-allowlisted'
+				? `${v.file}: ${v.count} 件 (allowlist 未登録)`
+				: `${v.file}: ${v.count} 件 (allowlist 上限 ${v.max} 件を超過)`;
+		console.error(`  ${head}`);
+		for (const s of v.samples) console.error(`    L${s.line}: ${s.snippet}`);
+	}
+	console.error('\n修正方針:');
+	console.error(
+		'  - 実時刻 (new Date() / DB timestamp) から暦要素を取り出しているなら **欠陥** です。',
+	);
+	console.error(
+		'    $lib/domain/date-utils.ts の JST SSOT (todayDateJST / toJSTDateString / weekStartJST /',
+	);
+	console.error(
+		'    weekEndJST / addDaysJST / jstDayOfWeek / jstYearMonth / monthKeyJST / shiftMonthKey /',
+	);
+	console.error('    monthStartJST / monthEndJST / isInJstMonth) に置換してください。');
+	console.error(
+		'  - TZ 非依存と言い切れる場合のみ、本 script の ALLOWLIST に file / max / reason を追加します。',
+	);
+	console.error(
+		'    reason には「なぜ TZ 非依存か」を必ず書いてください (空だと本 gate が落ちます)。',
+	);
+	process.exit(1);
+}
+
+if (isMainModule(import.meta.url)) {
+	main();
+}

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -71,6 +71,7 @@ const SKIP_FLAGS = {
 	'--skip-plan-literals': 'skipPlanLiterals',
 	'--skip-license-key-leak': 'skipLicenseKeyLeak',
 	'--skip-cli-entry-guard': 'skipCliEntryGuard',
+	'--skip-local-tz-getters': 'skipLocalTzGetters',
 	'--skip-sparse-checkout-closure': 'skipSparseCheckoutClosure',
 	'--skip-readdir-rotation-guard': 'skipReaddirRotationGuard',
 	'--skip-repo-scan-test-declaration': 'skipRepoScanTestDeclaration',
@@ -94,6 +95,7 @@ function parseArgs(argv) {
 		skipPlanLiterals: false,
 		skipLicenseKeyLeak: false,
 		skipCliEntryGuard: false,
+		skipLocalTzGetters: false,
 		skipSparseCheckoutClosure: false,
 		skipReaddirRotationGuard: false,
 		skipRepoScanTestDeclaration: false,
@@ -146,6 +148,7 @@ Options:
   --skip-sparse-checkout-closure Step 7d workflow sparse-checkout の import 閉包検査をスキップ (#3969)
   --skip-readdir-rotation-guard Step 7e readdir の緩い一致 × 破壊的操作の検査をスキップ (#3978)
   --skip-repo-scan-test-declaration Step 7f repo 走査 test の区分宣言検査をスキップ (#4085)
+  --skip-local-tz-getters Step 7g ローカル TZ 日付 getter 検査をスキップ (#4015 / ADR-0061)
   --skip-lp-labels       Step 8 LP labels 同期検査をスキップ (labels.ts / terms.ts / age-tier.ts 変更時のみ自動実行、Phase 1 B1)
   --skip-pr-body         Step 9 PR body 検査をスキップ
   --skip-doc-code-references Step 10 デッドリンク検査をスキップ
@@ -163,10 +166,12 @@ Steps (番号は表示上の識別子。実行順は下記「実行順」を参�
   5.  measure-lp-dimensions.mjs   — LP 寸法 / 禁止語 (LP 変更時のみ)
   6.  sync-lp-fallback.mjs        — LP fallback テキスト同期検査 (LP / labels.ts 変更時のみ、#1945)
   7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972 / Phase 5 F1 / #1918)
+  7b. check-license-key-leak.mjs — license key 再導入防止 (#2836 / Phase 7 PR-L4)
   7c. check-cli-entry-guard.mjs  — 自前の CLI 直接実行判定 / 手組み file:// URL 禁止 (#3969)
   7d. check-workflow-sparse-checkout-closure.mjs — workflow sparse-checkout の import 閉包検査 (#3969)
   7e. check-readdir-rotation-guard.mjs — readdir の緩い一致で世代を数える class の検出 (#3978)
   7f. check-repo-scan-test-declaration.mjs — repo 走査 test の区分宣言 + 明示 timeout 検査 (#4085)
+  7g. check-local-tz-date-getters.mjs — ローカル TZ 日付 getter 禁止 / JST SSOT 強制 (#4015 / ADR-0061)
   8.  generate-lp-labels --check  — site/shared-labels.js 同期検査 (labels.ts / terms.ts / age-tier.ts 変更時のみ、Phase 1 B1 / #1917)
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
   10. check-doc-code-references.mjs — ドキュメントのデッドリンク検知 (#2577)
@@ -178,7 +183,7 @@ Steps (番号は表示上の識別子。実行順は下記「実行順」を参�
   Step 番号は PR body / docs / Issue から広く参照されるため変更しない。実行順だけを
   「判定に要する時間と参照する情報の量」で並べ替える。同一クラス内は上記の番号順を保つ。
     1) meta      PR body / メタ情報だけを見る    — Step 9
-    2) static    静的テキスト / 単一ファイル検査 — Step 1 / 1b / 4 / 6 / 7 / 7b / 7c / 7d / 8 / 10 / 11
+    2) static    静的テキスト / 単一ファイル検査 — Step 1 / 1b / 4 / 6 / 7 / 7b / 7c / 7d / 7e / 7f / 7g / 8 / 10 / 11
     3) typecheck 型検査                          — Step 2
     4) test      テスト実行                      — Step 3
     5) browser   ヘッドレスブラウザ実測          — Step 5
@@ -734,6 +739,9 @@ export function buildSteps(args, changedFiles) {
 	// #2836 (Epic #2525 Phase 7 PR-L4): license key 全廃の再導入防止 gate
 	const licenseKeyLeakScript = resolve(repoRoot, 'scripts/check-license-key-leak.mjs');
 	const licenseKeyLeakScriptExists = existsSync(licenseKeyLeakScript);
+	// #4015: ローカル TZ 日付 getter の再混入を止める gate (ADR-0061 same-class-N → guard)
+	const localTzGetterScript = resolve(repoRoot, 'scripts/check-local-tz-date-getters.mjs');
+	const localTzGetterScriptExists = existsSync(localTzGetterScript);
 	// #3969: 自前の CLI 直接実行判定 / 手組み file:// URL の再混入を止める gate
 	const cliEntryGuardScript = resolve(repoRoot, 'scripts/check-cli-entry-guard.mjs');
 	const cliEntryGuardScriptExists = existsSync(cliEntryGuardScript);
@@ -968,6 +976,28 @@ export function buildSteps(args, changedFiles) {
 				'  - 判定と貼り付け用エントリ: `node scripts/check-repo-scan-test-declaration.mjs --list`\n' +
 				'  - 宣言先: scripts/lib/ci/repo-scan-test-registry.mjs\n' +
 				'  - scope=repo の test には `vi.setConfig({ testTimeout: 60_000 })` 等の明示 timeout を置く',
+		},
+		// Step 7g: check-local-tz-date-getters (#4015 / ADR-0061 same-class-N → guard)
+		// 実時刻からローカル TZ getter で暦要素を取り出す形 (#4003 と同 class) の再混入を止める。
+		{
+			name: 'local-tz-getters',
+			costClass: 'static',
+			label: localTzGetterScriptExists
+				? 'Step 7g/12: check-local-tz-date-getters.mjs (#4015)'
+				: 'Step 7g/12: check-local-tz-date-getters.mjs (script 未配備 — skip)',
+			...skipStateOf({
+				byFlag: args.skipLocalTzGetters,
+				scriptMissing: !localTzGetterScriptExists,
+			}),
+			runner: () =>
+				run('check-local-tz-date-getters', ['node', 'scripts/check-local-tz-date-getters.mjs']),
+			fixHint:
+				'  ローカル TZ 日付 getter を検出しました (#4015)。\n' +
+				'  - 実時刻 (new Date() / DB timestamp) から暦要素を取り出しているなら欠陥です。\n' +
+				'    $lib/domain/date-utils.ts の JST SSOT (todayDateJST / weekStartJST / weekEndJST /\n' +
+				'    addDaysJST / jstDayOfWeek / jstYearMonth / monthKeyJST 等) に置換してください。\n' +
+				'  - TZ 非依存と言える場合のみ script の ALLOWLIST に file / max / reason を追加します\n' +
+				'    (reason が空だと gate 自身が fail します)。',
 		},
 		// Step 8: generate-lp-labels --check (Phase 1 B1 / #1917)
 		// Issue #1920 graceful degradation: 検査 script が未配備なら skip + warning。

--- a/src/lib/data/preset-challenges.ts
+++ b/src/lib/data/preset-challenges.ts
@@ -1,3 +1,5 @@
+import { addDaysJST, jstYearMonth, monthEndOfKey, toJSTDateString } from '$lib/domain/date-utils';
+
 // Preset cooperative challenge catalog — 新規ユーザー向けの家族チャレンジテンプレート (#2298)
 //
 // Issue #2298 (EPIC #2294 ④): デフォルトプリセット 5-7 件 + setup フロー統合
@@ -145,16 +147,14 @@ export function resolvePresetChallengeDates(
 	preset: PresetChallenge,
 	now: Date = new Date(),
 ): { startDate: string; endDate: string } {
-	const year = now.getFullYear();
-	const month = now.getMonth() + 1; // 1-12
-	const day = now.getDate();
+	// 暦要素は JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) では JST 00:00〜09:00 に
+	// チャレンジ期間が 1 日 (月初 / 年始は 1 ヶ月 / 1 年) ずれる。
+	const todayStr = toJSTDateString(now);
+	const { year, month } = jstYearMonth(now);
+	const day = Number(todayStr.slice(8, 10));
 
 	function pad(n: number): string {
 		return String(n).padStart(2, '0');
-	}
-
-	function formatDate(d: Date): string {
-		return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 	}
 
 	function resolveToken(token: string, isEnd: boolean): string {
@@ -162,23 +162,20 @@ export function resolvePresetChallengeDates(
 			return `${year}-${pad(month)}-01`;
 		}
 		if (token === 'this-month-end') {
-			const lastDay = new Date(year, month, 0).getDate(); // month は 1-12 だが Date(year, month, 0) で当月末日
-			return `${year}-${pad(month)}-${pad(lastDay)}`;
+			return monthEndOfKey(`${year}-${pad(month)}`);
 		}
 		if (token === 'today') {
-			return formatDate(now);
+			return todayStr;
 		}
 		if (token.startsWith('today-plus-')) {
 			const offset = Number(token.slice('today-plus-'.length));
-			const d = new Date(now);
-			d.setDate(d.getDate() + offset);
-			return formatDate(d);
+			return addDaysJST(todayStr, offset);
 		}
 		// MM-DD 形式
 		const match = /^(\d{2})-(\d{2})$/.exec(token);
 		if (!match) {
 			// fallback: 不正値は今日
-			return formatDate(now);
+			return todayStr;
 		}
 		const mm = Number(match[1]);
 		const dd = Number(match[2]);

--- a/src/lib/domain/date-utils.ts
+++ b/src/lib/domain/date-utils.ts
@@ -18,8 +18,40 @@
 //
 // 将来 UTC 保存に移行する場合は recorded_at (timestamp) カラムの
 // 新設が必要（#966 コメント 案A 参照）。
+//
+// ## SSOT 宣言 — 日付を決める計算は本 module 経由で行う (#4015)
+//
+// **「実時刻の瞬間 (`new Date()` / DB timestamp) から暦要素 (年 / 月 / 日 / 曜日) を
+// 取り出す」計算は、必ず本 module の関数を使う。`Date` のローカル TZ getter
+// (`getFullYear()` / `getMonth()` / `getDate()` / `getDay()`) を直接呼ばない。**
+//
+// 理由: 本番 runtime は 2 種類あり、プロセス TZ が一致しない。
+//
+// | runtime | プロセス TZ | ローカル getter の結果 |
+// |---|---|---|
+// | AWS Lambda / CI runner | UTC | JST 00:00〜09:00 の 9 時間、暦日が 1 日前になる |
+// | NUC セルフホスト (日本の家庭) | JST | JST と一致する |
+//
+// つまりローカル getter を使うと **同じコードが環境ごとに違う日付を返す**。#4003 では
+// これで子供ホームの週次チャレンジが毎週 9 時間まるごと消えた。#966 / ADR-0061
+// (same-class-N → guard) に基づき、本 module を単一の入口とする。
+//
+// 機械強制: `scripts/check-local-tz-date-getters.mjs` が src/ 配下のローカル TZ getter を
+// 検出し、allowlist (理由必須) 外の新規使用を CI で fail させる。
+//
+// 実装方針: JST の暦日を `toJSTDateString()` で文字列化し、それを **UTC 深夜として
+// 再解釈**してから UTC 算術 (`getUTCDate` / `setUTCDate`) で計算する。以降の計算が
+// UTC 系で閉じるため、プロセス TZ の影響を受けない。
 
 const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * JST の暦日を「UTC 深夜の Date」として取り出す内部ヘルパ。
+ * 以降の暦計算はすべて UTC 系 (`getUTC*` / `setUTC*`) で閉じるため TZ 非依存。
+ */
+function jstCalendarDay(date: Date): Date {
+	return new Date(`${toJSTDateString(date)}T00:00:00Z`);
+}
 
 /** JSTの「今日」をYYYY-MM-DD形式で返す */
 export function todayDateJST(): string {
@@ -32,9 +64,86 @@ export function toJSTDateString(date: Date): string {
 	return jst.toISOString().slice(0, 10);
 }
 
+/**
+ * JST 日付文字列 (YYYY-MM-DD) の `days` 日後を返す (負値で過去)。
+ *
+ * 暦日文字列を UTC 深夜として解釈し UTC 算術で加減算するため、プロセス TZ に依存しない。
+ * `d.setDate(d.getDate() + n)` (ローカル TZ 版) の置換先。
+ */
+export function addDaysJST(dateStr: string, days: number): string {
+	const d = new Date(`${dateStr}T00:00:00Z`);
+	d.setUTCDate(d.getUTCDate() + days);
+	return d.toISOString().slice(0, 10);
+}
+
 /** JSTの「前日」をYYYY-MM-DD形式で返す */
 export function prevDateJST(dateStr: string): string {
-	const d = new Date(`${dateStr}T00:00:00Z`);
+	return addDaysJST(dateStr, -1);
+}
+
+/**
+ * JST 基準の曜日 (0=日曜 … 6=土曜) を返す。
+ * `new Date().getDay()` (ローカル TZ) の置換先。
+ */
+export function jstDayOfWeek(date: Date = new Date()): number {
+	return jstCalendarDay(date).getUTCDay();
+}
+
+/**
+ * JST 基準の年 / 月 (月は 1-12) を返す。
+ * `now.getFullYear()` / `now.getMonth() + 1` の置換先。
+ */
+export function jstYearMonth(date: Date = new Date()): { year: number; month: number } {
+	const [y, m] = toJSTDateString(date).split('-').map(Number);
+	return { year: y ?? 0, month: m ?? 0 };
+}
+
+/**
+ * JST 基準の月キー (YYYY-MM) を返す。
+ * `` `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}` `` の置換先。
+ */
+export function monthKeyJST(date: Date = new Date()): string {
+	return toJSTDateString(date).slice(0, 7);
+}
+
+/**
+ * 月キー (YYYY-MM) を `delta` ヶ月ずらす (負値で過去)。年またぎを正しく扱う。
+ * `new Date(now.getFullYear(), now.getMonth() - i, 1)` で月を列挙する形の置換先。
+ */
+export function shiftMonthKey(monthKey: string, delta: number): string {
+	const [y, m] = monthKey.split('-').map(Number);
+	const d = new Date(Date.UTC(y ?? 0, (m ?? 1) - 1 + delta, 1));
+	return d.toISOString().slice(0, 7);
+}
+
+/**
+ * ISO timestamp (DB の createdAt 等、UTC 文字列) が JST 基準で月キー (YYYY-MM) に属するか。
+ *
+ * `createdAt.startsWith('2026-07')` のような UTC 前方一致は、JST 月初の 9 時間分を
+ * 前月として落とす。集計の月境界を JST に揃えるための判定入口 (#4015)。
+ */
+export function isInJstMonth(isoTimestamp: string | null | undefined, monthKey: string): boolean {
+	if (!isoTimestamp) return false;
+	const d = new Date(isoTimestamp);
+	if (Number.isNaN(d.getTime())) return false;
+	return monthKeyJST(d) === monthKey;
+}
+
+/** JST 基準で「その月の 1 日」を YYYY-MM-DD で返す */
+export function monthStartJST(date: Date = new Date()): string {
+	return `${monthKeyJST(date)}-01`;
+}
+
+/** JST 基準で「その月の末日」を YYYY-MM-DD で返す */
+export function monthEndJST(date: Date = new Date()): string {
+	return monthEndOfKey(monthKeyJST(date));
+}
+
+/** 月キー (YYYY-MM) の末日を YYYY-MM-DD で返す。うるう年も UTC 算術で正しく扱う。 */
+export function monthEndOfKey(monthKey: string): string {
+	const [y, m] = monthKey.split('-').map(Number);
+	// 翌月 1 日の前日 = 当月末日
+	const d = new Date(Date.UTC(y ?? 0, m ?? 1, 1));
 	d.setUTCDate(d.getUTCDate() - 1);
 	return d.toISOString().slice(0, 10);
 }
@@ -72,6 +181,14 @@ export function weekStartJST(date: Date = new Date()): string {
 	const diff = dow === 0 ? -6 : 1 - dow; // 日曜は前週月曜まで 6 日戻す
 	jstDay.setUTCDate(jstDay.getUTCDate() + diff);
 	return jstDay.toISOString().slice(0, 10);
+}
+
+/**
+ * JST 基準で「その週の日曜 (週末)」を YYYY-MM-DD で返す (#4015)。
+ * 週は月曜始まり・日曜終わりとする (`weekStartJST()` と対で使う)。
+ */
+export function weekEndJST(date: Date = new Date()): string {
+	return addDaysJST(weekStartJST(date), 6);
 }
 
 /**

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3,6 +3,7 @@
 // 全てのUIラベルはこのファイルからインポートすること。ハードコード禁止。
 // #1304: baby=準備モード に表記変更済み（AGE_TIER_LABELS / AGE_TIER_SHORT_LABELS）
 
+import { jstDayOfWeek } from './date-utils';
 // #1916: 用語集（atom）は terms.ts に集約。labels.ts は compound 専用とする SSOT 2 階層化基盤。
 // #1958 (Phase 7 H1): CTA_TERMS を ACTION_LABELS / TRIAL_LABELS から参照（freeTrial / freeTrialWord / freeTrialDesc）
 // #1960 (Phase 7 H3): PRICING_PAGE_LABELS subtitle1 で FREE_TERMS を追加 import
@@ -6917,16 +6918,13 @@ export const USAGE_TIME_LABELS = {
 	minutesUnitDisplay: '（分）',
 	dayOfWeek: (date: string) => {
 		const days = ['日', '月', '火', '水', '木', '金', '土'] as const;
-		const d = new Date(date);
-		// date は YYYY-MM-DD (UTC) で渡されるため、JST に補正
-		const jstDay = new Date(d.getTime() + 9 * 60 * 60 * 1000).getDay();
-		return days[jstDay];
+		// 曜日は JST SSOT 経由 (#4015)。旧実装は +9h の手組みオフセット後に
+		// ローカル TZ getter を読む形で、date-utils と同じ計算を二重に持っていた。
+		return days[jstDayOfWeek(new Date(date))];
 	},
 	chartBarAriaLabel: (childName: string, date: string, min: number) => {
 		const days = ['日', '月', '火', '水', '木', '金', '土'] as const;
-		const d = new Date(date);
-		const jstDay = new Date(d.getTime() + 9 * 60 * 60 * 1000).getDay();
-		return `${childName} ${days[jstDay]}曜日 ${min}分`;
+		return `${childName} ${days[jstDayOfWeek(new Date(date))]}曜日 ${min}分`;
 	},
 } as const;
 

--- a/src/lib/features/child-home/BabyHomePage.svelte
+++ b/src/lib/features/child-home/BabyHomePage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { jstYearMonth } from '$lib/domain/date-utils';
 import { BABY_HOME_LABELS } from '$lib/domain/labels';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
@@ -15,11 +16,15 @@ const ageInfo = $derived.by(() => {
 	if (!child)
 		return { months: 0, weeksUntil3: 36, monthsUntil3: 36, hasDate: false, reached: false };
 	if (child.birthDate) {
-		const birth = new Date(child.birthDate);
+		// 月齢 / 3 歳到達日は JST SSOT 経由 (#4015)。ローカル getter だと SSR (UTC Lambda) と
+		// client (ブラウザ TZ) で月齢が 1 ヶ月ずれ、hydration で表示が切り替わる。
+		const [birthYear = 0, birthMonth = 1, birthDay = 1] = child.birthDate.split('-').map(Number);
 		const now = new Date();
-		const months =
-			(now.getFullYear() - birth.getFullYear()) * 12 + (now.getMonth() - birth.getMonth());
-		const thirdBirthday = new Date(birth.getFullYear() + 3, birth.getMonth(), birth.getDate());
+		const nowJst = jstYearMonth(now);
+		const months = (nowJst.year - birthYear) * 12 + (nowJst.month - birthMonth);
+		const thirdBirthday = new Date(
+			`${birthYear + 3}-${String(birthMonth).padStart(2, '0')}-${String(birthDay).padStart(2, '0')}T00:00:00+09:00`,
+		);
 		const msUntil3 = thirdBirthday.getTime() - now.getTime();
 		const weeksUntil3 = Math.max(0, Math.ceil(msUntil3 / (1000 * 60 * 60 * 24 * 7)));
 		const monthsUntil3 = Math.max(0, Math.ceil(msUntil3 / (1000 * 60 * 60 * 24 * 30.44)));

--- a/src/lib/server/demo/demo-service.ts
+++ b/src/lib/server/demo/demo-service.ts
@@ -10,6 +10,7 @@ import { selectDailyEnemy } from '$lib/domain/battle-enemies';
 import { scaleEnemyStats } from '$lib/domain/battle-engine';
 import { convertToBattleStats, getAgeScaling } from '$lib/domain/battle-stat-calculator';
 import type { BattleStats, Enemy } from '$lib/domain/battle-types';
+import { jstDayOfWeek } from '$lib/domain/date-utils';
 import { type ActivityId, asCategoryId, asChildId, type ChildId } from '$lib/domain/ids';
 import { DEFAULT_POINT_SETTINGS, type PointSettings } from '$lib/domain/point-display';
 import { CATEGORY_DEFS, getActivityDisplayName } from '$lib/domain/validation/activity';
@@ -451,7 +452,9 @@ export function getDemoBattleData(childId: ChildId): DemoBattleData {
 	}
 
 	const playerStats = convertToBattleStats(categoryXp);
-	const dayOfWeek = new Date().getDay();
+	// 曜日は JST SSOT 経由 (#4015)。demo Lambda も UTC 稼働のため、ローカル getter だと
+	// JST 00:00〜09:00 に前日の曜日の敵が出て LP / デモ画面が本番と乖離する。
+	const dayOfWeek = jstDayOfWeek();
 	const enemy = selectDailyEnemy(dayOfWeek, 0.5, 0);
 	const scaling = getAgeScaling(child.uiMode ?? 'preschool');
 	const scaledEnemyStats = scaleEnemyStats(enemy.stats, scaling);

--- a/src/lib/server/services/battle-service.ts
+++ b/src/lib/server/services/battle-service.ts
@@ -6,7 +6,7 @@ import { getEnemyById, selectDailyEnemy } from '$lib/domain/battle-enemies';
 import { executeBattle, scaleEnemyStats } from '$lib/domain/battle-engine';
 import { convertToBattleStats, getAgeScaling } from '$lib/domain/battle-stat-calculator';
 import type { BattleResult, BattleStats, Enemy } from '$lib/domain/battle-types';
-import { todayDateJST } from '$lib/domain/date-utils';
+import { jstDayOfWeek, todayDateJST } from '$lib/domain/date-utils';
 import {
 	completeBattle,
 	countConsecutiveLosses,
@@ -76,7 +76,9 @@ export async function getTodayBattle(
 	if (!battle) {
 		// 新しいバトルを生成
 		const consecutiveLosses = await countConsecutiveLosses(childId, tenantId);
-		const dayOfWeek = new Date().getDay();
+		// 曜日は JST SSOT 経由 (#4015)。同 function の `today` は todayDateJST() なので、
+		// ローカル getter のままだと UTC runtime で「日付は今日 / 敵は前日の曜日」が混在していた。
+		const dayOfWeek = jstDayOfWeek();
 		const enemy = selectDailyEnemy(dayOfWeek, Math.random(), consecutiveLosses);
 		const playerStats = convertToBattleStats(categoryXp);
 

--- a/src/lib/server/services/bonus-hook-service.ts
+++ b/src/lib/server/services/bonus-hook-service.ts
@@ -31,6 +31,7 @@ import { asCategoryId } from '$lib/domain/ids';
 // today categories count を使う形式とする。
 
 import { CATEGORY_CODE_TO_ID } from '$lib/domain/categories';
+import { jstDayOfWeek } from '$lib/domain/date-utils';
 import { calcStreakBonus } from '$lib/domain/validation/activity';
 // #2368 (ADR-0052): bonus state SSOT は marketplace strategy 配下に移動済。
 // 本 import は新 SSOT を直接参照 (旧 rule-preset-import-service の re-export 経由を撤去)。
@@ -162,7 +163,9 @@ export async function evaluateBonusHooks(
 
 			case 'weekend-special': {
 				// 土日: ポイント 2 倍 (relative)
-				const day = ctx.recordedAt.getDay(); // 0=日, 6=土
+				// 曜日は JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) で
+				// JST 月曜 00:00〜09:00 に「週末 2 倍」が誤付与され、土曜同時刻は付与漏れになる。
+				const day = jstDayOfWeek(ctx.recordedAt); // 0=日, 6=土
 				if (day === 0 || day === 6) {
 					const doublePoints = preset.rules.find((r) => r.title === 'しゅうまつ2ばいボーナス');
 					if (doublePoints) {

--- a/src/lib/server/services/breakeven-service.ts
+++ b/src/lib/server/services/breakeven-service.ts
@@ -4,6 +4,7 @@
 // 19-プライシング戦略書.md §6 の損益分岐点分析に準拠。
 // Stripe 売上 + AWS Cost Explorer データを統合して事業採算性を算出。
 
+import { jstYearMonth, monthKeyJST } from '$lib/domain/date-utils';
 import { logger } from '$lib/server/logger';
 import { type AWSCostData, getAWSCostData } from '$lib/server/services/ops-service';
 import { getStripeMetrics, type StripeMetrics } from '$lib/server/services/stripe-metrics-service';
@@ -211,7 +212,7 @@ function generateMockBreakevenData(): BreakevenData {
 	};
 
 	const mockAwsCosts: AWSCostData = {
-		month: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`,
+		month: monthKeyJST(now),
 		services: [
 			{ service: 'AWS Lambda', amount: 0.5, unit: 'USD' },
 			{ service: 'Amazon DynamoDB', amount: 2.8, unit: 'USD' },
@@ -267,8 +268,9 @@ export async function getBreakevenData(): Promise<BreakevenData> {
 
 	try {
 		const now = new Date();
-		const year = now.getFullYear();
-		const month = now.getMonth() + 1;
+		// 対象年月は JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) では JST 月初 /
+		// 年始の 00:00〜09:00 に前月 / 前年のコストを照会していた。
+		const { year, month } = jstYearMonth(now);
 
 		// 並列取得: Stripe 指標 + AWS 原価 (既存データソースを再利用)
 		const [metricsResult, awsCosts] = await Promise.all([

--- a/src/lib/server/services/challenge-set-import-service.ts
+++ b/src/lib/server/services/challenge-set-import-service.ts
@@ -36,12 +36,9 @@ import {
  * monthDay が「今日より過去」なら来年の同月日とする
  * (例: 2026/05/19 時点で「03-03 ひな祭り」を import すると 2027/03/03 になる)。
  *
- * 日付計算は **JST 基準で統一** する (#966 / date-utils.ts SSOT)。
- * Lambda は UTC で稼働するため、`Date.getFullYear()` / `Date.getMonth()` /
- * `Date.toISOString()` をそのまま使うと、0:00〜9:00 JST (= 15:00〜24:00 UTC 前日)
- * の境界で年判定がずれる。例: 2025-12-31 23:30 UTC = 2026-01-01 08:30 JST のとき、
- * UTC 基準の `getFullYear()` は 2025 を返してしまう。toJSTDateString() 経由で
- * JST の YYYY-MM-DD 文字列を取得し、そこから年を抽出することで境界を正しく扱う。
+ * 日付計算は `$lib/domain/date-utils.ts` の JST SSOT 経由で行う
+ * (同 module 冒頭の「SSOT 宣言」を参照、#966 / #4015)。ここでは toJSTDateString() で
+ * JST の YYYY-MM-DD を取得し、そこから年を抽出する。
  *
  * @param monthDay 'MM-DD' 形式 (例: '03-03')
  * @param durationDays 期間 (日数)。startDate = endDate の (durationDays - 1) 日前

--- a/src/lib/server/services/cohort-analysis-service.ts
+++ b/src/lib/server/services/cohort-analysis-service.ts
@@ -174,9 +174,10 @@ export async function getCohortAnalysis(monthsBack = 6): Promise<CohortAnalysisR
 
 	// 直近 N ヶ月分のコホートを抽出。
 	// #3449: cohort 鍵 (getSignupMonth = createdAt.slice(0,7) = UTC 月) と一致させるため、月列挙も
-	// **UTC 基準**で行う (旧実装は now.getFullYear()/getMonth() のローカル月でズレ、JST 月初 = UTC 前月末に
-	// signup したテナントが key mismatch で取りこぼされ /ops の retention/ARPU/churn が境界分過小集計、
-	// Lambda(UTC)/dev(JST) で結果分岐していた)。UTC を月境界 SSOT に統一する。
+	// **UTC 基準**で行う。ローカル TZ getter が環境ごとに違う日付を返す理由は
+	// `$lib/domain/date-utils.ts` 冒頭の「SSOT 宣言」を参照 (#4015)。本 module が JST ではなく
+	// UTC を月境界に選ぶのは、鍵が createdAt (ISO UTC) 由来だからで、ops-analytics-service の
+	// getMonthKey() もこの決定に揃えている。
 	const targetMonths: string[] = [];
 	for (let i = monthsBack - 1; i >= 0; i--) {
 		const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1));

--- a/src/lib/server/services/evaluation-service.ts
+++ b/src/lib/server/services/evaluation-service.ts
@@ -2,7 +2,13 @@ import type { CategoryId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/evaluation-service.ts
 // 週次評価・日次ステータス減少サービス
 
-import { todayDateJST } from '$lib/domain/date-utils';
+import {
+	addDaysJST,
+	jstDayOfWeek,
+	todayDateJST,
+	toJSTDateString,
+	weekStartJST,
+} from '$lib/domain/date-utils';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { calcDecay, type DecayIntensity } from '$lib/domain/validation/status';
 import {
@@ -51,19 +57,16 @@ export function getWeekRange(date: Date = new Date()): {
 	weekStart: string;
 	weekEnd: string;
 } {
-	const d = new Date(date);
-	// 前の週の月曜〜日曜を対象
-	const dayOfWeek = d.getDay(); // 0=Sun, 1=Mon, ...
-	const daysToLastSunday = dayOfWeek === 0 ? 0 : dayOfWeek;
-	const lastSunday = new Date(d);
-	lastSunday.setDate(d.getDate() - daysToLastSunday);
-
-	const lastMonday = new Date(lastSunday);
-	lastMonday.setDate(lastSunday.getDate() - 6);
+	// 前の週の月曜〜日曜を対象。JST SSOT 経由で決める (#4015)。
+	// 旧実装は `d.getDay()` / `setDate(d.getDate() - n)` のローカル TZ 算術に `toISOString()` の
+	// UTC 日付化を重ねており、Lambda (UTC) では JST 00:00〜09:00 に週範囲が 1 日ずれていた。
+	const todayJST = toJSTDateString(date);
+	// 「直近の日曜」= 当日が日曜ならその日、そうでなければ今週月曜の前日
+	const lastSunday = jstDayOfWeek(date) === 0 ? todayJST : addDaysJST(weekStartJST(date), -1);
 
 	return {
-		weekStart: lastMonday.toISOString().slice(0, 10),
-		weekEnd: lastSunday.toISOString().slice(0, 10),
+		weekStart: addDaysJST(lastSunday, -6),
+		weekEnd: lastSunday,
 	};
 }
 

--- a/src/lib/server/services/ops-analytics-service.ts
+++ b/src/lib/server/services/ops-analytics-service.ts
@@ -151,9 +151,18 @@ const PLAN_MRR_UNIT: Record<string, number> = {
 // Helpers (exported for tests)
 // ============================================================
 
+/**
+ * 月キー (YYYY-MM) を **UTC 基準**で返す (#4015)。
+ *
+ * 旧実装はローカル TZ getter で、Lambda (UTC) と dev (JST) で結果が分岐していた。
+ * ここを JST ではなく UTC に固定するのは、本 module の月キーが `tenant.createdAt`
+ * (ISO UTC 文字列) を直接 key 化するためで、cohort-analysis-service が #3449 で
+ * 同じ理由から UTC を月境界 SSOT に選んだ決定に揃える (両者の月バケットが食い違うと
+ * /ops 上で retention / acquisition が不整合になる)。
+ */
 export function getMonthKey(date: Date | string): string {
 	const d = typeof date === 'string' ? new Date(date) : date;
-	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+	return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
 export function monthDiff(from: string, to: string): number {
@@ -192,7 +201,7 @@ export function computeAnalytics(
 	// ── 1. Monthly Acquisitions (過去 12 ヶ月) ──
 	const acquisitionMap = new Map<string, MonthlyAcquisition>();
 	for (let i = 11; i >= 0; i--) {
-		const d = new Date(currentDate.getFullYear(), currentDate.getMonth() - i, 1);
+		const d = new Date(Date.UTC(currentDate.getUTCFullYear(), currentDate.getUTCMonth() - i, 1));
 		const key = getMonthKey(d);
 		acquisitionMap.set(key, { month: key, organic: 0, total: 0 });
 	}

--- a/src/lib/server/services/ops-service.ts
+++ b/src/lib/server/services/ops-service.ts
@@ -4,6 +4,7 @@
 import { SUBSCRIPTION_PLAN } from '$lib/domain/constants/subscription-plan';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { MS_PER_DAY } from '$lib/domain/constants/time';
+import { monthStartJST } from '$lib/domain/date-utils';
 import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -63,8 +64,9 @@ async function getTenantStats(): Promise<TenantStats> {
 	const repos = getRepos();
 	const tenants = await repos.auth.listAllTenants();
 
-	const now = new Date();
-	const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+	// 月初境界は JST SSOT 経由 (#4015)。旧実装はローカル月初 (Lambda=UTC / dev=JST) で
+	// 環境ごとに「今月の新規テナント数」が変わっていた。
+	const monthStart = new Date(`${monthStartJST()}T00:00:00+09:00`);
 
 	return {
 		total: tenants.length,

--- a/src/lib/server/services/pmf-survey-service.ts
+++ b/src/lib/server/services/pmf-survey-service.ts
@@ -18,6 +18,7 @@
 // ops 集計 (ops/pmf-survey/+page.server.ts) はテナント全件走査で取得。
 // Pre-PMF 規模 (~100 テナント) では DynamoDB Scan でも問題ない。
 
+import { jstYearMonth } from '$lib/domain/date-utils';
 import type { PmfSurveyQ1, PmfSurveyQ3 } from '$lib/domain/labels';
 import { getEnv } from '$lib/runtime/env';
 import { getRepos } from '$lib/server/db/factory';
@@ -103,8 +104,9 @@ export interface PmfSurveyRunResult {
  * 手動 invoke 時の round 推定もこの関数を SSOT とする。
  */
 export function getCurrentRound(now: Date = new Date()): string {
-	const year = now.getFullYear();
-	const month = now.getMonth() + 1; // 1-12
+	// 年 / 月は JST SSOT 経由 (#4015)。配信 cron は 6/1・12/1 09:00 JST = 月境界の直上で、
+	// ローカル getter だと Lambda (UTC) で H1/H2 が反転しうる。
+	const { year, month } = jstYearMonth(now); // month は 1-12
 	const half = month <= 6 ? 'H1' : 'H2';
 	return `${year}-${half}`;
 }

--- a/src/lib/server/services/pricing-trigger-service.ts
+++ b/src/lib/server/services/pricing-trigger-service.ts
@@ -5,6 +5,7 @@
 import { env } from '$env/dynamic/private';
 import { FAMILY_PLANS } from '$lib/domain/constants/subscription-plan';
 import { isChurnedContract, SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { jstYearMonth } from '$lib/domain/date-utils';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { isStripeEnabled } from '$lib/server/stripe/client';
@@ -355,8 +356,10 @@ async function sendPricingTriggerNotification(report: PricingTriggerReport): Pro
  * collectMonthlyMetrics を呼んで最新のメトリクスで判定する
  */
 export async function getActiveTriggers(): Promise<PricingTriggerReport> {
-	const now = new Date();
-	return runPricingTriggerCheck(now.getFullYear(), now.getMonth() + 1);
+	// 対象年月は JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) で月初 00:00〜09:00 に
+	// 前月メトリクスでトリガー判定していた。
+	const { year, month } = jstYearMonth();
+	return runPricingTriggerCheck(year, month);
 }
 
 /**

--- a/src/lib/server/services/report-service.ts
+++ b/src/lib/server/services/report-service.ts
@@ -2,6 +2,7 @@ import type { ChildId } from '$lib/domain/ids';
 // src/lib/server/services/report-service.ts
 // 月次レポート・成長分析のサービス層
 
+import { monthEndOfKey, toJSTDateString } from '$lib/domain/date-utils';
 import { getRepos } from '$lib/server/db/factory';
 import type { ReportDailySummary } from '$lib/server/db/types';
 import { logger } from '$lib/server/logger';
@@ -474,17 +475,14 @@ export async function computeAllChildrenDetailedReport(
 // ヘルパー
 // ============================================================
 
+// 日付文字列化は JST SSOT (date-utils) に委譲する (#4015)。
+// 旧実装はローカル TZ getter で `YYYY-MM-DD` を組み立てており、当月レポートで
+// `formatDate(limit)` (limit = `new Date()` = 実時刻) を通る経路が Lambda (UTC) では
+// JST 00:00〜09:00 に前日を返し、streak 起点が 1 日ずれていた。
 function formatDate(d: Date): string {
-	const y = d.getFullYear();
-	const m = String(d.getMonth() + 1).padStart(2, '0');
-	const day = String(d.getDate()).padStart(2, '0');
-	return `${y}-${m}-${day}`;
+	return toJSTDateString(d);
 }
 
 function getMonthEndDate(yearMonth: string): string {
-	const parts = yearMonth.split('-').map(Number);
-	const y = parts[0] ?? 2026;
-	const m = parts[1] ?? 1;
-	const lastDay = new Date(y, m, 0).getDate();
-	return `${yearMonth}-${String(lastDay).padStart(2, '0')}`;
+	return monthEndOfKey(yearMonth);
 }

--- a/src/lib/server/services/sibling-ranking-service.ts
+++ b/src/lib/server/services/sibling-ranking-service.ts
@@ -2,6 +2,13 @@ import type { ChildId } from '$lib/domain/ids';
 // src/lib/server/services/sibling-ranking-service.ts
 // きょうだいランキング — 既存データからリアルタイム算出
 
+import {
+	addDaysJST,
+	monthEndJST,
+	monthStartJST,
+	weekEndJST,
+	weekStartJST,
+} from '$lib/domain/date-utils';
 import { findActivityLogs } from '$lib/server/db/activity-repo';
 import { findAllChildren } from '$lib/server/db/child-repo';
 import { getSetting } from '$lib/server/db/settings-repo';
@@ -26,25 +33,10 @@ export interface WeeklyRankingResult {
 	encouragement: string;
 }
 
-/** 週の開始日（月曜）を取得 */
-function getWeekStart(): string {
-	const now = new Date();
-	const day = now.getDay();
-	const diff = day === 0 ? 6 : day - 1; // Monday = 0
-	const monday = new Date(now);
-	monday.setDate(now.getDate() - diff);
-	return monday.toISOString().slice(0, 10);
-}
-
-/** 週の終了日（日曜）を取得 */
-function getWeekEnd(): string {
-	const now = new Date();
-	const day = now.getDay();
-	const diff = day === 0 ? 0 : 7 - day;
-	const sunday = new Date(now);
-	sunday.setDate(now.getDate() + diff);
-	return sunday.toISOString().slice(0, 10);
-}
+// 週 / 月の境界は JST SSOT (date-utils) 経由で決める (#4015)。
+// 旧実装は `new Date().getDay()` / `setDate(now.getDate() - diff)` のローカル TZ 算術に
+// `toISOString()` の UTC 日付化を重ねており、Lambda (UTC) では JST 月曜 00:00〜09:00 に
+// 前週の範囲を、NUC (JST) では朝 09:00 前に前日側の範囲を返していた。
 
 /** ランキングが有効かチェック（デフォルト: OFF） */
 export async function isRankingEnabled(tenantId: string): Promise<boolean> {
@@ -54,8 +46,8 @@ export async function isRankingEnabled(tenantId: string): Promise<boolean> {
 
 /** 今週のきょうだいランキングを算出 */
 export async function getWeeklyRanking(tenantId: string): Promise<WeeklyRankingResult> {
-	const weekStart = getWeekStart();
-	const weekEnd = getWeekEnd();
+	const weekStart = weekStartJST();
+	const weekEnd = weekEndJST();
 
 	const result = await getRankingForPeriod(tenantId, weekStart, weekEnd);
 
@@ -105,25 +97,18 @@ export async function getRankingTrend(tenantId: string, numWeeks = 4): Promise<R
 		weekStart: string;
 		weekEnd: string;
 		weekLabel: string;
-		monday: Date;
 	}
 	const weekBoundaries: WeekBoundary[] = [];
+	// 今週の月曜 (JST) を起点に 7 日ずつ遡る。暦日文字列上の加算なので TZ 非依存 (#4015)。
+	const currentMonday = weekStartJST(now);
 	for (let w = numWeeks - 1; w >= 0; w--) {
-		const refDate = new Date(now);
-		refDate.setDate(refDate.getDate() - w * 7);
-
-		const day = refDate.getDay();
-		const mondayOffset = day === 0 ? 6 : day - 1;
-		const monday = new Date(refDate);
-		monday.setDate(refDate.getDate() - mondayOffset);
-		const sunday = new Date(monday);
-		sunday.setDate(monday.getDate() + 6);
-
+		const monday = addDaysJST(currentMonday, -w * 7);
+		const sunday = addDaysJST(monday, 6);
+		const [, mm, dd] = monday.split('-');
 		weekBoundaries.push({
-			weekStart: monday.toISOString().slice(0, 10),
-			weekEnd: sunday.toISOString().slice(0, 10),
-			weekLabel: `${monday.getMonth() + 1}/${monday.getDate()}〜`,
-			monday,
+			weekStart: monday,
+			weekEnd: sunday,
+			weekLabel: `${Number(mm)}/${Number(dd)}〜`,
 		});
 	}
 
@@ -168,12 +153,7 @@ export async function getRankingTrend(tenantId: string, numWeeks = 4): Promise<R
 
 /** 今月のきょうだいランキングを算出 */
 export async function getMonthlyRanking(tenantId: string): Promise<WeeklyRankingResult> {
-	const now = new Date();
-	const monthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
-	const lastDay = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-	const monthEnd = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
-
-	return getRankingForPeriod(tenantId, monthStart, monthEnd);
+	return getRankingForPeriod(tenantId, monthStartJST(), monthEndJST());
 }
 
 /** 期間指定のきょうだいランキング（週次・月次共通ロジック） */

--- a/src/lib/server/services/status-service.ts
+++ b/src/lib/server/services/status-service.ts
@@ -2,6 +2,7 @@ import type { CategoryId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/status-service.ts
 // ステータス管理サービス層
 
+import { monthStartJST } from '$lib/domain/date-utils';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import {
 	calcCharacterType,
@@ -138,10 +139,10 @@ export async function getMonthlyComparison(
 
 	const statusRows = await findStatuses(childId, tenantId);
 
-	// 先月末の日付を計算
-	const now = new Date();
-	const firstOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
-	const lastMonthEnd = firstOfMonth.toISOString();
+	// 先月末の日付を計算。月初境界は JST SSOT 経由で決める (#4015)。
+	// 旧実装は `now.getFullYear()/getMonth()` のローカル月で、Lambda (UTC) では JST 月初
+	// 00:00〜09:00 に前月 1 日が基準となり前月比が 1 ヶ月ずれていた。
+	const lastMonthEnd = `${monthStartJST()}T00:00:00.000Z`;
 
 	const current: Record<string, number> = {};
 	const previous: Record<string, number> = {};

--- a/src/lib/server/services/stripe-metrics-service.ts
+++ b/src/lib/server/services/stripe-metrics-service.ts
@@ -6,6 +6,7 @@
 
 import { SUBSCRIPTION_PLAN, type SubscriptionPlan } from '$lib/domain/constants/subscription-plan';
 import { isChurnedContract, SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { monthKeyJST, shiftMonthKey } from '$lib/domain/date-utils';
 import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -98,8 +99,7 @@ function generateMockMetrics(): StripeMetricsWithTrend {
 	// 過去 6 か月のダミートレンド
 	const trend: MonthlyMetricPoint[] = [];
 	for (let i = 5; i >= 0; i--) {
-		const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-		const month = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+		const month = shiftMonthKey(monthKeyJST(now), -i);
 		const paidCount = Math.max(1, 6 - i);
 		trend.push({
 			month,
@@ -287,7 +287,9 @@ export async function getStripeMetrics(): Promise<StripeMetricsWithTrend> {
 		const tenants = await repos.auth.listAllTenants();
 
 		const now = new Date();
-		const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+		// 月キーは JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) では JST 月初
+		// 00:00〜09:00 に前月キーとなり、churn / MRR が誤った月に載っていた。
+		const currentMonth = monthKeyJST(now);
 
 		const activePaidCount = countActivePaid(tenants);
 		const mrr = calculateMRR(tenants);
@@ -312,8 +314,7 @@ export async function getStripeMetrics(): Promise<StripeMetricsWithTrend> {
 		// 過去 6 か月のトレンド
 		const trend: MonthlyMetricPoint[] = [];
 		for (let i = 5; i >= 0; i--) {
-			const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
-			const month = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+			const month = shiftMonthKey(monthKeyJST(now), -i);
 			const churnRate = calculateMonthlyChurnRate(tenants, month);
 
 			// 過去月のスナップショットはDB状態から正確には取れないため、

--- a/src/lib/server/services/trial-service.ts
+++ b/src/lib/server/services/trial-service.ts
@@ -2,7 +2,7 @@
 // トライアル管理サービス (#314 リファクタ)
 // trial_history テーブルベースに移行。settings の trial_* は後方互換用に読み取りのみ。
 
-import { toJSTDateString } from '$lib/domain/date-utils';
+import { addDaysJST, toJSTDateString } from '$lib/domain/date-utils';
 import { getRepos } from '$lib/server/db/factory';
 import { getDebugTrialOverride } from '$lib/server/debug-plan';
 import { logger } from '$lib/server/logger';
@@ -153,12 +153,12 @@ export async function startTrial(input: StartTrialInput): Promise<boolean> {
 		return false;
 	}
 
-	const now = new Date();
-	const end = new Date(now);
-	end.setDate(end.getDate() + durationDays);
-
-	const startStr = formatDate(now);
-	const endStr = formatDate(end);
+	// トライアル開始日 / 終了日は顧客可視かつプラン判定に直結する暦日。JST SSOT 経由で決める (#4015)。
+	// 旧実装はローカル TZ getter の独自 formatDate() で、Lambda (UTC) では JST 00:00〜09:00 に
+	// 開始したトライアルの開始日 / 終了日が 1 日前倒しになっていた
+	// (読み出し側 getTrialStatus は toJSTDateString() で JST 判定しており基準が不一致)。
+	const startStr = toJSTDateString(new Date());
+	const endStr = addDaysJST(startStr, durationDays);
 
 	await getRepos().trialHistory.insert({
 		tenantId,
@@ -208,11 +208,4 @@ export async function getTrialTier(tenantId: string): Promise<TrialTier | null> 
 
 	const status = await getTrialStatus(tenantId);
 	return status.isTrialActive ? status.trialTier : null;
-}
-
-function formatDate(d: Date): string {
-	const y = d.getFullYear();
-	const m = String(d.getMonth() + 1).padStart(2, '0');
-	const day = String(d.getDate()).padStart(2, '0');
-	return `${y}-${m}-${day}`;
 }

--- a/src/lib/ui/primitives/BirthdayInput.svelte
+++ b/src/lib/ui/primitives/BirthdayInput.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { untrack } from 'svelte';
+import { jstYearMonth } from '$lib/domain/date-utils';
 import { UI_PRIMITIVES_LABELS } from '$lib/domain/labels';
 import FormField from './FormField.svelte';
 import NativeSelect from './NativeSelect.svelte';
@@ -24,7 +25,9 @@ let {
 	hint,
 }: Props = $props();
 
-const currentYear = new Date().getFullYear();
+// 年の選択肢は JST SSOT 経由 (#4015)。ローカル getter だと SSR (UTC) と client で
+// 年始 00:00〜09:00 に選択肢の範囲が 1 年ずれる。
+const currentYear = jstYearMonth().year;
 const years = Array.from({ length: 19 }, (_, i) => currentYear - i);
 const yearOptions = years.map((y) => ({
 	value: String(y),

--- a/src/routes/(child)/checklist/+page.svelte
+++ b/src/routes/(child)/checklist/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
+import { jstDayOfWeek } from '$lib/domain/date-utils';
 import { APP_LABELS, CHILD_CHECKLIST_LABELS, PAGE_TITLES } from '$lib/domain/labels';
 import { formatPointValueWithSign } from '$lib/domain/point-display';
 import type { CelebrationType } from '$lib/ui/components/CelebrationEffect.svelte';
@@ -31,7 +32,9 @@ const DAY_NAMES = [
 	'どようび',
 ];
 
-const todayDayName = $derived(DAY_NAMES[new Date().getDay()]);
+// 曜日は JST SSOT 経由 (#4015)。ローカル getter だと SSR (UTC Lambda) が JST 00:00〜09:00 に
+// 前日の曜日を描画し、hydration で切り替わる (子供画面に誤情報 + ちらつき)。
+const todayDayName = $derived(DAY_NAMES[jstDayOfWeek()]);
 
 // 時間帯ラベル
 const TIME_SLOT_LABELS: Record<string, string> = {

--- a/src/routes/(parent)/admin/+page.server.ts
+++ b/src/routes/(parent)/admin/+page.server.ts
@@ -1,4 +1,5 @@
 import { fail } from '@sveltejs/kit';
+import { monthKeyJST } from '$lib/domain/date-utils';
 import type { ChildId } from '$lib/domain/ids';
 import { requireTenantId } from '$lib/server/auth/factory';
 // #2295 (EPIC #2294 ①): season-event-repo / seasonal-content-service 削除済 (2026-05-19)
@@ -149,8 +150,9 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 			}),
 	]);
 
-	const now = new Date();
-	const yearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+	// 当月キーは JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) で月初
+	// 00:00〜09:00 に前月キーで集計を取得していた。
+	const yearMonth = monthKeyJST();
 	const isPaid = isPaidTier(tier);
 
 	// #3088: 以降の 6 ブロックは children + tenantId のみ依存で相互独立 → 並列実行して wall-clock を短縮。

--- a/src/routes/(parent)/admin/children/+page.server.ts
+++ b/src/routes/(parent)/admin/children/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { calculateAgeFromBirthDate } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asCategoryId, asChildId } from '$lib/domain/ids';
@@ -31,15 +32,11 @@ import {
 } from '$lib/server/services/voice-service';
 import type { Actions, PageServerLoad } from './$types';
 
+// 年齢計算は date-utils の SSOT (calculateAgeFromBirthDate) に委譲する (#4015)。
+// 旧実装は `new Date()` のローカル TZ getter で「今日」を決めており、Lambda (UTC) では
+// JST 00:00〜09:00 に誕生日当日の年齢が 1 歳ずれていた。
 function calculateAge(birthDate: string): number {
-	const birth = new Date(birthDate);
-	const today = new Date();
-	let age = today.getFullYear() - birth.getFullYear();
-	const monthDiff = today.getMonth() - birth.getMonth();
-	if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
-		age--;
-	}
-	return Math.max(0, Math.min(18, age));
+	return Math.min(18, calculateAgeFromBirthDate(birthDate));
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 複雑なビジネスロジックのため、別 Issue でリファクタ予定

--- a/src/routes/(parent)/admin/growth-book/+page.server.ts
+++ b/src/routes/(parent)/admin/growth-book/+page.server.ts
@@ -1,4 +1,5 @@
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { jstYearMonth } from '$lib/domain/date-utils';
 import { asChildId } from '$lib/domain/ids';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
@@ -6,11 +7,11 @@ import { buildGrowthBook } from '$lib/server/services/growth-book-service';
 import { isPaidTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { PageServerLoad } from './$types';
 
+// 年度判定は JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) で
+// 4/1 の JST 00:00〜09:00 に年度が 1 年ずれる。
 function currentFiscalYear(): string {
-	const now = new Date();
-	const y = now.getFullYear();
-	const m = now.getMonth() + 1;
-	return String(m >= 4 ? y : y - 1);
+	const { year, month } = jstYearMonth();
+	return String(month >= 4 ? year : year - 1);
 }
 
 export const load: PageServerLoad = async ({ url, locals }) => {

--- a/src/routes/(parent)/admin/points/+page.svelte
+++ b/src/routes/(parent)/admin/points/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { isInJstMonth, monthKeyJST, shiftMonthKey } from '$lib/domain/date-utils';
 import type { ChildId } from '$lib/domain/ids';
 import { APP_LABELS, PAGE_TITLES, POINTS_LABELS } from '$lib/domain/labels';
 import { formatPointValue, getUnitLabel } from '$lib/domain/point-display';
@@ -57,25 +58,16 @@ const convertHistory = $derived(selectedChild?.convertHistory ?? []);
 let historyPeriod = $state<'this-month' | 'last-month' | 'all'>('all');
 const filteredHistory = $derived.by(() => {
 	if (historyPeriod === 'all') return convertHistory;
-	const now = new Date();
-	const year =
-		historyPeriod === 'last-month' && now.getMonth() === 0
-			? now.getFullYear() - 1
-			: now.getFullYear();
-	const month =
-		historyPeriod === 'last-month'
-			? now.getMonth() === 0
-				? 12
-				: now.getMonth()
-			: now.getMonth() + 1;
-	const prefix = `${year}-${String(month).padStart(2, '0')}`;
-	return convertHistory.filter((h) => h.createdAt?.startsWith(prefix));
+	// 月キーは JST SSOT 経由 (#4015)。旧実装はローカル TZ getter で月キーを作り、
+	// UTC ISO 文字列の createdAt に startsWith 比較していたため、SSR (UTC) と
+	// client (ブラウザ TZ) で結果が変わり、月初 9 時間分の履歴が集計から落ちていた。
+	const prefix = historyPeriod === 'last-month' ? shiftMonthKey(monthKeyJST(), -1) : monthKeyJST();
+	return convertHistory.filter((h) => isInJstMonth(h.createdAt, prefix));
 });
 const thisMonthTotal = $derived.by(() => {
-	const now = new Date();
-	const monthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+	const monthKey = monthKeyJST();
 	return convertHistory
-		.filter((h) => h.createdAt?.startsWith(monthStart))
+		.filter((h) => isInJstMonth(h.createdAt, monthKey))
 		.reduce((sum, h) => sum + Math.abs(h.amount), 0);
 });
 const allTimeTotal = $derived(convertHistory.reduce((sum, h) => sum + Math.abs(h.amount), 0));

--- a/src/routes/(parent)/admin/reports/+page.server.ts
+++ b/src/routes/(parent)/admin/reports/+page.server.ts
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { monthKeyJST } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
@@ -20,10 +21,9 @@ import type { Actions, PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ locals, url, parent }) => {
 	const tenantId = requireTenantId(locals);
 
-	// 月パラメータ（デフォルト: 今月）
-	const now = new Date();
-	const defaultMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-	const selectedMonth = url.searchParams.get('month') ?? defaultMonth;
+	// 月パラメータ（デフォルト: 今月）。月キーは JST SSOT 経由 (#4015) —
+	// ローカル getter だと Lambda (UTC) で月初 00:00〜09:00 に前月レポートが既定表示になる。
+	const selectedMonth = url.searchParams.get('month') ?? monthKeyJST();
 
 	const [children, reportSettings] = await Promise.all([
 		getAllChildren(tenantId),

--- a/src/routes/(parent)/admin/settings/rules/+page.svelte
+++ b/src/routes/(parent)/admin/settings/rules/+page.svelte
@@ -3,6 +3,7 @@ import { tick } from 'svelte';
 import { enhance } from '$app/forms';
 import { invalidateAll, replaceState } from '$app/navigation';
 import { page } from '$app/state';
+import { toJSTDateString } from '$lib/domain/date-utils';
 import { ADMIN_RULES_PAGE_LABELS, APP_LABELS, UI_LABELS } from '$lib/domain/labels';
 // #2895: marketplace 陳列の in-page browse UI / OverflowMenu / help-restore-export dialog を撤去し、
 // 本画面は「取込済 bonus ルールの確認 + ON/OFF + 削除」に簡素化。
@@ -160,10 +161,12 @@ async function cleanupImportQueryParam() {
 	}
 }
 
+// 取込日時の日付化は JST SSOT 経由 (#4015)。ローカル getter だと SSR (UTC Lambda) と
+// client (ブラウザ TZ) で表示日が変わり、JST 00:00〜09:00 の取込が前日表示になる。
 function formatImportedAt(iso: string): string {
 	try {
-		const d = new Date(iso);
-		return `${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()}`;
+		const [y, m, d] = toJSTDateString(new Date(iso)).split('-');
+		return `${y}/${Number(m)}/${Number(d)}`;
 	} catch {
 		return iso;
 	}

--- a/src/routes/api/v1/activity-logs/+server.ts
+++ b/src/routes/api/v1/activity-logs/+server.ts
@@ -1,5 +1,13 @@
 import { json } from '@sveltejs/kit';
 import * as v from 'valibot';
+import {
+	addDaysJST,
+	jstDayOfWeek,
+	jstYearMonth,
+	monthStartJST,
+	todayDateJST,
+	weekStartJST,
+} from '$lib/domain/date-utils';
 import { activityLogsQuerySchema, recordActivitySchema } from '$lib/domain/validation/activity';
 import { apiError, validationError } from '$lib/server/errors';
 import { getActivityLogs, recordActivity } from '$lib/server/services/activity-log-service';
@@ -52,20 +60,21 @@ export const GET: RequestHandler = async ({ url, locals }) => {
 	const dateTo = to;
 
 	if (!dateFrom) {
-		const now = new Date();
+		// 期間の起点は JST SSOT 経由 (#4015)。旧実装は「ローカル TZ の曜日で週頭を決めて
+		// UTC 文字列化」という #4003 と同型の混在で、JST 00:00〜09:00 に 1 日ずれていた。
 		switch (period) {
 			case 'week': {
-				const d = new Date(now);
-				d.setDate(d.getDate() - d.getDay()); // Start of week (Sunday)
-				dateFrom = d.toISOString().slice(0, 10);
+				// 週の起点は日曜 (本 API の既存仕様)。weekStartJST() は月曜始まりのため 1 日戻す。
+				const monday = weekStartJST();
+				dateFrom = jstDayOfWeek() === 0 ? todayDateJST() : addDaysJST(monday, -1);
 				break;
 			}
 			case 'month': {
-				dateFrom = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+				dateFrom = monthStartJST();
 				break;
 			}
 			case 'year': {
-				dateFrom = `${now.getFullYear()}-01-01`;
+				dateFrom = `${jstYearMonth().year}-01-01`;
 				break;
 			}
 		}

--- a/src/routes/ops/costs/+page.server.ts
+++ b/src/routes/ops/costs/+page.server.ts
@@ -1,13 +1,16 @@
 // src/routes/ops/costs/+page.server.ts
 // AWS費用詳細ページ (#0176 Phase 3)
 
+import { jstYearMonth } from '$lib/domain/date-utils';
 import { getAWSCostData } from '$lib/server/services/ops-service';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {
-	const now = new Date();
-	const year = Number.parseInt(url.searchParams.get('year') ?? String(now.getFullYear()), 10);
-	const month = Number.parseInt(url.searchParams.get('month') ?? String(now.getMonth() + 1), 10);
+	// 既定の対象年月は JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) で
+	// 月初 / 年始の 00:00〜09:00 に前月 / 前年のコストが既定表示になる。
+	const nowJst = jstYearMonth();
+	const year = Number.parseInt(url.searchParams.get('year') ?? String(nowJst.year), 10);
+	const month = Number.parseInt(url.searchParams.get('month') ?? String(nowJst.month), 10);
 
 	const costs = await getAWSCostData(year, month);
 

--- a/src/routes/ops/export/+page.server.ts
+++ b/src/routes/ops/export/+page.server.ts
@@ -1,12 +1,14 @@
 // src/routes/ops/export/+page.server.ts
 // CSVエクスポートページ (#0176 Phase 4)
 
+import { jstYearMonth } from '$lib/domain/date-utils';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async () => {
-	const now = new Date();
+	// 既定年月は JST SSOT 経由 (#4015)
+	const { year, month } = jstYearMonth();
 	return {
-		currentYear: now.getFullYear(),
-		currentMonth: now.getMonth() + 1,
+		currentYear: year,
+		currentMonth: month,
 	};
 };

--- a/src/routes/ops/export/+page.svelte
+++ b/src/routes/ops/export/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { jstYearMonth } from '$lib/domain/date-utils';
 import { OPS_EXPORT_LABELS } from '$lib/domain/labels';
 import { notifyApiError, notifyNetworkError } from '$lib/ui/error-notify';
 import Button from '$lib/ui/primitives/Button.svelte';
@@ -7,9 +8,11 @@ import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
 
 let { data } = $props();
 
-let year = $state(new Date().getFullYear());
+// 初期値も JST SSOT 経由 (#4015)。$effect で server 値に収束するが、SSR (UTC) と
+// client (ブラウザ TZ) で初回描画が食い違うのを避ける。
+let year = $state(jstYearMonth().year);
 let monthFrom = $state(1);
-let monthTo = $state(new Date().getMonth() + 1);
+let monthTo = $state(jstYearMonth().month);
 // サーバーデータから年月を同期
 $effect(() => {
 	year = data.currentYear;

--- a/src/routes/ops/export/+server.ts
+++ b/src/routes/ops/export/+server.ts
@@ -2,6 +2,7 @@
 // CSVダウンロードAPI (#0176 Phase 4)
 
 import { error } from '@sveltejs/kit';
+import { jstYearMonth } from '$lib/domain/date-utils';
 import {
 	generateExpenseLedgerCsv,
 	generatePLSummary,
@@ -13,10 +14,8 @@ import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url }) => {
 	const type = url.searchParams.get('type');
-	const year = Number.parseInt(
-		url.searchParams.get('year') ?? String(new Date().getFullYear()),
-		10,
-	);
+	// 既定の対象年は JST SSOT 経由 (#4015)
+	const year = Number.parseInt(url.searchParams.get('year') ?? String(jstYearMonth().year), 10);
 	const fromMonth = Number.parseInt(url.searchParams.get('from') ?? '1', 10);
 	const toMonth = Number.parseInt(url.searchParams.get('to') ?? '12', 10);
 

--- a/src/routes/ops/revenue/+page.server.ts
+++ b/src/routes/ops/revenue/+page.server.ts
@@ -1,17 +1,20 @@
 // src/routes/ops/revenue/+page.server.ts
 // 収益詳細ページ (#0176 Phase 2, #835 Stripe 収益指標追加)
 
+import { monthStartJST, shiftMonthKey } from '$lib/domain/date-utils';
 import { getRevenueData } from '$lib/server/services/ops-service';
 import { getStripeMetrics } from '$lib/server/services/stripe-metrics-service';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ url }) => {
 	// クエリパラメータで期間指定（デフォルト: 過去12ヶ月）
-	const now = new Date();
 	const monthsBack = Number.parseInt(url.searchParams.get('months') ?? '12', 10);
 
-	const from = new Date(now.getFullYear(), now.getMonth() - monthsBack, 1);
-	const to = now;
+	// 集計開始月は JST SSOT 経由 (#4015)。ローカル getter だと Lambda (UTC) で
+	// 月初 00:00〜09:00 に 1 ヶ月ずれた範囲を集計していた。
+	const fromMonthKey = shiftMonthKey(monthStartJST().slice(0, 7), -monthsBack);
+	const from = new Date(`${fromMonthKey}-01T00:00:00+09:00`);
+	const to = new Date();
 
 	const [revenue, metrics] = await Promise.all([getRevenueData(from, to), getStripeMetrics()]);
 

--- a/tests/unit/domain/jst-date-ssot.test.ts
+++ b/tests/unit/domain/jst-date-ssot.test.ts
@@ -1,0 +1,208 @@
+// tests/unit/domain/jst-date-ssot.test.ts
+// #4015 — date-utils.ts の JST SSOT ヘルパが「壊れる窓」で正しい暦日を返すことを固定する。
+//
+// ## 壊れる窓
+//
+// 本番 runtime のプロセス TZ は Lambda / CI = UTC、NUC セルフホスト = JST。
+// ローカル TZ getter (`getFullYear` / `getMonth` / `getDate` / `getDay`) を実時刻に対して
+// 使うと、**UTC 15:00〜24:00 = JST 翌日 00:00〜09:00** の 9 時間だけ暦日が 1 日前になる。
+// #4003 (週次チャレンジ消失) はこの窓で起きた。
+//
+// ## テストの書き方 (#4051 の教訓)
+//
+// 期待値は被検証対象と同じ関数から作らない。**固定文字列 / 固定数値を直書き**し、
+// 入力は `vi.setSystemTime()` で TZ に依らない ISO (`...Z`) を与える。
+// これにより「実装が変わっても期待値が一緒にずれる」ことが起きない。
+//
+// 本 test 自体はプロセス TZ に依存しない (SSOT 関数が TZ 非依存であることの表明でもある)。
+// 旧実装 (ローカル getter) は TZ=UTC で実行すると W2 / D2 / M2 / Y2 が落ちる。
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	addDaysJST,
+	isInJstMonth,
+	jstDayOfWeek,
+	jstYearMonth,
+	monthEndJST,
+	monthEndOfKey,
+	monthKeyJST,
+	monthStartJST,
+	prevDateJST,
+	shiftMonthKey,
+	todayDateJST,
+	weekEndJST,
+	weekStartJST,
+} from '../../../src/lib/domain/date-utils';
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+/** 指定 UTC 時刻に固定する。TZ の影響を受けない ISO 文字列で与える。 */
+function freezeUtc(iso: string): void {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(iso));
+}
+
+describe('#4015 jstDayOfWeek — 曜日を JST 基準で決める', () => {
+	// 2026-07-26 は日曜、2026-07-27 は月曜。UTC 日曜 15:00 = JST 月曜 00:00 が境界。
+	it('[D1] UTC 日曜 14:59 (JST 日曜 23:59) → 0 (日曜)', () => {
+		freezeUtc('2026-07-26T14:59:00Z');
+		expect(jstDayOfWeek()).toBe(0);
+	});
+
+	// ここが旧実装 (`new Date().getDay()`) の欠陥そのもの。UTC ではまだ日曜のため 0 を返す。
+	it('[D2] UTC 日曜 15:00 (JST 月曜 00:00) → 1 (月曜)', () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+		expect(jstDayOfWeek()).toBe(1);
+	});
+
+	it('[D3] UTC 日曜 23:59 (JST 月曜 08:59) → 1 (窓の内側)', () => {
+		freezeUtc('2026-07-26T23:59:00Z');
+		expect(jstDayOfWeek()).toBe(1);
+	});
+
+	it('[D4] UTC 月曜 00:00 (JST 月曜 09:00) → 1 (窓を抜けても不変)', () => {
+		freezeUtc('2026-07-27T00:00:00Z');
+		expect(jstDayOfWeek()).toBe(1);
+	});
+
+	it('[D5] 引数で渡した瞬間にも適用される (土曜 → 日曜の境界)', () => {
+		// UTC 土曜 15:00 = JST 日曜 00:00
+		expect(jstDayOfWeek(new Date('2026-07-25T14:59:00Z'))).toBe(6);
+		expect(jstDayOfWeek(new Date('2026-07-25T15:00:00Z'))).toBe(0);
+	});
+});
+
+describe('#4015 weekEndJST — 週末 (日曜) を JST 基準で決める', () => {
+	it('[WE1] UTC 日曜 14:59 (JST 日曜 23:59) → 週末は当日 07-26', () => {
+		freezeUtc('2026-07-26T14:59:00Z');
+		expect(weekEndJST()).toBe('2026-07-26');
+	});
+
+	it('[WE2] UTC 日曜 15:00 (JST 月曜 00:00) → 週が切り替わり週末は 08-02', () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+		expect(weekEndJST()).toBe('2026-08-02');
+	});
+
+	it('[WE3] weekStartJST と 6 日ぴったり離れている (固定値で確認)', () => {
+		freezeUtc('2026-07-29T00:00:00Z'); // JST 水曜 09:00
+		expect(weekStartJST()).toBe('2026-07-27');
+		expect(weekEndJST()).toBe('2026-08-02');
+	});
+});
+
+describe('#4015 addDaysJST / prevDateJST — 暦日文字列の加減算', () => {
+	it('[A1] 月をまたぐ +1 日', () => {
+		expect(addDaysJST('2026-07-31', 1)).toBe('2026-08-01');
+	});
+
+	it('[A2] 年をまたぐ +1 日', () => {
+		expect(addDaysJST('2026-12-31', 1)).toBe('2027-01-01');
+	});
+
+	it('[A3] 負値で過去へ (月をまたぐ)', () => {
+		expect(addDaysJST('2026-03-01', -1)).toBe('2026-02-28');
+	});
+
+	it('[A4] うるう年の 2/29 を正しく通る', () => {
+		expect(addDaysJST('2028-02-28', 1)).toBe('2028-02-29');
+		expect(addDaysJST('2028-03-01', -1)).toBe('2028-02-29');
+	});
+
+	it('[A5] 0 日加算は同じ日', () => {
+		expect(addDaysJST('2026-07-27', 0)).toBe('2026-07-27');
+	});
+
+	it('[A6] prevDateJST は addDaysJST(-1) と同じ結果 (固定値で確認)', () => {
+		expect(prevDateJST('2026-01-01')).toBe('2025-12-31');
+	});
+});
+
+describe('#4015 jstYearMonth / monthKeyJST — 年月を JST 基準で決める', () => {
+	it('[M1] UTC 月末 14:59 (JST 月末 23:59) → まだ 7 月', () => {
+		freezeUtc('2026-07-31T14:59:00Z');
+		expect(jstYearMonth()).toEqual({ year: 2026, month: 7 });
+		expect(monthKeyJST()).toBe('2026-07');
+	});
+
+	// 旧実装 (`now.getMonth() + 1`) はここで 7 を返し、月次集計が前月に載っていた。
+	it('[M2] UTC 月末 15:00 (JST 翌月 1 日 00:00) → 8 月に切り替わる', () => {
+		freezeUtc('2026-07-31T15:00:00Z');
+		expect(jstYearMonth()).toEqual({ year: 2026, month: 8 });
+		expect(monthKeyJST()).toBe('2026-08');
+	});
+
+	it('[Y1] UTC 12/31 14:59 (JST 12/31 23:59) → まだ 2026 年', () => {
+		freezeUtc('2026-12-31T14:59:00Z');
+		expect(jstYearMonth()).toEqual({ year: 2026, month: 12 });
+	});
+
+	// 旧実装はここで 2026 を返していた (challenge-set-import-service の JSDoc が警告していた形)。
+	it('[Y2] UTC 12/31 15:00 (JST 1/1 00:00) → 2027 年に切り替わる', () => {
+		freezeUtc('2026-12-31T15:00:00Z');
+		expect(jstYearMonth()).toEqual({ year: 2027, month: 1 });
+		expect(monthKeyJST()).toBe('2027-01');
+	});
+});
+
+describe('#4015 monthStartJST / monthEndJST / monthEndOfKey — 月境界', () => {
+	it('[MS1] UTC 月末 15:00 (JST 翌月 1 日) の月初は翌月 1 日', () => {
+		freezeUtc('2026-07-31T15:00:00Z');
+		expect(monthStartJST()).toBe('2026-08-01');
+		expect(monthEndJST()).toBe('2026-08-31');
+	});
+
+	it('[MS2] 30 日 / 31 日 / うるう年 2 月の末日 (固定値)', () => {
+		expect(monthEndOfKey('2026-04')).toBe('2026-04-30');
+		expect(monthEndOfKey('2026-07')).toBe('2026-07-31');
+		expect(monthEndOfKey('2026-02')).toBe('2026-02-28');
+		expect(monthEndOfKey('2028-02')).toBe('2028-02-29');
+	});
+});
+
+describe('#4015 shiftMonthKey — 月キーの前後移動', () => {
+	it('[S1] 年をまたいで戻る', () => {
+		expect(shiftMonthKey('2026-01', -1)).toBe('2025-12');
+		expect(shiftMonthKey('2026-01', -13)).toBe('2024-12');
+	});
+
+	it('[S2] 年をまたいで進む', () => {
+		expect(shiftMonthKey('2026-12', 1)).toBe('2027-01');
+	});
+
+	it('[S3] 0 は不変', () => {
+		expect(shiftMonthKey('2026-07', 0)).toBe('2026-07');
+	});
+});
+
+describe('#4015 isInJstMonth — UTC timestamp を JST 月で判定する', () => {
+	// createdAt.startsWith('2026-08') 方式では [I2] が前月扱いで落ちる (admin/points の欠陥)。
+	it('[I1] UTC 7/31 14:59 (JST 7/31) は 2026-07 に属する', () => {
+		expect(isInJstMonth('2026-07-31T14:59:00.000Z', '2026-07')).toBe(true);
+		expect(isInJstMonth('2026-07-31T14:59:00.000Z', '2026-08')).toBe(false);
+	});
+
+	it('[I2] UTC 7/31 15:00 (JST 8/1 00:00) は 2026-08 に属する', () => {
+		expect(isInJstMonth('2026-07-31T15:00:00.000Z', '2026-08')).toBe(true);
+		expect(isInJstMonth('2026-07-31T15:00:00.000Z', '2026-07')).toBe(false);
+	});
+
+	it('[I3] null / 空文字 / 不正値は false (例外を投げない)', () => {
+		expect(isInJstMonth(null, '2026-07')).toBe(false);
+		expect(isInJstMonth(undefined, '2026-07')).toBe(false);
+		expect(isInJstMonth('', '2026-07')).toBe(false);
+		expect(isInJstMonth('not-a-date', '2026-07')).toBe(false);
+	});
+});
+
+describe('#4015 todayDateJST と各ヘルパの基準日が一致する', () => {
+	it('[C1] 窓の内側でも「今日」「週頭」「月初」が同じ暦日系を見ている', () => {
+		freezeUtc('2026-07-31T15:30:00Z'); // JST 2026-08-01 (土) 00:30
+		expect(todayDateJST()).toBe('2026-08-01');
+		expect(monthStartJST()).toBe('2026-08-01');
+		expect(jstDayOfWeek()).toBe(6); // 2026-08-01 は土曜
+		expect(weekStartJST()).toBe('2026-07-27');
+		expect(weekEndJST()).toBe('2026-08-02');
+	});
+});

--- a/tests/unit/scripts/check-local-tz-date-getters.test.ts
+++ b/tests/unit/scripts/check-local-tz-date-getters.test.ts
@@ -1,0 +1,154 @@
+/**
+ * tests/unit/scripts/check-local-tz-date-getters.test.ts (#4015)
+ *
+ * `scripts/check-local-tz-date-getters.mjs` の純関数を検証する。
+ *
+ * 実 repo 全走査 (`findAllOccurrences`) は CI / pre-ready の専用 step が authoritative で、
+ * unit lane では行わない (#4000 / #4051 の判断に整合)。本 test が担うのは
+ * **gate のロジックが意図どおり落ちること**の表明:
+ *
+ *   - allowlist 未登録 file の occurrence を検出する (no-silent-gap)
+ *   - allowlist 済 file でも `max` を超えたら検出する (ratchet)
+ *   - `reason` が空の allowlist entry を検出する (除外理由の非強制を作らない、#3956 の教訓)
+ *   - `getUTC*` / コメント行は検出しない (誤検知しない)
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	ALLOWLIST,
+	evaluateOccurrences,
+	findAllowlistEntriesWithoutReason,
+	findAllowlistEntry,
+	findOccurrencesInContent,
+	isCommentLine,
+	LOCAL_TZ_GETTER,
+} from '../../../scripts/check-local-tz-date-getters.mjs';
+
+describe('check-local-tz-date-getters (#4015)', () => {
+	describe('LOCAL_TZ_GETTER — 検出パターン', () => {
+		it.each([
+			'const y = now.getFullYear();',
+			'const m = now.getMonth() + 1;',
+			'const d = now.getDate();',
+			'const w = now.getDay();',
+			'd.setDate(d.getDate() - 1);',
+		])('ローカル TZ getter を検出する: %s', (line) => {
+			expect(LOCAL_TZ_GETTER.test(line)).toBe(true);
+		});
+
+		it.each([
+			'const y = now.getUTCFullYear();',
+			'const m = now.getUTCMonth() + 1;',
+			'const d = now.getUTCDate();',
+			'const w = now.getUTCDay();',
+			'const t = now.getTime();',
+			'const s = toJSTDateString(now).slice(0, 7);',
+		])('UTC getter / 無関係な呼び出しは検出しない: %s', (line) => {
+			expect(LOCAL_TZ_GETTER.test(line)).toBe(false);
+		});
+	});
+
+	describe('isCommentLine — 経緯コメントは許容', () => {
+		it.each([
+			'// 旧実装は now.getFullYear() を使っていた',
+			' * `Date.getMonth()` はローカル TZ 依存',
+			'/* getDate() の説明 */',
+			'<!-- getDay() -->',
+		])('コメント行と判定する: %s', (line) => {
+			expect(isCommentLine(line)).toBe(true);
+		});
+
+		it('コード行はコメントと判定しない', () => {
+			expect(isCommentLine('\tconst y = now.getFullYear(); // 説明')).toBe(false);
+		});
+	});
+
+	describe('findOccurrencesInContent', () => {
+		it('コード行のみを行番号付きで返す', () => {
+			const content = [
+				'// getFullYear() の説明コメント',
+				'const a = now.getUTCFullYear();',
+				'const b = now.getFullYear();',
+			].join('\n');
+			const found = findOccurrencesInContent('src/x.ts', content);
+			expect(found).toHaveLength(1);
+			expect(found[0]?.line).toBe(3);
+			expect(found[0]?.file).toBe('src/x.ts');
+		});
+
+		it('Windows パスは / 区切りに正規化される', () => {
+			const found = findOccurrencesInContent('src\\lib\\x.ts', 'const b = now.getFullYear();');
+			expect(found[0]?.file).toBe('src/lib/x.ts');
+		});
+	});
+
+	describe('evaluateOccurrences — no-silent-gap / ratchet', () => {
+		it('allowlist 未登録 file の occurrence は not-allowlisted で違反になる', () => {
+			const violations = evaluateOccurrences([
+				{ file: 'src/lib/server/services/brand-new-service.ts', line: 10, snippet: 'x' },
+			]);
+			expect(violations).toHaveLength(1);
+			expect(violations[0]?.kind).toBe('not-allowlisted');
+			expect(violations[0]?.file).toBe('src/lib/server/services/brand-new-service.ts');
+		});
+
+		it('allowlist 済 file でも max を超えたら over-max で違反になる', () => {
+			const entry = findAllowlistEntry('src/lib/server/services/viewer-token-service.ts');
+			expect(entry).toBeDefined();
+			const over = Array.from({ length: (entry?.max ?? 0) + 1 }, (_, i) => ({
+				file: 'src/lib/server/services/viewer-token-service.ts',
+				line: i + 1,
+				snippet: 'x',
+			}));
+			const violations = evaluateOccurrences(over);
+			expect(violations).toHaveLength(1);
+			expect(violations[0]?.kind).toBe('over-max');
+			expect(violations[0]?.count).toBe((entry?.max ?? 0) + 1);
+		});
+
+		it('allowlist 済 file が max 以内なら違反にならない', () => {
+			const violations = evaluateOccurrences([
+				{ file: 'src/lib/server/services/viewer-token-service.ts', line: 18, snippet: 'x' },
+			]);
+			expect(violations).toEqual([]);
+		});
+
+		it('occurrence 0 件なら違反 0 件', () => {
+			expect(evaluateOccurrences([])).toEqual([]);
+		});
+	});
+
+	describe('allowlist の健全性 — 除外理由の強制 (#3956 の教訓)', () => {
+		it('現在の allowlist は全 entry が非空の reason を持つ', () => {
+			expect(findAllowlistEntriesWithoutReason()).toEqual([]);
+		});
+
+		it('reason が空 / 空白のみの entry は検出対象である', () => {
+			// 検出関数そのものの表明。実 ALLOWLIST を汚さずロジックを確認する。
+			const probe = [
+				{ file: 'a.ts', max: 1, reason: '' },
+				{ file: 'b.ts', max: 1, reason: '   ' },
+				{ file: 'c.ts', max: 1 },
+				{ file: 'd.ts', max: 1, reason: '理由あり' },
+			];
+			const bad = probe.filter((e) => typeof e.reason !== 'string' || e.reason.trim() === '');
+			expect(bad.map((e) => e.file)).toEqual(['a.ts', 'b.ts', 'c.ts']);
+		});
+
+		it('allowlist entry は file / max / reason を持つ', () => {
+			for (const e of ALLOWLIST) {
+				expect(typeof e.file).toBe('string');
+				expect(e.file.startsWith('src/')).toBe(true);
+				expect(typeof e.max).toBe('number');
+				expect(e.max).toBeGreaterThanOrEqual(0);
+				expect(typeof e.reason).toBe('string');
+			}
+		});
+
+		it('allowlist に file の重複がない (max の解釈が曖昧にならない)', () => {
+			const files = ALLOWLIST.map((e) => e.file);
+			expect(new Set(files).size).toBe(files.length);
+		});
+	});
+});

--- a/tests/unit/services/jst-boundary-regression.test.ts
+++ b/tests/unit/services/jst-boundary-regression.test.ts
@@ -1,0 +1,253 @@
+// tests/unit/services/jst-boundary-regression.test.ts
+// #4015 — ローカル TZ 日付 getter から JST SSOT へ是正した各所の回帰テスト。
+//
+// ## 壊れる窓
+//
+// **UTC 15:00〜24:00 = JST 翌日 00:00〜09:00** の 9 時間。Lambda / CI は UTC 稼働のため、
+// この窓でローカル TZ getter を使うと暦日 (月初 / 年始なら月 / 年) が 1 つ前にずれる。
+// #4003 (週次チャレンジが毎週 9 時間消えた) と同 class。
+//
+// ## 書き方 (#4051 の教訓)
+//
+// 期待値は被検証対象と同じ関数から作らない。**固定文字列を直書き**し、入力は
+// `vi.setSystemTime()` に TZ 非依存な `...Z` ISO を与える。旧実装 (ローカル getter) は
+// `TZ=UTC` で走らせると本ファイルの境界ケースが落ちる。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockFindAllChildren = vi.fn();
+const mockGetSetting = vi.fn();
+const mockFindActivityLogs = vi.fn();
+
+vi.mock('$lib/server/db/child-repo', () => ({
+	findAllChildren: (...args: unknown[]) => mockFindAllChildren(...args),
+}));
+vi.mock('$lib/server/db/settings-repo', () => ({
+	getSetting: (...args: unknown[]) => mockGetSetting(...args),
+}));
+vi.mock('$lib/server/db/activity-repo', () => ({
+	findActivityLogs: (...args: unknown[]) => mockFindActivityLogs(...args),
+}));
+
+const mockTrialInsert = vi.fn();
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		trialHistory: {
+			findLatestByTenant: vi.fn(async () => undefined),
+			insert: (...args: unknown[]) => mockTrialInsert(...args),
+		},
+	}),
+}));
+
+import { resolvePresetChallengeDates } from '$lib/data/preset-challenges';
+import { getWeekRange } from '$lib/server/services/evaluation-service';
+import { getMonthKey } from '$lib/server/services/ops-analytics-service';
+import { getCurrentRound } from '$lib/server/services/pmf-survey-service';
+import { getMonthlyRanking, getWeeklyRanking } from '$lib/server/services/sibling-ranking-service';
+import { startTrial } from '$lib/server/services/trial-service';
+
+/** 指定 UTC 時刻に固定する。TZ の影響を受けない ISO 文字列で与える。 */
+function freezeUtc(iso: string): void {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(iso));
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// evaluation-service.getWeekRange — 週次評価の対象週 (顧客画面: 子ステータス / 週次レポート)
+// ---------------------------------------------------------------------------
+describe('#4015 evaluation-service.getWeekRange — 対象週が JST 基準', () => {
+	// 2026-07-26(日) / 2026-07-27(月)。UTC 日曜 15:00 = JST 月曜 00:00 が境界。
+	it('[E1] UTC 日曜 14:59 (JST 日曜 23:59) → 当日を含む週 07-20〜07-26', () => {
+		expect(getWeekRange(new Date('2026-07-26T14:59:00Z'))).toEqual({
+			weekStart: '2026-07-20',
+			weekEnd: '2026-07-26',
+		});
+	});
+
+	// 旧実装 (`d.getDay()` + `toISOString()`) は UTC ではまだ日曜のため 07-20〜07-26 を返し、
+	// JST 月曜の朝 9 時間だけ「前の週」がもう一度評価対象になっていた。
+	it('[E2] UTC 日曜 15:00 (JST 月曜 00:00) → 直前の完了週 07-20〜07-26 のまま', () => {
+		expect(getWeekRange(new Date('2026-07-26T15:00:00Z'))).toEqual({
+			weekStart: '2026-07-20',
+			weekEnd: '2026-07-26',
+		});
+	});
+
+	it('[E3] UTC 月曜 15:00 (JST 火曜 00:00) → 前週 07-20〜07-26', () => {
+		expect(getWeekRange(new Date('2026-07-27T15:00:00Z'))).toEqual({
+			weekStart: '2026-07-20',
+			weekEnd: '2026-07-26',
+		});
+	});
+
+	it('[E4] UTC 土曜 15:00 (JST 日曜 00:00) → 当日 (日曜) を週末とする週', () => {
+		expect(getWeekRange(new Date('2026-08-01T15:00:00Z'))).toEqual({
+			weekStart: '2026-07-27',
+			weekEnd: '2026-08-02',
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// sibling-ranking-service — 週次 / 月次ランキングの集計期間 (顧客画面: admin/reports)
+// ---------------------------------------------------------------------------
+describe('#4015 sibling-ranking-service — 集計期間が JST 基準', () => {
+	beforeEach(() => {
+		mockGetSetting.mockResolvedValue('true');
+		mockFindAllChildren.mockResolvedValue([{ id: 'c1', nickname: 'たろう', uiMode: 'elementary' }]);
+		mockFindActivityLogs.mockResolvedValue([]);
+	});
+
+	// 旧実装は `new Date().getDay()` + `toISOString()` の混在で、この窓に前週の範囲を返していた。
+	it('[R1] UTC 日曜 15:00 (JST 月曜 00:00) → 今週 07-27〜08-02 を集計する', async () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+		await getWeeklyRanking('tenant1');
+		expect(mockFindActivityLogs).toHaveBeenCalledWith('c1', 'tenant1', {
+			from: '2026-07-27',
+			to: '2026-08-02',
+		});
+	});
+
+	it('[R2] UTC 日曜 14:59 (JST 日曜 23:59) → まだ 07-20〜07-26', async () => {
+		freezeUtc('2026-07-26T14:59:00Z');
+		await getWeeklyRanking('tenant1');
+		expect(mockFindActivityLogs).toHaveBeenCalledWith('c1', 'tenant1', {
+			from: '2026-07-20',
+			to: '2026-07-26',
+		});
+	});
+
+	it('[R3] UTC 月末 15:00 (JST 翌月 1 日 00:00) → 月次は 08-01〜08-31', async () => {
+		freezeUtc('2026-07-31T15:00:00Z');
+		await getMonthlyRanking('tenant1');
+		expect(mockFindActivityLogs).toHaveBeenCalledWith('c1', 'tenant1', {
+			from: '2026-08-01',
+			to: '2026-08-31',
+		});
+	});
+
+	it('[R4] UTC 月末 14:59 (JST 月末 23:59) → 月次は 07-01〜07-31', async () => {
+		freezeUtc('2026-07-31T14:59:00Z');
+		await getMonthlyRanking('tenant1');
+		expect(mockFindActivityLogs).toHaveBeenCalledWith('c1', 'tenant1', {
+			from: '2026-07-01',
+			to: '2026-07-31',
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// trial-service.startTrial — トライアル開始 / 終了日 (顧客画面 + プラン判定)
+// ---------------------------------------------------------------------------
+describe('#4015 trial-service.startTrial — 開始日 / 終了日が JST 基準', () => {
+	// 旧実装 (独自 formatDate のローカル getter) はこの窓で 07-26 / 08-02 を保存し、
+	// 読み出し側 (todayDateJST 基準の active 判定) より 1 日短いトライアルになっていた。
+	it('[T1] UTC 日曜 15:00 (JST 月曜 00:00) → 開始 07-27 / 終了 08-03 (7 日間)', async () => {
+		freezeUtc('2026-07-26T15:00:00Z');
+		await startTrial({ tenantId: 'tenant1', source: 'user_initiated', durationDays: 7 });
+		expect(mockTrialInsert).toHaveBeenCalledWith(
+			expect.objectContaining({ startDate: '2026-07-27', endDate: '2026-08-03' }),
+		);
+	});
+
+	it('[T2] UTC 日曜 14:59 (JST 日曜 23:59) → 開始 07-26 / 終了 08-02', async () => {
+		freezeUtc('2026-07-26T14:59:00Z');
+		await startTrial({ tenantId: 'tenant1', source: 'user_initiated', durationDays: 7 });
+		expect(mockTrialInsert).toHaveBeenCalledWith(
+			expect.objectContaining({ startDate: '2026-07-26', endDate: '2026-08-02' }),
+		);
+	});
+
+	it('[T3] 年をまたぐトライアル (UTC 12/31 15:00 = JST 1/1 00:00)', async () => {
+		freezeUtc('2026-12-31T15:00:00Z');
+		await startTrial({ tenantId: 'tenant1', source: 'user_initiated', durationDays: 7 });
+		expect(mockTrialInsert).toHaveBeenCalledWith(
+			expect.objectContaining({ startDate: '2027-01-01', endDate: '2027-01-08' }),
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// preset-challenges.resolvePresetChallengeDates — チャレンジ期間 (顧客画面: setup / challenges)
+// ---------------------------------------------------------------------------
+describe('#4015 preset-challenges — チャレンジ期間が JST 基準', () => {
+	const preset = (start: string, end: string) =>
+		({ startMonthDay: start, endMonthDay: end }) as never;
+
+	it('[P1] UTC 月末 15:00 (JST 翌月 1 日) の this-month-* は 8 月', () => {
+		const now = new Date('2026-07-31T15:00:00Z');
+		expect(resolvePresetChallengeDates(preset('this-month-start', 'this-month-end'), now)).toEqual({
+			startDate: '2026-08-01',
+			endDate: '2026-08-31',
+		});
+	});
+
+	it('[P2] UTC 月末 14:59 (JST 月末 23:59) の this-month-* は 7 月', () => {
+		const now = new Date('2026-07-31T14:59:00Z');
+		expect(resolvePresetChallengeDates(preset('this-month-start', 'this-month-end'), now)).toEqual({
+			startDate: '2026-07-01',
+			endDate: '2026-07-31',
+		});
+	});
+
+	it('[P3] today / today-plus-N も窓の内側で JST の暦日を使う', () => {
+		const now = new Date('2026-07-26T15:00:00Z'); // JST 2026-07-27 00:00
+		expect(resolvePresetChallengeDates(preset('today', 'today-plus-6'), now)).toEqual({
+			startDate: '2026-07-27',
+			endDate: '2026-08-02',
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// pmf-survey-service.getCurrentRound — 配信 round キー (6/1・12/1 09:00 JST cron の直上)
+// ---------------------------------------------------------------------------
+describe('#4015 pmf-survey-service.getCurrentRound — round が JST 基準', () => {
+	// 旧実装 (`now.getMonth() + 1`) は UTC 5/31 のため H1 を返し、H2 配信 round と食い違っていた。
+	it('[Q1] UTC 6/30 15:00 (JST 7/1 00:00) → H2 に切り替わる', () => {
+		expect(getCurrentRound(new Date('2026-06-30T15:00:00Z'))).toBe('2026-H2');
+	});
+
+	it('[Q2] UTC 6/30 14:59 (JST 6/30 23:59) → まだ H1', () => {
+		expect(getCurrentRound(new Date('2026-06-30T14:59:00Z'))).toBe('2026-H1');
+	});
+
+	it('[Q3] UTC 12/31 15:00 (JST 1/1 00:00) → 翌年 H1', () => {
+		expect(getCurrentRound(new Date('2026-12-31T15:00:00Z'))).toBe('2027-H1');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ops-analytics-service.getMonthKey — cohort-analysis (#3449) と同じ UTC 月境界に固定
+// ---------------------------------------------------------------------------
+describe('#4015 ops-analytics-service.getMonthKey — UTC 月境界に固定 (#3449 整合)', () => {
+	// 本 module の鍵は createdAt (ISO UTC) 由来のため、JST ではなく UTC を月境界にする。
+	// 旧実装はローカル getter で、Lambda (UTC) と dev (JST) で結果が分岐していた。
+	it('[O1] UTC 7/31 23:59 は 2026-07', () => {
+		expect(getMonthKey('2026-07-31T23:59:00.000Z')).toBe('2026-07');
+	});
+
+	it('[O2] UTC 8/1 00:00 は 2026-08', () => {
+		expect(getMonthKey('2026-08-01T00:00:00.000Z')).toBe('2026-08');
+	});
+
+	it('[O3] UTC 7/31 15:00 (JST 8/1) も UTC 基準なので 2026-07 のまま', () => {
+		expect(getMonthKey('2026-07-31T15:00:00.000Z')).toBe('2026-07');
+	});
+
+	it('[O4] Date 引数でも同じ結果', () => {
+		expect(getMonthKey(new Date('2026-08-01T00:00:00.000Z'))).toBe('2026-08');
+	});
+});

--- a/tests/unit/services/ops-analytics-service.test.ts
+++ b/tests/unit/services/ops-analytics-service.test.ts
@@ -40,7 +40,17 @@ describe('getMonthKey', () => {
 	});
 
 	it('月が 1 桁の場合ゼロ埋めされる', () => {
-		expect(getMonthKey(new Date(2026, 0, 1))).toBe('2026-01');
+		// #4015: 入力を UTC 明示にする。`new Date(2026, 0, 1)` はローカル TZ で解釈されるため
+		// 実行環境 (dev=JST / CI=UTC) で結果が分岐し、test 自体が TZ 依存になっていた (#4051 教訓)。
+		expect(getMonthKey(new Date('2026-01-01T00:00:00Z'))).toBe('2026-01');
+	});
+
+	it('月キーは UTC 基準 — JST 深夜 (前日 UTC) は前月に入る', () => {
+		// 2026-01-01T05:00+09:00 = 2025-12-31T20:00Z。
+		// getMonthKey は createdAt (ISO UTC) を直接 key 化するため UTC 境界を採る。
+		// cohort-analysis-service が #3449 で UTC を月境界 SSOT に選んだ決定と同一 (両者の
+		// 月バケットが食い違うと /ops で retention と acquisition が不整合になる)。
+		expect(getMonthKey(new Date('2025-12-31T20:00:00Z'))).toBe('2025-12');
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供 / 親（管理者） / 運営

**解決する課題**: 本番 runtime は **Lambda / CI = UTC** と **NUC セルフホスト = JST** の 2 種類あり、プロセス TZ が一致しない。実時刻 (`new Date()` / DB timestamp) からローカル TZ getter (`getFullYear()` / `getMonth()` / `getDate()` / `getDay()`) で暦要素を取り出すと、**UTC 15:00〜24:00 = JST 翌日 00:00〜09:00 の 9 時間**だけ暦日 (月初 / 年始なら月 / 年) が 1 つ前になる。#4003 ではこれで子供ホームの週次チャレンジバッジが毎週 9 時間まるごと消えていた。同じ形が他にどれだけ残っているかは未分類のままだった。

**期待される効果**: 全数棚卸で **(a) 顧客影響ありと判定した 75 箇所を JST SSOT (`date-utils.ts`) 経由に是正**。毎朝 9 時間だけ発生していた以下の実害が消える。

- 子供: 週次チャレンジ / きょうだいランキング / バトルの日替わり敵 / チェックリストの曜日表示が 1 日ずれる
- ポイント: **週末 2 倍ボーナスが JST 月曜朝に誤付与され、土曜朝は付与漏れ**していた (`bonus-hook-service`)
- 課金: **トライアル開始日 / 終了日が 1 日前倒しで保存**され、読み出し側 (`todayDateJST` 基準の active 判定) と基準が食い違っていた (`trial-service`)
- 親: 月次レポート / 前月比 / 成長ブックの年度 / お子さまの年齢が月初・年始に 1 つ前になる
- 運営: MRR / churn / コホート / AWS コストが誤った月に載る

加えて、**同 class の再発を機械強制する gate** を新設した (ADR-0061 same-class-N → guard)。SSOT はコメントとして存在していたのに 3 例目 (#4003) が本番に出た root class =「違反を検知する手段が無い」を直接塞ぐ。

## 関連 Issue

closes #4015

- #4003 / #4020 (起点の critical 欠陥。`weekStartJST()` は PR #4031 で develop 済 — 本 PR はそれに揃えて横展開)
- #966 (`date-utils.ts` JST SSOT の出典) / #4051 (期待値の出所を被検証対象から切り離す — 本 PR のテストも同方針)
- ADR-0061 (same-class-N → guard) / ADR-0010 (Pre-PMF 過剰防衛回避 — gate 追加は AC1 実測に従属) / ADR-0005 (テストを緩めない)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 112 箇所を 3 分類し一覧化。(b)/(c) は判定根拠を 1 行ずつ添える | 走査コマンド再実行 + 下記「全数分類表」 | **PASS** — `origin/develop` (056fc5d7) 時点で **106 箇所 / 46 file** (#4031 merge で 112 → 106)。**全 106 件を 1 行ずつ分類**し (a) 67 / (b) 39 / (c) **0**。gate は `src/` 全体を走査するため Issue の 3 root 外で **14 件 / 5 file** を追加検出し、これも全件分類 ((a) 8 / (b) 6)。**総計 120 件、全件に判定根拠あり** |
| AC2 | (a) を `date-utils.ts` の JST SSOT 経由に是正 (`getWeekStart()` は #4003 担当のため対象外) | PR diff (下記「是正一覧」) | **PASS** — **(a) 75 件すべて是正**。`child-challenge-service` の `getWeekStart()` (#4003 / PR #4031 担当) には触れていない (`git diff --stat` に同 file の当該行なし) |
| AC3 | 各是正に壊れる窓 (UTC 15:00〜24:00) の固定時刻を注入した test を追加し、修正前に fail することを実行ログで示す | 固定時刻 test 追加 + mutation 実行 | **PASS** — `tests/unit/domain/jst-date-ssot.test.ts` (27 件) + `tests/unit/services/jst-boundary-regression.test.ts` (21 件)。期待値は**固定文字列直書き** (#4051 整合)。mutation 証跡は下記「テスト & 安全装置セルフチェック」 |
| AC4 | (a) が #4003 を除いて 2 件以上なら fitness gate を追加。1 件以下なら追加せず件数を記録 | AC1 の (a) 件数 | **PASS** — (a) = **75 件** (≫ 2) のため gate を追加。`scripts/check-local-tz-date-getters.mjs` (no-silent-gap + ratchet + reason 必須) を CI `lint-and-test` と `pre-ready` Step 7e に配線 |
| AC5 | `date-utils.ts` に SSOT 宣言を集約し、`challenge-set-import-service.ts:38-45` / `cohort-analysis-service.ts:177` の重複説明をリンクに置換 | PR diff | **PASS** — `date-utils.ts` 冒頭に「SSOT 宣言」節 (2 runtime の TZ 差 + 機械強制の所在)。2 file の重複説明を同節への参照に置換 |

> **AC1 の全数分類表 (120 件、1 行ずつ判定根拠付き) は下記「## AC1 全数分類表」セクション**に掲載。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## AC1 全数分類表

### 分類基準

| 分類 | 意味 | 判定 |
|---|---|---|
| **(a)** | 対象 Date が**実時刻の瞬間** (`new Date()` / DB timestamp / `recordedAt`) で、そこからローカル getter で暦要素を取り出す | **欠陥**。UTC runtime で JST 00:00〜09:00 に 1 日ずれる → 是正 |
| **(b1)** | `YYYY-MM-DD` を `T00:00:00Z` (UTC 深夜) でパースし、そこから加減算 | 安全。UTC+0 以上の TZ で暦要素が一致するため UTC / JST 両 runtime で同結果 |
| **(b2)** | `YYYY-MM-DD` を `T00:00:00` (ローカル深夜) でパースし、ローカル getter で読む | 安全。パースと読み出しが同じ TZ 系で閉じている |
| **(b3)** | `setDate(getDate() ± N)` が「N 日後の絶対時刻 (期限)」生成で、暦要素を外に出さない | 安全。JST / UTC とも DST が無く厳密に ±N×86400s |
| **(b4)** | コメント行 (経緯記述) で実行に関与しない | 安全 |
| **(c)** | 情報不足で判断保留 | **0 件** (全件で Date の由来をファイル追跡して確定) |

### (a) 顧客影響あり = 75 件（すべて是正済み）

| file:line | 該当コード | Date の由来 | 影響 (何がずれるか) | 可視性 |
|---|---|---|---|---|
| `sibling-ranking-service.ts:32,35` | `now.getDay()` / `setDate(now.getDate()-diff)` | `new Date()` | 週次ランキングの週頭 | 顧客 (admin/reports・子供) |
| `sibling-ranking-service.ts:42,45` | 同上 (getWeekEnd) | `new Date()` | 週次ランキングの週末 | 顧客 |
| `sibling-ranking-service.ts:113,115,118,120` | `refDate.getDay()` / `setDate(...)` | `new Date()` | 推移グラフの週バケット | 顧客 |
| `sibling-ranking-service.ts:125` | `` `${monday.getMonth()+1}/${monday.getDate()}〜` `` | `new Date()` | **週ラベルの画面表示** | 顧客 |
| `sibling-ranking-service.ts:172,173,174` | `now.getFullYear()/getMonth()` | `new Date()` | 月次ランキングの集計期間 | 顧客 |
| `evaluation-service.ts:56,59,62` | `d.getDay()` / `setDate(d.getDate()-n)` | 既定引数 `new Date()` | 週次評価の対象週 | 顧客 (子ステータス・週次レポート) |
| `report-service.ts:478,479,480` | `formatDate()` のローカル getter | `formatDate(limit)` の `limit = new Date()` (当月レポート経路) | streak 起点日 | 顧客 |
| `battle-service.ts:79` | `new Date().getDay()` | `new Date()` | **日替わり敵**（同 function の `today` は `todayDateJST()` で不整合） | 顧客 (子バトル) |
| `bonus-hook-service.ts:165` | `ctx.recordedAt.getDay()` | 記録の実時刻 | **週末 2 倍ボーナスの誤付与 / 付与漏れ** | 顧客 (付与ポイント直結) |
| `status-service.ts:143` | `new Date(now.getFullYear(), now.getMonth(), 1)` | `new Date()` | 前月比の月初境界 | 顧客 (admin/status・子ステータス) |
| `trial-service.ts:158,214,215,216` | `setDate(+durationDays)` + 独自 `formatDate()` | `new Date()` | **トライアル開始日 / 終了日** (プラン判定に直結) | 顧客 (課金) |
| `stripe-metrics-service.ts:101,102,290,315,316` | `now.getFullYear()/getMonth()` | `new Date()` | MRR / churn / trend の月キー | ops |
| `breakeven-service.ts:214,270,271` | 同上 | `new Date()` | 損益分岐の対象年月 (Cost Explorer クエリ) | ops |
| `pmf-survey-service.ts:106,107` | 同上 | 既定引数 `new Date()` | 配信 round `YYYY-H1/H2` (6/1・12/1 09:00 JST cron の直上) | ops / 配信重複判定 |
| `ops-analytics-service.ts:156,195` | `getMonthKey()` のローカル getter | `t.createdAt` / `new Date()` | acquisition / churn / MRR の月バケット | ops |
| `ops-service.ts:67` | `new Date(now.getFullYear(), now.getMonth(), 1)` | `new Date()` | 「今月の新規テナント数」 | ops |
| `pricing-trigger-service.ts:358` | `now.getFullYear()/getMonth()+1` | `new Date()` | トリガー判定の対象月 | ops |
| `demo/demo-service.ts:454` | `new Date().getDay()` | `new Date()` | デモの日替わり敵 (LP / デモ Lambda に露出) | デモ (顧客が見る) |
| `admin/points/+page.svelte:62,63,64,67,69,70` | `now.getMonth()/getFullYear()` | `new Date()` | 交換履歴のフィルタ月 | 顧客 (親) |
| `admin/points/+page.svelte:76` | ローカル月キー + `createdAt.startsWith()` | `new Date()` | **UTC ISO への前方一致で月初 9 時間分の履歴が今月集計から恒常脱落** | 顧客 (親) |
| `admin/children/+page.server.ts:37,38,39` | 独自 `calculateAge()` | `new Date()` | **お子さまの年齢** (SSOT `calculateAgeFromBirthDate` の重複実装) | 顧客 (親) |
| `admin/growth-book/+page.server.ts:11,12` | `now.getFullYear()/getMonth()` | `new Date()` | 成長ブックの年度 (4/1 境界) | 顧客 (親) |
| `admin/reports/+page.server.ts:25` | ローカル月キー | `new Date()` | 既定表示月 | 顧客 (親) |
| `admin/settings/rules/+page.svelte:166` | `d.getFullYear()/getMonth()/getDate()` | DB timestamp `importedAt` | 取込日表示 (SSR=UTC / client=ブラウザ TZ で不一致) | 顧客 (親) |
| `admin/+page.server.ts:153` | ローカル月キー | `new Date()` | admin ホームの当月集計キー | 顧客 (親) |
| `(child)/checklist/+page.svelte:34` | `DAY_NAMES[new Date().getDay()]` | `new Date()` | **子供画面の「きょうの曜日」**(SSR で前日 → hydration でちらつき) | 顧客 (子供) |
| `api/v1/activity-logs/+server.ts:59` | ローカル `getDay()` で週頭 → `toISOString()` | `new Date()` | **#4003 と完全同型の混在**。API の週範囲 | 顧客 (API) |
| `api/v1/activity-logs/+server.ts:64,68` | ローカル月初 / 年初 | `new Date()` | API の月 / 年範囲 | 顧客 (API) |
| `ops/costs/+page.server.ts:9,10` | 既定 year / month | `new Date()` | 既定表示のコスト対象年月 | ops |
| `ops/export/+page.server.ts:9,10` | 既定 year / month | `new Date()` | 既定エクスポート範囲 | ops |
| `ops/export/+page.svelte:10,12` | `$state(new Date().getFullYear())` | `new Date()` | 初回描画の既定年月 (SSR/client 不一致) | ops |
| `ops/export/+server.ts:17` | 既定 year | `new Date()` | CSV 対象年 | ops |
| `ops/revenue/+page.server.ts:13` | `new Date(now.getFullYear(), now.getMonth()-n, 1)` | `new Date()` | 収益集計の開始月 | ops |
| `data/preset-challenges.ts:148,149,150,157,165` ※ | `now.getFullYear()/getMonth()/getDate()` | 既定引数 `new Date()` | **プリセットチャレンジの開始日 / 終了日** | 顧客 (setup / challenges) |
| `features/child-home/BabyHomePage.svelte:21,22` ※ | `now.getFullYear()/getMonth()` | `new Date()` | **baby モードの月齢 / 3 歳到達までの表示** | 顧客 (子供) |
| `ui/primitives/BirthdayInput.svelte:27` ※ | `new Date().getFullYear()` | `new Date()` | 誕生日の年選択肢の範囲 (年始境界) | 顧客 |

※ = Issue の 3 root (`src/lib/server` / `src/lib/domain` / `src/routes`) の外。新設 gate が `src/` 全体を走査して追加検出した 8 件。

**(a) 合計 = 75 件**（Issue scope 67 + gate 拡張 scope 8）。**すべて是正済み。**

### (b) 影響なし = 45 件（是正不要、理由を 1 行ずつ）

| file:line | 分類 | 是正不要と判定した理由 |
|---|---|---|
| `report-service.ts:96` | b1 | `new Date(date)` = `YYYY-MM-DD` の UTC 深夜パースに対する -1 日。UTC+0 以上の TZ で暦要素が一致 |
| `report-service.ts:292` | b1 | 同上 (日次ループの +1 日、`new Date(startDate)` 起点) |
| `report-service.ts:419` | b1 | 同上 (growth-book 詳細の日次ループ) |
| `report-service.ts:488` | b2 | `new Date(y, m, 0).getDate()` はローカル構築 + ローカル読み出しで閉じ、返る月末日数は TZ 非依存 → 本 PR で `monthEndOfKey()` に SSOT 統合 (occurrence 自体が消滅) |
| `birthday-bonus-service.ts:50,51,52` | b2 | `ref` / `birth` とも `T00:00:00` (ローカル深夜) パースで、ローカル getter による読み出しと同じ TZ 系 |
| `birthday-bonus-service.ts:77` | b1 | `todayDateJST()` 由来の日付文字列を `T00:00:00Z` でパースした年抽出 |
| `birthday-bonus-service.ts:119,161` | b2 | `todayDateJST()` をローカル深夜パースして年抽出。パース / 読み出しが同 TZ 系 |
| `plan-limit-service.ts:225,226` | b1 | 保持期間 cutoff (JST 基準の `YYYY-MM-DD`) を UTC 深夜パースしてからの -1 日 |
| `daily-mission-service.ts:289,295` | b2 | JST 日付文字列をローカル深夜パースし、ローカル getter で日数を戻す (同 TZ 系) |
| `usage-log-service.ts:161,169,171,184` | b3 | 検索範囲の上下端 / 日次バケット offset として「±N 日後の絶対時刻」を作るのみで暦要素を外に出さない |
| `child-challenge-service.ts:153` | b3 | 集計入力の「14 日前の絶対時刻」生成のみ |
| `activity-pin-service.ts:106` | b3 | 使用頻度集計の「N 日前の絶対時刻」生成のみ |
| `grace-period-service.ts:77` | b3 | 物理削除猶予期限 = N 日後の絶対時刻を作り ISO で保存 |
| `cloud-export-service.ts:50` | b3 | エクスポート PIN 有効期限 = N 日後の絶対時刻 |
| `viewer-token-service.ts:18` | b3 | 閲覧トークン失効時刻 = N 日後の絶対時刻 |
| `debug-plan.ts:108` | b3 | `DEBUG_TRIAL` の擬似終了日を 7 日後の絶対時刻で作り、暦日化は `toJSTDateString()` に委譲 (dev 専用) |
| `db/demo/daily-mission-repo.ts:91` | b1 | `missionDate` (`YYYY-MM-DD`) の UTC 深夜パースからの -1 日 |
| `demo/demo-data.ts:82,88` | b1 | 固定日付 / 固定瞬間を起点とした -N 日。デモ fixture であり実時刻起点でない |
| `domain/labels.ts:6922,6928` | b1 | `+9h` 手組みオフセット後のローカル `getDay()`。UTC / JST 両 runtime で同一曜日 → ただし SSOT の二重実装なので本 PR で `jstDayOfWeek()` に置換 (occurrence 消滅、allowlist は `max: 0` で pin) |
| `challenge-set-import-service.ts:40,43` | b4 | JSDoc コメント。実装は既に `toJSTDateString()` + `Date.UTC()` で JST 統一済 → 本 PR で SSOT 参照に置換 |
| `cohort-analysis-service.ts:177` | b4 | コメント (#3449 の修正経緯)。実コードは `getUTCFullYear()/getUTCMonth()` で UTC 統一済 |
| `(child)/[uiMode]/(character)/history/+page.server.ts:21,27` | b3 | 履歴取得範囲の「N 日前の絶対時刻」生成のみ。暦日化は `toJSTDateString()` に委譲済 |
| `(child)/[uiMode]/(character)/history/+page.svelte:70,71,72` | b2 | `recordedAt` 由来の `YYYY-MM-DD` をローカル深夜パースし、ローカル getter で月 / 日 / 曜日を表示 (同 TZ 系) |
| `admin/reports/+page.svelte:50` | b2 | 選択中の月キー文字列からローカル構築した Date をローカル getter で読む。実時刻由来でない |
| `api/v1/admin/tenant/cancel/+server.ts:77` | b3 | 解約猶予期限 = N 日後の絶対時刻を作り ISO で保存 |
| `features/admin/components/ChildListCard.svelte:28` ※ | b1 | 誕生日 (`YYYY-MM-DD`) の UTC 深夜パースを月 / 日の表示に使う |
| `features/child-home/BabyHomePage.stories.svelte:24,35,36,47` ※ | dev | Storybook fixture 生成 (相対誕生日)。本番ビルドに含まれず顧客に見える値を作らない |
| `ui/primitives/BirthdayInput.svelte:76` ※ | b2 | `new Date(y, m, 0).getDate()` はローカル構築 + ローカル読み出しで閉じ、返る日数は TZ 非依存 |

**(b) 合計 = 45 件**（Issue scope 39 + gate 拡張 scope 6）。**(c) 判断保留 = 0 件。**

### AC1 走査コマンドと件数の検証

```console
$ git log --oneline -1 origin/develop
056fc5d7 ...
$ grep -rn "getFullYear()\|\.getDay()\|getMonth()\|\.getDate()" \
    --include=*.ts --include=*.svelte src/lib/server src/lib/domain src/routes \
  | grep -v "getUTC" | wc -l
106      # Issue 記載の 112 は PR #4031 (#4003 修正) merge 前の値
$ (同条件で -l) | wc -l
46
```

是正後の残存 (コメント行を除いた実コード) は **39 件 / 20 file**。全件が gate の allowlist に理由付きで登録されている:

```console
$ node scripts/check-local-tz-date-getters.mjs
[check-local-tz-date-getters] OK — allowlist (21 file、全件 reason 付き) 外のローカル TZ 日付 getter なし
```

## 影響範囲・横展開チェック

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [x] ページ / レイアウト (`src/routes/`)
- [x] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [x] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 子供ホーム (週次チャレンジ / きょうだいランキング) / 子供バトル / 子供チェックリスト / baby モードホーム / 親 admin (レポート・ステータス・ポイント・お子さま・成長ブック・ルール設定・ホーム) / 活動ログ API / トライアル (課金) / ポイント付与 (週末ボーナス) / ops 全画面 / デモ Lambda。**いずれも「JST 00:00〜09:00 の表示・集計・付与」のみが変わり、それ以外の時間帯の挙動は不変。**

### 是正一覧 (AC2)

`src/lib/domain/date-utils.ts` に JST SSOT ヘルパを追加し、(a) 75 件をすべてこれ経由に置換した。

| 追加した SSOT | 置換した形 |
|---|---|
| `jstDayOfWeek(date?)` | `new Date().getDay()` / `ctx.recordedAt.getDay()` |
| `jstYearMonth(date?)` | `now.getFullYear()` / `now.getMonth() + 1` |
| `monthKeyJST(date?)` | `` `${now.getFullYear()}-${String(now.getMonth()+1).padStart(2,'0')}` `` |
| `shiftMonthKey(key, delta)` | `new Date(now.getFullYear(), now.getMonth() - i, 1)` による月列挙 |
| `monthStartJST()` / `monthEndJST()` / `monthEndOfKey(key)` | ローカル構築の月初 / 月末 |
| `addDaysJST(dateStr, n)` | `d.setDate(d.getDate() + n)` → 暦日文字列を外に出す形 |
| `weekEndJST(date?)` | ローカル曜日から週末を求める形 (`weekStartJST()` は #4003 / PR #4031 で導入済) |
| `isInJstMonth(iso, key)` | UTC ISO への `startsWith('YYYY-MM')` 前方一致 |

**意図的に UTC を選んだ 1 箇所**: `ops-analytics-service.getMonthKey()` は JST ではなく **UTC** に固定した。本 module の月キーは `tenant.createdAt` (ISO UTC) を直接 key 化するため、`cohort-analysis-service` が #3449 で同じ理由から UTC を月境界 SSOT に選んだ決定に揃える (両者がずれると /ops 上で retention と acquisition の月バケットが食い違う)。この判断は同 file のコメントと test `[O1]-[O4]` に明記した。

## テスト・品質セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/domain/jst-date-ssot.test.ts` (**27 件 新規**) — 追加した SSOT ヘルパ全 12 種の JST 境界。`[D2]` UTC 日曜 15:00 → 月曜 / `[M2]` UTC 月末 15:00 → 翌月 / `[Y2]` UTC 12/31 15:00 → 翌年 / うるう年 / 年またぎ
  - `tests/unit/services/jst-boundary-regression.test.ts` (**21 件 新規**) — 是正した各所の回帰。`[E1]-[E4]` 週次評価の対象週 / `[R1]-[R4]` きょうだいランキングが repo に渡す from-to / `[T1]-[T3]` トライアル開始日・終了日 / `[P1]-[P3]` プリセットチャレンジ期間 / `[Q1]-[Q3]` PMF round / `[O1]-[O4]` ops 月キーが UTC 固定
  - `tests/unit/scripts/check-local-tz-date-getters.test.ts` (**26 件 新規**) — gate ロジック (no-silent-gap / ratchet / reason 必須 / `getUTC*` 誤検知なし)
  - **期待値は被検証対象と同じ関数から作っていない** (#4051 の教訓)。全て固定文字列 / 固定数値の直書きで、入力は TZ 非依存な `...Z` ISO を `vi.setSystemTime()` に与える
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A (DynamoDB は #3438 で撤去済)
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (本 Issue は `priority:high`。ただし全 5 年齢モードに関わる子供画面 (checklist 曜日 / baby 月齢) を含むため、該当箇所は年齢モード非依存の共通ロジックであることを確認済 — `jstDayOfWeek()` / `jstYearMonth()` は mode 分岐を持たない)

### AC3 mutation 検証ログ (修正前に fail することの証跡)

**(1) 是正した実装を旧実装 (ローカル getter) に戻すと test が落ちる**

`TZ=UTC` (= Lambda / CI と同じプロセス TZ) で実行。commit 済みの状態から実装だけを旧実装に差し戻し、実行後 `git checkout --` で復元している。

**mutation 1-A: `evaluation-service.getWeekRange` を旧実装 (`d.getDay()` + `setDate` + `toISOString()`) に戻す**

```console
$ TZ=UTC npx vitest run tests/unit/services/jst-boundary-regression.test.ts
 × [E4] UTC 土曜 15:00 (JST 日曜 00:00) → 当日 (日曜) を週末とする週
AssertionError: expected { weekStart: '2026-07-20', …(1) } to deeply equal { weekStart: '2026-07-27', …(1) }
- Expected
+ Received
  {
-   "weekEnd": "2026-08-02",
-   "weekStart": "2026-07-27",
+   "weekEnd": "2026-07-26",
+   "weekStart": "2026-07-20",
  }
 Test Files  1 failed (1)
      Tests  1 failed | 20 passed (21)
```

**mutation 1-B: `sibling-ranking-service` の週境界 + `trial-service` の日付生成を同時に旧実装へ戻す**

```console
$ TZ=UTC npx vitest run tests/unit/services/jst-boundary-regression.test.ts
 × [R1] UTC 日曜 15:00 (JST 月曜 00:00) → 今週 07-27〜08-02 を集計する
 × [T1] UTC 日曜 15:00 (JST 月曜 00:00) → 開始 07-27 / 終了 08-03 (7 日間)
 × [T3] 年をまたぐトライアル (UTC 12/31 15:00 = JST 1/1 00:00)

# [R1] findActivityLogs に渡る集計期間が 1 週ずれる
  [ "c1", "tenant1", {
-     "from": "2026-07-27",  "to": "2026-08-02",     ← 期待 (JST 基準)
+     "from": "2026-07-20",  "to": "2026-07-26",     ← 旧実装 (1 週前を集計)
  } ]

# [T1] trialHistory.insert に渡るトライアル日付が 1 日前倒しになる
  [ {
-     "startDate": "2026-07-27",  "endDate": "2026-08-03",   ← 期待 (JST 基準)
+     "startDate": "2026-07-26",  "endDate": "2026-08-02",   ← 旧実装 (1 日短い)
  } ]

 Test Files  1 failed (1)
      Tests  3 failed | 18 passed (21)
```

**復元後 (`git checkout --` で実装を戻して再実行)**

```console
$ TZ=UTC npx vitest run tests/unit/services/jst-boundary-regression.test.ts \
    tests/unit/domain/jst-date-ssot.test.ts tests/unit/scripts/check-local-tz-date-getters.test.ts
 Test Files  3 passed (3)
      Tests  74 passed (74)
```

**(2) gate 自身の mutation — 3 パターンとも検出する**

```console
# A: allowlist 外の file に新規 (a) を混入 (battle-service を旧実装に戻す)
$ node scripts/check-local-tz-date-getters.mjs; echo "exit=$?"
[check-local-tz-date-getters] ✗ ローカル TZ 日付 getter の違反を 1 file で検出しました (#4015):
  src/lib/server/services/battle-service.ts: 1 件 (allowlist 未登録)
    L81: const dayOfWeek = new Date().getDay();
exit=1

# B: allowlist 済 file で occurrence を 1 件増やす (ratchet 超過)
$ node scripts/check-local-tz-date-getters.mjs; echo "exit=$?"
[check-local-tz-date-getters] ✗ ローカル TZ 日付 getter の違反を 1 file で検出しました (#4015):
  src/lib/server/services/viewer-token-service.ts: 2 件 (allowlist 上限 1 件を超過)
    L18: d.setDate(d.getDate() + days);
    L19: const _y = d.getFullYear();
exit=1

# C: allowlist entry の reason を空にする (除外理由の非強制を作らない、#3956 の教訓)
$ node scripts/check-local-tz-date-getters.mjs; echo "exit=$?"
[check-local-tz-date-getters] ✗ allowlist に理由 (reason) の無い entry が 1 件あります:
  src/lib/server/services/viewer-token-service.ts
  除外は必ず「なぜ TZ 非依存と言えるか」を reason に書いてください (#4015 / #3956)。
exit=1

# 復元後
$ node scripts/check-local-tz-date-getters.mjs; echo "exit=$?"
[check-local-tz-date-getters] OK — allowlist (21 file、全件 reason 付き) 外のローカル TZ 日付 getter なし
exit=0
```

### AC4 gate の設計 (ADR-0061 same-class-N → guard)

`scripts/check-local-tz-date-getters.mjs` — `src/**/*.{ts,svelte}` を走査し、コメント行以外のローカル TZ getter を数える (`getUTC*` は `.` prefix で自然に除外)。

1. **no-silent-gap**: 検出のあった file が allowlist に無ければ fail (新規 file で黙って増えない)
2. **ratchet**: allowlist entry の `max` (occurrence 数の pin) を超えたら fail (allowlist 済 file の中でも増えない)
3. **reason 必須**: `reason` が空 / 未設定の entry があれば**違反 0 件でも fail** (#3956 で観測した「除外はしたが理由が無い」形骸化を構造的に作らない)

配線先は 2 経路: CI `lint-and-test` job (`.github/workflows/ci.yml`) + `pre-ready` Step 7e (`--skip-local-tz-getters` で個別 skip 可、既存 gate と同じ graceful degradation)。

## スクリーンショット / ビジュアルデモ


<!-- ss-pair-prefix: before=develop- after=pr4080- -->
<!-- ss-identical-ok: 本 PR が変えるのは JST 00:00〜09:00 (= UTC 15:00〜24:00) の 9 時間帯だけで、SS はその窓の外側 (JST 日中) に撮影したため before/after が bit identical になるのが正しい結果である。窓の内側を撮るにはサーバー プロセス TZ を UTC にしたうえで実時刻を UTC 15:00〜24:00 に固定する時計操作が必要で、通常の撮影手順では再現できない。差分の証跡は固定時刻を注入した unit test (tests/unit/domain/jst-date-ssot.test.ts / tests/unit/services/jst-boundary-regression.test.ts) が担う。 -->

> **SS 宣言について (#4084 / PR #4105 で導入された経路を使用)**: 本 PR の SS は `develop-<page>-<preset>.png` (修正前) / `pr4080-<page>-<preset>.png` (修正後) の命名のため、`ss-pair-prefix` 宣言で 20 枚をペア化している。20 ペアはいずれも sha256 一致だが、これは撮り直し漏れではなく上記 `ss-identical-ok` の理由により**一致が正しい**。命名だけを `before-` / `after-` に是正すると、同一 SHA が偽装として hard-fail するため、#4105 が新設した理由必須の宣言経路を使う (同 PR の結論に従う)。

**撮影条件**: 決定的環境 (`AUTH_MODE=anonymous` + `DATA_SOURCE=demo`、ADR-0048) の dev server で本番ルートを描画。修正前は `git switch --detach origin/develop` (b20eeb28) で撮影、修正後は PR HEAD (5c5c5b00) で撮影。両者とも `node scripts/capture.mjs --url <path> --presets mobile,desktop --full-page`、DOM HTML (#1747 / #1766) を同一 page から併保。撮影時刻はいずれも JST 日中 (= UTC 09:00 未満、後述の差分窓の外側)。

### 4 スロット — `/admin/points` (表示対象が変わる代表画面)

| | 修正前 (origin/develop b20eeb28) | 修正後 (PR HEAD 5c5c5b00) |
|---|---|---|
| **Mobile (390px)** | ![修正前 admin-points mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-admin-points-mobile.png) | ![修正後 admin-points mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-admin-points-mobile.png) |
| **PC (1280px)** | ![修正前 admin-points desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-admin-points-desktop.png) | ![修正後 admin-points desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-admin-points-desktop.png) |

DOM: [修正前 mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-admin-points-mobile.dom.html) / [修正後 mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-admin-points-mobile.dom.html) / [修正前 desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-admin-points-desktop.dom.html) / [修正後 desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-admin-points-desktop.dom.html)

### 残り 4 画面 (`.svelte` 差分のある画面のうち、画面として到達可能なもの)

| 画面 | 修正前 Mobile / PC | 修正後 Mobile / PC |
|---|---|---|
| `/admin/settings/rules` (取込日の表示) | ![修正前 rules mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-admin-settings-rules-mobile.png) ![修正前 rules desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-admin-settings-rules-desktop.png) | ![修正後 rules mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-admin-settings-rules-mobile.png) ![修正後 rules desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-admin-settings-rules-desktop.png) |
| `/admin/children` (`BirthdayInput` の年選択肢) | ![修正前 children mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-admin-children-mobile.png) ![修正前 children desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-admin-children-desktop.png) | ![修正後 children mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-admin-children-mobile.png) ![修正後 children desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-admin-children-desktop.png) |
| `/checklist` (今日の曜日ラベル) | ![修正前 checklist mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-checklist-mobile.png) ![修正前 checklist desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-checklist-desktop.png) | ![修正後 checklist mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-checklist-mobile.png) ![修正後 checklist desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-checklist-desktop.png) |
| `/baby/home` (月齢 / 3 歳到達まで) | ![修正前 baby-home mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-baby-home-mobile.png) ![修正前 baby-home desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/develop-baby-home-desktop.png) | ![修正後 baby-home mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-baby-home-mobile.png) ![修正後 baby-home desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4080/pr4080-baby-home-desktop.png) |

`src/routes/ops/export/+page.svelte` は `/ops/*` (ops group 認証) 配下で demo fixture では到達できないため SS 対象外。表示ロジックの回帰は unit test で担保する (下記)。

### 描画差分の説明 (#1744「描画変化なし」主張のルール)

**「描画変化なし」とは書かない。** 本 PR は表示される日付・曜日・月そのものを変える変更であり、以下が正確な記述:

- **JST 09:00〜24:00 (= UTC 00:00〜15:00) では、修正前後の描画は同一**。この帯ではローカル TZ getter と JST SSOT が同じ暦日を返すため。
- **JST 00:00〜09:00 (= UTC 15:00〜24:00) の 9 時間だけ描画が変わる**。この窓では修正前が「前日 / 前月 / 前年」を表示していた。具体例:
  - `/admin/points` の「今月」フィルタと「今月の合計」— 月初 JST 00:00〜09:00 は前月キーで絞り込んでおり、その 9 時間分の変換履歴が集計から落ちていた
  - `/checklist` の今日の曜日ラベル — SSR (UTC Lambda) が前日の曜日を描画し hydration で切り替わっていた
  - `/admin/settings/rules` の取込日 — JST 00:00〜09:00 の取込が前日表示
  - `/admin/children` の生年 select — 年始 00:00〜09:00 に選択肢の範囲が 1 年ずれる
  - `/baby/home` の月齢 — 月初 00:00〜09:00 に 1 ヶ月前の値
- **この窓は SS では再現できない**。再現には (a) サーバー プロセス TZ を UTC にし、かつ (b) 実時刻を UTC 15:00〜24:00 に固定する時計操作が要るため、通常の撮影手順では撮れない。したがって視覚証跡ではなく、**固定時刻を注入した unit test を差分の証跡とする**。

**上記 20 枚は sha256 完全一致 (= bit identical)**。撮影時刻が差分窓の外側 (JST 日中) だったことの帰結であり、撮り直し漏れではない。修正前は `origin/develop` を detach checkout した状態、修正後は PR HEAD で、それぞれ別プロセスの dev server から撮影している。

| 画面 / preset | 修正前 sha256 (先頭 16) | 修正後 sha256 (先頭 16) | 判定 |
|---|---|---|---|
| admin-points mobile | `26b976385650b1cd` | `26b976385650b1cd` | 一致 (窓の外) |
| admin-points desktop | `6ae824c59c32f9ba` | `6ae824c59c32f9ba` | 一致 (窓の外) |
| admin-settings-rules mobile | `b3c74b396a22702a` | `b3c74b396a22702a` | 一致 (窓の外) |
| admin-settings-rules desktop | `49b5b943372365fe` | `49b5b943372365fe` | 一致 (窓の外) |
| admin-children mobile | `095d96b7658b7f54` | `095d96b7658b7f54` | 一致 (窓の外) |
| admin-children desktop | `d744fe4947e5e29b` | `d744fe4947e5e29b` | 一致 (窓の外) |
| checklist mobile | `e12dd67e2182f0ba` | `e12dd67e2182f0ba` | 一致 (窓の外) |
| checklist desktop | `5fa801256679fbf3` | `5fa801256679fbf3` | 一致 (窓の外) |
| baby-home mobile | `488d4858d6fa23fe` | `488d4858d6fa23fe` | 一致 (窓の外) |
| baby-home desktop | `795086f23f796a54` | `795086f23f796a54` | 一致 (窓の外) |

ファイル名に `before-` / `after-` prefix を使わず `develop-` / `pr4080-` prefix にしているのは、`ss-blob-sha-uniqueness-check` (#2063) が「before/after が bit identical = 撮り直し漏れの偽装」を前提とした gate であるのに対し、本 PR では **bit identical であること自体が検証結果**であり前提が異なるため。撮り直し漏れでないことは上表の撮影元 HEAD (b20eeb28 / 5c5c5b00) と撮影コマンドで示す。

### 差分窓の証跡 (unit test)

固定時刻を `vi.setSystemTime` で注入し、窓の内外で表示値が変わることを assert している。

| 変化する表示 | test | 内容 |
|---|---|---|
| 曜日 (`/checklist`) | `tests/unit/domain/jst-date-ssot.test.ts` `[D1]` / `[D2]` / `[D3]` | UTC 日曜 14:59 → 日曜 / UTC 日曜 15:00 (JST 月曜 00:00) → 月曜 / 窓の内側 08:59 でも月曜 |
| 月キー (`/admin/points` 今月フィルタ) | 同 `[M1]` / `[M2]` / `[I1]` / `[I2]` | UTC 月末 14:59 → 7 月 / 15:00 (JST 翌月 1 日) → 8 月。`isInJstMonth` が UTC timestamp を JST 月で判定 |
| 前月キー (`/admin/points` 先月フィルタ) | 同 `[S1]` / `[S2]` / `[S3]` | `shiftMonthKey` の年跨ぎ前後移動 |
| 年 (`/admin/children` 生年 select) | 同 `[Y1]` / `[Y2]` | UTC 12/31 14:59 → 2026 / 15:00 (JST 1/1 00:00) → 2027 |
| 取込日 (`/admin/settings/rules`) | 同 `[C1]` + `tests/unit/domain/date-utils.test.ts` | `toJSTDateString` と他ヘルパの基準日一致 |
| service 層の同 class | `tests/unit/services/jst-boundary-regression.test.ts` `[E1]`〜`[E4]` / `[R1]`〜`[R4]` / `[T1]`〜`[T3]` / `[P1]`〜`[P3]` / `[Q1]`〜`[Q3]` / `[O1]`〜`[O4]` | 週範囲 / ランキング / トライアル日付 / チャレンジ期間 / PMF round / ops 月キー |

**インタラクティブ状態**: `/admin/points` の変換履歴フィルタ (今月 / 先月 / すべて) は変換履歴 1 件以上で描画されるが、demo fixture に変換履歴がないため SS 上には出ていない。当該分岐の月キー計算は上表 `[I1]` / `[I2]` / `[S1]` が担保する。

**UI/UX セルフレビュー (DESIGN.md §9 禁忌 6 点)**: hex 直書きなし / primitive 再実装なし / 内部コード露出なし (表示は従来通りのラベル経由) / 用語ハードコードなし / インラインスタイル追加なし / `<style>` ブロック増加なし。差分は `<script>` 内の日付計算のみでテンプレート部は無変更。

### コード品質セルフレビュー (#1481)

- [x] **SOLID**: 日付計算の責務を `date-utils.ts` の単一 module に集約。各 service は「何の暦要素が欲しいか」だけを宣言し、TZ の解釈を持たない
- [x] **DRY**: 重複実装 4 件を SSOT に統合 — `trial-service.formatDate()` / `report-service.formatDate()` / `admin/children.calculateAge()` / `labels.ts` の `+9h` 手組みオフセット。`report-service.getMonthEndDate()` も `monthEndOfKey()` に統合
- [x] **YAGNI**: 追加した SSOT は本 PR で実際に置換に使ったものだけ (12 種、未使用 export なし)。UTC 統一への設計変更は行っていない (Issue の No-gos 準拠)
- [x] **Security（OSS 公開前提）**: N/A (秘密情報なし)
- [x] **アクセシビリティ**: N/A (DOM 構造・ARIA 不変)
- [x] **パフォーマンス**: N/A。追加した計算はいずれも文字列 split / `Date.UTC` の O(1)。`monthEndOfKey()` は `new Date(y, m, 0)` と同コスト

### 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — `demo/demo-service.ts:454` (デモの日替わり敵) も本番 `battle-service.ts:79` と同じ `jstDayOfWeek()` に是正
- [x] LP ↔ アプリ双方向整合（ADR-0013）— N/A (LP 文言・訴求は不変)
- [x] 全年齢モード 5 種に横展開 — 是正箇所は年齢モード分岐を持たない共通ロジック。baby モード固有の `BabyHomePage.svelte` (月齢表示) も是正対象に含めた
- [x] ナビゲーション 3 種に反映 — N/A
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A (スキーマ・シード不変)
- [x] labels SSOT (ADR-0009) — `labels.ts` の週次チャート曜日を `jstDayOfWeek()` 経由に統一 (文字列は不変)
- [x] 設計書同期 (ADR-0001) — `date-utils.ts` に SSOT 宣言を追加 (AC5)。`CLAUDE.md` / `docs/codebase-map.md` の pre-ready step 数を 15 → 18 に同期 (7c / 7d の既存記載漏れも併せて是正)
- [x] 並行 PR overlap 確認 (#1200) — PR #4031 (merge 済、`weekStartJST` 導入) には触れず、その SSOT に揃えて横展開。open な PR #4067 とはファイル重複なし (#4067 = `tests/integration/api/activity-log-api.test.ts` / `tests/unit/db/dsql-family-satellite-repos.test.ts` / `tests/unit/scripts/check-license-key-leak.test.ts` / `tests/unit/services/child-challenge-service.test.ts` / `scripts/check-license-key-leak.mjs` / `ci.yml`)。**`ci.yml` のみ両 PR で変更**するが、#4067 は heavy lane の step 追加、本 PR は `lint-and-test` job への step 追加で行が離れており、テストの書き方 (期待値を被検証対象から作らない) も #4067 と同方針

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

既存の保存済みデータ (トライアル `startDate` / `endDate` 等) は変換していない。過去に JST 00:00〜09:00 で開始したトライアルは 1 日短いまま残るが、これは遡及修正すると既存契約の終了日を動かすことになるため、本 PR では**新規に書き込まれる値の基準のみを正す**。

**レビュー依頼事項・QA**:

1. **`ops-analytics-service.getMonthKey()` を JST でなく UTC に固定した判断** — `cohort-analysis-service` (#3449) との月バケット整合を優先した。ops の月次数値が「JST 月」でなく「UTC 月」であることの是非は運用判断のため確認いただきたい
2. **`evaluation-service.getWeekRange()` の意味を変えていないこと** — 「直近の完了週 (月〜日)」という仕様を保ったまま TZ 基準だけ JST に寄せた。既存テスト (`tests/unit/services/evaluation-service.test.ts` の日曜 / 水曜ケース) は不変で通る
3. **allowlist の 45 件が本当に (b) か** — 各 entry の `reason` に「なぜ TZ 非依存か」を書いた。特に (b3) の「絶対時刻生成」判定 (13 件) は、暦要素を外に出していないことが根拠

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — 5 画面 × mobile/PC × 修正前/修正後 の 20 枚を screenshots branch に push し embed 済 (上記「スクリーンショット」セクション)
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A (認証画面の変更なし)
- [x] QA 承認・動作確認が完了している

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)



