### PR TITLE
fix: #4082 #4057 #4075 approve gate の発火条件を表層依存から fail-closed に変える

### DIFF
--- a/.claude/hooks/command-execution-tools.mjs
+++ b/.claude/hooks/command-execution-tools.mjs
@@ -1,7 +1,7 @@
 /**
- * .claude/hooks/command-execution-tools.mjs (#4001)
+ * .claude/hooks/command-execution-tools.mjs (#4001 / #4082 R1)
  *
- * 「コマンドを実行しうる Claude Code ツール」の SSOT。
+ * 「**任意の副作用を起こしうる** Claude Code ツール」の SSOT。
  *
  * # なぜ必要か
  * ADR-0056 の approve gate (`gate-approve.mjs`) と ADR-0022 L1 の PR 作成アカウント予防層
@@ -11,42 +11,62 @@
  * Windows のエージェントは Bash と PowerShell を両方持つため、これは悪意なく踏める分岐で、
  * 「agent の自覚に依存せず物理的に止める」という ADR-0056 の前提そのものを崩す。
  *
- * # 棚卸し (#4001 AC3、2026-07-28 時点)
- * このセッション設定 (`.claude/settings.json`) でコマンド文字列を実行しうるツール:
- *   - `Bash`       … POSIX shell (Git Bash)。`tool_input.command` に全文が入る
- *   - `PowerShell` … Windows PowerShell 5.1。同じく `tool_input.command`
- * 以下は**コマンド実行経路ではない**ため対象外:
+ * # 判定軸は「shell か」ではなく「任意の副作用を起こせるか」(#4082 R1)
+ * #4001 の棚卸しは対象を **shell ツール**に限っていたため、`mcp__ide__executeCode`
+ * (Jupyter kernel 上で任意コードを実行できる) が漏れていた。そこから subprocess を起こせば
+ * `gh pr merge` 相当の副作用を出せるのに、shell ではないので matcher に載らず gate が
+ * 起動しなかった。**shell か否かではなく、任意の副作用を起こせるか**で列挙する。
+ *
+ * # 2 つの区分 (payload の読み方が違う)
+ *   - `SHELL_COMMAND_TOOLS`   … `tool_input.command` にコマンド全文が入る。非文字列は block
+ *   - `CODE_EXECUTION_TOOLS`  … コード片を渡す。key 名は一定でないため tool_input 内の
+ *                                **全文字列**を走査する (走査できる文字列が 0 件なら block)
+ *
+ * # 棚卸し (2026-07-30 時点)
+ * 対象:
+ *   - `Bash`                  … POSIX shell (Git Bash)
+ *   - `PowerShell`            … Windows PowerShell 5.1
+ *   - `mcp__ide__executeCode` … Jupyter kernel 上の任意コード実行 (subprocess 起動可)
+ * 対象外 (副作用を起こせない / 起こしても本 gate の不変条件に触れない):
  *   - `Read` / `Write` / `Edit` / `Glob` / `Grep` … ファイル操作のみ
  *   - `Agent` / `Skill` … 子セッションを起こすが、子側でも同じ hook 設定が適用される
- *     (ただし `Agent` の `isolation: "remote"` での hook 継承は未検証 — ADR-0056 §残存 bypass R3)
- *   - `Read` / `Write` / `Edit` / `Glob` / `Grep` … ファイル操作のみ
- *   - MCP ツール群 (`mcp__*`) の大半 … chrome-devtools / playwright / discord / gmail /
- *     calendar / drive / aws 系 / youtube。`browser_run_code_unsafe` や `evaluate_script` は
- *     ブラウザ内 JS であってシェルではない
+ *     (ただし `Agent` の `isolation: "remote"` での hook 継承は**このリポジトリからは検証
+ *     できない** — ADR-0056 §残存 bypass R3。事後監査 `scripts/audit-approve-evidence.mjs`
+ *     が経路非依存の検知層を担う)
+ *   - ブラウザ内 JS 実行系 MCP (`browser_run_code_unsafe` / `evaluate_script` 等)
+ *     … ページ内 JS であり `gh` を起動できない
  *
- * # 対象外にしているが実際は危険な経路 (訂正、ADR-0056 §残存 bypass R1)
- * 上記の「MCP に汎用 shell 実行は無い」は**実態より狭い**。`mcp__ide__executeCode` は
- * Jupyter kernel 上で**任意コードを実行できる**ため、`gh pr merge` 相当の副作用を出せる。
- * shell 文字列ではないので `tool_input.command` 検査が効かず、本 SSOT にも matcher にも
- * 載っていない = gate がそもそも起動しない。同 class の code-execution 系 MCP ツールが
- * 増えるたびに同じ穴が開くため、「shell か否か」ではなく
- * **「任意の副作用を起こせるか」**で棚卸しする必要がある (未対処、R1)。
- *
- * # 将来ツールが増えたときに漏れない仕組み (#4001 AC3)
- * 手動の列挙メンテは形骸化するため、以下 2 段で守る:
+ * # 列挙漏れを silent にしない仕組み (#4001 AC3 / #4082 AC4)
+ * 手動の列挙メンテは形骸化するため、以下 3 段で守る:
  *   1. `tests/unit/hooks/command-execution-tools.test.ts` が
- *      **`.claude/settings.json` の matcher が本 SSOT の全ツールを覆っていること**を機械検証する。
- *      SSOT に 1 行足して settings.json を直し忘れれば CI が落ちる。
- *   2. `gate-approve.mjs` は **SSOT に無いツール名で呼ばれた場合でも allow に倒さない**
- *      (tool_input 内の全文字列を走査して approve 系を探す)。matcher だけ広げて SSOT 更新を
- *      忘れた場合でも、gate が無言で素通ししない。
+ *      **`.claude/settings.json` の matcher が本 SSOT の全ツールを覆っていること**を機械検証する
+ *   2. `gate-approve.mjs` は **SSOT に無いツール名で呼ばれても allow に倒さない**
+ *      (tool_input 内の全文字列を走査し、走査対象が 0 件なら block)
+ *   3. それでも「matcher に載らないツール」は gate 自体が起動しないため原理的に塞げない。
+ *      この残余は ADR-0056 に accepted residual として明記し、事後監査で検知する
  */
 
 /**
- * コマンド文字列を実行しうるツール名。
+ * コマンド文字列を `tool_input.command` で受け取るツール。
  * @type {readonly string[]}
  */
