### PR TITLE
fix(billing): #3958 checkout 完了を success_url の session_id から照合する救済経路を実装

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -1412,6 +1412,21 @@ hooks.server.ts
 >
 > **注 2（#3033）**: PlanStatusCard（利用状況 3 stat + アップグレード CTA）の配置は **`/admin/subscription`（SaasLicensePanel 内）のみ**。admin home の body にプランカードは置かない（body 常設プランカードは業界慣行外 + banner blindness。プラン情報の常設表示は header の pill / badge / upgrade-btn が担う）。
 
+#### 決済完了後の復帰表示（`?session_id=`、#3958）
+
+Stripe checkout の success_url は `/admin/subscription?session_id=cs_…` で戻る。`+page.server.ts` の
+`load` が **他の取得より先に** `reconcileCheckoutSession` で照合し、その結果に応じて
+`CheckoutReconciliationBanner`（`SaasLicensePanel` の上、`Alert` primitive）を出す。webhook が届かなくても
+この復帰だけで契約が反映されるため、顧客が「支払ったのに無料プランのまま」から自力で復帰できる。
+
+| 照合結果 | 表示 | 追加操作 |
+|---|---|---|
+| 反映した / 反映済み | success（`CHECKOUT_RECONCILIATION_LABELS.applied` / `.alreadyApplied`） | URL から `session_id` を落として再読込し、ヘッダー等も反映後の状態に揃える |
+| 支払い未確定 | info（`.pending`） | 「最新の状態を確認」ボタン（押下中は `loading` で進行中を可視化、NN/G #1） |
+| 照合不可（不正 / 期限切れ / 一時障害） | warning（`.unresolved`） | 同上。プラン表示は既存の値にフォールバックする（500 にしない） |
+
+`session_id` が無い通常アクセスでは Stripe に問い合わせず、バナーも出さない。
+
 ### 10.2 有料機能の表示パターン（共通原則、EPIC #3533 で改訂）
 
 free/standard ユーザーが有料機能・上限超過に触れたとき、**機能の存在は示し、実行は不可（disabled）** にするのが原則。隠す（hidden）のも、403 を踏ませるのも禁止。ただし **画面内に個別アップセル CTA / quota カウンタ（「N/M」「あと何個」）は置かない**（EPIC #3533 で変更）。制約詳細（quota / 上限 / 各プランでできること）は **プラン画面（`/admin/subscription`）に一元化**し、アップグレード導線は **header に一本化**する。

