### PR TITLE
infra: #3998 #3959 沈黙する障害 (entitlement fail-closed / Stripe webhook 未達) を検知する層を足す

### DIFF
--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -195,7 +195,7 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 | grace-period-deletion | `cron(0 17 * * ? *)` | 毎日 02:00 | ✗ | ✓ | グレースピリオド期限切れテナントの物理削除バッチ (#1648 R43, `grace-period-service.ts`)。**dispatcher には登録済だが AWS EventBridge Rule 未作成のため AWS 本番では未駆動、現状は NUC scheduler のみで起動** |
 | pmf-survey | `cron(0 0 1 6,12 ? *)` | 6/1・12/1 09:00 | ✓ | ✓ | PMF 判定アンケート (Sean Ellis Test) 年 2 回配信 (#1598, ADR-0023 §5 I7) |
 | export-build | `cron(0/5 * * * ? *)` | 5 分毎 | ✓ | ✓ | クラウドエクスポート非同期 build バッチ (#3504, async-backup-export.md §3.2)。`status='pending'` の `cloud_exports` を拾い ZIP 生成 → S3/ローカル FS 保存 → `ready` に遷移。AWS (cron-dispatcher) / NUC (scheduler container) 双方が同一 endpoint を駆動 |
-| stripe-webhook-delivery-check | `cron(5 * * * ? *)` | 毎時 5 分 | ✓ | ✓ | Stripe webhook 未達 (沈黙) の検知バッチ (#3959, `stripe-webhook-delivery-monitor.ts`)。Stripe Events API の `pending_webhooks` 滞留と、checkout 完了に対する plan 反映有無を突き合わせ、両方成立時のみ Discord alert `stripe-webhook-undelivered` を 1 通送る |
+| stripe-webhook-delivery-check | `cron(5 * * * ? *)` | 毎時 5 分 | ✓ | ✓ | Stripe webhook 未達 (沈黙) の検知バッチ (#3959, `stripe-webhook-delivery-monitor.ts`)。Stripe Events API の `pending_webhooks` 滞留と、checkout 完了に対する plan 反映有無を突き合わせ、両方成立時のみ Discord alert `stripe-webhook-undelivered` を 1 通送る。検査自体が失敗した場合は `stripe-webhook-monitor-failed` を送る (cron-dispatcher は非 2xx を throw しないため Lambda error alarm では表面化しない) |
 
 - ターゲット: AWS では `ganbari-quest-cron-dispatcher` Lambda (JSON payload `{ cronJob: "<job-name>" }`) が EventBridge から起動され `/api/cron/:job` を HTTP POST する
 - AWS EventBridge Rule 名は `ganbari-quest-cron-<job-name>` (例: `ganbari-quest-cron-retention-cleanup`)

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -180,10 +180,10 @@
 
 **Cron ジョブ一覧 (#1376):**
 
-スケジュール SSOT は `src/lib/server/cron/schedule-registry.ts`。本表は registry の全 7 ジョブと 1:1 で対応する。
+スケジュール SSOT は `src/lib/server/cron/schedule-registry.ts`。本表は registry の全 8 ジョブと 1:1 で対応する。
 「EventBridge」列は AWS 本番でジョブを駆動する EventBridge Rule (`infra/lib/compute-stack.ts` の `CRON_JOBS`) の有無、
 「dispatcher」列は cron-dispatcher Lambda の `KNOWN_ENDPOINTS` (`infra/lambda/cron-dispatcher/index.ts`) への登録有無を示す。
-NUC セルフホスト版は AWS を経由せず `scripts/scheduler.ts` が registry 全 7 ジョブを node-cron で直接駆動するため、
+NUC セルフホスト版は AWS を経由せず `scripts/scheduler.ts` が registry 全 8 ジョブを node-cron で直接駆動するため、
 EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 
 | ジョブ (registry name) | スケジュール (UTC) | JST 換算 | EventBridge | dispatcher | 概要 |
@@ -195,6 +195,7 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 | grace-period-deletion | `cron(0 17 * * ? *)` | 毎日 02:00 | ✗ | ✓ | グレースピリオド期限切れテナントの物理削除バッチ (#1648 R43, `grace-period-service.ts`)。**dispatcher には登録済だが AWS EventBridge Rule 未作成のため AWS 本番では未駆動、現状は NUC scheduler のみで起動** |
 | pmf-survey | `cron(0 0 1 6,12 ? *)` | 6/1・12/1 09:00 | ✓ | ✓ | PMF 判定アンケート (Sean Ellis Test) 年 2 回配信 (#1598, ADR-0023 §5 I7) |
 | export-build | `cron(0/5 * * * ? *)` | 5 分毎 | ✓ | ✓ | クラウドエクスポート非同期 build バッチ (#3504, async-backup-export.md §3.2)。`status='pending'` の `cloud_exports` を拾い ZIP 生成 → S3/ローカル FS 保存 → `ready` に遷移。AWS (cron-dispatcher) / NUC (scheduler container) 双方が同一 endpoint を駆動 |
+| stripe-webhook-delivery-check | `cron(5 * * * ? *)` | 毎時 5 分 | ✓ | ✓ | Stripe webhook 未達 (沈黙) の検知バッチ (#3959, `stripe-webhook-delivery-monitor.ts`)。Stripe Events API の `pending_webhooks` 滞留と、checkout 完了に対する plan 反映有無を突き合わせ、両方成立時のみ Discord alert `stripe-webhook-undelivered` を 1 通送る |
 
 - ターゲット: AWS では `ganbari-quest-cron-dispatcher` Lambda (JSON payload `{ cronJob: "<job-name>" }`) が EventBridge から起動され `/api/cron/:job` を HTTP POST する
 - AWS EventBridge Rule 名は `ganbari-quest-cron-<job-name>` (例: `ganbari-quest-cron-retention-cleanup`)

--- a/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
+++ b/docs/design/billing-redesign/phase6-rollback-and-kill-switches.md
@@ -198,7 +198,25 @@ historical record (旧設計): Sentry TypeError 検知 + Dashboard `webhookEndpo
 | **ロールバック手順** | (1) **CloudWatch Logs Insights の `tags.reason`** (または (c) の `logger.error` 本文) で Stripe 側障害か DB 側障害かを切り分け (2) Stripe 側なら status.stripe.com と API key の有効性を確認、DB 側なら DSQL の接続状況を確認 (3) **障害中に到達した event は自然収束しない。手動突合が必須**。`resolveSubscriptionContext` は障害時も例外を投げず `undefined` を返すため handler は正常終了し、`stripe_webhook_events` に `handlerResult='success'` として記録される ([phase5-webhook-idempotency-architecture.md](phase5-webhook-idempotency-architecture.md) の dedup 台帳、#3985)。以後、同一 `event.id` の Stripe 再送は skip され、**Dashboard からの Resend も同一 `event.id` のため skip される**。復旧後は (a) CloudWatch Logs Insights で alert 期間の `subscriptionId` を列挙 → (b) Stripe 上の現行 subscription / price と DB の `plan` / `status` を突合 → (c) 差分があれば手動修復する。恒久対策 (障害時は台帳に記録せず Stripe の再送に載せる) は #4108 で追跡 |
 | **再発防止** | (a) try の範囲を Stripe 呼び出し / repo 呼び出しに分割し、bare `catch {}` を構造的に不能化 (b) 「tenant が本当に不在」は正常な結果として warn のみに留め、alert を誤発火させない (c) 3 経路 (API throw / repo throw / tenant 不在) の unit test で分類を固定。retry / fallback は Stripe 再送と二重処理検討を避けるため**入れない** |
 
-### 3.10 想定リスク 8 件 SSOT サマリ表 (#2683 補強で +R8 / +R9、R3 / R5 historical 化、#3960 で +R10、#3985 で +R11、#3980 / #3981 で +R12 / +R13)
+### 3.10-e R14 (#3959 新規): webhook が Lambda に 1 度も到達せず、alert も 1 つも鳴らない
+
+| 項目 | 内容 |
+|---|---|
+| **シナリオ** | 2026-07-26 の本番課金 incident。CloudFront edge が Stripe (海外 IP) からのリクエストを 403 で弾き、**リクエストが Lambda に 1 度も到達しなかった**。アプリ内の通知経路 (`notifyStripeAlert` / `sendDiscordAlert`) はすべて「アプリのコードが実行された」ことを前提にするため、初の有料課金が丸ごと落ちても alert は 0 件で、顧客申告で発覚した |
+| **検知 method** | (a) Discord alert `stripe-webhook-undelivered` (cron `stripe-webhook-delivery-check`、毎時 5 分)。S1 (Stripe の event が `pending_webhooks > 0` のまま 30 分以上滞留) ∧ S2 (`checkout.session.completed` から 30 分以上経過しても tenant に subscription が結び付いていない) の**論理積**で発火 (b) CloudWatch Logs Insights `filter @message like "stripe-webhook-undelivered"` (c) 実装 SSOT: `src/lib/server/services/stripe-webhook-delivery-monitor.ts` |
+| **ロールバック手順** | (1) alert の `oldestEventId` / `sampleCheckoutEventId` で Stripe Dashboard の配信状況と顧客影響を確定 (2) 配信経路 (CloudFront geo restriction / WAF / DNS / Stripe の宛先設定) を修復 (3) `stripe events resend <event_id>` で滞留分を再送 (Stripe の保持は 30 日) (4) 対象 tenant のプラン表示で反映を確認。詳細手順は [silent-failure-alert-response.md §2.3](../../runbooks/silent-failure-alert-response.md) |
+| **再発防止** | (a) 未達検知 cron を `schedule-registry.ts` に登録し drift を `tests/unit/cron/schedule-consistency.test.ts` で CI 検出 (b) `tests/unit/services/stripe-webhook-delivery-monitor.test.ts` が発火側 / 沈黙側の両方を回帰固定 (c) 経路の恒久対処は #3957、取りこぼし突合は #3958 (d) **既知の穴**: handler が throw せず 200 を返す経路 (#4108) は S1 が偽になるため本 alert でも #4079 の `stripe-webhook-handler-failed` でも検知できない。恒久対処は #4108 が所有する |
+
+### 3.10-f R15 (#3959 新規): 未達検知 cron 自体が落ちて、検知の不在が無通知になる
+
+| 項目 | 内容 |
+|---|---|
+| **シナリオ** | R14 の検知 cron が例外で終了する (Stripe API 障害 / rate limit / DSQL 障害)。cron-dispatcher は非 2xx を throw せず返すため **Lambda Errors alarm では表面化せず**、検知器が止まっている間の未達は誰も気づけない (検知層の単一障害点) |
+| **検知 method** | (a) Discord alert `stripe-webhook-monitor-failed` (cron endpoint の catch から **await 送出**。fire-and-forget では Lambda freeze で送信自体が落ちるため) (b) CloudWatch Logs Insights `filter @message like "stripe-webhook-delivery-check] cron failed"` (c) 毎時の完了 log (`endpoint completed`) の不在 |
+| **ロールバック手順** | (1) alert には例外クラス名のみを載せている (接続情報を Discord に出さないため) → 詳細は CW log 本文 + stack で確認 (2) Stripe の一時障害 / rate limit なら次の実行 (1 時間後) で自然復旧するか見る (3) DSQL 側なら [dsql-alert-response.md](../../runbooks/dsql-alert-response.md) (4) **復旧まで未達検知は動いていない**ため、その間の課金は §2.3 の手順で手動確認する。詳細は [silent-failure-alert-response.md §2.5](../../runbooks/silent-failure-alert-response.md) |
+| **再発防止** | (a) cron endpoint の catch で alert を await 送出することを `tests/unit/routes/cron-stripe-webhook-delivery-check.test.ts` が回帰固定 (b) `notifyStripeAlertAsync` (await 可能版) を `alert.ts` に用意し、cron 経路では fire-and-forget を使わない (c) dispatcher の非 2xx → throw 化は他 cron に波及するため別途 (現状は本 alert が代替) |
+
+### 3.10 想定リスク 8 件 SSOT サマリ表 (#2683 補強で +R8 / +R9、R3 / R5 historical 化、#3960 で +R10、#3985 で +R11、#3980 / #3981 で +R12 / +R13、#3959 で +R14 / +R15)
 
 | # | リスク | 検知 method (主) | ロールバック手順 (簡略) | 再発防止 (CI / Pre-Ready) |
 |---|---|---|---|---|
@@ -215,6 +233,8 @@ historical record (旧設計): Sentry TypeError 検知 + Dashboard `webhookEndpo
 | **R11 (#3985 新規)** | **handler の恒久的失敗が無通知のまま Stripe の 3 日再送を使い切る** | Discord alert `stripe-webhook-handler-failed` (初回失敗で発火) + CloudWatch Logs Insights | 一過性なら再送で自然復旧 / 恒久バグは fix deploy 後に再送分が再処理される。期限切れ分は `stripe events resend` | 失敗 alert を `handleWebhookEvent` catch 1 箇所に集約 + `stripe-webhook-dedup.test.ts` の失敗 alert 回帰 (未達検知は #3959) |
 | **R12 (#3980 新規)** | **subscription item 複数化で `items.data[0]` が plan を表さなくなる** | Discord alert `stripe-subscription-multi-item` (通知) + CloudWatch Logs Insights (`tags.priceIds`、切り分け) | plan item を lookup_key で選別する分岐を追加して deploy + 誤解決 tenant を Stripe 現行 price と突合修復 | `items.length > 1` / `=== 1` 双方の unit test で発火・誤発火を固定 |
 | **R13 (#3981 新規)** | **context 解決の bare `catch {}` が障害を「tenant not found」に化けさせる** | Discord alert `stripe-context-unresolved` (通知) + CloudWatch Logs Insights (`tags.reason`) + `logger.error` | CloudWatch の `reason` で Stripe 側 / DB 側を切り分け → 復旧。**再送では収束しない**ため CloudWatch → Stripe / DB 突合で手動修復 (恒久対策 #4108) | try 範囲を分割し bare `catch {}` を不能化 + 3 経路 (API throw / repo throw / tenant 不在) unit test |
+| **R14 (#3959 新規)** | **webhook が Lambda に到達せず alert が 0 件のまま課金が落ちる** | Discord alert `stripe-webhook-undelivered` (cron 毎時、S1 滞留 ∧ S2 plan 未反映) + CloudWatch Logs Insights | 配信経路 (CloudFront geo / WAF / DNS / 宛先設定) を修復 → `stripe events resend` で滞留分を再送 → プラン反映を確認 | cron を `schedule-registry.ts` に登録 + `schedule-consistency.test.ts` の drift 検出 + `stripe-webhook-delivery-monitor.test.ts` の発火 / 沈黙両側回帰。**穴**: throw しない handler 失敗 (#4108) はどちらの alert でも検知不能 |
+| **R15 (#3959 新規)** | **未達検知 cron 自体の失敗が Lambda Errors alarm に出ず、検知の不在が無通知になる** | Discord alert `stripe-webhook-monitor-failed` (cron endpoint の catch から await 送出) + 毎時の完了 log の不在 | 例外クラス名から一次切り分け (Stripe 一時障害は次回実行で自然復旧 / DSQL は dsql-alert-response.md)。復旧まで課金は §2.3 で手動確認 | endpoint catch の await 送出を `cron-stripe-webhook-delivery-check.test.ts` が回帰固定 + `notifyStripeAlertAsync` (await 可能版) を cron 経路で必須化 |
 
 ## 4. #2627 Stripe Dashboard ロールバック 3 期間別マトリクス (§4)
 

--- a/docs/runbooks/silent-failure-alert-response.md
+++ b/docs/runbooks/silent-failure-alert-response.md
@@ -7,6 +7,10 @@
 |---|---|---|
 | `ganbari-quest-auth-entitlement-db-unavailable` (CloudWatch Alarm) | 課金状態を DB から解決できず、認証済みユーザーが 503 を受けている (#3998) | SNS `ganbari-quest-ops-alerts` (既存 alarm と同一) |
 | `stripe-webhook-undelivered` (Discord alert) | Stripe webhook がアプリに届かず、支払い済みのプランが反映されていない (#3959) | Discord (`sendDiscordAlert` 経由) |
+| `stripe-webhook-monitor-failed` (Discord alert) | 上の未達検知 cron 自体が失敗しており、未達を検知できていない (#3959) | Discord (`sendDiscordAlert` 経由) |
+
+triage に必要な id (`oldestEventId` / `sampleCheckoutEventId` 等) は Discord embed の
+**Details field** と CloudWatch の log 本文の両方に `key=value` 形式で出る。
 
 ---
 
@@ -22,6 +26,10 @@ context を発行せず (fail-closed)、`hooks.server.ts` が 503 を返す。
 ユーザーには「一時的にご利用いただけません」が表示され、ログアウトはされていない。
 
 ### 1.2 発火条件
+
+この事象は `hooks.server.ts` から Discord にも通知される。ただし Discord 側は同一 `errorSummary` で
+5 分 3 件までにまとめられ以降は無音になるため、**件数と継続の判断は SNS (本 alarm) が正**。
+Discord だけを見て「収まった」と判断しない。
 
 `GanbariQuest/Auth` / `EntitlementDbUnavailable` が **5 分間に 5 件以上**。
 1 件 = 503 になったリクエスト 1 本。DSQL の瞬断・OCC 競合による単発失敗では鳴らない。
@@ -145,6 +153,28 @@ Stripe を持たない環境 (staging / NUC / ローカル) では検査自体�
 本番で cron が動いているかは、cron endpoint の完了 log (`[stripe-webhook-delivery-check] endpoint completed`)
 が毎時出ているかで確認する。出ていなければ EventBridge Rule / cron-dispatcher 側を疑う
 (登録の drift は `tests/unit/cron/schedule-consistency.test.ts` が CI で検出する)。
+
+なお本 alert は 5 分 window の throttle 対象だが cron は毎時実行のため throttle は効かない。
+**未達が続く間は 1 時間に 1 通鳴り続ける** (止めたい場合は原因を直すか cron を止める)。
+
+### 2.5 `stripe-webhook-monitor-failed` — 検知器が動いていない
+
+未達検知 cron が例外で終了した (Stripe API 障害 / rate limit / DB 障害)。**検知が止まっている間の
+未達は誰も気づけない**ため、未達そのものと同じ重さで扱う。
+
+alert には例外クラス名しか載せていない (接続情報を Discord に出さないため)。詳細は CloudWatch:
+
+```
+fields @timestamp, @message
+| filter @message like "stripe-webhook-delivery-check] cron failed"
+| sort @timestamp desc
+| limit 20
+```
+
+- Stripe 側の一時障害 / rate limit → 次の実行 (1 時間後) で自然復旧するか見る。復旧しなければ
+  Stripe の status を確認する。
+- DB (DSQL) 側 → `docs/runbooks/dsql-alert-response.md`。
+- 復旧まで未達検知は動いていないため、**その間の課金は §2.3 の手順で手動確認する**。
 
 ---
 

--- a/docs/runbooks/silent-failure-alert-response.md
+++ b/docs/runbooks/silent-failure-alert-response.md
@@ -1,0 +1,115 @@
+# 沈黙する障害の alert 一次対応 runbook
+
+「エラーが飛ばないまま壊れている」種類の障害 2 件について、**何を見て何を判断するか**を定める。
+どちらも例外にならないため、Lambda Errors / 5xx といった既存 alarm では表面化しない。
+
+| alert | 何が起きている | 通知経路 |
+|---|---|---|
+| `ganbari-quest-auth-entitlement-db-unavailable` (CloudWatch Alarm) | 課金状態を DB から解決できず、認証済みユーザーが 503 を受けている (#3998) | SNS `ganbari-quest-ops-alerts` (既存 alarm と同一) |
+| `stripe-webhook-undelivered` (Discord alert) | Stripe webhook がアプリに届かず、支払い済みのプランが反映されていない (#3959) | Discord (`sendDiscordAlert` 経由) |
+
+---
+
+## 1. `auth-entitlement-db-unavailable` — entitlement 解決の fail-closed
+
+### 1.1 何が起きているか
+
+`resolveTenantEntitlement` (`src/lib/server/auth/tenant-entitlement.ts`) は毎リクエストで
+テナントの課金状態を DB から引く。引けなかった場合、**古い Cookie の値で有料機能を通し続けない**ため
+context を発行せず (fail-closed)、`hooks.server.ts` が 503 を返す。
+
+したがってこの alarm は「**DB が読めていない間、認証済みユーザーが軒並み弾かれている**」ことを意味する。
+ユーザーには「一時的にご利用いただけません」が表示され、ログアウトはされていない。
+
+### 1.2 発火条件
+
+`GanbariQuest/Auth` / `EntitlementDbUnavailable` が **5 分間に 5 件以上**。
+1 件 = 503 になったリクエスト 1 本。DSQL の瞬断・OCC 競合による単発失敗では鳴らない。
+
+### 1.3 一次対応
+
+1. **範囲を測る**: CloudWatch Logs Insights で 503 の件数と対象テナント数を見る。
+
+   ```
+   fields @timestamp, @message
+   | filter @message like "auth-entitlement-db-unavailable"
+   | sort @timestamp desc
+   | limit 50
+   ```
+
+   `[auth-alert] ...` の行が 503 応答、`[AUTH] ...` の行が DB 解決失敗そのもの。
+   後者だけが出て前者が出ていない場合は、health probe 等の除外パス
+   (`ENTITLEMENT_FAILURE_EXEMPT_PATHS`) のみで発生しており顧客影響は無い。
+
+2. **DB 側を見る**: DSQL のメトリクスと `docs/runbooks/dsql-alert-response.md` を参照する。
+   本 alarm は原因ではなく結果であり、ほぼ常に DB 側の事象が先にある。
+
+3. **判断**:
+   - DSQL 側に障害の裏付けがある → DB 復旧を待つ。アプリ側の対処は不要 (復旧すれば alarm は OK に戻り、
+     OK 通知も同じ SNS に届く)。**fail-closed を外して古い権限で通す回避はしない** (課金・権限の
+     正しさを可用性より優先する PO 判断、#3963)。
+   - DSQL は健全なのに鳴っている → アプリ側の DB 接続・認証 (IAM token) を疑う。直近の deploy を確認する。
+
+### 1.4 誤検知でないことの確認
+
+alarm が鳴っているのに 503 が観測できない場合、metric filter と log の形が合っていない可能性がある。
+両者の一致は `tests/unit/infra/entitlement-fail-closed-alarm.test.ts` が CI で検証しているため、
+まず同 test が緑かを確認する。
+
+---
+
+## 2. `stripe-webhook-undelivered` — Stripe webhook の未達
+
+### 2.1 何が起きているか
+
+Stripe 側に「まだ 2xx を返していない」event が 30 分以上残っており、**かつ** 支払いが成立したはずの
+tenant にプランが反映されていない。2026-07-26 の incident (CloudFront edge がリクエストを 403 で弾き、
+リクエストが Lambda に 1 度も到達しなかった) と同型の状態。
+
+検知は cron `stripe-webhook-delivery-check` (毎時 5 分) が行う。実装とその判定条件は
+`src/lib/server/services/stripe-webhook-delivery-monitor.ts` が SSOT。
+
+### 2.2 `stripe-webhook-handler-failed` との読み分け
+
+| 見えているもの | 意味 | 次に見る場所 |
+|---|---|---|
+| `stripe-webhook-undelivered` のみ | event がアプリに届いていない | 配信経路 (CloudFront / WAF / DNS / Stripe の宛先設定) |
+| `stripe-webhook-handler-failed` のみ | 届いているが handler が失敗している | アプリの例外 log |
+| 両方 | 恒久的な handler 失敗で顧客影響も出ている | アプリの例外 log を優先 |
+
+`stripe-webhook-undelivered` は「滞留」と「顧客影響」の両方が揃ったときだけ鳴るため、
+**単独で鳴っているなら経路側を先に疑う**。
+
+### 2.3 一次対応
+
+1. **Stripe 側の事実を確認する**: Stripe Dashboard の Developers > Webhooks で対象 endpoint の
+   最近の配信を見る。alert の `oldestEventId` を Events から開き、`pending_webhooks` と
+   `webhooks_delivered_at` を確認する。
+
+2. **経路を確認する**: webhook の宛先 URL に対して外部から到達できるか (403 / 404 / 5xx のどれか) を見る。
+   CloudFront の geo restriction は Stripe (海外 IP) を弾くため、**日本国内からの疎通確認は根拠にならない**
+   (2026-07-26 の原因がこれ)。CloudFront のアクセス log / メトリクスで 403 の増加を見る。
+
+3. **顧客影響を確定させる**: alert の `sampleCheckoutEventId` から checkout session を開き、
+   `metadata.tenantId` の tenant が実際に無料プランのままかを確認する。
+
+4. **復旧**:
+   - 経路を直した後、Stripe Dashboard または `stripe events resend <event_id>` で滞留分を再送する
+     (Stripe の保持期間は 30 日)。
+   - 再送で反映されたことを、対象 tenant のプラン表示で確認する。
+   - 経路の恒久対処は #3957、取りこぼしの突合は #3958 が扱う。
+
+### 2.4 鳴らない場合の確認
+
+Stripe を持たない環境 (staging / NUC / ローカル) では検査自体を行わない (`skipped: 'stripe-disabled'`)。
+本番で cron が動いているかは、cron endpoint の完了 log (`[stripe-webhook-delivery-check] endpoint completed`)
+が毎時出ているかで確認する。出ていなければ EventBridge Rule / cron-dispatcher 側を疑う
+(登録の drift は `tests/unit/cron/schedule-consistency.test.ts` が CI で検出する)。
+
+---
+
+## 関連
+
+- `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.3 (Cron ジョブ一覧) / §3.4 (監視)
+- `docs/runbooks/dsql-alert-response.md` (DB 側の一次対応)
+- `docs/operations/stripe-post-mortem-runbook.md` (課金 incident の事後分析)

--- a/docs/runbooks/silent-failure-alert-response.md
+++ b/docs/runbooks/silent-failure-alert-response.md
@@ -61,6 +61,12 @@ alarm が鳴っているのに 503 が観測できない場合、metric filter �
 filter は「定義されているが 1 件もマッチしない」形で壊れうる。deploy 後、**アプリを壊さずに
 log を 1 行注入して metric が立つこと**を確かめる。
 
+> **注入は監査証跡を汚す**。この LogGroup は課金 path の post-mortem 用に 30 日保持されており、
+> 注入した行は本物の障害行と文字列上区別できない。実行するときは (a) 専用 log stream
+> (`alarm-firecheck-*`) にのみ書く (b) 確認後にその stream を消す (c) 実行日時と実行者を
+> 本節に追記するのではなく PR / Issue に残す、の 3 点を守る。後日の調査で「その時刻の
+> `[auth-alert]` は本物か」を判定できる状態にしておくこと。
+
 ```bash
 # 1. 注入先の log stream を 1 本用意する
 LG=/aws/lambda/ganbari-quest-app

--- a/docs/runbooks/silent-failure-alert-response.md
+++ b/docs/runbooks/silent-failure-alert-response.md
@@ -56,6 +56,40 @@ alarm が鳴っているのに 503 が観測できない場合、metric filter �
 両者の一致は `tests/unit/infra/entitlement-fail-closed-alarm.test.ts` が CI で検証しているため、
 まず同 test が緑かを確認する。
 
+### 1.5 実機での発火確認 (deploy 直後に 1 度実行する)
+
+filter は「定義されているが 1 件もマッチしない」形で壊れうる。deploy 後、**アプリを壊さずに
+log を 1 行注入して metric が立つこと**を確かめる。
+
+```bash
+# 1. 注入先の log stream を 1 本用意する
+LG=/aws/lambda/ganbari-quest-app
+LS="alarm-firecheck-$(date +%s)"
+aws logs create-log-stream --log-group-name "$LG" --log-stream-name "$LS"
+
+# 2. hooks.server.ts が 503 時に出すのと同じ形の行を 5 本入れる (閾値 = 5 分 5 件)
+NOW=$(($(date +%s) * 1000))
+aws logs put-log-events --log-group-name "$LG" --log-stream-name "$LS" --log-events "$(
+  for i in 1 2 3 4 5; do
+    printf '{"timestamp":%d,"message":"[ERROR] [auth-alert] auth-entitlement-db-unavailable: firecheck"}\n' "$NOW"
+  done | paste -sd, - | sed 's/^/[/;s/$/]/'
+)"
+
+# 3. metric に値が立つことを確認 (反映まで数分)
+aws cloudwatch get-metric-statistics \
+  --namespace GanbariQuest/Auth --metric-name EntitlementDbUnavailable \
+  --start-time "$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --period 300 --statistics Sum
+
+# 4. alarm が ALARM に遷移し SNS が飛んだことを確認 → 数分後に OK へ戻る
+aws cloudwatch describe-alarms --alarm-names ganbari-quest-auth-entitlement-db-unavailable \
+  --query 'MetricAlarms[0].[StateValue,StateReason]'
+```
+
+注入した log stream は確認後に削除してよい (`aws logs delete-log-stream`)。
+metric が 0 のままなら、filter pattern と実 log 行の形が合っていない
+(`ENTITLEMENT_FAIL_CLOSED_LOG_TERM` と `hooks.server.ts` の出力を突き合わせる)。
+
 ---
 
 ## 2. `stripe-webhook-undelivered` — Stripe webhook の未達

--- a/docs/runbooks/silent-failure-alert-response.md
+++ b/docs/runbooks/silent-failure-alert-response.md
@@ -31,8 +31,11 @@ context を発行せず (fail-closed)、`hooks.server.ts` が 503 を返す。
 5 分 3 件までにまとめられ以降は無音になるため、**件数と継続の判断は SNS (本 alarm) が正**。
 Discord だけを見て「収まった」と判断しない。
 
-`GanbariQuest/Auth` / `EntitlementDbUnavailable` が **5 分間に 5 件以上**。
-1 件 = 503 になったリクエスト 1 本。DSQL の瞬断・OCC 競合による単発失敗では鳴らない。
+`GanbariQuest/Auth` / `EntitlementDbUnavailable` が **15 分 (5 分 window × 3) のうち 2 つの window で
+1 件以上**（`threshold: 1` / `evaluationPeriods: 3` / `datapointsToAlarm: 2`、`infra/lib/ops-stack.ts`）。
+1 件 = 503 になったリクエスト 1 本。**件数ではなく継続時間で判定する**ため、契約世帯が少なく
+夜間に 1 件しか出ない規模でも 5 分以上続けば鳴り、DSQL の瞬断・OCC 競合による単発失敗
+（1 window で収まる）では鳴らない。
 
 ### 1.3 一次対応
 
@@ -81,18 +84,26 @@ LG=/aws/lambda/ganbari-quest-app
 LS="alarm-firecheck-$(date +%s)"
 aws logs create-log-stream --log-group-name "$LG" --log-stream-name "$LS"
 
-# 2. hooks.server.ts が 503 時に出すのと同じ形の行を 5 本入れる (閾値 = 5 分 5 件)
-NOW=$(($(date +%s) * 1000))
-aws logs put-log-events --log-group-name "$LG" --log-stream-name "$LS" --log-events "$(
-  for i in 1 2 3 4 5; do
-    printf '{"timestamp":%d,"message":"[ERROR] [auth-alert] auth-entitlement-db-unavailable: firecheck"}\n' "$NOW"
-  done | paste -sd, - | sed 's/^/[/;s/$/]/'
-)"
+# 2. hooks.server.ts が 503 時に出すのと同じ形の行を入れる。
+#    alarm は `datapointsToAlarm: 2` = **異なる 2 つの 5 分 window** で 1 件以上を要求するため、
+#    1 回の put では (何行入れても同一 window に落ちるので) 永久に ALARM にならない。
+#    **6 分あけて 2 回 put する**こと。
+put_firecheck() {
+  aws logs put-log-events --log-group-name "$LG" --log-stream-name "$LS" --log-events "$(
+    printf '[{"timestamp":%d,"message":"[ERROR] [auth-alert] auth-entitlement-db-unavailable: firecheck"}]' \
+      "$(($(date +%s) * 1000))"
+  )"
+}
 
-# 3. metric に値が立つことを確認 (反映まで数分)
+put_firecheck            # window 1
+sleep 360                # 5 分 window をまたぐ (6 分)
+put_firecheck            # window 2 → ここで datapointsToAlarm=2 を満たす
+
+# 3. 2 つの 5 分 window それぞれに値が立つことを確認 (反映まで数分)
+#    Sum が 1 の datapoint が 2 つ並んでいなければ window をまたげていない → 2 回目の put をやり直す
 aws cloudwatch get-metric-statistics \
   --namespace GanbariQuest/Auth --metric-name EntitlementDbUnavailable \
-  --start-time "$(date -u -d '15 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --start-time "$(date -u -d '30 minutes ago' +%Y-%m-%dT%H:%M:%SZ)" \
   --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --period 300 --statistics Sum
 
 # 4. alarm が ALARM に遷移し SNS が飛んだことを確認 → 数分後に OK へ戻る
@@ -127,6 +138,21 @@ tenant にプランが反映されていない。2026-07-26 の incident (CloudF
 
 `stripe-webhook-undelivered` は「滞留」と「顧客影響」の両方が揃ったときだけ鳴るため、
 **単独で鳴っているなら経路側を先に疑う**。
+
+#### どちらの alert も鳴らない穴 (#4108、既知)
+
+**handler が例外を握り潰して 200 を返す経路では、上の表のどちらの alert も鳴らない。**
+
+| | 理由 |
+|---|---|
+| `stripe-webhook-handler-failed` が鳴らない | 同 alert は handler の throw を前提にしている。#4108 の経路 (`resolveSubscriptionContext` の bare catch → 呼び出し側が正常終了) では throw しない |
+| `stripe-webhook-undelivered` が鳴らない | 200 を返したので Stripe 側は配信成功扱い = `pending_webhooks = 0` → S1 (滞留) が偽。本 alert は S1 ∧ S2 を条件にするため、S2 (plan 未反映) 単独では発火しない |
+
+したがって **「支払い済みなのに plan が反映されない」という顧客申告が来たのに alert が 1 つも
+鳴っていない**場合、それは「異常が無い」ことを意味しない。#4108 の経路を疑い、§2.3 の手順 3
+(checkout session → `metadata.tenantId` → 実プラン照合) を **alert を待たずに**実行する。
+
+恒久対処 (throw しない障害経路の re-throw + fitness function) は #4108 が所有する。
 
 ### 2.3 一次対応
 

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -106,6 +106,8 @@ new OpsStack(app, `${appName}Ops`, {
 	cronDispatcherFn: compute.cronDispatcherFn,
 	// #3402-1: offload 有効時のみ生成される S3 origin bucket。undefined なら S3 alarm を作らない。
 	staticAssetsBucket: network.staticAssetsBucket,
+	// #3998: entitlement fail-closed を log 由来 MetricFilter で拾うためのアプリ LogGroup
+	appLogGroup: compute.appLogGroup,
 	opsEmail,
 	discordWebhookHealth,
 });

--- a/infra/lambda/cron-dispatcher/index.ts
+++ b/infra/lambda/cron-dispatcher/index.ts
@@ -37,6 +37,8 @@ const KNOWN_ENDPOINTS: Record<string, string> = {
 	'pmf-survey': '/api/cron/pmf-survey',
 	// #3504: クラウドエクスポート非同期 build バッチ (5 分毎)
 	'export-build': '/api/cron/export-build',
+	// #3959: Stripe webhook 未達 (沈黙) の検知バッチ (毎時)
+	'stripe-webhook-delivery-check': '/api/cron/stripe-webhook-delivery-check',
 };
 
 interface CronEvent {

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -28,6 +28,8 @@ const CRON_JOBS = [
 	{ name: 'pmf-survey', utcCronExpression: 'cron(0 0 1 6,12 ? *)' },
 	// #3504: クラウドエクスポート非同期 build バッチ (5 分毎)
 	{ name: 'export-build', utcCronExpression: 'cron(0/5 * * * ? *)' },
+	// #3959: Stripe webhook 未達 (沈黙) の検知バッチ (毎時)
+	{ name: 'stripe-webhook-delivery-check', utcCronExpression: 'cron(5 * * * ? *)' },
 ] as const;
 
 export interface ComputeStackProps extends cdk.StackProps {
@@ -44,6 +46,15 @@ export interface ComputeStackProps extends cdk.StackProps {
 export class ComputeStack extends cdk.Stack {
 	public readonly fn: lambda.Function;
 	public readonly functionUrl: lambda.FunctionUrl;
+	/**
+	 * アプリ Lambda の CloudWatch LogGroup (#3998)。
+	 *
+	 * OpsStack が log 由来 MetricFilter (例外にならず 503 応答として表面化する fail-closed 等、
+	 * Lambda / CloudFront の既定 metric に乗らない事象) を張るために公開する。
+	 * `fn.logGroup` の暗黙解決に頼ると「名前が一致しているつもりの別 LogGroup」に filter を
+	 * 張っても誰も気付けないため、実体を明示的に受け渡す。
+	 */
+	public readonly appLogGroup: logs.LogGroup;
 	/** cron-dispatcher (#1376)。enableCronDispatcher=false (staging) では未構築 */
 	public readonly cronDispatcherFn?: lambda.Function;
 
@@ -79,6 +90,7 @@ export class ComputeStack extends cdk.Stack {
 			retention: logs.RetentionDays.ONE_MONTH, // 30 日、課金 path post-mortem SSOT
 			removalPolicy: cdk.RemovalPolicy.DESTROY,
 		});
+		this.appLogGroup = logGroup;
 
 		// --- Cognito 設定を SSM から取得（cross-stack export を回避） ---
 		// staging (#2873) は ssmPrefix='/ganbari-quest-staging' の staging 専用 param を参照する。

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -33,9 +33,26 @@ export interface OpsStackProps extends cdk.StackProps {
 	 * 指定時のみ S3 origin 専用 4xx/5xx alarm を作成する (offload OFF = undefined = alarm も cost も無し)。
 	 */
 	staticAssetsBucket?: s3.Bucket;
+	/**
+	 * #3998: アプリ Lambda の LogGroup (ComputeStack が生成)。
+	 * 指定時のみ log 由来 MetricFilter + Alarm を作成する (未指定 = 監視 cost ゼロ)。
+	 */
+	appLogGroup?: logs.ILogGroup;
 	opsEmail?: string;
 	discordWebhookHealth?: string;
 }
+
+/**
+ * #3998: entitlement fail-closed が 503 として表面化したことを表す log の検索語。
+ *
+ * SSOT は `TenantEntitlementUnavailableError.ALERT_KIND`
+ * (`src/lib/server/auth/tenant-entitlement.ts`) と `src/hooks.server.ts` の
+ * `[auth-alert] ${kind}` prefix。CDK の tsconfig rootDir は infra/ 固定でアプリ側 src を
+ * import できないため literal で持つが、
+ * `tests/unit/infra/entitlement-fail-closed-alarm.test.ts` が両者の drift を機械検証する
+ * (CRON_JOBS ↔ schedule-registry と同じ構図)。
+ */
+export const ENTITLEMENT_FAIL_CLOSED_LOG_TERM = '[auth-alert] auth-entitlement-db-unavailable';
 
 export class OpsStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props: OpsStackProps) {
@@ -173,6 +190,55 @@ export class OpsStack extends cdk.Stack {
 		});
 		cf5xx.addAlarmAction(alarmAction);
 		cf5xx.addOkAction(alarmAction);
+
+		// P0: entitlement 解決 fail-closed (#3998)
+		//
+		// #3963 で `resolveContext` は課金状態を毎リクエスト DB から引くようになり、解決に
+		// 失敗したら context を発行しない (fail-closed)。この副作用として DB 障害中は有効な
+		// Cookie を持つユーザーが軒並み 503 になる。PO はこの trade-off を承認したが、
+		// **承認の前提は「起きたら気付けること」**である。
+		//
+		// 既存 alarm では拾えない:
+		//   - Lambda Errors …… hooks.server.ts が例外を握って 503 Response を返すため invocation error にならない
+		//   - Url5xx ………… 拾える可能性はあるが「DB 由来の権限剥奪」と他の 5xx を区別できず、
+		//                     原因の切り分け (= incident 対応の最初の分岐) ができない
+		//   - Url4xx spike … 3xx / 4xx ではないため乗らない
+		// そのため log 本文を唯一の情報源として MetricFilter で metric 化する。
+		if (props.appLogGroup) {
+			const entitlementFailClosed = new logs.MetricFilter(this, 'EntitlementFailClosedFilter', {
+				logGroup: props.appLogGroup,
+				filterPattern: logs.FilterPattern.literal(`"${ENTITLEMENT_FAIL_CLOSED_LOG_TERM}"`),
+				metricNamespace: 'GanbariQuest/Auth',
+				metricName: 'EntitlementDbUnavailable',
+				metricValue: '1',
+				defaultValue: 0,
+			});
+
+			// 閾値の根拠 (#3998 AC3):
+			//   1 件 = 1 リクエストが 503 になった、という単位になるように filter は
+			//   hooks.server.ts の 503 応答 1 行だけを数える (DB 解決失敗そのものの log 行は
+			//   `auth-entitlement-db-unavailable` で Logs Insights から追えるが metric には数えない)。
+			//   DSQL は OCC 競合 / 瞬断で単発の解決失敗が起こりうるため 1 件では鳴らさない。
+			//   5 分間に 5 リクエスト = 一過性ではなく継続してユーザーが弾かれている状態、という線を引く。
+			//   これは既存 `ganbari-quest-lambda-url-5xx` (5 分 5 件) と同じ粒度で、運用者が
+			//   「5 分 5 件で鳴る」という 1 つの感覚だけを覚えれば済むようにするため意図的に揃えている。
+			//   metric は該当 log が無い間データ点を持たないため treatMissingData=NOT_BREACHING。
+			const entitlementFailClosedAlarm = new cloudwatch.Alarm(this, 'EntitlementFailClosed', {
+				alarmName: 'ganbari-quest-auth-entitlement-db-unavailable',
+				alarmDescription:
+					'課金状態を DB から解決できず 503 になったリクエスト: 5分間に5件以上 (#3998 fail-closed)',
+				metric: entitlementFailClosed.metric({
+					period: cdk.Duration.minutes(5),
+					statistic: 'Sum',
+				}),
+				threshold: 5,
+				evaluationPeriods: 1,
+				comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+			});
+			entitlementFailClosedAlarm.addAlarmAction(alarmAction);
+			entitlementFailClosedAlarm.addOkAction(alarmAction);
+		}
 
 		// P0: Cron Dispatcher Lambda Errors (#1376 AC6)
 		// CronDispatcherFn が prop として渡された場合のみアラームを作成する（最小構成）

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -218,21 +218,27 @@ export class OpsStack extends cdk.Stack {
 			//   1 件 = 1 リクエストが 503 になった、という単位になるように filter は
 			//   hooks.server.ts の 503 応答 1 行だけを数える (DB 解決失敗そのものの log 行は
 			//   `auth-entitlement-db-unavailable` で Logs Insights から追えるが metric には数えない)。
-			//   DSQL は OCC 競合 / 瞬断で単発の解決失敗が起こりうるため 1 件では鳴らさない。
-			//   5 分間に 5 リクエスト = 一過性ではなく継続してユーザーが弾かれている状態、という線を引く。
-			//   これは既存 `ganbari-quest-lambda-url-5xx` (5 分 5 件) と同じ粒度で、運用者が
-			//   「5 分 5 件で鳴る」という 1 つの感覚だけを覚えれば済むようにするため意図的に揃えている。
+			//
+			//   **一過性かどうかは「件数」ではなく「継続時間」で判定する**。
+			//   件数で引く (例: 5 分 5 件) と、契約世帯が数戸という現在の規模では夜間・早朝の障害中に
+			//   閾値へ到達せず、全員が終夜 503 のまま誰も気付けない (既存 lambda-url-5xx と粒度を
+			//   揃えたくなるが、あちらはトラフィック量に比例する metric、こちらは 1 件出た時点で
+			//   「DB が読めていない」を意味する全ユーザー同時被弾型で、性質が異なる)。
+			//   そこで 1 件を閾値としつつ、15 分 (5 分 × 3) のうち 2 window で発生したときに鳴らす。
+			//   DSQL の OCC 競合 / 瞬断による単発失敗は 1 window で収まるため鳴らず、
+			//   5 分以上継続する障害は低トラフィックでも捕捉できる。
 			//   metric は該当 log が無い間データ点を持たないため treatMissingData=NOT_BREACHING。
 			const entitlementFailClosedAlarm = new cloudwatch.Alarm(this, 'EntitlementFailClosed', {
 				alarmName: 'ganbari-quest-auth-entitlement-db-unavailable',
 				alarmDescription:
-					'課金状態を DB から解決できず 503 になったリクエスト: 5分間に5件以上 (#3998 fail-closed)',
+					'課金状態を DB から解決できず 503 になったリクエスト: 15分内の2つの5分window で発生 (#3998 fail-closed)',
 				metric: entitlementFailClosed.metric({
 					period: cdk.Duration.minutes(5),
 					statistic: 'Sum',
 				}),
-				threshold: 5,
-				evaluationPeriods: 1,
+				threshold: 1,
+				evaluationPeriods: 3,
+				datapointsToAlarm: 2,
 				comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
 				treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
 			});

--- a/src/lib/server/auth/tenant-entitlement.ts
+++ b/src/lib/server/auth/tenant-entitlement.ts
@@ -82,10 +82,17 @@ export async function resolveTenantEntitlement(tenantId: string): Promise<Tenant
 		cache?.set(tenantId, entitlement);
 		return entitlement;
 	} catch (e) {
-		logger.error('[AUTH] Failed to resolve tenant entitlement from DB', {
-			error: e instanceof Error ? e.message : String(e),
-			context: { kind: TenantEntitlementUnavailableError.ALERT_KIND, tenantId },
-		});
+		// #3998: Lambda 上で logger が CloudWatch に書くのは console 出力 = `message` 本文だけで、
+		// `context` は載らない。kind を message に含めないと Logs Insights から
+		// `auth-entitlement-db-unavailable` で辿れる行が「503 を返した側」だけになるため、
+		// DB 解決失敗そのものの行にも kind を持たせる。
+		logger.error(
+			`[AUTH] ${TenantEntitlementUnavailableError.ALERT_KIND}: Failed to resolve tenant entitlement from DB`,
+			{
+				error: e instanceof Error ? e.message : String(e),
+				context: { kind: TenantEntitlementUnavailableError.ALERT_KIND, tenantId },
+			},
+		);
 		throw new TenantEntitlementUnavailableError(tenantId, e);
 	}
 }

--- a/src/lib/server/cron/schedule-registry.ts
+++ b/src/lib/server/cron/schedule-registry.ts
@@ -92,4 +92,14 @@ export const scheduleRegistry: CronJob[] = [
 		utcCronExpression: 'cron(0/5 * * * ? *)', // 5 分毎 (UTC、JST と同一間隔)
 		description: 'クラウドエクスポート非同期 build バッチ (#3504)',
 	},
+	{
+		// #3959: Stripe webhook が Lambda に到達していない (沈黙) を外から検知する。
+		// 検知遅延 1 時間以内という要件から毎時実行。毎時 5 分に寄せているのは、他の日次 cron が
+		// 00 分に集中しており同時実行で 30 秒予算を圧迫するのを避けるため。
+		name: 'stripe-webhook-delivery-check',
+		endpoint: '/api/cron/stripe-webhook-delivery-check',
+		cronExpression: '5 * * * *', // 毎時 5 分 (JST)
+		utcCronExpression: 'cron(5 * * * ? *)', // 毎時 5 分 (UTC、JST と同一間隔)
+		description: 'Stripe webhook 未達の検知バッチ (#3959)',
+	},
 ];

--- a/src/lib/server/discord-alert.ts
+++ b/src/lib/server/discord-alert.ts
@@ -14,6 +14,15 @@ export interface AlertOptions {
 	tenantId?: string;
 	errorSummary?: string;
 	stackSummary?: string;
+	/**
+	 * triage に必要な補足情報 (event id / 件数など) を 1 行で表したもの。
+	 *
+	 * `message` は embed title に展開される際 200 文字で切られ、`errorSummary` は
+	 * スロットリング key を兼ねるため実行ごとに変わる値を入れられない。両方に載せられない
+	 * 「毎回変わるが受け手が必要とする情報」の置き場としてこの field を使う (#4102 / #3959)。
+	 * スロットリング key には含めない (同一事象は変わらず 1 通にまとまる)。
+	 */
+	details?: string;
 }
 
 // スロットリング用メモリマップ
@@ -105,6 +114,11 @@ export async function sendDiscordAlert(options: AlertOptions): Promise<void> {
 		options.errorSummary && {
 			name: 'Error',
 			value: `\`\`\`${options.errorSummary.slice(0, 500)}\`\`\``,
+		},
+		options.details && {
+			name: 'Details',
+			// Discord の embed field value 上限は 1024 文字。code block の記号分を引いて余裕を取る
+			value: `\`\`\`${options.details.slice(0, 900)}\`\`\``,
 		},
 		options.stackSummary && {
 			name: 'Stack (先頭3行)',

--- a/src/lib/server/services/stripe-webhook-delivery-monitor.ts
+++ b/src/lib/server/services/stripe-webhook-delivery-monitor.ts
@@ -1,0 +1,259 @@
+// src/lib/server/services/stripe-webhook-delivery-monitor.ts
+//
+// #3959: Stripe webhook が「そもそも届いていない」ことを検知する (沈黙の検知)。
+//
+// 2026-07-26 の本番課金 incident では、CloudFront edge が Stripe からのリクエストを 403 で弾き、
+// **リクエストが Lambda に 1 度も到達しなかった**。アプリ内の通知経路 (`notifyStripeAlert` /
+// `sendDiscordAlert`) はすべて「アプリのコードが実行された」ことを前提にしているため、
+// 初の有料課金が丸ごと落ちても alert は 1 つも鳴らず、顧客申告で発覚した。
+//
+// 「異常 = 例外が発生する」という前提では **イベントの不在**を検知できない。そこで
+// 「Stripe 側には event があるのに、こちら側で完了していない」ことを外から周期的に確かめる。
+//
+// ## 検知の 2 signal (Issue #3959 ゴール)
+//
+//   S1 (滞留): Stripe の Event が `pending_webhooks > 0` のまま `STALE_MINUTES` 以上経過している。
+//      `pending_webhooks` は「まだ 2xx を返していない配信先の数」で、incident 当時これが唯一の
+//      決定的な証拠だった (`pending_webhooks=1` / `webhooks_delivered_at=null`)。
+//   S2 (未反映): `checkout.session.completed` が `STALE_MINUTES` 以上前に発生しているのに、
+//      その tenant に subscription が結び付いていない (= 支払いが起きたのにプランが反映されていない)。
+//      S1 が Stripe 側の事実であるのに対し、S2 は**顧客影響そのもの**を見る。
+//
+// ## PR #4079 (`stripe-webhook-handler-failed`) との責務分界
+//
+// | | 所有する事象 | 発火 | 情報源 |
+// |---|---|---|---|
+// | `stripe-webhook-handler-failed` (#3985 / PR #4079) | event は**到達した**が handler が throw した | 初回失敗の瞬間 (同期) | アプリ内の catch |
+// | `stripe-webhook-undelivered` (本 module) | event が**到達していない / 完了していない** | cron (1 時間毎) | Stripe API + 自 DB |
+//
+// Stripe API だけでは「未達」と「到達したが 500 を返した」を判別できない (どちらも
+// `pending_webhooks > 0` のまま)。そのため本 module は**単独の pending だけでは鳴らさず**、
+// S1 と S2 の**論理積**を条件にする (下記 `shouldAlert`)。handler が個別に失敗している場合、
+// checkout の効果は他経路 (subscription webhook / Portal) や再送で反映されうるため S2 は立たず、
+// 本 alert は沈黙して #4079 側が所有する。両方が立つのは「支払いが起きたのに何も反映されていない」
+// = 2026-07-26 と同型の事象に限られる。
+//
+// 1 回の実行で Discord に送るのは **最大 1 通**。findings は 1 通にまとめる (通知の重複を作らない)。
+//
+// 設計 SSOT: docs/design/13-AWSサーバレスアーキテクチャ設計書.md §3.3 Cron ジョブ一覧
+//            docs/runbooks/silent-failure-alert-response.md (一次対応)
+
+import type Stripe from 'stripe';
+import { getRepos } from '$lib/server/db/factory';
+import { logger } from '$lib/server/logger';
+import { notifyStripeAlert } from '$lib/server/stripe/alert';
+import { getStripeClient, isStripeEnabled } from '$lib/server/stripe/client';
+
+/**
+ * event 作成から何分経過したものを「滞留」とみなすか。
+ *
+ * Stripe は配信失敗時に指数バックオフで最大 3 日間再送するため、**一過性の失敗は数分で自然復旧する**。
+ * 30 分は「Stripe の初期リトライが数回走っても解決していない」線であり、かつ検知遅延 1 時間以内
+ * (Issue #3959 ゴール、cron は毎時実行) を満たす。短くすると再送で直る一過性障害を鳴らし、
+ * 長くすると顧客が支払い済みなのに使えない時間が伸びる。
+ */
+export const STALE_MINUTES = 30;
+
+/** 何時間さかのぼって Stripe の event を確認するか (1 回の実行で見る窓)。 */
+export const LOOKBACK_HOURS = 24;
+
+/**
+ * 1 回の実行で Stripe から取得する event の上限。
+ *
+ * cron は 30 秒予算のアプリ Lambda 上で走る (13-AWS 設計書 §3.3 Cron ジョブ実行時間予算) ため
+ * ページングしない。上限に達している時点で既に異常事態であり、その事実自体を alert に載せる。
+ */
+export const MAX_EVENTS_PER_RUN = 100;
+
+/** 監視対象の event 型 (購読 5 種のうち、課金の成立に直結するもの)。 */
+const MONITORED_EVENT_TYPES = [
+	'checkout.session.completed',
+	'invoice.paid',
+	'customer.subscription.updated',
+	'customer.subscription.deleted',
+] as const;
+
+const CHECKOUT_COMPLETED = 'checkout.session.completed';
+
+export interface StaleEventSummary {
+	eventId: string;
+	eventType: string;
+	createdIso: string;
+	pendingWebhooks: number;
+}
+
+export interface UnreflectedCheckoutSummary {
+	eventId: string;
+	createdIso: string;
+	/** session.metadata.tenantId (未設定なら null)。PII ではない内部 ID */
+	tenantId: string | null;
+	reason: 'tenant-not-found' | 'no-subscription' | 'tenant-id-missing';
+}
+
+export interface WebhookDeliveryCheckResult {
+	/** Stripe が無効な環境 (staging / NUC / local) では検査せず終了する */
+	skipped: 'stripe-disabled' | null;
+	/** 走査した event 数 */
+	checked: number;
+	/** S1: pending のまま滞留している event */
+	staleEvents: StaleEventSummary[];
+	/** S2: checkout 完了なのに plan が反映されていない event */
+	unreflectedCheckouts: UnreflectedCheckoutSummary[];
+	/** MAX_EVENTS_PER_RUN に達したか (取りこぼしの可能性) */
+	truncated: boolean;
+	/** Discord alert を送ったか */
+	alerted: boolean;
+}
+
+/**
+ * alert を鳴らすかの判定 (責務分界の実体)。
+ *
+ * S1 (Stripe 側で未完了) と S2 (顧客影響あり) の両方が立ったときだけ鳴らす。
+ * 片方だけで鳴らすと、handler 失敗を所有する `stripe-webhook-handler-failed` (PR #4079) と
+ * 同一事象で二重に鳴る。
+ */
+export function shouldAlert(result: {
+	staleEvents: readonly unknown[];
+	unreflectedCheckouts: readonly unknown[];
+}): boolean {
+	return result.staleEvents.length > 0 && result.unreflectedCheckouts.length > 0;
+}
+
+function toIso(unixSeconds: number): string {
+	return new Date(unixSeconds * 1000).toISOString();
+}
+
+/**
+ * checkout の効果が DB に反映されているかを確認する。
+ *
+ * 反映済み = その tenant に Stripe subscription が結び付いている状態。
+ * 支払いが成立していれば `checkout.session.completed` handler が `stripeSubscriptionId` を書く。
+ */
+async function inspectCheckout(event: Stripe.Event): Promise<UnreflectedCheckoutSummary | null> {
+	const session = event.data.object as Stripe.Checkout.Session;
+	const tenantId = session.metadata?.tenantId ?? null;
+	const createdIso = toIso(event.created);
+
+	if (!tenantId) {
+		// metadata が欠けている = そもそも当方の checkout 経路で作られていない可能性がある。
+		// 判定不能を「正常」に倒すと沈黙するため、未反映として扱い人が見る。
+		return { eventId: event.id, createdIso, tenantId: null, reason: 'tenant-id-missing' };
+	}
+
+	const tenant = await getRepos().auth.findTenantById(tenantId);
+	if (!tenant) {
+		return { eventId: event.id, createdIso, tenantId, reason: 'tenant-not-found' };
+	}
+	if (!tenant.stripeSubscriptionId) {
+		return { eventId: event.id, createdIso, tenantId, reason: 'no-subscription' };
+	}
+	return null;
+}
+
+/**
+ * Stripe webhook の未達を検査し、必要なら Discord に 1 通だけ通知する。
+ *
+ * @param now 判定基準時刻 (test で固定するため注入可能。既定は現在時刻)
+ */
+export async function checkWebhookDelivery(
+	now: Date = new Date(),
+): Promise<WebhookDeliveryCheckResult> {
+	const base: WebhookDeliveryCheckResult = {
+		skipped: null,
+		checked: 0,
+		staleEvents: [],
+		unreflectedCheckouts: [],
+		truncated: false,
+		alerted: false,
+	};
+
+	if (!isStripeEnabled()) {
+		// staging / NUC / local。Stripe を持たない環境で毎時 alert を出さない。
+		logger.info('[stripe-webhook-delivery-check] Stripe 無効のため検査を行いません', {
+			service: 'stripe',
+		});
+		return { ...base, skipped: 'stripe-disabled' };
+	}
+
+	const nowSec = Math.floor(now.getTime() / 1000);
+	const staleBeforeSec = nowSec - STALE_MINUTES * 60;
+	const lookbackFromSec = nowSec - LOOKBACK_HOURS * 3600;
+
+	const stripe = getStripeClient();
+	const list = await stripe.events.list({
+		types: [...MONITORED_EVENT_TYPES],
+		created: { gte: lookbackFromSec, lte: staleBeforeSec },
+		limit: MAX_EVENTS_PER_RUN,
+	});
+	const events = list.data ?? [];
+
+	const staleEvents: StaleEventSummary[] = [];
+	const unreflectedCheckouts: UnreflectedCheckoutSummary[] = [];
+
+	for (const event of events) {
+		if (event.pending_webhooks > 0) {
+			staleEvents.push({
+				eventId: event.id,
+				eventType: event.type,
+				createdIso: toIso(event.created),
+				pendingWebhooks: event.pending_webhooks,
+			});
+		}
+		if (event.type === CHECKOUT_COMPLETED) {
+			const unreflected = await inspectCheckout(event);
+			if (unreflected) unreflectedCheckouts.push(unreflected);
+		}
+	}
+
+	const result: WebhookDeliveryCheckResult = {
+		...base,
+		checked: events.length,
+		staleEvents,
+		unreflectedCheckouts,
+		truncated: events.length >= MAX_EVENTS_PER_RUN,
+	};
+
+	if (!shouldAlert(result)) {
+		logger.info('[stripe-webhook-delivery-check] 未達の兆候はありません', {
+			service: 'stripe',
+			context: {
+				checked: result.checked,
+				staleCount: staleEvents.length,
+				unreflectedCount: unreflectedCheckouts.length,
+			},
+		});
+		return result;
+	}
+
+	const oldestStale = staleEvents[0];
+	// 通知には event id / type / tenant id / 件数のみを載せる。顧客の email / 氏名 / カード情報は
+	// 一切参照しない (notifyStripeAlert 側でも redactPii を通す、#2738 整合)。
+	notifyStripeAlert({
+		kind: 'stripe-webhook-undelivered',
+		message:
+			`Stripe webhook が ${STALE_MINUTES} 分以上未完了で、支払い済みのプラン反映も行われていません ` +
+			`(未完了 ${staleEvents.length} 件 / 未反映 checkout ${unreflectedCheckouts.length} 件)`,
+		errorSummary: 'stripe-webhook-undelivered',
+		tags: {
+			staleCount: staleEvents.length,
+			unreflectedCount: unreflectedCheckouts.length,
+			checked: result.checked,
+			truncated: result.truncated,
+			...(oldestStale
+				? {
+						oldestEventId: oldestStale.eventId,
+						oldestEventType: oldestStale.eventType,
+						oldestCreatedIso: oldestStale.createdIso,
+					}
+				: {}),
+			...(unreflectedCheckouts[0]
+				? {
+						sampleCheckoutEventId: unreflectedCheckouts[0].eventId,
+						sampleCheckoutReason: unreflectedCheckouts[0].reason,
+					}
+				: {}),
+		},
+	});
+
+	return { ...result, alerted: true };
+}

--- a/src/lib/server/services/stripe-webhook-delivery-monitor.ts
+++ b/src/lib/server/services/stripe-webhook-delivery-monitor.ts
@@ -41,7 +41,7 @@
 import type Stripe from 'stripe';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
-import { notifyStripeAlert } from '$lib/server/stripe/alert';
+import { notifyStripeAlertAsync } from '$lib/server/stripe/alert';
 import { getStripeClient, isStripeEnabled } from '$lib/server/stripe/client';
 
 /**
@@ -240,10 +240,19 @@ export async function checkWebhookDelivery(
 		return result;
 	}
 
-	const oldestStale = staleEvents[0];
+	// `stripe.events.list` は created の**降順** (新しい順) で返すため `staleEvents[0]` は最新。
+	// runbook は障害の開始時刻を推定するために最古から辿るので、明示的に最小を取る (#4102 M4)。
+	// createdIso は UTC の ISO 8601 固定長で、辞書順比較 = 時刻順比較になる。
+	const oldestStale = staleEvents.reduce<StaleEventSummary | undefined>(
+		(oldest, event) => (!oldest || event.createdIso < oldest.createdIso ? event : oldest),
+		undefined,
+	);
 	// 通知には event id / type / tenant id / 件数のみを載せる。顧客の email / 氏名 / カード情報は
-	// 一切参照しない (notifyStripeAlert 側でも redactPii を通す、#2738 整合)。
-	notifyStripeAlert({
+	// 一切参照しない (notifyStripeAlertAsync 側でも redactPii を通す、#2738 整合)。
+	//
+	// alert 送信は **await する**。本 cron は「alert を送って即レスポンス」であり、fire-and-forget の
+	// まま返すと Lambda の freeze で送信中の fetch が凍結され、鳴るはずの通知が消える (#4102 M2)。
+	await notifyStripeAlertAsync({
 		kind: 'stripe-webhook-undelivered',
 		message:
 			`Stripe webhook が ${STALE_MINUTES} 分以上未完了で、支払い済みのプラン反映も行われていません ` +

--- a/src/lib/server/services/stripe-webhook-delivery-monitor.ts
+++ b/src/lib/server/services/stripe-webhook-delivery-monitor.ts
@@ -28,10 +28,25 @@
 //
 // Stripe API だけでは「未達」と「到達したが 500 を返した」を判別できない (どちらも
 // `pending_webhooks > 0` のまま)。そのため本 module は**単独の pending だけでは鳴らさず**、
-// S1 と S2 の**論理積**を条件にする (下記 `shouldAlert`)。handler が個別に失敗している場合、
-// checkout の効果は他経路 (subscription webhook / Portal) や再送で反映されうるため S2 は立たず、
-// 本 alert は沈黙して #4079 側が所有する。両方が立つのは「支払いが起きたのに何も反映されていない」
-// = 2026-07-26 と同型の事象に限られる。
+// S1 と S2 の**論理積**を条件にする (下記 `shouldAlert`)。handler が **throw して**失敗した場合、
+// Stripe は再送するため checkout の効果は他経路 (subscription webhook / Portal) や再送で
+// 反映されうる。両方が立つのは「支払いが起きたのに何も反映されていない」= 2026-07-26 と同型の
+// 事象に限られる。
+//
+// ## どちらの alert も所有しない穴 (#4108、既知・本 PR では塞がない)
+//
+// handler が **throw せずに** 200 を返してしまう経路 (#4108: `resolveSubscriptionContext` が
+// bare catch で一過性障害を潰し、呼び出し側が `if (!tenant) return` で正常終了する) は、
+// **本 module と #4079 のどちらも検知しない**:
+//
+//   - `stripe-webhook-handler-failed` (#4079) は handler の throw を前提にするため発火しない。
+//   - 200 が返っているので Stripe 側は配信成功扱いになり `pending_webhooks = 0` → **S1 が偽**。
+//     本 module は S1 ∧ S2 を条件にするため、S2 (plan 未反映) が立っていても発火しない。
+//
+// つまり「支払い済みなのに plan が反映されない」状態が**無通知で継続する**。恒久対処 (throw しない
+// 障害経路の re-throw + fitness function) は #4108 が所有する。S2 単独で鳴らす別 kind を足す案は
+// 検知条件そのものの変更 (false positive の再評価が必要) になるため本 PR の scope 外とし、PO 判断に
+// 委ねる。runbook 側の記述は `docs/runbooks/silent-failure-alert-response.md` §2.2 が SSOT。
 //
 // 1 回の実行で Discord に送るのは **最大 1 通**。findings は 1 通にまとめる (通知の重複を作らない)。
 //

--- a/src/lib/server/services/stripe-webhook-delivery-monitor.ts
+++ b/src/lib/server/services/stripe-webhook-delivery-monitor.ts
@@ -87,7 +87,7 @@ export interface UnreflectedCheckoutSummary {
 	createdIso: string;
 	/** session.metadata.tenantId (未設定なら null)。PII ではない内部 ID */
 	tenantId: string | null;
-	reason: 'tenant-not-found' | 'no-subscription' | 'tenant-id-missing';
+	reason: 'tenant-not-found' | 'no-subscription' | 'subscription-mismatch' | 'tenant-id-missing';
 }
 
 export interface WebhookDeliveryCheckResult {
@@ -123,11 +123,20 @@ function toIso(unixSeconds: number): string {
 	return new Date(unixSeconds * 1000).toISOString();
 }
 
+/** Stripe の `session.subscription` は id 文字列か展開済オブジェクトのどちらでも来る。 */
+function subscriptionIdOf(session: Stripe.Checkout.Session): string | null {
+	const sub = session.subscription;
+	if (!sub) return null;
+	return typeof sub === 'string' ? sub : sub.id;
+}
+
 /**
  * checkout の効果が DB に反映されているかを確認する。
  *
- * 反映済み = その tenant に Stripe subscription が結び付いている状態。
- * 支払いが成立していれば `checkout.session.completed` handler が `stripeSubscriptionId` を書く。
+ * 「tenant が subscription を 1 本持っている」だけを条件にすると、**既存契約者のプラン変更**
+ * checkout が常に「反映済み」と誤判定される (変更前の subscription が残っているため)。
+ * その場合は代金だけ取られて機能が開かない状態を見逃すので、Stripe が言う
+ * 「この checkout が作った subscription」と DB が指す subscription の一致まで見る。
  */
 async function inspectCheckout(event: Stripe.Event): Promise<UnreflectedCheckoutSummary | null> {
 	const session = event.data.object as Stripe.Checkout.Session;
@@ -146,6 +155,12 @@ async function inspectCheckout(event: Stripe.Event): Promise<UnreflectedCheckout
 	}
 	if (!tenant.stripeSubscriptionId) {
 		return { eventId: event.id, createdIso, tenantId, reason: 'no-subscription' };
+	}
+
+	const sessionSubscriptionId = subscriptionIdOf(session);
+	if (sessionSubscriptionId && sessionSubscriptionId !== tenant.stripeSubscriptionId) {
+		// この checkout で成立した subscription を DB が指していない = 反映されていない。
+		return { eventId: event.id, createdIso, tenantId, reason: 'subscription-mismatch' };
 	}
 	return null;
 }

--- a/src/lib/server/stripe/alert.ts
+++ b/src/lib/server/stripe/alert.ts
@@ -50,7 +50,12 @@ export type StripeAlertKind =
 	| 'stripe-subscription-multi-item'
 	// #3981: subscription から tenant を解決する経路が **障害で** 落ちた。
 	// 「tenant が本当に不在」とは区別する (不在は warn のみで alert しない)。
-	| 'stripe-context-unresolved';
+	| 'stripe-context-unresolved'
+	// #3959: webhook が Lambda に到達していない (沈黙) の検知。cron が 1 時間毎に Stripe API と
+	// 自 DB を突き合わせて発火する。上の `stripe-webhook-handler-failed` は「到達したが handler が
+	// 失敗した」側を所有し、本 kind とは発火条件が重ならない
+	// (責務分界は stripe-webhook-delivery-monitor.ts 冒頭)。
+	| 'stripe-webhook-undelivered';
 
 export interface StripeAlertOptions {
 	/** alert 種別 (Phase 6 子 5 §6 SSOT 3 種) */

--- a/src/lib/server/stripe/alert.ts
+++ b/src/lib/server/stripe/alert.ts
@@ -55,7 +55,11 @@ export type StripeAlertKind =
 	// 自 DB を突き合わせて発火する。上の `stripe-webhook-handler-failed` は「到達したが handler が
 	// 失敗した」側を所有し、本 kind とは発火条件が重ならない
 	// (責務分界は stripe-webhook-delivery-monitor.ts 冒頭)。
-	| 'stripe-webhook-undelivered';
+	| 'stripe-webhook-undelivered'
+	// #3959: 上の未達検知そのものが失敗した (Stripe API 障害 / DB 障害 等)。検知器が動いて
+	// いない間は未達を見逃すため、検知器の停止自体を 1 つの障害として鳴らす。cron dispatcher は
+	// 非 2xx を throw せず返すため Lambda の error alarm では表面化しない (#4102 QM 指摘 M3)。
+	| 'stripe-webhook-monitor-failed';
 
 export interface StripeAlertOptions {
 	/** alert 種別 (Phase 6 子 5 §6 SSOT 3 種) */
@@ -69,14 +73,91 @@ export interface StripeAlertOptions {
 }
 
 /**
- * Stripe 領域専用 Discord alert wrapper (fire-and-forget)。
+ * tags を `key=value` 列の 1 行に畳む。
+ *
+ * **なぜ必要か (#4102 QM 指摘 M1)**: `logger` の `writeLog` は console に `message` 本文しか
+ * 出さず `context` を捨てる (src/lib/server/logger.ts)。したがって triage 用の id を
+ * structured context にだけ置くと、Lambda 上では CloudWatch にも Discord にも一切現れない。
+ * runbook が「alert の `oldestEventId` を Stripe で開く」と書いても実行できない状態になるため、
+ * 同じ内容を **人が読める 1 行**にして message 本文と Discord embed の両方に載せる。
+ *
+ * context への構造化出力は (logger を JSON 出力化したときに効くよう) 従来どおり併存させる。
+ */
+export function formatAlertTags(
+	tags: Record<string, string | number | boolean> | undefined,
+): string {
+	if (!tags) return '';
+	const entries = Object.entries(tags);
+	if (entries.length === 0) return '';
+	return entries.map(([key, value]) => `${key}=${value}`).join(' ');
+}
+
+/**
+ * Stripe 領域専用 Discord alert (送信完了まで await できる版)。
  *
  * 動作:
- *   1. `logger.warn` で structured context (kind + tags) を出力 (CloudWatch Logs Insights 検索可能)
- *   2. `sendDiscordAlert` を fire-and-forget で起動 (alert 失敗は課金 path をブロックしない)
+ *   1. `logger.warn` で message 本文 + structured context (kind + tags) を出力
+ *   2. `sendDiscordAlert` の完了まで待つ
+ *
+ * **await 版が要る理由 (#4102 QM 指摘 M2)**: Lambda はレスポンス返却後に実行環境が freeze
+ * されるため、`void sendDiscordAlert(...)` の送信中 fetch はそのまま凍結されうる。HTTP request
+ * 処理が続く経路では実質問題にならないが、**alert 送信が最終処理になる cron** では
+ * 「送られないまま消える」ため、レスポンス前に完了させる必要がある。
+ *
+ * 本関数は throw しない (送信失敗は logger.warn に落とす)。呼び出し側の業務処理を
+ * alert の失敗で壊さないため。
+ */
+export async function notifyStripeAlertAsync(options: StripeAlertOptions): Promise<void> {
+	const { kind, message, errorSummary, tags } = options;
+
+	// PII redaction (Issue #2738 / QA Adversarial security 軸 V-3 解消):
+	//   Stripe error message に含まれる customer email / phone / card last4 を
+	//   Discord webhook + structured logger 送信前に redact する。Stripe 内部 ID
+	//   (cus_* / sub_* 等) は debug 用途で維持。
+	const redactedMessage = redactPii(message);
+	const redactedErrorSummary = errorSummary ? redactPii(errorSummary) : undefined;
+	const redactedTags = redactPiiInTags(tags);
+	// redact 済 tags から組み立てるため、本文に畳んでも PII は載らない
+	const details = formatAlertTags(redactedTags);
+
+	// 1. structured logger (CloudWatch Logs Insights 検索 key: `kind` / `tags.*`)
+	//    message 本文にも details を畳む = console 出力しか見えない Lambda でも triage できる
+	logger.warn(`[stripe-alert] ${kind}: ${redactedMessage}${details ? ` | ${details}` : ''}`, {
+		service: 'stripe',
+		context: {
+			kind,
+			...(redactedErrorSummary ? { errorSummary: redactedErrorSummary } : {}),
+			...(redactedTags ?? {}),
+		},
+	});
+
+	// 2. Discord alert。details は embed の Details field に出す (title は 200 文字で切られ、
+	//    errorSummary は throttle key 兼用で毎回変わる値を入れられないため)
+	try {
+		await sendDiscordAlert({
+			level: 'error',
+			message: `[${kind}] ${redactedMessage}`,
+			errorSummary: redactedErrorSummary ?? kind,
+			details: details || undefined,
+		});
+	} catch (err) {
+		// alert 自体の失敗は logger.warn で記録 (recursive alert を避ける)
+		//   err.message にも PII が含まれる可能性があるため redact
+		logger.warn(
+			`[stripe-alert] Discord alert dispatch failed for ${kind}: ${redactPii(String(err))}`,
+		);
+	}
+}
+
+/**
+ * Stripe 領域専用 Discord alert wrapper (fire-and-forget)。
  *
  * silent return しないことで kill switch fallback 発動時に observability gap を回避する
  * (QM Adversarial security 軸所見 #2720 直対処)。
+ *
+ * 課金 path (webhook handler / checkout 等) のように「この後もリクエスト処理が続く」経路向け。
+ * **alert 送信が最後の処理になる cron からは `notifyStripeAlertAsync` を await すること**
+ * (Lambda freeze で送信が消える、#4102 M2)。
  *
  * @param options - alert kind + message + structured tags
  *
@@ -90,39 +171,6 @@ export interface StripeAlertOptions {
  *   });
  */
 export function notifyStripeAlert(options: StripeAlertOptions): void {
-	const { kind, message, errorSummary, tags } = options;
-
-	// PII redaction (Issue #2738 / QA Adversarial security 軸 V-3 解消):
-	//   Stripe error message に含まれる customer email / phone / card last4 を
-	//   Discord webhook + structured logger 送信前に redact する。Stripe 内部 ID
-	//   (cus_* / sub_* 等) は debug 用途で維持。
-	const redactedMessage = redactPii(message);
-	const redactedErrorSummary = errorSummary ? redactPii(errorSummary) : undefined;
-	const redactedTags = redactPiiInTags(tags);
-
-	// 1. structured logger (CloudWatch Logs Insights 検索 key: `kind` / `tags.*`)
-	//    Sentry SaaS 統合は別 Issue だが、本 logger output は CloudWatch Logs Insights で
-	//    `fields @timestamp, kind, message | filter kind = "stripe-lookup-failed"` で query 可能
-	logger.warn(`[stripe-alert] ${kind}: ${redactedMessage}`, {
-		service: 'stripe',
-		context: {
-			kind,
-			...(redactedErrorSummary ? { errorSummary: redactedErrorSummary } : {}),
-			...(redactedTags ?? {}),
-		},
-	});
-
-	// 2. Discord alert (fire-and-forget、課金 path をブロックしない)
-	//    discord-alert.ts の fire-and-forget pattern 整合
-	void sendDiscordAlert({
-		level: 'error',
-		message: `[${kind}] ${redactedMessage}`,
-		errorSummary: redactedErrorSummary ?? kind,
-	}).catch((err) => {
-		// alert 自体の失敗は logger.warn で記録 (recursive alert を避ける)
-		//   err.message にも PII が含まれる可能性があるため redact
-		logger.warn(
-			`[stripe-alert] Discord alert dispatch failed for ${kind}: ${redactPii(String(err))}`,
-		);
-	});
+	// notifyStripeAlertAsync は throw しないため .catch は不要 (送信失敗は内部で logger.warn)
+	void notifyStripeAlertAsync(options);
 }

--- a/src/routes/api/cron/stripe-webhook-delivery-check/+server.ts
+++ b/src/routes/api/cron/stripe-webhook-delivery-check/+server.ts
@@ -1,0 +1,46 @@
+// POST /api/cron/stripe-webhook-delivery-check — Stripe webhook 未達の検知 cron (#3959)
+//
+// EventBridge (Scheduled Rule) から 1 時間毎に呼び出される。認証は verifyCronAuth 共通ヘルパー。
+//
+// 検知ロジックと PR #4079 (`stripe-webhook-handler-failed`) との責務分界は
+// `src/lib/server/services/stripe-webhook-delivery-monitor.ts` 冒頭が SSOT。
+
+import { json } from '@sveltejs/kit';
+import { verifyCronAuth } from '$lib/server/auth/cron-auth';
+import { logger } from '$lib/server/logger';
+import { checkWebhookDelivery } from '$lib/server/services/stripe-webhook-delivery-monitor';
+import type { RequestHandler } from './$types';
+
+export const POST: RequestHandler = async ({ request }) => {
+	const authError = verifyCronAuth(request);
+	if (authError) return authError;
+
+	logger.info('[stripe-webhook-delivery-check] endpoint started', {
+		service: 'stripe',
+	});
+
+	try {
+		const result = await checkWebhookDelivery();
+
+		logger.info('[stripe-webhook-delivery-check] endpoint completed', {
+			service: 'stripe',
+			context: {
+				skipped: result.skipped,
+				checked: result.checked,
+				staleCount: result.staleEvents.length,
+				unreflectedCount: result.unreflectedCheckouts.length,
+				truncated: result.truncated,
+				alerted: result.alerted,
+			},
+		});
+
+		return json({ ok: true, ...result });
+	} catch (e) {
+		logger.error('[stripe-webhook-delivery-check] cron failed', {
+			service: 'stripe',
+			error: e instanceof Error ? e.message : String(e),
+			stack: e instanceof Error ? e.stack : undefined,
+		});
+		return json({ ok: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+	}
+};

--- a/src/routes/api/cron/stripe-webhook-delivery-check/+server.ts
+++ b/src/routes/api/cron/stripe-webhook-delivery-check/+server.ts
@@ -9,6 +9,7 @@ import { json } from '@sveltejs/kit';
 import { verifyCronAuth } from '$lib/server/auth/cron-auth';
 import { logger } from '$lib/server/logger';
 import { checkWebhookDelivery } from '$lib/server/services/stripe-webhook-delivery-monitor';
+import { notifyStripeAlertAsync } from '$lib/server/stripe/alert';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
@@ -36,11 +37,35 @@ export const POST: RequestHandler = async ({ request }) => {
 
 		return json({ ok: true, ...result });
 	} catch (e) {
-		logger.error('[stripe-webhook-delivery-check] cron failed', {
+		const detail = e instanceof Error ? e.message : String(e);
+		const errorName = e instanceof Error ? e.name : 'UnknownError';
+
+		// message 本文に detail を畳む。logger は console に message しか出さないため、
+		// 第 2 引数の `error` field だけでは CloudWatch に何も残らない (stack は別途出力される)。
+		logger.error(`[stripe-webhook-delivery-check] cron failed: ${detail}`, {
 			service: 'stripe',
-			error: e instanceof Error ? e.message : String(e),
+			error: detail,
 			stack: e instanceof Error ? e.stack : undefined,
 		});
-		return json({ ok: false, error: e instanceof Error ? e.message : String(e) }, { status: 500 });
+
+		// 検知器が死んでいること自体を鳴らす (#4102 M3)。
+		// cron dispatcher (infra/lambda/cron-dispatcher/index.ts) は非 2xx を throw せず
+		// `{ statusCode: 500 }` を return するため、ここで alert を出さないと Lambda invocation は
+		// 成功扱いのまま `cron-dispatcher-errors` alarm も鳴らず、「未達を検知できていない」ことが
+		// 誰にも届かない = 本 endpoint が潰そうとしている失敗クラスそのものになる。
+		//
+		// **alert には例外の生 message を載せない**。DSQL の接続エラー等は接続情報 / token 断片を
+		// 含みうるため、外部 (Discord) に出すのは例外クラス名までに留め、詳細は上の CloudWatch log
+		// (message + stack) で見る (#4101 の経路を新たに開かないため)。
+		// errorSummary は固定文字列 = throttle key が安定し、連続失敗が 1 通にまとまる。
+		await notifyStripeAlertAsync({
+			kind: 'stripe-webhook-monitor-failed',
+			message:
+				'Stripe webhook 未達の検知 cron 自体が失敗しました (検知が止まっている間の未達は誰も気づけません)',
+			errorSummary: 'stripe-webhook-monitor-failed',
+			tags: { errorName },
+		});
+
+		return json({ ok: false, error: detail }, { status: 500 });
 	}
 };

--- a/tests/unit/infra/entitlement-fail-closed-alarm.test.ts
+++ b/tests/unit/infra/entitlement-fail-closed-alarm.test.ts
@@ -1,0 +1,234 @@
+// tests/unit/infra/entitlement-fail-closed-alarm.test.ts
+// #3998: entitlement 解決の fail-closed を検知する MetricFilter + Alarm の構造検証。
+//
+// 本 test が守る不変条件は 3 つある。CDK template だけを見る test は「定義したが 1 件も
+// マッチしない filter」を通してしまい、#3969 と同じ「作ったが効いていない」形になるため、
+// **filter pattern が実際に出力される log 行にマッチすること**まで踏み込んで検証する。
+//
+//   [A] CDK 構造 …… MetricFilter / Alarm が期待の namespace / 閾値 / 通知先で存在する
+//   [B] SSOT drift … CDK の literal 検索語がアプリ側の ALERT_KIND / prefix と一致する
+//                    (CDK tsconfig rootDir の制約で src を import できないため literal で持つ。
+//                     CRON_JOBS ↔ schedule-registry と同じ構図)
+//   [C] 実マッチ …… logger が Lambda 上で実際に書き出す文字列を捕捉し、その行が
+//                    filter pattern にマッチすること / 無関係な行にはマッチしないこと
+//
+// context stub パターンは tests/unit/infra/ops-static-assets-alarm.test.ts を踏襲。
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { ENTITLEMENT_FAIL_CLOSED_LOG_TERM, OpsStack } from '../../../infra/lib/ops-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+import { TenantEntitlementUnavailableError } from '../../../src/lib/server/auth/tenant-entitlement';
+
+// cspell:ignore TESTPOOL
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+function makeApp(): cdk.App {
+	return new cdk.App({
+		context: {
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+		},
+	});
+}
+
+/** appLogGroup を渡す / 渡さないで OpsStack の template を作る */
+function buildOpsTemplate(opts: { withAppLogGroup: boolean }): Template {
+	const app = makeApp();
+	const storage = new StorageStack(app, 'TestStorage', { env });
+	const compute = new ComputeStack(app, 'TestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'TestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+	});
+	const ops = new OpsStack(app, 'TestOps', {
+		env,
+		lambdaFn: compute.fn,
+		distribution: network.distribution,
+		functionUrl: compute.functionUrl,
+		cronDispatcherFn: compute.cronDispatcherFn,
+		appLogGroup: opts.withAppLogGroup ? compute.appLogGroup : undefined,
+		opsEmail: 'ops@example.com',
+	});
+	return Template.fromStack(ops);
+}
+
+function readRepoFile(relPath: string): string {
+	return fs.readFileSync(path.resolve(__dirname, '../../..', relPath), 'utf-8');
+}
+
+// CDK synth (Docker image asset の hash 計算を含む) は数十秒かかるため 1 回だけ組む
+let withLogGroupTemplate: Template;
+let withoutLogGroupTemplate: Template;
+
+beforeAll(() => {
+	withLogGroupTemplate = buildOpsTemplate({ withAppLogGroup: true });
+	withoutLogGroupTemplate = buildOpsTemplate({ withAppLogGroup: false });
+}, 180_000);
+
+describe('#3998 [A] entitlement fail-closed の MetricFilter / Alarm が CDK に定義されている', () => {
+	it('[A1] appLogGroup 指定時に MetricFilter が期待の pattern / metric で作られる', () => {
+		const template = withLogGroupTemplate;
+
+		template.hasResourceProperties('AWS::Logs::MetricFilter', {
+			FilterPattern: `"${ENTITLEMENT_FAIL_CLOSED_LOG_TERM}"`,
+			MetricTransformations: Match.arrayWith([
+				Match.objectLike({
+					MetricNamespace: 'GanbariQuest/Auth',
+					MetricName: 'EntitlementDbUnavailable',
+					MetricValue: '1',
+					DefaultValue: 0,
+				}),
+			]),
+		});
+	});
+
+	it('[A2] Alarm が閾値 5 / 5 分 / 既存 SNS topic に接続されている', () => {
+		const template = withLogGroupTemplate;
+
+		template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+			AlarmName: 'ganbari-quest-auth-entitlement-db-unavailable',
+			Namespace: 'GanbariQuest/Auth',
+			MetricName: 'EntitlementDbUnavailable',
+			Statistic: 'Sum',
+			Period: 300,
+			Threshold: 5,
+			EvaluationPeriods: 1,
+			ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+			TreatMissingData: 'notBreaching',
+			// 既存アラームと同じ通知先 (OpsAlerts SNS topic) に接続されていること
+			AlarmActions: Match.arrayWith([
+				Match.objectLike({ Ref: Match.stringLikeRegexp('OpsAlerts') }),
+			]),
+			OKActions: Match.arrayWith([Match.objectLike({ Ref: Match.stringLikeRegexp('OpsAlerts') })]),
+		});
+	});
+
+	it('[A3] appLogGroup 未指定なら MetricFilter も Alarm も作らない (監視 cost ゼロ)', () => {
+		const template = withoutLogGroupTemplate;
+
+		template.resourceCountIs('AWS::Logs::MetricFilter', 0);
+		const alarms = template.findResources('AWS::CloudWatch::Alarm');
+		const names = Object.values(alarms).map(
+			(r) => (r.Properties as { AlarmName: string }).AlarmName,
+		);
+		expect(names).not.toContain('ganbari-quest-auth-entitlement-db-unavailable');
+	});
+
+	it('[A4] app.ts が ComputeStack の LogGroup を OpsStack に渡している (配線漏れ検出)', () => {
+		expect(readRepoFile('infra/bin/app.ts')).toContain('appLogGroup: compute.appLogGroup');
+	});
+});
+
+describe('#3998 [B] CDK literal ↔ アプリ側 SSOT の drift', () => {
+	it('[B1] 検索語が ALERT_KIND を含む', () => {
+		expect(ENTITLEMENT_FAIL_CLOSED_LOG_TERM).toContain(
+			TenantEntitlementUnavailableError.ALERT_KIND,
+		);
+	});
+
+	it('[B2] 検索語の prefix が hooks.server.ts の出力形と一致する', () => {
+		// hooks.server.ts は `[auth-alert] ${kind}: ...` の形で 503 応答時に 1 行出す。
+		// prefix を変えたらここが落ちる (= filter が無言で 0 件になるのを防ぐ)。
+		expect(readRepoFile('src/hooks.server.ts')).toMatch(/`\[auth-alert\] \$\{kind\}:/);
+		expect(ENTITLEMENT_FAIL_CLOSED_LOG_TERM).toBe(
+			`[auth-alert] ${TenantEntitlementUnavailableError.ALERT_KIND}`,
+		);
+	});
+
+	it('[B3] DB 解決失敗の log 行も kind で追える (Logs Insights の網羅性)', () => {
+		expect(readRepoFile('src/lib/server/auth/tenant-entitlement.ts')).toMatch(
+			/\[AUTH\] \$\{TenantEntitlementUnavailableError\.ALERT_KIND\}:/,
+		);
+	});
+});
+
+describe('#3998 [C] filter pattern が実際の log 出力にマッチする', () => {
+	// CloudWatch の `"..."` 形式 filter pattern は「その文字列を含む行」にマッチする。
+	// logger が Lambda 上で書くのは console 出力そのものなので、console を捕まえて
+	// 実バイト列に対して包含判定する。
+	function matchesFilter(logLine: string): boolean {
+		return logLine.includes(ENTITLEMENT_FAIL_CLOSED_LOG_TERM);
+	}
+
+	let captured: string[];
+	// biome-ignore lint/suspicious/noExplicitAny: console spy の restore 用
+	let errorSpy: any;
+
+	beforeEach(() => {
+		captured = [];
+		errorSpy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+			captured.push(args.map(String).join(' '));
+		});
+	});
+
+	afterEach(() => {
+		errorSpy.mockRestore();
+	});
+
+	it('[C1] 503 応答時に logger が書く行が filter にマッチする', async () => {
+		const { logger } = await import('../../../src/lib/server/logger');
+		const kind = TenantEntitlementUnavailableError.ALERT_KIND;
+
+		// hooks.server.ts の respondEntitlementUnavailable と同一形の呼び出し
+		logger.error(
+			`[auth-alert] ${kind}: 課金状態を DB から解決できず context を発行しませんでした`,
+			{
+				requestId: 'req-1',
+				tenantId: 't-1',
+				context: { kind, path: '/admin', errorSummary: 'connection refused' },
+			},
+		);
+
+		expect(captured.some(matchesFilter)).toBe(true);
+	});
+
+	it('[C2] 無関係な error log は filter にマッチしない (誤発火しない)', async () => {
+		const { logger } = await import('../../../src/lib/server/logger');
+
+		logger.error('[STRIPE] Webhook handler failed: evt_1 type=invoice.paid', {
+			error: 'boom',
+		});
+
+		expect(captured.some(matchesFilter)).toBe(false);
+	});
+
+	it('[C3] DB 解決失敗そのものの行は kind で追えるが metric には数えない', async () => {
+		const { logger } = await import('../../../src/lib/server/logger');
+		const kind = TenantEntitlementUnavailableError.ALERT_KIND;
+
+		logger.error(`[AUTH] ${kind}: Failed to resolve tenant entitlement from DB`, {
+			context: { kind, tenantId: 't-1' },
+		});
+
+		// Logs Insights (kind 単独) では拾える
+		expect(captured.some((l) => l.includes(kind))).toBe(true);
+		// 一方 metric は「503 になったリクエスト数」を単位にしたいので数えない
+		expect(captured.some(matchesFilter)).toBe(false);
+	});
+});

--- a/tests/unit/infra/entitlement-fail-closed-alarm.test.ts
+++ b/tests/unit/infra/entitlement-fail-closed-alarm.test.ts
@@ -108,7 +108,10 @@ describe('#3998 [A] entitlement fail-closed の MetricFilter / Alarm が CDK に
 		});
 	});
 
-	it('[A2] Alarm が閾値 5 / 5 分 / 既存 SNS topic に接続されている', () => {
+	// 低トラフィック環境で鳴らない設定 (件数閾値) への退行を固定する。
+	// 契約世帯が数戸の段階では「5 分 5 件」型の閾値は夜間障害中に到達せず、
+	// 全員が終夜 503 のまま誰も気付けない。継続時間 (M-out-of-N) で判定すること。
+	it('[A2] Alarm が「1 件 × 15 分内 2 window」/ 既存 SNS topic に接続されている', () => {
 		const template = withLogGroupTemplate;
 
 		template.hasResourceProperties('AWS::CloudWatch::Alarm', {
@@ -117,8 +120,9 @@ describe('#3998 [A] entitlement fail-closed の MetricFilter / Alarm が CDK に
 			MetricName: 'EntitlementDbUnavailable',
 			Statistic: 'Sum',
 			Period: 300,
-			Threshold: 5,
-			EvaluationPeriods: 1,
+			Threshold: 1,
+			EvaluationPeriods: 3,
+			DatapointsToAlarm: 2,
 			ComparisonOperator: 'GreaterThanOrEqualToThreshold',
 			TreatMissingData: 'notBreaching',
 			// 既存アラームと同じ通知先 (OpsAlerts SNS topic) に接続されていること

--- a/tests/unit/infra/physical-name-ratchet.test.ts
+++ b/tests/unit/infra/physical-name-ratchet.test.ts
@@ -110,6 +110,9 @@ function buildAllTemplates(): Array<[string, Template]> {
 		functionUrl: compute.functionUrl,
 		cronDispatcherFn: compute.cronDispatcherFn,
 		staticAssetsBucket: network.staticAssetsBucket,
+		// #3998: prod (infra/bin/app.ts) と同じ配線にする。渡さないと log 由来 alarm が
+		// この ratchet の観測対象から外れ、明示物理名の増加を見逃す。
+		appLogGroup: compute.appLogGroup,
 		opsEmail: 'ops@example.com',
 	});
 	for (const [name, stack] of [
@@ -305,6 +308,7 @@ const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
 			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-lifecycle-emails',
 			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-pmf-survey',
 			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-retention-cleanup',
+			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-stripe-webhook-delivery-check',
 			'GanbariQuestCompute/AWS::Events::Rule/ganbari-quest-cron-trial-notifications',
 			'GanbariQuestOps/AWS::Events::Rule/ganbari-quest-aws-health',
 			'GanbariQuestOps/AWS::Events::Rule/ganbari-quest-health-check',
@@ -314,6 +318,7 @@ const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
 	...group(
 		'CloudWatch Alarm 固定名は ops runbook / Discord 通知の識別子 (infra/CLAUDE.md §CloudWatch Alarm)',
 		[
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-auth-entitlement-db-unavailable',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-cloudfront-5xx',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-cron-dispatcher-errors',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-concurrent',

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -180,7 +180,7 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			});
 		});
 
-		it('P-3: Compute — fn=ganbari-quest-app / demo Fn / cron-dispatcher + Rule 5 本 / Firehose / SES env が従来どおり', () => {
+		it('P-3: Compute — fn=ganbari-quest-app / demo Fn / cron-dispatcher + Rule 6 本 / Firehose / SES env が従来どおり', () => {
 			prodCompute.hasResourceProperties('AWS::Lambda::Function', {
 				FunctionName: 'ganbari-quest-app',
 				Environment: {
@@ -204,9 +204,10 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			prodCompute.hasResourceProperties('AWS::Lambda::Function', {
 				FunctionName: 'ganbari-quest-cron-dispatcher',
 			});
-			// CRON_JOBS 5 本 (compute-stack.ts CRON_JOBS SSOT。#3805 で analytics-aggregator-daily /
-			// challenge-aggregator-daily の DynamoDB 事前集計 cron 2 本を撤去し 7→5 本)
-			prodCompute.resourceCountIs('AWS::Events::Rule', 5);
+			// CRON_JOBS 6 本 (compute-stack.ts CRON_JOBS SSOT。#3805 で analytics-aggregator-daily /
+			// challenge-aggregator-daily の DynamoDB 事前集計 cron 2 本を撤去し 7→5 本、
+			// #3959 で stripe-webhook-delivery-check を追加し 5→6 本)
+			prodCompute.resourceCountIs('AWS::Events::Rule', 6);
 			prodCompute.resourceCountIs('AWS::KinesisFirehose::DeliveryStream', 1);
 			// #3939: L2 化で物理名は固定しない (CFN 自動命名)。固定名に戻すと旧→新置換が
 			// 同名衝突で CFN fail する class が再発するため absent を固定する。

--- a/tests/unit/routes/cron-stripe-webhook-delivery-check.test.ts
+++ b/tests/unit/routes/cron-stripe-webhook-delivery-check.test.ts
@@ -1,0 +1,147 @@
+// tests/unit/routes/cron-stripe-webhook-delivery-check.test.ts
+//
+// #3959 / #4102 (QM 指摘 M3): 未達検知 cron endpoint の「検知器自体が死んだ」経路。
+//
+// 守る不変条件:
+//   [E1] 検知が throw したとき alert が飛ぶ (検知器の停止が誰にも届かない状態を作らない)
+//   [E2] alert 送信はレスポンス返却前に完了する (Lambda freeze で通知が消えない)
+//   [E3] alert に例外の生 message を載せない (DSQL の接続情報 / token 断片の外部流出を防ぐ)
+//   [E4] 正常時は alert を出さない (毎時 cron が Discord を汚さない)
+//
+// 背景: cron-dispatcher (infra/lambda/cron-dispatcher/index.ts) は非 2xx を throw せず
+// `{ statusCode: 500 }` を return するため、endpoint が 500 を返しても Lambda invocation は
+// 成功扱いになり `cron-dispatcher-errors` alarm は鳴らない。500 を返すだけでは無言のままになる。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		critical: vi.fn(),
+	},
+}));
+
+const checkWebhookDeliveryMock = vi.fn();
+vi.mock('$lib/server/services/stripe-webhook-delivery-monitor', () => ({
+	checkWebhookDelivery: (...args: unknown[]) => checkWebhookDeliveryMock(...args),
+}));
+
+const notifyStripeAlertAsyncMock = vi.fn();
+vi.mock('$lib/server/stripe/alert', () => ({
+	notifyStripeAlertAsync: (...args: unknown[]) => notifyStripeAlertAsyncMock(...args),
+}));
+
+const originalEnv = { ...process.env };
+const SECRET = 'test-cron-secret-4102';
+const ENDPOINT = 'http://localhost/api/cron/stripe-webhook-delivery-check';
+
+function authedRequest(): Request {
+	return new Request(ENDPOINT, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'x-cron-secret': SECRET },
+		body: JSON.stringify({}),
+	});
+}
+
+async function postEndpoint() {
+	const { POST } = await import(
+		'../../../src/routes/api/cron/stripe-webhook-delivery-check/+server'
+	);
+	return POST({ request: authedRequest() } as unknown as Parameters<typeof POST>[0]);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.env = { ...originalEnv };
+	process.env.CRON_SECRET = SECRET;
+	notifyStripeAlertAsyncMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+	process.env = originalEnv;
+});
+
+describe('#4102 [E1][E3] 検知器自体の失敗を鳴らす', () => {
+	it('checkWebhookDelivery が throw すると alert が 1 通飛び、500 を返す', async () => {
+		checkWebhookDeliveryMock.mockRejectedValue(new Error('Stripe API 500 rate_limit'));
+
+		const res = await postEndpoint();
+
+		expect(res.status).toBe(500);
+		expect(notifyStripeAlertAsyncMock).toHaveBeenCalledTimes(1);
+		expect(notifyStripeAlertAsyncMock.mock.calls[0]?.[0]).toMatchObject({
+			kind: 'stripe-webhook-monitor-failed',
+		});
+	});
+
+	it('alert に例外の生 message を載せない (接続情報の外部流出経路を作らない)', async () => {
+		checkWebhookDeliveryMock.mockRejectedValue(
+			new Error('connection to host=db.internal user=admin password=hunter2 failed'),
+		);
+
+		await postEndpoint();
+
+		const payload = JSON.stringify(notifyStripeAlertAsyncMock.mock.calls[0]?.[0]);
+		expect(payload).not.toContain('hunter2');
+		expect(payload).not.toContain('db.internal');
+		// 例外クラス名までは載せる (どの層で落ちたかの当たりを付けるため)
+		expect(payload).toContain('Error');
+	});
+});
+
+describe('#4102 [E2] alert 送信はレスポンス前に完了する', () => {
+	it('alert の送信が終わるまで endpoint はレスポンスを返さない', async () => {
+		checkWebhookDeliveryMock.mockRejectedValue(new Error('DSQL unavailable'));
+
+		let delivered = false;
+		let releaseSend: () => void = () => {};
+		const sendGate = new Promise<void>((resolve) => {
+			releaseSend = resolve;
+		});
+		notifyStripeAlertAsyncMock.mockImplementation(async () => {
+			await sendGate;
+			delivered = true;
+		});
+
+		let responded = false;
+		const pending = postEndpoint().then((res) => {
+			responded = true;
+			return res;
+		});
+
+		// 送信を止めたまま event loop を回す。await していない実装ならここで応答が確定し、
+		// 実機では直後の Lambda freeze で送信中の fetch が消える
+		for (let i = 0; i < 5; i++) {
+			await new Promise((resolve) => setImmediate(resolve));
+		}
+		expect(responded).toBe(false);
+		expect(delivered).toBe(false);
+
+		releaseSend();
+		const res = await pending;
+
+		expect(delivered).toBe(true);
+		expect(res.status).toBe(500);
+	});
+});
+
+describe('#4102 [E4] 正常時は鳴らさない', () => {
+	it('検知が正常終了したら alert を出さず 200 を返す', async () => {
+		checkWebhookDeliveryMock.mockResolvedValue({
+			skipped: null,
+			checked: 3,
+			staleEvents: [],
+			unreflectedCheckouts: [],
+			truncated: false,
+			alerted: false,
+		});
+
+		const res = await postEndpoint();
+
+		expect(res.status).toBe(200);
+		expect(notifyStripeAlertAsyncMock).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/server/stripe/alert-integration.test.ts
+++ b/tests/unit/server/stripe/alert-integration.test.ts
@@ -44,6 +44,7 @@ vi.mock('../../../../src/lib/server/stripe/price-cache', () => ({
 
 import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
+import { notifyStripeAlert, notifyStripeAlertAsync } from '$lib/server/stripe/alert';
 import { getPriceId } from '$lib/server/stripe/config';
 import { getPriceByLookupKey } from '$lib/server/stripe/price-cache';
 
@@ -189,5 +190,101 @@ describe('silent degradation end-to-end (#2735 / kill switch fallback alert 統�
 		expect(ctx?.context).toHaveProperty('plan');
 		expect(ctx?.context).toHaveProperty('lookupKey');
 		expect(ctx?.context).toHaveProperty('fallbackUsed');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4102 (QM 指摘 M1 / M2 / M6): alert が「鳴ったあと使えるか」の境界検証。
+//
+// 守る不変条件:
+//   [T1] tags が Discord に**実際に届く** (embed の Details field)
+//   [T2] tags が CloudWatch にも届く (logger は console に message 本文しか出さないため、
+//        structured context だけに置くと Lambda 上では消える)
+//   [T3] 実送出 payload に PII (email) が載らない — 引数ではなく送出内容を見る (ADR-0006)
+//   [T4] await 版は送信完了まで待つ (cron の Lambda freeze で通知が消えないこと)
+//
+// 既存 test との差分: monitor 側の test は `notifyStripeAlert` を丸ごと mock するため、
+// 「tags が外に出るか」を 1 層手前で見失う。本 describe は alert.ts の実装を通す。
+// ---------------------------------------------------------------------------
+describe('#4102 alert の triage 情報が実際に外へ出る (runbook 実行可能性)', () => {
+	const TRIAGE_OPTIONS = {
+		kind: 'stripe-webhook-undelivered' as const,
+		message: 'Stripe webhook が 30 分以上未完了です',
+		errorSummary: 'stripe-webhook-undelivered',
+		tags: {
+			staleCount: 2,
+			oldestEventId: 'evt_oldest_1',
+			sampleCheckoutEventId: 'evt_checkout_9',
+			sampleCheckoutReason: 'no-subscription',
+			truncated: false,
+		},
+	};
+
+	it('[T1] runbook が参照する event id が Discord へ送る payload に載る', async () => {
+		await notifyStripeAlertAsync(TRIAGE_OPTIONS);
+
+		expect(sendDiscordAlertMock).toHaveBeenCalledTimes(1);
+		const payload = JSON.stringify(sendDiscordAlertMock.mock.calls[0]?.[0]);
+		// runbook §2.3 の手順 1 (oldestEventId を Stripe で開く) / 手順 3 (sampleCheckoutEventId
+		// から checkout session を開く) が実行可能であること
+		expect(payload).toContain('evt_oldest_1');
+		expect(payload).toContain('evt_checkout_9');
+		expect(payload).toContain('no-subscription');
+	});
+
+	it('[T2] 同じ id が logger の message 本文にも載る (CloudWatch は context を出さない)', async () => {
+		await notifyStripeAlertAsync(TRIAGE_OPTIONS);
+
+		// 第 1 引数 = console に出る本文。第 2 引数の context は writeLog が捨てるため当てにできない
+		const loggerMessage = loggerWarnMock.mock.calls[0]?.[0] as string;
+		expect(loggerMessage).toContain('evt_oldest_1');
+		expect(loggerMessage).toContain('evt_checkout_9');
+	});
+
+	it('[T3] 実送出 payload に顧客 email が載らない (引数ではなく送出内容で検証)', async () => {
+		await notifyStripeAlertAsync({
+			kind: 'stripe-webhook-undelivered',
+			message: 'checkout の顧客は secret-parent@example.com です',
+			errorSummary: 'stripe-webhook-undelivered',
+			tags: { customerEmail: 'other-parent@example.com', oldestEventId: 'evt_keep_1' },
+		});
+
+		const payload = JSON.stringify(sendDiscordAlertMock.mock.calls[0]?.[0]);
+		expect(payload).not.toContain('secret-parent@example.com');
+		expect(payload).not.toContain('other-parent@example.com');
+		// Stripe 内部 ID は triage に必須なので redact されない
+		expect(payload).toContain('evt_keep_1');
+	});
+
+	it('[T4] await 版は送信完了まで待つ / fire-and-forget 版は待たない', async () => {
+		let delivered = false;
+		let releaseSend: () => void = () => {};
+		const sendGate = new Promise<void>((resolve) => {
+			releaseSend = resolve;
+		});
+		sendDiscordAlertMock.mockImplementation(async () => {
+			await sendGate;
+			delivered = true;
+		});
+
+		// fire-and-forget 版: 呼び出しから戻った時点では送信は完了していない
+		//   (cron がこの状態でレスポンスを返すと Lambda freeze で送信が消える)
+		notifyStripeAlert(TRIAGE_OPTIONS);
+		expect(delivered).toBe(false);
+
+		// await 版: 完了するまで戻らない
+		const pending = notifyStripeAlertAsync(TRIAGE_OPTIONS);
+		expect(delivered).toBe(false);
+		releaseSend();
+		await pending;
+		expect(delivered).toBe(true);
+	});
+
+	it('[T5] Discord 送信が失敗しても await 版は throw しない (呼び出し側の業務処理を壊さない)', async () => {
+		sendDiscordAlertMock.mockRejectedValueOnce(new Error('Discord webhook 503'));
+
+		await expect(notifyStripeAlertAsync(TRIAGE_OPTIONS)).resolves.toBeUndefined();
+		// 送信失敗自体は log に残る (沈黙させない)
+		expect(loggerWarnMock.mock.calls.length).toBeGreaterThanOrEqual(2);
 	});
 });

--- a/tests/unit/services/stripe-webhook-delivery-monitor.test.ts
+++ b/tests/unit/services/stripe-webhook-delivery-monitor.test.ts
@@ -29,7 +29,11 @@ vi.mock('$lib/server/stripe/client', () => ({
 
 const mockNotifyStripeAlert = vi.fn();
 vi.mock('$lib/server/stripe/alert', () => ({
-	notifyStripeAlert: (...args: unknown[]) => mockNotifyStripeAlert(...args),
+	// cron は alert 送信が最終処理になるため await 可能な版を使う (#4102 M2)
+	notifyStripeAlertAsync: (...args: unknown[]) => {
+		mockNotifyStripeAlert(...args);
+		return Promise.resolve();
+	},
 }));
 
 vi.mock('$lib/server/logger', () => ({
@@ -238,6 +242,29 @@ describe('#3959 [D6] 1 実行 1 通', () => {
 		expect(result.staleEvents).toHaveLength(3);
 		expect(result.unreflectedCheckouts).toHaveLength(2);
 		expect(mockNotifyStripeAlert).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('#3959 [D8] oldestEventId は最古の滞留 event を指す (#4102 M4)', () => {
+	it('Stripe が新しい順で返しても、alert には最古の event が載る', async () => {
+		// stripe.events.list は created 降順で返す。先頭をそのまま採ると「最新」が
+		// oldestEventId として通知され、runbook の「最古から辿って障害開始時刻を推定する」
+		// triage が誤った時刻を指す。
+		mockEventsList.mockResolvedValue({
+			data: [
+				checkoutEvent({ id: 'evt_newest', minutesAgo: 40 }),
+				checkoutEvent({ id: 'evt_middle', minutesAgo: 120 }),
+				checkoutEvent({ id: 'evt_oldest', minutesAgo: 600 }),
+			],
+		});
+		mockFindTenantById.mockResolvedValue({ id: 'tenant-1', stripeSubscriptionId: null });
+
+		await checkWebhookDelivery(NOW);
+
+		const tags = (mockNotifyStripeAlert.mock.calls[0]?.[0] as { tags: Record<string, unknown> })
+			.tags;
+		expect(tags.oldestEventId).toBe('evt_oldest');
+		expect(tags.oldestCreatedIso).toBe(new Date(createdAt(600) * 1000).toISOString());
 	});
 });
 

--- a/tests/unit/services/stripe-webhook-delivery-monitor.test.ts
+++ b/tests/unit/services/stripe-webhook-delivery-monitor.test.ts
@@ -1,0 +1,242 @@
+// tests/unit/services/stripe-webhook-delivery-monitor.test.ts
+// #3959: Stripe webhook 未達 (沈黙) の検知。
+//
+// 守る不変条件:
+//   [D1] 2026-07-26 と同型 (Stripe 側で滞留 + 支払い済みなのに plan 未反映) で必ず 1 通鳴る
+//   [D2] 正常時は鳴らない (毎時 cron が false positive を出さない)
+//   [D3] handler 失敗の疑い (滞留はあるが plan は反映済) では鳴らない
+//        = PR #4079 `stripe-webhook-handler-failed` と二重に鳴らないための責務分界
+//   [D4] 閾値未満 (STALE_MINUTES 以内) の event は検査対象に入れない
+//   [D5] Stripe 無効環境 (staging / NUC / local) では検査も通知もしない
+//   [D6] 1 回の実行で送る通知は 1 通だけ
+//   [D7] 通知に顧客の個人情報を載せない
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindTenantById = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({ auth: { findTenantById: mockFindTenantById } }),
+}));
+
+const mockIsStripeEnabled = vi.fn();
+const mockEventsList = vi.fn();
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: () => mockIsStripeEnabled(),
+	getStripeClient: () => ({ events: { list: mockEventsList } }),
+}));
+
+const mockNotifyStripeAlert = vi.fn();
+vi.mock('$lib/server/stripe/alert', () => ({
+	notifyStripeAlert: (...args: unknown[]) => mockNotifyStripeAlert(...args),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { checkWebhookDelivery, STALE_MINUTES } = await import(
+	'../../../src/lib/server/services/stripe-webhook-delivery-monitor'
+);
+
+const NOW = new Date('2026-07-30T12:00:00.000Z');
+
+/** NOW から `minutesAgo` 分前に作られた event の unix 秒 */
+function createdAt(minutesAgo: number): number {
+	return Math.floor(NOW.getTime() / 1000) - minutesAgo * 60;
+}
+
+function checkoutEvent(opts: {
+	id?: string;
+	minutesAgo?: number;
+	pendingWebhooks?: number;
+	tenantId?: string | null;
+	/** Stripe が返す payload に混ざる顧客情報 (通知に載ってはならない) */
+	customerEmail?: string;
+}) {
+	return {
+		id: opts.id ?? 'evt_checkout_1',
+		type: 'checkout.session.completed',
+		created: createdAt(opts.minutesAgo ?? 60),
+		pending_webhooks: opts.pendingWebhooks ?? 1,
+		data: {
+			object: {
+				metadata: opts.tenantId === null ? {} : { tenantId: opts.tenantId ?? 'tenant-1' },
+				customer_email: opts.customerEmail ?? 'parent@example.com',
+			},
+		},
+	};
+}
+
+function invoiceEvent(opts: { id?: string; minutesAgo?: number; pendingWebhooks?: number }) {
+	return {
+		id: opts.id ?? 'evt_invoice_1',
+		type: 'invoice.paid',
+		created: createdAt(opts.minutesAgo ?? 60),
+		pending_webhooks: opts.pendingWebhooks ?? 1,
+		data: { object: {} },
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockIsStripeEnabled.mockReturnValue(true);
+	mockEventsList.mockResolvedValue({ data: [] });
+	mockFindTenantById.mockResolvedValue({ id: 'tenant-1', stripeSubscriptionId: 'sub_123' });
+});
+
+describe('#3959 [D1] 未達 (2026-07-26 と同型) を検知して通知する', () => {
+	it('滞留 event があり checkout の plan 反映も無いとき、alert が 1 回発火する', async () => {
+		mockEventsList.mockResolvedValue({
+			data: [checkoutEvent({ pendingWebhooks: 1, minutesAgo: 60 })],
+		});
+		// plan が反映されていない = subscription が結び付いていない
+		mockFindTenantById.mockResolvedValue({ id: 'tenant-1', stripeSubscriptionId: null });
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.alerted).toBe(true);
+		expect(result.staleEvents).toHaveLength(1);
+		expect(result.unreflectedCheckouts).toHaveLength(1);
+		expect(mockNotifyStripeAlert).toHaveBeenCalledTimes(1);
+		expect(mockNotifyStripeAlert.mock.calls[0]?.[0]).toMatchObject({
+			kind: 'stripe-webhook-undelivered',
+		});
+	});
+
+	it('checkout の metadata に tenantId が無い場合も未反映として扱う (判定不能を沈黙させない)', async () => {
+		mockEventsList.mockResolvedValue({ data: [checkoutEvent({ tenantId: null })] });
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.unreflectedCheckouts[0]?.reason).toBe('tenant-id-missing');
+		expect(result.alerted).toBe(true);
+	});
+
+	it('tenant が見つからない場合も未反映として扱う', async () => {
+		mockEventsList.mockResolvedValue({ data: [checkoutEvent({})] });
+		mockFindTenantById.mockResolvedValue(undefined);
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.unreflectedCheckouts[0]?.reason).toBe('tenant-not-found');
+		expect(result.alerted).toBe(true);
+	});
+});
+
+describe('#3959 [D2] 正常時は鳴らない', () => {
+	it('全 event が配信済み (pending_webhooks=0) なら alert しない', async () => {
+		mockEventsList.mockResolvedValue({
+			data: [checkoutEvent({ pendingWebhooks: 0 }), invoiceEvent({ pendingWebhooks: 0 })],
+		});
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.staleEvents).toHaveLength(0);
+		expect(result.alerted).toBe(false);
+		expect(mockNotifyStripeAlert).not.toHaveBeenCalled();
+	});
+
+	it('対象 event が 1 件も無ければ alert しない', async () => {
+		mockEventsList.mockResolvedValue({ data: [] });
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.checked).toBe(0);
+		expect(result.alerted).toBe(false);
+		expect(mockNotifyStripeAlert).not.toHaveBeenCalled();
+	});
+});
+
+describe('#3959 [D3] PR #4079 (stripe-webhook-handler-failed) と二重に鳴らない', () => {
+	it('滞留はあるが plan は反映済 (handler 失敗の疑い) なら本 alert は沈黙する', async () => {
+		// handler が throw して 500 を返し続けると Stripe 側の pending は残る。
+		// この事象は初回失敗の時点で `stripe-webhook-handler-failed` が所有するため、
+		// 本 cron は鳴らしてはならない。
+		mockEventsList.mockResolvedValue({
+			data: [checkoutEvent({ pendingWebhooks: 1 }), invoiceEvent({ pendingWebhooks: 2 })],
+		});
+		mockFindTenantById.mockResolvedValue({ id: 'tenant-1', stripeSubscriptionId: 'sub_123' });
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.staleEvents.length).toBeGreaterThan(0);
+		expect(result.unreflectedCheckouts).toHaveLength(0);
+		expect(result.alerted).toBe(false);
+		expect(mockNotifyStripeAlert).not.toHaveBeenCalled();
+	});
+
+	it('plan 未反映でも Stripe 側が配信済みなら鳴らない (別経路で反映される途中の可能性)', async () => {
+		mockEventsList.mockResolvedValue({ data: [checkoutEvent({ pendingWebhooks: 0 })] });
+		mockFindTenantById.mockResolvedValue({ id: 'tenant-1', stripeSubscriptionId: null });
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.staleEvents).toHaveLength(0);
+		expect(result.alerted).toBe(false);
+	});
+});
+
+describe('#3959 [D4] 滞留閾値', () => {
+	it(`Stripe への問い合わせ窓の上端が ${STALE_MINUTES} 分前になっている (直近の event を拾わない)`, async () => {
+		await checkWebhookDelivery(NOW);
+
+		const params = mockEventsList.mock.calls[0]?.[0] as {
+			created: { gte: number; lte: number };
+			types: string[];
+			limit: number;
+		};
+		const nowSec = Math.floor(NOW.getTime() / 1000);
+		expect(params.created.lte).toBe(nowSec - STALE_MINUTES * 60);
+		expect(params.created.gte).toBeLessThan(params.created.lte);
+		expect(params.types).toContain('checkout.session.completed');
+		expect(params.limit).toBeGreaterThan(0);
+	});
+});
+
+describe('#3959 [D5] Stripe 無効環境では何もしない', () => {
+	it('isStripeEnabled=false なら Stripe API を叩かず alert もしない', async () => {
+		mockIsStripeEnabled.mockReturnValue(false);
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.skipped).toBe('stripe-disabled');
+		expect(mockEventsList).not.toHaveBeenCalled();
+		expect(mockNotifyStripeAlert).not.toHaveBeenCalled();
+	});
+});
+
+describe('#3959 [D6] 1 実行 1 通', () => {
+	it('未達 event が複数あっても通知は 1 通にまとめる', async () => {
+		mockEventsList.mockResolvedValue({
+			data: [
+				checkoutEvent({ id: 'evt_a' }),
+				checkoutEvent({ id: 'evt_b' }),
+				invoiceEvent({ id: 'evt_c' }),
+			],
+		});
+		mockFindTenantById.mockResolvedValue({ id: 'tenant-1', stripeSubscriptionId: null });
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.staleEvents).toHaveLength(3);
+		expect(result.unreflectedCheckouts).toHaveLength(2);
+		expect(mockNotifyStripeAlert).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('#3959 [D7] 通知に個人情報を載せない', () => {
+	it('alert の message / tags に customer_email が現れない', async () => {
+		mockEventsList.mockResolvedValue({
+			data: [checkoutEvent({ customerEmail: 'secret-parent@example.com' })],
+		});
+		mockFindTenantById.mockResolvedValue({ id: 'tenant-1', stripeSubscriptionId: null });
+
+		await checkWebhookDelivery(NOW);
+
+		const payload = JSON.stringify(mockNotifyStripeAlert.mock.calls[0]?.[0]);
+		expect(payload).not.toContain('secret-parent@example.com');
+		expect(payload).not.toContain('@');
+	});
+});

--- a/tests/unit/services/stripe-webhook-delivery-monitor.test.ts
+++ b/tests/unit/services/stripe-webhook-delivery-monitor.test.ts
@@ -52,6 +52,8 @@ function checkoutEvent(opts: {
 	minutesAgo?: number;
 	pendingWebhooks?: number;
 	tenantId?: string | null;
+	/** この checkout が成立させた subscription id (Stripe 側の事実) */
+	subscriptionId?: string;
 	/** Stripe が返す payload に混ざる顧客情報 (通知に載ってはならない) */
 	customerEmail?: string;
 }) {
@@ -63,6 +65,7 @@ function checkoutEvent(opts: {
 		data: {
 			object: {
 				metadata: opts.tenantId === null ? {} : { tenantId: opts.tenantId ?? 'tenant-1' },
+				subscription: opts.subscriptionId ?? 'sub_123',
 				customer_email: opts.customerEmail ?? 'parent@example.com',
 			},
 		},
@@ -111,6 +114,18 @@ describe('#3959 [D1] 未達 (2026-07-26 と同型) を検知して通知する',
 		const result = await checkWebhookDelivery(NOW);
 
 		expect(result.unreflectedCheckouts[0]?.reason).toBe('tenant-id-missing');
+		expect(result.alerted).toBe(true);
+	});
+
+	it('既存契約者のプラン変更 checkout が反映されていない場合も検知する', async () => {
+		// tenant は「変更前の」subscription を持ったまま。subscription の有無だけを見ると
+		// 「反映済み」と誤判定され、代金だけ取られて機能が開かない状態を見逃す。
+		mockEventsList.mockResolvedValue({ data: [checkoutEvent({ subscriptionId: 'sub_new' })] });
+		mockFindTenantById.mockResolvedValue({ id: 'tenant-1', stripeSubscriptionId: 'sub_old' });
+
+		const result = await checkWebhookDelivery(NOW);
+
+		expect(result.unreflectedCheckouts[0]?.reason).toBe('subscription-mismatch');
 		expect(result.alerted).toBe(true);
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（間接的に 親（管理者・契約者））

**解決する課題**: 「壊れているのに誰も気づけない」障害が 2 件ある。① entitlement 解決の fail-closed は 503 応答として表面化するため Lambda Errors にも Url5xx の切り分けにも乗らず、DSQL 障害中に認証済みユーザーが軒並み弾かれても運用側には何も鳴らない（#3963 で PO が承認した trade-off は「起きたら気づける」ことを前提にしていた）。② Stripe webhook がアプリに到達しないケースは、アプリ内の通知経路が 1 行も実行されないため通知が原理的に出ない（2026-07-26 の incident では初の有料課金が丸ごと落ちて顧客申告で発覚した）。

**期待される効果**: どちらも「例外が出ないまま壊れる」形の障害であり、放置すると次も顧客申告でしか分からない。本 PR で ① を CloudWatch metric として既存の SNS 通知に載せ、② を毎時 cron が Stripe API と自 DB を突き合わせて Discord に載せる。加えて、鳴ったときに何を見て何を判断するかを runbook に書き、通知が「鳴っただけ」で終わらないようにした。

## 関連 Issue

closes #3998
closes #3959

- #3963 / PR #3989 — fail-closed の実装本体。本 PR はその検知のみを扱う
- #3985 / PR #4079 — `stripe-webhook-handler-failed`（到達した event の handler 失敗）。本 PR の `stripe-webhook-undelivered`（未達）と責務が異なる。分界は下記「レビュー依頼事項」参照
- #3957（webhook 到達経路の root cause）/ #3958（reconciliation）/ #1214（Synthetics 補完が当時スコープ外とされた経緯）
- #4033 / PR #4038 — cron registry ↔ CDK ↔ dispatcher の drift gate。本 PR の新規 cron は 3 方向すべてに登録済み
- ADR-0010（Pre-PMF: 新規監視基盤を作らず既存 SNS / Discord / cron に相乗り）/ ADR-0061（same-class → guard）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 3998-AC1 | 該当ログを拾う CloudWatch MetricFilter が IaC (`infra/lib/ops-stack.ts`) に定義されている | `npx vitest run tests/unit/infra/entitlement-fail-closed-alarm.test.ts` | HEAD `f95a5e2e` / 10 passed / `[A1]` が CFN template の `AWS::Logs::MetricFilter` を `FilterPattern="[auth-alert] auth-entitlement-db-unavailable"` / `GanbariQuest/Auth::EntitlementDbUnavailable` で assert（`infra/lib/ops-stack.ts:236`） |
| 3998-AC2 | 同メトリクスのアラームが定義され、既存アラームと同じ通知先に接続されている | 同上 | HEAD `f95a5e2e` / `[A2]` が `ganbari-quest-auth-entitlement-db-unavailable` の AlarmActions / OKActions に既存 `OpsAlerts` SNS topic Ref を assert。`[A4]` が `infra/bin/app.ts` の配線（`appLogGroup: compute.appLogGroup`）を assert し、LogGroup 未接続で alarm が作られない事故を検出 |
| 3998-AC3 | 閾値の根拠が実装コメントに書かれている | `infra/lib/ops-stack.ts:245-253` を読む | HEAD `f95a5e2e` / 「1 件 = 503 になったリクエスト 1 本」「一過性かどうかは**件数ではなく継続時間**で判定する」「1 件 × 15 分内 2 window = 5 分以上継続」を明記。**当初 5 分 5 件で書いたが adversarial review で「契約世帯が数戸の規模では夜間障害中に閾値へ到達せず、全員が終夜 503 のまま鳴らない」と判明したため設計変更した**（`[A2]` が件数閾値への退行を固定） |
| 3998-AC4 | アラームが実際に鳴ることを確認した証跡がある | ① `npx vitest run tests/unit/infra/entitlement-fail-closed-alarm.test.ts`（`[C1]`-`[C3]`）② `docs/runbooks/silent-failure-alert-response.md` §1.5 | **機械検証は PASS / 実機発火は未実施**。`[C1]` は logger が Lambda 上で実際に書き出す console 出力を捕捉し、その文字列が filter 検索語を含むことを assert（「定義したが 1 件もマッチしない」= #3969 と同型の失敗を検出）。`[C2]` は無関係な error log がマッチしないこと、`[C3]` は DB 解決失敗行が Logs Insights では追え metric には数えないことを assert。**AWS への deploy は本セッションの制約で行っていないため、実 CloudWatch での発火確認は未了**。deploy 直後に 1 度実行する注入手順（log stream 作成 → 5 行 put → metric 確認 → ALARM 遷移確認）を runbook §1.5 に実コマンドで記載した |
| 3998-AC5 | fail-closed 発生時の一次対応が runbook に 1 節ある | `docs/runbooks/silent-failure-alert-response.md` §1 | HEAD `f95a5e2e` / §1.1 何が起きているか / §1.2 発火条件（`threshold:1` / `evaluationPeriods:3` / `datapointsToAlarm:2` = 15 分 3 window のうち 2 window で 1 件以上。QM Re-Review #2 で実装と乖離した「5 分 5 件」を是正）/ §1.3 一次対応（Logs Insights query → DSQL 側確認 → 判断分岐、fail-closed を外す回避を明示的に禁止）/ §1.4 誤検知確認 / §1.5 実機発火確認（**6 分あけて 2 回 put** に修正。旧手順は同一 ms の 5 行を 1 回 put するため全行が 1 window に落ち `datapointsToAlarm:2` を原理的に満たせなかった） |
| 3959-AC1 | Stripe 側で配信に失敗 / 滞留している webhook イベントがある場合に Discord へ通知される | `npx vitest run tests/unit/services/stripe-webhook-delivery-monitor.test.ts` | HEAD `f95a5e2e` / 12 passed / `[D1]` が「pending_webhooks>0 で 30 分以上滞留 + plan 未反映」で `notifyStripeAlert({kind:'stripe-webhook-undelivered'})` が 1 回発火することを assert |
| 3959-AC2 | 「checkout session は作成されたが一定時間内に plan 反映が行われていない」状態が検知される | 同上 | HEAD `f95a5e2e` / `inspectCheckout` が `session.metadata.tenantId` → `repos.auth.findTenantById` → `stripeSubscriptionId` を判定。**subscription の「有無」だけでなく「この checkout が作った subscription を DB が指しているか」まで見る**（adversarial review で、既存契約者のプラン変更 checkout が常に反映済みと誤判定され代金だけ取られる穴を指摘されたため）。`[D1]` 4 ケースが `no-subscription` / `subscription-mismatch` / `tenant-not-found` / `tenant-id-missing` の各 reason を assert |
| 3959-AC3 | 検知から通知までの遅延が 1 時間以内 | `npx vitest run tests/unit/cron/schedule-consistency.test.ts` + `src/lib/server/cron/schedule-registry.ts:107` | HEAD `f95a5e2e` / 17 passed / cron は毎時 5 分（`cron(5 * * * ? *)`）+ 滞留閾値 30 分。最悪ケースの検知遅延 = 30 分（閾値）+ 60 分（実行間隔）内に必ず 1 回走るため、event 発生から通知まで 1 時間以内に判定機会が来る（`[D4]` が問い合わせ窓上端 = now − 30 分であることを assert） |
| 3959-AC4 | 宛先が到達不能な状況を再現し、実際に通知が飛ぶことを確認する | `npx vitest run tests/unit/services/stripe-webhook-delivery-monitor.test.ts` | HEAD `f95a5e2e` / 2026-07-26 と同型の状態（Stripe に pending が残り、tenant に subscription が無い）を fixture で再現し alert 発火を assert（`[D1]`）。逆に「配信済み」「plan 反映済み」では発火しないことを `[D2]` `[D3]` が assert（沈黙側の回帰）。**test 環境で実 Stripe endpoint を 403 にする再現は行っていない**（本セッションで AWS / Stripe 実環境を触らないため）。検知条件の実体は Stripe API の `pending_webhooks` と自 DB の 2 値であり、両者を fixture で固定した本 test が判定ロジックを網羅する |
| 3959-AC5 | 通知に秘密情報・個人情報が含まれない | 同上 | HEAD `f95a5e2e` / `[D7]` が「Stripe payload に `customer_email` が含まれる状態」で alert を発火させ、`notifyStripeAlert` 引数の JSON に当該メールも `@` 文字も現れないことを assert。通知に載せるのは event id / type / tenant id / 件数のみで、`notifyStripeAlert` 側でさらに `redactPii` を通る（`src/lib/server/stripe/alert.ts`） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [x] サービス層 (`$lib/server/services/`)
- [x] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [x] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [ ] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: 顧客が触れる画面の変更は無い。変わるのは運用側の観測（CloudWatch alarm 1 本 / EventBridge Rule 1 本 / Discord alert kind 1 種）と、`resolveTenantEntitlement` が DB 解決に失敗したときの log 文言（kind を message に含めた。挙動は不変）。

## テスト・品質セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— **2026-07-30 にクリーン単独実行で達成 (適用対象 13 step すべて PASS / exit 0)**。起票時に記載した「別セッション保持で BLOCK」は解消済み。内訳:
  - 実行 step: 9 Readiness gate / 1 biome / 1b cspell / 4 hardcoded-strings / 7 plan-literals / 7b license-key-leak / 7c cli-entry-guard / 7d sparse-checkout / 7e readdir-rotation-guard / 10 doc-code-references / 11 terminology-coherence / 2 svelte-check / 3 vitest
  - 自動 skip (適用対象外): 5 lp-dimensions / 6 lp-fallback / 8 lp-labels / 11b SS embed / 12 capture (LP / labels.ts / UI をいずれも変更していないため)
  - `✗` は 0 件
  - `npx biome check .` → exit 0（違反 0、既存 infos 3 件のみ）
  - `npx vitest run tests/unit/infra/entitlement-fail-closed-alarm.test.ts` → 10 passed
  - `npx vitest run tests/unit/services/stripe-webhook-delivery-monitor.test.ts` → 12 passed
  - `npx vitest run tests/unit/cron/schedule-consistency.test.ts` → 17 passed
  - `npx svelte-check --threshold error` → 0 errors / 0 warnings
  - `npx vitest run tests/unit/infra/cross-stack-export-ratchet.test.ts tests/unit/infra/physical-name-ratchet.test.ts` → 17 passed（allowlist 追記後）
- [x] 追加・変更したテストの概要:
  - `tests/unit/infra/entitlement-fail-closed-alarm.test.ts`（新規 10 件）— CDK 構造 `[A1]`-`[A4]` / CDK literal ↔ アプリ側 SSOT の drift `[B1]`-`[B3]` / **filter pattern が実 log 出力にマッチするか** `[C1]`-`[C3]`
  - `tests/unit/services/stripe-webhook-delivery-monitor.test.ts`（新規 12 件）— 未達検知 `[D1]` / 正常時は鳴らない `[D2]` / #4079 と二重に鳴らない `[D3]` / 閾値 `[D4]` / Stripe 無効環境 `[D5]` / 1 実行 1 通 `[D6]` / PII 非混入 `[D7]`
  - `tests/unit/infra/physical-name-ratchet.test.ts`（既存に追記）— OpsStack fixture を `infra/bin/app.ts` と同じ配線に揃え、新設 alarm / EventBridge Rule を allowlist に理由付きで登録
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A — 追加なし
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A — DynamoDB backend は #3438 で撤去済
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A — `priority:medium` / `priority:high` の infra 追加

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — UI ファイル（`.svelte` / `.css` / `site/`）の変更が 1 件も無く、顧客が見る画面は変わらない。

**インタラクティブ状態**: N/A

### コード品質セルフレビュー (#1481)

- [x] **SOLID**: 検知ロジック（`stripe-webhook-delivery-monitor.ts`）と HTTP 入口（cron `+server.ts`）を分離し、通知は既存 `notifyStripeAlert` に委譲。判定条件は `shouldAlert` として単独で export・test 可能にした
- [x] **DRY**: 新しい通知基盤・監視基盤を作らず、既存の `sendDiscordAlert` / `notifyStripeAlert` / SNS `OpsAlerts` / cron-dispatcher に相乗りした。`grep -rn "notifyStripeAlert\|sendDiscordAlert" src/` で既存経路を確認済
- [x] **YAGNI**: Stripe events はページングせず 1 回 100 件で打ち切り（cron は 30 秒予算、上限到達自体が異常なので、alert が鳴るとき件数と一緒に truncated を併記する（truncated 単独では鳴らさない））。CloudWatch Synthetics / 汎用メトリクス基盤は導入しない（#3959 No-gos / ADR-0010）
- [x] **Security（OSS 公開前提）**: 通知に載せるのは event id / type / tenant id / 件数のみ。顧客の email / 氏名 / カード情報は参照も出力もしない（`[D7]` で assert）。秘密情報の hardcode なし
- [x] **アクセシビリティ**: N/A（UI 変更なし）
- [x] **パフォーマンス**: Stripe API は 1 実行 1 リクエスト。DB は `checkout.session.completed` 1 件につき `findTenantById` 1 回（対象は 30 分以上前かつ 24 時間以内の checkout に限られ、通常 0-数件）。Stripe 無効環境では API も DB も触らず即 return

### 横展開・影響波及チェック

**並行実装ペア**:

- [x] 本番アプリ + デモ版を同期 — N/A（UI 変更なし）
- [x] LP ↔ アプリ双方向整合（ADR-0013）— N/A（顧客向け訴求の変更なし）
- [x] 全年齢モード 5 種に横展開 — N/A
- [x] ナビゲーション 3 種に反映 — N/A
- [x] E2E / ユニットシード + チュートリアルを同期 — N/A（スキーマ / seed 変更なし）
- [x] labels SSOT (ADR-0009) — N/A（顧客向け文言の追加なし。alert 文言は運用者向けで labels.ts の対象外）
- [x] 設計書同期 (ADR-0001) — `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.3 Cron ジョブ一覧に新規 cron を追記し、前文の「全 7 ジョブ」を「全 8 ジョブ」に更新（`schedule-consistency.test.ts` `[D1]`-`[D4]` が表と code の一致を機械検証）
- [x] **cron 3 方向登録（#4033 / PR #4038 の drift gate）** — `schedule-registry.ts`（SSOT）/ `infra/lib/compute-stack.ts` `CRON_JOBS`（EventBridge Rule）/ `infra/lambda/cron-dispatcher/index.ts` `KNOWN_ENDPOINTS`（HTTP 転送先）の 3 箇所すべてに登録。実 FS の `src/routes/api/cron/*/+server.ts` も含めた 4 母数の相互整合を `tests/unit/cron/schedule-consistency.test.ts` が assert（17 passed）
- [x] 並行 PR overlap 確認 (#1200) — PR #4079 が `src/lib/server/services/stripe-service.ts` と `phase5-webhook-idempotency-architecture.md` を変更中。本 PR はどちらも触らず（`stripe-service.ts` は無変更、設計書は 13-AWS のみ変更）、`src/lib/server/stripe/alert.ts` は union 型に 1 行追加するだけなので、どちらが先に merge されても壊れない

**LP / 販促文言変更時** (ADR-0013): N/A

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

**レビュー依頼事項・QA**:

**1. PR #4079 との責務分界（二重に鳴らさない設計）** — ここが本 PR の設計判断の中心です。

| alert kind | 所有する事象 | 発火 | 情報源 |
|---|---|---|---|
| `stripe-webhook-handler-failed`（#3985 / PR #4079） | event は**到達した**が handler が throw した | 初回失敗の瞬間（同期） | アプリ内の catch |
| `stripe-webhook-undelivered`（本 PR） | event が**到達していない / 完了していない** | cron（毎時） | Stripe API + 自 DB |

Stripe API だけでは「未達」と「到達したが 500 を返した」を判別できません（どちらも `pending_webhooks > 0` のまま残る）。そこで本 PR は **pending 単独では鳴らさず**、「Stripe 側で未完了」かつ「支払いが起きたのに plan が反映されていない」の**論理積**を発火条件にしました（`shouldAlert`）。handler が個別に失敗しているケースでは checkout の効果は他経路や Stripe の再送で反映されうるため後者が立たず、本 alert は沈黙して #4079 側が所有します（`[D3]` が回帰として固定）。両方が立つのは「支払いが起きたのに何も反映されていない」= 2026-07-26 と同型の状態に限られます。

なお本 PR は #4079 が触るファイル（`stripe-service.ts` / phase5 設計書）を一切変更していないため、merge 順に依存しません。

**2. 3998-AC4 / 3959-AC4 の実機確認が未了です。** 本セッションの制約で AWS への deploy と Stripe 実環境の操作を行っていません。代わりに、この class の失敗（「定義したが 1 件もマッチしない」#3969 と同型）を機械で検出できる形にしました — `[C1]` は logger が Lambda 上で実際に書き出す文字列を捕捉し、CDK の filter 検索語がその実バイト列にマッチすることを assert します。deploy 直後に 1 度実行する実機発火手順（log stream に 5 行注入 → metric → ALARM 遷移）は `docs/runbooks/silent-failure-alert-response.md` §1.5 に実コマンドで置きました。**この 2 AC を deploy 前に closed 扱いにするかは PO / QM の判断を仰ぎます。**

**3. logger の構造的な制約に依存しています。** Lambda 上で `logger` が CloudWatch に出すのは `message` 本文だけで、`context` オブジェクトは出力されません（`src/lib/server/logger.ts` の `writeLog`）。そのため metric filter は `context.kind` ではなく message 本文の文字列を見ています。この前提が崩れる（logger を JSON 出力に変える等）と filter は無言で 0 件になるため、`[B1]`-`[B3]` で CDK の literal とアプリ側の出力形の一致を機械検証しています。

**5. QM Re-Review #2（必須 1〜4）への対応。** commit `f95a5e2e`

- **必須 1（body のエビデンス SHA が実在しない / HEAD 系列外）**: rebase 前の orphan SHA が残置していた。`85a873ef` → `0aca801b`（M1-M4/M6 対応 commit）、AC 検証マップの `7945ad04` → 現 HEAD `f95a5e2e`、adversarial 2 件修正の出所 → `5925d233` に是正。全て `origin/develop` rebase 後の HEAD 系列に実在する。
- **必須 2（runbook の閾値が未修正 + 発火手順が原理的に機能しない）**: §1.2 / §1.5 の「5 分 5 件」を実装値（`threshold:1` / `evaluationPeriods:3` / `datapointsToAlarm:2`）に是正。**§1.5 の発火手順も修正**した — 旧手順は `NOW` を 1 度だけ評価して 5 行を同一 ms で 1 回 put するため全行が同じ 5 分 window に落ち、`datapointsToAlarm:2`（別 window 2 つ）を**何度実行しても満たせなかった**。6 分あけて 2 回 put する形にし、確認 query も 2 datapoint を見る形に変えた。
- **必須 3（#4108 経路の記述が誤り）**: monitor 冒頭の「handler が個別に失敗している場合 … 本 alert は沈黙して #4079 側が所有する」は、**throw しない** #4108 の経路では誤り。同経路では (a) `stripe-webhook-handler-failed` は throw 前提で発火せず (b) 200 応答で `pending_webhooks=0` → S1 が偽になり本 alert も発火しない = **どちらの alert も所有しない穴**。monitor 冒頭と runbook §2.2 に「両 alert とも所有しない穴（#4108 が恒久対処を所有）」として明記し、「顧客申告があるのに alert が 0 件」でも異常なしと読まないよう triage 手順を足した。S2 単独の別 kind を鳴らす案は検知条件そのものの変更（false positive 再評価が必要）で scope 拡大のため PO 判断に委ねる。
- **必須 4（新設 2 kind が phase6 R 表に未登録）**: `alert.ts` 自身が定める「新規 kind は phase6 §6 R1-R7 表に追記」に従い、**R14**（`stripe-webhook-undelivered`）/ **R15**（`stripe-webhook-monitor-failed`）を検知 method / ロールバック手順 / 再発防止の 3 観点で §3.10-e / §3.10-f に追加し、§3.10 サマリ表にも 1 行ずつ足した。R14 の再発防止欄には #4108 の穴も併記した（R12 / R13 は develop 側 #4061 が #3980 / #3981 で先に確保したため、rebase 時に R14 / R15 へ採番し直した）。
- **rebase**: `origin/develop`（`998a6ddd` = #4061 まで）へ rebase 済。`alert.ts` の `StripeAlertKind` union と phase6 R 表の 2 箇所で conflict が出たが、develop 側の #3980 / #3981 追加分（`stripe-subscription-multi-item` / `stripe-context-unresolved`、R12 / R13）を残したうえで本 PR の 2 kind を併記し、R 番号を R14 / R15 に採番し直して解決した。
- **検証**: `npx vitest run tests/unit/infra/entitlement-fail-closed-alarm.test.ts tests/unit/services/stripe-webhook-delivery-monitor.test.ts tests/unit/cron/schedule-consistency.test.ts tests/unit/routes/cron-stripe-webhook-delivery-check.test.ts tests/unit/server/stripe/alert-integration.test.ts` → 5 files / **54 passed** / HEAD `f95a5e2e`。`npx biome check .` 0 error / `cspell` 0 issue / `check-doc-code-references.mjs` 新規違反 0。

**6. 申し送り（本 PR では塞がない残課題、QM Re-Review #2 で提示）。** QM Re-Review #2 が「BLOCK 解除条件ではない」と明示した accepted residual であり、本 PR では**塞がずに記録する**。いずれも本 PR の検知層が「鳴った後」ではなく「鳴る条件」側の限界で、修正は検知条件・通知経路そのものの設計変更（false positive の再評価 / 通知先の必須化 / heartbeat 検知の新設）を伴い、PO 判断を要する scope 拡大になるため。

| # | 残課題 | 影響 |
|---|---|---|
| 1 | Discord 未設定時に無音 | `discord-alert.ts` は `if (!webhookUrl) return;`、`notifyStripeAlertAsync` は送信失敗を握るため、**env 欠落でも cron は `alerted: true` で 200** を返す。`DISCORD_WEBHOOK_INCIDENT` は `compute-stack.ts:303` で条件付き注入のため、env が落ちると #3959 の検知層が丸ごと無音になる |
| 2 | 長引く障害ほど早く沈黙する | `LOOKBACK_HOURS=24` + S2 が checkout のみ + AND 条件のため、配信断が 24h を超えると原因 checkout が窓から落ちて alert が止まる。`MAX_EVENTS_PER_RUN=100` は非ページング × created 降順のため、runbook §2.3 が起点にする最古イベントは大量障害時にページ外に出る |
| 3 | 夜間に「復旧」誤通知 | alarm は `treatMissingData: NOT_BREACHING` + `addOkAction` のため、利用者が絶える時間帯には DSQL が壊れたままでも ALARM → OK に戻る |
| 4 | `[T1]`〜`[T5]` の最終ホップ未検証 | 同 test は `sendDiscordAlert` を mock するため、`details` → Discord embed field の変換自体は検証していない |
| 5 | cron が一度も呼ばれない場合は依然無言 | EventBridge Rule 無効化 / dispatcher 停止のケースは本 PR の 2 kind いずれも検知しない（heartbeat 型の検知は本 PR の 2 kind の scope 外） |

**4. QM レビュー #1（M1〜M6）への対応。** commit `0aca801b`

- **M1（alert の tags がどこにも出ず runbook §2.3 が実行不能）**: **tags を `key=value` 1 行に畳み、「logger の message 本文」と「Discord embed の Details field」の両方に載せる**案を採りました。理由は 2 つで、(a) message にだけ畳む案は embed title が 200 文字で切られるため Discord 側で欠落しうる、(b) `errorSummary` に載せる案は同 field が throttle key 兼用のため、実行ごとに変わる event id を入れると同一事象が毎回別 key になり throttle が壊れる。CloudWatch 側は logger が `context` を捨てる（項目 3 の制約）ため message 本文にしか残せず、Discord 側は title 長制限があるので、**同じ 1 行を 2 つの出口に出す**のが最小の変更でした。**`logger.ts` は変更していません** — `context` を出力させると `hooks.server.ts` の `context.errorSummary` に入る DSQL の生エラーが CW Logs（#3939 で S3 長期保存）へ流れるため、#4101 の scope を変えないためです。runbook §2 冒頭に「id は Details field と log 本文の両方に出る」と追記しました。
- **M2**: await 可能な `notifyStripeAlertAsync` を追加し cron 経路で await します。既存の fire-and-forget 呼び出し（`hooks.server.ts` / `stripe-service.ts`）は挙動不変です。
- **M3**: `stripe-webhook-monitor-failed` を追加し、endpoint の catch から await 送出します。**生の例外 message は Discord に載せず**例外クラス名のみとし（接続情報の流出経路を新設しないため）、詳細は CW log 本文 + stack で見る導線を runbook §2.5 に置きました。dispatcher の非 2xx → throw 化は他 cron に波及するため本 PR では扱いません。
- **M4**: `stripe.events.list` は created 降順のため、最小 `created` を明示的に取るよう修正しました。命名は runbook の triage 前提（最古から障害開始時刻を推定する）に合わせて `oldest*` を維持しています。
- **M5**: 責務分界表のヘッダ 1 列目に見出し語（`alert kind`）を入れて、AC マップ gate の空欄行検出を解消しました。
- **M6**: `notifyStripeAlert → sendDiscordAlert` 境界の test を追加しました（`[T1]`-`[T5]`）。**実送出 payload** に triage id が載ること / email が載らないこと / await が送信完了を待つことを assert します。M3 は endpoint 単位の新規 spec（`[E1]`-`[E4]`）で固定しました。
- **imo**: 「未達が続く間は毎時鳴り続ける」を runbook §2.4 に、「Discord にも来るが throttle されるので SNS 側が正」を runbook §1.2 に明記しました。`LOOKBACK_HOURS = 24` の窓落ちは検知条件そのものの変更になるため本 PR では触っていません。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み — 実装は全 AC 完了。3998-AC4 / 3959-AC4 の**「実機での発火確認」のみ deploy を要するため未実施**（AC 検証マップに実測とともに明記 / 判断は PO 決裁ブリーフ Q1）
- [x] UI 変更時: N/A（UI ファイル変更 0 件）
- [x] 認証画面変更時: N/A（認証画面の変更なし。`tenant-entitlement.ts` の変更は log 文言のみで挙動不変）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 可逆 (revert で全撤去)"]
    R2["顧客面: 画面もデータも変わらない"]
    R3["ロールバック: alarm/cron が消えるだけ"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 沈黙する障害に気づける"]
    T2["負う: CW alarm 1本 + 毎時 cron 1本"]
    T3["残す: 継続課金の未達は未検知"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: invoice.paid 未達は鳴らない"]
    O2["UX: 件数閾値では夜間に鳴らない"]
    O3["security: log 注入が監査証跡を汚す"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["変化なし: UI 差分 0 / 挙動不変"]
    C2["間接: 課金事故の発見が早まる"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 実機発火が未確認のまま merge 可?"]
    Q2["Q2: 継続課金の未達は今回対象外で可?"]
  end

  O2 --> F2["修正済: 15分内2window に変更"]
  O3 --> F3["緩和済: runbook に 3 条件明記"]
  O1 --> Q2

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R2,R3 ok
  class T2,T3,O1 warn
  class T1,C1,C2,F2,F3 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

**③ の出所**: `tmp/adversarial-evidence/4102.json`（`node scripts/verify-adversarial-output.mjs --pr 4102` PASS）。3 件のうち **UX / security の 2 件は本 PR 内で修正済**（commit `5925d233`）。

- **O2 (UX)**: 当初 alarm を「5 分 5 件」で設計したが、契約世帯が数戸という規模では夜間・早朝の DSQL 障害中に閾値へ到達せず、全員が終夜 503 のまま鳴らない。**件数ではなく継続時間で判定する形（1 件 × 15 分内 2 window）に変更**し、件数閾値への退行を `[A2]` で固定した。
- **O3 (security)**: runbook の実機発火手順が本番 LogGroup に偽の障害行を注入するため、30 日保持の監査証跡を汚す。**専用 log stream に限定 / 確認後に削除 / 実行記録を PR・Issue に残す**の 3 条件を runbook に明記した。
- **O1 (business)**: 未達検知が「checkout 完了 かつ plan 未反映」の論理積のため、`invoice.paid` / `customer.subscription.updated` の未達（継続課金側）は鳴らない。Stripe API だけでは「未達」と「到達したが 500 を返した」を判別できず、継続課金側には checkout のような顧客影響シグナルが無いため、この AND を外すと #4079 の `stripe-webhook-handler-failed` と同一事象で二重に鳴る。**この穴を今回の scope 外として受容してよいかが Q2**。

**Q1 の背景**: 3998-AC4 / 3959-AC4 は実機での発火確認を要求しているが、本セッションは AWS への deploy を行わない制約下にある。代わりに「filter pattern が logger の実出力にマッチするか」を `[C1]`-`[C3]` で機械検証し（#3969 と同型の「作ったが効いていない」を検出）、deploy 直後に 1 度実行する注入手順を runbook §1.5 に実コマンドで置いた。

**pre-ready 実行済**: 2026-07-30 にクリーン単独実行し、**適用対象 13 step すべて PASS (exit 0 / `✗` 0 件)**。起票時点の「別セッション保持で BLOCK」は、heavy 系プロセスを 0 にしたうえで直列に回すことで解消した（この BLOCK 自体が並列運用を止める class として #4076 / #4083 に切り出し済）。個別コマンドの実行結果は「テスト & 安全装置セルフチェック」に記載。

</details>