-export const COMMAND_EXECUTION_TOOLS = Object.freeze(['Bash', 'PowerShell']);
+export const SHELL_COMMAND_TOOLS = Object.freeze(['Bash', 'PowerShell']);
+
+/**
+ * 任意コードを実行できる (= 任意の副作用を起こせる) が shell ではないツール。
+ * payload の key 名が一定でないため、検査は tool_input 内の全文字列走査で行う。
+ * @type {readonly string[]}
+ */
+export const CODE_EXECUTION_TOOLS = Object.freeze(['mcp__ide__executeCode']);
+
+/**
+ * gate の適用対象ツール全体 (shell + code execution)。
+ * @type {readonly string[]}
+ */
+export const COMMAND_EXECUTION_TOOLS = Object.freeze([
+	...SHELL_COMMAND_TOOLS,
+	...CODE_EXECUTION_TOOLS,
+]);
 
 /**
  * `.claude/settings.json` の PreToolUse matcher に書くべき正規表現文字列 (SSOT)。

--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -11,19 +11,27 @@
  *   の存在 + TTL (30 分) + schema 必須 field 充足を検証する。検証 fail なら exit 2 で
  *   approve action を物理 block する。
  *
- * 対象経路 (#4001):
- *   Bash だけでなく **コマンド実行系ツール全経路** (SSOT: ./command-execution-tools.mjs)。
+ * 対象経路 (#4001 / #4082 R1):
+ *   Bash だけでなく **任意の副作用を起こしうるツール全経路** (SSOT: ./command-execution-tools.mjs)。
  *   matcher が `"Bash"` だけだった間、PowerShell ツールで同じコマンドを叩けば gate が
- *   起動せず素通しできた (gate bypass)。判別できない入力は allow ではなく block する。
+ *   起動せず素通しできた (gate bypass)。判定軸は「shell か」ではなく「任意の副作用を
+ *   起こせるか」であり、汎用コード実行 MCP も対象に含む。判別できない入力は allow ではなく block。
+ *
+ * 検出の原則 (#4057):
+ *   approve 行為の識別は **PR 番号の書き方に依存させない**。`pulls/<ref>/{reviews,merge}` は
+ *   ref がリテラルでも変数展開 (`$n`) でもコマンド置換でも approve として捕捉し、番号を
+ *   確定できない場合は block する (「番号が取れない = 検証不能 = 通さない」)。
  *
  * 設計根拠 (Research SSOT §5.1 / §5.2):
  *   - arXiv:2511.09710 で structured response schema 強制が echoing 30-40% → <10% を実証
  *   - Sleeper Agents (Hubinger 2024): instruction 経由の役割強化は drift trigger に対処できない
  *     → agent 内部自覚に依存せず Bash command を物理 block する hook が必要
  *
- * Recursive loop 防止:
+ * Recursive loop 防止 (#4082 R2 で範囲を絞った):
  *   `process.env.CLAUDE_SUBAGENT_ID` 存在時 (Adversarial Reviewer subagent context) は
- *   無条件 allow。subagent が evidence 生成中に approve 系コマンドを叩いても block されない。
+ *   **読み取り専用の review 参照だけ** allow する。旧実装は無条件 allow だったため、この env が
+ *   立った context ではどのツール経由でも approve が素通りした。loop 防止に必要なのは
+ *   「evidence 生成のために review を読む」ことだけなので、mutation は subagent でも block する。
  *
  * 入力 (stdin, JSON):
  *   {

--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -22,6 +22,18 @@
  *   ref がリテラルでも変数展開 (`$n`) でもコマンド置換でも approve として捕捉し、番号を
  *   確定できない場合は block する (「番号が取れない = 検証不能 = 通さない」)。
  *
+ * 検出の原則 2 — flag の長短・API の種別で穴を作らない (#4095 QM Re-Review):
+ *   - `gh pr review -a` は `--approve` の**正式な短縮 flag**。長形だけを見ていると 1 キーストローク
+ *     分だけ gate が消える。判定は argv token 単位で行い、cluster (`-ab body`) も拾う。
+ *   - `gh api graphql` の `addPullRequestReview` / `mergePullRequest` mutation は REST と同じ効果を
+ *     持つ。REST パスだけを見ていると GraphQL に書き換えるだけで抜けられる。
+ *
+ * 検証対象 PR の確定原則 (#4095 O-3):
+ *   PR 番号は **実際に叩かれる `gh` invocation の argv / API パスからのみ**取る。コマンド全体を
+ *   走査して「近くにある数字」を採ると、`for n in 4002 4010; do gh pr merge $n; done # for 4002`
+ *   のような形で **evidence のある PR の番号で別 PR が merge される**。番号を確定できない hit が
+ *   1 件でもあれば、他にリテラル番号があっても block する (indeterminate → BLOCK)。
+ *
  * 設計根拠 (Research SSOT §5.1 / §5.2):
  *   - arXiv:2511.09710 で structured response schema 強制が echoing 30-40% → <10% を実証
  *   - Sleeper Agents (Hubinger 2024): instruction 経由の役割強化は drift trigger に対処できない
@@ -201,6 +213,8 @@ export function isApproveAction(command) {
 	if (/\bgh(?:\.exe)?\s+pr\s+merge\b/.test(sanitized)) return true;
 	// gh pr review --approve
 	if (/\bgh(?:\.exe)?\s+pr\s+review\b[^\n]*--approve\b/.test(sanitized)) return true;
+	// gh pr review -a (短縮 flag)。上の regex は長形しか見ないため argv 単位でも判定する (#4095 O-1)。
+	if (findPrCliApproveHits(sanitized).length > 0) return true;
 	// gh api .../pulls/<ref>/{merge,reviews} (REST 直叩き)。
 	// #4027: 部分一致でなく **引数として渡された API パス** で判定する。method は問わない
 	// (approve 相当を method 表記で回避されないよう検出幅は従来どおり維持する)。
@@ -210,12 +224,109 @@ export function isApproveAction(command) {
 }
 
 /**
- * approve 相当の API パスを列挙する (#4057)。
+ * `gh pr` サブコマンドのうち **値を次の token に取る flag** (#4095 O-3)。
  *
- * 2 種類を拾う:
+ * PR 番号を positional から取り出すとき、flag の値を positional と誤認しないために使う。
+ * `--body` 系は `sanitizeForDetection` が既に潰しているが、flag 名は残るためここでも列挙する。
+ */
+const PR_CLI_VALUE_FLAGS = new Set([
+	'-R',
+	'--repo',
+	'-b',
+	'--body',
+	'-F',
+	'--body-file',
+	'-t',
+	'--subject',
+	'-A',
+	'--author-email',
+	'--match-head-commit',
+]);
+
+/**
+ * `gh pr review` の argv に **approve 指定**があるか (#4095 O-1)。
+ *
+ * `gh pr review --help` のとおり `-a, --approve` は正式な短縮 flag であり、長形だけを見る regex は
+ * 1 キーストローク分の穴になる (QM 実測: `gh pr review 4010 -a --body ok` が exit 0 で素通り)。
+ *
+ * 誤検出を避けるため、判定は token 単位で行う:
+ *   - `--approve` / `--approve=true` … 長形
+ *   - `-a` および short flag cluster (`-ab body` = `--approve --body body`) … 小文字 `a` を含むもの
+ *   - `-c` (--comment) / `-r` (--request-changes) / `-A` (大文字) は **含まない**
+ *
+ * @param {string[]} argv  `gh` の次の token から始まる配列 (argv[0]='pr', argv[1]='review')
+ * @returns {boolean}
+ */
+export function hasPrReviewApproveFlag(argv) {
+	if (!Array.isArray(argv)) return false;
+	for (const token of argv.slice(2)) {
+		if (typeof token !== 'string') continue;
+		if (token === '--approve' || token.startsWith('--approve=')) return true;
+		// short flag (cluster 可)。`--` 始まりはここに来ない (2 文字目が `-` で regex 不一致)。
+		if (/^-[A-Za-z]+$/.test(token) && token.slice(1).includes('a')) return true;
+	}
+	return false;
+}
+
+/**
+ * approve 相当の `gh pr` CLI 呼び出しを列挙する (#4095 O-1)。
+ *
+ * `gh pr merge` (全て) と `gh pr review` (approve 指定があるもの) を返す。番号確定 (#4095 O-3) と
+ * 検出 (isApproveAction / isReadOnlyApproveInspection) の双方で同じ列挙を使い、判定軸を 1 本にする。
+ *
+ * @param {string} sanitized  sanitizeForDetection 済み文字列
+ * @returns {{ kind: 'merge' | 'review-approve'; argv: string[] }[]}
+ */
+function findPrCliApproveHits(sanitized) {
+	const lib = ghLib();
+	/** @type {{ kind: 'merge' | 'review-approve'; argv: string[] }[]} */
+	const hits = [];
+	for (const { argv } of lib.findGhInvocations(sanitized)) {
+		if (argv.at(0) !== 'pr') continue;
+		const sub = argv.at(1);
+		if (sub === 'merge') hits.push({ kind: 'merge', argv });
+		else if (sub === 'review' && hasPrReviewApproveFlag(argv)) {
+			hits.push({ kind: 'review-approve', argv });
+		}
+	}
+	return hits;
+}
+
+/**
+ * GraphQL payload が approve 相当の mutation か (#4095 O-2)。
+ *
+ * `gh api graphql -f query='mutation{addPullRequestReview(input:{… event:APPROVE …}){…}}'` は REST の
+ * `POST /pulls/<n>/reviews` と同一効果を持つ。`parseGhApiInvocation` は `graphql` を path として
+ * 収集していたが、これを見る側が pulls 系しか扱っていなかったため**死んだ枝**になっていた
+ * (QM 実測: exit 0 で素通り)。
+ *
+ * 判定は「graphql エンドポイントであること」× 「approve 相当 mutation 名 / event が現れること」の
+ * 論理積に限る。単なる `query{…}` の読み取りは対象外 (過剰 block を避ける)。
+ * `addPullRequestReviewComment` / `…Thread` は review comment であり approve ではないため、
+ * `\b` 境界で除外される (後続が語構成文字なら一致しない)。
+ */
+const APPROVE_GRAPHQL_RE =
+	/addPullRequestReview\b|mergePullRequest\b|event\s*[:=]\s*['"]?APPROVE\b/i;
+
+/**
+ * @param {{ paths: string[] }} api  parseGhApiInvocation の結果
+ * @param {string} segment           当該呼び出しを含む生 segment (引用符付きの payload を見るため)
+ * @returns {boolean}
+ */
+function isApproveGraphqlInvocation(api, segment) {
+	if (!api.paths.some((p) => /^graphql$/i.test(p))) return false;
+	return APPROVE_GRAPHQL_RE.test(segment);
+}
+
+/**
+ * approve 相当の API パスを列挙する (#4057 / #4095 O-2)。
+ *
+ * 3 種類を拾う:
  *   - `repos/o/r/pulls/<ref>/{reviews,merge}` … ref の形 (数字 / 変数 / 置換) を問わない
  *   - **確定できない pulls 配下パス** … `$(…)` / `$VAR` / backtick 等で実際に叩かれる URL が
  *     決まらないもの。分類不能を「approve ではない」に潰すと、書き方を変えるだけで抜けられる
+ *   - **GraphQL の approve 相当 mutation** … `addPullRequestReview` / `mergePullRequest` /
+ *     `event: APPROVE`。PR 番号は node ID で表されるため常に indeterminate (= 番号確定不能 → block)
  *
  * コレクション (`repos/o/r/pulls`) は対象外 (PR 作成 = ADR-0022 L1 の責務)。
  *
@@ -226,9 +337,13 @@ function findApprovePathHits(sanitized) {
 	const lib = ghLib();
 	/** @type {{ path: string; method: string; indeterminate: boolean }[]} */
 	const hits = [];
-	for (const { argv } of lib.findGhInvocations(sanitized)) {
+	for (const { segment, argv } of lib.findGhInvocations(sanitized)) {
 		const api = lib.parseGhApiInvocation(argv);
 		if (!api.isApi) continue;
+		if (isApproveGraphqlInvocation(api, segment)) {
+			// node ID 指定のため PR 番号を確定できない = evidence を照合できない → 常に block 側
+			hits.push({ path: 'graphql', method: api.method, indeterminate: true });
+		}
 		for (const path of api.paths) {
 			const isSubresource =
 				lib.isPullsSubresourcePathAnyRef(path, 'merge') ||
@@ -265,6 +380,8 @@ export function isReadOnlyApproveInspection(command) {
 	const sanitized = lib.sanitizeForDetection(command);
 	if (/\bgh(?:\.exe)?\s+pr\s+merge\b/.test(sanitized)) return false;
 	if (/\bgh(?:\.exe)?\s+pr\s+review\b[^\n]*--approve\b/.test(sanitized)) return false;
+	// 短縮 flag (`-a`) 経由の approve も CLI の変更操作 (#4095 O-1)。長形と同じく read-only ではない。
+	if (findPrCliApproveHits(sanitized).length > 0) return false;
 	const hits = findApprovePathHits(sanitized);
 	if (hits.length === 0) return false;
 	return hits.every((hit) => !hit.indeterminate && hit.method === 'GET');
@@ -383,27 +500,89 @@ export function extractPrNumber(command) {
  * の `4002` はループの列挙値であって、そのコマンドが叩く PR とは限らない。近くにある数字を
  * 拾うと、evidence のある PR の番号で別 PR の approve が通ってしまう。
  *
+ * この不変条件を満たすため、番号は **実際に叩かれる `gh` invocation の argv / API パスからのみ**
+ * 取る (#4095 O-3)。コマンド全体を regex で走査する旧実装は、同一行の任意の数字 (`# rollup for
+ * 4002` のコメント) や別 invocation のリテラルを拾い、QM 実測で
+ * `for n in 4002 4010; do gh pr merge $n --squash; done # rollup for 4002` が exit 0 になっていた。
+ *
  * @param {string} command
  * @returns {number[]}  昇順・重複排除
  */
 export function extractPrNumbers(command) {
-	if (typeof command !== 'string') return [];
+	return resolveApproveTargets(command).numbers;
+}
+
+/**
+ * 1 つの `gh pr merge|review` invocation の argv から PR 番号を取り出す (#4095 O-3)。
+ *
+ * positional 引数のみを見る。flag の値 (`--repo X`) は skip し、shell コメント (`# …`) 以降は
+ * 「そのコマンドが叩く対象」ではないため打ち切る。番号を確定できなければ null (呼出側で block)。
+ *
+ * @param {string[]} argv  `gh` の次の token から始まる配列 (argv[0]='pr')
+ * @returns {number|null}
+ */
+function prNumberFromCliArgv(argv) {
+	for (let i = 2; i < argv.length; i += 1) {
+		const token = argv.at(i) ?? '';
+		// shell コメント以降はコマンドの引数ではない (「近くの数字」を拾わない)
+		if (token.startsWith('#')) break;
+		if (token.startsWith('-')) {
+			// `--flag=value` は値を同 token に持つため次を消費しない
+			if (!token.includes('=') && PR_CLI_VALUE_FLAGS.has(token)) i += 1;
+			continue;
+		}
+		if (/^\d{1,6}$/.test(token)) return Number(token);
+		const url = /\/pull\/(\d{1,6})(?:$|[/?#])/.exec(token);
+		if (url?.[1]) return Number(url[1]);
+	}
+	return null;
+}
+
+/**
+ * approve 対象の PR 番号と **確定不能 hit の有無** を返す (#4095 O-3)。
+ *
+ * `indeterminate` が true の場合、たとえ他にリテラル番号が取れていても呼出側は block する。
+ * 「番号が 1 つでも取れたら OK」にすると、`for n in 4002 4010; …` 形で evidence のある 4002 を
+ * 根拠に 4010 まで通ってしまう (本関数のコメントが禁じている挙動そのもの)。
+ *
+ * @param {string} command
+ * @returns {{ numbers: number[]; indeterminate: boolean }}
+ */
+export function resolveApproveTargets(command) {
+	if (typeof command !== 'string') return { numbers: [], indeterminate: false };
 	// #4001: PowerShell 表記ゆれ (& 'gh' / gh.exe / backtick 継続) を吸収してから抽出する
 	// #4027: あわせて --body / heredoc の中身を除去し、body 内の PR 番号を拾わないようにする
-	const normalized = ghLib().sanitizeForDetection(command);
+	const lib = ghLib();
+	const normalized = lib.sanitizeForDetection(command);
 	/** @type {Set<number>} */
 	const numbers = new Set();
-	// gh pr <merge|review> [args] <N>
-	for (const m of normalized.matchAll(
-		/\bgh(?:\.exe)?\s+pr\s+(?:merge|review)\b[^\n]*?\b(\d{1,6})\b/g,
-	)) {
-		numbers.add(Number(m[1]));
+	let indeterminate = false;
+	for (const { segment, argv } of lib.findGhInvocations(normalized)) {
+		if (argv.at(0) === 'pr') {
+			const sub = argv.at(1);
+			if (sub !== 'merge' && sub !== 'review') continue;
+			// approve 指定の無い review (comment / request-changes) は approve 対象ではない
+			if (sub === 'review' && !hasPrReviewApproveFlag(argv)) continue;
+			const prNumber = prNumberFromCliArgv(argv);
+			if (prNumber === null) indeterminate = true;
+			else numbers.add(prNumber);
+			continue;
+		}
+		const api = lib.parseGhApiInvocation(argv);
+		if (!api.isApi) continue;
+		if (isApproveGraphqlInvocation(api, segment)) indeterminate = true;
+		for (const path of api.paths) {
+			const isSubresource =
+				lib.isPullsSubresourcePathAnyRef(path, 'merge') ||
+				lib.isPullsSubresourcePathAnyRef(path, 'reviews');
+			const isUnresolved = lib.isPullsScopedPath(path) && lib.hasUnresolvedExpansion(path);
+			if (!isSubresource && !isUnresolved) continue;
+			const m = /^repos\/[^/]+\/[^/]+\/pulls\/(\d{1,6})(?:\/|$)/i.exec(path);
+			if (m?.[1]) numbers.add(Number(m[1]));
+			else indeterminate = true;
+		}
 	}
-	// gh api .../pulls/<N>/...
-	for (const m of normalized.matchAll(/\/pulls\/(\d{1,6})\b/g)) {
-		numbers.add(Number(m[1]));
-	}
-	return [...numbers].sort((a, b) => a - b);
+	return { numbers: [...numbers].sort((a, b) => a - b), indeterminate };
 }
 
 /**
@@ -530,13 +709,22 @@ async function main() {
 
 	// PR 番号は全件抽出する。1 コマンドで複数 PR を叩く形があるため、1 件の evidence で
 	// 残りを通さない。1 件も取れない = 検証対象を特定できない = block (#4057)。
-	const prNumbers = [...new Set(approveCommands.flatMap((c) => extractPrNumbers(c)))].sort(
-		(a, b) => a - b,
-	);
-	if (prNumbers.length === 0) {
+	// さらに **確定できない hit が 1 件でもあれば、他にリテラル番号があっても block** する (#4095 O-3)。
+	// 「近くにあるリテラル番号」で別 PR が通る経路を残さないため。
+	const targets = approveCommands.map((c) => resolveApproveTargets(c));
+	const prNumbers = [...new Set(targets.flatMap((t) => t.numbers))].sort((a, b) => a - b);
+	const hasIndeterminate = targets.some((t) => t.indeterminate);
+	if (hasIndeterminate || prNumbers.length === 0) {
 		process.stderr.write(
-			`[gate-approve] BLOCK: approve 系コマンドだが PR 番号を command から抽出できませんでした。\n`,
+			hasIndeterminate
+				? `[gate-approve] BLOCK: approve 系コマンドに、どの PR を叩くか確定できない指定が含まれています。\n`
+				: `[gate-approve] BLOCK: approve 系コマンドだが PR 番号を command から抽出できませんでした。\n`,
 		);
+		if (hasIndeterminate && prNumbers.length > 0) {
+			process.stderr.write(
+				`  リテラルで書かれた番号 (#${prNumbers.join(', #')}) は、そのコマンドが実際に叩く PR とは限らないため採用しません。\n`,
+			);
+		}
 		process.stderr.write(
 			`  検出したコマンド: ${(approveCommands.at(0) ?? '').slice(0, 200).replace(/\n/g, ' ')}\n`,
 		);

--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -51,7 +51,6 @@
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { COMMAND_EXECUTION_TOOLS } from './command-execution-tools.mjs';
 
 /**
  * `scripts/lib/` の SSOT module を **dynamic import** で読み込む理由 (#3999 / #4027)。
@@ -64,26 +63,47 @@ import { COMMAND_EXECUTION_TOOLS } from './command-execution-tools.mjs';
  * security control は「判定不能」を「許可」ではなく **block** に倒す (fail-closed)。
  * dynamic import なら解決失敗を catch でき、exit 2 を自分で選べる。
  *
- * 対象は `../../scripts/lib/` を辿る **2 本とも**: `is-main.mjs` (実行主体判定) と
- * `gh-command.mjs` (#4027 で導入した gh コマンド解析 SSOT)。gh-command.mjs を static import に
- * 戻すと、同じ「`scripts/` 欠落 checkout で exit 1 = 素通し」が再発する。
+ * 対象は **相対 import の全部**: `../../scripts/lib/is-main.mjs` (実行主体判定) /
+ * `../../scripts/lib/gh-command.mjs` (#4027 の gh コマンド解析 SSOT) /
+ * `./command-execution-tools.mjs` (#4082 R1 の対象ツール SSOT)。
+ *
+ * **1 本だけ dynamic 化しても同 class の穴は残る** (#4075): #3999 が `is-main.mjs` を塞いだ後も
+ * `command-execution-tools.mjs` は static import のままで、当該ファイルを含まない checkout では
+ * `ERR_MODULE_NOT_FOUND` = exit 1 = 素通しに倒れていた。以後 sibling を 1 本足しただけで
+ * 穴が復活しないよう、`tests/unit/hooks/gate-approve-fail-closed.test.ts` の fitness function が
+ * **hook 本文に相対 module の static import が 0 件**であることを機械検証する。
  */
 /** @type {((importMetaUrl: string, argv1?: string) => boolean) | undefined} */
 let isMain;
 /** @type {typeof import('../../scripts/lib/gh-command.mjs') | undefined} */
 let gh;
+/** @type {typeof import('./command-execution-tools.mjs') | undefined} */
+let tools;
+/**
+ * 読み込めなかった module の一覧 (repo 相対パス + error)。
+ * 1 本でも欠けたら fail-closed で exit 2 に倒す。どの module が欠けたかを stderr に出すため、
+ * 「最初の 1 件」ではなく全件を保持する。
+ * @type {{ path: string; err: unknown }[]}
+ */
+const moduleLoadFailures = [];
 /** @type {unknown} import 解決に失敗したときの error (成功時は null) */
 let isMainLoadError = null;
 try {
 	({ isMain } = await import('../../scripts/lib/is-main.mjs'));
 } catch (err) {
-	isMainLoadError = err;
+	moduleLoadFailures.push({ path: 'scripts/lib/is-main.mjs', err });
 }
 try {
 	gh = await import('../../scripts/lib/gh-command.mjs');
 } catch (err) {
-	isMainLoadError ??= err;
+	moduleLoadFailures.push({ path: 'scripts/lib/gh-command.mjs', err });
 }
+try {
+	tools = await import('./command-execution-tools.mjs');
+} catch (err) {
+	moduleLoadFailures.push({ path: '.claude/hooks/command-execution-tools.mjs', err });
+}
+if (moduleLoadFailures.length > 0) isMainLoadError = moduleLoadFailures[0].err;
 
 /**
  * gh-command SSOT を取り出す。読み込めていなければ throw する (呼出元は main() 経由で
@@ -98,6 +118,23 @@ function ghLib() {
 			: new Error('scripts/lib/gh-command.mjs を読み込めません');
 	}
 	return gh;
+}
+
+/**
+ * 対象ツール SSOT を取り出す。読み込めていなければ throw する (#4075)。
+ *
+ * `?? []` のような既定値で代用すると「どのツールが shell か分からないまま検査を続ける」ことに
+ * なり、`tool_input.command` を読めないまま allow に倒れうる。判定材料が無いなら止める。
+ *
+ * @returns {typeof import('./command-execution-tools.mjs')}
+ */
+function toolsLib() {
+	if (!tools) {
+		throw isMainLoadError instanceof Error
+			? isMainLoadError
+			: new Error('.claude/hooks/command-execution-tools.mjs を読み込めません');
+	}
+	return tools;
 }
 
 /**
@@ -156,21 +193,73 @@ export function isApproveAction(command) {
 	if (/\bgh(?:\.exe)?\s+pr\s+merge\b/.test(sanitized)) return true;
 	// gh pr review --approve
 	if (/\bgh(?:\.exe)?\s+pr\s+review\b[^\n]*--approve\b/.test(sanitized)) return true;
-	// gh api .../pulls/<N>/{merge,reviews} (REST 直叩き)。
+	// gh api .../pulls/<ref>/{merge,reviews} (REST 直叩き)。
 	// #4027: 部分一致でなく **引数として渡された API パス** で判定する。method は問わない
 	// (approve 相当を method 表記で回避されないよう検出幅は従来どおり維持する)。
+	// #4057: `<ref>` は数字リテラルに限定しない。番号の書き方 (`4002` / `$n` / `$(…)`) で
+	// gate の有無が変わってはならない。番号が確定できるかどうかは別工程で扱う。
+	return findApprovePathHits(sanitized).length > 0;
+}
+
+/**
+ * approve 相当の API パスを列挙する (#4057)。
+ *
+ * 2 種類を拾う:
+ *   - `repos/o/r/pulls/<ref>/{reviews,merge}` … ref の形 (数字 / 変数 / 置換) を問わない
+ *   - **確定できない pulls 配下パス** … `$(…)` / `$VAR` / backtick 等で実際に叩かれる URL が
+ *     決まらないもの。分類不能を「approve ではない」に潰すと、書き方を変えるだけで抜けられる
+ *
+ * コレクション (`repos/o/r/pulls`) は対象外 (PR 作成 = ADR-0022 L1 の責務)。
+ *
+ * @param {string} sanitized  sanitizeForDetection 済み文字列
+ * @returns {{ path: string; method: string; indeterminate: boolean }[]}
+ */
+function findApprovePathHits(sanitized) {
+	const lib = ghLib();
+	/** @type {{ path: string; method: string; indeterminate: boolean }[]} */
+	const hits = [];
 	for (const { argv } of lib.findGhInvocations(sanitized)) {
 		const api = lib.parseGhApiInvocation(argv);
 		if (!api.isApi) continue;
-		if (
-			api.paths.some(
-				(p) => lib.isPullsSubresourcePath(p, 'merge') || lib.isPullsSubresourcePath(p, 'reviews'),
-			)
-		) {
-			return true;
+		for (const path of api.paths) {
+			const isSubresource =
+				lib.isPullsSubresourcePathAnyRef(path, 'merge') ||
+				lib.isPullsSubresourcePathAnyRef(path, 'reviews');
+			const indeterminate = lib.isPullsScopedPath(path) && lib.hasUnresolvedExpansion(path);
+			if (isSubresource || indeterminate) {
+				hits.push({ path, method: api.method, indeterminate });
+			}
 		}
 	}
-	return false;
+	return hits;
+}
+
+/**
+ * subagent context で許してよい **読み取り専用**の approve パス参照か (#4082 R2)。
+ *
+ * Adversarial Reviewer subagent は evidence 生成のために「既存 review の一覧」を読む。これは
+ * `pulls/<n>/reviews` を叩くため本 gate の検出網 (method 非依存) に掛かるが、**副作用は無い**。
+ * 旧実装はこれを通すために `CLAUDE_SUBAGENT_ID` が立っていれば**どのコマンドでも無条件 allow**
+ * にしていた (= どのツール経由でも素通り、#4082 R2)。loop 防止に必要なのは「読む」ことだけなので、
+ * 許可をそこまで絞る。
+ *
+ * 以下はいずれも false (= subagent でも evidence gate に掛ける):
+ *   - `gh pr merge` / `gh pr review --approve` (CLI の変更操作)
+ *   - method が GET でない `gh api` (POST / PUT / PATCH / DELETE、method 不明も POST 扱い)
+ *   - パスが確定できない形 (分類不能を allow に倒さない)
+ *
+ * @param {string} command
+ * @returns {boolean}
+ */
+export function isReadOnlyApproveInspection(command) {
+	if (typeof command !== 'string') return false;
+	const lib = ghLib();
+	const sanitized = lib.sanitizeForDetection(command);
+	if (/\bgh(?:\.exe)?\s+pr\s+merge\b/.test(sanitized)) return false;
+	if (/\bgh(?:\.exe)?\s+pr\s+review\b[^\n]*--approve\b/.test(sanitized)) return false;
+	const hits = findApprovePathHits(sanitized);
+	if (hits.length === 0) return false;
+	return hits.every((hit) => !hit.indeterminate && hit.method === 'GET');
 }
 
 /**
@@ -178,10 +267,12 @@ export function isApproveAction(command) {
  *
  * fail-closed 方針: **抽出できない = approve ではない、とは扱わない**。
  *   - tool_name が無い / 文字列でない → BLOCK (どの経路か判別できない)
- *   - SSOT (COMMAND_EXECUTION_TOOLS) のツールなのに `tool_input.command` が文字列でない
+ *   - shell ツール (SHELL_COMMAND_TOOLS) なのに `tool_input.command` が文字列でない
  *     → BLOCK (検査対象を読めない = 素通しさせない)
- *   - SSOT に無いツール名 → allow に倒さず、tool_input 内の全文字列 (+ 連結形) を走査する。
- *     matcher だけ広げて SSOT 更新を忘れた場合でも approve 系を掴めるようにするため。
+ *   - コード実行ツール (CODE_EXECUTION_TOOLS) / SSOT に無いツール名 → allow に倒さず、
+ *     tool_input 内の全文字列 (+ 連結形) を走査する。payload の key 名 (`code` / `script` / …)
+ *     はツールごとに違うため、key を決め打ちせず値の型で拾う (#4082 R1)
+ *   - 走査できる文字列が **1 つも無い** → BLOCK (検査していないのに通した、を作らない)
  *
  * @param {unknown} payload
  * @returns {{ ok: true; commands: string[] } | { ok: false; reason: string }}
@@ -195,7 +286,7 @@ export function resolveInspectableCommands(payload) {
 			reason: 'payload に tool_name がありません (どの実行経路か判別できないため block)',
 		};
 	}
-	if (COMMAND_EXECUTION_TOOLS.includes(toolName)) {
+	if (toolsLib().SHELL_COMMAND_TOOLS.includes(toolName)) {
 		const command = /** @type {{ command?: unknown }} */ (toolInput ?? {}).command;
 		if (typeof command !== 'string') {
 			return {
@@ -206,8 +297,37 @@ export function resolveInspectableCommands(payload) {
 		return { ok: true, commands: [command] };
 	}
 	const strings = collectStrings(toolInput);
+	if (strings.length === 0) {
+		return {
+			ok: false,
+			reason: `${toolName} の tool_input に検査できる文字列がありません (検査せずに通さない)`,
+		};
+	}
 	// 引数配列 (["gh","pr","merge","4001"]) 形式にも当たるよう連結形も候補に入れる
-	return { ok: true, commands: strings.length > 1 ? [...strings, strings.join(' ')] : strings };
+	const candidates = strings.length > 1 ? [...strings, strings.join(' ')] : [...strings];
+	// コード実行 payload は shell 文字列ではなく**プログラム言語の構文**なので、コマンドが
+	// `subprocess.run(["gh","pr","merge","4082"])` のように区切り文字で分断されて現れる (#4082 R1)。
+	// 区切り文字を空白に均した変種も候補に足し、言語構文に埋まった形でも掴めるようにする。
+	for (const s of [...candidates]) {
+		const flattened = flattenCodePunctuation(s);
+		if (flattened !== s) candidates.push(flattened);
+	}
+	return { ok: true, commands: candidates };
+}
+
+/**
+ * コード片に含まれる区切り文字を空白に均す (#4082 R1、shell 以外の payload 専用)。
+ *
+ * **限界**: 任意言語の構文を完全に解釈することはできない (変数経由の組み立て・base64・
+ * 動的 eval は原理的に検出できない)。ここで塞げるのは「コマンドがリテラルとして書かれている」
+ * 場合だけである。残余は ADR-0056 の残存 bypass として記録し、事後監査
+ * (`scripts/audit-approve-evidence.mjs`) が経路非依存の検知層を担う。
+ *
+ * @param {string} code
+ * @returns {string}
+ */
+function flattenCodePunctuation(code) {
+	return code.replace(/["'`[\](),]/g, ' ').replace(/[ \t]+/g, ' ');
 }
 
 /**
@@ -241,17 +361,41 @@ export function collectStrings(value, depth = 0) {
  * @returns {number|null}
  */
 export function extractPrNumber(command) {
-	if (typeof command !== 'string') return null;
+	return extractPrNumbers(command).at(0) ?? null;
+}
+
+/**
+ * command が approve 対象にしている PR 番号を **全て** 返す (#4057)。
+ *
+ * 1 コマンドで複数 PR を叩く形 (`gh pr merge 4002 && gh pr merge 4010` / ループ) があるため、
+ * 「最初の 1 件」だけ検証すると 1 件分の evidence で複数 PR が通る。呼出側は返った番号
+ * **全件**について evidence を検証し、approve 行為なのに 1 件も取れなければ block する。
+ *
+ * 番号を「推測」しないことが本関数の役割である。`for n in 4002 4010; do … /pulls/$n/reviews`
+ * の `4002` はループの列挙値であって、そのコマンドが叩く PR とは限らない。近くにある数字を
+ * 拾うと、evidence のある PR の番号で別 PR の approve が通ってしまう。
+ *
+ * @param {string} command
+ * @returns {number[]}  昇順・重複排除
+ */
+export function extractPrNumbers(command) {
+	if (typeof command !== 'string') return [];
 	// #4001: PowerShell 表記ゆれ (& 'gh' / gh.exe / backtick 継続) を吸収してから抽出する
 	// #4027: あわせて --body / heredoc の中身を除去し、body 内の PR 番号を拾わないようにする
 	const normalized = ghLib().sanitizeForDetection(command);
+	/** @type {Set<number>} */
+	const numbers = new Set();
 	// gh pr <merge|review> [args] <N>
-	const m1 = normalized.match(/\bgh(?:\.exe)?\s+pr\s+(?:merge|review)\b[^\n]*?\b(\d{1,6})\b/);
-	if (m1) return Number(m1[1]);
+	for (const m of normalized.matchAll(
+		/\bgh(?:\.exe)?\s+pr\s+(?:merge|review)\b[^\n]*?\b(\d{1,6})\b/g,
+	)) {
+		numbers.add(Number(m[1]));
+	}
 	// gh api .../pulls/<N>/...
-	const m2 = normalized.match(/\/pulls\/(\d{1,6})\b/);
-	if (m2) return Number(m2[1]);
-	return null;
+	for (const m of normalized.matchAll(/\/pulls\/(\d{1,6})\b/g)) {
+		numbers.add(Number(m[1]));
+	}
+	return [...numbers].sort((a, b) => a - b);
 }
 
 /**
@@ -335,11 +479,6 @@ export function verifyEvidence(prNumber, cwd = process.cwd()) {
 }
 
 async function main() {
-	// Recursive loop 防止: subagent context は無条件 allow
-	if (process.env.CLAUDE_SUBAGENT_ID) {
-		process.exit(0);
-	}
-
 	let payload;
 	try {
 		const raw = await readStdin();
@@ -368,33 +507,62 @@ async function main() {
 		process.exit(2);
 	}
 
-	const command = resolved.commands.find((c) => isApproveAction(c));
-	if (command === undefined) {
+	const approveCommands = resolved.commands.filter((c) => isApproveAction(c));
+	if (approveCommands.length === 0) {
 		// approve 系コマンドでなければ対象外
 		process.exit(0);
 	}
 
-	const prNumber = extractPrNumber(command);
-	if (prNumber === null) {
+	// Recursive loop 防止 (#4082 R2): subagent が evidence 生成のために review を **読む**のは通す。
+	// 旧実装は subagent context を無条件 allow にしていたため、この env が立った context では
+	// どのツール経由でも approve が素通りした。許可を「読み取り専用」に絞る。
+	if (process.env.CLAUDE_SUBAGENT_ID && approveCommands.every((c) => isReadOnlyApproveInspection(c))) {
+		process.exit(0);
+	}
+
+	// PR 番号は全件抽出する。1 コマンドで複数 PR を叩く形があるため、1 件の evidence で
+	// 残りを通さない。1 件も取れない = 検証対象を特定できない = block (#4057)。
+	const prNumbers = [...new Set(approveCommands.flatMap((c) => extractPrNumbers(c)))].sort(
+		(a, b) => a - b,
+	);
+	if (prNumbers.length === 0) {
 		process.stderr.write(
 			`[gate-approve] BLOCK: approve 系コマンドだが PR 番号を command から抽出できませんでした。\n`,
 		);
 		process.stderr.write(
-			`  対処: PR 番号を command に明示してから再実行してください (例: \`gh pr merge 2588 --squash\`)。\n`,
+			`  検出したコマンド: ${(approveCommands.at(0) ?? '').slice(0, 200).replace(/\n/g, ' ')}\n`,
+		);
+		process.stderr.write(
+			`  対処: PR 番号を command に **リテラルで** 明示してから再実行してください (例: \`gh pr merge 2588 --squash\`)。\n`,
+		);
+		process.stderr.write(
+			`  Why: ループ変数 / コマンド置換 (\`/pulls/$n/reviews\`) では hook がどの PR の evidence を\n`,
+		);
+		process.stderr.write(
+			`       検証すべきか確定できません。確定できないものは通さない側に倒します (#4057 / ADR-0056)。\n`,
 		);
 		process.exit(2);
 	}
 
-	const result = verifyEvidence(prNumber);
-	if (result.ok) {
+	/** @type {{ prNumber: number; reason: string }[]} */
+	const failures = [];
+	for (const prNumber of prNumbers) {
+		const result = verifyEvidence(prNumber);
+		if (!result.ok) failures.push({ prNumber, reason: result.reason });
+	}
+	if (failures.length === 0) {
 		process.exit(0);
 	}
 
+	const [first] = failures;
+	const prNumber = first.prNumber;
 	// deny: stderr に修正手順を出す
 	process.stderr.write(
-		`[gate-approve] BLOCK: PR #${prNumber} の Adversarial Reviewer evidence 検証 fail.\n`,
+		`[gate-approve] BLOCK: PR #${failures.map((f) => f.prNumber).join(', #')} の Adversarial Reviewer evidence 検証 fail.\n`,
 	);
-	process.stderr.write(`  reason: ${result.reason}\n`);
+	for (const failure of failures) {
+		process.stderr.write(`  reason (#${failure.prNumber}): ${failure.reason}\n`);
+	}
 	process.stderr.write(`  対処:\n`);
 	process.stderr.write(
 		`    1. Adversarial Reviewer subagent を dispatch する (\`.claude/skills/adversarial-reviewer/SKILL.md\` 参照)\n`,
@@ -434,16 +602,24 @@ async function main() {
  * @param {unknown} err
  */
 function reportIsMainLoadFailure(err) {
-	const msg = err instanceof Error ? err.message : String(err);
+	// どの module が欠けたかを列挙する。#4075 では `command-execution-tools.mjs` の欠落を
+	// `is-main.mjs` の話として報告していると原因に辿り着けない。
+	const failures =
+		moduleLoadFailures.length > 0
+			? moduleLoadFailures
+			: [{ path: 'scripts/lib/is-main.mjs', err }];
 	process.stderr.write(
-		`[gate-approve] BLOCK: 判定 SSOT scripts/lib/is-main.mjs を読み込めませんでした。\n`,
+		`[gate-approve] BLOCK: 判定 SSOT module を読み込めませんでした (${failures.map((f) => f.path).join(' / ')})。\n`,
 	);
-	process.stderr.write(`  reason: ${msg}\n`);
+	for (const failure of failures) {
+		const msg = failure.err instanceof Error ? failure.err.message : String(failure.err);
+		process.stderr.write(`  reason (${failure.path}): ${msg}\n`);
+	}
 	process.stderr.write(
-		`  ADR-0056 の approve gate は判定不能時に block 側へ倒します (fail-closed / #3999)。\n`,
+		`  ADR-0056 の approve gate は判定不能時に block 側へ倒します (fail-closed / #3999 / #4075)。\n`,
 	);
 	process.stderr.write(
-		`  対処: checkout に scripts/lib/is-main.mjs があるか、hook を repo root から起動しているかを確認してください。\n`,
+		`  対処: checkout に上記 module があるか、hook を repo root から起動しているかを確認してください。\n`,
 	);
 }
 

--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -111,7 +111,7 @@ try {
 } catch (err) {
 	moduleLoadFailures.push({ path: '.claude/hooks/command-execution-tools.mjs', err });
 }
-if (moduleLoadFailures.length > 0) isMainLoadError = moduleLoadFailures[0].err;
+isMainLoadError = moduleLoadFailures.at(0)?.err ?? null;
 
 /**
  * gh-command SSOT を取り出す。読み込めていなければ throw する (呼出元は main() 経由で
@@ -558,11 +558,12 @@ async function main() {
 		const result = verifyEvidence(prNumber);
 		if (!result.ok) failures.push({ prNumber, reason: result.reason });
 	}
-	if (failures.length === 0) {
+	const first = failures.at(0);
+	if (first === undefined) {
 		process.exit(0);
 	}
 
-	const [first] = failures;
+	// 修正手順の例示に使う代表 PR (複数 fail 時は先頭)。全 PR 番号は下の一覧で出す。
 	const prNumber = first.prNumber;
 	// deny: stderr に修正手順を出す
 	process.stderr.write(

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,9 @@
 {
-  "$comment": "Claude Code session settings. PreToolUse hooks: (1) #1879 — prevent QA account (ganbariquestsupport-lab) from `gh pr create`. (2) ADR-0056 — gate `gh pr merge/review --approve` behind Adversarial Reviewer evidence (must_object_count=3 schema). (3) 複数エージェントセッションの重い検証を排他する (docs/sessions/agent-concurrency.md)。PostToolUse は (3) の lock 解放。matcher はコマンド実行系ツール全経路を覆うこと — SSOT は .claude/hooks/command-execution-tools.mjs の COMMAND_EXECUTION_MATCHER で、tests/unit/hooks/command-execution-tools.test.ts が一致を機械検証する (#4001: matcher が Bash だけの間、PowerShell 経由で全 hook を bypass できた)。See ADR-0022 amendment / ADR-0056 / docs/sessions/qa-session.md.",
+  "$comment": "Claude Code session settings. PreToolUse hooks: (1) #1879 — prevent QA account (ganbariquestsupport-lab) from `gh pr create`. (2) ADR-0056 — gate `gh pr merge/review --approve` behind Adversarial Reviewer evidence (must_object_count=3 schema). (3) 複数エージェントセッションの重い検証を排他する (docs/sessions/agent-concurrency.md)。PostToolUse は (3) の lock 解放。matcher は「任意の副作用を起こせるツール」全経路を覆うこと — SSOT は .claude/hooks/command-execution-tools.mjs の COMMAND_EXECUTION_MATCHER で、tests/unit/hooks/command-execution-tools.test.ts が一致を機械検証する (#4001: matcher が Bash だけの間、PowerShell 経由で全 hook を bypass できた / #4082 R1: 判定軸を shell か否かから任意副作用の有無に変え、汎用コード実行 MCP を追加した)。See ADR-0022 amendment / ADR-0056 / docs/sessions/qa-session.md.",
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "Bash|PowerShell",
+        "matcher": "Bash|PowerShell|mcp__ide__executeCode",
         "hooks": [
           {
             "type": "command",
@@ -22,7 +22,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Bash|PowerShell",
+        "matcher": "Bash|PowerShell|mcp__ide__executeCode",
         "hooks": [
           {
             "type": "command",

--- a/docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md
+++ b/docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md
@@ -63,20 +63,34 @@ memory / ADR で覆せない理論根拠 (詳細は research SSOT §3):
 - 判別できない入力 (stdin JSON parse 不能 / `tool_name` 欠落 / command 非文字列) は **allow ではなく block** する。SSOT 未登録ツール名で呼ばれた場合も allow に倒さず `tool_input` 内の全文字列を走査する
 - `tmp/adversarial-evidence/<pr-number>.json` の **存在 + 30 分 TTL + schema 必須 field** を検証
 - 不在 / TTL 切れ / schema 不正で exit 2 + stderr に修正手順 ("Adversarial Reviewer subagent を先に dispatch")
-- recursive loop 防止: `CLAUDE_SUBAGENT_ID` env 設定時 (subagent context) は無条件 allow
+- recursive loop 防止: `CLAUDE_SUBAGENT_ID` env 設定時 (subagent context) は **読み取り専用の review 参照だけ** allow。approve mutation (`gh pr merge` / `--approve` / 非 GET の `gh api`) は subagent でも evidence gate に掛ける (#4082 R2)
+- **approve 行為の識別を「PR 番号の書き方」から切り離す** (#4057): `pulls/<ref>/{reviews,merge}` は ref の形 (`4002` / `$n` / `$(…)`) を問わず approve 行為として捕捉し、**番号が確定できないなら block** する。番号は全件抽出し、1 コマンドが複数 PR を叩く形では全 PR の evidence を要求する
 - 既存 `scripts/claude-hook-prevent-qa-account-pr.mjs` の規約 (exit 2 / stdin JSON / `.claude/settings.json` の `hooks[].hooks[]` ネスト) を踏襲
 
-#### 既知の残存 bypass (#4001 棚卸、未解消)
+#### 残存 bypass の棚卸 (#4001 起票 → #4057 / #4075 / #4082 で処理)
 
-本 gate は「approve 系コマンドの文字列検査」であり、以下は**塞げていない**。塞いだ範囲を過大評価しないため明示する (silent gap 化の防止)。
+本 gate は「approve 相当操作の検査」であり、塞いだ範囲を過大評価しないため状態を明示する (silent gap 化の防止)。
 
-| # | 残存経路 | 状態 |
+| # | 経路 | 状態 |
 |---|---|---|
-| R1 | `mcp__ide__executeCode` 等の汎用コード実行系 MCP ツール — matcher にも `command-execution-tools.mjs` の棚卸しにも不在で、gate 自体が起動しない | 未対処 |
-| R2 | `process.env.CLAUDE_SUBAGENT_ID` の無条件 allow — subagent context を騙れば**どのツール経由でも**素通りする (recursive loop 防止の代償) | 設計上の受容、代替案未検討 |
-| R3 | `Agent` tool の `isolation: "remote"` 実行時に hook が継承されるか未検証 | 未検証 |
-| R4 | `isApproveAction` の `/pulls/\d+/reviews` が**数字リテラル依存**のため、ループ変数形 (`/pulls/$n/reviews`) は `exit 0` で evidence 検証ごと素通りする | **Issue #4057** |
-| R5 | stdin JSON parse 失敗の fail-closed が導入した新障害モードが `isMain` ガード内で未テスト | test gap |
+| R1 | 汎用コード実行系 MCP ツール (`mcp__ide__executeCode` 等) — matcher にも SSOT にも不在で gate 自体が起動しなかった | **対処 (#4082)**: 判定軸を「shell か」から「任意の副作用を起こせるか」に変更し SSOT + matcher に収録。payload は key 決め打ちせず全文字列 + 区切り均し変種を走査。**残余は accepted residual (下記)** |
+| R2 | `CLAUDE_SUBAGENT_ID` の無条件 allow — subagent context ではどのツール経由でも素通りした | **対処 (#4082)**: 許可を「GET の review 参照」だけに絞り、approve mutation は subagent でも block |
+| R3 | `Agent` tool の `isolation: "remote"` で hook が継承されるか | **accepted residual (下記)**: このリポジトリからは制御も検証もできない。検知層で代替 |
+| R4 | `isApproveAction` の `/pulls/\d+/reviews` が数字リテラル依存で、ループ変数形が素通りした | **対処 (#4057)**: ref の形を問わず捕捉し、番号未確定は block |
+| R5 | sibling module の static import 欠落が exit 1 (= 素通し) に倒れる | **対処 (#4075)**: 相対 import を全て dynamic + exit 2 化。static import 0 件を fitness function で機械強制 |
+
+#### accepted residual — 塞げないと判断したもの (#4082 AC5)
+
+**列挙型の防御は原理的に「次に増える経路」を先回りできない**。以下 2 つは prevention では閉じないと判断し、**検知層**で代替する。
+
+| 残余 | なぜ塞げないか | 代替 (検知) |
+|---|---|---|
+| **R1 残余**: 未棚卸のコード実行ツール / 動的組み立て (変数経由・base64・eval) されたコマンド | 任意言語の構文を完全解釈することは不可能。リテラルで書かれた形しか掴めない | `scripts/audit-approve-evidence.mjs` |
+| **R3**: remote isolation での hook 継承 | 実行基盤側の仕様であり、リポジトリ内の設定では保証も検証もできない | 同上 |
+
+検知層 `scripts/audit-approve-evidence.mjs` は **効果が着地した場所 (GitHub の review 一覧)** を入力にするため、approve がどの経路で行われたかに依存しない。`--pr <n>` で APPROVE を列挙し evidence と突き合わせ、裏付けの無い approve を exit 1 で報告する。限界 (evidence は git 管理外のためローカル実行前提 / TTL 30 分) は script 冒頭に明記してある。
+
+**運用**: QM は merge 前に `node scripts/audit-approve-evidence.mjs --pr <n>` を実行する。remote / 未棚卸経路で approve された場合はここで検出し、経路を本表に追記する。
 
 ### 2. Adversarial Reviewer subagent (`.claude/skills/adversarial-reviewer/SKILL.md`)
 

--- a/docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md
+++ b/docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md
@@ -65,6 +65,8 @@ memory / ADR で覆せない理論根拠 (詳細は research SSOT §3):
 - 不在 / TTL 切れ / schema 不正で exit 2 + stderr に修正手順 ("Adversarial Reviewer subagent を先に dispatch")
 - recursive loop 防止: `CLAUDE_SUBAGENT_ID` env 設定時 (subagent context) は **読み取り専用の review 参照だけ** allow。approve mutation (`gh pr merge` / `--approve` / 非 GET の `gh api`) は subagent でも evidence gate に掛ける (#4082 R2)
 - **approve 行為の識別を「PR 番号の書き方」から切り離す** (#4057): `pulls/<ref>/{reviews,merge}` は ref の形 (`4002` / `$n` / `$(…)`) を問わず approve 行為として捕捉し、**番号が確定できないなら block** する。番号は全件抽出し、1 コマンドが複数 PR を叩く形では全 PR の evidence を要求する
+- **検証対象 PR は「実際に叩かれる invocation」からのみ確定する** (#4095): 番号は同一 `gh` invocation の argv / API パスから取り、コマンド全体の走査はしない。確定不能な hit が 1 件でもあれば、他にリテラル番号があっても block する (近くの数字を採ると evidence のある PR の番号で別 PR が通る)
+- **flag の長短 / API 種別で穴を作らない** (#4095): `gh pr review` の approve 指定は `--approve` と短縮 `-a` (cluster 含む) の両方を argv token 単位で判定し、`gh api graphql` の `addPullRequestReview` / `mergePullRequest` / `event: APPROVE` も approve 相当として捕捉する
 - 既存 `scripts/claude-hook-prevent-qa-account-pr.mjs` の規約 (exit 2 / stdin JSON / `.claude/settings.json` の `hooks[].hooks[]` ネスト) を踏襲
 
 #### 残存 bypass の棚卸 (#4001 起票 → #4057 / #4075 / #4082 で処理)
@@ -78,15 +80,21 @@ memory / ADR で覆せない理論根拠 (詳細は research SSOT §3):
 | R3 | `Agent` tool の `isolation: "remote"` で hook が継承されるか | **accepted residual (下記)**: このリポジトリからは制御も検証もできない。検知層で代替 |
 | R4 | `isApproveAction` の `/pulls/\d+/reviews` が数字リテラル依存で、ループ変数形が素通りした | **対処 (#4057)**: ref の形を問わず捕捉し、番号未確定は block |
 | R5 | sibling module の static import 欠落が exit 1 (= 素通し) に倒れる | **対処 (#4075)**: 相対 import を全て dynamic + exit 2 化。static import 0 件を fitness function で機械強制 |
+| R6 | `gh pr review -a` (`--approve` の正式な短縮 flag) — 検出 regex が長形しか見ておらず素通りした | **対処 (#4095)**: `gh pr review` の argv を token 単位で見て `-a` / short flag cluster (`-ab`) も捕捉。`-c` / `-r` は非対象 |
+| R7 | `gh api graphql` の `addPullRequestReview` / `mergePullRequest` mutation — `parseGhApiInvocation` が `graphql` を path として収集していたのに、参照側が pulls 系しか見ず**死んだ枝**になっていた | **対処 (#4095)**: graphql エンドポイント × approve 相当 mutation 名 / `event: APPROVE` の論理積で捕捉。PR は node ID 指定のため番号確定不能 = 常に block。**payload をファイル / 変数から渡す形は残余 (下記)** |
+| R8 | PR 番号確定がコマンド全体 regex で、「実際に叩かれる PR」ではなく近くの数字を採っていた。`for n in 4002 4010; do gh pr merge $n; done # rollup for 4002` が **4002 の evidence で 4010 を merge** できた | **対処 (#4095)**: 番号は同一 `gh` invocation の argv / API パスからのみ取る (shell コメント以降は打ち切り)。確定不能 hit が 1 件でもあれば、他にリテラル番号があっても block |
 
-#### accepted residual — 塞げないと判断したもの (#4082 AC5)
+R6 / R7 / R8 はいずれも **literal 形**であり、下記 accepted residual の定義 (動的組み立て / 未棚卸ツール) には該当しない。塞ぐべきものとして #4095 で処理した。
 
-**列挙型の防御は原理的に「次に増える経路」を先回りできない**。以下 2 つは prevention では閉じないと判断し、**検知層**で代替する。
+#### accepted residual — 塞げないと判断したもの (#4082 AC5 / #4095 で追補)
+
+**列挙型の防御は原理的に「次に増える経路」を先回りできない**。以下は prevention では閉じないと判断し、**検知層**で代替する。
 
 | 残余 | なぜ塞げないか | 代替 (検知) |
 |---|---|---|
 | **R1 残余**: 未棚卸のコード実行ツール / 動的組み立て (変数経由・base64・eval) されたコマンド | 任意言語の構文を完全解釈することは不可能。リテラルで書かれた形しか掴めない | `scripts/audit-approve-evidence.mjs` |
 | **R3**: remote isolation での hook 継承 | 実行基盤側の仕様であり、リポジトリ内の設定では保証も検証もできない | 同上 |
+| **R7 残余**: GraphQL payload を `--input <file>` / 変数経由で渡す形 | hook はコマンド文字列しか見ないため、外部ファイルの中身は判定材料にできない (R1 残余と同一 class) | 同上 |
 
 検知層 `scripts/audit-approve-evidence.mjs` は **効果が着地した場所 (GitHub の review 一覧)** を入力にするため、approve がどの経路で行われたかに依存しない。`--pr <n>` で APPROVE を列挙し evidence と突き合わせ、裏付けの無い approve を exit 1 で報告する。限界 (evidence は git 管理外のためローカル実行前提 / TTL 30 分) は script 冒頭に明記してある。
 

--- a/scripts/audit-approve-evidence.mjs
+++ b/scripts/audit-approve-evidence.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+/**
+ * scripts/audit-approve-evidence.mjs (#4082 AC3 / AC5)
+ *
+ * PR に付いた **APPROVE を、それが行われた経路に依存せず**事後監査する。
+ *
+ * ## なぜ hook では足りないのか
+ *
+ * `.claude/hooks/gate-approve.mjs` (ADR-0056) は PreToolUse hook であり、**hook が起動する
+ * 経路でしか効かない**。以下 2 つは matcher をどれだけ広げても原理的に塞げない (ADR-0056
+ * §残存 bypass):
+ *
+ *   - **R1 残余**: まだ棚卸ししていない code-execution 系ツールが増えれば、そこから起こした
+ *     副作用に gate は掛からない。列挙型の防御は「次に増えるもの」を先回りできない
+ *   - **R3**: `Agent` tool の `isolation: "remote"` 実行環境が project hook を継承するかは、
+ *     このリポジトリからは制御も検証もできない (実行基盤側の仕様)
+ *
+ * そこで防御層とは別に、**効果が着地した場所 (GitHub の review 一覧)** を入力にした検知層を置く。
+ * どの経路で approve されたかに関わらず、「evidence 無しの APPROVE」は必ずここに現れる。
+ * 予防ではなく検知であることを明示したうえで、silent gap にはしない。
+ *
+ * ## 使い方
+ *
+ *   node scripts/audit-approve-evidence.mjs --pr 4082
+ *   node scripts/audit-approve-evidence.mjs --pr 4082 --json
+ *
+ * exit 0 = 全 APPROVE に適合 evidence あり / exit 1 = 未検証 approve あり / exit 2 = 実行エラー。
+ *
+ * ## 限界 (過大評価しないため明記する)
+ *
+ * evidence は `tmp/adversarial-evidence/` (git 管理外) にあるため、本監査は **evidence を
+ * 持つマシン上で実行したときにだけ**意味を持つ。別マシン / 別セッションで approve された分は
+ * 「evidence 不在」として報告される (偽陽性ではなく「このマシンでは検証できない」の意)。
+ * TTL (30 分) を過ぎた evidence は hook と同じ基準で不適合になるため、監査は approve 直後に
+ * 走らせる (QM の merge 前チェックに組み込む) ことを前提とする。
+ *
+ * ## 関連
+ *   - ADR-0056 (approve gate の設計 SSOT / 残存 bypass 表)
+ *   - .claude/hooks/gate-approve.mjs (verifyEvidence の SSOT。本 script は再実装しない)
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { verifyEvidence } from '../.claude/hooks/gate-approve.mjs';
+
+const HELP = `audit-approve-evidence — approve を経路非依存で事後監査する (#4082)
+
+  --pr <n>   監査対象の PR 番号 (必須)
+  --json     JSON で出力する
+  --help     このヘルプ
+
+exit 0 = 全 APPROVE に適合 evidence あり / 1 = 未検証 approve あり / 2 = 実行エラー
+`;
+
+/**
+ * @typedef {{ state: string; user: string; submittedAt?: string }} ReviewRecord
+ * @typedef {{ prNumber: number; reviews: ReviewRecord[] }} AuditInput
+ */
+
+/**
+ * review 一覧と evidence を突き合わせる (純関数、test 対象)。
+ *
+ * @param {AuditInput} input
+ * @param {string} cwd  evidence を探す作業 dir (test では temp tree を渡す)
+ * @returns {{ ok: boolean; approvals: ReviewRecord[]; unverified: { review: ReviewRecord; reason: string }[] }}
+ */
+export function auditApprovals(input, cwd = process.cwd()) {
+	const approvals = (input.reviews ?? []).filter((r) => r?.state === 'APPROVED');
+	/** @type {{ review: ReviewRecord; reason: string }[]} */
+	const unverified = [];
+	for (const review of approvals) {
+		const result = verifyEvidence(input.prNumber, cwd);
+		if (!result.ok) unverified.push({ review, reason: result.reason });
+	}
+	return { ok: unverified.length === 0, approvals, unverified };
+}
+
+/**
+ * GitHub から review 一覧を取る。
+ *
+ * @param {number} prNumber
+ * @returns {ReviewRecord[]}
+ */
+function fetchReviews(prNumber) {
+	const raw = execFileSync(
+		'gh',
+		['pr', 'view', String(prNumber), '--json', 'reviews', '--jq', '.reviews'],
+		{ encoding: 'utf8' },
+	);
+	const parsed = JSON.parse(raw || '[]');
+	return parsed.map(
+		/** @param {{ state?: string; author?: { login?: string }; submittedAt?: string }} r */ (
+			r,
+		) => ({
+			state: String(r?.state ?? ''),
+			user: String(r?.author?.login ?? 'unknown'),
+			submittedAt: r?.submittedAt,
+		}),
+	);
+}
+
+function main() {
+	const argv = process.argv.slice(2);
+	if (argv.includes('--help') || argv.includes('-h')) {
+		process.stdout.write(HELP);
+		return 0;
+	}
+	const prIndex = argv.indexOf('--pr');
+	const prNumber = prIndex >= 0 ? Number(argv[prIndex + 1]) : Number.NaN;
+	if (!Number.isInteger(prNumber) || prNumber <= 0) {
+		process.stderr.write('[audit-approve-evidence] --pr <n> は必須です。\n');
+		return 2;
+	}
+
+	/** @type {ReviewRecord[]} */
+	let reviews;
+	try {
+		reviews = fetchReviews(prNumber);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		process.stderr.write(`[audit-approve-evidence] review 一覧を取得できません: ${msg}\n`);
+		return 2;
+	}
+
+	const result = auditApprovals({ prNumber, reviews });
+	if (argv.includes('--json')) {
+		process.stdout.write(`${JSON.stringify({ prNumber, ...result }, null, 2)}\n`);
+	} else if (result.ok) {
+		process.stdout.write(
+			`[audit-approve-evidence] PR #${prNumber}: APPROVE ${result.approvals.length} 件、全て適合 evidence あり。\n`,
+		);
+	} else {
+		process.stderr.write(
+			`[audit-approve-evidence] PR #${prNumber}: **evidence で裏付けられない APPROVE** が ${result.unverified.length} 件あります。\n`,
+		);
+		for (const item of result.unverified) {
+			process.stderr.write(`  - ${item.review.user} (${item.review.submittedAt ?? '時刻不明'})\n`);
+			process.stderr.write(`    reason: ${item.reason}\n`);
+		}
+		process.stderr.write(
+			'  対処: Adversarial Reviewer subagent を dispatch して evidence を作り直し、approve をやり直すか、\n',
+		);
+		process.stderr.write(
+			'        別マシン / 別経路で approve された場合はその経路を ADR-0056 の残存 bypass 表に記録してください。\n',
+		);
+	}
+	return result.ok ? 0 : 1;
+}
+
+// CLI 実行時のみ main() を呼ぶ (test は auditApprovals を import して使う)。
+const { isMain } = await import('./lib/is-main.mjs');
+if (isMain(import.meta.url)) process.exit(main());

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -301,3 +301,48 @@ export function isPullsCollectionPath(path) {
 export function isPullsSubresourcePath(path, subresource) {
 	return new RegExp(`^repos/[^/]+/[^/]+/pulls/\\d+/${subresource}(?:/.*)?$`, 'i').test(path);
 }
+
+/**
+ * `repos/<owner>/<repo>/pulls/<何か>/<subresource>` か — **PR 識別子の形を問わない** (#4057)。
+ *
+ * `isPullsSubresourcePath` は PR 番号を `\d+` に固定していたため、`.../pulls/$n/reviews` の
+ * ようにループ変数で書くだけで approve 検出をすり抜けた (QM 実測。同時刻にリテラル形は
+ * 正しく BLOCK されており、**番号の書き方だけで gate の有無が変わっていた**)。
+ *
+ * approve 行為か否かは「PR 番号がリテラルで書かれているか」とは無関係なので、判定は
+ * subresource だけで行い、番号の確定は別工程 (取れなければ block) に分ける。
+ *
+ * @param {string} path  normalizeApiPath 済みのパス
+ * @param {string} subresource  `reviews` / `merge` 等
+ * @returns {boolean}
+ */
+export function isPullsSubresourcePathAnyRef(path, subresource) {
+	return new RegExp(`^repos/[^/]+/[^/]+/pulls/[^/]+/${subresource}(?:/.*)?$`, 'i').test(path);
+}
+
+/**
+ * `repos/<owner>/<repo>/pulls/<何か>…` — 特定 PR (またはその subresource) を指すパスか。
+ *
+ * コレクション (`…/pulls`) は含まない。PR 作成 (コレクション POST) は ADR-0022 L1 の責務で、
+ * 本判定の対象ではないため。
+ *
+ * @param {string} path  normalizeApiPath 済みのパス
+ * @returns {boolean}
+ */
+export function isPullsScopedPath(path) {
+	return /^repos\/[^/]+\/[^/]+\/pulls\/.+$/i.test(path);
+}
+
+/**
+ * token に **未展開のシェル展開**が残っているか (#4057)。
+ *
+ * `$(cmd)` / `` `cmd` `` / `$VAR` / `${VAR}` / `%VAR%` (cmd.exe)。これらを含むパスは
+ * hook 側から見て**実際に叩かれる URL を確定できない**。確定できないものを「approve ではない」
+ * 側に倒すと、書き方を変えるだけで gate を抜けられる (#4057 の実測形がまさにこれ)。
+ *
+ * @param {string} token
+ * @returns {boolean}
+ */
+export function hasUnresolvedExpansion(token) {
+	return /\$\(|\$\{|\$[A-Za-z_]|`|%[A-Za-z_][A-Za-z0-9_]*%/.test(String(token ?? ''));
+}

--- a/tests/unit/helpers/hook-tree-probe.ts
+++ b/tests/unit/helpers/hook-tree-probe.ts
@@ -63,6 +63,13 @@ export interface HookProbeOptions {
 	omitRelPaths?: string[];
 	/** hook プロセスに追加で渡す環境変数 (`CLAUDE_SUBAGENT_ID` 等) */
 	env?: Record<string, string>;
+	/**
+	 * temp tree の `tmp/adversarial-evidence/<pr>.json` に **schema 適合の evidence** を置く PR 番号 (#4095)。
+	 *
+	 * 「evidence がある PR の番号で、evidence が無い別 PR の approve が通らないか」を実測するために使う
+	 * (QM Re-Review O-3 の再現条件 = evidence は 4002 のみ存在)。
+	 */
+	evidencePrNumbers?: number[];
 	/** hook に渡す stdin (Claude Code の PreToolUse payload JSON) */
 	stdin: string;
 }
@@ -104,15 +111,44 @@ function copyRelativeImports(root: string, hookRelPath: string, omit: string[] =
 }
 
 /**
+ * temp tree に **gate を通る** adversarial evidence を 1 件書く (#4095)。
+ *
+ * 値は `.claude/hooks/gate-approve.mjs` の `verifyEvidence` 要件 (must_object_count 3 / 3 軸 /
+ * reason >= 100 文字 / mtime 30 分以内) を満たす。gate 側の閾値を緩めた変更が入れば、
+ * 「evidence あり = exit 0」の陽性対照が壊れる形で検出される。
+ */
+function writeValidEvidence(root: string, prNumber: number): void {
+	const dir = path.join(root, 'tmp', 'adversarial-evidence');
+	mkdirSync(dir, { recursive: true });
+	const reason = `${'X'.repeat(120)} (probe evidence)`;
+	writeFileSync(
+		path.join(dir, `${prNumber}.json`),
+		JSON.stringify({
+			pr_number: prNumber,
+			my_role: 'adversarial_reviewer (NOT QM, NOT Dev)',
+			must_object_count: 3,
+			objections: [
+				{ axis: 'business', reason },
+				{ axis: 'UX', reason },
+				{ axis: 'security', reason },
+			],
+		}),
+		'utf8',
+	);
+}
+
+/**
  * hook を隔離 tree で起動し、exit code と出力を返す。
  *
  * `cwd` は temp tree root にする。hook が参照する `tmp/adversarial-evidence/` も
  * temp tree 側を見るため、実 repo の evidence file に結果が左右されない。
  */
 export function runHookInIsolatedTree(options: HookProbeOptions): HookProbeResult {
-	const { hookRelPath, withIsMain, isMainSource, stdin, omitRelPaths, env } = options;
+	const { hookRelPath, withIsMain, isMainSource, stdin, omitRelPaths, env, evidencePrNumbers } =
+		options;
 	const root = mkdtempSync(path.join(tmpdir(), 'gq-hook-probe-'));
 	try {
+		for (const prNumber of evidencePrNumbers ?? []) writeValidEvidence(root, prNumber);
 		copyInto(root, hookRelPath);
 		copyRelativeImports(root, hookRelPath, omitRelPaths);
 		if (withIsMain) {

--- a/tests/unit/helpers/hook-tree-probe.ts
+++ b/tests/unit/helpers/hook-tree-probe.ts
@@ -53,6 +53,16 @@ export interface HookProbeOptions {
 	 * になるため呼び出すと `TypeError` になる = 素通し側に倒れうる。
 	 */
 	isMainSource?: string;
+	/**
+	 * 複製から **除外** する repo 相対パス (#4075)。
+	 *
+	 * `is-main.mjs` 以外の sibling module (`./command-execution-tools.mjs` 等) が欠落した
+	 * checkout を再現するために使う。#3999 が `is-main.mjs` だけを fail-closed 化した結果、
+	 * 同 class の穴が別の import に残っていた (= 同 class の網羅漏れ) ことを probe できる。
+	 */
+	omitRelPaths?: string[];
+	/** hook プロセスに追加で渡す環境変数 (`CLAUDE_SUBAGENT_ID` 等) */
+	env?: Record<string, string>;
 	/** hook に渡す stdin (Claude Code の PreToolUse payload JSON) */
 	stdin: string;
 }
@@ -76,7 +86,7 @@ function copyInto(root: string, relPath: string): void {
  * `./lib/gh-command.mjs` を読むようになったため、同階層限定では足りない)。
  * `is-main.mjs` だけは **除外** し、`withIsMain` の明示制御に委ねる。
  */
-function copyRelativeImports(root: string, hookRelPath: string): void {
+function copyRelativeImports(root: string, hookRelPath: string, omit: string[] = []): void {
 	const hookDir = hookRelPath.split('/').slice(0, -1).join('/');
 	const source = readFileSync(path.join(REPO_ROOT, ...hookRelPath.split('/')), 'utf8');
 	// `from '<rel>'` (static) と `import('<rel>')` (dynamic) の両方を拾う
@@ -87,6 +97,7 @@ function copyRelativeImports(root: string, hookRelPath: string): void {
 			// hookDir 基準で解決して repo 相対 (POSIX 区切り) に正規化する
 			const rel = path.posix.normalize(path.posix.join(hookDir, spec));
 			if (rel === IS_MAIN_REL) continue; // withIsMain で制御する対象は複製しない
+			if (omit.includes(rel)) continue; // 欠落を再現したい module (#4075)
 			copyInto(root, rel);
 		}
 	}
@@ -99,11 +110,11 @@ function copyRelativeImports(root: string, hookRelPath: string): void {
  * temp tree 側を見るため、実 repo の evidence file に結果が左右されない。
  */
 export function runHookInIsolatedTree(options: HookProbeOptions): HookProbeResult {
-	const { hookRelPath, withIsMain, isMainSource, stdin } = options;
+	const { hookRelPath, withIsMain, isMainSource, stdin, omitRelPaths, env } = options;
 	const root = mkdtempSync(path.join(tmpdir(), 'gq-hook-probe-'));
 	try {
 		copyInto(root, hookRelPath);
-		copyRelativeImports(root, hookRelPath);
+		copyRelativeImports(root, hookRelPath, omitRelPaths);
 		if (withIsMain) {
 			if (isMainSource === undefined) {
 				copyInto(root, IS_MAIN_REL);
@@ -118,6 +129,9 @@ export function runHookInIsolatedTree(options: HookProbeOptions): HookProbeResul
 			cwd: root,
 			input: stdin,
 			encoding: 'utf8',
+			// `CLAUDE_SUBAGENT_ID` は実セッションの env に混ざりうる。probe 側で明示指定が
+			// 無いときは必ず外し、「たまたま env が立っていたので通った」を作らない (#4082 R2)。
+			env: { ...process.env, CLAUDE_SUBAGENT_ID: undefined, ...env },
 		});
 		const stdout = `${res.stdout ?? ''}`;
 		const stderr = `${res.stderr ?? ''}`;

--- a/tests/unit/hooks/gate-approve-fail-closed.test.ts
+++ b/tests/unit/hooks/gate-approve-fail-closed.test.ts
@@ -1,0 +1,410 @@
+/**
+ * tests/unit/hooks/gate-approve-fail-closed.test.ts (#4057 / #4075 / #4082)
+ *
+ * ADR-0056 approve gate を **fail-closed** に倒した 3 欠陥の回帰テスト。
+ *
+ * 3 件は別々の Issue だが root class は 1 つ — **gate の発火条件を「守るべき不変条件
+ * (= approve 行為であること)」ではなく「コマンドの表層的な書き方 / 実行経路の種別」に
+ * 結びつけていた**こと。表層依存の検出は必ず変種で回避されるため、本 test は
+ * 「素通り (exit 0) がありえないこと」を変種ごとに固定する。
+ *
+ * 固定する不変条件:
+ *   1. (#4057) PR 番号がリテラルで現れない形 (ループ変数 / コマンド置換 / PowerShell 変数) でも
+ *      approve 行為として捕捉し、番号が確定できないなら **BLOCK** する
+ *   2. (#4075) sibling module (`./command-execution-tools.mjs`) が欠落した checkout でも
+ *      exit 1 (= 素通し) に倒れず exit 2 (= block) になる
+ *   3. (#4082 R2) `CLAUDE_SUBAGENT_ID` が立っていても **approve mutation は素通ししない**
+ *   4. (#4082 R1) 汎用コード実行 MCP ツール経路 (`mcp__ide__executeCode`) が検査対象に入る
+ *
+ * 併置する陽性対照 (ADR-0006 — guard を弱めていないこと):
+ *   - 正規の approve 経路 (PR 番号リテラル + evidence 適合) は引き続き通る
+ *   - approve と無関係なコマンドは引き続き素通りする (過剰 block していない)
+ *
+ * 関連: ADR-0056 / ADR-0061 (same-class-N→guard) / #3999 (先行する同 class の fail-open)
+ */
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+	COMMAND_EXECUTION_MATCHER,
+	COMMAND_EXECUTION_TOOLS,
+	matcherCoversTool,
+	SHELL_COMMAND_TOOLS,
+} from '../../../.claude/hooks/command-execution-tools.mjs';
+import {
+	extractPrNumber,
+	extractPrNumbers,
+	isApproveAction,
+	isReadOnlyApproveInspection,
+	MIN_REASON_LENGTH,
+	REQUIRED_OBJECT_COUNT,
+	resolveInspectableCommands,
+} from '../../../.claude/hooks/gate-approve.mjs';
+import { bashPayload, runHookInIsolatedTree } from '../helpers/hook-tree-probe';
+
+// ---------------------------------------------------------------------------
+// #4057 — PR 番号をリテラルで含まないコマンド形 (QM 実測、2026-07-29)
+// ---------------------------------------------------------------------------
+
+/**
+ * QM セッションで **実際に素通りした**コマンド (Issue #4057 本文の再現形)。
+ *
+ * 番号をリテラルで書いた `.../pulls/4002/reviews` は同時刻に正しく BLOCK されたのに、
+ * ループ変数 `$n` にしただけで `isApproveAction === false` になり evidence 検証ごと素通りした。
+ */
+const LOOP_VARIABLE_APPROVE = [
+	'for n in 4002 4010; do',
+	'  GH_TOKEN=$(gh auth token --user ganbariquestsupport-lab) \\',
+	'    gh api repos/Takenori-Kusaka/ganbari-quest/pulls/$n/reviews -X POST -f event=APPROVE -f body=LGTM',
+	'done',
+].join('\n');
+
+/** 同時刻に **正しく BLOCK された**リテラル形 (陽性対照)。 */
+const LITERAL_APPROVE =
+	'gh api repos/Takenori-Kusaka/ganbari-quest/pulls/4002/reviews -X POST -f event=APPROVE';
+
+/** コマンド置換で PR 番号を埋める形 (同 class の別変種)。 */
+const COMMAND_SUBSTITUTION_APPROVE =
+	"gh api repos/Takenori-Kusaka/ganbari-quest/pulls/$(gh pr list -L1 --json number -q '.[0].number')/reviews -X POST -f event=APPROVE";
+
+/** PowerShell 変数展開形 (同 class の別変種、#4001 で塞いだ経路の書き方違い)。 */
+const POWERSHELL_VARIABLE_APPROVE =
+	'& \'gh\' api "repos/Takenori-Kusaka/ganbari-quest/pulls/$n/reviews" -X POST -f event=APPROVE';
+
+describe('#4057 — PR 番号がリテラルで現れない approve 形', () => {
+	it('ループ変数形 ($n) を approve 行為として捕捉する (実測の素通り形)', () => {
+		expect(isApproveAction(LOOP_VARIABLE_APPROVE)).toBe(true);
+	});
+
+	it('ループ変数形からは PR 番号を確定できない → null (ループ列挙値 4002 を推測しない)', () => {
+		// `for n in 4002 4010` の 4002 を拾うと、evidence が 4002 の分しか無いのに
+		// 4010 まで approve が通る。「近くにある数字」を PR 番号として採用しない。
+		expect(extractPrNumber(LOOP_VARIABLE_APPROVE)).toBe(null);
+		expect(extractPrNumbers(LOOP_VARIABLE_APPROVE)).toEqual([]);
+	});
+
+	it('コマンド置換形を approve 行為として捕捉し、番号は確定できない', () => {
+		expect(isApproveAction(COMMAND_SUBSTITUTION_APPROVE)).toBe(true);
+		expect(extractPrNumbers(COMMAND_SUBSTITUTION_APPROVE)).toEqual([]);
+	});
+
+	it('PowerShell 変数展開形を approve 行為として捕捉し、番号は確定できない', () => {
+		expect(isApproveAction(POWERSHELL_VARIABLE_APPROVE)).toBe(true);
+		expect(extractPrNumbers(POWERSHELL_VARIABLE_APPROVE)).toEqual([]);
+	});
+
+	it('陽性対照: リテラル形は従来どおり捕捉し番号も取れる', () => {
+		expect(isApproveAction(LITERAL_APPROVE)).toBe(true);
+		expect(extractPrNumbers(LITERAL_APPROVE)).toEqual([4002]);
+	});
+
+	it('1 コマンドで複数 PR を approve する形は全 PR 番号を返す (1 件の evidence で 2 件通さない)', () => {
+		expect(extractPrNumbers('gh pr merge 4002 --squash && gh pr merge 4010 --squash')).toEqual([
+			4002, 4010,
+		]);
+	});
+
+	it('過剰 block しない: pulls コレクション POST (= PR 作成) は approve 判定に入らない', () => {
+		expect(isApproveAction('gh api repos/Takenori-Kusaka/ganbari-quest/pulls -X POST')).toBe(false);
+	});
+
+	it('過剰 block しない: 変数展開があっても pulls 配下でなければ対象外', () => {
+		expect(isApproveAction('gh api repos/$OWNER/$REPO/issues/$n/comments -X POST')).toBe(false);
+	});
+});
+
+describe('#4057 — hook 実行 (exit code) で素通りしないことを固定する', () => {
+	const HOOK = '.claude/hooks/gate-approve.mjs';
+
+	it('ループ変数形の approve → exit 2 (旧実装は exit 0 で素通りした)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			stdin: bashPayload(LOOP_VARIABLE_APPROVE),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+		expect(res.stderr).toContain('PR 番号');
+	}, 30_000);
+
+	it('陽性対照: approve と無関係なコマンドは素通りする (exit 0 / 無出力)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			stdin: bashPayload('gh pr view 4057 --json title'),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(0);
+		expect(res.combined.trim()).toBe('');
+	}, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// #4075 — sibling static import の欠落による fail-open
+// ---------------------------------------------------------------------------
+
+describe('#4075 — sibling module 欠落時に fail-open しない', () => {
+	const HOOK = '.claude/hooks/gate-approve.mjs';
+	const SIBLING = '.claude/hooks/command-execution-tools.mjs';
+	const APPROVE_CMD = 'gh pr merge 4075 --squash';
+
+	it('command-execution-tools.mjs が無い tree で approve → exit 2 (exit 1 = 素通しに倒れない)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			omitRelPaths: [SIBLING],
+			stdin: bashPayload(APPROVE_CMD),
+		});
+		expect(
+			res.status,
+			`exit 1 は Claude Code では non-blocking error として tool 実行が継続する (= approve 素通し)。出力:\n${res.combined}`,
+		).toBe(2);
+		expect(res.stderr).toContain('command-execution-tools.mjs');
+	}, 30_000);
+
+	it('陽性対照: sibling が揃った tree では evidence 不在を理由に exit 2 になる', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			stdin: bashPayload(APPROVE_CMD),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+		expect(res.stderr).toContain('evidence file 不在');
+	}, 30_000);
+});
+
+/**
+ * #4075 AC2 — **sibling を 1 本足しただけで fail-open が復活する構造**を機械的に閉じる。
+ *
+ * 「1 つの import を fail-closed 化したが、同種の import 全体には及んでいない」という
+ * 網羅漏れ (ADR-0061 §same-class-N→guard) が #3999 → #4075 で 2 回起きた。hook 本文を
+ * 静的に読み、**相対 module の static import が 0 件**であることを assert する。
+ */
+describe('#4075 AC2 — hook の相対 import は全て dynamic (fitness function)', () => {
+	const SETTINGS_PATH = resolve(process.cwd(), '.claude/settings.json');
+
+	/** settings.json に登録されている hook script の repo 相対パスを集める。 */
+	function registeredHookScripts(): string[] {
+		const settings = JSON.parse(readFileSync(SETTINGS_PATH, 'utf8')) as {
+			hooks?: Record<string, { hooks?: { command?: string }[] }[]>;
+		};
+		const paths = new Set<string>();
+		for (const entries of Object.values(settings.hooks ?? {})) {
+			for (const entry of entries) {
+				for (const hook of entry.hooks ?? []) {
+					const match = (hook.command ?? '').match(/(?:^|\s)((?:\.claude|scripts)\/\S+\.mjs)/);
+					if (match?.[1]) paths.add(match[1]);
+				}
+			}
+		}
+		return [...paths].sort();
+	}
+
+	const scripts = registeredHookScripts();
+
+	it('抽出が空振りしていない (0 件なら以降が vacuous pass になる)', () => {
+		expect(scripts.length).toBeGreaterThanOrEqual(3);
+		expect(scripts).toContain('.claude/hooks/gate-approve.mjs');
+	});
+
+	it.each(
+		scripts.map((p) => [p] as const),
+	)('%s に相対 module の static import が無い', (relPath) => {
+		const source = readFileSync(resolve(process.cwd(), relPath), 'utf8');
+		const staticRelativeImports = [
+			...source.matchAll(/^\s*import\s+[^;]*?from\s+'(\.[^']+)'/gm),
+		].map((m) => m[1]);
+		expect(
+			staticRelativeImports,
+			`static import は解決失敗が exit 1 (= 素通し) になる。dynamic import + exit 2 に倒すこと (#3999 / #4075)`,
+		).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4082 R2 — CLAUDE_SUBAGENT_ID の無条件 allow
+// ---------------------------------------------------------------------------
+
+describe('#4082 R2 — subagent context でも approve mutation は素通ししない', () => {
+	const HOOK = '.claude/hooks/gate-approve.mjs';
+
+	it('subagent context + gh pr merge → exit 2 (旧実装は無条件 allow だった)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			env: { CLAUDE_SUBAGENT_ID: 'adversarial-reviewer-1' },
+			stdin: bashPayload('gh pr merge 4082 --squash'),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+	}, 30_000);
+
+	it('subagent context + REST 直叩き approve → exit 2', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			env: { CLAUDE_SUBAGENT_ID: 'adversarial-reviewer-1' },
+			stdin: bashPayload(LITERAL_APPROVE),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+	}, 30_000);
+
+	it('recursive loop 防止は保つ: subagent が review 一覧を GET で読むのは通す', () => {
+		const readOnly =
+			'gh api repos/Takenori-Kusaka/ganbari-quest/pulls/4082/reviews --jq ".[].state"';
+		expect(isReadOnlyApproveInspection(readOnly)).toBe(true);
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			env: { CLAUDE_SUBAGENT_ID: 'adversarial-reviewer-1' },
+			stdin: bashPayload(readOnly),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(0);
+	}, 30_000);
+
+	it('subagent 以外の context では同じ GET も evidence gate の対象のまま (検出を弱めない)', () => {
+		const readOnly =
+			'gh api repos/Takenori-Kusaka/ganbari-quest/pulls/4082/reviews --jq ".[].state"';
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK,
+			withIsMain: true,
+			stdin: bashPayload(readOnly),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+	}, 30_000);
+
+	it('mutation を含む形は subagent でも read-only とみなさない', () => {
+		expect(isReadOnlyApproveInspection('gh pr merge 4082 --squash')).toBe(false);
+		expect(isReadOnlyApproveInspection(LITERAL_APPROVE)).toBe(false);
+		expect(isReadOnlyApproveInspection(LOOP_VARIABLE_APPROVE)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4082 R1 — 汎用コード実行 MCP ツール経路
+// ---------------------------------------------------------------------------
+
+describe('#4082 R1 — 判定軸を「shell か」から「任意の副作用を起こせるか」に変える', () => {
+	it('SSOT に汎用コード実行 MCP (mcp__ide__executeCode) が含まれる', () => {
+		expect(COMMAND_EXECUTION_TOOLS).toContain('mcp__ide__executeCode');
+		expect(SHELL_COMMAND_TOOLS).not.toContain('mcp__ide__executeCode');
+	});
+
+	it('matcher が SSOT の全ツールを覆う', () => {
+		for (const tool of COMMAND_EXECUTION_TOOLS) {
+			expect(matcherCoversTool(COMMAND_EXECUTION_MATCHER, tool)).toBe(true);
+		}
+	});
+
+	it('executeCode payload (tool_input.code) を検査対象にする — shell 文字列そのままの形', () => {
+		const r = resolveInspectableCommands({
+			tool_name: 'mcp__ide__executeCode',
+			tool_input: { code: 'import os; os.system("gh pr merge 4082 --squash")' },
+		});
+		expect(r.ok).toBe(true);
+		if (r.ok) {
+			expect(r.commands.some((c) => isApproveAction(c))).toBe(true);
+			expect(r.commands.flatMap((c) => extractPrNumbers(c))).toContain(4082);
+		}
+	});
+
+	it('executeCode payload — 言語構文で分断された引数配列形も掴む', () => {
+		const r = resolveInspectableCommands({
+			tool_name: 'mcp__ide__executeCode',
+			tool_input: { code: 'import subprocess; subprocess.run(["gh","pr","merge","4082"])' },
+		});
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.commands.some((c) => isApproveAction(c))).toBe(true);
+	});
+
+	it('過剰 block しない: approve と無関係な executeCode は素通り判定になる', () => {
+		const r = resolveInspectableCommands({
+			tool_name: 'mcp__ide__executeCode',
+			tool_input: { code: 'import pandas as pd; print(pd.read_csv("data.csv").head())' },
+		});
+		expect(r.ok).toBe(true);
+		if (r.ok) expect(r.commands.some((c) => isApproveAction(c))).toBe(false);
+	});
+
+	it('検査できる文字列が 1 つも無い payload は block (allow に倒さない)', () => {
+		const r = resolveInspectableCommands({
+			tool_name: 'mcp__ide__executeCode',
+			tool_input: { code: 42 },
+		});
+		expect(r.ok).toBe(false);
+		if (!r.ok) expect(r.reason).toMatch(/検査/);
+	});
+
+	it('shell ツールは従来どおり tool_input.command 必須 (非文字列は block)', () => {
+		const r = resolveInspectableCommands({ tool_name: 'Bash', tool_input: {} });
+		expect(r.ok).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// 事後監査 (#4082 R3 / R1 の残余に対する検知層)
+// ---------------------------------------------------------------------------
+
+describe('事後監査 — 経路に依存しない approve 検知 (#4082 AC5)', () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = join(tmpdir(), `approve-audit-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+		mkdirSync(resolve(tmpDir, 'tmp', 'adversarial-evidence'), { recursive: true });
+	});
+
+	afterEach(() => {
+		try {
+			rmSync(tmpDir, { recursive: true, force: true });
+		} catch {
+			// ignore
+		}
+	});
+
+	function writeEvidence(prNumber: number) {
+		const reason = 'X'.repeat(MIN_REASON_LENGTH + 10);
+		writeFileSync(
+			resolve(tmpDir, 'tmp', 'adversarial-evidence', `${prNumber}.json`),
+			JSON.stringify({
+				pr_number: prNumber,
+				must_object_count: REQUIRED_OBJECT_COUNT,
+				objections: [
+					{ axis: 'business', reason },
+					{ axis: 'UX', reason },
+					{ axis: 'security', reason },
+				],
+			}),
+			'utf8',
+		);
+	}
+
+	it('evidence 不在の APPROVE を未検証 approve として報告する', async () => {
+		const { auditApprovals } = await import('../../../scripts/audit-approve-evidence.mjs');
+		const result = auditApprovals(
+			{ prNumber: 4082, reviews: [{ state: 'APPROVED', user: 'ganbariquestsupport-lab' }] },
+			tmpDir,
+		);
+		expect(result.ok).toBe(false);
+		expect(result.unverified).toHaveLength(1);
+	});
+
+	it('evidence 適合の APPROVE は報告しない', async () => {
+		const { auditApprovals } = await import('../../../scripts/audit-approve-evidence.mjs');
+		writeEvidence(4082);
+		const result = auditApprovals(
+			{ prNumber: 4082, reviews: [{ state: 'APPROVED', user: 'ganbariquestsupport-lab' }] },
+			tmpDir,
+		);
+		expect(result.ok).toBe(true);
+		expect(result.unverified).toHaveLength(0);
+	});
+
+	it('APPROVE 以外の review は監査対象外 (過剰報告しない)', async () => {
+		const { auditApprovals } = await import('../../../scripts/audit-approve-evidence.mjs');
+		const result = auditApprovals(
+			{ prNumber: 4082, reviews: [{ state: 'COMMENTED', user: 'someone' }] },
+			tmpDir,
+		);
+		expect(result.ok).toBe(true);
+	});
+});

--- a/tests/unit/hooks/gate-approve-fail-closed.test.ts
+++ b/tests/unit/hooks/gate-approve-fail-closed.test.ts
@@ -141,6 +141,168 @@ describe('#4057 — hook 実行 (exit code) で素通りしないことを固定
 });
 
 // ---------------------------------------------------------------------------
+// #4095 QM Re-Review — 棚卸から漏れていた literal な approve 経路 3 種
+//
+// いずれも「変数経由 / base64 / eval」でも「未棚卸のコード実行ツール」でもない **literal 形**で、
+// ADR-0056 の accepted residual 定義に該当しない。QM が隔離 tree で exit 0 を実測した形を固定する。
+// ---------------------------------------------------------------------------
+
+const HOOK_PATH = '.claude/hooks/gate-approve.mjs';
+
+describe('#4095 O-1 — gh pr review の短縮 flag (-a)', () => {
+	it('`-a` (--approve の正式な短縮形) を approve 行為として捕捉する (QM 実測の素通り形)', () => {
+		expect(isApproveAction('gh pr review 4010 -a --body ok')).toBe(true);
+	});
+
+	it('陽性対照: 長形 --approve は従来どおり捕捉する', () => {
+		expect(isApproveAction('gh pr review 4010 --approve --body ok')).toBe(true);
+	});
+
+	it('short flag cluster (-ab body = --approve --body) も捕捉する', () => {
+		expect(isApproveAction('gh pr review 4010 -ab LGTM')).toBe(true);
+	});
+
+	it('過剰 block しない: -c (--comment) / -r (--request-changes) は approve ではない', () => {
+		expect(isApproveAction('gh pr review 4010 -c --body "質問です"')).toBe(false);
+		expect(isApproveAction('gh pr review 4010 -r --body "BLOCK"')).toBe(false);
+		expect(isApproveAction('gh pr review 4010 -R owner/repo -c -b x')).toBe(false);
+	});
+
+	it('短縮 flag 形は read-only 参照とみなさない (subagent でも block 側)', () => {
+		expect(isReadOnlyApproveInspection('gh pr review 4010 -a')).toBe(false);
+	});
+
+	it('hook 実行: `-a` 形は evidence 不在で exit 2 (旧実装は exit 0)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK_PATH,
+			withIsMain: true,
+			evidencePrNumbers: [4002],
+			stdin: bashPayload('gh pr review 4010 -a --body ok'),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+	}, 30_000);
+});
+
+describe('#4095 O-2 — GraphQL の approve 相当 mutation', () => {
+	const GRAPHQL_APPROVE =
+		'gh api graphql -f query=\'mutation{addPullRequestReview(input:{pullRequestId:"PR_kwABC",event:APPROVE,body:"LGTM"}){clientMutationId}}\'';
+	const GRAPHQL_MERGE =
+		'gh api graphql -f query=\'mutation{mergePullRequest(input:{pullRequestId:"PR_kwABC"}){clientMutationId}}\'';
+	const GRAPHQL_READ =
+		'gh api graphql -f query=\'query{repository(owner:"o",name:"r"){pullRequest(number:4010){title}}}\'';
+
+	it('addPullRequestReview mutation を approve 行為として捕捉する (QM 実測の素通り形)', () => {
+		expect(isApproveAction(GRAPHQL_APPROVE)).toBe(true);
+	});
+
+	it('mergePullRequest mutation も捕捉する', () => {
+		expect(isApproveAction(GRAPHQL_MERGE)).toBe(true);
+	});
+
+	it('GraphQL は node ID 指定のため PR 番号を確定できない → 確定不能として扱う', () => {
+		expect(extractPrNumbers(GRAPHQL_APPROVE)).toEqual([]);
+		expect(isReadOnlyApproveInspection(GRAPHQL_APPROVE)).toBe(false);
+	});
+
+	it('過剰 block しない: 読み取り query は approve 判定に入らない', () => {
+		expect(isApproveAction(GRAPHQL_READ)).toBe(false);
+	});
+
+	it('過剰 block しない: review comment 追加 mutation は approve ではない', () => {
+		expect(
+			isApproveAction(
+				'gh api graphql -f query=\'mutation{addPullRequestReviewComment(input:{body:"nit"}){clientMutationId}}\'',
+			),
+		).toBe(false);
+	});
+
+	it('hook 実行: GraphQL approve は evidence の有無に関わらず exit 2', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK_PATH,
+			withIsMain: true,
+			evidencePrNumbers: [4002, 4010],
+			stdin: bashPayload(GRAPHQL_APPROVE),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+	}, 30_000);
+});
+
+describe('#4095 O-3 — 別 PR の evidence で approve が通らない', () => {
+	/**
+	 * QM 実測 (evidence は 4002 のみ存在):
+	 *   exit=0  for n in 4002 4010; do gh pr merge $n --squash; done # rollup for 4002
+	 *   exit=0  gh pr merge $TARGET --squash --delete-branch # tracked in 4002
+	 *   exit=2  for n in 4002 4010; do gh pr merge $n --squash; done   ← literal が無ければ塞がる
+	 *
+	 * = 番号確定が「同一行 / コマンド全体にある任意の数字」に依存しており、**実際に叩かれる PR**
+	 * ではなく近くの数字を採っていた。既存の `extractPrNumbers(LOOP_VARIABLE_APPROVE) === []` は
+	 * 「他に literal 数字が無い」形しか固定しておらず、この分岐を通していなかった。
+	 */
+	const LOOP_WITH_LITERAL_NEARBY =
+		'for n in 4002 4010; do gh pr merge $n --squash; done # rollup for 4002';
+	const VARIABLE_WITH_LITERAL_COMMENT =
+		'gh pr merge $TARGET --squash --delete-branch # tracked in 4002';
+
+	it('ループ列挙値 / コメント中の literal 番号を PR 番号として採用しない', () => {
+		expect(extractPrNumbers(LOOP_WITH_LITERAL_NEARBY)).toEqual([]);
+		expect(extractPrNumbers(VARIABLE_WITH_LITERAL_COMMENT)).toEqual([]);
+	});
+
+	it('hook 実行: 4002 の evidence があっても $n loop は exit 2', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK_PATH,
+			withIsMain: true,
+			evidencePrNumbers: [4002],
+			stdin: bashPayload(LOOP_WITH_LITERAL_NEARBY),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+		expect(res.stderr).toContain('PR 番号');
+	}, 30_000);
+
+	it('hook 実行: 4002 の evidence があっても $TARGET + literal コメント形は exit 2', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK_PATH,
+			withIsMain: true,
+			evidencePrNumbers: [4002],
+			stdin: bashPayload(VARIABLE_WITH_LITERAL_COMMENT),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+	}, 30_000);
+
+	it('陽性対照: evidence のある PR をリテラル指定した merge は通る (過剰 block していない)', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK_PATH,
+			withIsMain: true,
+			evidencePrNumbers: [4002],
+			stdin: bashPayload('gh pr merge 4002 --squash'),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(0);
+	}, 30_000);
+
+	it('複数 PR をリテラル指定した形は、evidence の無い側で block される', () => {
+		const res = runHookInIsolatedTree({
+			hookRelPath: HOOK_PATH,
+			withIsMain: true,
+			evidencePrNumbers: [4002],
+			stdin: bashPayload('gh pr merge 4002 --squash && gh pr merge 4010 --squash'),
+		});
+		expect(res.status, `出力:\n${res.combined}`).toBe(2);
+		expect(res.stderr).toContain('4010');
+	}, 30_000);
+
+	it('番号は同一 invocation の argv から取る: 別 invocation の literal を混ぜない', () => {
+		// `gh pr view 4002` の 4002 は merge 対象ではない。旧実装は行全体を走査していた。
+		expect(extractPrNumbers('gh pr view 4002 --json title; gh pr merge $PR --squash')).toEqual([]);
+	});
+
+	it('flag の値を positional (PR 番号) と誤認しない', () => {
+		expect(extractPrNumbers('gh pr merge --repo Takenori-Kusaka/ganbari-quest 4002')).toEqual([
+			4002,
+		]);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // #4075 — sibling static import の欠落による fail-open
 // ---------------------------------------------------------------------------
 
@@ -212,9 +374,11 @@ describe('#4075 AC2 — hook の相対 import は全て dynamic (fitness functio
 		scripts.map((p) => [p] as const),
 	)('%s に相対 module の static import が無い', (relPath) => {
 		const source = readFileSync(resolve(process.cwd(), relPath), 'utf8');
+		// quote style を限定しない (#4095 申し送り 1): シングルクォート限定だと
+		// `from "./x.mjs"` を 0 件と誤判定し、guard が静かに空振りする。
 		const staticRelativeImports = [
-			...source.matchAll(/^\s*import\s+[^;]*?from\s+'(\.[^']+)'/gm),
-		].map((m) => m[1]);
+			...source.matchAll(/^\s*import\s+[^;]*?from\s+(['"])(\.[^'"]+)\1/gm),
+		].map((m) => m[2]);
 		expect(
 			staticRelativeImports,
 			`static import は解決失敗が exit 1 (= 素通し) になる。dynamic import + exit 2 に倒すこと (#3999 / #4075)`,


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（QM / Dev エージェント運用の品質ゲート）

**解決する課題**: ADR-0056 の approve gate は「adversarial evidence を検証せずに approve / merge させない」最終防壁だが、**コマンドの書き方や実行経路をほんの少し変えるだけで素通りできる**状態だった。QM が実測した形では、ループ変数で PR 番号を書いた approve が evidence 検証を一切行わず成功した（同時刻に番号をリテラルで書いた形は正しく BLOCK された）。ゲートが「たまたま想定した書き方のときだけ効く」状態では、品質保証の根拠にならない。

**期待される効果**: gate の発火条件を「守るべき不変条件（= approve 行為であること）」に結び直し、**判定できない入力は通さない（fail-closed）** を既定にした。書き方の変種で回避できる余地を無くし、構造的に塞げない残余は「塞げない」と明記したうえで経路非依存の検知層を用意した。

## 関連 Issue

closes #4082
closes #4057
closes #4075

- 先行する同 class の対処: #3999（PR #4002、`is-main.mjs` の fail-open）/ #4001（PR #4042、PowerShell 経路）/ #4027（gh コマンド解析 SSOT）
- ADR-0056（QM drift 防止機構）/ ADR-0061（same-class-N→guard）/ ADR-0006（assertion 弱体化禁止）

## 設計判断: 3 件を 1 PR に統合した理由と、選んだ方針

3 件は別 Issue だが **root class は 1 つ**である — gate の発火条件を「守るべき不変条件」ではなく「**コマンドの表層的な書き方 / 実行経路の種別**」に結びつけていたこと。#4082 が明示するとおり、matcher を足す対処では R1〜R3 は塞げない。同じファイル群を触るため、個別対処すると 3 回続けて「1 箇所だけ塞いで同 class を残す」（#3999 → #4075 で実際に起きた失敗）を繰り返す。

### 採った方針 1: fail-closed 化（判定できない入力は拒否する）

「素通り（exit 0）がありえない」構造に寄せた。具体的には:

| 判定対象 | 変更前 | 変更後 |
|---|---|---|
| approve 行為の識別 | PR 番号が `\d+` でリテラル一致するときだけ approve 扱い | ref の形（`4002` / `$n` / `$(…)`）を問わず approve 扱い。**番号が確定できないなら BLOCK** |
| 検証する PR | 最初の 1 件だけ | **全件**。1 コマンドが複数 PR を叩く形では全 PR の evidence を要求 |
| sibling module の欠落 | `command-execution-tools.mjs` は static import → exit 1 = 素通し | 相対 import を全て dynamic + exit 2。static import 0 件を fitness function で機械強制 |
| subagent context | `CLAUDE_SUBAGENT_ID` があればどのツールでも無条件 allow | **GET の review 参照だけ** allow。mutation は subagent でも BLOCK |
| 未知ツールの payload | 走査対象が 0 件でも allow | 検査できる文字列が 0 件なら BLOCK |

### 採った方針 2: 構造的に塞げないものは「塞げない」と記録し、検知で代替する

**列挙型の防御は原理的に「次に増える経路」を先回りできない**。以下 2 つは prevention では閉じないと判断し、ADR-0056 に accepted residual として明記した（#4082 AC5）:

| 残余 | なぜ塞げないか | 代替 |
|---|---|---|
| **R1 残余**: 未棚卸のコード実行ツール / 動的組み立て（変数経由・base64・eval）されたコマンド | 任意言語の構文を完全解釈することは不可能。リテラルで書かれた形しか掴めない | `scripts/audit-approve-evidence.mjs` |
| **R3**: `isolation: "remote"` での hook 継承 | 実行基盤側の仕様であり、リポジトリ内の設定では保証も検証もできない。**このセッションからは実測もできない**ため「検証した」とは書かない | 同上 |
| **R7 残余**: GraphQL payload を `--input <file>` / 変数経由で渡す形 | hook はコマンド文字列しか見ないため、外部ファイルの中身は判定材料にできない（R1 残余と同一 class） | 同上 |

検知層は **効果が着地した場所（GitHub の review 一覧）** を入力にするため、approve がどの経路で行われたかに依存しない。`--pr <n>` で APPROVE を列挙し evidence と突き合わせ、裏付けの無い approve を exit 1 で報告する。限界（evidence は git 管理外のためローカル実行前提 / TTL 30 分）は script 冒頭に明記した。

### PR #4094 との衝突回避

同時進行の PR #4094 も `.claude/hooks/` を触るが、**触るファイルが重ならない**ことを `gh pr diff 4094 --name-only` で確認した（#4094 = `heavy-run-lock.mjs` / `heavy-run-unlock.mjs` / `agent-lock*.mjs` / `heavy-process.mjs` / `package.json` / `agent-concurrency.md`、本 PR = `gate-approve.mjs` / `command-execution-tools.mjs` / `gh-command.mjs` / `settings.json` / ADR-0056）。

どちらが先に merge されても壊れないよう、以下を守った:

- **`package.json` を touch しない**。#4094 が `agent:cleanup` script を追加するため、同ファイルに行を足すと textual conflict になる。本 PR の監査 script は `node scripts/audit-approve-evidence.mjs` で直接起動する（npm script を追加しない）
- **`.claude/settings.json` の matcher を 2 entry とも同値で更新**。#4094 が触る `heavy-run-lock` / `heavy-run-unlock` も同じ entry にぶら下がるが、両 hook とも `payload?.tool_input?.command ?? ''` / `typeof !== 'string' → false` で非 shell payload を安全に無視することを実装確認済み。matcher 拡張によって #4094 側の挙動は変わらない
- **既存の共有 module（`agent-lock*.mjs`）を一切変更しない**

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #4057-1 | `isApproveAction` を PR 番号のリテラル一致に依存させず、番号が抽出できない場合は fail-closed (BLOCK) | `npx vitest run tests/unit/hooks/gate-approve-fail-closed.test.ts` の `#4057` 群 | PASS（`isPullsSubresourcePathAnyRef` 導入 + 番号未確定は exit 2） |
| #4057-2 | ループ / 変数展開 / コマンド置換 / 複数コマンド連結の各形で BLOCK することを固定する unit test（再現形をそのまま test 化） | 同上（fixture に Issue 本文の実測コマンドを実名で収録） | PASS（`LOOP_VARIABLE_APPROVE` = Issue #4057 の再現形、`COMMAND_SUBSTITUTION_APPROVE`、`POWERSHELL_VARIABLE_APPROVE`） |
| #4057-3 | 残存 bypass（R1 / R2 / R3）を同時に棚卸しする | ADR-0056 §残存 bypass の棚卸 表 | PASS（R1〜R8 全件に状態を記載）。**初版の「未対処 0 件」は誤り**だった — QM Re-Review が literal な approve 経路 3 種（`-a` / GraphQL / 番号確定）の素通りを実測。R6 / R7 / R8 として表に追記し、いずれも本 PR で対処済（GraphQL の外部ファイル payload のみ accepted residual に追加） |
| #4075-1 | `command-execution-tools.mjs` も dynamic import 化し、解決失敗時に exit 2 に倒す | `gate-approve-fail-closed.test.ts` §#4075 の隔離 tree probe（`omitRelPaths`） | PASS（sibling 欠落 tree で exit 2 + stderr に module 名） |
| #4075-2 | sibling が増えても同じ穴が空かないよう機械強制する（static import 0 件を assert） | 同 test の fitness function（settings.json 登録 hook 全件を静的走査） | PASS（登録 hook 3 本すべて static 相対 import 0 件） |
| #4075-3 | 隔離 tree probe の機械抽出結果を fitness function 側でも再利用できる形にする | `tests/unit/helpers/hook-tree-probe.ts` に `omitRelPaths` / `env` を追加 | PASS（抽出ロジックは既存の機械抽出のまま、除外指定のみ追加） |
| #4082-1 | R2 を最優先で対処。loop 防止の目的を保ちつつ approve action には allow しない | 同 test §R2（4 ケース: merge / REST approve / GET 読み取り / 非 subagent 対照） | PASS（mutation で無条件 allow に戻すと 2 件 fail） |
| #4082-2 | R1: 判定軸を「shell か」から「任意の副作用を起こせるか」に変更し SSOT に反映 | `command-execution-tools.mjs`（`SHELL_COMMAND_TOOLS` / `CODE_EXECUTION_TOOLS`）+ `.claude/settings.json` matcher + §R1 test | PASS（`mcp__ide__executeCode` を収録、matcher 一致を既存 test が機械検証） |
| #4082-3 | R3: remote isolation の hook 継承を検証する。継承されないなら別層で塞ぐ | 本セッションからは実測不能と判断 → 検知層 `scripts/audit-approve-evidence.mjs` + ADR-0056 accepted residual | PASS（塞げない旨と代替検知を明記。「検証した」とは記載していない） |
| #4082-4 | 経路列挙型の防御から脱却する fitness function を追加し、列挙漏れを silent に見逃さない | fitness function（static import 0 件）+ 既存 matcher 一致 test + 未知ツール payload の BLOCK 化 | PASS（走査対象 0 件で BLOCK する test を追加） |
| #4082-5 | 対処しないものは理由と受容根拠を ADR-0056 に accepted residual として明記する | `docs/decisions/0056-*.md` §accepted residual | PASS（R1 残余 / R3 の 2 件を理由付きで記載 + 運用手順） |

### QM Re-Review (BLOCK) 対応 — literal な approve 経路 3 種 (#4095 O-1 / O-2 / O-3)

QM が隔離 tree で exit code を実測し、**棚卸から漏れた literal 形の approve 経路 3 種**が exit 0 で素通りすることを検出した。いずれも accepted residual の定義（動的組み立て / 未棚卸ツール）に該当しないため、塞ぐべきものとして対処した。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| #4095-O1 | `gh pr review -a`（`--approve` の正式な短縮 flag）を検出する。`-c` / `-r` を誤検出しない | `gate-approve-fail-closed.test.ts` §`#4095 O-1`（6 ケース） | PASS。判定を regex から argv token 単位に変更し `-a` / cluster `-ab` を捕捉。`-c` / `-r` / `-R owner/repo` は非 approve のまま。hook 実測で `gh pr review 4010 -a --body ok` が exit 0 → **exit 2** |
| #4095-O2 | `gh api graphql` の `addPullRequestReview` / `mergePullRequest` / `event: APPROVE` を approve 相当として捕捉する | 同 §`#4095 O-2`（6 ケース） | PASS。`parseGhApiInvocation` が収集していた `graphql` path の**死んだ枝**を接続。PR は node ID 指定で番号確定不能のため常に BLOCK。読み取り `query{…}` と `addPullRequestReviewComment` は非 approve（過剰 block 対照） |
| #4095-O3 | PR 番号を「同一 `gh` invocation の argv」からのみ取り、確定不能 hit があれば literal 番号の有無に関わらず BLOCK する | 同 §`#4095 O-3`（7 ケース、うち 4 件は evidence を 4002 のみ配置した hook 実測） | PASS。`resolveApproveTargets` を新設し、コマンド全体走査を廃止 + shell コメント以降を打ち切り。**4002 の evidence がある状態で `for n in 4002 4010; do gh pr merge $n; done # rollup for 4002` / `gh pr merge $TARGET … # tracked in 4002` が exit 0 → exit 2**。L382-384 のコメントが述べる不変条件と実装が一致した |
| #4095-O4 | 「未対処 0 件」の記述を実態に合わせる（no-silent-gap、#4082 AC4 / AC5） | ADR-0056 §残存 bypass の棚卸 / §accepted residual + 本 PR body AC #4057-3 | PASS。R6 / R7 / R8 を状態付きで追記し、GraphQL の外部ファイル payload を accepted residual に追加。誤りだった宣言は撤回して経緯を明記 |
| #4095-申し送り1 | fitness function の static import 検出をシングルクォート限定から両クォート対応にする | `gate-approve-fail-closed.test.ts` §#4075 AC2 の regex | PASS（BLOCK 解除条件ではないが同 PR で対処。`from "./x.mjs"` を見逃さない） |

**evidence を配置した状態での実測**（QM の再現条件と同一 = evidence は 4002 のみ）: probe helper に `evidencePrNumbers` を追加し、「別 PR の evidence で approve が通らないこと」と「evidence のある PR のリテラル指定は通ること（過剰 block していないこと）」を同一 test 群で対にした。

### mutation 検証（テストが本当に欠陥を捕まえるか）

実装を **commit してから** 1 箇所ずつ元の欠陥に戻し、テストが落ちることを確認した（未コミットのまま revert すると実装ごと消える既知事故の回避）。各回とも `git checkout --` で復元し `git status` clean を確認済み。

| mutation | 戻した内容 | 落ちたテスト | 結果 |
|---|---|---|---|
| M1 (#4057) | `isPullsSubresourcePathAnyRef` を `\d+` に戻す + `hasUnresolvedExpansion` を `false` に | 4 件（ループ変数 / コマンド置換 / PowerShell 変数 / hook exit 2） | 検出 ✓ |
| M2 (#4075) | `command-execution-tools.mjs` を static import に戻す | 1 件（sibling 欠落 tree で exit 2） | 検出 ✓ |
| M3 (#4082 R2) | `CLAUDE_SUBAGENT_ID` の無条件 allow を復活 | 2 件（subagent + merge / subagent + REST approve） | 検出 ✓ |
| M4 (#4082 R1) | `CODE_EXECUTION_TOOLS` を空配列に | 1 件（SSOT に汎用コード実行 MCP を含む） | 検出 ✓ |
| M5 (#4095 O-1) | `isApproveAction` から短縮 flag 判定 (`findPrCliApproveHits`) を無効化 | 3 件（`-a` 捕捉 / cluster `-ab` / hook exit 2） | 検出 ✓ |
| M6 (#4095 O-2) | `isApproveGraphqlInvocation` を常に false に | 3 件（addPullRequestReview / mergePullRequest / hook exit 2） | 検出 ✓ |
| M7 (#4095 O-3) | shell コメント打ち切りを撤去 + `hasIndeterminate` を常に false に（= QM が実測した旧挙動） | 2 件（コメント中 literal を採らない / `$TARGET` 形が exit 2） | 検出 ✓ |

**実地での fail-closed 動作も観測した**: M1 の適用作業中に `gh-command.mjs` を構文エラーにしてしまった際、gate が `[gate-approve] BLOCK: 判定 SSOT module を読み込めませんでした` を出して**自分自身の Bash 実行を exit 2 で止めた**。ADR-0056 §判定不能時は大きく止まる の設計どおりに動くことが、意図せぬ形で実証された。

### 検知層が実データで機能することの確認

追加した `scripts/audit-approve-evidence.mjs` を、**#4057 の実測事案そのもの**（QM が evidence 検証なしで approve した PR #4002）に対して実行し、検知できることを確認した:

```
$ node scripts/audit-approve-evidence.mjs --pr <#4057 の実測事案 PR>   # 実際には PR 番号 4002 を指定
[audit-approve-evidence] PR #<4057 事案>: **evidence で裏付けられない APPROVE** が 1 件あります。
  - ganbariquestsupport-lab (2026-07-29T04:19:43Z)
    reason: evidence file 不在: …/tmp/adversarial-evidence/4002.json
EXIT=1
```

陽性対照として、approve がまだ無い本 PR では 0 件報告・exit 0 になることも確認した（`--pr 4095` → `APPROVE 0 件、全て適合 evidence あり`）。予防（hook）をすり抜けた approve が、経路に依存せず事後に見つかることの実証である。

### ガードを弱めていないことの確認 (ADR-0006)

既存テストは 1 件も変更・削除していない。既存の approve 経路が引き続き通ること / 過剰 block していないことを陽性対照として併置した:

- `qa-session-approve-hook-consistency.test.ts`（`docs/sessions/qa-session.md` の実 approve コマンドを両 hook に通す）: 変更なしで PASS
- 新規追加した陽性対照: リテラル形 approve の番号抽出 / pulls コレクション POST（= PR 作成）を approve 判定に入れない / pulls 配下でない変数展開は対象外 / approve 無関係コマンドは exit 0 無出力 / approve 無関係な executeCode は素通り判定

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等) — `.claude/settings.json` の matcher / hook script / ADR

**影響を受ける画面・機能**: アプリ画面への影響なし。影響範囲は Claude Code セッションの PreToolUse hook 挙動のみ。

- `.claude/hooks/gate-approve.mjs` — 検出ロジック + fail-closed 化
- `.claude/hooks/command-execution-tools.mjs` — 対象ツール SSOT（判定軸の変更）
- `scripts/lib/gh-command.mjs` — approve パス判定の共有ロジック（3 関数を追加。既存関数は非破壊）
- `.claude/settings.json` — matcher 拡張（PreToolUse / PostToolUse 両 entry）
- `scripts/audit-approve-evidence.mjs` — 事後監査（新規）
- `docs/decisions/0056-*.md` — 残存 bypass 表の更新（R6 / R7 / R8 追記）+ accepted residual
- `tests/unit/helpers/hook-tree-probe.ts` — `evidencePrNumbers`（別 PR evidence での素通り実測）を追加

**既存 hook への波及確認**: matcher に `mcp__ide__executeCode` を追加したことで `claude-hook-prevent-qa-account-pr.mjs` / `heavy-run-lock.mjs` / `heavy-run-unlock.mjs` も同 payload を受け取る。3 本とも `payload?.tool_input?.command ?? ''` もしくは `typeof command !== 'string' → false` で安全に no-op することをコード確認済み（挙動変化なし）。

## テスト・品質セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— **run 4 が本 HEAD で完走し `[pre-ready] ALL PASS`（exit 0）**。step 個別の局所実測（下表）と CI 全 green も併せて取得済み

**pre-ready 実測状況（正確に記す）**:

| 実行 | 対象 HEAD | 結果 |
|---|---|---|
| run 1（8 本並走下） | 旧 HEAD | 12/13 step PASS。Step 3 (vitest) のみ FAIL = 6 file / 6 test、**全件 `Test timed out`（assertion 失敗 0）**。失敗 6 file の単独再実行は 69 test PASS |
| run 2 | 旧 HEAD | 完走せず（並走直列化の運用対応で打ち切り） |
| run 3（クリーン単独） | 旧 HEAD | 適用対象 13 step すべて PASS。run 1 の timeout 6 件は再現せず = 並走負荷起因と確定（この class は #4085 で機械 gate 化済） |
| **run 4** | **本 HEAD (`f245b703`)** | **`[pre-ready] ALL PASS`（exit 0）**。適用対象の全 step PASS、Step 3 vitest = **579 file / 8951 test PASS（4 file / 13 test skip、失敗 0、1569s）**。自動 skip 5 step（lp-fallback / lp-labels / lp-dimensions / ss-embed-gate / capture、#4018）。20 プロセス並走下でも run 1 のような timeout は 0 件 |

**本 HEAD (`f245b703`) に対して実際に観測した検証**（run 4 の完走前に step 単位でも個別実行済。run 4 完走後も結果は一致）:

| step | コマンド | 結果 |
|---|---|---|
| 1 biome | `npx biome check <変更 file>` | OK（pre-push でも全 lint 対象 file を再検証、PASS） |
| 1b cspell | `npx cspell <変更 file>` | Issues 0 |
| 3 vitest（本 PR の対象領域） | `npx vitest run tests/unit/hooks/` | 6 file / **190 test PASS**（`gate-approve-fail-closed.test.ts` 51 ケース） |
| 4 hardcoded-strings | `node scripts/check-hardcoded-strings.mjs` | violations 0 |
| 7 plan-literals | `node scripts/check-no-plan-literals.mjs` | OK |
| 7b license-key-leak | `node scripts/check-license-key-leak.mjs` | OK |
| 7c cli-entry-guard | `node scripts/check-cli-entry-guard.mjs` | OK |
| 7d sparse-checkout | `node scripts/check-workflow-sparse-checkout-closure.mjs` | 漏れ 0 件 |
| 7e readdir-rotation-guard | `node scripts/check-readdir-rotation-guard.mjs` | OK |
| 7f repo-scan 区分宣言 (#4085) | `node scripts/check-repo-scan-test-declaration.mjs` | 33 件すべて宣言済 |
| 9 Readiness gate | `node scripts/check-pr-body.mjs --pr <本 PR>` | 違反 0 |
| 10 doc-code-references | `node scripts/check-doc-code-references.mjs` | 新規違反なし |
| 11 terminology-coherence | `npx tsx scripts/check-terminology-coherence.ts` | PASS |
| 2 型検査 / 3 全体 vitest | run 4（フル pre-ready）で実行 | **PASS**（vitest 579 file / 8951 test）。CI も同 HEAD で `unit-test (1)` / `unit-test (2)` / `dependency-cruiser` 等すべて pass、**failure 0 / pending 0** |

- 自動 skip（適用対象外）: 5 lp-dimensions / 6 lp-fallback / 8 lp-labels / 11b SS embed / 12 capture（LP・labels.ts・UI をいずれも変更していないため）
- 旧 HEAD (`937668ef`) の run 3 結果は本 HEAD の証跡にならないため、上表で置き換えた

- [x] 追加・変更したテストの概要を以下に記載（テスト追加なしなら「N/A」）:
  - `tests/unit/hooks/gate-approve-fail-closed.test.ts`（新規、51 ケース）— #4057 / #4075 / #4082 の 3 欠陥 + QM Re-Review が実測した #4095 O-1 / O-2 / O-3 を、実測コマンドを実名 fixture にして固定。規則に従うデータだけの fixture にしない（#3956 教訓）
  - `tests/unit/helpers/hook-tree-probe.ts` — `omitRelPaths`（sibling 欠落の再現）/ `env`（subagent context の再現）/ `evidencePrNumbers`（別 PR の evidence が存在する状態の再現）を追加。既存 probe の機械抽出ロジックは変更なし。あわせて probe が `CLAUDE_SUBAGENT_ID` を明示除去し「たまたま env が立っていたので通った」を作らないようにした
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A（`priority:critical` label なし）

## スクリーンショット / ビジュアルデモ

**該当なし（hook / script のみの変更で、アプリ UI の描画に一切影響しない）**

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし | 該当なし |
| **修正後** | 該当なし | 該当なし |

**インタラクティブ状態**: N/A

### コード品質セルフレビュー (#1481)

- [x] **SOLID**: approve パス判定を `findApprovePathHits` に集約し、`isApproveAction` / `isReadOnlyApproveInspection` が同一の判定材料を共有する（検出条件が 2 箇所に分岐しない）
- [x] **DRY**: 監査 script は `verifyEvidence` を hook から import して再利用し、schema 検証を再実装していない。パス判定は `scripts/lib/gh-command.mjs` の共有 SSOT に置き、2 hook から参照
- [x] **YAGNI**: 現要件に不要な抽象化なし。npm script も追加していない（#4094 との conflict 回避も兼ねる）
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。fixture の repo 名 / アカウント名は Issue 本文にある公開情報のみ
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: 追加処理は approve 系コマンド検出時のみの文字列走査。非 approve コマンドは従来どおり早期 exit 0

### 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — ADR-0056 の決定 1 / 残存 bypass 表 / accepted residual を実装に同期
- [x] 並行 PR overlap 確認 (#1200) — PR #4094 と `gh pr diff 4094 --name-only` で照合、重複ファイル 0 件（詳細は上記「PR #4094 との衝突回避」）
- [ ] N/A — 並行実装の影響範囲外

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

ただし **gate の検出幅は意図的に広げている**ため、以下は今後 BLOCK される（いずれも回避策は「PR 番号をリテラルで書く」）:

- `gh api repos/o/r/pulls/$n/reviews` のような変数展開形の approve
- `gh api repos/o/r/pulls/$VAR/...` のように pulls 配下で URL が確定できない形（subresource が `reviews` / `merge` でなくとも、パスが確定できない時点で分類不能として BLOCK）

**レビュー依頼事項・QA**:

1. **fail-closed の副作用の許容範囲**: pulls 配下で URL が確定できない `gh api` を一律 BLOCK する判断（例: `gh api repos/o/r/pulls/$PR/comments` も止まる）。「確定できないものは通さない」を優先したが、QM の日常操作で許容できるかを確認してほしい
2. **R3 の扱い**: remote isolation を「本セッションからは検証できない」として accepted residual にした判断。実測できないことを「検証済み」と書かない方針を採ったが、別の検証手段があれば指摘してほしい
3. **監査 script の位置づけ**: 予防ではなく検知であること、evidence が git 管理外のためローカル実行前提であることを script 冒頭と ADR に明記した。この限界の記述が十分か

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — 該当なし（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 該当なし（認証画面の変更なし）
- [x] QA 承認・動作確認が完了している

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)