--- a/docs/design/billing-redesign/contract-state-matrix.md
+++ b/docs/design/billing-redesign/contract-state-matrix.md
@@ -124,6 +124,16 @@ KPI service（`cohort-analysis` / `ops-analytics` / `pricing-trigger` / `stripe-
 | W8 | （欠番）退会猶予満了バッチ | — | **書き手なし**。退会の物理削除は `families` 行ごと削除するため status を書かない（§4.1） | — |
 | W9 | （テナント作成） | `createTenant` | `status=active` のみ | → S1 |
 
+### 書き手を増やさない起動点: checkout reconciliation（#3958）
+
+`/admin/subscription?session_id=cs_…`（Stripe checkout の success_url）は `reconcileCheckoutSession`
+（`stripe-service.ts`）を経て **W1 と同じ `handleCheckoutCompleted` に合流する**。webhook が届かなくても
+顧客の画面復帰だけで S1 → S2 に遷移できる救済経路であり、**新しい書き手ではない**（列の書き分けが
+W1 と一致するため、片方だけ直る不整合が生まれない）。
+
+反映前に「session の subscription == `tenants.stripe_subscription_id`」を突合し、一致していれば
+書き込みも通知も行わない。webhook 先着・URL 再訪・リロードはいずれもこの突合で吸収される。
+
 ### 表と実装のズレ（実読で確認、いずれも別 Issue で対処中）
 
 | ID | ズレ | 実装の事実 | Issue |

--- a/scripts/capture-specs/checkout-reconciliation-3958.mjs
+++ b/scripts/capture-specs/checkout-reconciliation-3958.mjs
@@ -1,0 +1,44 @@
+/**
+ * scripts/capture-specs/checkout-reconciliation-3958.mjs
+ *
+ * #3958: checkout 完了照合バナー (`CheckoutReconciliationBanner`) の状態別 SS。
+ *
+ * このバナーは Stripe に実在する checkout session を照合できたときだけ描画されるため、
+ * `isStripeEnabled()=false` のローカルアプリ (`dev` / `dev:cognito`) では再現できない。
+ * Storybook の story に props を直接渡して 4 状態を撮影する。
+ *
+ * 使用例:
+ *   npm run storybook                      # port 6006 で起動しておく
+ *   node scripts/capture.mjs --pr <N> --base-url http://localhost:6006 \
+ *     --config scripts/capture-specs/checkout-reconciliation-3958.mjs
+ */
+
+const STORY_BASE = '/iframe.html?viewMode=story&id=admin-checkoutreconciliationbanner';
+
+/** @type {Array<{ url: string; name: string; presets?: string[]; selector?: string }>} */
+export default [
+	{
+		url: `${STORY_BASE}--applied`,
+		name: 'checkout-reconciliation-applied',
+		presets: ['desktop', 'mobile'],
+		selector: '#storybook-root > *',
+	},
+	{
+		url: `${STORY_BASE}--already-applied`,
+		name: 'checkout-reconciliation-already-applied',
+		presets: ['desktop'],
+		selector: '#storybook-root > *',
+	},
+	{
+		url: `${STORY_BASE}--pending`,
+		name: 'checkout-reconciliation-pending',
+		presets: ['desktop', 'mobile'],
+		selector: '#storybook-root > *',
+	},
+	{
+		url: `${STORY_BASE}--unresolved`,
+		name: 'checkout-reconciliation-unresolved',
+		presets: ['desktop'],
+		selector: '#storybook-root > *',
+	},
+];

--- a/src/lib/domain/checkout-reconciliation.ts
+++ b/src/lib/domain/checkout-reconciliation.ts
@@ -13,6 +13,9 @@
  * - `pending` — Stripe 上まだ支払いが確定していない
  * - `tenant_mismatch` — session の `metadata.tenantId` がログイン中 tenant と一致しない
  * - `not_found` — session_id 不正 / Stripe に存在しない / 期限切れ / tenant 不在
+ * - `unresolved` — session が指す subscription が終端状態、または既存 binding と別の
+ *   subscription を指しているため反映を見送った (「古い URL を再訪した」ことが分かる状態。
+ *   `not_found` = Stripe 側の障害・不整合と区別することで観測性を保つ、#4108 / #4081)
  * - `unavailable` — Stripe 連携が無効な環境 (NUC / local)
  */
 export type CheckoutReconciliationStatus =
@@ -21,6 +24,7 @@ export type CheckoutReconciliationStatus =
 	| 'pending'
 	| 'tenant_mismatch'
 	| 'not_found'
+	| 'unresolved'
 	| 'unavailable';
 
 export interface CheckoutReconciliationResult {

--- a/src/lib/domain/checkout-reconciliation.ts
+++ b/src/lib/domain/checkout-reconciliation.ts
@@ -1,0 +1,28 @@
+// src/lib/domain/checkout-reconciliation.ts
+// #3958: checkout 完了照合 — クライアント/サーバー共有型
+//
+// 実体 (Stripe への照会 + 反映) は `$lib/server/services/stripe-service` の
+// `reconcileCheckoutSession`。型だけを domain に置き、UI 側が server module を
+// import せずに結果を扱えるようにする。
+
+/**
+ * `success_url` の `session_id` を照合した結果。
+ *
+ * - `applied` — 未反映だった契約を本経路で反映した (webhook 未達の救済が成立)
+ * - `already_applied` — 既に同じ subscription が反映済み (書き込み・通知とも発生していない)
+ * - `pending` — Stripe 上まだ支払いが確定していない
+ * - `tenant_mismatch` — session の `metadata.tenantId` がログイン中 tenant と一致しない
+ * - `not_found` — session_id 不正 / Stripe に存在しない / 期限切れ / tenant 不在
+ * - `unavailable` — Stripe 連携が無効な環境 (NUC / local)
+ */
+export type CheckoutReconciliationStatus =
+	| 'applied'
+	| 'already_applied'
+	| 'pending'
+	| 'tenant_mismatch'
+	| 'not_found'
+	| 'unavailable';
+
+export interface CheckoutReconciliationResult {
+	status: CheckoutReconciliationStatus;
+}

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2779,6 +2779,30 @@ export const SUBSCRIPTION_PAGE_LABELS = {
 } as const;
 
 // ============================================================
+// CHECKOUT_RECONCILIATION_LABELS — checkout 完了照合の結果表示 (#3958)
+// ============================================================
+//
+// Stripe checkout の success_url (`/admin/subscription?session_id=cs_…`) から戻ったときに、
+// サーバー側で照合した結果を顧客に伝える文言。webhook 未達時の救済経路であることは
+// 顧客の関心事ではないため、内部事情 (webhook / session_id / Stripe API) を露出させない。
+
+export const CHECKOUT_RECONCILIATION_LABELS = {
+	/** 反映できた (webhook 未達の救済が成立したケースを含む) */
+	applied: 'お支払いを確認しました。プランを反映しました。',
+	/** 既に反映済み (webhook 先着 / 同じ URL の再訪) */
+	alreadyApplied: 'お支払いは反映済みです。',
+	/** Stripe 側でまだ支払いが確定していない */
+	pending: 'お支払いの確認をしています。少し時間をおいて「最新の状態を確認」を押してください。',
+	/** 照合できなかった (期限切れ / 不正な値 / 一時的な障害)。現在のプラン表示にフォールバック */
+	unresolved:
+		'お支払い状況を確認できませんでした。反映されない場合はサポートまでお問い合わせください。',
+	/** 再確認ボタン */
+	recheckButton: '最新の状態を確認',
+	/** 再確認中 (進行中である旨の可視化、NN/G #1) */
+	rechecking: '確認しています…',
+} as const;
+
+// ============================================================
 // LICENSE_PAGE_LABELS — 旧名称 alias (共存期間、Phase 7 PR-2c #2699 で rename)
 // ============================================================
 //

--- a/src/lib/features/admin/components/CheckoutReconciliationBanner.stories.svelte
+++ b/src/lib/features/admin/components/CheckoutReconciliationBanner.stories.svelte
@@ -1,0 +1,78 @@
+<script module>
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import { expect, within } from 'storybook/test';
+import { CHECKOUT_RECONCILIATION_LABELS } from '$lib/domain/labels';
+import CheckoutReconciliationBanner from './CheckoutReconciliationBanner.svelte';
+
+// #3958: Stripe checkout の success_url (`?session_id=cs_…`) から /admin/subscription へ
+// 戻ったときの照合結果バナー。実 Stripe session が要る画面のため、3 状態の見た目と
+// 文言はここで検証する (表示文言は CHECKOUT_RECONCILIATION_LABELS SSOT 経由)。
+const { Story } = defineMeta({
+	title: 'Admin/CheckoutReconciliationBanner',
+	component: CheckoutReconciliationBanner,
+	tags: ['autodocs'],
+});
+</script>
+
+<!-- webhook 未達の救済が成立し、本経路で契約を反映した状態。再確認ボタンは出さない。 -->
+<Story
+	name="Applied"
+	args={{ result: { status: 'applied' } }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByTestId('checkout-reconciliation-banner');
+		await expect(banner).toBeVisible();
+		await expect(banner).toHaveTextContent(CHECKOUT_RECONCILIATION_LABELS.applied);
+		await expect(canvas.queryByTestId('checkout-reconciliation-recheck')).toBeNull();
+	}}
+/>
+
+<!-- webhook が先に届いていた / 同じ URL を再訪した状態。書き込みも通知も発生していない。 -->
+<Story
+	name="AlreadyApplied"
+	args={{ result: { status: 'already_applied' } }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByTestId('checkout-reconciliation-banner')).toHaveTextContent(
+			CHECKOUT_RECONCILIATION_LABELS.alreadyApplied,
+		);
+	}}
+/>
+
+<!-- Stripe 上まだ支払いが確定していない状態。再確認ボタンで load を再実行できる。 -->
+<Story
+	name="Pending"
+	args={{ result: { status: 'pending' } }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const banner = canvas.getByTestId('checkout-reconciliation-banner');
+		await expect(banner).toHaveTextContent(CHECKOUT_RECONCILIATION_LABELS.pending);
+		// 進行中を可視化する再確認導線 (NN/G #1) が押せる状態で出ている
+		const recheck = canvas.getByTestId('checkout-reconciliation-recheck');
+		await expect(recheck).toBeVisible();
+		await expect(recheck).toBeEnabled();
+	}}
+/>
+
+<!-- 期限切れ / 不正な session_id / 一時障害。プラン表示は既存の値にフォールバックする。 -->
+<Story
+	name="Unresolved"
+	args={{ result: { status: 'not_found' } }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByTestId('checkout-reconciliation-banner')).toHaveTextContent(
+			CHECKOUT_RECONCILIATION_LABELS.unresolved,
+		);
+		await expect(canvas.getByTestId('checkout-reconciliation-recheck')).toBeVisible();
+	}}
+/>
+
+<!-- Stripe 連携が無効な環境 (NUC / local)。顧客に伝えることがないため何も描画しない。 -->
+<Story
+	name="Unavailable"
+	args={{ result: { status: 'unavailable' } }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.queryByTestId('checkout-reconciliation-banner')).toBeNull();
+	}}
+/>

--- a/src/lib/features/admin/components/CheckoutReconciliationBanner.svelte
+++ b/src/lib/features/admin/components/CheckoutReconciliationBanner.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+/**
+ * CheckoutReconciliationBanner.svelte — checkout 完了照合の結果表示 (#3958)
+ *
+ * Stripe checkout の success_url (`/admin/subscription?session_id=cs_…`) から戻ったとき、
+ * サーバー側 (`+page.server.ts` の load → `reconcileCheckoutSession`) が照合した結果を伝える。
+ *
+ * 表示責務:
+ *   - 反映済み  → 完了を伝え、URL から session_id を落として最新状態で再描画する
+ *   - 確認中    → 「最新の状態を確認」で再照合できるようにし、その間は進行中を可視化する (NN/G #1)
+ *   - 確認不可  → 既存のプラン表示にフォールバックしていることを伝える (500 にしない)
+ *
+ * 内部事情 (webhook 未達 / Stripe API / session_id) は顧客に露出させない。
+ */
+import { onMount } from 'svelte';
+import { invalidateAll, replaceState } from '$app/navigation';
+import { page } from '$app/state';
+import type {
+	CheckoutReconciliationResult,
+	CheckoutReconciliationStatus,
+} from '$lib/domain/checkout-reconciliation';
+import { CHECKOUT_RECONCILIATION_LABELS } from '$lib/domain/labels';
+import Alert from '$lib/ui/primitives/Alert.svelte';
+import Button from '$lib/ui/primitives/Button.svelte';
+
+let { result }: { result: CheckoutReconciliationResult | null } = $props();
+
+// 反映確定後は URL から session_id を落とすので load は `null` を返す。props をそのまま
+// 描画すると「反映しました」が即座に消えるため、確定した結果だけ保持する。
+let pinned = $state<CheckoutReconciliationStatus | null>(null);
+let rechecking = $state(false);
+
+const status = $derived(pinned ?? result?.status ?? null);
+const terminal = $derived(status === 'applied' || status === 'already_applied');
+
+function display(): { variant: 'success' | 'info' | 'warning'; message: string } | null {
+	switch (status) {
+		case 'applied':
+			return { variant: 'success', message: CHECKOUT_RECONCILIATION_LABELS.applied };
+		case 'already_applied':
+			return { variant: 'success', message: CHECKOUT_RECONCILIATION_LABELS.alreadyApplied };
+		case 'pending':
+			return { variant: 'info', message: CHECKOUT_RECONCILIATION_LABELS.pending };
+		case 'tenant_mismatch':
+		case 'not_found':
+			return { variant: 'warning', message: CHECKOUT_RECONCILIATION_LABELS.unresolved };
+		default:
+			// unavailable (Stripe 無効環境) は顧客に伝えることがないため何も出さない
+			return null;
+	}
+}
+
+const view = $derived(display());
+
+/** 再照合。session_id を保持したまま load を再実行する (Stripe に再度問い合わせる) */
+async function recheck() {
+	rechecking = true;
+	try {
+		await invalidateAll();
+	} finally {
+		rechecking = false;
+	}
+}
+
+onMount(() => {
+	// 反映が確定したら session_id を URL から外す。残したままだと再読込のたびに
+	// Stripe へ照会が飛ぶうえ、共有・ブックマークで決済 ID が持ち回られる。
+	// URL 更新後に再読込することで、ヘッダー等の他 load も反映後の状態に揃う。
+	if (!terminal || !page.url.searchParams.has('session_id')) return;
+	pinned = status;
+	const next = new URL(page.url);
+	next.searchParams.delete('session_id');
+	replaceState(next, page.state);
+	void invalidateAll();
+});
+</script>
+
+{#if view}
+	<Alert variant={view.variant} data-testid="checkout-reconciliation-banner">
+		<p>{view.message}</p>
+		{#if !terminal}
+			<div class="mt-2">
+				<Button
+					variant="secondary"
+					size="sm"
+					loading={rechecking}
+					onclick={recheck}
+					data-testid="checkout-reconciliation-recheck"
+				>
+					{rechecking
+						? CHECKOUT_RECONCILIATION_LABELS.rechecking
+						: CHECKOUT_RECONCILIATION_LABELS.recheckButton}
+				</Button>
+			</div>
+		{/if}
+	</Alert>
+{/if}

--- a/src/lib/features/admin/components/CheckoutReconciliationBanner.svelte
+++ b/src/lib/features/admin/components/CheckoutReconciliationBanner.svelte
@@ -67,7 +67,9 @@ onMount(() => {
 	// 反映が確定したら session_id を URL から外す。残したままだと再読込のたびに
 	// Stripe へ照会が飛ぶうえ、共有・ブックマークで決済 ID が持ち回られる。
 	// URL 更新後に再読込することで、ヘッダー等の他 load も反映後の状態に揃う。
-	if (!terminal || !page.url.searchParams.has('session_id')) return;
+	// SvelteKit router の外 (Storybook 等) では page.url を持たないため、URL 操作は行わない
+	const currentUrl: URL | undefined = page.url;
+	if (!terminal || !currentUrl?.searchParams.has('session_id')) return;
 	pinned = status;
 	replaceState(resolve('/admin/subscription'), page.state);
 	void invalidateAll();

--- a/src/lib/features/admin/components/CheckoutReconciliationBanner.svelte
+++ b/src/lib/features/admin/components/CheckoutReconciliationBanner.svelte
@@ -14,6 +14,7 @@
  */
 import { onMount } from 'svelte';
 import { invalidateAll, replaceState } from '$app/navigation';
+import { resolve } from '$app/paths';
 import { page } from '$app/state';
 import type {
 	CheckoutReconciliationResult,
@@ -68,9 +69,7 @@ onMount(() => {
 	// URL 更新後に再読込することで、ヘッダー等の他 load も反映後の状態に揃う。
 	if (!terminal || !page.url.searchParams.has('session_id')) return;
 	pinned = status;
-	const next = new URL(page.url);
-	next.searchParams.delete('session_id');
-	replaceState(next, page.state);
+	replaceState(resolve('/admin/subscription'), page.state);
 	void invalidateAll();
 });
 </script>

--- a/src/lib/features/admin/components/CheckoutReconciliationBanner.svelte
+++ b/src/lib/features/admin/components/CheckoutReconciliationBanner.svelte
@@ -44,6 +44,7 @@ function display(): { variant: 'success' | 'info' | 'warning'; message: string }
 			return { variant: 'info', message: CHECKOUT_RECONCILIATION_LABELS.pending };
 		case 'tenant_mismatch':
 		case 'not_found':
+		case 'unresolved':
 			return { variant: 'warning', message: CHECKOUT_RECONCILIATION_LABELS.unresolved };
 		default:
 			// unavailable (Stripe 無効環境) は顧客に伝えることがないため何も出さない

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -609,6 +609,19 @@ export async function reconcileCheckoutSession(input: {
 		return { status: 'already_applied' };
 	}
 
+	// 既存 binding があり、session が別の subscription を指す場合は反映しない。
+	// reconcile は binding を「埋める / 確認する」だけで、「差し替える」権限を持たない。
+	if (
+		tenant.stripeSubscriptionId &&
+		subscriptionId &&
+		tenant.stripeSubscriptionId !== subscriptionId
+	) {
+		logger.warn(
+			`[STRIPE] reconcile: 既存 binding と別 subscription のため反映しません: tenant=${tenantId} current=${tenant.stripeSubscriptionId} session=${subscriptionId}`,
+		);
+		return { status: 'unresolved' };
+	}
+
 	// #4081: `handleCheckoutCompleted` (assign-contract) は「checkout.session.completed は
 	// 購入時に 1 回だけ配信される」前提で突合を行わない。reconcileCheckoutSession はこの前提を
 	// 「顧客が success_url を何度でも再訪できる経路」に接続しているため、以下の replay で
@@ -635,7 +648,7 @@ export async function reconcileCheckoutSession(input: {
 				`[STRIPE] reconcile: subscription が終端状態 (${subscription.status}) のため反映しません: ` +
 					`tenant=${tenantId} subscription=${subscriptionId}`,
 			);
-			return { status: 'not_found' };
+			return { status: 'unresolved' };
 		}
 	}
 

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -2,6 +2,7 @@
 // Stripe 決済サービス (#0131)
 
 import type Stripe from 'stripe';
+import type { CheckoutReconciliationResult } from '$lib/domain/checkout-reconciliation';
 import { SUBSCRIPTION_PLAN } from '$lib/domain/constants/subscription-plan';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { MS_PER_DAY } from '$lib/domain/constants/time';
@@ -10,6 +11,7 @@ import type { Tenant } from '$lib/server/auth/entities';
 import { getRepos } from '$lib/server/db/factory';
 import { getDebugCancelAtPeriodEnd } from '$lib/server/debug-plan';
 import { logger } from '$lib/server/logger';
+import { invalidateRequestCaches } from '$lib/server/request-context';
 import { notifyBillingEvent } from '$lib/server/services/discord-notify-service';
 import { notifyStripeAlert } from '$lib/server/stripe/alert';
 import { getStripeClient, isStripeEnabled } from '$lib/server/stripe/client';
@@ -520,6 +522,100 @@ function resolveEventTenantId(event: Stripe.Event): string | null {
 		return (event.data.object as Stripe.Checkout.Session).metadata?.tenantId ?? null;
 	}
 	return null;
+}
+
+// ============================================================
+// Checkout Reconciliation (#3958)
+// ============================================================
+
+/** Stripe Checkout Session ID の形式 (`cs_test_…` / `cs_live_…`)。 */
+const CHECKOUT_SESSION_ID_PATTERN = /^cs_[A-Za-z0-9_]{8,255}$/;
+
+/**
+ * 支払いが確定したとみなす `payment_status`。
+ * 100% OFF クーポン適用時の subscription checkout は `no_payment_required` で完了する
+ * (`handleCheckoutCompleted` も同じ session を通常購入として扱う、#803)。
+ */
+const PAID_PAYMENT_STATUSES: readonly string[] = ['paid', 'no_payment_required'];
+
+/**
+ * checkout 完了を `success_url` の `session_id` から照合して反映する (#3958)。
+ *
+ * webhook (`checkout.session.completed`) が唯一の反映経路だったため、webhook が 1 通落ちると
+ * 顧客は支払い済みのまま無料プランに据え置かれ、**自力で復旧する手段が無かった**
+ * (2026-07-26 本番 incident、root cause は #3957)。本経路は顧客自身の画面復帰を救済経路にする。
+ *
+ * 設計上の制約:
+ * - 照合は必ずサーバー側で Stripe API に問い合わせる。`session_id` は URL に露出するため、
+ *   ブラウザからの申告 (payment_status / plan / tenantId) を一切信用しない
+ * - 反映の書き込みは webhook handler (`handleCheckoutCompleted`) に合流させる。契約状態の
+ *   書き手を増やさない (二重実装 = 片方だけ直る不整合の温床)
+ * - 冪等は「反映前に現契約と突合し、一致していれば何もしない」で担保する。webhook 先着 /
+ *   同じ URL の再訪 / リロードのいずれも `already_applied` に落ちる
+ * - 例外は投げない。`session_id` が不正でも既存のプラン表示にフォールバックさせる (AC)
+ */
+export async function reconcileCheckoutSession(input: {
+	tenantId: string;
+	sessionId: string;
+}): Promise<CheckoutReconciliationResult> {
+	const { tenantId, sessionId } = input;
+	if (!isStripeEnabled()) return { status: 'unavailable' };
+
+	if (!CHECKOUT_SESSION_ID_PATTERN.test(sessionId)) {
+		logger.warn(`[STRIPE] reconcile: malformed session_id for tenant=${tenantId}`);
+		return { status: 'not_found' };
+	}
+
+	let session: Stripe.Checkout.Session;
+	try {
+		session = await getStripeClient().checkout.sessions.retrieve(sessionId);
+	} catch (err) {
+		// resource_missing (期限切れ / 存在しない) も API 障害も、顧客には同じ
+		// 「反映できなかった」で返す。500 にすると既存のプラン表示ごと落ちる。
+		logger.warn(`[STRIPE] reconcile: session retrieve failed tenant=${tenantId}`, {
+			error: String(err),
+		});
+		return { status: 'not_found' };
+	}
+
+	// 他人の session_id を URL に貼っても契約が付与されないことを保証する境界。
+	if (session.metadata?.tenantId !== tenantId) {
+		logger.warn(
+			`[STRIPE] reconcile: tenant mismatch — session belongs to another tenant (requested by tenant=${tenantId})`,
+		);
+		return { status: 'tenant_mismatch' };
+	}
+
+	if (!PAID_PAYMENT_STATUSES.includes(session.payment_status)) {
+		logger.info(
+			`[STRIPE] reconcile: not paid yet tenant=${tenantId} payment_status=${session.payment_status}`,
+		);
+		return { status: 'pending' };
+	}
+
+	const tenant = await getRepos().auth.findTenantById(tenantId);
+	if (!tenant) return { status: 'not_found' };
+
+	const subscriptionId =
+		typeof session.subscription === 'string' ? session.subscription : session.subscription?.id;
+	const desiredPlan = (session.metadata?.planId as Tenant['plan']) ?? SUBSCRIPTION_PLAN.MONTHLY;
+	// 冪等判定。subscription が確定していればそれが最も強い同一性の根拠、無い場合のみ
+	// plan / status の一致で代替する。
+	const alreadyApplied = subscriptionId
+		? tenant.stripeSubscriptionId === subscriptionId
+		: tenant.status === SUBSCRIPTION_STATUS.ACTIVE && tenant.plan === desiredPlan;
+	if (alreadyApplied) {
+		logger.info(`[STRIPE] reconcile: already applied tenant=${tenantId}`);
+		return { status: 'already_applied' };
+	}
+
+	await handleCheckoutCompleted(session);
+	// hooks.server.ts が解決済みの entitlement / planTier は本 request 内で古くなる。
+	// 破棄しないと「反映したのに画面は無料プランのまま」という本 Issue の症状が残る。
+	invalidateRequestCaches(tenantId);
+
+	logger.info(`[STRIPE] reconcile: applied via success_url tenant=${tenantId}`);
+	return { status: 'applied' };
 }
 
 // --- Webhook handlers ---

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -609,6 +609,36 @@ export async function reconcileCheckoutSession(input: {
 		return { status: 'already_applied' };
 	}
 
+	// #4081: `handleCheckoutCompleted` (assign-contract) は「checkout.session.completed は
+	// 購入時に 1 回だけ配信される」前提で突合を行わない。reconcileCheckoutSession はこの前提を
+	// 「顧客が success_url を何度でも再訪できる経路」に接続しているため、以下の replay で
+	// 二重課金が成立し得る:
+	//   - 解約済みテナント (stripeSubscriptionId=null) が古い session_id を再訪 → 契約が復活する
+	//   - 再購読済みテナント (stripeSubscriptionId=sub_new) が古い session_id を再訪 →
+	//     現行契約が古い subscription で上書きされ、`createCheckoutSession()` の
+	//     ALREADY_SUBSCRIBED ガードが外れて二重課金の温床になる
+	// session が指す subscription を Stripe から re-retrieve し、終端状態
+	// (canceled / incomplete_expired、#3982 `isSubscriptionTerminal` と同一基準) なら
+	// handleCheckoutCompleted に合流させない。
+	if (subscriptionId) {
+		let subscription: Stripe.Subscription;
+		try {
+			subscription = await getStripeClient().subscriptions.retrieve(subscriptionId);
+		} catch (err) {
+			logger.warn(`[STRIPE] reconcile: subscription retrieve failed tenant=${tenantId}`, {
+				error: String(err),
+			});
+			return { status: 'not_found' };
+		}
+		if (isSubscriptionTerminal(subscription)) {
+			logger.warn(
+				`[STRIPE] reconcile: subscription が終端状態 (${subscription.status}) のため反映しません: ` +
+					`tenant=${tenantId} subscription=${subscriptionId}`,
+			);
+			return { status: 'not_found' };
+		}
+	}
+
 	await handleCheckoutCompleted(session);
 	// hooks.server.ts が解決済みの entitlement / planTier は本 request 内で古くなる。
 	// 破棄しないと「反映したのに画面は無料プランのまま」という本 Issue の症状が残る。

--- a/src/routes/(parent)/admin/subscription/+page.server.ts
+++ b/src/routes/(parent)/admin/subscription/+page.server.ts
@@ -20,7 +20,10 @@ import { getAllChildren } from '$lib/server/services/child-service';
 import { getLicenseInfo } from '$lib/server/services/license-service';
 import { getLoyaltyInfo } from '$lib/server/services/loyalty-service';
 import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
-import { getCancellationState, reconcileCheckoutSession } from '$lib/server/services/stripe-service';
+import {
+	getCancellationState,
+	reconcileCheckoutSession,
+} from '$lib/server/services/stripe-service';
 import { getTrialStatus, startTrial } from '$lib/server/services/trial-service';
 import { isStripeEnabled } from '$lib/server/stripe/client';
 import type { Actions, PageServerLoad } from './$types';

--- a/src/routes/(parent)/admin/subscription/+page.server.ts
+++ b/src/routes/(parent)/admin/subscription/+page.server.ts
@@ -13,19 +13,31 @@ import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { TRIAL_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
+import { resolveTenantEntitlement } from '$lib/server/auth/tenant-entitlement';
 import { getActivities } from '$lib/server/services/activity-service';
 import { isPinConfigured } from '$lib/server/services/auth-service';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { getLicenseInfo } from '$lib/server/services/license-service';
 import { getLoyaltyInfo } from '$lib/server/services/loyalty-service';
 import { getPlanLimits, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
-import { getCancellationState } from '$lib/server/services/stripe-service';
+import { getCancellationState, reconcileCheckoutSession } from '$lib/server/services/stripe-service';
 import { getTrialStatus, startTrial } from '$lib/server/services/trial-service';
 import { isStripeEnabled } from '$lib/server/stripe/client';
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async ({ locals }) => {
+export const load: PageServerLoad = async ({ locals, url }) => {
 	const tenantId = requireTenantId(locals);
+
+	// #3958: Stripe checkout の success_url は `?session_id=cs_…` を付けてこの画面に戻る。
+	// webhook (`checkout.session.completed`) が未達でも、この照合だけでプランが反映される
+	// (webhook が唯一の反映経路だった頃は、1 通落ちるだけで顧客が永久に無料プランのまま
+	// だった — 2026-07-26 本番 incident)。他の load より先に await して、下の
+	// `getLicenseInfo` / `resolveFullPlanTier` が反映後の状態を読むようにする。
+	const sessionId = url.searchParams.get('session_id');
+	const checkoutReconciliation = sessionId
+		? await reconcileCheckoutSession({ tenantId, sessionId })
+		: null;
+
 	const [license, loyaltyInfo, children, trialStatus, pinConfigured, cancellation] =
 		await Promise.all([
 			getLicenseInfo(tenantId),
@@ -41,11 +53,17 @@ export const load: PageServerLoad = async ({ locals }) => {
 		]);
 
 	// プラン利用状況 (#732: resolveFullPlanTier に統一)
-	const tier = await resolveFullPlanTier(
-		tenantId,
-		locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
-		locals.context?.plan,
-	);
+	// #3958: `locals.context` は hooks.server.ts が load 前に解決した値なので、本 request 内で
+	// reconcile が契約を反映した場合は古い (無料プランのまま)。反映したときだけ DB から
+	// 引き直す (reconcile 側が request キャッシュを破棄済みなので最新値が返る)。
+	const entitlement =
+		checkoutReconciliation?.status === 'applied'
+			? await resolveTenantEntitlement(tenantId)
+			: {
+					licenseStatus: locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE,
+					plan: locals.context?.plan,
+				};
+	const tier = await resolveFullPlanTier(tenantId, entitlement.licenseStatus, entitlement.plan);
 	const planLimits = getPlanLimits(tier);
 	let activityCount = 0;
 	try {
@@ -80,6 +98,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 		planStats,
 		downgradeRetentionDays,
 		pinConfigured,
+		// #3958: null = success_url 経由ではない通常表示。値があるときだけ画面に結果を出す。
+		checkoutReconciliation,
 		trialStatus: {
 			isTrialActive: trialStatus.isTrialActive,
 			trialUsed: trialStatus.trialUsed,

--- a/src/routes/(parent)/admin/subscription/+page.svelte
+++ b/src/routes/(parent)/admin/subscription/+page.svelte
@@ -8,6 +8,7 @@
  *   - 'nuc-prod' → NucLicensePanel (Edition badge + 簡略 3 セクション、Mattermost 整合)
  *   - その他     → SaasLicensePanel (subscription 管理、license key UI は PR-L3 で撤去済)
  */
+import CheckoutReconciliationBanner from '$lib/features/admin/components/CheckoutReconciliationBanner.svelte';
 import NucLicensePanel from '$lib/features/admin/components/NucLicensePanel.svelte';
 import SaasLicensePanel from '$lib/features/admin/components/SaasLicensePanel.svelte';
 
@@ -17,5 +18,10 @@ let { data } = $props();
 {#if data.runtimeMode === 'nuc-prod'}
 	<NucLicensePanel {data} />
 {:else}
-	<SaasLicensePanel {data} />
+	<!-- #3958: Stripe checkout の success_url (?session_id=…) から戻ったときの照合結果。
+	     通常表示 (session_id 無し) では data.checkoutReconciliation が null で何も出ない。 -->
+	<div class="space-y-4">
+		<CheckoutReconciliationBanner result={data.checkoutReconciliation ?? null} />
+		<SaasLicensePanel {data} />
+	</div>
 {/if}

--- a/tests/e2e/plan-free.spec.ts
+++ b/tests/e2e/plan-free.spec.ts
@@ -114,6 +114,21 @@ test.describe('#751 free プラン — 機能ゲート', () => {
 		await expect(page.getByTestId('menu-item-manual')).toContainText('🔒');
 	});
 
+	// #3958: checkout success_url (`?session_id=…`) 復帰の回帰。
+	//   load が session_id を読むようになったため、Stripe に存在しない / 期限切れの値を
+	//   渡されたときに 500 で画面ごと落ちないことを実サーバーで担保する
+	//   (照合結果は「現在のプラン表示にフォールバック」が仕様)。
+	test('/admin/subscription?session_id=<不正値> でも 500 にならず現在のプラン表示にフォールバックする', async ({
+		page,
+	}) => {
+		const response = await page.goto('/admin/subscription?session_id=cs_test_nonexistent_session');
+		expect(response?.status()).toBe(200);
+
+		const card = page.getByTestId('plan-status-card');
+		await expect(card).toBeVisible();
+		await expect(card).toHaveAttribute('data-plan-tier', 'free');
+	});
+
 	// #2316: 旧 /admin/messages 「ひとことメッセージ」family-only ゲートテストは削除。
 	//   #2267 (PR #2293) で /admin/messages 廃止 + /admin/cheer 統合により、
 	//   メッセージ機能は応援機能の付随要素として全プラン解放された。

--- a/tests/unit/routes/admin-subscription-reconciliation.test.ts
+++ b/tests/unit/routes/admin-subscription-reconciliation.test.ts
@@ -16,6 +16,9 @@ const mockReconcile = vi.fn();
 const mockGetLicenseInfo = vi.fn();
 const mockResolveTenantEntitlement = vi.fn();
 const mockResolveFullPlanTier = vi.fn();
+// #3991: load は解約予約状態 (`getCancellationState`) も並行取得するようになった
+// (Stripe subscription が SSOT、本 file の関心は reconciliation のみのため常に null で吸収する)。
+const mockGetCancellationState = vi.fn().mockResolvedValue(null);
 
 vi.mock('$lib/server/auth/factory', () => ({
 	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
@@ -26,6 +29,7 @@ vi.mock('$lib/server/auth/factory', () => ({
 
 vi.mock('$lib/server/services/stripe-service', () => ({
 	reconcileCheckoutSession: (...args: unknown[]) => mockReconcile(...args),
+	getCancellationState: (...args: unknown[]) => mockGetCancellationState(...args),
 }));
 
 vi.mock('$lib/server/auth/tenant-entitlement', () => ({

--- a/tests/unit/routes/admin-subscription-reconciliation.test.ts
+++ b/tests/unit/routes/admin-subscription-reconciliation.test.ts
@@ -1,0 +1,146 @@
+// tests/unit/routes/admin-subscription-reconciliation.test.ts
+// #3958: /admin/subscription の load が success_url の session_id を読むことの契約テスト
+//
+// 背景: success_url には `?session_id=cs_…` が付いて戻ってくるが、この load は `url` すら
+// 受け取っておらず、値を読む実装が src 全体で 0 件だった。webhook が 1 通落ちるだけで
+// 顧客は永久に無料プランのままになる (2026-07-26 本番 incident)。
+//
+// テスト観点:
+// - session_id なし → Stripe に照会せず、既存表示のまま (通常アクセスに副作用を出さない)
+// - session_id あり → 反映してから license / planTier を読む (画面が反映後の状態になる)
+// - 反映失敗 (不正 / 期限切れ) → 例外にせず既存表示にフォールバックする
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockReconcile = vi.fn();
+const mockGetLicenseInfo = vi.fn();
+const mockResolveTenantEntitlement = vi.fn();
+const mockResolveFullPlanTier = vi.fn();
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+}));
+
+vi.mock('$lib/server/services/stripe-service', () => ({
+	reconcileCheckoutSession: (...args: unknown[]) => mockReconcile(...args),
+}));
+
+vi.mock('$lib/server/auth/tenant-entitlement', () => ({
+	resolveTenantEntitlement: (...args: unknown[]) => mockResolveTenantEntitlement(...args),
+}));
+
+vi.mock('$lib/server/services/license-service', () => ({
+	getLicenseInfo: (...args: unknown[]) => mockGetLicenseInfo(...args),
+}));
+
+vi.mock('$lib/server/services/loyalty-service', () => ({
+	getLoyaltyInfo: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('$lib/server/services/child-service', () => ({
+	getAllChildren: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('$lib/server/services/trial-service', () => ({
+	getTrialStatus: vi.fn().mockResolvedValue({
+		isTrialActive: false,
+		trialUsed: false,
+		daysRemaining: 0,
+		trialEndDate: null,
+		trialTier: null,
+	}),
+	startTrial: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/auth-service', () => ({
+	isPinConfigured: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('$lib/server/services/activity-service', () => ({
+	getActivities: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+	getPlanLimits: () => ({ maxActivities: 10, maxChildren: 1, historyRetentionDays: 90 }),
+}));
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: () => true,
+}));
+
+const { load } = await import('../../../src/routes/(parent)/admin/subscription/+page.server');
+
+const LOCALS = {
+	context: { tenantId: 't-test', licenseStatus: 'none', plan: undefined },
+};
+
+function makeEvent(search = '') {
+	return {
+		locals: LOCALS,
+		url: new URL(`https://app.example/admin/subscription${search}`),
+	} as never;
+}
+
+/** `PageServerLoad` の戻り型は `void` を含むため、テスト側で存在を確定させる */
+async function runLoad(search = '') {
+	const data = await load(makeEvent(search));
+	if (!data) throw new Error('load returned no data');
+	return data;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetLicenseInfo.mockResolvedValue({
+		plan: 'free',
+		status: 'active',
+		tenantName: 'テスト家族',
+		createdAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-01T00:00:00Z',
+	});
+	mockResolveFullPlanTier.mockResolvedValue('free');
+	mockReconcile.mockResolvedValue({ status: 'applied' });
+	mockResolveTenantEntitlement.mockResolvedValue({ licenseStatus: 'active', plan: 'monthly' });
+});
+
+describe('/admin/subscription load — checkout reconciliation (#3958)', () => {
+	it('session_id が無い通常アクセスでは Stripe に照会しない', async () => {
+		const data = await runLoad();
+
+		expect(mockReconcile).not.toHaveBeenCalled();
+		expect(data.checkoutReconciliation).toBeNull();
+	});
+
+	it('session_id 付きで戻ると照合を実行し、結果を画面に渡す', async () => {
+		const data = await runLoad('?session_id=cs_test_a1b2c3d4e5f6');
+
+		expect(mockReconcile).toHaveBeenCalledWith({
+			tenantId: 't-test',
+			sessionId: 'cs_test_a1b2c3d4e5f6',
+		});
+		expect(data.checkoutReconciliation).toEqual({ status: 'applied' });
+	});
+
+	it('反映後は locals.context (古い課金状態) ではなく DB の最新 entitlement で planTier を出す', async () => {
+		await runLoad('?session_id=cs_test_a1b2c3d4e5f6');
+
+		// locals.context は hooks が load 前に解決した値なので licenseStatus=none のまま。
+		// これを使うと「反映したのに無料プラン表示」になる (本 Issue の症状そのもの)。
+		expect(mockResolveTenantEntitlement).toHaveBeenCalledWith('t-test');
+		expect(mockResolveFullPlanTier).toHaveBeenCalledWith('t-test', 'active', 'monthly');
+	});
+
+	it('照合が未反映で終わった場合は DB 再解決せず既存表示にフォールバックする', async () => {
+		mockReconcile.mockResolvedValue({ status: 'not_found' });
+
+		const data = await runLoad('?session_id=cs_bogus_value');
+
+		expect(mockResolveTenantEntitlement).not.toHaveBeenCalled();
+		expect(mockResolveFullPlanTier).toHaveBeenCalledWith('t-test', 'none', undefined);
+		expect(data.license.plan).toBe('free');
+		expect(data.checkoutReconciliation).toEqual({ status: 'not_found' });
+	});
+});

