### PR TITLE
docs: Graphify を OSS 調査済み・不採用として記録する

### DIFF
--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -79,6 +79,14 @@ ADR-0010 (Pre-PMF scope 判断) と併せて、OSS 導入コストが Pre-PMF �
 
 各採用 OSS の詳細根拠は対応する ADR / 設計書 (`docs/design/*-architecture.md`) を参照。本表は採用済み OSS の「インデックス」として機能し、新規実装者が `npm install` 前にまず参照する SSOT。
 
+### OSS 調査済み・不採用記録 (#1350 整合)
+
+調査したが採用しなかった OSS。同じ候補の再調査を繰り返さないためのインデックス。再評価トリガを満たした場合のみ再検討する。
+
+| 領域 | 調査 OSS | 調査日 | 不採用根拠 | 再評価トリガ |
+|------|---------|-------|-----------|------------|
+| コードベース探索性 (knowledge graph 化) | [Graphify](https://github.com/Graphify-Labs/graphify) (Apache-2.0、YC S26) | 2026-07-29 | 実測ビルド済 (20,973 nodes / 39,750 edges / 2m13s / ローカル AST のみ・API キー不要、日本語 UTF-8 健全)。`god-nodes` は中核 (`ChildId` / `getRepos()` / `requireTenantId()`) を正しく検出するが、**`tree-sitter-svelte` 非対応で `.svelte` 238 files が全て `L1` ファイルレベル node のみ (479 nodes)** = UI 層が空白。SvelteKit の `+page.server.ts` / `+server.ts` 同名衝突で `explain` / `path` がルート層で識別不能。`query` は BFS が 434 nodes → 42 件 truncate されハブノイズ優位で狙った Grep 以下。`cites` (code→ADR 979 edge) は `git grep -ohE 'ADR-[0-9]{4}'` で代替可 (ADR 月1棚卸の現役参照判定はこれで足りる)。`affected` は import 逆引きで dependency-cruiser (ADR-0007 §7) + `impact-analysis` skill の layer 1-2 と重複し、同 skill が本来狙う派生 artifact 22 カテゴリ (testid / baseline / SS / 設計書参照 / CI config) は非カバー。運用面も `graph.json` 21.6MB (commit 不可 / 未 commit なら全員 2m13s 再ビルド + 陳腐化) + `graphify claude install` が CLAUDE.md 追記と **`Bash\|Grep` / `Read\|Glob` への PreToolUse hook** を仕込み、CLAUDE.md 階層 + `docs/codebase-map.md` の SSOT ナビを劣化 BFS に誘導するため侵襲的 | `tree-sitter-svelte` 対応が入る (本評価の決定要因) / v1.0.0 正式リリース時の Svelte・SvelteKit 対応状況 |
+
 ## ボリューム上限ルール（削除主義、#2440 PR-A5 改定）
 
 ADR を現場の常時参照ルールとして機能させるため、以下の上限を設ける。

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -81,11 +81,19 @@ ADR-0010 (Pre-PMF scope 判断) と併せて、OSS 導入コストが Pre-PMF �
 
 ### OSS 調査済み・不採用記録 (#1350 整合)
 
-調査したが採用しなかった OSS。同じ候補の再調査を繰り返さないためのインデックス。再評価トリガを満たした場合のみ再検討する。
+調査したが採用しなかった OSS の**薄いインデックス**。同じ候補の再調査ループを断つことが目的。再評価トリガを満たした場合のみ再検討する。
 
-| 領域 | 調査 OSS | 調査日 | 不採用根拠 | 再評価トリガ |
-|------|---------|-------|-----------|------------|
-| コードベース探索性 (knowledge graph 化) | [Graphify](https://github.com/Graphify-Labs/graphify) (Apache-2.0、YC S26) | 2026-07-29 | 実測ビルド済 (20,973 nodes / 39,750 edges / 2m13s / ローカル AST のみ・API キー不要、日本語 UTF-8 健全)。`god-nodes` は中核 (`ChildId` / `getRepos()` / `requireTenantId()`) を正しく検出するが、**`tree-sitter-svelte` 非対応で `.svelte` 238 files が全て `L1` ファイルレベル node のみ (479 nodes)** = UI 層が空白。SvelteKit の `+page.server.ts` / `+server.ts` 同名衝突で `explain` / `path` がルート層で識別不能。`query` は BFS が 434 nodes → 42 件 truncate されハブノイズ優位で狙った Grep 以下。`cites` (code→ADR 979 edge) は `git grep -ohE 'ADR-[0-9]{4}'` で代替可 (ADR 月1棚卸の現役参照判定はこれで足りる)。`affected` は import 逆引きで dependency-cruiser (ADR-0007 §7) + `impact-analysis` skill の layer 1-2 と重複し、同 skill が本来狙う派生 artifact 22 カテゴリ (testid / baseline / SS / 設計書参照 / CI config) は非カバー。運用面も `graph.json` 21.6MB (commit 不可 / 未 commit なら全員 2m13s 再ビルド + 陳腐化) + `graphify claude install` が CLAUDE.md 追記と **`Bash\|Grep` / `Read\|Glob` への PreToolUse hook** を仕込み、CLAUDE.md 階層 + `docs/codebase-map.md` の SSOT ナビを劣化 BFS に誘導するため侵襲的 | `tree-sitter-svelte` 対応が入る (本評価の決定要因) / v1.0.0 正式リリース時の Svelte・SvelteKit 対応状況 |
+| 領域 | 調査 OSS | 調査日 | 結論 (1 行) | 再評価トリガ | 詳細 |
+|------|---------|-------|------------|------------|------|
+| コードベース探索性 (knowledge graph 化) | [Graphify](https://github.com/Graphify-Labs/graphify) (Apache-2.0) | 2026-07-29 | `tree-sitter-svelte` 非対応で UI 層がグラフ上の空白、増分機能は既存資産と重複 | `tree-sitter-svelte` 対応が入る / v1.0.0 の Svelte・SvelteKit 対応状況 | [rationale](../rationale/16-graphify-evaluation-rationale.md) |
+
+**記録する基準**: 10 行超の独自実装 / 既存機構の置換候補として**実測評価した**もののみ。カタログを見て軽く外したものは記録しない (記録の価値 = 再調査コストの回避であり、再調査が安いものは対象外)。
+
+**書き方**: 本表は 1 行 = 1 候補のインデックスに保つ。実測値・棄却理由・確度 (実測か推測か) は `docs/rationale/` 側に置く (`docs/CLAUDE.md` §docs SSOT 原則「棄却案比較 → `docs/rationale/`」整合)。
+
+**削除トリガ**: (a) 再評価トリガを満たして再検討が完了した行 (採用したなら §OSS 採用記録 へ移し、再度不採用なら結論と調査日を更新する) / (b) 対象 OSS が廃止・アーカイブされた行。いずれも削除し、履歴は git で追跡する。
+
+**§ボリューム上限ルールとの関係**: 同ルールの削除主義が挙げる「採択されなかった調査」は、**再評価トリガが生きている間は役目を終えた record ではない**ため本表は削除対象外とする。上記削除トリガを満たした時点で通常の削除主義に戻る。
 
 ## ボリューム上限ルール（削除主義、#2440 PR-A5 改定）
 

--- a/docs/rationale/01-README.md
+++ b/docs/rationale/01-README.md
@@ -118,6 +118,7 @@ cp docs/rationale/_template.md docs/rationale/NN-機能名-rationale.md
 | [11-branch-strategy-rationale.md](11-branch-strategy-rationale.md) | git ブランチ戦略 (develop 二層 + gate 二層、3 案比較) | 2026-06-04 | #2858 |
 | [12-auto-challenge-generation-rationale.md](12-auto-challenge-generation-rationale.md) | 自動生成週間チャレンジ アルゴリズム (child_challenges 一本化) | 2026-06-20 | #3194, #3213 |
 | [13-aurora-dsql-migration-evaluation-rationale.md](13-aurora-dsql-migration-evaluation-rationale.md) | Aurora DSQL 移管評価 (DB バックエンド一本化。superseded by EPIC #3424) | 2026-06-28 | #3424, #3461 |
+| [16-graphify-evaluation-rationale.md](16-graphify-evaluation-rationale.md) | Graphify (コードベース knowledge graph 化) 評価 — 不採用 + 再評価トリガ | 2026-07-29 | PR #4092, #1350 |
 
 ---
 

--- a/docs/rationale/16-graphify-evaluation-rationale.md
+++ b/docs/rationale/16-graphify-evaluation-rationale.md
@@ -1,0 +1,71 @@
+# Graphify (コードベース knowledge graph 化) 評価 設計経緯
+
+## 議論の発端
+
+- **日時**: 2026-07-29
+- **発端 Issue / セッション**: Issue 非紐づけ（PO 依頼「リポジトリを調査してこのプロダクトへの適合性、効果性を踏まえて検討し、導入価値があれば導入」）/ 参照ルール: #1350（OSS 先調査ルール）
+- **問題意識**: コードベース探索性（どこに何があるか / 変更の影響範囲はどこか）の向上手段として [Graphify](https://github.com/Graphify-Labs/graphify)（knowledge graph 化 CLI、Apache-2.0 / YC S26）が候補に挙がった。現状の探索資産は CLAUDE.md 階層 + `docs/codebase-map.md`（人手 SSOT）+ grep + dependency-cruiser（ADR-0007 §7）+ `impact-analysis` skill であり、これらを置き換える / 補完する価値があるかを実測で判定する必要があった。
+
+## 実測条件
+
+以下はすべて HEAD `2f4573d3` の本リポジトリに対する実測値である（カタログ情報からの引用ではない）。
+
+| 項目 | 実測値 | 取得方法 |
+|---|---|---|
+| グラフ規模 | 20,973 nodes / 39,750 edges | `graphify update . --no-cluster` |
+| ビルド時間 | 2m13s（ローカル AST のみ・API キー不要） | 同上 |
+| `.svelte` カバレッジ | 237〜238 files → 479 nodes（全て `L1` = ファイルレベル、コンポーネント内部構造なし） | `graph.json` の node を拡張子別集計 |
+| 対比: `.ts` / `.md` | `.ts` 1,514 files → 9,629 nodes / `.md` 8,370 nodes | 同上 |
+| 日本語健全性 | 日本語 node 7,578 件 / U+FFFD 混入 0 件 | `graph.json` を Python で走査 |
+| `god-nodes` | 中核を正しく検出（`ChildId` 457 edges / `getRepos()` 420 / `requireTenantId()` 125） | `graphify god-nodes --top 12` |
+| `query` | BFS が 434 nodes にヒット → 42 件に truncate、内容はハブノイズ優位（`logger` / `labels.ts` / `ChildId`） | `graphify query "how does marketplace import assign items to children"` |
+| `explain` / `path` | SvelteKit の `+page.server.ts` / `+server.ts` 同名衝突でルート層が識別不能 | `graphify explain "labels.ts"` |
+| `cites`（code→ADR） | 979 edge。`git grep -ohE 'ADR-[0-9]{4}'` 1 コマンドで 56 ADR を件数付き取得でき増分なし | 実測比較 |
+| `affected` | import 逆引き。dependency-cruiser（ADR-0007 §7）+ `impact-analysis` skill の layer 1-2 と重複、同 skill が担保する派生 artifact 22 カテゴリ（testid / baseline / SS / 設計書参照 / CI config）は非カバー | `graphify affected "requireTenantId()" --depth 2` の出力突合 |
+| `graph.json` サイズ | 21.6MB | `ls -la graphify-out/` |
+
+**未実測（ドキュメント読解による推測）**: `graphify claude install` の挙動 — CLAUDE.md への追記に加え、PreToolUse hook を `Bash|Grep` / `Read|Glob` matcher で登録し（`--strict` でセッション初回の生 Read をブロック）、探索を graph 経由に誘導する、という理解は `install.py` の `_claude_pretooluse_hooks` と `always_on/claude-md.md` の**読解に基づく推測**であり、実際に `graphify claude install` を実行して確認してはいない。導入すれば CLAUDE.md 階層 + `docs/codebase-map.md` の SSOT ナビが（`query` で劣化を実測した）BFS に置き換わる、という侵襲性評価も同じ確度である。
+
+## 検討した代替案
+
+| 案 | 概要 | 検討した理由 |
+|----|------|-----------|
+| 案 A: Graphify を導入し `graphify claude install` まで実施 | knowledge graph をコード探索の主経路に据える | PO 依頼の本線。探索性が構造的に改善するなら人手 SSOT の保守コストを下げられる |
+| 案 B: Graphify を導入するが hook は入れず CLI 単体で併用 | `god-nodes` 等の有用サブコマンドのみ手動利用 | 侵襲性を避けつつ増分価値だけ取る折衷案 |
+| **採用案: 不採用 + 記録を残す** | 導入せず、不採用根拠と再評価トリガを `docs/decisions/README.md` §OSS 調査済み・不採用記録 に薄いインデックス行として残す | 現時点の適合性が低く、かつ「同じ候補が再度挙がる」ことが確実に予想されるため |
+
+## 棄却理由
+
+### 案 A 棄却理由（フル導入 + hook）
+
+- **UI 層がグラフ上の空白になる**: `tree-sitter-svelte` 非対応のため `.svelte` 237〜238 files が全て `L1` ファイルレベル node（479 nodes）にとどまる。SvelteKit + Svelte 5 が主戦場の本リポジトリで、探索の主経路を「UI 層が空白なグラフ」に切り替えるのは劣化になる。**これが不採用の決定要因**
+- **ルート層が識別不能**: SvelteKit の `+page.server.ts` / `+server.ts` 同名衝突で `explain` / `path` がルートを区別できない
+- **`query` が既存 Grep 以下**: BFS 434 nodes → 42 件 truncate でハブノイズ（`logger` / `labels.ts` / `ChildId`）が優位を占め、狙った grep より当たらない
+- **hook による SSOT ナビの置換が侵襲的（推測、未実測）**: 上記「未実測」節のとおり、`Bash|Grep` / `Read|Glob` matcher の PreToolUse hook が CLAUDE.md 階層 + `docs/codebase-map.md` の探索導線を BFS に誘導すると読める。実測した `query` 品質を踏まえるとこの置換は避けたい
+
+### 案 B 棄却理由（CLI 単体併用）
+
+- **増分価値が既存資産と重複**: `cites`（code→ADR 979 edge）は `git grep -ohE 'ADR-[0-9]{4}'` で代替可能（ADR 月 1 棚卸の現役参照判定はこれで足りる）。`affected` は dependency-cruiser + `impact-analysis` skill の layer 1-2 と重複し、同 skill が本来狙う派生 artifact 22 カテゴリは非カバー
+- **有用だったのは `god-nodes` のみ**: 中核（`ChildId` / `getRepos()` / `requireTenantId()`）を正しく検出したが、この 1 コマンドのために下記の運用コストを常時負う ROI が成立しない（ADR-0010 Pre-PMF）
+- **運用コストが恒常的**: `graph.json` 21.6MB は git commit 不可。commit しなければ全員が 2m13s の再ビルドを負い、かつ放置すれば陳腐化する
+
+## 採用案とその理由（不採用 + 記録を残す）
+
+現時点のスタック適合性が低く（UI 層が空白）、増分価値のある機能が既存資産と重複するため導入しない。ただし **判断を捨てずに記録する**。Graphify は活発な新興 OSS であり、記録がなければ候補として再浮上するたびに同じ調査（インストール + 2 分超のグラフ構築 + 適合性分析 + 既存資産との突合）を繰り返すことになる。
+
+記録は `docs/decisions/README.md` §OSS 調査済み・不採用記録 に **1 行のインデックス**として置き、詳細（実測値・棄却理由・確度）は本 rationale に置く。§OSS 採用記録 が「`npm install` 前にまず参照するインデックス」と役割を明記しているのと対をなす構造で、README 側は「調べたか / 結論 / 何が変われば覆るか」だけを 1 行で答え、深掘りは本ファイルに委ねる。
+
+**再評価トリガ**: `tree-sitter-svelte` 対応が入る（本評価の決定要因が消える）/ v1.0.0 正式リリース時点の Svelte・SvelteKit 対応状況。
+
+## 残された懸念・フォローアップ
+
+- [ ] `graphify claude install` の hook 挙動は未実測のまま。再評価時（`tree-sitter-svelte` 対応後）に実際に install して侵襲性を実測する
+- [ ] `.svelte` カバレッジの実測値は集計方法により 237 / 238 files と 1 件差がある（拡張子別集計と file 走査の差）。結論（全て `L1` ファイルレベル node のみ）には影響しない
+- [ ] 探索性の課題自体は残る。人手 SSOT（CLAUDE.md 階層 + `docs/codebase-map.md`）の保守コストが顕在化した場合は、別手段（dependency-cruiser の出力活用等）を検討する
+
+## 関連
+
+- **議論源**: PO 依頼（2026-07-29）/ PR #4092
+- **参照する既存ルール**: #1350（OSS 先調査ルール）/ [ADR-0007 §7](../decisions/0007-static-analysis-tier-policy.md)（dependency-cruiser required 昇格、#3895）/ [ADR-0010](../decisions/0010-pre-pmf-scope-judgment.md)（Pre-PMF スコープ判断）
+- **記録先**: [docs/decisions/README.md](../decisions/README.md) §OSS 調査済み・不採用記録
+- **重複判定した既存資産**: `.claude/skills/impact-analysis/SKILL.md` / [docs/codebase-map.md](../codebase-map.md)


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発者 / AI エージェント）

**解決する課題**: コードベース探索性向上の手段として [Graphify](https://github.com/Graphify-Labs/graphify)（knowledge graph 化 CLI、Apache-2.0 / YC S26）が候補に挙がった。実測評価した結果、本リポジトリのスタック（SvelteKit + Svelte 5）とは適合せず不採用と判断した。この判断を残さないと、同じ候補が再び挙がるたびに同じ調査（インストール + 2 分超のグラフ構築 + 適合性分析）を繰り返すことになる。

**期待される効果**: `docs/decisions/README.md` に「OSS 調査済み・不採用記録」節を新設し、不採用根拠と再評価トリガをセットで記録する。これにより (a) 同一候補の再調査ループを断つ、(b) 何が変われば結論が変わるか（`tree-sitter-svelte` 対応）を明示して将来の判断を安くする。ADR-0014 / #1350 の「OSS 先調査ルール」は採用事例のみを表に残す設計だったため、不採用側の記録層が欠けていたのを埋める。

## 関連 Issue

<!-- no-issue-close: 本 PR は PO からの調査依頼（Graphify の適合性評価）に対する記録層の新設であり、close 対象の Issue を持たない。判断基準となる既存ルールを以下に参照する -->

Issue との紐づけなし（closing keyword なし）。理由は上記コメントのとおり。

参照する既存ルール:
- #1350 — OSS 先調査ルール（`docs/decisions/README.md` §OSS 採用記録 の起点。本 PR は同節と対をなす不採用記録節を追加する）
- ADR-0007 §7 / #3895 — dependency-cruiser required 昇格（Graphify の `affected` と機能が重複する既存資産）
- ADR-0010 — Pre-PMF スコープ判断（導入コスト評価の基準）

## AC 検証マップ (ADR-0004)

Issue 非紐づけのため、PO 依頼「リポジトリを調査してこのプロダクトへの適合性、効果性を踏まえて検討し、導入価値があれば導入」を AC に分解して検証した。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Graphify を実際に本リポジトリで動作させ、実測値に基づいて評価する（カタログ情報のみの机上判断にしない） | `uv tool install graphifyy` → `graphify update . --no-cluster` を本リポジトリ root で実行 | HEAD `2f4573d3` / 20,973 nodes / 39,750 edges / 実行時間 2m13s / ローカル AST のみ・API キー不要。日本語 node 7,578 件 かつ U+FFFD 混入 0 件（`graph.json` を Python で走査）で UTF-8 健全性も確認 |
| AC2 | 本リポジトリ主要スタック（Svelte / SvelteKit）のカバレッジを定量測定する | `graph.json` の node を `source_file` 拡張子別に集計 + `source_location` 分布確認 | HEAD `2f4573d3` / `.svelte` = 237 files → 479 nodes（全 `L1` = ファイルレベルのみ、コンポーネント内部構造なし）。対比: `.ts` = 1,514 files → 9,629 nodes / `.md` = 8,370 nodes。`uv tool install` 依存一覧に `tree-sitter-svelte` が不在（`tree-sitter-typescript` 等 36 言語は存在） |
| AC3 | query / explain / affected / god-nodes の実効性を本リポジトリ固有の問いで検証する | `graphify god-nodes --top 12` / `graphify explain "labels.ts"` / `graphify affected "requireTenantId()" --depth 2` / `graphify query "how does marketplace import assign items to children"` | HEAD `2f4573d3` / god-nodes は中核（`ChildId` 457 edges / `getRepos()` 420 / `requireTenantId()` 125）を正しく検出。一方 query は BFS が 434 nodes にヒットし 42 件に truncate、内容は `logger` / `labels.ts` / `ChildId` 等のハブノイズ優位で狙った Grep 以下。`explain` は SvelteKit の `+page.server.ts` / `+page.svelte` 同名衝突でルート層が識別不能 |
| AC4 | 既存資産（grep / dependency-cruiser / impact-analysis skill / codebase-map.md）との重複を判定し、Graphify 固有の増分価値を切り分ける | `git grep -ohE 'ADR-[0-9]{4}' -- 'src/**' 'infra/**' 'scripts/**'` で `cites` edge 979 件の代替可能性を実測 + `affected` 出力と dependency-cruiser / impact-analysis skill の担保範囲を突合 | HEAD `2f4573d3` / ADR 引用は grep 1 コマンドで 56 ADR を件数付き取得でき `cites` に増分なし。`affected` = import 逆引きで dependency-cruiser（ADR-0007 §7）+ impact-analysis skill の layer 1-2 と重複し、同 skill が担保対象とする派生 artifact 22 カテゴリ（testid / baseline / SS / 設計書参照 / CI config）は非カバー |
| AC5 | 導入時の運用コスト・侵襲性を評価する | `ls -la graphify-out/` でサイズ実測 + 導入 script（`install.py` の `_claude_pretooluse_hooks`）と `always_on/claude-md.md` を読解 | HEAD `2f4573d3` / `graph.json` = 21.6MB（git commit 不可。未 commit なら全員が 2m13s 再ビルド + 陳腐化）。`graphify claude install` は CLAUDE.md 追記に加え `Bash\|Grep` / `Read\|Glob` matcher の PreToolUse hook を登録（`--strict` でセッション初回の生 Read をブロック）し、CLAUDE.md 階層 + `docs/codebase-map.md` の SSOT ナビを AC3 で劣化を実測した BFS に誘導する |
| AC6 | 「導入価値があれば導入」の判定を下し、結論を再調査不能ループにしない形で記録する | 判定 = 不採用。`docs/decisions/README.md` に §OSS 調査済み・不採用記録 を新設（不採用根拠 + 再評価トリガの 5 列表） | HEAD `6b7de1cb` / `docs/decisions/README.md` §OSS 調査済み・不採用記録（6 列インデックス 1 行 + 記録基準 / 削除トリガ / §ボリューム上限ルールとの関係）+ `docs/rationale/16-graphify-evaluation-rationale.md`（実測値・棄却理由・未実測項目の確度）。QM BLOCK 対応で棄却案比較 narrative を rationale へ切り出し済（`docs/CLAUDE.md` §docs SSOT 原則）。再評価トリガ = `tree-sitter-svelte` 対応 / v1.0.0 正式リリース時の Svelte 対応状況。評価用に生成した `graphify-out/`（21.6MB）は削除済（`git status --short` に残留なし）、CLAUDE.md / `.claude/settings.json` は未変更（`graphify install` 未実行） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

実行コードの変更は 0 件。変更は docs 3 ファイル（`docs/decisions/README.md` / `docs/rationale/16-graphify-evaluation-rationale.md` 新規 / `docs/rationale/01-README.md` 一覧追記）、計 +88 行。

**影響を受ける画面・機能**: なし（顧客向け画面・API・DB に一切触れない）。影響先は開発プロセス（OSS 選定時の参照先ドキュメント）のみ。

## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— 下記のとおり docs 変更に対応する gate をローカル実行し PASS を確認
- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  N/A — 実行コード変更 0 件のためテスト追加なし。docs 変更に効く既存 gate で担保する
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

実行した gate と結果（rebase 後の HEAD `2f4573d3` で再実行済）:

| gate | コマンド | 結果 |
|---|---|---|
| doc-code 参照整合（#2577） | `node scripts/check-doc-code-references.mjs` | PASS（exit 0 / baseline 139 件・53 ファイル内、新規違反 0） |
| 内部用語 UI 露出（#2288 / #3259） | `node scripts/check-internal-terms.mjs` | PASS（exit 0 / 新規違反 0 件、self-ref-change group 371 files 違反 0） |
| cspell（1b） | — | 検査対象外。`package.json` の cspell scope は `src` / `tests` / `infra` / `site` のみで `docs/**` を含まないため、`Graphify` の辞書追加は不要 |
| biome / svelte-check / vitest | — | 対象ファイルなし（`.ts` / `.svelte` / test の変更 0 件） |

vitest 判定は #4007 のとおり CI `unit-test` に委ねる。本 PR は実行コード 0 変更のため同 job が path filter で skip される想定であり、その場合も「ローカル代替実行の対象となるテスト変更が存在しない」ことをもって根拠とする。

## スクリーンショット / ビジュアルデモ

**該当なし（docs）** — UI 変更を含まない（`.svelte` / `.css` / `.scss` / `site/` の変更 0 件）。変更は `docs/decisions/README.md` の 1 節追加のみで、描画される画面は存在しない。

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: N/A（実行コード変更なし）
- [x] **DRY**: 既存 §OSS 採用記録 表に不採用行を混ぜず別節にした。同表は「採用済み OSS のインデックスとして機能し、新規実装者が `npm install` 前にまず参照する SSOT」と役割が明記されているため、不採用行の混在は同表の用途を壊す。`grep -n "OSS 採用記録" docs/decisions/README.md` で既存節の重複がないことを確認済
- [x] **YAGNI**: 5 列（領域 / 調査 OSS / 調査日 / 不採用根拠 / 再評価トリガ）に絞り、CI gate script や新規 ADR は追加していない。ADR 新規起票 gate（README §新規 ADR 追加 gate）の 3 条件をいずれも満たさない記録であり、ADR ではなく既存 README の 1 節が正しい置き場所と判断した
- [x] **Security（OSS 公開前提）**: N/A（秘密情報・内部 URL なし。記載 URL は公開 GitHub リポジトリのみ）
- [x] **アクセシビリティ**: N/A
- [x] **パフォーマンス**: N/A

**docs SSOT 原則（`docs/CLAUDE.md`）との整合**: 本節は「経緯の物語」ではなく「現状の正解 = この OSS は調査済みで不採用、条件 X を満たせば再検討」を端的に記述する記録である。datestamp は「調査日」列に限定し、変更履歴・supersede 経緯は本文に書かず git 履歴に委ねている。

## 横展開・影響波及チェック

- [x] N/A — 並行実装の影響範囲外

`docs/design/parallel-implementations.md` の全ペア（UI ラベル / 年齢モード / 本番↔デモ / ナビ 3 種 / DB スキーマ 3 箇所 / チュートリアル）に該当しない。ADR-0001 の設計書同期についても、実装変更が 0 件のため同期対象の設計書は発生しない。

**LP / 販促文言変更時** (ADR-0013 / #1314): N/A（`site/**` / pricing / `plan-features.ts` / `pricing-strategy.md` の変更なし）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項・QA**:

QM レビュー BLOCK 3 点（2026-07-29）に対応済み。

1. **棄却案比較 narrative の置き場所** — `docs/CLAUDE.md` §docs SSOT 原則（「棄却案比較 → `docs/rationale/`」）に従い、約 800 字あった「不採用根拠」セルを `docs/rationale/16-graphify-evaluation-rationale.md` へ切り出した。README 側は「領域 / 調査 OSS / 調査日 / 結論 1 行 / 再評価トリガ / 詳細」の 6 列インデックス 1 行に圧縮し、§OSS 採用記録 と同じ「`npm install` 前にまず参照するインデックス」の役割に揃えた。
2. **追加基準・削除トリガの欠落** — 新節に (a) 記録する基準（実測評価したもののみ。軽く調べて外したものは記録しない）(b) 書き方（1 行 = 1 候補、実測値は rationale 側）(c) 削除トリガ（再評価トリガを満たし再検討完了した行 / OSS 廃止された行は削除、履歴は git）(d) §ボリューム上限ルール（削除主義）との関係（再評価トリガが生きている間は「役目を終えた record」ではないため削除対象外）を明記した。
3. **未実測項目が実測値と同格** — `graphify claude install` の PreToolUse hook 挙動（`Bash|Grep` / `Read|Glob` matcher）は AC6 のとおり未実行の機能であり、rationale 側で「未実測（ドキュメント読解による推測）」節として実測表から分離し、「侵襲的」評価も同じ確度である旨を明記した（ADR-0013 LP truth と同じ精神）。あわせて未実測部分の実測を「残された懸念・フォローアップ」に残した。

なお本 PR は「不採用」の記録であり、Graphify の CLI 自体はローカルのユーザプロファイルに残っている（`uv tool uninstall graphifyy` で削除可能）。リポジトリ側には一切の痕跡を残していない（`graphify-out/` 削除済 / CLAUDE.md・settings.json 未変更 / `.gitignore` 追記なし）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— `git diff origin/develop --stat` = 3 files / +88 行、差分全行を目視確認済
- [x] 全 AC が実装済み（未実装・先送りのまま残っている AC がない）— AC1〜AC6 すべて検証済、部分対応なし
- [x] Phase 分割した場合: 着手前に PO と合意し、子 Issue を起票済み — Phase 分割なし（単一 PR で完結）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記（#1741 / #1747）+ DESIGN.md §9 禁忌 6 点を目視確認 — UI 変更なしのため対象外
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 認証画面変更なしのため対象外

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