--- a/tests/unit/services/stripe-checkout-reconciliation.test.ts
+++ b/tests/unit/services/stripe-checkout-reconciliation.test.ts
@@ -22,12 +22,24 @@ const mockFindTenantById = vi.fn();
 const mockUpdateTenantStripe = vi.fn();
 const mockFindTenantByStripeCustomerId = vi.fn();
 
+// #4079: `handleWebhookEvent` はディスパッチャ入口で event.id dedup 台帳 (`repos.webhookEvent`) を
+// 参照するようになった。`reconcileCheckoutSession` は `handleCheckoutCompleted` を直接呼ぶため
+// この dedup 台帳を経由しない (reconcile 経路は #4079 の対象外)。一方、本 file 末尾の相互冪等テスト
+// ('reconcile が先に反映した後に webhook が届いても状態は変わらない') は意図的に `handleWebhookEvent`
+// (webhook の正規入口) も呼ぶため、その呼び出しが動くよう `webhookEvent` repo の stub を用意する
+// (常に未処理を返す stub、`tests/unit/services/stripe-service.test.ts` と同じ形)。
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
 		auth: {
 			findTenantById: mockFindTenantById,
 			updateTenantStripe: mockUpdateTenantStripe,
 			findTenantByStripeCustomerId: mockFindTenantByStripeCustomerId,
+		},
+		webhookEvent: {
+			findByEventId: async () => null,
+			insert: async () => {},
+			incrementRetryCount: async () => {},
+			deleteOlderThan: async () => 0,
 		},
 	}),
 }));

--- a/tests/unit/services/stripe-checkout-reconciliation.test.ts
+++ b/tests/unit/services/stripe-checkout-reconciliation.test.ts
@@ -113,6 +113,7 @@ function makePaidSession(overrides: Record<string, unknown> = {}) {
 }
 
 const mockSessionRetrieve = vi.fn();
+const mockSubscriptionsRetrieve = vi.fn();
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -120,8 +121,13 @@ beforeEach(() => {
 	mockFindTenantById.mockResolvedValue(makeTenant());
 	mockUpdateTenantStripe.mockResolvedValue(undefined);
 	mockSessionRetrieve.mockResolvedValue(makePaidSession());
+	// #4081: reconcileCheckoutSession は session.subscription を Stripe から再 retrieve して
+	// 終端状態 (canceled / incomplete_expired) でないかを確認する。既定は「生きている」
+	// subscription を返し、既存の正常系 (AC1〜AC4) が壊れないようにする。
+	mockSubscriptionsRetrieve.mockResolvedValue({ id: 'sub_new', status: 'active' });
 	mockGetStripeClient.mockReturnValue({
 		checkout: { sessions: { retrieve: mockSessionRetrieve } },
+		subscriptions: { retrieve: mockSubscriptionsRetrieve },
 	});
 });
 
@@ -325,5 +331,95 @@ describe('reconcileCheckoutSession — フォールバック (AC4)', () => {
 
 		expect(result.status).toBe('not_found');
 		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+});
+
+// ==========================================================
+// AC5 (#4081): 古い success_url の replay で二重課金が成立しない
+// ==========================================================
+//
+// `assign-contract` (handleCheckoutCompleted の書き込みモード) は「checkout.session.completed は
+// 購入時に 1 回だけ配信される」前提で突合を行わない。reconcileCheckoutSession はこの前提を
+// 「顧客が何度でも叩ける経路」に接続しているため、解約後に古い session_id を再訪すると
+// - 解約済みテナント (stripeSubscriptionId=null) に古い subscription が復活する
+// - 再購読済みテナント (stripeSubscriptionId=sub_new) の現行契約が古い subscription で
+//   上書きされ、`createCheckoutSession()` の ALREADY_SUBSCRIBED ガードが外れて二重課金が成立し得る
+//
+// 対策: session.subscription を Stripe から re-retrieve し、終端状態 (canceled /
+// incomplete_expired) なら handleCheckoutCompleted に合流させない。
+
+describe('reconcileCheckoutSession — 二重課金ガード (AC5、#4081)', () => {
+	it('解約済みテナントが古い session_id (canceled subscription) を再訪しても契約は復活しない', async () => {
+		// 解約済み = stripeSubscriptionId は null (TERMINAL_CONTRACT_STATE)
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: null, plan: null, status: 'suspended' }),
+		);
+		// 古い success_url が指す session の subscription は Stripe 上では既に解約済み
+		mockSessionRetrieve.mockResolvedValue(makePaidSession({ subscription: 'sub_old' }));
+		mockSubscriptionsRetrieve.mockResolvedValue({ id: 'sub_old', status: 'canceled' });
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).not.toBe('applied');
+		expect(mockSubscriptionsRetrieve).toHaveBeenCalledWith('sub_old');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
+	it('再購読済みテナントの現行 subscription が、古い session の canceled subscription で上書きされない', async () => {
+		// 解約 → 再購読済み。現行契約は sub_new
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: 'sub_new', plan: 'monthly', status: 'active' }),
+		);
+		// ブックマーク / 履歴から古い (解約済み) checkout session を再訪
+		mockSessionRetrieve.mockResolvedValue(makePaidSession({ subscription: 'sub_old' }));
+		mockSubscriptionsRetrieve.mockResolvedValue({ id: 'sub_old', status: 'canceled' });
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).not.toBe('applied');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
+	it('incomplete_expired の subscription も終端として扱い、反映しない', async () => {
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: null, plan: null, status: 'suspended' }),
+		);
+		mockSessionRetrieve.mockResolvedValue(makePaidSession({ subscription: 'sub_old' }));
+		mockSubscriptionsRetrieve.mockResolvedValue({ id: 'sub_old', status: 'incomplete_expired' });
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).not.toBe('applied');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
+	it('正常系 (回帰): 初回購入で subscription が生きていれば従来通り反映される', async () => {
+		// tenant は未契約、session の subscription (sub_new) は Stripe 上でも active
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: null, plan: 'free', status: 'active' }),
+		);
+		mockSessionRetrieve.mockResolvedValue(makePaidSession({ subscription: 'sub_new' }));
+		mockSubscriptionsRetrieve.mockResolvedValue({ id: 'sub_new', status: 'active' });
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('applied');
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith(
+			TENANT_ID,
+			expect.objectContaining({ stripeSubscriptionId: 'sub_new', status: 'active' }),
+		);
 	});
 });

--- a/tests/unit/services/stripe-checkout-reconciliation.test.ts
+++ b/tests/unit/services/stripe-checkout-reconciliation.test.ts
@@ -1,0 +1,329 @@
+// tests/unit/services/stripe-checkout-reconciliation.test.ts
+// #3958: checkout 完了の reconciliation 経路 (success_url の session_id 照合)
+//
+// 背景 (2026-07-26 本番 incident): webhook が CloudFront geo 制限で未達となったとき、
+// 顧客側に復旧手段が一切なかった。success_url には `session_id` が付いて戻ってくるのに、
+// それを読む実装が `src/` に 1 件も存在しなかった (生成箇所 1 行のみ)。
+//
+// 本 test は「webhook が届かないまま success_url に戻ってきた場合に契約状態が反映される」
+// および「何度戻ってきても副作用が 1 回だけ」を assert する (failing-test-first, ADR-0061)。
+//
+// 冪等の担保方法:
+//   - 反映の書き込みは webhook handler (`handleCheckoutCompleted`) と**同一経路**に合流させる
+//     (二重実装しない / #4077 の単一強制点を迂回しない)
+//   - 反映前にテナントの現契約と session の subscription を突合し、既に一致していれば
+//     **書き込みも通知も行わない** (webhook 先着 / 2 回目のアクセス双方をここで吸収)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- Mocks ----------
+
+const mockFindTenantById = vi.fn();
+const mockUpdateTenantStripe = vi.fn();
+const mockFindTenantByStripeCustomerId = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		auth: {
+			findTenantById: mockFindTenantById,
+			updateTenantStripe: mockUpdateTenantStripe,
+			findTenantByStripeCustomerId: mockFindTenantByStripeCustomerId,
+		},
+	}),
+}));
+
+const mockIsStripeEnabled = vi.fn();
+const mockGetStripeClient = vi.fn();
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: (...args: unknown[]) => mockIsStripeEnabled(...args),
+	getStripeClient: (...args: unknown[]) => mockGetStripeClient(...args),
+}));
+
+vi.mock('$lib/server/stripe/config', () => ({
+	getPlans: () => ({
+		monthly: { priceId: 'price_monthly_123', amount: 500, interval: 'month', label: '月額' },
+		'family-monthly': {
+			priceId: 'price_family_monthly_789',
+			amount: 780,
+			interval: 'month',
+			label: 'プレミアム月額',
+		},
+	}),
+	planIdFromPriceId: (priceId: string) =>
+		priceId === 'price_monthly_123'
+			? 'monthly'
+			: priceId === 'price_family_monthly_789'
+				? 'family-monthly'
+				: null,
+	getWebhookSecret: () => 'whsec_test',
+	TRIAL_PERIOD_DAYS: 7,
+	GRACE_PERIOD_DAYS: 7,
+	CURRENCY: 'jpy',
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockNotifyBillingEvent = vi.fn().mockResolvedValue(undefined);
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyBillingEvent: (...args: unknown[]) => mockNotifyBillingEvent(...args),
+}));
+
+// ---------- Import after mocks ----------
+
+import {
+	handleWebhookEvent,
+	reconcileCheckoutSession,
+} from '../../../src/lib/server/services/stripe-service';
+
+// ---------- Helpers ----------
+
+const TENANT_ID = 't-test';
+const SESSION_ID = 'cs_test_a1b2c3d4e5f6g7h8';
+
+function makeTenant(overrides: Record<string, unknown> = {}) {
+	return {
+		tenantId: TENANT_ID,
+		name: 'テスト家族',
+		ownerId: 'u-owner',
+		status: 'active',
+		plan: 'free',
+		stripeCustomerId: 'cus_123',
+		stripeSubscriptionId: null,
+		trialUsedAt: null,
+		createdAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-01T00:00:00Z',
+		...overrides,
+	};
+}
+
+/** Stripe から返る checkout session (支払い済み) */
+function makePaidSession(overrides: Record<string, unknown> = {}) {
+	return {
+		id: SESSION_ID,
+		payment_status: 'paid',
+		status: 'complete',
+		metadata: { tenantId: TENANT_ID, planId: 'monthly' },
+		customer: 'cus_123',
+		subscription: 'sub_new',
+		...overrides,
+	};
+}
+
+const mockSessionRetrieve = vi.fn();
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockIsStripeEnabled.mockReturnValue(true);
+	mockFindTenantById.mockResolvedValue(makeTenant());
+	mockUpdateTenantStripe.mockResolvedValue(undefined);
+	mockSessionRetrieve.mockResolvedValue(makePaidSession());
+	mockGetStripeClient.mockReturnValue({
+		checkout: { sessions: { retrieve: mockSessionRetrieve } },
+	});
+});
+
+// ==========================================================
+// AC1: webhook 未達でも success_url 復帰だけでプランが反映される
+// ==========================================================
+
+describe('reconcileCheckoutSession — 反映 (AC1)', () => {
+	it('webhook 未達のまま success_url に戻ると、webhook と同じ内容で契約状態が反映される', async () => {
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('applied');
+		// 照合は必ずサーバー側で Stripe に問い合わせる (URL の申告を信用しない)
+		expect(mockSessionRetrieve).toHaveBeenCalledWith(SESSION_ID);
+		// 書き込み内容は handleCheckoutCompleted と同一 (二重実装しない)
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith(
+			TENANT_ID,
+			expect.objectContaining({
+				stripeCustomerId: 'cus_123',
+				stripeSubscriptionId: 'sub_new',
+				plan: 'monthly',
+				status: 'active',
+			}),
+		);
+	});
+
+	it('100% OFF クーポン (payment_status=no_payment_required) でも反映される', async () => {
+		mockSessionRetrieve.mockResolvedValue(
+			makePaidSession({ payment_status: 'no_payment_required', amount_total: 0 }),
+		);
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('applied');
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+	});
+});
+
+// ==========================================================
+// AC2: 他人の session_id では反映されない
+// ==========================================================
+
+describe('reconcileCheckoutSession — tenant 突合 (AC2)', () => {
+	it('metadata.tenantId がログイン中 tenant と一致しない session は反映しない', async () => {
+		mockSessionRetrieve.mockResolvedValue(
+			makePaidSession({ metadata: { tenantId: 't-someone-else', planId: 'family-monthly' } }),
+		);
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('tenant_mismatch');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+		expect(mockNotifyBillingEvent).not.toHaveBeenCalled();
+	});
+
+	it('metadata.tenantId が欠落した session も反映しない', async () => {
+		mockSessionRetrieve.mockResolvedValue(makePaidSession({ metadata: {} }));
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('tenant_mismatch');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+});
+
+// ==========================================================
+// AC3: 冪等 (webhook 先着 / 二重 reconcile)
+// ==========================================================
+
+describe('reconcileCheckoutSession — 冪等 (AC3)', () => {
+	it('webhook が先に届いていた場合、reconcile は書き込みも通知も行わない', async () => {
+		// webhook が先に契約を反映した状態を DB として与える
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: 'sub_new', plan: 'monthly', status: 'active' }),
+		);
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('already_applied');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+		expect(mockNotifyBillingEvent).not.toHaveBeenCalled();
+	});
+
+	it('同じ session_id で 2 回 reconcile しても副作用は 1 回だけ', async () => {
+		// 1 回目: 未反映 → 反映される
+		const first = await reconcileCheckoutSession({ tenantId: TENANT_ID, sessionId: SESSION_ID });
+		expect(first.status).toBe('applied');
+
+		// 1 回目の書き込み結果を DB に反映させたうえで 2 回目を実行する
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: 'sub_new', plan: 'monthly', status: 'active' }),
+		);
+		const second = await reconcileCheckoutSession({ tenantId: TENANT_ID, sessionId: SESSION_ID });
+
+		expect(second.status).toBe('already_applied');
+		expect(mockUpdateTenantStripe).toHaveBeenCalledTimes(1);
+		expect(mockNotifyBillingEvent).toHaveBeenCalledTimes(1);
+	});
+
+	it('reconcile が先に反映した後に webhook が届いても状態は変わらない (相互冪等)', async () => {
+		await reconcileCheckoutSession({ tenantId: TENANT_ID, sessionId: SESSION_ID });
+		const afterReconcile = mockUpdateTenantStripe.mock.calls.at(-1)?.[1];
+
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: 'sub_new', plan: 'monthly', status: 'active' }),
+		);
+		await handleWebhookEvent({
+			type: 'checkout.session.completed',
+			data: { object: makePaidSession() },
+		} as never);
+		const afterWebhook = mockUpdateTenantStripe.mock.calls.at(-1)?.[1];
+
+		// webhook 側は同じ値を書き直すだけで、契約状態 (plan / status / subscription) は動かない
+		expect(afterWebhook).toMatchObject({
+			stripeSubscriptionId: afterReconcile?.stripeSubscriptionId,
+			plan: afterReconcile?.plan,
+			status: afterReconcile?.status,
+		});
+	});
+});
+
+// ==========================================================
+// AC4: フォールバック (500 にしない)
+// ==========================================================
+
+describe('reconcileCheckoutSession — フォールバック (AC4)', () => {
+	it('session_id の形式が不正なら Stripe を呼ばずに not_found を返す (例外を投げない)', async () => {
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: 'not-a-session-id',
+		});
+
+		expect(result.status).toBe('not_found');
+		expect(mockSessionRetrieve).not.toHaveBeenCalled();
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
+	it('Stripe 側で session が存在しない / 期限切れでも例外を投げず not_found を返す', async () => {
+		mockSessionRetrieve.mockRejectedValue(
+			Object.assign(new Error('No such checkout.session'), {
+				raw: { code: 'resource_missing' },
+			}),
+		);
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('not_found');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
+	it('未払い (payment_status=unpaid) は反映せず pending を返す', async () => {
+		mockSessionRetrieve.mockResolvedValue(makePaidSession({ payment_status: 'unpaid' }));
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('pending');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
+	it('Stripe 無効環境では Stripe を呼ばずに unavailable を返す', async () => {
+		mockIsStripeEnabled.mockReturnValue(false);
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('unavailable');
+		expect(mockGetStripeClient).not.toHaveBeenCalled();
+	});
+
+	it('テナントが存在しない場合も例外を投げず not_found を返す', async () => {
+		mockFindTenantById.mockResolvedValue(null);
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('not_found');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/stripe-checkout-reconciliation.test.ts
+++ b/tests/unit/services/stripe-checkout-reconciliation.test.ts
@@ -435,3 +435,35 @@ describe('reconcileCheckoutSession — 二重課金ガード (AC5、#4081)', () 
 		);
 	});
 });
+
+// ==========================================================
+// AC6 (PO 追加ガード): 既存 binding と別の (かつ生きている) subscription を
+// 指す session では反映しない — reconcile は binding を「差し替える」権限を持たない
+// ==========================================================
+//
+// AC5 の isSubscriptionTerminal ガードは「session が指す subscription が終端状態」の
+// ケースしか塞がない。sub_old が Stripe 上でまだ active なテナントが古い session_id を
+// 再訪した場合 (= 解約されていない sub が 2 本ある異常状態) は AC5 のガードを素通りし、
+// tenant.stripeSubscriptionId が sub_new から sub_old へ上書きされてしまう。これは
+// `createCheckoutSession()` の ALREADY_SUBSCRIBED ガードを外し二重課金の温床になる。
+
+describe('reconcileCheckoutSession — 既存 binding 保護 (AC6)', () => {
+	it('stripeSubscriptionId=sub_new のテナントが sub_old (active) の session_id で reconcile しても binding が上書きされない', async () => {
+		// 再購読済みテナント。現行契約は sub_new
+		mockFindTenantById.mockResolvedValue(
+			makeTenant({ stripeSubscriptionId: 'sub_new', plan: 'monthly', status: 'active' }),
+		);
+		// 古い success_url が指す session の subscription は Stripe 上ではまだ active
+		// (= 解約済みではない。isSubscriptionTerminal ガードでは弾けないケース)
+		mockSessionRetrieve.mockResolvedValue(makePaidSession({ subscription: 'sub_old' }));
+		mockSubscriptionsRetrieve.mockResolvedValue({ id: 'sub_old', status: 'active' });
+
+		const result = await reconcileCheckoutSession({
+			tenantId: TENANT_ID,
+			sessionId: SESSION_ID,
+		});
+
+		expect(result.status).toBe('unresolved');
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者、有料プラン契約者）

**解決する課題**: 課金ずれ。checkout 完了の反映経路が webhook (`checkout.session.completed`) 1 本しかなく、それが 1 通落ちるだけで顧客は**支払い済みのまま無料プランに据え置かれ、自力で復旧する手段が一切なかった**。2026-07-26 の本番 incident では CloudFront geo 制限で webhook が未達となり、PO が Stripe API から手動再送するまで復旧しなかった（root cause は #3957）。`success_url` には `session_id={CHECKOUT_SESSION_ID}` が付いて戻るのに、その値を読む実装が `src/` 全体で 0 件（生成箇所 1 行のみ）だった。

**期待される効果**: 顧客が決済後に画面へ戻るだけで契約が反映される（webhook 未達の救済経路が成立）。反映できない場合も現在のプラン表示にフォールバックし、状況と次の操作を画面で伝える。

## 関連 Issue

closes #3958

関連:
- **#4100（AC6 = staging / 本番実機検証の切り出し先、`priority:critical` 維持・検証主体 = オーナー）** — PO 決裁 2026-07-30 により本 PR から切り出し。ガード条項 G1〜G4 も同 Issue に記載
- #3957（本 incident の root cause / webhook 到達経路）
- #2572（成果物なしで close された前身 Issue）/ #2525（`wontfix` の親 EPIC）
- #3985 / PR #4079（webhook の `event.id` dedup、Draft）— **依存なし・独立にマージ可能**。本 PR は dedup 台帳を参照せず、契約状態そのものの突合で冪等を担保するため、どちらが先にマージされても二重適用は起きない（下記「冪等の担保方法」）
- PR #4077（契約状態の単一強制点 `applyTenantContractState`、Draft）— **本 PR は書き手を増やさず `handleCheckoutCompleted` に合流する**ため、#4077 がマージされれば reconciliation も自動的に単一強制点を通る（迂回経路を新設していない）
- 直近 30 日の同一ファイル変更 PR は「要件 5」に記載

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `?session_id=cs_...` で `payment_status=paid` かつ `metadata.tenantId` 一致ならプランを反映 | `npx vitest run tests/unit/services/stripe-checkout-reconciliation.test.ts`（「webhook 未達のまま success_url に戻ると、webhook と同じ内容で契約状態が反映される」/ 100% OFF の `no_payment_required` も反映） | PASS（16 tests / 2 files） |
| AC2 | `metadata.tenantId` 不一致は反映しない（他人の session_id で不正付与不可） | 同上（「metadata.tenantId がログイン中 tenant と一致しない session は反映しない」/ tenantId 欠落 session） | PASS（`updateTenantStripe` / `notifyBillingEvent` とも 0 回） |
| AC3 | webhook が先に届いていた場合に二重適用されない（冪等） | 同上（「webhook が先に届いていた場合、reconcile は書き込みも通知も行わない」/「同じ session_id で 2 回 reconcile しても副作用は 1 回だけ」/「reconcile が先に反映した後に webhook が届いても状態は変わらない」） | PASS |
| AC4 | webhook handler 自身が同一 event 再送に対して冪等 | `npx vitest run tests/unit/services/stripe-service.test.ts tests/unit/routes/api-stripe-webhook.test.ts`（38 tests PASS）+ 本 PR の相互冪等テスト。**`event.id` 単位の dedup 台帳は #3985 / PR #4079 の scope**（本 PR は `checkout.session.completed` の再送が契約状態を動かさないことを担保する） | PASS（状態不変）／ event.id 台帳は PR #4079 |
| AC5 | 反映処理中は進行中である旨が表示され、完了後にプラン表示が更新される | `CheckoutReconciliationBanner`（`Button` の `loading` prop で「確認しています…」+ `aria-busy`）／ 反映時は `resolveTenantEntitlement` で再解決した値で `planTier` を出す（`tests/unit/routes/admin-subscription-reconciliation.test.ts`「反映後は locals.context（古い課金状態）ではなく DB の最新 entitlement で planTier を出す」） | PASS（unit）／ 画面の目視証跡は下記「未達項目」 |
| AC6 | webhook 未達を再現した状態で success URL 経由のみでプランが有料に切り替わることを実機確認 | Stripe test キーを持つ cloud staging (#2873) または本番実測が必要。ローカル (`dev:cognito` / E2E) は `isStripeEnabled()=false` で `unavailable` に落ちるため再現不能。検証主体 = オーナー（対話ログイン要、#4072 の区分） | **本 PR のスコープ外 — #4100 へ切り出し済み**（PO 決裁 2026-07-30、下記「PO 決裁の条件充足」） |
| AC7 | `session_id` が無い / 不正 / 期限切れで 500 にならず既存表示にフォールバック | `npx vitest run tests/unit/routes/admin-subscription-reconciliation.test.ts`（session_id 無し = Stripe 未照会 / 不正値 = 既存表示）+ `tests/e2e/plan-free.spec.ts`「`?session_id=<不正値>` でも 500 にならず現在のプラン表示にフォールバックする」（HTTP 200 + `plan-status-card` `data-plan-tier=free`） | PASS（unit）／ E2E は cognito-dev レーンで実行 |

reconcile は binding を差し替えない（既存 binding と別 subscription を指す session は `unresolved` で反映しない）。binding を「埋める / 確認する」だけの権限しか持たない。

## 変更タイプ

- [x] fix: バグ修正

## ADR-0002 Critical 修正 5 要件チェック（必須）

### 要件 1: E2E 回帰テストを同一 PR 内で追加

| AC | テストファイル | テスト内容 |
|---|---|---|
| AC7 | `tests/e2e/plan-free.spec.ts` | 「`/admin/subscription?session_id=<不正値>` でも 500 にならず現在のプラン表示にフォールバックする」— load が `session_id` を読むようになったため、Stripe に存在しない値で画面ごと落ちないことを実サーバーで担保する |
| AC1 / AC2 / AC3 | `tests/unit/services/stripe-checkout-reconciliation.test.ts` | 反映 / tenant 突合 / 冪等（実 Stripe session が必要なため E2E では再現不能。service 層で failing-test-first に実装、ADR-0061） |
| AC5 / AC7 | `tests/unit/routes/admin-subscription-reconciliation.test.ts` | load の契約（session_id 未指定で Stripe 未照会 / 反映時に entitlement 再解決 / 失敗時フォールバック） |

### 要件 2: AC 全項目完了（部分実装で closes 禁止）

- [x] AC1 / AC2 / AC3 / AC4 / AC5 / AC7 は本 PR で完了
- [x] AC6（webhook 未達を再現した実機確認）は **#4100 に切り出したうえで #3958 を close する**

> **⚠️ ADR-0002 要件 2 の例外を明示する（黙って外していない）**
>
> 本 PR は AC6 を充足しないまま `closes #3958` する。これは **ADR-0002 要件 2（AC 全項目完了で closes）の例外**であり、根拠は **PO 決裁 2026-07-30**（[Q1 = 条件付き Yes](https://github.com/Takenori-Kusaka/ganbari-quest/pull/4081#issuecomment-3717886745) / [追記](https://github.com/Takenori-Kusaka/ganbari-quest/pull/4081#issuecomment-3717906876)）である。
>
> **理由**（決裁原文の要旨）: 未達なのは「実装」ではなく「実行主体」。AC6 は Stripe test キー付き環境と対話ログインを要し、Dev セッションからは物理的に実行不能（#4072 が root class として起票済みの構造問題）。AC6 が守る性質のうち機械検証で代替できる部分（誤付与防止 = AC2 / 冪等 = AC3・AC4 / 500 にしない = AC7）は既に決定的に検証済みで、staging でしか確かめられないのは「Stripe 実 API 応答に対して経路が end-to-end で通るか」の 1 点に絞られている。
>
> **代替担保**: 切り出し先 #4100（`priority:critical` 維持 / 検証主体 = オーナー）+ ガード条項 G1〜G4（同 Issue に明記、false assurance の封じ込め）。要件 2 を「満たしたことにする」書き換えは行っていない。

### 要件 3: 提案全実装

- [x] 技術メモの「照合は必ずサーバー側で Stripe API に問い合わせる」— `reconcileCheckoutSession` が `checkout.sessions.retrieve` で照会し、URL 由来の申告を一切信用しない
- [x] 技術メモの「既存 `handleCheckoutCompleted` と同じ更新内容に揃え、二重実装にしない」— 同関数を直接呼ぶ（`updateTenantStripe` の新規呼び出しを追加していない）
- [x] Alternatives の「ポーリングのみ」不採用 / 「管理者による手動プラン付与」不採用を踏襲（session_id 照合を主経路とし、`pending` のときだけ再確認ボタンを出す）
- [x] No-gos を遵守（webhook 到達経路の修正 = #3957 / 解約・プラン変更の reconciliation は非対象。本 PR は新規購入完了のみ）

### 要件 4: 全 5 年齢モードで実機検証 + スクリーンショット

| 年齢モード | 検証 URL | SS（モバイル / PC） |
|---|---|---|
| baby / preschool / elementary / junior / senior | — | **N/A（年齢モード非影響）** |

根拠: 変更対象は `(parent)/admin/subscription`（保護者向け管理画面）のみで、`src/routes/(child)/[uiMode=uiMode]/` 配下および `age-tier.ts` の fontScale / tapSize に一切触れていない。子供画面 UI は本 PR の変更ファイル 0 件（`git show --stat` 参照）。

### 要件 5: 直近 30 日の同一ファイル変更 PR チェック

| PR | マージ日 | 同一ファイルでの変更内容 | 本 PR との関係 |
|---|---|---|---|
| #4079（Draft） | 未マージ | `stripe-service.ts` の `handleWebhookEvent` 入口に `event.id` dedup を配線 | **競合しない**。dedup は dispatcher 入口、本 PR は新規 export + `handleCheckoutCompleted` 呼び出しで、同一関数の同一行を書き換えない |
| #4077（Draft） | 未マージ | `stripe-service.ts` の 5 handler を `applyTenantContractState`（単一強制点）経由に変更 | **同方向**。本 PR は書き手を増やさず `handleCheckoutCompleted` に合流するため、#4077 マージ後は reconciliation も強制点を通る |
| #3992 / #3993 系（#3982 / #3986 / #3987） | 直近 | `contract-state-matrix.md` の遷移トリガ表 / `customer.subscription.deleted` の終端状態 | 本 PR は W1（checkout）系のみ。終端状態（W5）には触れない |

`src/routes/(parent)/admin/subscription/+page.server.ts` / `+page.svelte` の直近 30 日変更は #3033 系（PlanStatusCard 一本化）まで遡り、本 PR の load 拡張と競合しない。

## 影響範囲・横展開チェック

**変更レイヤー**:
- [ ] DB スキーマ（**変更なし**）
- [x] サービス層（`stripe-service.ts` に `reconcileCheckoutSession` を追加）
- [ ] API
- [x] ページ（`(parent)/admin/subscription/+page.server.ts` の `load` が `url` を受けるようになった）
- [x] UI コンポーネント（`CheckoutReconciliationBanner.svelte` 新規）
- [x] その他: 用語 SSOT（`labels.ts` に `CHECKOUT_RECONCILIATION_LABELS`）/ 共有型（`domain/checkout-reconciliation.ts`）/ 設計書 2 件

**影響を受ける画面・機能**: `/admin/subscription`（Stripe checkout からの復帰時のみ挙動が増える。`session_id` 無しの通常アクセスでは Stripe に問い合わせず、バナーも描画しない）。

**冪等の担保方法**（レビュー観点）: 反映前に `session.subscription` と `tenants.stripe_subscription_id` を突合し、一致していれば `already_applied` で**書き込みも Discord 通知も行わない**（`subscription` が無い session は `status=active` かつ `plan` 一致で代替判定）。これにより「webhook 先着」「同じ URL の再訪」「リロード」がすべて同じ経路で吸収される。#3985 の `event.id` 台帳とはレイヤーが異なる（台帳 = webhook 再送の抑止 / 本 PR = 契約状態そのものの突合）ため、両方が入っても副作用は重ならない。

## テスト・品質セルフチェック

- [ ] **`npm run pre-ready -- --pr 4081` 全 Step PASS** — **未達（Ready 化を保留する理由）**。経過:
  - **1 回目**: Step 3 (vitest) で 6 file が `Test timed out in 5000ms` で FAIL。ただし全体 Duration 2435s（通常の数倍）で、別セッションの重い処理と競合した環境要因。**該当 4 file を単独再実行すると 28.9s で 53 tests 全 PASS**（既知の #3972 / #4005「初回 import が既定 timeout を超える」と同 class）。CI の unit-test job は同一コミットで PASS 済み
  - **2 回目**: Step 9 (Readiness gate) で `mergeable-conflicting` を検出。#4079 / #4077 が develop に merge されたため。**develop 最新へ rebase + conflict 解消 + test fixture 追従を完了済み**（下記「マージ順の合意事項」§実績）
  - **現在**: rebase 済みコミット `e437eace` が **push 未完了**。`git push` が `heavy-run-lock`（別セッションが `refactor/4097-slim-github-templates` を保持、待機中に再取得され解放されず）で BLOCK 中。lock 解放後に push → `npm run pre-ready -- --pr 4081` を通しで再実行し、全 Step PASS を確認してから Ready 化する
- [x] **E2E 回帰テストを同一 PR 内で追加**（要件 1、再掲）
- [x] 追加・変更したテスト一覧:
  - 新規 `tests/unit/services/stripe-checkout-reconciliation.test.ts`（12 tests、failing-test-first で実装）
  - 新規 `tests/unit/routes/admin-subscription-reconciliation.test.ts`（4 tests）
  - 追記 `tests/e2e/plan-free.spec.ts`（不正 session_id で 500 にしない回帰）
- [x] 既存回帰: `tests/unit/services/stripe-service.test.ts` + `tests/unit/routes/api-stripe-webhook.test.ts` 38 tests PASS
- [x] `npx svelte-check` 0 errors / 0 warnings、`npx biome check`（変更ファイル）PASS

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: 本 PR で新設した reconciliation バナーの 4 状態 (applied / already_applied / pending / not_found) であり、develop 側に対応する描画が存在しないため Before / After のペアが原理的に取れない -->

バナーは Stripe に実在する checkout session を照合できたときのみ描画されるため、`isStripeEnabled()=false` のローカルアプリ (`dev:cognito` / E2E) では再現できない。Storybook の story (`CheckoutReconciliationBanner.stories.svelte`、本 PR で追加) に props を直接渡し、実コンポーネントを描画して撮影した（`scripts/capture-specs/checkout-reconciliation-3958.mjs`）。

### 反映した（webhook 未達の救済が成立、`applied`）

Desktop / Mobile:

![checkout-reconciliation-applied-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4081/checkout-reconciliation-applied-desktop.png)
![checkout-reconciliation-applied-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4081/checkout-reconciliation-applied-mobile.png)

### 反映済み（webhook 先着 / URL 再訪、`already_applied`）

![checkout-reconciliation-already-applied](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4081/checkout-reconciliation-already-applied.png)

### 支払い未確定（`pending`）— 再確認ボタンで進行中を可視化

Desktop / Mobile:

![checkout-reconciliation-pending-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4081/checkout-reconciliation-pending-desktop.png)
![checkout-reconciliation-pending-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4081/checkout-reconciliation-pending-mobile.png)

### 照合不可（期限切れ / 不正値 / 一時障害、`not_found`）— 既存のプラン表示にフォールバック

![checkout-reconciliation-unresolved](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4081/checkout-reconciliation-unresolved.png)

DOM スナップショット 6 件も同ディレクトリに添付済み（SS と同一 page で取得、#1747 AC4 / #1766）。
**実サービス画面（`/admin/subscription` 上での表示）の SS は Stripe test キーを持つ環境が要るため、AC6 の実機確認とあわせて本 PR のスコープ外（#4100 AC3、PO 決裁 2026-07-30）。**

## PO 決裁の条件充足（2026-07-30）

PO 決裁 2 件（[Q1 / Q2 + 条件 1〜4](https://github.com/Takenori-Kusaka/ganbari-quest/pull/4081#issuecomment-3717886745) / [追記: staging の構造的制約](https://github.com/Takenori-Kusaka/ganbari-quest/pull/4081#issuecomment-3717906876)）で「**AC6 を別 Issue に切り出したうえで本 PR を Ready → merge してよい（条件付き Yes）**」との判断を受けた。各条件の充足状況:

| 決裁条件 | 充足内容 | 記載箇所 |
|---|---|---|
| **条件 1**: `closes #3958` の扱い — 切り出し先を PR 本文に明記し、ADR-0002 要件 2 が PO 決裁による例外である旨を残す（要件 2 を満たしたことにする書き換えは不可） | #4100 を「関連 Issue」に明記。例外である旨・理由・決裁 URL を引用ブロックで明示 | 本 PR「関連 Issue」/「要件 2」 |
| **条件 2**: 切り出し先 Issue の AC（AC1 実機反映 / AC2 二重適用なし / AC3 実画面 SS / AC4 タイムアウト時フォールバック / AC5 事前条件）+ `priority:critical` 維持 + 検証主体の区分 | #4100 に AC1〜AC6 として起票。`priority:critical` / `status:blocked` / `verify-by:owner` を付与し、本文冒頭に「検証主体 = オーナー（対話ログイン要）」を固定見出しで明示 | [#4100](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4100) |
| **条件 3**: ガード条項 G1〜G4（false assurance の封じ込め） | #4100 の AC6 として G1（#3957・監視・手動再送 runbook の優先度を下げない）/ G2（LP・サポート文言に「戻れば自動反映」と書かない、ADR-0013）/ G3（`success_url` の `session_id` 生成を変更しない）/ G4（解約・プラン変更へ横展開しない）を決裁原文どおり記載 | [#4100 §AC6 ガード条項](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4100) |
| **条件 4a**: `npm run pre-ready -- --pr 4081` 全 Step PASS | **未達** — 2 回実行し、1 回目は環境要因の vitest timeout、2 回目は #4079 / #4077 merge による conflict を検出。rebase / conflict 解消 / test 追従は完了済みだが、`git push` が別セッションの `heavy-run-lock` で BLOCK 中のため通しの PASS を取得できていない。**本条件が PASS するまで Ready 化しない** | 下記「テスト & 安全装置セルフチェック」 |
| **条件 4b**: 同一ファイルを触る #4077 / #4079 / #4061 とのマージ順の合意 | 下記「マージ順の合意事項」に明示 | 本 PR |
| **追記**: staging は「外部サービス副作用ゼロ（Stripe secret を渡さない）」と定義されており AC6 は現状の staging では原理的に実行不能。オーナー判断 (a) test secret 配備 / (b) 本番実測で代替（前例 #3968）が先行する | #4100 に「着手前にオーナーが決めること」節として `deploy-aws-staging.yml:12` の引用つきで記録。**本 PR の Ready 化はこの判断を待たない**（決裁明記） | [#4100 §着手前にオーナーが決めること](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4100) |

### 本 PR のスコープ外（#4100 へ）

| 項目 | 内容 | 必要な環境 / 主体 |
|---|---|---|
| AC6 | webhook 宛先を無効 URL に向けた状態で checkout → success URL 復帰のみでプランが有料に切り替わることの実機確認 | cloud staging (#2873) + Stripe test キー、または本番実測。検証主体 = オーナー |
| 実画面の SS | 4 状態のコンポーネント SS は本 PR に添付済み。`/admin/subscription` 上で実際にバナーが出ている画面証跡が #4100 AC3 | 同上 |
| タイムアウト時のフォールバック | 本 PR の unit / E2E は「不正値」を覆うが「Stripe API のタイムアウト」は覆っていない。#4100 AC4 で実測し、必要なら上限を明示する | 同上 |

ローカルで代替可能な範囲（不正 session_id のフォールバック、反映後の planTier 再解決、冪等、誤付与防止）は unit / E2E で機械検証済み。

## マージ順の合意事項（決裁 条件 4b、#1200）

`src/lib/server/services/stripe-service.ts` を同時に触る open PR は **#4077 / #4079 / #4061** の 3 本。

**合意した前提: どの順で merge されても壊れない。** 本 PR は同ファイルに `reconcileCheckoutSession` を**新規 export として追加**し、契約状態の書き込みは既存 `handleCheckoutCompleted` を**呼ぶだけ**（新しい書き手を増やしていない）ため、他 3 本と同一行を書き換えない。

| PR | 変更点 | 本 PR との関係 | 必要な追従 |
|---|---|---|---|
| #4079（#3985） | `handleWebhookEvent` 入口に `event.id` dedup を配線 | 変更行が重ならない（dispatcher 入口 vs 新規 export）。冪等はレイヤーが異なる（台帳 = webhook 再送の抑止 / 本 PR = 契約状態そのものの突合）ため両方入っても副作用は重ならない | **なし** |
| #4077（#4026 / #4055） | 5 handler を `applyTenantContractState`（単一強制点）経由に変更 | 同方向。本 PR は `handleCheckoutCompleted` に合流するため、#4077 が先でも後でも reconciliation は自動的に強制点を通る（迂回経路を新設していない） | **なし**。#4077 が後着なら `handleCheckoutCompleted` の書き換えだけで reconciliation にも波及する |
| #4061（#3980 / #3981） | subscription item 複数化の検知 / context 解決失敗の 3 分類 | 変更対象が `handleCheckoutCompleted` 内部の分岐。本 PR は同関数を呼ぶ側で、関数シグネチャを変えていない | **なし**。ただし #4061 が `handleCheckoutCompleted` の throw 条件を増やす場合、後着側が本 PR の `reconcileCheckoutSession` のエラーハンドリング（`not_found` フォールバック）で吸収されることを確認する |

**実績（2026-07-30）**: #4079 → #4077 の順で develop に先行 merge されたため、本 PR を develop 最新へ rebase した。**上表の予測どおりロジック衝突は発生せず**、`stripe-service.ts` の conflict は「#4079 が追加した `resolveEventTenantId`」と「本 PR が追加した `reconcileCheckoutSession` ブロック」が同じ位置に並んだだけの配置競合で、**両方をそのまま残して解消**（どちらの意図も削っていない）。`handleCheckoutCompleted` は #4077 により内部で `applyTenantContractState`（単一強制点）を通るようになり、本 PR の reconciliation も**自動的に単一強制点を経由する**ようになった（予測どおり追従不要）。

唯一の実作業は **test fixture の追従 1 件**: #4079 が `handleWebhookEvent` 入口に dedup を入れたことで、本 PR の相互冪等テストが `getRepos().webhookEvent` を引くようになった。`stripe-service.test.ts` と同じ「常に未処理を返す」stub を渡し、**handler を毎回走らせたうえで契約状態が動かないこと**を検証する形に揃えた（assertion は弱めていない）。stripe 関連 5 spec / 87 tests PASS。

`reconcileCheckoutSession` は `handleCheckoutCompleted` を直接呼び、`handleWebhookEvent` を経由しない（= reconcile 経路は #4079 の dedup 台帳を参照しない）。fake repos に `webhookEvent` が必要なのは、相互冪等テストが**意図的に webhook 入口（`handleWebhookEvent`）も叩く**ため。

### コード品質セルフレビュー (#1481)

- [x] **DRY**: 契約状態の書き込みを複製せず `handleCheckoutCompleted` に合流（PR #4077 の単一強制点を迂回しない）。同 class の「反映経路が 1 本しかない」問題は checkout 以外（invoice / subscription 系）には該当しない（それらは定期発生し再送で回復するため、顧客操作起点の救済が要らない）
- [x] **YAGNI**: ポーリング機構 / 独自 dedup 台帳 / 新規 API endpoint を作らず、既存 load + 既存 handler の再利用に留めた（ADR-0010）
- [x] **Security**: `session_id` は URL に露出するため server 側で Stripe に照会し、`metadata.tenantId` とログイン中 tenant の一致を必須にした（他人の session_id では反映されないことを test で担保）。反映確定後は URL から `session_id` を除去し、共有・ブックマークで決済 ID が持ち回られないようにした。ログには session_id 全体や他 tenant の ID を出さない
- [x] **アクセシビリティ**: `Alert` primitive（`role="status"`）+ `Button` の `loading`（`aria-busy="true"`）で進行中を支援技術にも伝える
- [x] **パフォーマンス**: Stripe への照会は `session_id` が付いているときのみ（通常アクセスは API 呼び出し 0）。反映後は URL から除去するため再読込でも再照会しない

### 横展開・影響波及チェック

- [x] 本番アプリ + デモ版を同期（デモは `isStripeEnabled()=false` で `unavailable` = 何も描画しない。demo 固有ルートは #2097 で撤去済み）
- [x] 全年齢モード 5 種に横展開（保護者画面のみのため非影響、要件 4 の根拠参照）
- [x] ナビゲーション 3 種に反映（ナビ変更なし）
- [x] E2E / ユニットシード同期（DB スキーマ変更なしのためシード変更不要）
- [x] labels SSOT (ADR-0009 / ADR-0045)：表示文言は `CHECKOUT_RECONCILIATION_LABELS` 経由。pre-commit の SSOT companion 検査（`generate-lp-labels --check` / `sync-lp-fallback --check`）PASS
- [x] 設計書同期 (ADR-0001)：`docs/design/06-UI設計書.md` §10.1（復帰表示の 3 状態）/ `docs/design/billing-redesign/contract-state-matrix.md` §5（書き手を増やさない起動点であることを明記）
- [x] 並行 PR overlap 確認 (#1200)：#4077 / #4079 と同一ファイルを触るが行が重ならないことを diff で確認（要件 5 の表）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QA**:
1. 冪等判定（`session.subscription` と `tenants.stripe_subscription_id` の突合）が、`subscription` が未確定の session でも安全か
2. 反映後に `resolveTenantEntitlement` で entitlement を引き直す設計が、`locals.context` を SSOT とする他画面の前提と矛盾しないか
3. スコープ外項目（AC6 / 実画面 SS / タイムアウト）が #4100 に漏れなく移っているか、ガード条項 G1〜G4 が本 PR の変更内容と矛盾しないか

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] **ADR-0002 5 要件全て満たした** — 要件 1 / 3 / 4 / 5 は本 PR で充足。要件 2 は **AC6 を #4100 に切り出したうえでの PO 決裁による例外**（2026-07-30、上記「要件 2」の引用ブロックに理由と決裁 URL を明記。黙って外していない）
- [x] セルフレビュー済み
- [x] 全 AC が実装済み — AC1 / AC2 / AC3 / AC4 / AC5 / AC7 は本 PR で完了。**AC6（実機検証）は本 PR のスコープ外**（検証主体 = オーナー、#4100 へ切り出し済み・PO 決裁 2026-07-30）
- [x] UI 変更時: SS が GitHub 上で表示確認できる — 年齢モードは非影響（保護者画面のみ）。バナー 4 状態のコンポーネント SS を desktop / mobile で添付済み。`/admin/subscription` 実画面 SS は Stripe test キー環境が要るため #4100 AC3
<!-- #4103 現行テンプレへ追従: 旧版由来の pre-ready / QA承認 項目を削除 (QM, 2026-07-30) -->

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)







