### PR TITLE
fix(ci): #4074 #4084 #4085 #4086 検査しなかったことを silent に通さない

### DIFF
--- a/.claude/skills/dev-open-pr/SKILL.md
+++ b/.claude/skills/dev-open-pr/SKILL.md
@@ -234,6 +234,15 @@ node scripts/check-pr-template-sections-sync.mjs --fix
 
 `scripts/check-pr-body.mjs` の `ac-map-incomplete` / `ac-map-empty` は 4 列未満 or 空セルを exit 1 で検出する。Ready 化前に必ず `node scripts/check-pr-body.mjs --pr <N>` PASS を verify する。
 
+#### 根拠コマンドの `--pr <番号>` は自 PR に一致させる — #4074
+
+根拠欄に `--pr <番号>` を書くときは、**その番号が本 PR 自身**でなければならない。別 PR / 存在しない番号を指した証跡は「宛先違い」であり、その PR を検証した根拠にならない。
+
+- 実測 (#4074): PR #4063 の AC 検証マップに `npm run pre-ready -- --pr 4059` と書かれていた。#4059 は存在しない PR (`gh api .../pulls/4059` → 404) だが、`check-pr-body.mjs --pr 4063` は「OK — 違反なし」を返し CI も全 pass した
+- **`gh pr view <N> --json <単一フィールド>` は存在しない PR でも値を返す**。AI が生成した PR 番号は検証なしに信用できない。番号を書いたら `gh api repos/<owner>/<repo>/pulls/<N>` で実在を確認する
+- 現在は `check-pr-body.mjs` が `evidence-pr-mismatch` として exit 1 にする（AC 検証マップセクション内の `--pr <数字>` が対象。body の他所での他 PR 言及は対象外）
+- 番号を書かない `--pr <num>` 等のプレースホルダ形式は従来どおり通る。**実際に実行した番号を書くなら自 PR 番号にする**
+
 ```bash
 # gh アカウント確認 (ADR-0022 / #1728)
 node scripts/check-gh-account-before-pr.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,14 @@ jobs:
         # 3 度目を待たず機械 gate 化した (ADR-0061 same-class-N → guard)。
         run: node scripts/check-readdir-rotation-guard.mjs
 
+      - name: repo 走査 test の区分宣言 guard (#4085)
+        # repo 全体の file を実読する test は実行時間が入力サイズに比例する。既定 timeout (5s) の
+        # まま unit lane に置くと並列実行の負荷で落ちるが壊れてはいないため、毎回「本物か負荷か」の
+        # 切り分けが発生し、間違えれば本物の回帰を「また負荷だろう」と見逃す。同 class 4 例目
+        # (#3972/#4000 / #3978 / page-guide-coverage 6240ms / path-filter-closure 5533ms) で
+        # instance 修正をやめ、追加時に区分の判断を必ず発生させる gate にした (ADR-0061)。
+        run: node scripts/check-repo-scan-test-declaration.mjs
+
       - name: License key re-introduction guard (#2836 / Epic #2525 Phase 7 PR-L4)
         # license key 全廃 (Phase 1 補強 3 #2788) の再導入防止。allowlist 外のコード行に
         # ライセンスキー / licenseKey / license-key / LICENSE_KEY 参照を検出したら fail。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,9 +46,9 @@ Ready 化前は依然として `npm run pre-ready -- --pr <num>` 全 step PASS �
 
 ### Ready 化前チェック（必須）
 
-`npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #1920 / #2918 で SSOT 検証 step 拡張)。全 17 step (Step 1〜12 + 1b / 7b / 7c / 7d / 11b) を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`** (#2929 で同期):
+`npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #1920 / #2918 で SSOT 検証 step 拡張)。全 19 step (Step 1〜12 + 1b / 7b / 7c / 7d / 7e / 7f / 11b) を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`** (#2929 で同期):
 
-1. biome check / 1b. cspell (#3649, CI 同一コマンド) / 2. svelte-check / 3. vitest run / 4. check-hardcoded-strings (#1452) / 5. measure-lp-dimensions (#1163, LP 変更時のみ) / 6. sync-lp-fallback --check (#1945, LP / labels.ts 変更時のみ) / 7. check-no-plan-literals (#972) / 7b. check-license-key-leak (#2836) / 8. generate-lp-labels --check (#1917, labels.ts / terms.ts / age-tier.ts 変更時のみ) / 9. Readiness gate = check-pr-body (PR 番号必須) / 10. check-doc-code-references (#2577) / 11. check-terminology-coherence (#2555) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail) / 12. capture (UI 変更時のみガイダンス)
+1. biome check / 1b. cspell (#3649, CI 同一コマンド) / 2. svelte-check / 3. vitest run / 4. check-hardcoded-strings (#1452) / 5. measure-lp-dimensions (#1163, LP 変更時のみ) / 6. sync-lp-fallback --check (#1945, LP / labels.ts 変更時のみ) / 7. check-no-plan-literals (#972) / 7b. check-license-key-leak (#2836) / 7c. check-cli-entry-guard (#3969) / 7d. check-workflow-sparse-checkout-closure (#3969) / 7e. check-readdir-rotation-guard (#3978) / 7f. check-repo-scan-test-declaration (#4085) / 8. generate-lp-labels --check (#1917, labels.ts / terms.ts / age-tier.ts 変更時のみ) / 9. Readiness gate = check-pr-body (PR 番号必須) / 10. check-doc-code-references (#2577) / 11. check-terminology-coherence (#2555) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail) / 12. capture (UI 変更時のみガイダンス)
 
 **Step 番号は表示上の識別子であり実行順ではない (#4048)**。実行は cheap-fail-first — PR body だけを見る検査 (Step 9) → 静的テキスト検査 (1 / 1b / 4 / 6 / 7 / 7b / 7c / 7d / 8 / 10 / 11) → 型検査 (2) → テスト (3) → ブラウザ実測 (5) → SS 系 (11b / 12) の順。検査の集合・合否条件は番号順実行時と同一。
 

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -137,7 +137,7 @@
 | `npm run dev` | 開発サーバー (port 5173、local モード) |
 | `npm run dev:cognito` | Cognito 認証画面 (#1026、認証画面 PR Ready 前必須) |
 | `npm run build` | SvelteKit production build |
-| `npm run pre-ready -- --pr <num>` | Ready 化前 全 17 step 検証 (ADR-0030 / #1920 / #2918。一覧 SSOT は `--help`。実行順は cheap-fail-first で Step 番号順ではない、#4048) |
+| `npm run pre-ready -- --pr <num>` | Ready 化前 全 19 step 検証 (ADR-0030 / #1920 / #2918。一覧 SSOT は `--help`。実行順は cheap-fail-first で Step 番号順ではない、#4048) |
 | `npx biome check .` | Biome lint (Tier T1) |
 | `npx svelte-check` | Svelte 型チェック |
 | `npx vitest run` | unit / integration テスト |

--- a/scripts/check-design-doc-sync.mjs
+++ b/scripts/check-design-doc-sync.mjs
@@ -13,7 +13,8 @@
  * **判定ロジック (新)**:
  * 1. `src/routes/` 変更なし → skip
  * 2. `docs/design/` 同期あり → pass
- * 3. (file-pattern exempt) 全変更ファイルが CLAUDE.md / scripts/ / docs/ / infra/ / .github/ / site/ → skip
+ * 3. (file-pattern exempt) 全変更ファイルが CLAUDE.md / scripts/ / tests/ / docs/ / infra/ /
+ *    .github/ / site/ / .claude/**\/*.md → skip
  * 4. (label exempt #1985 NEW) PR ラベルに `refactor:internal-no-doc-impact` 含む → skip
  * 5. それ以外 → fail
  *
@@ -57,6 +58,12 @@ const FILE_EXEMPT_MATCHERS = [
 	/^infra\//, // インフラ設定
 	/^\.github\//, // CI 設定
 	/^site\//, // LP (設計書管轄外)
+	// #4085: .claude 配下の **markdown のみ** (Skill / agent 定義などのプロセス文書)。
+	// docs/ と同じく「文書そのもの」であり src/routes/ の挙動を変えない。
+	// `.claude/hooks/*.mjs` / `.claude/settings.json` は実行される設定・コードなので exempt しない
+	// (`.claude/` 全体を exempt にすると gate が空洞化する)。
+	// #3152 で `tests/` が同じ理由 (列挙漏れによる false fail) で追加されたのと同 class の 2 例目。
+	/^\.claude\/.*\.md$/,
 ];
 
 /**
@@ -148,7 +155,7 @@ export function checkDesignDocSync({ files, labels = [] }) {
 		return {
 			status: 'skip',
 			reason:
-				'変更ファイルが全て設計書更新不要なパターン (CLAUDE.md / scripts/ / docs/ / infra/ / .github/ / site/) のみ (ADR-0003)',
+				'変更ファイルが全て設計書更新不要なパターン (CLAUDE.md / scripts/ / tests/ / docs/ / infra/ / .github/ / site/ / .claude/**/*.md) のみ (ADR-0003)',
 		};
 	}
 

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -275,6 +275,7 @@ export function checkAcMap(body) {
 export function extractEvidencePrNumbers(body) {
 	const section = extractAcMapSection(body);
 	if (!section) return [];
+	/** @type {number[]} */
 	const found = [];
 	for (const m of section.matchAll(/--pr[=\s]+(\d+)\b/g)) {
 		const n = Number(m[1]);

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -261,6 +261,70 @@ export function checkAcMap(body) {
 }
 
 // ---------------------------------------------------------------------------
+// AC 検証マップ 根拠の参照整合 (#4074)
+// ---------------------------------------------------------------------------
+
+/**
+ * 根拠欄に現れる `--pr <番号>` の PR 番号を抽出する (#4074)。
+ *
+ * `--pr <num>` / `--pr <N>` 等のプレースホルダは数字でないので拾わない (AC3 後方互換)。
+ *
+ * @param {string} body
+ * @returns {number[]} 出現順・重複除去済みの PR 番号
+ */
+export function extractEvidencePrNumbers(body) {
+	const section = extractAcMapSection(body);
+	if (!section) return [];
+	const found = [];
+	for (const m of section.matchAll(/--pr[=\s]+(\d+)\b/g)) {
+		const n = Number(m[1]);
+		if (!found.includes(n)) found.push(n);
+	}
+	return found;
+}
+
+/**
+ * AC 検証マップの根拠が **その PR 自身**を検証したものかを検証する (#4074 AC1)。
+ *
+ * 実測 (#4074): PR #4063 の AC 検証マップに `npm run pre-ready -- --pr 4059` と書かれていた。
+ * #4059 は存在しない PR (`gh api .../pulls/4059` → 404) だが、`check-pr-body.mjs --pr 4063` は
+ * 「OK — 違反なし」を返し CI も全 pass した。**宛先違いの証跡でも Ready 化を通過できた。**
+ *
+ * 番号の実在確認 (GitHub API) ではなく **自 PR 番号との一致**で判定する。
+ * `gh pr view <N> --json <単一フィールド>` は存在しない PR でも値を返すため実在確認は当てにならず、
+ * 一方「自 PR と一致しない番号」は実在・非実在を問わず宛先違いなので、一致判定だけで
+ * 本 Issue の欠陥 (実在しない 4059 / 別 PR の番号) を両方とも落とせる。ネットワーク非依存。
+ *
+ * 対象は AC 検証マップセクションのみ。body の他所 (背景・関連 PR への言及) は正当に他 PR 番号を
+ * 含むため対象外にして誤検出を作らない (AC3)。
+ *
+ * @param {string} body
+ * @param {string | number | null | undefined} prNumber 自 PR 番号 (`--body-file` dry-run では null)
+ * @returns {{ id: string; message: string } | null}
+ */
+export function checkEvidencePrReferences(body, prNumber) {
+	// 自 PR 番号が分からない dry-run では「一致」を判定できない。ここで嘘の pass / fail を作らない
+	// (`--pr` 指定の pre-ready Step 9 / CI では必ず判定される)。
+	if (prNumber === null || prNumber === undefined || String(prNumber).trim() === '') return null;
+	const self = Number(String(prNumber).trim());
+	if (!Number.isFinite(self)) return null;
+
+	const mismatched = extractEvidencePrNumbers(body).filter((n) => n !== self);
+	if (mismatched.length === 0) return null;
+
+	return {
+		id: 'evidence-pr-mismatch',
+		message:
+			`AC 検証マップの根拠が本 PR (#${self}) 以外の PR 番号を指しています: ` +
+			`${mismatched.map((n) => `--pr ${n}`).join(' / ')}\n` +
+			`  根拠コマンドの \`--pr <番号>\` は **その PR 自身**を検証したものでなければ証跡になりません ` +
+			`(別 PR / 存在しない番号を指した状態で Ready 化を通した実測: PR #4063 の \`--pr 4059\`)。\n` +
+			`  対応: 根拠欄の番号を ${self} に直し、\`npm run pre-ready -- --pr ${self}\` を実際に実行し直して結果を貼る。\n` +
+			`  番号を書かない形式 (\`--pr <num>\` 等のプレースホルダ) は従来どおり通ります。`,
+	};
+}
+
+// ---------------------------------------------------------------------------
 // Ready for Review チェックリスト未チェック検出
 // ---------------------------------------------------------------------------
 
@@ -1394,6 +1458,10 @@ function collectViolations(body, requiredSections, template, args, notes = []) {
 
 	const acMap = checkAcMap(body);
 	if (acMap) violations.push({ ...acMap, issue: '#1775 AC2' });
+
+	// #4074: 根拠欄の `--pr <番号>` が自 PR を指しているか (宛先違いの証跡を通さない)
+	const evidencePrRef = checkEvidencePrReferences(body, args.pr);
+	if (evidencePrRef) violations.push({ ...evidencePrRef, issue: '#4074' });
 
 	const unchecked = findUncheckedReadyChecklist(body);
 	if (unchecked.length > 0) {

--- a/scripts/check-repo-scan-test-declaration.mjs
+++ b/scripts/check-repo-scan-test-declaration.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-repo-scan-test-declaration.mjs (#4085)
+ *
+ * 「repo 走査 test」の区分宣言を機械強制する gate。
+ *
+ * ## 背景
+ *
+ * repo 全体の file を実読する test は実行時間が入力サイズに比例する。既定 timeout (5s) のまま
+ * unit lane に置くと並列実行の負荷次第で落ちるが、**壊れてはいない**ため開発者は毎回「本物か
+ * 負荷か」を切り分けることになる。切り分けを間違えれば無い回帰を追うか、本物の回帰を
+ * 「また負荷だろう」と見逃す。
+ *
+ * 同 class が 4 例に達した (#3972/#4000 → PR #4067 / #3978 → PR #4066 /
+ * `page-guide-coverage` 6240ms / `ci-unit-test-path-filter-closure` 5533ms) ため、
+ * instance ごとの timeout 引き上げをやめて、**追加時に区分の判断を必ず発生させる** gate にした
+ * (ADR-0061 same-class-N→guard / #4048 `costClass` 未登録 throw と同型)。
+ *
+ * ## 検査内容
+ *
+ *   1. 走査 API (`readdirSync` / `globSync` / `readdir(` / `glob(` / `fg(` ...) を使う test file を
+ *      候補として洗い出す
+ *   2. 候補が `REPO_SCAN_TEST_REGISTRY` に未宣言なら fail (区分宣言の強制)
+ *   3. 宣言された `scope` が静的判定と食い違えば fail
+ *      (`bounded` と自己申告して timeout 要求を回避することを許さない)
+ *   4. `scope: 'repo'` の test file に明示 timeout (≥ MIN_REPO_SCAN_TIMEOUT_MS) が無ければ fail
+ *   5. registry にあるのに file が無い / もう走査していないエントリは fail (stale 宣言の除去)
+ *
+ * 「検査しなかったことを silent に通さない」ため、候補 0 件は異常 (走査 API の綴りが変わった等)
+ * として fail する。
+ *
+ * ## 実行
+ *
+ *   node scripts/check-repo-scan-test-declaration.mjs
+ *   node scripts/check-repo-scan-test-declaration.mjs --list   # 判定結果を一覧表示 (常に exit 0)
+ *
+ * ## exit code
+ *
+ *   0 — 違反なし
+ *   1 — 違反あり
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+	MIN_REPO_SCAN_TIMEOUT_MS,
+	REPO_SCAN_TEST_REGISTRY,
+} from './lib/ci/repo-scan-test-registry.mjs';
+import { isMain } from './lib/is-main.mjs';
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '../..');
+
+/** 走査 API のシグネチャ。1 つでも含めば「候補」。 */
+const SCAN_API_PATTERN =
+	/\breaddirSync\s*\(|\breaddir\s*\(|\bglobSync\s*\(|\bglob\s*\(|\bfg\s*\(|from ['"]fast-glob['"]|from ['"]glob['"]/;
+
+/**
+ * repo のディレクトリツリーを指す文字列リテラル。
+ *
+ * 「ディレクトリそのもの」を名指しするのは走査するときだけなので、単一ファイル参照
+ * (`'src/lib/domain/labels.ts'`) とは区別できる。
+ */
+const REPO_ROOT_DIR_PATTERN =
+	/(['"`])(src|scripts|tests|docs|site|infra|static|\.github|\.claude)(\/[a-z0-9_.-]+){0,2}\1/i;
+
+/** 明示 timeout の宣言。`}, 60_000)` / `{ timeout: 60_000 }` / `testTimeout: 30000` を拾う。 */
+const EXPLICIT_TIMEOUT_PATTERN = /(?:[Tt]imeout\s*:\s*|\}\s*,\s*)([0-9][0-9_]*)/g;
+
+/**
+ * test file を列挙する (tests/ 配下の *.test.ts)。
+ *
+ * @param {string} dir
+ * @returns {string[]} repo root からの POSIX 相対パス
+ */
+export function listTestFiles(dir = join(repoRoot, 'tests')) {
+	const out = [];
+	for (const entry of readdirSync(dir)) {
+		if (entry === 'node_modules') continue;
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) out.push(...listTestFiles(full));
+		else if (/\.test\.ts$/.test(entry)) out.push(relative(repoRoot, full).replace(/\\/g, '/'));
+	}
+	return out;
+}
+
+/**
+ * source から「走査 API を使うか」「repo ツリーを指すか」「明示 timeout があるか」を判定する。
+ *
+ * @param {string} source
+ * @returns {{ usesScanApi: boolean; scope: 'repo' | 'bounded'; maxTimeoutMs: number }}
+ */
+export function analyzeTestSource(source) {
+	const usesScanApi = SCAN_API_PATTERN.test(source);
+	const scope = usesScanApi && REPO_ROOT_DIR_PATTERN.test(source) ? 'repo' : 'bounded';
+	let maxTimeoutMs = 0;
+	for (const m of source.matchAll(EXPLICIT_TIMEOUT_PATTERN)) {
+		const value = Number(m[1].replace(/_/g, ''));
+		if (Number.isFinite(value)) maxTimeoutMs = Math.max(maxTimeoutMs, value);
+	}
+	return { usesScanApi, scope, maxTimeoutMs };
+}
+
+/**
+ * gate 本体。file 読み込みを DI 可能にして test から fixture を注入する。
+ *
+ * @param {{ files: string[]; readFile: (path: string) => string;
+ *           registry?: Record<string, { scope: 'repo' | 'bounded'; note: string }> }} input
+ * @returns {{ violations: { id: string; path: string; message: string }[];
+ *             candidates: { path: string; scope: string; maxTimeoutMs: number }[] }}
+ */
+export function checkRepoScanTestDeclarations({
+	files,
+	readFile,
+	registry = REPO_SCAN_TEST_REGISTRY,
+}) {
+	const violations = [];
+	const candidates = [];
+
+	for (const path of files) {
+		const analysis = analyzeTestSource(readFile(path));
+		if (!analysis.usesScanApi) continue;
+		candidates.push({ path, scope: analysis.scope, maxTimeoutMs: analysis.maxTimeoutMs });
+
+		const declared = registry[path];
+		if (!declared) {
+			violations.push({
+				id: 'undeclared',
+				path,
+				message:
+					`repo 走査 test の区分が未宣言です (静的判定: scope='${analysis.scope}')。\n` +
+					`      scripts/lib/ci/repo-scan-test-registry.mjs に以下を追加してください:\n` +
+					`        '${path}': { scope: '${analysis.scope}', note: '<何を走査するか>' },` +
+					(analysis.scope === 'repo'
+						? `\n      scope='repo' の test には明示 timeout (≥ ${MIN_REPO_SCAN_TIMEOUT_MS}ms) も必要です。`
+						: ''),
+			});
+			continue;
+		}
+
+		if (declared.scope !== analysis.scope) {
+			violations.push({
+				id: 'scope-mismatch',
+				path,
+				message:
+					`宣言された scope='${declared.scope}' が静的判定 scope='${analysis.scope}' と一致しません。\n` +
+					`      走査範囲を変えたなら registry の宣言も直してください ` +
+					`(自己申告だけで区分を下げることはできません)。`,
+			});
+			continue;
+		}
+
+		if (declared.scope === 'repo' && analysis.maxTimeoutMs < MIN_REPO_SCAN_TIMEOUT_MS) {
+			violations.push({
+				id: 'missing-timeout',
+				path,
+				message:
+					`scope='repo' ですが明示 timeout がありません (検出した最大値: ${analysis.maxTimeoutMs}ms、` +
+					`必要: ${MIN_REPO_SCAN_TIMEOUT_MS}ms 以上)。\n` +
+					`      対応: 当該 it(...) の第 3 引数に \`${MIN_REPO_SCAN_TIMEOUT_MS * 3}\` 等を渡すか、\n` +
+					`            describe(..., { timeout: ${MIN_REPO_SCAN_TIMEOUT_MS * 3} }) を付ける。\n` +
+					`      既定 5s のままだと並列実行の負荷で落ち、「本物か負荷か」の切り分けが毎回発生します (#4085)。`,
+			});
+		}
+	}
+
+	const candidatePaths = new Set(candidates.map((c) => c.path));
+	for (const path of Object.keys(registry)) {
+		if (candidatePaths.has(path)) continue;
+		violations.push({
+			id: 'stale-entry',
+			path,
+			message: files.includes(path)
+				? 'registry に宣言されていますが、もう走査 API を使っていません。エントリを削除してください。'
+				: 'registry に宣言されていますが file が存在しません。エントリを削除してください。',
+		});
+	}
+
+	if (candidates.length === 0) {
+		violations.push({
+			id: 'no-candidates',
+			path: '(全体)',
+			message:
+				'走査 API を使う test が 1 件も見つかりませんでした。検出 pattern が実装と乖離した疑いがあります ' +
+				'(0 件を「違反なし」として黙って通すと gate が無効化されたことに誰も気付けないため fail にします、#4085)。',
+		});
+	}
+
+	return { violations, candidates };
+}
+
+function main(argv = process.argv.slice(2)) {
+	const files = listTestFiles();
+	const readFile = (/** @type {string} */ p) => readFileSync(resolve(repoRoot, p), 'utf8');
+	const { violations, candidates } = checkRepoScanTestDeclarations({ files, readFile });
+	const prefix = '[repo-scan-test-declaration]';
+
+	if (argv.includes('--list')) {
+		for (const c of candidates) {
+			console.log(
+				`  ${c.scope.padEnd(7)} timeout=${String(c.maxTimeoutMs).padStart(6)}ms  ${c.path}`,
+			);
+		}
+		console.log(
+			`${prefix} 候補 ${candidates.length} 件 / 違反 ${violations.length} 件 (--list は常に exit 0)`,
+		);
+		return 0;
+	}
+
+	if (violations.length === 0) {
+		console.log(
+			`${prefix} OK — repo 走査 test ${candidates.length} 件すべて区分宣言済 ` +
+				`(scope='repo' は明示 timeout ≥ ${MIN_REPO_SCAN_TIMEOUT_MS}ms を確認)`,
+		);
+		return 0;
+	}
+
+	console.log(`\n${prefix} ERROR — ${violations.length} 件の違反:\n`);
+	for (const v of violations) {
+		console.log(`  [${v.id}] ${v.path}\n      ${v.message}\n`);
+	}
+	console.log(
+		'SSOT: scripts/lib/ci/repo-scan-test-registry.mjs / 運用は tests/CLAUDE.md §「repo 走査 test」(#4085)',
+	);
+	return 1;
+}
+
+if (isMain(import.meta.url)) {
+	process.exit(main());
+}

--- a/scripts/check-repo-scan-test-declaration.mjs
+++ b/scripts/check-repo-scan-test-declaration.mjs
@@ -95,7 +95,7 @@ export function analyzeTestSource(source) {
 	const scope = usesScanApi && REPO_ROOT_DIR_PATTERN.test(source) ? 'repo' : 'bounded';
 	let maxTimeoutMs = 0;
 	for (const m of source.matchAll(EXPLICIT_TIMEOUT_PATTERN)) {
-		const value = Number(m[1].replace(/_/g, ''));
+		const value = Number((m[1] ?? '').replace(/_/g, ''));
 		if (Number.isFinite(value)) maxTimeoutMs = Math.max(maxTimeoutMs, value);
 	}
 	return { usesScanApi, scope, maxTimeoutMs };

--- a/scripts/check-ss-blob-sha-uniqueness.mjs
+++ b/scripts/check-ss-blob-sha-uniqueness.mjs
@@ -100,6 +100,139 @@ export function pairBeforeAfter(paths) {
 	return pairs;
 }
 
+// ---------------------------------------------------------------------------
+// #4084: 命名非依存のペアリング宣言 + 理由必須の例外宣言
+// ---------------------------------------------------------------------------
+
+/**
+ * 理由記述を要求する宣言の最小長 (全角前提の目安)。
+ *
+ * 「理由の非強制」を作らないための下限 (#3956 教訓 / #4084 AC3)。空欄・`TODO`・`n/a` のような
+ * 定型 stub は理由として認めない。lint の `-- <reason>` 付き抑制コメントと同じ思想。
+ */
+export const MIN_REASON_LENGTH = 12;
+
+/** 理由として認めない定型 stub (小文字化して完全一致で判定)。 */
+const STUB_REASONS = new Set([
+	'todo',
+	'tbd',
+	'n/a',
+	'na',
+	'-',
+	'—',
+	'なし',
+	'後で書く',
+	'あとで書く',
+	'理由',
+	'wip',
+	'fixme',
+]);
+
+/**
+ * `<!-- <key>: <理由> -->` 形式の宣言を読み、理由の実体があるかを判定する (#4084 AC3)。
+ *
+ * @param {string} body
+ * @param {string} key 例: `ss-identical-ok` / `ss-pair-none`
+ * @returns {{ present: boolean; reason: string; valid: boolean }}
+ */
+export function parseReasonDeclaration(body, key) {
+	const m = body.match(new RegExp(`<!--\\s*${key}\\s*:([^>]*?)-->`));
+	if (!m) return { present: false, reason: '', valid: false };
+	const reason = m[1].trim();
+	const normalized = reason.toLowerCase();
+	const valid =
+		reason.length >= MIN_REASON_LENGTH &&
+		!STUB_REASONS.has(normalized) &&
+		!/^[-—\s]*$/.test(reason);
+	return { present: true, reason, valid };
+}
+
+/**
+ * ペアリング宣言を読む (#4084 AC2)。
+ *
+ * 撮影者の命名自由度を保ったまま機械が対応関係を取れるようにする。実測 (#4080) の
+ * `develop-*` / `pr4080-*` は prefix 宣言 1 行で 20 枚すべてペアになる。
+ *
+ *   <!-- ss-pair-prefix: before=develop- after=pr4080- -->
+ *   <!-- ss-pair: before=<path or raw URL> after=<path or raw URL> -->
+ *
+ * @param {string} body
+ * @returns {{ prefixes: { before: string; after: string }[]; explicit: { before: string; after: string }[] }}
+ */
+export function parsePairDeclarations(body) {
+	const prefixes = [];
+	for (const m of body.matchAll(/<!--\s*ss-pair-prefix\s*:\s*before=(\S+)\s+after=(\S+)\s*-->/g)) {
+		prefixes.push({ before: m[1], after: m[2] });
+	}
+	const explicit = [];
+	for (const m of body.matchAll(/<!--\s*ss-pair\s*:\s*before=(\S+)\s+after=(\S+)\s*-->/g)) {
+		explicit.push({ before: toScreenshotPath(m[1]), after: toScreenshotPath(m[2]) });
+	}
+	return { prefixes, explicit };
+}
+
+/**
+ * raw URL でも path でも受け取れるように、screenshots branch 以下の path に正規化する。
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function toScreenshotPath(value) {
+	const m = value.match(
+		/https:\/\/raw\.githubusercontent\.com\/[^/]+\/[^/]+\/screenshots\/([^\s)]+)/,
+	);
+	return m ? m[1] : value;
+}
+
+/**
+ * SS path 一覧をペアリングする (#4084 AC2)。
+ *
+ * 優先順位: 明示ペア宣言 → prefix 宣言 → 既定の `before-*` / `after-*` 命名。
+ * どれか 1 つで対応が取れれば SHA 比較まで進む (= 命名を変えただけで検査が消えない)。
+ *
+ * @param {string[]} paths
+ * @param {{ prefixes: { before: string; after: string }[]; explicit: { before: string; after: string }[] }} decls
+ * @returns {Array<{ key: string; before: string; after: string }>}
+ */
+export function pairScreenshots(paths, decls = { prefixes: [], explicit: [] }) {
+	const available = new Set(paths);
+	const used = new Set();
+	const pairs = [];
+
+	for (const { before, after } of decls.explicit ?? []) {
+		if (available.has(before) && available.has(after)) {
+			pairs.push({ key: `${before} ⇄ ${after}`, before, after });
+			used.add(before);
+			used.add(after);
+		}
+	}
+
+	for (const { before: bp, after: ap } of decls.prefixes ?? []) {
+		const beforeMap = new Map();
+		const afterMap = new Map();
+		for (const p of paths) {
+			if (used.has(p)) continue;
+			const slash = p.lastIndexOf('/');
+			const dir = slash >= 0 ? p.slice(0, slash + 1) : '';
+			const basename = slash >= 0 ? p.slice(slash + 1) : p;
+			if (basename.startsWith(bp)) beforeMap.set(`${dir}${basename.slice(bp.length)}`, p);
+			else if (basename.startsWith(ap)) afterMap.set(`${dir}${basename.slice(ap.length)}`, p);
+		}
+		for (const [key, before] of beforeMap) {
+			const after = afterMap.get(key);
+			if (!after) continue;
+			pairs.push({ key, before, after });
+			used.add(before);
+			used.add(after);
+		}
+	}
+
+	for (const pair of pairBeforeAfter(paths.filter((p) => !used.has(p)))) {
+		pairs.push(pair);
+	}
+	return pairs;
+}
+
 /**
  * GitHub Contents API で Blob SHA を取得する。
  *
@@ -214,15 +347,32 @@ export async function checkSsBlobShaUniqueness({ body, labels, fetcher = fetch }
 		};
 	}
 
-	// 2. before/after ペアリング
-	// 同 ref からの path 一覧をペア化
+	// 2. ペアリング (#4084 AC2: 明示宣言 → prefix 宣言 → 既定命名の順で対応を取る)
 	const paths = refs.map((r) => r.path);
-	const pairs = pairBeforeAfter(paths);
+	const decls = parsePairDeclarations(body);
+	const pairs = pairScreenshots(paths, decls);
 
 	if (pairs.length === 0) {
+		// #4084 AC1: SS が embed されているのにペアが 0 件 = **偽装検知が 1 度も実行できていない**。
+		// 旧実装はここを skip にしていたため「20 枚あって 0 ペア」が silent に pass していた
+		// (実測: PR #4080)。検知できなかったことを黙って通さない (#3983 / #4074 と同 class)。
+		const none = parseReasonDeclaration(body, 'ss-pair-none');
+		if (none.present && none.valid) {
+			return {
+				status: 'pass',
+				reason:
+					`SS ${refs.length} 件でペアが 0 件だが、宣言により対象外と判定: ${none.reason} ` +
+					'(<!-- ss-pair-none: <理由> -->、#4084 AC1)',
+			};
+		}
 		return {
-			status: 'skip',
-			reason: `before-* / after-* ペアが 0 件 (SS ${refs.length} 件中)。命名規則 (before-<key> / after-<key>) に従っていない、または single-side のみ`,
+			status: 'fail',
+			reason:
+				`SS ${refs.length} 件が embed されているのに Before/After ペアが 0 件で、偽装検知を 1 ペアも実行できていません (#4084 AC1)。` +
+				(none.present
+					? ' `<!-- ss-pair-none: ... -->` は宣言されていますが理由が空 / 定型 stub のため受理できません。'
+					: ''),
+			pairingHelp: true,
 		};
 	}
 
@@ -250,9 +400,29 @@ export async function checkSsBlobShaUniqueness({ body, labels, fetcher = fetch }
 		};
 	}
 
+	// #4084 AC3: 「Before / After が同一であることが正しい」ケースの明示経路。
+	// 実測 (#4080): JST 00:00〜09:00 の 9 時間帯だけ日付がずれる修正を、その窓の外 (JST 日中) に
+	// 撮影したため描画が一致するのが正しい結果だった。理由の記述を必須とし (空なら fail)、
+	// 同一だった事実自体は握り潰さず列挙する。`refactor:internal-no-doc-impact` (挙動不変の
+	// 内部 refactor 用) とは意味が違うので別経路にする。
+	const identicalOk = parseReasonDeclaration(body, 'ss-identical-ok');
+	if (identicalOk.present && identicalOk.valid) {
+		return {
+			status: 'pass',
+			reason:
+				`${violations.length} ペアが Blob SHA 一致だが、理由付き宣言により正当と判定: ${identicalOk.reason} ` +
+				'(<!-- ss-identical-ok: <理由> -->、#4084 AC3)',
+			acknowledgedIdenticalPairs: violations,
+		};
+	}
+
 	return {
 		status: 'fail',
-		reason: `${violations.length} ペアの SS が完全同一画像 (Blob SHA 一致 = 偽装疑い)`,
+		reason:
+			`${violations.length} ペアの SS が完全同一画像 (Blob SHA 一致 = 偽装疑い)` +
+			(identicalOk.present
+				? '。`<!-- ss-identical-ok: ... -->` は宣言されていますが理由が空 / 定型 stub のため受理できません (理由必須、#4084 AC3 / #3956)'
+				: ''),
 		violations,
 	};
 }
@@ -291,6 +461,29 @@ async function main() {
 
 	// fail
 	console.log(`\n${prefix} ${isError ? 'ERROR' : 'WARN'} — ${result.reason}`);
+
+	// #4084 AC1: ペアが 0 件で検査そのものが実行できなかった場合の対応手順
+	if (result.pairingHelp) {
+		console.log(`\n対応方法 (いずれか 1 つ):`);
+		console.log(`  1. SS の file 名を規約どおり before-<key> / after-<key> にする`);
+		console.log(
+			`  2. 命名を変えたくない場合は PR body に prefix 宣言を置く:\n` +
+				`       <!-- ss-pair-prefix: before=develop- after=pr<PR番号>- -->`,
+		);
+		console.log(
+			`  3. 個別に対応を書く場合:\n` +
+				`       <!-- ss-pair: before=<raw URL or path> after=<raw URL or path> -->`,
+		);
+		console.log(
+			`  4. ペアが原理的に存在しない場合 (新規画面で修正前が無い 等) は理由を書いて宣言する:\n` +
+				`       <!-- ss-pair-none: <${MIN_REASON_LENGTH} 文字以上の理由> -->`,
+		);
+		console.log(
+			`\nSS が embed されているのにペア 0 件を skip で通すと、偽装検知 (#2063) が黙って無効化されます (#4084)。`,
+		);
+		return isError ? 1 : 0;
+	}
+
 	console.log(`\nSS forging detected (Blob SHA 完全一致):`);
 	for (const v of result.violations) {
 		console.log(`  - ${v.before} == ${v.after} (SHA: ${v.sha})`);
@@ -305,6 +498,11 @@ async function main() {
 	console.log(`  1. 修正後 SS を撮影し直す (scripts/capture.mjs --pr <N>)`);
 	console.log(`  2. 撮影したファイルを screenshots branch に push`);
 	console.log(`  3. PR body の after-* URL が新しい SHA を指していることを確認`);
+	console.log(
+		`  4. **同一であることが正しい**場合 (差分が現れる条件の外で撮影した 等) は理由を書いて宣言する:\n` +
+			`       <!-- ss-identical-ok: <${MIN_REASON_LENGTH} 文字以上の理由> -->\n` +
+			`     理由が空 / TODO 等の定型 stub では受理しません (#4084 AC3 / #3956)。`,
+	);
 	console.log(
 		`\n[${prefix.replace(/[[\]]/g, '')}] mode=${MODE}, violations=${result.violations.length} ` +
 			`(${isError ? 'CI を red にします' : '段階適用中: warning として記録、CI は通過させます'})`,

--- a/scripts/check-ss-blob-sha-uniqueness.mjs
+++ b/scripts/check-ss-blob-sha-uniqueness.mjs
@@ -51,7 +51,7 @@ const RAW_GITHUB_PATTERN =
 export function extractScreenshotRefs(body) {
 	const refs = [];
 	for (const m of body.matchAll(RAW_GITHUB_PATTERN)) {
-		const [url, owner, repo, ref, path] = m;
+		const [url, owner = '', repo = '', ref = '', path = ''] = m;
 		if (ref !== 'screenshots') continue;
 		refs.push({ owner, repo, ref, path, url });
 	}
@@ -138,7 +138,7 @@ const STUB_REASONS = new Set([
 export function parseReasonDeclaration(body, key) {
 	const m = body.match(new RegExp(`<!--\\s*${key}\\s*:([^>]*?)-->`));
 	if (!m) return { present: false, reason: '', valid: false };
-	const reason = m[1].trim();
+	const reason = (m[1] ?? '').trim();
 	const normalized = reason.toLowerCase();
 	const valid =
 		reason.length >= MIN_REASON_LENGTH &&
@@ -162,11 +162,11 @@ export function parseReasonDeclaration(body, key) {
 export function parsePairDeclarations(body) {
 	const prefixes = [];
 	for (const m of body.matchAll(/<!--\s*ss-pair-prefix\s*:\s*before=(\S+)\s+after=(\S+)\s*-->/g)) {
-		prefixes.push({ before: m[1], after: m[2] });
+		prefixes.push({ before: m[1] ?? '', after: m[2] ?? '' });
 	}
 	const explicit = [];
 	for (const m of body.matchAll(/<!--\s*ss-pair\s*:\s*before=(\S+)\s+after=(\S+)\s*-->/g)) {
-		explicit.push({ before: toScreenshotPath(m[1]), after: toScreenshotPath(m[2]) });
+		explicit.push({ before: toScreenshotPath(m[1] ?? ''), after: toScreenshotPath(m[2] ?? '') });
 	}
 	return { prefixes, explicit };
 }
@@ -181,7 +181,7 @@ function toScreenshotPath(value) {
 	const m = value.match(
 		/https:\/\/raw\.githubusercontent\.com\/[^/]+\/[^/]+\/screenshots\/([^\s)]+)/,
 	);
-	return m ? m[1] : value;
+	return m?.[1] ?? value;
 }
 
 /**
@@ -240,12 +240,13 @@ export function pairScreenshots(paths, decls = { prefixes: [], explicit: [] }) {
  * Actions runner では `GH_TOKEN` / `GITHUB_TOKEN` 経由で自動認証。
  *
  * @param {{ owner: string; repo: string; ref: string; path: string }} loc
- * @param {typeof fetch} [fetcher] — DI 用 (test では mock)
+ * @param {typeof fetch} [fetcher] - DI 用 (test では mock)
  * @returns {Promise<string>}
  */
 export async function fetchBlobSha(loc, fetcher = fetch) {
 	const { owner, repo, ref, path } = loc;
 	const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents/${encodeURI(path)}?ref=${encodeURIComponent(ref)}`;
+	/** @type {Record<string, string>} */
 	const headers = {
 		Accept: 'application/vnd.github+json',
 		'X-GitHub-Api-Version': '2022-11-28',
@@ -327,7 +328,10 @@ export const PR_2054_SENTINEL_FIXTURE = Object.freeze({
  * 本体処理。fetcher を DI 可能にして test で mock 注入する。
  *
  * @param {{ body: string; labels: string[]; fetcher?: typeof fetch }} input
- * @returns {Promise<{ status: 'pass' | 'fail' | 'skip'; reason: string; violations?: Array<{ key: string; before: string; after: string; sha: string }> }>}
+ * @returns {Promise<{ status: 'pass' | 'fail' | 'skip'; reason: string;
+ *   violations?: Array<{ key: string; before: string; after: string; sha: string }>;
+ *   acknowledgedIdenticalPairs?: Array<{ key: string; before: string; after: string; sha: string }>;
+ *   pairingHelp?: boolean }>}
  */
 export async function checkSsBlobShaUniqueness({ body, labels, fetcher = fetch }) {
 	// AC3: label exempt
@@ -435,7 +439,10 @@ async function main() {
 	try {
 		result = await checkSsBlobShaUniqueness({ body: PR_BODY, labels: PR_LABELS });
 	} catch (err) {
-		console.error('[ss-blob-sha-uniqueness] internal error:', err.message);
+		console.error(
+			'[ss-blob-sha-uniqueness] internal error:',
+			err instanceof Error ? err.message : String(err),
+		);
 		return 2;
 	}
 
@@ -484,8 +491,9 @@ async function main() {
 		return isError ? 1 : 0;
 	}
 
+	const violations = result.violations ?? [];
 	console.log(`\nSS forging detected (Blob SHA 完全一致):`);
-	for (const v of result.violations) {
+	for (const v of violations) {
 		console.log(`  - ${v.before} == ${v.after} (SHA: ${v.sha})`);
 	}
 	console.log(
@@ -504,7 +512,7 @@ async function main() {
 			`     理由が空 / TODO 等の定型 stub では受理しません (#4084 AC3 / #3956)。`,
 	);
 	console.log(
-		`\n[${prefix.replace(/[[\]]/g, '')}] mode=${MODE}, violations=${result.violations.length} ` +
+		`\n[${prefix.replace(/[[\]]/g, '')}] mode=${MODE}, violations=${violations.length} ` +
 			`(${isError ? 'CI を red にします' : '段階適用中: warning として記録、CI は通過させます'})`,
 	);
 

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -1,0 +1,182 @@
+/**
+ * scripts/lib/ci/repo-scan-test-registry.mjs (#4085)
+ *
+ * 「repo 走査 test」の区分宣言 SSOT。
+ *
+ * # なぜ宣言を要求するか
+ *
+ * repo 全体の file を実読する test は **実行時間が入力サイズに比例する**。それを既定 timeout
+ * (5s、vite.config.ts) のまま unit lane に置くと、他 worker との CPU / FS 競合次第で落ちる。
+ * 落ちても壊れてはいないので、開発者は毎回「本物か負荷か」を切り分けることになり、切り分けを
+ * 間違えれば無い回帰を追うか、本物の回帰を「また負荷だろう」と見逃す。
+ *
+ * 同 class が 4 例に達したため (#3972/#4000 → PR #4067 / #3978 → PR #4066 /
+ * `page-guide-coverage` 6240ms / `ci-unit-test-path-filter-closure` 5533ms)、instance 修正を
+ * やめて機械 gate 化した (ADR-0061 same-class-N→guard)。#4048 の `costClass` 宣言 (未登録なら
+ * throw) と同型で、**追加時に区分の判断を必ず発生させる**のが目的。
+ *
+ * # 区分
+ *
+ * | scope | 意味 | 要求 |
+ * |---|---|---|
+ * | `repo` | repo のディレクトリツリーを走査する (`src` / `scripts` / `tests` ...) | 明示 timeout (≥ `MIN_REPO_SCAN_TIMEOUT_MS`) 必須 |
+ * | `bounded` | 走査 API を使うが入力が fixture / temp dir / 単一 dir で有界 | 追加要求なし |
+ *
+ * `scope` は gate 側が静的に判定した値と**一致していなければ fail** する。`bounded` と自己申告
+ * するだけで timeout 要求を回避することはできない (宣言が検査を無効化しないようにする)。
+ *
+ * # 追加手順
+ *
+ * 1. test を追加する
+ * 2. `node scripts/check-repo-scan-test-declaration.mjs` を実行する (未宣言なら fail し、
+ *    判定した scope と貼り付け用のエントリを出力する)
+ * 3. 出力どおりに本 registry へ 1 行足す。`scope: 'repo'` なら当該 test に明示 timeout を付ける
+ */
+
+/** `scope: 'repo'` の test が unit lane に残る場合に要求する最小 timeout (ms)。 */
+export const MIN_REPO_SCAN_TIMEOUT_MS = 20_000;
+
+/**
+ * repo 走査 test の区分宣言。
+ *
+ * key は repo root からの POSIX 相対パス。
+ *
+ * @type {Record<string, { scope: 'repo' | 'bounded'; note: string }>}
+ */
+export const REPO_SCAN_TEST_REGISTRY = {
+	// --- scope: repo (repo ツリーを走査。明示 timeout 必須) ---
+	'tests/unit/ai-evaluation/axe-runner-inline.test.ts': {
+		scope: 'repo',
+		note: 'scripts/ai-evaluation 配下を走査して inline inject 経路の残存を検査する',
+	},
+	'tests/unit/arch/no-direct-db-access.test.ts': {
+		scope: 'repo',
+		note: 'src 配下を走査して直接 DB アクセスを検出する',
+	},
+	'tests/unit/architecture/action-primary-white-text-contrast.test.ts': {
+		scope: 'repo',
+		note: 'src 配下の .svelte を走査して配色コントラスト違反を検出する',
+	},
+	'tests/unit/architecture/base-token-routes-ratchet.test.ts': {
+		scope: 'repo',
+		note: 'src/routes + src/lib を走査して Base トークン直接使用を数える (ratchet、#3152)',
+	},
+	'tests/unit/architecture/ci-unit-test-path-filter-closure.test.ts': {
+		scope: 'repo',
+		note: '#4085 実測 例4 (5533ms で timeout)。.github + scripts を走査する scanner の健全性検査 (#4007)',
+	},
+	'tests/unit/architecture/cloudfront-s3-user-content-bypass-fitness.test.ts': {
+		scope: 'repo',
+		note: 'infra 配下の CDK 定義を走査して配信経路の bypass を検出する',
+	},
+	'tests/unit/architecture/db-access-boundary.test.ts': {
+		scope: 'repo',
+		note: 'src 配下の import 境界を走査する',
+	},
+	'tests/unit/architecture/dsql-txn-work-allowlist.test.ts': {
+		scope: 'repo',
+		note: 'src 配下の txn 内 work を走査する (ADR-0065)',
+	},
+	'tests/unit/architecture/dsql-uuid-guard-ssot-fitness.test.ts': {
+		scope: 'repo',
+		note: 'src 配下の uuid guard 利用を走査する',
+	},
+	'tests/unit/architecture/fetch-error-handling-ratchet.test.ts': {
+		scope: 'repo',
+		note: 'src 配下の fetch 呼び出しを走査する (ratchet)',
+	},
+	'tests/unit/architecture/page-guide-coverage.test.ts': {
+		scope: 'repo',
+		note: '#4085 実測 例3 (6240ms で timeout)。REGISTERED ガイドの anchor を src から走査する',
+	},
+	'tests/unit/architecture/route-db-boundary.test.ts': {
+		scope: 'repo',
+		note: 'src/routes 配下の server route から禁止 import を走査する (#3152 / ADR-0061)',
+	},
+	'tests/unit/architecture/user-content-delivery-headers-fitness.test.ts': {
+		scope: 'repo',
+		note: 'infra + src を走査して配信ヘッダを検査する',
+	},
+	'tests/unit/cron/schedule-consistency.test.ts': {
+		scope: 'repo',
+		note: 'src + .github/workflows を走査して cron schedule の整合を検査する',
+	},
+	'tests/unit/domain/settings-backup-classification.test.ts': {
+		scope: 'repo',
+		note: 'src 配下の settings 定義を走査して backup 分類の網羅を検査する',
+	},
+	'tests/unit/features/admin-resource-model-registry.test.ts': {
+		scope: 'repo',
+		note: 'src/routes 配下の admin 画面を走査して registry の網羅漏れを検出する (#3134 no-silent-gap)',
+	},
+	'tests/unit/scripts/check-orphan-repos-population.test.ts': {
+		scope: 'repo',
+		note: 'src 配下の repo 実装を走査して orphan を検出する',
+	},
+	'tests/unit/scripts/check-readdir-rotation-guard.test.ts': {
+		scope: 'repo',
+		note: '#4085 実測 例2 (PR #4066 で明示 60s 付与済)。src + scripts の 900+ file を実読する',
+	},
+	'tests/unit/scripts/check-repo-scan-test-declaration.test.ts': {
+		scope: 'repo',
+		note: '実走査はしないが fixture 文字列に走査 API と repo root を含むため静的判定が repo になる (保守的判定を受け入れ明示 timeout を置く)',
+	},
+
+	// --- scope: bounded (走査 API を使うが入力が有界。追加要求なし) ---
+	'tests/integration/db/legacy-schema-upgrade.test.ts': {
+		scope: 'bounded',
+		note: 'temp dir に作った DB ファイルのみを読む',
+	},
+	'tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts': {
+		scope: 'bounded',
+		note: 'DSQL repo の単一 dir のみを走査する',
+	},
+	'tests/unit/architecture/dsql-append-only-update-fitness.test.ts': {
+		scope: 'bounded',
+		note: 'DSQL repo の単一 dir のみを走査する',
+	},
+	'tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts': {
+		scope: 'bounded',
+		note: 'DSQL repo の単一 dir のみを走査する',
+	},
+	'tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts': {
+		scope: 'bounded',
+		note: 'DSQL repo の単一 dir のみを走査する',
+	},
+	'tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts': {
+		scope: 'bounded',
+		note: 'DSQL repo の単一 dir のみを走査する (ADR-0063)',
+	},
+	'tests/unit/architecture/dsql-write-path-db-import-ban.test.ts': {
+		scope: 'bounded',
+		note: 'DSQL write path の単一 dir のみを走査する',
+	},
+	'tests/unit/architecture/ledger-grant-atomicity-fitness.test.ts': {
+		scope: 'bounded',
+		note: 'ledger service の単一 dir のみを走査する',
+	},
+	'tests/unit/db/pglite-backup-3950.test.ts': {
+		scope: 'bounded',
+		note: 'temp の backup dir のみを読む',
+	},
+	'tests/unit/db/restore-idempotency-registry.test.ts': {
+		scope: 'bounded',
+		note: 'restore registry と単一 dir のみを読む',
+	},
+	'tests/unit/infra/cdk-hook-timeout-guard.test.ts': {
+		scope: 'bounded',
+		note: 'CDK hook の単一 dir のみを走査する',
+	},
+	'tests/unit/routes/export-authz-symmetry-3246.test.ts': {
+		scope: 'bounded',
+		note: 'export route の単一 dir のみを走査する (#3972 同 class 3 例目、#4005 で明示 timeout 済)',
+	},
+	'tests/unit/routes/settings-hub-coverage.test.ts': {
+		scope: 'bounded',
+		note: 'admin/settings サブツリーのみを走査する (#3954)',
+	},
+	'tests/unit/scripts/backup-db.test.ts': {
+		scope: 'bounded',
+		note: 'temp の backup dir を rotate するだけ',
+	},
+};

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -73,6 +73,7 @@ const SKIP_FLAGS = {
 	'--skip-cli-entry-guard': 'skipCliEntryGuard',
 	'--skip-sparse-checkout-closure': 'skipSparseCheckoutClosure',
 	'--skip-readdir-rotation-guard': 'skipReaddirRotationGuard',
+	'--skip-repo-scan-test-declaration': 'skipRepoScanTestDeclaration',
 	'--skip-lp-labels': 'skipLpLabels',
 	'--skip-pr-body': 'skipPrBody',
 	'--skip-doc-code-references': 'skipDocCodeReferences',
@@ -95,6 +96,7 @@ function parseArgs(argv) {
 		skipCliEntryGuard: false,
 		skipSparseCheckoutClosure: false,
 		skipReaddirRotationGuard: false,
+		skipRepoScanTestDeclaration: false,
 		skipLpLabels: false,
 		skipPrBody: false,
 		skipDocCodeReferences: false,
@@ -143,6 +145,7 @@ Options:
   --skip-cli-entry-guard Step 7c 自前の CLI 直接実行判定 / 手組み file:// URL 検査をスキップ (#3969)
   --skip-sparse-checkout-closure Step 7d workflow sparse-checkout の import 閉包検査をスキップ (#3969)
   --skip-readdir-rotation-guard Step 7e readdir の緩い一致 × 破壊的操作の検査をスキップ (#3978)
+  --skip-repo-scan-test-declaration Step 7f repo 走査 test の区分宣言検査をスキップ (#4085)
   --skip-lp-labels       Step 8 LP labels 同期検査をスキップ (labels.ts / terms.ts / age-tier.ts 変更時のみ自動実行、Phase 1 B1)
   --skip-pr-body         Step 9 PR body 検査をスキップ
   --skip-doc-code-references Step 10 デッドリンク検査をスキップ
@@ -163,6 +166,7 @@ Steps (番号は表示上の識別子。実行順は下記「実行順」を参�
   7c. check-cli-entry-guard.mjs  — 自前の CLI 直接実行判定 / 手組み file:// URL 禁止 (#3969)
   7d. check-workflow-sparse-checkout-closure.mjs — workflow sparse-checkout の import 閉包検査 (#3969)
   7e. check-readdir-rotation-guard.mjs — readdir の緩い一致で世代を数える class の検出 (#3978)
+  7f. check-repo-scan-test-declaration.mjs — repo 走査 test の区分宣言 + 明示 timeout 検査 (#4085)
   8.  generate-lp-labels --check  — site/shared-labels.js 同期検査 (labels.ts / terms.ts / age-tier.ts 変更時のみ、Phase 1 B1 / #1917)
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
   10. check-doc-code-references.mjs — ドキュメントのデッドリンク検知 (#2577)
@@ -453,61 +457,83 @@ export const STEP_COST_CLASSES = /** @type {const} */ ([
 ]);
 
 /**
- * step 名 → コストクラスの SSOT (#4048 AC2)。
+ * step 定義オブジェクトの必須フィールド SSOT (#4086)。
  *
- * **新しい step を buildSteps に足したら、必ずここにも登録する。** 登録漏れは
- * `orderSteps` が throw して即座に落ちる (末尾に黙って足されて cheap-fail-first が
- * 崩れる劣化は、動いてしまうと誰も気づけないため fail closed にする / ADR-0061 same-class→guard)。
+ * **step を 1 つ足すのに必要な登録はここに並ぶ 7 フィールドだけ**であり、他の registry への
+ * 二重登録は要らない。旧実装は `skipStateOf()` 経由の skip 分類 (#4018 `[K10]`) と
+ * `STEP_COST_CLASS_BY_NAME` (#4048 `[O1]`) の 2 registry への同時登録を要求しており、片方を
+ * 直しても残りは次の CI が回るまで分からず、PR #4066 が 2 度連続 red になった (#4086 実測)。
  *
- * @type {Record<string, typeof STEP_COST_CLASSES[number]>}
+ * `costClass` を step 定義に取り込んで registry を 1 本化し、欠落・不正値は
+ * `assertStepShapes` (= `orderSteps` の入口) が throw する。強度は旧 `[O1]` / `[O9]` と同じか
+ * それ以上 (runner / fixHint / skipKind の欠落も同じ 1 箇所で落ちる)。
  */
-export const STEP_COST_CLASS_BY_NAME = {
-	// meta — PR body のテキストだけを見る。最も早く落ちうる
-	'pr-body': 'meta',
-	// static — 静的テキスト / 単一ファイル検査
-	biome: 'static',
-	cspell: 'static',
-	'hardcoded-strings': 'static',
-	'lp-fallback': 'static',
-	'plan-literals': 'static',
-	'license-key-leak': 'static',
-	'cli-entry-guard': 'static',
-	'sparse-checkout-closure': 'static',
-	'readdir-rotation-guard': 'static',
-	'lp-labels': 'static',
-	'doc-code-references': 'static',
-	'terminology-coherence': 'static',
-	// typecheck / test
-	'svelte-check': 'typecheck',
-	vitest: 'test',
-	// browser — LP を実ブラウザで描画して寸法を測る
-	'lp-dimensions': 'browser',
-	// ui — SS 撮影 / embed 検証
-	'ss-embed-gate': 'ui',
-	capture: 'ui',
-};
+export const REQUIRED_STEP_FIELDS = /** @type {const} */ ([
+	'name',
+	'label',
+	'costClass',
+	'skip',
+	'skipKind',
+	'runner',
+	'fixHint',
+]);
+
+/**
+ * step 定義の shape を検証し、欠落 / 不正値があれば throw する (#4086 案 A + 案 B)。
+ *
+ * 登録漏れを silent に通さない (ADR-0061 same-class→guard)。`skipKind` は `null` を取り得るので
+ * 「値が falsy か」ではなく **キーが存在するか** で判定する。
+ *
+ * @param {{ name?: string }[]} steps
+ * @returns {void}
+ */
+export function assertStepShapes(steps) {
+	const problems = [];
+	for (const [index, step] of steps.entries()) {
+		const label = step?.name ?? `(name 未設定 / index ${index})`;
+		const missing = REQUIRED_STEP_FIELDS.filter((f) => !(step && f in step));
+		// 型も見る: runner が関数でない / label・fixHint が文字列でない step は実行時に落ちる
+		const typeErrors = [];
+		if (step && 'runner' in step && typeof step.runner !== 'function')
+			typeErrors.push('runner (関数であること)');
+		if (step && 'skip' in step && typeof step.skip !== 'boolean')
+			typeErrors.push('skip (boolean であること)');
+		if (missing.length > 0 || typeErrors.length > 0) {
+			problems.push(`  - ${label}: 必須フィールド不足 [${[...missing, ...typeErrors].join(', ')}]`);
+			continue;
+		}
+		if (!STEP_COST_CLASSES.includes(step.costClass)) {
+			problems.push(
+				`  - ${label}: costClass の値が不正 (${JSON.stringify(step.costClass)}) — ` +
+					`許容値: ${STEP_COST_CLASSES.join(' / ')}`,
+			);
+		}
+	}
+	if (problems.length > 0) {
+		throw new Error(
+			`[pre-ready] step 定義が不完全です (#4086):\n${problems.join('\n')}\n` +
+				`  対応: scripts/pre-ready.mjs の buildSteps() の当該 step に ` +
+				`${REQUIRED_STEP_FIELDS.join(' / ')} を揃える。\n` +
+				`  skip / skipKind は \`...skipStateOf({...})\` の spread で入る (#4018)。` +
+				`costClass は step 定義に直接書く (第 2 registry は #4086 で廃止)。`,
+		);
+	}
+}
 
 /**
  * step 配列を cheap-fail-first に並べ替える (#4048 AC1)。
  *
  * - 検査の集合・合否条件は変えない。**順序だけ**を変える (AC2)
  * - 同一クラス内は定義順 (= Step 番号順) を保つ安定ソート
- * - `STEP_COST_CLASS_BY_NAME` に未登録の step があれば throw (登録漏れを silent に通さない)
+ * - shape 不備 (costClass 欠落 / 不正値 / runner 欠落 等) があれば throw (#4086)
  *
  * @template {{ name: string }} T
  * @param {T[]} steps
  * @returns {T[]}
  */
 export function orderSteps(steps) {
-	const unknown = steps.filter((s) => !(s.name in STEP_COST_CLASS_BY_NAME)).map((s) => s.name);
-	if (unknown.length > 0) {
-		throw new Error(
-			`[pre-ready] step のコストクラス未登録: ${unknown.join(', ')} — ` +
-				'scripts/pre-ready.mjs の STEP_COST_CLASS_BY_NAME に追加してください (#4048)',
-		);
-	}
-	const rank = (/** @type {{ name: string }} */ s) =>
-		STEP_COST_CLASSES.indexOf(STEP_COST_CLASS_BY_NAME[s.name]);
+	assertStepShapes(steps);
+	const rank = (/** @type {{ costClass: string }} */ s) => STEP_COST_CLASSES.indexOf(s.costClass);
 	// index を tiebreaker にして安定ソートを明示 (Array#sort の安定性に依存しない)
 	return steps
 		.map((step, index) => ({ step, index }))
@@ -720,10 +746,14 @@ export function buildSteps(args, changedFiles) {
 	// #3978: readdir の緩い一致で世代を数え、その結果を破壊的操作の対象にする class の検出
 	const readdirRotationScript = resolve(repoRoot, 'scripts/check-readdir-rotation-guard.mjs');
 	const readdirRotationScriptExists = existsSync(readdirRotationScript);
+	// #4085: repo 走査 test の区分宣言 gate (未宣言 / 明示 timeout 欠落を検出)
+	const repoScanTestScript = resolve(repoRoot, 'scripts/check-repo-scan-test-declaration.mjs');
+	const repoScanTestScriptExists = existsSync(repoScanTestScript);
 
 	return [
 		{
 			name: 'biome',
+			costClass: 'static',
 			label: 'Step 1/12: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)',
 			...skipStateOf({ byFlag: args.skipBiome }),
 			// #2503 (Issue #2475 14 件目): pre-ready Step 1 は CI .github/workflows/ci.yml
@@ -736,6 +766,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'cspell',
+			costClass: 'static',
 			label: 'Step 1b/12: cspell (CI lint-and-test と同一コマンド — #3649)',
 			...skipStateOf({ byFlag: args.skipCspell }),
 			// #3649: CI lint-and-test の `npm run cspell` (#1432 warning=error) と同一。
@@ -747,6 +778,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'svelte-check',
+			costClass: 'typecheck',
 			label: 'Step 2/12: svelte-check (TS strict)',
 			...skipStateOf({ byFlag: args.skipSvelteCheck }),
 			runner: () => run('svelte-check', ['npx', 'svelte-check', '--tsconfig', './tsconfig.json']),
@@ -754,6 +786,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'vitest',
+			costClass: 'test',
 			label: args.skipVitest
 				? 'Step 3/12: vitest run (unit test) — ローカル未実行 / CI unit-test へ委譲 (#4007)'
 				: 'Step 3/12: vitest run (unit test)',
@@ -776,6 +809,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'hardcoded-strings',
+			costClass: 'static',
 			label: 'Step 4/12: check-hardcoded-strings.mjs (#1452 Phase A)',
 			...skipStateOf({ byFlag: args.skipHardcoded }),
 			runner: () => run('check-hardcoded-strings', ['node', 'scripts/check-hardcoded-strings.mjs']),
@@ -785,6 +819,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'lp-dimensions',
+			costClass: 'browser',
 			label: `Step 5/12: measure-lp-dimensions.mjs (LP 変更検知: ${lpChanged ? 'YES' : 'NO — skip'})`,
 			...skipStateOf({ byFlag: args.skipLpDimensions, notApplicable: !lpChanged }),
 			runner: () => run('measure-lp-dimensions', ['node', 'scripts/measure-lp-dimensions.mjs']),
@@ -796,6 +831,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'lp-fallback',
+			costClass: 'static',
 			label: `Step 6/12: sync-lp-fallback.mjs --check (LP / labels.ts 変更検知: ${lpFallbackTrigger ? 'YES' : 'NO — skip'})`,
 			...skipStateOf({ byFlag: args.skipLpFallback, notApplicable: !lpFallbackTrigger }),
 			runner: () => run('sync-lp-fallback', ['node', 'scripts/sync-lp-fallback.mjs', '--check']),
@@ -809,6 +845,7 @@ export function buildSteps(args, changedFiles) {
 		// scripts/check-no-plan-literals.mjs 自体は #972 で main 取込済 (本 step は無条件で実行する)
 		{
 			name: 'plan-literals',
+			costClass: 'static',
 			label: planLiteralsScriptExists
 				? 'Step 7/12: check-no-plan-literals.mjs (#972 / Phase 5 F1)'
 				: 'Step 7/12: check-no-plan-literals.mjs (script 未配備 — skip)',
@@ -824,6 +861,7 @@ export function buildSteps(args, changedFiles) {
 		// license key 全廃の再導入防止。allowlist 外のコード行に license key 参照を検出したら fail。
 		{
 			name: 'license-key-leak',
+			costClass: 'static',
 			label: licenseKeyLeakScriptExists
 				? 'Step 7b/12: check-license-key-leak.mjs (#2836 / Phase 7 PR-L4)'
 				: 'Step 7b/12: check-license-key-leak.mjs (script 未配備 — skip)',
@@ -844,6 +882,7 @@ export function buildSteps(args, changedFiles) {
 		// scripts/lib/is-main.mjs で、本 step は次の方言が持ち込まれるのを止める。
 		{
 			name: 'cli-entry-guard',
+			costClass: 'static',
 			label: cliEntryGuardScriptExists
 				? 'Step 7c/12: check-cli-entry-guard.mjs (#3969)'
 				: 'Step 7c/12: check-cli-entry-guard.mjs (script 未配備 — skip)',
@@ -862,6 +901,7 @@ export function buildSteps(args, changedFiles) {
 		// job が ERR_MODULE_NOT_FOUND で落ちる (#3969 対応時に必須 gate 6 job が同時 fail した)。
 		{
 			name: 'sparse-checkout-closure',
+			costClass: 'static',
 			label: sparseClosureScriptExists
 				? 'Step 7d/12: check-workflow-sparse-checkout-closure.mjs (#3969)'
 				: 'Step 7d/12: check-workflow-sparse-checkout-closure.mjs (script 未配備 — skip)',
@@ -885,6 +925,7 @@ export function buildSteps(args, changedFiles) {
 		// (docs/sessions/dev-session.md §「QA 指摘の再発防止台帳」#2 / ADR-0061)。
 		{
 			name: 'readdir-rotation-guard',
+			costClass: 'static',
 			label: readdirRotationScriptExists
 				? 'Step 7e/12: check-readdir-rotation-guard.mjs (#3978)'
 				: 'Step 7e/12: check-readdir-rotation-guard.mjs (script 未配備 — skip)',
@@ -900,11 +941,40 @@ export function buildSteps(args, changedFiles) {
 				'  - 生成側にも同じパターンの assert を置く (命名変更で silent に壊れないようにする)\n' +
 				'  - 別 class だと判断した場合のみ `rotation-gate-ok: <理由>` を当該行/直前行に置く',
 		},
+		// Step 7f: check-repo-scan-test-declaration (#4085)
+		// repo 全体を実読する test を既定 timeout (5s) のまま unit lane に置くと、並列実行の負荷で
+		// 落ちる。壊れてはいないので毎回「本物か負荷か」の切り分けが発生し、間違えれば本物の回帰を
+		// 「また負荷だろう」と見逃す。同 class 4 例目で機械 gate 化した (ADR-0061 same-class-N→guard)。
+		//
+		// 本 step は #4086 で step 定義を 1 箇所化した後に追加した最初の step であり、
+		// `costClass` を step 定義に直接書くだけで登録が完結する (第 2 registry への同時登録は不要)。
+		{
+			name: 'repo-scan-test-declaration',
+			costClass: 'static',
+			label: repoScanTestScriptExists
+				? 'Step 7f/12: check-repo-scan-test-declaration.mjs (#4085)'
+				: 'Step 7f/12: check-repo-scan-test-declaration.mjs (script 未配備 — skip)',
+			...skipStateOf({
+				byFlag: args.skipRepoScanTestDeclaration,
+				scriptMissing: !repoScanTestScriptExists,
+			}),
+			runner: () =>
+				run('check-repo-scan-test-declaration', [
+					'node',
+					'scripts/check-repo-scan-test-declaration.mjs',
+				]),
+			fixHint:
+				'  repo 走査 test の区分が未宣言 / 明示 timeout 欠落です (#4085)。\n' +
+				'  - 判定と貼り付け用エントリ: `node scripts/check-repo-scan-test-declaration.mjs --list`\n' +
+				'  - 宣言先: scripts/lib/ci/repo-scan-test-registry.mjs\n' +
+				'  - scope=repo の test には `vi.setConfig({ testTimeout: 60_000 })` 等の明示 timeout を置く',
+		},
 		// Step 8: generate-lp-labels --check (Phase 1 B1 / #1917)
 		// Issue #1920 graceful degradation: 検査 script が未配備なら skip + warning。
 		// labels.ts / terms.ts / age-tier.ts いずれかの変更検知時のみ実行 (LP shared-labels.js への波及)
 		{
 			name: 'lp-labels',
+			costClass: 'static',
 			label: !lpLabelsScriptExists
 				? 'Step 8/12: generate-lp-labels --check (script 未配備 — skip)'
 				: `Step 8/12: generate-lp-labels --check (labels.ts / terms.ts / age-tier.ts 変更検知: ${lpLabelsTrigger ? 'YES' : 'NO — skip'})`,
@@ -922,6 +992,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'pr-body',
+			costClass: 'meta',
 			// #2632: Step 9 ラベルに「Ready checklist + AC 4 列 + forbidden-terms」を明示。
 			// 本日 (2026-05-29) 7 連続再発 (#2625 / #2626 / #2629 / #2630) で「Step 9 が何を見ているか」が
 			// 実装者に伝わっていない問題が露出した。check-pr-body.mjs は既に Ready checklist `[ ]` / AC 4 列 /
@@ -951,6 +1022,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'doc-code-references',
+			costClass: 'static',
 			label: 'Step 10/12: check-doc-code-references.mjs (#2577)',
 			...skipStateOf({ byFlag: args.skipDocCodeReferences }),
 			runner: () =>
@@ -962,6 +1034,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'terminology-coherence',
+			costClass: 'static',
 			label: 'Step 11/12: check-terminology-coherence.ts (#2555)',
 			...skipStateOf({ byFlag: args.skipTerminologyCoherence }),
 			runner: () =>
@@ -982,6 +1055,7 @@ export function buildSteps(args, changedFiles) {
 		// UI 変更がない / --pr 未指定 / exempt label 時は gate 内部で skip。
 		{
 			name: 'ss-embed-gate',
+			costClass: 'ui',
 			label:
 				uiChanged && args.pr
 					? 'Step 11b/12: SS embed gate (check-pr-screenshot.mjs、UI 変更 PR の SS embed 未完了を hard-fail、#2918)'
@@ -1026,6 +1100,7 @@ export function buildSteps(args, changedFiles) {
 		},
 		{
 			name: 'capture',
+			costClass: 'ui',
 			label: `Step 12/12: capture.mjs (UI 変更検知: ${uiChanged ? 'YES' : 'NO — skip'})`,
 			...skipStateOf({ byFlag: args.skipCapture, prMissing: !args.pr, notApplicable: !uiChanged }),
 			runner: async () => {

--- a/src/routes/CLAUDE.md
+++ b/src/routes/CLAUDE.md
@@ -91,6 +91,22 @@ node scripts/capture.mjs --pr <N>            # 修正後 SS を撮り直す
 # 手動運用時は capture 結果を screenshots branch にコミット & push
 ```
 
+##### SS の命名規約と、gate が「検査できなかった」ときの扱い（#4084）
+
+`ss-blob-sha-uniqueness` は **Before / After のペアが取れて初めて偽装を検知できる**。旧実装はペアが 0 件だと `skip` で通していたため、命名を変えるだけで検査が黙って消えた（実測: PR #4080 は SS 20 枚 embed 済で `[ss-blob-sha-uniqueness] SKIP` = 1 ペアも検査されず）。現在は **SS が embed されているのにペア 0 件なら fail** する。
+
+| 状況 | 対応 |
+|---|---|
+| 通常 | file 名を `before-<key>.png` / `after-<key>.png` にする（既定のペアリング） |
+| 別の命名で撮りたい | PR body に prefix 宣言を置く: `<!-- ss-pair-prefix: before=develop- after=pr<PR番号>- -->` |
+| 個別に対応を書きたい | `<!-- ss-pair: before=<raw URL or path> after=<raw URL or path> -->` |
+| ペアが原理的に存在しない（新規画面で修正前が無い 等） | `<!-- ss-pair-none: <12 文字以上の理由> -->` |
+| **Before / After が同一なのが正しい** | `<!-- ss-identical-ok: <12 文字以上の理由> -->` |
+
+- **理由は必須**。空欄 / `TODO` / `n/a` 等の定型 stub は受理されない（理由の非強制を作らない、#3956 教訓）
+- `ss-identical-ok` は「差分が現れる条件の外で撮影したため描画が一致するのが正しい」ケース用（例: JST 00:00〜09:00 だけ日付がずれる修正を JST 日中に撮影した #4080）。**撮り直し漏れの言い訳には使わない**。宣言しても同一だったペアは出力に列挙される
+- `refactor:internal-no-doc-impact` label（視覚差分ゼロの内部 refactor 用）とは意味が違う。**顧客に見える挙動を変える PR には label を付けず、`ss-identical-ok` を使う**
+
 ## 局所テストコマンド (#2184)
 
 routes 配下のみ修正時は全体テストを待たず以下で高速検証:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -48,6 +48,56 @@ CI ログでも同 warning が出るため、PR の CI fail 調査時にまず�
 判断: 実サーバー必要 → E2E / 不要 + モックで完結 → Integration / それ以外 → Unit。
 `tests/e2e/integration/upgrade-checkout.spec.ts` は `page.route()` で Stripe モック (Integration 相当) だが cognito-dev 認証必要のため `playwright.cognito-dev.config.ts` 管理。
 
+## repo 走査 test (実行コストが入力サイズに比例する test) — #4085
+
+### 定義
+
+`readdirSync` / `globSync` 等で **repo のディレクトリツリー (`src` / `scripts` / `tests` / `docs` / `site` / `infra` / `.github` / `.claude`) を走査する test**。実行時間が repo の file 数に比例し、unit lane の並列実行で他 worker と CPU / FS を奪い合うと既定 timeout (5s、`vite.config.ts`) を超える。
+
+**落ちても壊れていない**ため、開発者は毎回「本物の回帰か負荷か」を切り分けることになる。切り分けを間違えれば無い回帰を追うか、本物の回帰を「また負荷だろう」と見逃す。同 class が 4 例に達したため機械 gate 化した (ADR-0061 same-class-N→guard)。
+
+### ルール (区分宣言は必須)
+
+| scope | 意味 | 要求 |
+|---|---|---|
+| `repo` | repo ツリーを走査する | **明示 timeout 必須** (`vi.setConfig({ testTimeout: 60_000 })` / `it(..., 60_000)` / `describe(..., { timeout })`)。`MIN_REPO_SCAN_TIMEOUT_MS` = 20s 以上 |
+| `bounded` | 走査 API を使うが入力が fixture / temp dir / 単一 dir で有界 | 追加要求なし |
+
+- **宣言 SSOT**: `scripts/lib/ci/repo-scan-test-registry.mjs`
+- **gate**: `node scripts/check-repo-scan-test-declaration.mjs` (pre-ready Step 7f / CI `lint-and-test`)
+- 未宣言 / `scope` 不一致 / `scope: 'repo'` の timeout 欠落 / stale エントリはすべて **fail**
+- `scope` は gate が静的判定した値と一致していないと fail する。**`bounded` と自己申告するだけで timeout 要求を回避することはできない**
+- 静的判定は保守的なので、実走査しない file が `repo` と判定されることがある (fixture 文字列に走査 API と repo root を含む場合)。判定を緩めるのではなく明示 timeout 1 行を置いて合わせる
+
+追加手順:
+
+```bash
+# 1. test を書く
+# 2. 判定と貼り付け用エントリを出す
+node scripts/check-repo-scan-test-declaration.mjs --list
+node scripts/check-repo-scan-test-declaration.mjs        # 未宣言なら fail + 追加すべき行を表示
+# 3. registry に 1 行足す。scope='repo' なら明示 timeout も置く
+```
+
+### 「全体実行だと落ち単独だと通る」の一次切り分け手順
+
+repo 走査 test が落ちたら、**まず負荷起因かどうかを分離する**。同一 commit で以下 2 つの結果が食い違えば負荷起因であり、走査対象も assertion も壊れていない。
+
+```bash
+# (1) 落ちた test file だけを単独で実行する
+npx vitest run tests/unit/architecture/ci-unit-test-path-filter-closure.test.ts \
+                tests/unit/architecture/page-guide-coverage.test.ts
+#   → 単独で PASS (実測 3.28s) なら他 worker との CPU / FS 競合が原因 (#4085 実測)
+
+# (2) 同時に走っている重いプロセスがないかを確認する (Windows)
+Get-CimInstance Win32_Process -Filter "Name='node.exe'" | Select-Object ProcessId, CommandLine
+
+# (3) 単独でも落ちるなら本物の回帰。差分を疑う
+git log --oneline -5 -- <走査対象の path>
+```
+
+負荷起因と判明した場合は timeout を都度伸ばすのではなく、**registry の区分が正しいか / 明示 timeout が付いているか**を確認する (付いていなければ gate が落ちているはず)。それでも落ちるなら走査範囲の縮小か専用 CI step への移設を検討する (#4067 が `check-license-key-leak` に対して採った方式)。
+
 ## demo Lambda E2E (`tests/e2e/demo-lambda/`、#2205)
 
 ADR-0048 Multi-Lambda Demo Deployment で導入された demo Lambda (`demo.ganbari-quest.com`、

--- a/tests/unit/ai-evaluation/axe-runner-inline.test.ts
+++ b/tests/unit/ai-evaluation/axe-runner-inline.test.ts
@@ -26,7 +26,12 @@
 import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 /**
  * .mjs file dynamic import で TypeScript 型推論が effectively any になるため、

--- a/tests/unit/arch/no-direct-db-access.test.ts
+++ b/tests/unit/arch/no-direct-db-access.test.ts
@@ -3,7 +3,12 @@
 
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const SERVICES_DIR = join(process.cwd(), 'src', 'lib', 'server', 'services');
 

--- a/tests/unit/architecture/action-primary-white-text-contrast.test.ts
+++ b/tests/unit/architecture/action-primary-white-text-contrast.test.ts
@@ -20,7 +20,12 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SCAN_DIRS = [resolve(REPO_ROOT, 'src/routes'), resolve(REPO_ROOT, 'src/lib')];

--- a/tests/unit/architecture/base-token-routes-ratchet.test.ts
+++ b/tests/unit/architecture/base-token-routes-ratchet.test.ts
@@ -15,7 +15,12 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SCAN_DIRS = [resolve(REPO_ROOT, 'src/routes'), resolve(REPO_ROOT, 'src/lib/features')];

--- a/tests/unit/architecture/ci-unit-test-path-filter-closure.test.ts
+++ b/tests/unit/architecture/ci-unit-test-path-filter-closure.test.ts
@@ -39,7 +39,12 @@ import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../../..');

--- a/tests/unit/architecture/cloudfront-s3-user-content-bypass-fitness.test.ts
+++ b/tests/unit/architecture/cloudfront-s3-user-content-bypass-fitness.test.ts
@@ -36,7 +36,12 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const INFRA_LIB_DIR = resolve(REPO_ROOT, 'infra/lib');

--- a/tests/unit/architecture/db-access-boundary.test.ts
+++ b/tests/unit/architecture/db-access-boundary.test.ts
@@ -19,7 +19,12 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SRC_DIR = resolve(REPO_ROOT, 'src');

--- a/tests/unit/architecture/dsql-txn-work-allowlist.test.ts
+++ b/tests/unit/architecture/dsql-txn-work-allowlist.test.ts
@@ -28,7 +28,12 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SERVER_DIR = resolve(REPO_ROOT, 'src/lib/server');

--- a/tests/unit/architecture/dsql-uuid-guard-ssot-fitness.test.ts
+++ b/tests/unit/architecture/dsql-uuid-guard-ssot-fitness.test.ts
@@ -25,7 +25,12 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SRC_DIR = resolve(REPO_ROOT, 'src');

--- a/tests/unit/architecture/fetch-error-handling-ratchet.test.ts
+++ b/tests/unit/architecture/fetch-error-handling-ratchet.test.ts
@@ -21,7 +21,12 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SCAN_DIRS = [resolve(REPO_ROOT, 'src/routes'), resolve(REPO_ROOT, 'src/lib/features')];

--- a/tests/unit/architecture/page-guide-coverage.test.ts
+++ b/tests/unit/architecture/page-guide-coverage.test.ts
@@ -12,7 +12,13 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
+
 import {
 	filterGuideStepsByTier,
 	filterGuideStepsToOverview,

--- a/tests/unit/architecture/route-db-boundary.test.ts
+++ b/tests/unit/architecture/route-db-boundary.test.ts
@@ -18,7 +18,12 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const ROUTES_DIR = resolve(REPO_ROOT, 'src/routes');

--- a/tests/unit/architecture/user-content-delivery-headers-fitness.test.ts
+++ b/tests/unit/architecture/user-content-delivery-headers-fitness.test.ts
@@ -30,6 +30,12 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
+
 import { createMockEvent } from '../../helpers/mock-event';
 
 // storage / child-service を mock (behavioral probe は配信ヘッダの検証が目的で、実 storage / DB は不要)。

--- a/tests/unit/cron/schedule-consistency.test.ts
+++ b/tests/unit/cron/schedule-consistency.test.ts
@@ -29,7 +29,13 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
+
 import { scheduleRegistry } from '../../../src/lib/server/cron/schedule-registry';
 
 // Sub A-3 で検証対象となる既存 endpoint

--- a/tests/unit/domain/settings-backup-classification.test.ts
+++ b/tests/unit/domain/settings-backup-classification.test.ts
@@ -7,7 +7,13 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
+
 import {
 	EXPORTABLE_SETTING_KEYS,
 	isValidSettingValue,

--- a/tests/unit/features/admin-resource-model-registry.test.ts
+++ b/tests/unit/features/admin-resource-model-registry.test.ts
@@ -8,7 +8,13 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
+
 import {
 	ADMIN_RESOURCE_MODEL_REGISTRY,
 	ADMIN_RESOURCE_PAGE_ROUTE_TO_KEY,

--- a/tests/unit/scripts/check-design-doc-sync.test.ts
+++ b/tests/unit/scripts/check-design-doc-sync.test.ts
@@ -41,3 +41,34 @@ describe('#3152 check-design-doc-sync exempt 判定', () => {
 		expect(result.status).not.toBe('fail');
 	});
 });
+
+// #4085: #3152 と同 class の 2 例目。`.claude/` 配下の markdown (Skill / agent 定義) が
+// FILE_EXEMPT_MATCHERS に無かったため、「src/routes/CLAUDE.md + .claude/skills/*/SKILL.md」だけの
+// 文書 PR が誤って fail していた (PR #4105 実測)。`.claude/` 全体ではなく **markdown のみ**を
+// exempt にして、hooks / settings.json (実行される設定・コード) の gate は維持する。
+describe('#4085 .claude 配下 markdown の exempt 判定', () => {
+	it('.claude 配下の markdown は exempt (Skill / agent 定義はプロセス文書)', () => {
+		expect(isAllFilesExempt(['.claude/skills/dev-open-pr/SKILL.md'])).toBe(true);
+		expect(isAllFilesExempt(['.claude/agents/dev-session.md'])).toBe(true);
+	});
+
+	it('src/routes/CLAUDE.md + .claude/skills/*.md のみの文書 PR は skip する (誤 fail 回帰)', () => {
+		const files = [
+			'src/routes/CLAUDE.md',
+			'.claude/skills/dev-open-pr/SKILL.md',
+			'tests/CLAUDE.md',
+			'scripts/check-pr-body.mjs',
+		];
+		expect(hasRouteChanges(files)).toBe(true);
+		expect(isAllFilesExempt(files)).toBe(true);
+		expect(checkDesignDocSync({ files, labels: [] }).status).toBe('skip');
+	});
+
+	it('.claude 配下でも markdown 以外 (hooks / settings) は exempt しない (gate を弱めない)', () => {
+		expect(isAllFilesExempt(['.claude/hooks/gate-approve.mjs'])).toBe(false);
+		expect(isAllFilesExempt(['.claude/settings.json'])).toBe(false);
+		// route 変更と併せて出てきたら従来どおり fail する
+		const files = ['src/routes/(parent)/admin/foo/+page.svelte', '.claude/hooks/gate-approve.mjs'];
+		expect(checkDesignDocSync({ files, labels: [] }).status).toBe('fail');
+	});
+});

--- a/tests/unit/scripts/check-orphan-repos-population.test.ts
+++ b/tests/unit/scripts/check-orphan-repos-population.test.ts
@@ -24,7 +24,12 @@ import { execFileSync } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。既定 5s のままだと unit lane の
+// 並列実行の負荷で落ち、「本物の回帰か負荷か」の切り分けが毎回発生するため file 単位で明示する。
+// 区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
 
 const repoRoot = resolve(fileURLToPath(import.meta.url), '../../../..');
 const scriptUrl = pathToFileURL(resolve(repoRoot, 'scripts/check-orphan-repos.mjs')).href;

--- a/tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts
+++ b/tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts
@@ -1,0 +1,87 @@
+/**
+ * tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts (#4074)
+ *
+ * 検証対象: AC 検証マップの根拠欄に書かれた `--pr <番号>` が **その PR 自身**を指しているか。
+ *
+ * 旧実装では根拠欄が自由記述で、`--pr <番号>` に別 PR / 実在しない PR 番号が書かれていても
+ * どの gate も検出しなかった。PR #4063 の AC 検証マップに `npm run pre-ready -- --pr 4059`
+ * (= 404、存在しない PR) が書かれたまま `check-pr-body.mjs --pr 4063` が「OK — 違反なし」を
+ * 返した (#4074 実測)。宛先違いの証跡で Ready 化を通過できる状態だった。
+ *
+ * 本 test は実測値 `--pr 4059` / 自 PR `4063` を実名 fixture として固定する (AC2)。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	checkEvidencePrReferences,
+	extractEvidencePrNumbers,
+} from '../../../scripts/check-pr-body.mjs';
+
+/** #4063 の AC 検証マップ実物 (根拠が別 PR = 存在しない #4059 を指していた行を含む)。 */
+const PR_4063_AC_MAP_WITH_WRONG_PR = `## AC 検証マップ (ADR-0004)
+
+| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
+|---|---|---|---|
+| AC1 | CRLF shebang import が落ちない | \`npx vitest run tests/unit/scripts/crlf-shebang-import.test.ts\` | PASS |
+| 共通-AC | \`npm run pre-ready -- --pr <num>\` 全 Step PASS | \`npm run pre-ready -- --pr 4059\` | PASS — §証跡 4 |
+
+## 次のセクション
+`;
+
+/** 同じ body の根拠を自 PR 番号に是正したもの (正当な pass 経路)。 */
+const PR_4063_AC_MAP_CORRECT = PR_4063_AC_MAP_WITH_WRONG_PR.replace('--pr 4059', '--pr 4063');
+
+/** 根拠欄に PR 番号を書かない従来形式 (AC3 後方互換)。 */
+const AC_MAP_WITHOUT_PR_NUMBER = `## AC 検証マップ (ADR-0004)
+
+| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
+|---|---|---|---|
+| AC1 | gate が落ちる | \`npx vitest run tests/unit/scripts/foo.test.ts\` | PASS (12 tests) |
+| 共通-AC | pre-ready 全 Step PASS | \`npm run pre-ready -- --pr <num>\` | PASS |
+
+## 次のセクション
+`;
+
+describe('#4074 AC 検証マップの根拠が指す PR 番号の参照整合', () => {
+	it('[E1] 別 PR / 実在しない PR 番号を指す根拠を検出する (実測: --pr 4059 @ PR #4063)', () => {
+		const v = checkEvidencePrReferences(PR_4063_AC_MAP_WITH_WRONG_PR, '4063');
+		expect(v).not.toBeNull();
+		expect(v?.id).toBe('evidence-pr-mismatch');
+		expect(v?.message).toContain('4059');
+		expect(v?.message).toContain('4063');
+	});
+
+	it('[E2] 根拠が自 PR 番号なら通す (是正後の正当な pass 経路)', () => {
+		expect(checkEvidencePrReferences(PR_4063_AC_MAP_CORRECT, '4063')).toBeNull();
+	});
+
+	it('[E3] 根拠欄に PR 番号を書かない従来形式は通す (AC3 後方互換)', () => {
+		expect(checkEvidencePrReferences(AC_MAP_WITHOUT_PR_NUMBER, '4063')).toBeNull();
+		// プレースホルダ `<num>` を PR 番号と誤認しない
+		expect(extractEvidencePrNumbers(AC_MAP_WITHOUT_PR_NUMBER)).toEqual([]);
+	});
+
+	it('[E4] AC マップ外 (他 PR への言及) は対象外 — 誤検出を作らない', () => {
+		const body = `## 背景
+
+PR #4066 では \`npm run pre-ready -- --pr 4066\` が 2 度連続 red になった。
+
+${AC_MAP_WITHOUT_PR_NUMBER}`;
+		expect(checkEvidencePrReferences(body, '4090')).toBeNull();
+	});
+
+	it('[E5] 自 PR 番号が不明 (--body-file dry-run) なら判定しない', () => {
+		expect(checkEvidencePrReferences(PR_4063_AC_MAP_WITH_WRONG_PR, null)).toBeNull();
+	});
+
+	it('[E6] 複数の不一致をすべて列挙する (1 件目で打ち切らない)', () => {
+		const body = PR_4063_AC_MAP_WITH_WRONG_PR.replace('--pr <num>', '--pr 1234');
+		const v = checkEvidencePrReferences(body, '4063');
+		expect(v?.message).toContain('4059');
+		expect(v?.message).toContain('1234');
+	});
+
+	it('[E7] AC マップが無い body では判定しない (ac-map-missing が別途出る)', () => {
+		expect(checkEvidencePrReferences('## 変更概要\n\nなし\n', '4063')).toBeNull();
+	});
+});

--- a/tests/unit/scripts/check-repo-scan-test-declaration.test.ts
+++ b/tests/unit/scripts/check-repo-scan-test-declaration.test.ts
@@ -56,7 +56,7 @@ function runGate(
 ) {
 	return checkRepoScanTestDeclarations({
 		files: Object.keys(files),
-		readFile: (p) => files[p],
+		readFile: (p) => files[p] ?? '',
 		registry,
 	});
 }
@@ -69,9 +69,9 @@ describe('#4085 repo 走査 test の区分宣言 gate', () => {
 		);
 		const undeclared = violations.filter((v) => v.id === 'undeclared');
 		expect(undeclared).toHaveLength(1);
-		expect(undeclared[0].path).toBe('tests/unit/x/new-scan.test.ts');
+		expect(undeclared[0]?.path).toBe('tests/unit/x/new-scan.test.ts');
 		// 貼り付け用のエントリを出して「どう直すか」を示す
-		expect(undeclared[0].message).toContain("scope: 'repo'");
+		expect(undeclared[0]?.message).toContain("scope: 'repo'");
 	});
 
 	it('[R2] scope=repo で明示 timeout が無ければ fail (例3 / 例4 の再発を止める)', () => {
@@ -82,7 +82,7 @@ describe('#4085 repo 走査 test の区分宣言 gate', () => {
 			},
 		);
 		expect(violations.map((v) => v.id)).toContain('missing-timeout');
-		expect(violations[0].message).toContain(String(MIN_REPO_SCAN_TIMEOUT_MS));
+		expect(violations[0]?.message).toContain(String(MIN_REPO_SCAN_TIMEOUT_MS));
 	});
 
 	it('[R3] scope=repo + 明示 timeout なら pass', () => {

--- a/tests/unit/scripts/check-repo-scan-test-declaration.test.ts
+++ b/tests/unit/scripts/check-repo-scan-test-declaration.test.ts
@@ -1,0 +1,166 @@
+/**
+ * tests/unit/scripts/check-repo-scan-test-declaration.test.ts (#4085)
+ *
+ * 検証対象: repo 走査 test の「区分宣言」gate。
+ *
+ * repo 全体の file を実読する test は実行時間が入力サイズに比例するため、既定 timeout (5s) の
+ * まま unit lane に置くと並列実行の負荷で落ちる。同 class が 4 例に達した (#3972/#4000 →
+ * PR #4067 / #3978 → PR #4066 / `page-guide-coverage` 6240ms /
+ * `ci-unit-test-path-filter-closure` 5533ms) ため、instance 修正ではなく機械 gate 化した
+ * (ADR-0061 same-class-N→guard)。
+ *
+ * 本 test は fixture 注入で gate の判定だけを固定する (実 repo は走査しないので bounded)。
+ * 実 repo に対する検査は pre-ready Step 7f / CI job が担う。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: 本 file は実走査をしないが、fixture 文字列に走査 API と repo root リテラルを含むため
+// gate の静的判定は保守的に scope='repo' になる。誤検出のコストは明示 timeout 1 行なので、
+// 判定を緩めるのではなくこちらを合わせる (宣言で検査を無効化しない原則を自分にも適用する)。
+vi.setConfig({ testTimeout: 60_000 });
+
+import {
+	analyzeTestSource,
+	checkRepoScanTestDeclarations,
+} from '../../../scripts/check-repo-scan-test-declaration.mjs';
+import {
+	MIN_REPO_SCAN_TIMEOUT_MS,
+	REPO_SCAN_TEST_REGISTRY,
+} from '../../../scripts/lib/ci/repo-scan-test-registry.mjs';
+
+/** repo ツリーを走査する test の骨格 (timeout の有無を切り替えられる)。 */
+function repoScanSource(withTimeout: boolean): string {
+	return `import { readdirSync } from 'node:fs';
+import { describe, expect, it${withTimeout ? ', vi' : ''} } from 'vitest';
+${withTimeout ? 'vi.setConfig({ testTimeout: 60_000 });' : ''}
+const SCAN_ROOTS = ['src', 'scripts'];
+describe('x', () => { it('y', () => { expect(readdirSync(SCAN_ROOTS[0]).length).toBeGreaterThan(0); }); });
+`;
+}
+
+/** fixture dir だけを読む有界 test。 */
+const BOUNDED_SOURCE = `import { readdirSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+describe('x', () => { it('y', () => { expect(readdirSync(tmpDir).length).toBe(0); }); });
+`;
+
+/** 走査 API を使わない普通の test。 */
+const PLAIN_SOURCE = `import { describe, expect, it } from 'vitest';
+describe('x', () => { it('y', () => { expect(1).toBe(1); }); });
+`;
+
+function runGate(
+	files: Record<string, string>,
+	registry: Record<string, { scope: 'repo' | 'bounded'; note: string }>,
+) {
+	return checkRepoScanTestDeclarations({
+		files: Object.keys(files),
+		readFile: (p) => files[p],
+		registry,
+	});
+}
+
+describe('#4085 repo 走査 test の区分宣言 gate', () => {
+	it('[R1] 未宣言の repo 走査 test を fail させる (AC2 の核)', () => {
+		const { violations } = runGate(
+			{ 'tests/unit/x/new-scan.test.ts': repoScanSource(true) },
+			{ 'tests/unit/x/other.test.ts': { scope: 'repo', note: 'n' } },
+		);
+		const undeclared = violations.filter((v) => v.id === 'undeclared');
+		expect(undeclared).toHaveLength(1);
+		expect(undeclared[0].path).toBe('tests/unit/x/new-scan.test.ts');
+		// 貼り付け用のエントリを出して「どう直すか」を示す
+		expect(undeclared[0].message).toContain("scope: 'repo'");
+	});
+
+	it('[R2] scope=repo で明示 timeout が無ければ fail (例3 / 例4 の再発を止める)', () => {
+		const { violations } = runGate(
+			{ 'tests/unit/architecture/page-guide-coverage.test.ts': repoScanSource(false) },
+			{
+				'tests/unit/architecture/page-guide-coverage.test.ts': { scope: 'repo', note: 'n' },
+			},
+		);
+		expect(violations.map((v) => v.id)).toContain('missing-timeout');
+		expect(violations[0].message).toContain(String(MIN_REPO_SCAN_TIMEOUT_MS));
+	});
+
+	it('[R3] scope=repo + 明示 timeout なら pass', () => {
+		const { violations } = runGate(
+			{ 'tests/unit/x/scan.test.ts': repoScanSource(true) },
+			{ 'tests/unit/x/scan.test.ts': { scope: 'repo', note: 'n' } },
+		);
+		expect(violations).toEqual([]);
+	});
+
+	it('[R4] bounded と自己申告して timeout 要求を回避できない (宣言が検査を無効化しない)', () => {
+		const { violations } = runGate(
+			{ 'tests/unit/x/scan.test.ts': repoScanSource(false) },
+			{ 'tests/unit/x/scan.test.ts': { scope: 'bounded', note: '嘘の申告' } },
+		);
+		expect(violations.map((v) => v.id)).toContain('scope-mismatch');
+	});
+
+	it('[R5] 有界 test は bounded 宣言のみで pass / 走査しない test は対象外', () => {
+		const { violations, candidates } = runGate(
+			{
+				'tests/unit/x/bounded.test.ts': BOUNDED_SOURCE,
+				'tests/unit/x/plain.test.ts': PLAIN_SOURCE,
+			},
+			{ 'tests/unit/x/bounded.test.ts': { scope: 'bounded', note: 'temp dir のみ' } },
+		);
+		expect(violations).toEqual([]);
+		expect(candidates.map((c) => c.path)).toEqual(['tests/unit/x/bounded.test.ts']);
+	});
+
+	it('[R6] stale なエントリ (file 消滅 / 走査をやめた) を fail させる', () => {
+		const { violations } = runGate(
+			{
+				'tests/unit/x/plain.test.ts': PLAIN_SOURCE,
+				'tests/unit/x/scan.test.ts': repoScanSource(true),
+			},
+			{
+				'tests/unit/x/scan.test.ts': { scope: 'repo', note: 'n' },
+				'tests/unit/x/plain.test.ts': { scope: 'bounded', note: 'もう走査していない' },
+				'tests/unit/x/deleted.test.ts': { scope: 'repo', note: '消えた file' },
+			},
+		);
+		expect(
+			violations
+				.filter((v) => v.id === 'stale-entry')
+				.map((v) => v.path)
+				.sort(),
+		).toEqual(['tests/unit/x/deleted.test.ts', 'tests/unit/x/plain.test.ts']);
+	});
+
+	it('[R7] 候補 0 件は「違反なし」ではなく fail (検出 pattern の腐りを silent に通さない)', () => {
+		const { violations } = runGate({ 'tests/unit/x/plain.test.ts': PLAIN_SOURCE }, {});
+		expect(violations.map((v) => v.id)).toEqual(['no-candidates']);
+	});
+
+	it('[R8] analyzeTestSource が timeout 宣言 3 形式を拾う', () => {
+		expect(analyzeTestSource(repoScanSource(true)).maxTimeoutMs).toBe(60_000);
+		expect(
+			analyzeTestSource(`import { readdirSync } from 'node:fs';
+const roots = ['src'];
+it('x', () => { readdirSync(roots[0]); }, 60_000);`).maxTimeoutMs,
+		).toBe(60_000);
+		expect(
+			analyzeTestSource(`import { readdirSync } from 'node:fs';
+const roots = ['scripts'];
+describe('x', { timeout: 30000 }, () => { readdirSync(roots[0]); });`).maxTimeoutMs,
+		).toBe(30_000);
+	});
+
+	it('[R9] 実 registry の 4 実測例が scope=repo で宣言されている (AC3)', () => {
+		// 例1 (#3972/#4000) は PR #4067 で unit lane から外れたため候補ではない。
+		// 例2 (#3978)・例3 (page-guide)・例4 (path-filter-closure) は unit lane に残る repo 走査。
+		for (const p of [
+			'tests/unit/scripts/check-readdir-rotation-guard.test.ts',
+			'tests/unit/architecture/page-guide-coverage.test.ts',
+			'tests/unit/architecture/ci-unit-test-path-filter-closure.test.ts',
+		]) {
+			expect(REPO_SCAN_TEST_REGISTRY[p]?.scope).toBe('repo');
+		}
+	});
+});

--- a/tests/unit/scripts/check-ss-blob-sha-uniqueness.test.ts
+++ b/tests/unit/scripts/check-ss-blob-sha-uniqueness.test.ts
@@ -58,7 +58,8 @@ function canonicalBody(extra = ''): string {
 /** path → sha を返す fetch mock。 */
 function shaFetcher(shaByPath: Record<string, string>): typeof fetch {
 	return (async (url: string) => {
-		const path = decodeURIComponent(String(url).split('/contents/')[1].split('?')[0]);
+		const afterContents = String(url).split('/contents/')[1] ?? '';
+		const path = decodeURIComponent(afterContents.split('?')[0] ?? '');
 		const sha = shaByPath[path];
 		if (!sha) throw new Error(`fixture に sha 未定義: ${path}`);
 		return { ok: true, status: 200, statusText: 'OK', json: async () => ({ sha }) };

--- a/tests/unit/scripts/check-ss-blob-sha-uniqueness.test.ts
+++ b/tests/unit/scripts/check-ss-blob-sha-uniqueness.test.ts
@@ -1,0 +1,264 @@
+/**
+ * tests/unit/scripts/check-ss-blob-sha-uniqueness.test.ts (#4084 / #2063)
+ *
+ * 検証対象: SS 偽装検知 gate が「検知できなかったとき」に黙らないこと。
+ *
+ * 実測 (#4084、PR #4080):
+ *   - PR body に SS が 20 枚 embed されている (`ref=screenshots` の raw URL を 20 件抽出)
+ *   - しかし file 名が `develop-*` / `pr4080-*` で `before-*` / `after-*` に一致しないため
+ *     `pairBeforeAfter()` が 0 件を返し、gate は `[ss-blob-sha-uniqueness] SKIP` で終わっていた
+ *   - **20 枚あって偽装検知が 1 ペアも実行されない**状態が silent に pass していた
+ *   - さらに #4080 の Before / After 20 枚は sha256 完全一致だが、これは「JST 00:00〜09:00 の
+ *     9 時間帯だけ日付がずれる」修正を差分窓の外 (JST 日中) に撮影したためで**同一が正しい**。
+ *     命名を規約どおりに直すと今度は hard-fail する = 正直に撮った PR が落ちる経路しかなかった
+ *
+ * 本 test は (a) 0 ペア = fail、(b) 命名非依存のペアリング宣言、(c) 同一が正しい場合の
+ * 理由必須宣言 の 3 点を固定し、既存の偽装検知 (#2063 PR-2054 sentinel) を弱めないことも固定する。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	checkSsBlobShaUniqueness,
+	detectIdenticalPairs,
+	PR_2054_SENTINEL_FIXTURE,
+	pairBeforeAfter,
+	pairScreenshots,
+	parsePairDeclarations,
+	parseReasonDeclaration,
+} from '../../../scripts/check-ss-blob-sha-uniqueness.mjs';
+
+const OWNER = 'Takenori-Kusaka';
+const REPO = 'ganbari-quest';
+
+/** #4080 の実 SS 命名 (develop-* / pr4080-*)。抜粋 3 組。 */
+const PR_4080_KEYS = ['admin-points-mobile', 'admin-points-desktop', 'child-home-mobile'];
+
+function rawUrl(path: string): string {
+	return `https://raw.githubusercontent.com/${OWNER}/${REPO}/screenshots/${path}`;
+}
+
+/** #4080 と同じ命名で SS を embed した body を組み立てる。 */
+function pr4080Body(extra = ''): string {
+	const imgs = PR_4080_KEYS.flatMap((k) => [
+		`![before](${rawUrl(`pr-4080/develop-${k}.png`)})`,
+		`![after](${rawUrl(`pr-4080/pr4080-${k}.png`)})`,
+	]).join('\n');
+	return `## スクリーンショット\n\n${imgs}\n\n${extra}\n`;
+}
+
+/** 規約どおりの before-* / after-* 命名 body。 */
+function canonicalBody(extra = ''): string {
+	const imgs = PR_4080_KEYS.flatMap((k) => [
+		`![before](${rawUrl(`pr-4090/before-${k}.png`)})`,
+		`![after](${rawUrl(`pr-4090/after-${k}.png`)})`,
+	]).join('\n');
+	return `## スクリーンショット\n\n${imgs}\n\n${extra}\n`;
+}
+
+/** path → sha を返す fetch mock。 */
+function shaFetcher(shaByPath: Record<string, string>): typeof fetch {
+	return (async (url: string) => {
+		const path = decodeURIComponent(String(url).split('/contents/')[1].split('?')[0]);
+		const sha = shaByPath[path];
+		if (!sha) throw new Error(`fixture に sha 未定義: ${path}`);
+		return { ok: true, status: 200, statusText: 'OK', json: async () => ({ sha }) };
+	}) as unknown as typeof fetch;
+}
+
+/** 全ペアが同一 SHA になる fetcher (#4080 の実状況)。 */
+function identicalShaFetcher(beforePrefix: string, afterPrefix: string, dir: string): typeof fetch {
+	const map: Record<string, string> = {};
+	PR_4080_KEYS.forEach((k, i) => {
+		const sha = `deadbeef${i}`.padEnd(40, '0');
+		map[`${dir}/${beforePrefix}${k}.png`] = sha;
+		map[`${dir}/${afterPrefix}${k}.png`] = sha;
+	});
+	return shaFetcher(map);
+}
+
+/** 全ペアが別 SHA になる fetcher (正常に撮り直した PR)。 */
+function distinctShaFetcher(beforePrefix: string, afterPrefix: string, dir: string): typeof fetch {
+	const map: Record<string, string> = {};
+	PR_4080_KEYS.forEach((k, i) => {
+		map[`${dir}/${beforePrefix}${k}.png`] = `aaaa${i}`.padEnd(40, '0');
+		map[`${dir}/${afterPrefix}${k}.png`] = `bbbb${i}`.padEnd(40, '0');
+	});
+	return shaFetcher(map);
+}
+
+const VALID_REASON =
+	'JST 00:00〜09:00 の窓外 (日中) に撮影したため描画一致が正しい。差分は固定時刻注入の unit test で実証';
+
+describe('#4084 (a) SS があるのにペア 0 件を silent skip しない', () => {
+	it('[P1] SS 20 枚相当が embed されているのにペア 0 件なら fail する (現状は skip だった)', async () => {
+		const r = await checkSsBlobShaUniqueness({
+			body: pr4080Body(),
+			labels: [],
+			fetcher: shaFetcher({}),
+		});
+		expect(r.status).toBe('fail');
+		expect(r.reason).toContain('0');
+		// 「何枚あって何ペア検査できたか」が出力から読めること (検知できたか否かの可視化)
+		expect(r.reason).toMatch(/6\s*件|SS 6/);
+	});
+
+	it('[P2] SS が 1 枚も無い body は従来どおり skip (対象なし)', async () => {
+		const r = await checkSsBlobShaUniqueness({
+			body: '## スクリーンショット\n\n該当なし (script / test のみ)\n',
+			labels: [],
+			fetcher: shaFetcher({}),
+		});
+		expect(r.status).toBe('skip');
+	});
+
+	it('[P3] refactor:internal-no-doc-impact label は従来どおり skip (#2063 AC3 を弱めない)', async () => {
+		const r = await checkSsBlobShaUniqueness({
+			body: pr4080Body(),
+			labels: ['refactor:internal-no-doc-impact'],
+			fetcher: shaFetcher({}),
+		});
+		expect(r.status).toBe('skip');
+	});
+
+	it('[P4] ペアが取れない正当理由は宣言で通す。理由が空なら fail (#3956 教訓)', async () => {
+		const withReason = await checkSsBlobShaUniqueness({
+			body: pr4080Body('<!-- ss-pair-none: 新規画面のため修正前の SS が原理的に存在しない -->'),
+			labels: [],
+			fetcher: shaFetcher({}),
+		});
+		expect(withReason.status).toBe('pass');
+		expect(withReason.reason).toContain('新規画面');
+
+		const emptyReason = await checkSsBlobShaUniqueness({
+			body: pr4080Body('<!-- ss-pair-none: -->'),
+			labels: [],
+			fetcher: shaFetcher({}),
+		});
+		expect(emptyReason.status).toBe('fail');
+
+		const stubReason = await checkSsBlobShaUniqueness({
+			body: pr4080Body('<!-- ss-pair-none: TODO -->'),
+			labels: [],
+			fetcher: shaFetcher({}),
+		});
+		expect(stubReason.status).toBe('fail');
+	});
+});
+
+describe('#4084 (b) ペアリングを命名依存から緩和する', () => {
+	it('[P5] prefix 宣言で develop-* / pr4080-* をペアにできる (#4080 の実命名)', () => {
+		const paths = PR_4080_KEYS.flatMap((k) => [
+			`pr-4080/develop-${k}.png`,
+			`pr-4080/pr4080-${k}.png`,
+		]);
+		const decls = parsePairDeclarations('<!-- ss-pair-prefix: before=develop- after=pr4080- -->');
+		const pairs = pairScreenshots(paths, decls);
+		expect(pairs).toHaveLength(3);
+		expect(pairs.map((p) => p.before)).toContain('pr-4080/develop-admin-points-mobile.png');
+		expect(pairs.map((p) => p.after)).toContain('pr-4080/pr4080-admin-points-mobile.png');
+	});
+
+	it('[P6] 個別ペア宣言 (ss-pair) でも対応関係を取れる', () => {
+		const decls = parsePairDeclarations(
+			`<!-- ss-pair: before=${rawUrl('x/old-1.png')} after=${rawUrl('x/new-1.png')} -->`,
+		);
+		const pairs = pairScreenshots(['x/old-1.png', 'x/new-1.png'], decls);
+		expect(pairs).toEqual([
+			{ key: 'x/old-1.png ⇄ x/new-1.png', before: 'x/old-1.png', after: 'x/new-1.png' },
+		]);
+	});
+
+	it('[P7] 宣言が無ければ従来の before-* / after-* 命名で引き続きペアが取れる', () => {
+		const paths = PR_4080_KEYS.flatMap((k) => [
+			`pr-4090/before-${k}.png`,
+			`pr-4090/after-${k}.png`,
+		]);
+		expect(pairScreenshots(paths, parsePairDeclarations(''))).toHaveLength(3);
+		// 既存 export も従来どおり動く (#2063 回帰)
+		expect(pairBeforeAfter(paths)).toHaveLength(3);
+	});
+
+	it('[P8] prefix 宣言で pair が取れれば SHA 比較まで進み、別 SHA なら pass', async () => {
+		const r = await checkSsBlobShaUniqueness({
+			body: pr4080Body('<!-- ss-pair-prefix: before=develop- after=pr4080- -->'),
+			labels: [],
+			fetcher: distinctShaFetcher('develop-', 'pr4080-', 'pr-4080'),
+		});
+		expect(r.status).toBe('pass');
+		expect(r.reason).toContain('3');
+	});
+});
+
+describe('#4084 (c) Before/After が同一で正しいケースの明示経路', () => {
+	it('[P9] 同一 SHA + 理由あり宣言なら pass (理由を出力に残す)', async () => {
+		const r = await checkSsBlobShaUniqueness({
+			body: pr4080Body(
+				`<!-- ss-pair-prefix: before=develop- after=pr4080- -->\n<!-- ss-identical-ok: ${VALID_REASON} -->`,
+			),
+			labels: [],
+			fetcher: identicalShaFetcher('develop-', 'pr4080-', 'pr-4080'),
+		});
+		expect(r.status).toBe('pass');
+		expect(r.reason).toContain('JST');
+		// 同一だった事実自体は握り潰さず列挙する
+		expect(r.acknowledgedIdenticalPairs).toHaveLength(3);
+	});
+
+	it('[P10] 同一 SHA + 理由なし宣言は fail (理由の非強制を作らない、#3956)', async () => {
+		const r = await checkSsBlobShaUniqueness({
+			body: pr4080Body(
+				'<!-- ss-pair-prefix: before=develop- after=pr4080- -->\n<!-- ss-identical-ok: -->',
+			),
+			labels: [],
+			fetcher: identicalShaFetcher('develop-', 'pr4080-', 'pr-4080'),
+		});
+		expect(r.status).toBe('fail');
+		expect(r.reason).toContain('理由');
+	});
+
+	it('[P11] 同一 SHA + 宣言なしは従来どおり fail (#2063 偽装検知を弱めない)', async () => {
+		const r = await checkSsBlobShaUniqueness({
+			body: canonicalBody(),
+			labels: [],
+			fetcher: identicalShaFetcher('before-', 'after-', 'pr-4090'),
+		});
+		expect(r.status).toBe('fail');
+		expect(r.violations).toHaveLength(3);
+	});
+
+	it('[P12] PR-2054 偽装 sentinel は引き続き検出される (#2063 AC5 回帰)', () => {
+		const pairsWithSha = PR_2054_SENTINEL_FIXTURE.identicalPairs.map((p) => ({
+			key: p.key,
+			before: p.before,
+			after: p.after,
+			beforeSha: p.sha,
+			afterSha: p.sha,
+		}));
+		expect(detectIdenticalPairs(pairsWithSha)).toHaveLength(4);
+		// 命名規則ペアリングも維持
+		expect(
+			pairBeforeAfter(PR_2054_SENTINEL_FIXTURE.identicalPairs.flatMap((p) => [p.before, p.after])),
+		).toHaveLength(4);
+	});
+
+	it('[P13] parseReasonDeclaration が空 / 定型 stub を理由として認めない', () => {
+		expect(parseReasonDeclaration('<!-- ss-identical-ok: -->', 'ss-identical-ok')).toEqual({
+			present: true,
+			reason: '',
+			valid: false,
+		});
+		for (const stub of ['TODO', 'n/a', '-', 'なし', '後で書く']) {
+			expect(
+				parseReasonDeclaration(`<!-- ss-identical-ok: ${stub} -->`, 'ss-identical-ok').valid,
+			).toBe(false);
+		}
+		expect(parseReasonDeclaration('', 'ss-identical-ok')).toEqual({
+			present: false,
+			reason: '',
+			valid: false,
+		});
+		expect(
+			parseReasonDeclaration(`<!-- ss-identical-ok: ${VALID_REASON} -->`, 'ss-identical-ok').valid,
+		).toBe(true);
+	});
+});

--- a/tests/unit/scripts/pre-ready-order-and-base.test.ts
+++ b/tests/unit/scripts/pre-ready-order-and-base.test.ts
@@ -61,8 +61,19 @@ function costClasses(): string[] {
 	return evalInModule(preReadyUrl, 'm.STEP_COST_CLASSES') as string[];
 }
 
-function costClassByName(): Record<string, string> {
-	return evalInModule(preReadyUrl, 'm.STEP_COST_CLASS_BY_NAME') as Record<string, string>;
+/**
+ * step 名 → コストクラスの対応。
+ *
+ * #4086 で第 2 registry (`STEP_COST_CLASS_BY_NAME`) を廃止し、`costClass` は step 定義
+ * オブジェクト自身が持つようになった。取得元が変わっただけで [O1]〜[O8] が固定する不変条件
+ * (全 step が有効なクラスを持ち、実行順が単調非減少で、同一クラス内は定義順) は同一。
+ * shape 不備そのものの検出は `pre-ready-step-shape.test.ts` [S2]〜[S5] が担う (#4086)。
+ */
+function costClassByName(changedFiles: string[] = []): Record<string, string> {
+	return evalInModule(
+		preReadyUrl,
+		`Object.fromEntries(m.buildSteps(${JSON.stringify(DEFAULT_ARGS)}, ${JSON.stringify(changedFiles)}).map((s) => [s.name, s.costClass]))`,
+	) as Record<string, string>;
 }
 
 describe('#4048 実行順が cheap-fail-first であること', () => {
@@ -100,6 +111,13 @@ describe('#4048 実行順が cheap-fail-first であること', () => {
 
 	it('[O6] 型検査 → テスト → ブラウザ実測 → UI 系 の相対順序を保つ', () => {
 		const order = orderedStepNames(['site/index.html', 'src/lib/ui/x.svelte']);
+		// LP / UI 変更ありの step 集合でも全 step にクラスが付いていること (旧 [O1] の条件付き step 分)
+		const classes = costClasses();
+		expect(
+			Object.entries(costClassByName(['site/index.html', 'src/lib/ui/x.svelte'])).filter(
+				([, c]) => !classes.includes(c),
+			),
+		).toEqual([]);
 		const at = (n: string) => order.indexOf(n);
 		expect(at('svelte-check')).toBeLessThan(at('vitest'));
 		expect(at('vitest')).toBeLessThan(at('lp-dimensions'));
@@ -132,7 +150,9 @@ describe('#4048 実行順が cheap-fail-first であること', () => {
 			`(() => { try { m.orderSteps([{ name: 'brand-new-step' }]); return null; } catch (e) { return e.message; } })()`,
 		) as string | null;
 		expect(thrown).toContain('brand-new-step');
-		expect(thrown).toContain('STEP_COST_CLASS_BY_NAME');
+		// #4086: 未登録の指摘先は「第 2 registry」ではなく step 定義自身の costClass になった
+		expect(thrown).toContain('costClass');
+		expect(thrown).toContain('buildSteps');
 	});
 });
 

--- a/tests/unit/scripts/pre-ready-step-shape.test.ts
+++ b/tests/unit/scripts/pre-ready-step-shape.test.ts
@@ -1,0 +1,141 @@
+/**
+ * tests/unit/scripts/pre-ready-step-shape.test.ts (#4086)
+ *
+ * 検証対象: pre-ready の step 追加が **1 箇所の登録**で完結すること。
+ *
+ * 旧実装では step を 1 つ足すのに 2 つの独立 registry (`skipStateOf()` 経由の skip 分類 +
+ * `STEP_COST_CLASS_BY_NAME`) への同時登録が必要で、片方だけ直しても CI が回るまで気づけず、
+ * PR #4066 が 2 度連続 red になった (#4086 実測)。
+ *
+ * 本 test は「step 定義オブジェクト 1 箇所に必須フィールドが揃っていなければ即 throw する」
+ * という新しい単一強制点 (`assertStepShapes` / `orderSteps`) を固定する。既存の
+ * `[O1]`〜`[O9]` (#4048) / `[K10]` (#4018) の強度は落とさない (ADR-0006):
+ *   - 旧 [O1] (コストクラス登録漏れ検出) は [S2] が step 定義側で同じ不変条件を assert する
+ *   - 旧 [O9] (未登録 step で throw) は [S4] が同じ throw を assert する (対象が広がっただけ)
+ *
+ * pre-ready.mjs は plain .mjs のため、他の pre-ready test と同じく子プロセスの dynamic import
+ * 経由で実関数を呼ぶ (svelte-check の型 program に取り込ませないため)。
+ */
+
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '../../../..');
+const preReadyUrl = pathToFileURL(resolve(repoRoot, 'scripts/pre-ready.mjs')).href;
+
+function evalInModule(expression: string): unknown {
+	const code = `const m = await import(${JSON.stringify(preReadyUrl)});
+process.stdout.write(JSON.stringify(${expression}));`;
+	const out = execFileSync(process.execPath, ['--input-type=module', '-e', code], {
+		encoding: 'utf8',
+	});
+	return JSON.parse(out);
+}
+
+const DEFAULT_ARGS = { pr: '4086' };
+
+/** buildSteps の各 step から「関数以外の」フィールドを取り出す (JSON 化のため runner は有無だけ)。 */
+function stepShapes(changedFiles: string[] = []): {
+	name: string;
+	costClass: string;
+	skipKindPresent: boolean;
+	hasRunner: boolean;
+	hasFixHint: boolean;
+	hasLabel: boolean;
+	hasSkip: boolean;
+}[] {
+	return evalInModule(
+		`m.buildSteps(${JSON.stringify(DEFAULT_ARGS)}, ${JSON.stringify(changedFiles)}).map((s) => ({
+			name: s.name,
+			costClass: s.costClass,
+			skipKindPresent: 'skipKind' in s,
+			hasRunner: typeof s.runner === 'function',
+			hasFixHint: typeof s.fixHint === 'string',
+			hasLabel: typeof s.label === 'string',
+			hasSkip: typeof s.skip === 'boolean',
+		}))`,
+	) as ReturnType<typeof stepShapes>;
+}
+
+function requiredFields(): string[] {
+	return evalInModule('m.REQUIRED_STEP_FIELDS') as string[];
+}
+
+function costClasses(): string[] {
+	return evalInModule('m.STEP_COST_CLASSES') as string[];
+}
+
+/** assertStepShapes / orderSteps を呼び、throw した場合はその message を返す。 */
+function throwMessage(expression: string): string | null {
+	return evalInModule(
+		`(() => { try { ${expression}; return null; } catch (e) { return e.message; } })()`,
+	) as string | null;
+}
+
+describe('#4086 step 定義 1 箇所で登録が完結すること', () => {
+	it('[S1] 必須フィールドの SSOT が step 定義の全項目を列挙している', () => {
+		// 「どこに何を書けばよいか」を 1 箇所で読めることが本 Issue の主目的。
+		expect(requiredFields().sort()).toEqual(
+			['costClass', 'fixHint', 'label', 'name', 'runner', 'skip', 'skipKind'].sort(),
+		);
+	});
+
+	it('[S2] 全 step が有効な costClass を step 定義自身に持つ (旧 [O1]/[O2] を定義側で担保)', () => {
+		const classes = costClasses();
+		const invalid = stepShapes()
+			.filter((s) => !classes.includes(s.costClass))
+			.map((s) => `${s.name}=${String(s.costClass)}`);
+		expect(invalid).toEqual([]);
+	});
+
+	it('[S3] 全 step が必須フィールドを 1 つも欠かない', () => {
+		const incomplete = stepShapes(['site/index.html', 'src/lib/ui/x.svelte']).filter(
+			(s) =>
+				!s.hasLabel ||
+				!s.hasRunner ||
+				!s.hasFixHint ||
+				!s.hasSkip ||
+				!s.skipKindPresent ||
+				!s.costClass,
+		);
+		expect(incomplete).toEqual([]);
+	});
+
+	it('[S4] 不完全な step 定義は orderSteps が throw する (旧 [O9] の対象拡張)', () => {
+		// costClass だけ欠けたケース (= #4048 の登録漏れと同じ症状)
+		const missingCostClass = throwMessage(
+			`m.orderSteps([{ name: 'brand-new-step', label: 'x', skip: false, skipKind: null, runner: () => 0, fixHint: 'x' }])`,
+		);
+		expect(missingCostClass).toContain('brand-new-step');
+		expect(missingCostClass).toContain('costClass');
+
+		// runner / fixHint 欠落も同じ 1 箇所で落ちる (2 registry 時代には検出できなかった)
+		const missingRunner = throwMessage(
+			`m.orderSteps([{ name: 'no-runner-step', label: 'x', costClass: 'static', skip: false, skipKind: null, fixHint: 'x' }])`,
+		);
+		expect(missingRunner).toContain('no-runner-step');
+		expect(missingRunner).toContain('runner');
+
+		// skipKind 欠落 = #4018 [K10] が防いでいた劣化。step shape でも落ちる (二重防御)
+		const missingSkipKind = throwMessage(
+			`m.orderSteps([{ name: 'no-skipkind-step', label: 'x', costClass: 'static', skip: false, runner: () => 0, fixHint: 'x' }])`,
+		);
+		expect(missingSkipKind).toContain('skipKind');
+	});
+
+	it('[S5] 不正な costClass 値も throw する (typo を silent に通さない)', () => {
+		const msg = throwMessage(
+			`m.orderSteps([{ name: 'typo-step', label: 'x', costClass: 'statik', skip: false, skipKind: null, runner: () => 0, fixHint: 'x' }])`,
+		);
+		expect(msg).toContain('typo-step');
+		expect(msg).toContain('statik');
+	});
+
+	it('[S6] 第 2 registry (STEP_COST_CLASS_BY_NAME) が廃止されている', () => {
+		// 残っていると「step 定義に書いたのに古い registry も要る」状態が復活する。
+		const exists = evalInModule(`'STEP_COST_CLASS_BY_NAME' in m`) as boolean;
+		expect(exists).toBe(false);
+	});
+});

--- a/tests/unit/scripts/pre-ready-step-shape.test.ts
+++ b/tests/unit/scripts/pre-ready-step-shape.test.ts
@@ -17,6 +17,11 @@
  * 経由で実関数を呼ぶ (svelte-check の型 program に取り込ませないため)。
  */
 
+// cspell:ignore skipkind statik
+// 上記は意図的な負例 fixture。`no-skipkind-step` は skipKind を欠いた step 名、`statik` は
+// costClass の typo を再現するための値であり、綴りを直すと negative case が成立しなくなる
+// (= 登録漏れ / typo を検出できないことを検出できなくなる)。tests/CLAUDE.md §負例 fixture と cspell。
+
 import { execFileSync } from 'node:child_process';
 import { resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: PR をレビューする QA / QM と、その根拠で main へのリリースを判断する PO / システム全体

**解決する課題**: 4 件の Issue はいずれも同じ root class を持つ ——「**検査しなかったことが silent に pass になる**」。gate は動いているように見えるのに、実際には何も検査していない (あるいは宛先違いのものを検査している) 状態を、出力から読み取れなかった。

| Issue | 何が黙って通っていたか (実測) |
|---|---|
| #4074 | AC 検証マップの根拠が **存在しない PR 番号** (`--pr 4059`) を指していても `check-pr-body.mjs --pr 4063` が「OK — 違反なし」を返した |
| #4084 | SS が 20 枚 embed されているのに命名不一致でペア 0 件 → 偽装検知が 1 ペアも走らないまま `SKIP` |
| #4085 | repo 走査 test が既定 timeout (5s) のまま unit lane に同居し負荷で落ちる。落ちても壊れていないので毎回「本物か負荷か」の切り分けが発生する (**同 class 4 例目**) |
| #4086 | pre-ready の step 追加に 2 registry への同時登録が必要で、片方だけ直しても次の CI まで分からない (PR #4066 で 2 度連続 red を実測) |

**期待される効果**: 「skip / 未検証 / 未登録」が **必ず出力に現れて fail になる**。正当な例外は **理由を必須とする明示宣言**でだけ通り、宣言が検査そのものを無効化できない。リリース判断の根拠 (監査証跡 #2950 AC4) が「宛先が合っていること」まで機械保証される。

## 関連 Issue

closes #4074
closes #4084
closes #4085
closes #4086

関連: #2063 (SS 偽装検知 gate 導入) / #3956 (理由の非強制を作らない) / #3983 (silent skip 同 class) / #4007 / #4018 (`[K10]`) / #4048 (`[O1]` コストクラス登録強制) / #4066 / #4067 / #4080 (#4084 の発見元 PR) / ADR-0004 / ADR-0006 / ADR-0061

## AC 検証マップ (ADR-0004)

検証はすべて HEAD `d9a6c7cb` で実行。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| 4074-AC1 | 根拠欄の `--pr <番号>` が自 PR と一致することを gate が検証する (不一致・存在しない番号は fail) | `npx vitest run tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts` | PASS 7/7。`checkEvidencePrReferences` (`scripts/check-pr-body.mjs`) が `evidence-pr-mismatch` を返し `collectViolations` で violation に積まれる |
| 4074-AC2 | 存在しない PR 番号 (4059) を根拠に書いた body を fixture として回帰テストに実名で含める | 同上 `[E1]` | PASS。`PR_4063_AC_MAP_WITH_WRONG_PR` に PR #4063 の実測行 (pre-ready を 4059 に向けた根拠) をそのまま格納。本 PR body 側にその文字列を書くと本 gate 自身が fail するため、実名 fixture は test file 内のみに置く (dogfooding で確認) |
| 4074-AC3 | 既存 PR body の後方互換を壊さない (番号を書かない形式は通す) | 同上 `[E3]` `[E4]` `[E5]` `[E7]` | PASS。プレースホルダ `--pr <num>` は非数字なので拾わない / AC マップ外の他 PR 言及は対象外 / `--body-file` dry-run は判定しない |
| 4074-AC4 | guard を外すと AC2 が落ちることを実行して証跡に残す | 下記「mutation 検証」表 M1 | PASS — `if (true) return null` 挿入で 2 tests failed |
| 4074-AC5 | `.claude/skills/dev-open-pr/SKILL.md` に「根拠コマンドの PR 番号は自 PR に一致させる」を追記 | `git diff d9a6c7cb~2 -- .claude/skills/dev-open-pr/SKILL.md` | PASS — §「根拠コマンドの `--pr <番号>` は自 PR に一致させる — #4074」を新設 |
| 4084-AC1 | SS が embed されているのにペアが 0 件の場合 `skip` ではなく `fail` にする | `npx vitest run tests/unit/scripts/check-ss-blob-sha-uniqueness.test.ts` `[P1]` `[P2]` `[P3]` | PASS 13/13。`checkSsBlobShaUniqueness` が `status: 'fail'` + `pairingHelp` を返す。SS 0 枚 / exempt label は従来どおり skip |
| 4084-AC2 | ペアリングを命名依存から緩和する | 同上 `[P5]` `[P6]` `[P7]` `[P8]` | PASS。`parsePairDeclarations` + `pairScreenshots` が (明示ペア → prefix 宣言 → 既定命名) の順で対応を取る。#4080 の `develop-*` / `pr4080-*` が prefix 宣言 1 行でペア化 |
| 4084-AC3 | 「Before / After が同一であることが正しい」ケースの明示経路を用意し、理由の記述を必須とする (理由が空なら fail) | 同上 `[P9]` `[P10]` `[P11]` `[P13]` | PASS。`<!-- ss-identical-ok: <理由> -->` は `MIN_REASON_LENGTH=12` 未満 / 定型 stub (`TODO` / `n/a` / `なし` 等) を拒否。宣言なしは従来どおり fail |
| 4084-AC4 | AC1〜AC3 の回帰テストを追加し、fixture に実測 (20 枚 / 0 ペア / sha256 一致) を実名で含める | `tests/unit/scripts/check-ss-blob-sha-uniqueness.test.ts` | PASS。`PR_4080_KEYS` + `pr4080Body()` が `develop-*` / `pr4080-*` 命名を、`identicalShaFetcher` が sha 全一致を再現 |
| 4084-AC5 | guard を外すと AC4 が落ちる | 下記「mutation 検証」表 M2 | PASS — 3 tests failed |
| 4084-AC6 | `src/routes/CLAUDE.md` に命名規約と AC3 の宣言方法を追記 | `git diff d9a6c7cb~2 -- src/routes/CLAUDE.md` | PASS — §「SS の命名規約と、gate が『検査できなかった』ときの扱い（#4084）」を新設 (5 宣言の対応表 + `refactor:internal-no-doc-impact` との使い分け) |
| 4085-AC1 | 「repo 走査 test」の定義と置き場所ルールを `tests/CLAUDE.md` に SSOT として記述 | `git diff d9a6c7cb~2 -- tests/CLAUDE.md` | PASS — §「repo 走査 test (実行コストが入力サイズに比例する test) — #4085」を新設 (定義 / scope 表 / 追加手順) |
| 4085-AC2 | 区分の宣言が無い repo 走査 test を追加したら CI が落ちる gate を追加する | `node scripts/check-repo-scan-test-declaration.mjs` + `npx vitest run tests/unit/scripts/check-repo-scan-test-declaration.test.ts` | PASS 9/9 + gate `OK — repo 走査 test 33 件すべて区分宣言済`。未宣言 / scope 詐称 / timeout 欠落 / stale / 候補 0 件 をすべて fail |
| 4085-AC3 | 既存 4 例をルールに沿って是正する (例3 / 例4 が未対処だった) | `node scripts/check-repo-scan-test-declaration.mjs --list` | PASS。`page-guide-coverage` / `ci-unit-test-path-filter-closure` を含む repo 走査 18 file に明示 timeout (60s) を付与。例1 は PR #4067 で unit lane から外れ済 (候補外)、例2 は PR #4066 で対処済 |
| 4085-AC4 | AC2 の gate を外すと落ちる回帰テストを追加する | 下記「mutation 検証」表 M3 | PASS — 3 tests failed |
| 4085-AC5 | 「全体実行だと落ち単独だと通る」の一次切り分け手順を `tests/CLAUDE.md` に書く | `git diff d9a6c7cb~2 -- tests/CLAUDE.md` | PASS — §「『全体実行だと落ち単独だと通る』の一次切り分け手順」に本 Issue の実測コマンド 3 手順を収録 |
| 4086-AC1 | 新規 step を意図的に不完全な形で追加すると fail することを mutation 検証で示す | `npx vitest run tests/unit/scripts/pre-ready-step-shape.test.ts` `[S4]` `[S5]` + 下記表 M4 | PASS 6/6。案 A + 案 B 併用 (costClass を step 定義へ移し `assertStepShapes` が 7 必須フィールドを検証) |
| 4086-AC2 | 既存の `[K10]` / `[O1]`〜`[O8]` が green のまま維持される (fitness function を弱めない) | `npx vitest run tests/unit/scripts/pre-ready-order-and-base.test.ts tests/unit/scripts/pre-ready-skip-classification.test.ts` | PASS 22/22 + 15/15。詳細は下記「ガードを弱めていない根拠」 |
| 4086-AC3 | `pre-ready --help` の step 一覧 (SSOT) との整合が保たれる | `node scripts/pre-ready.mjs --help` | PASS — Step 7f を Options / Steps 両方に追記。`CLAUDE.md` / `docs/codebase-map.md` の step 数を 17 → 19 に是正 (7e / 7f の反映漏れも同時修正) |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・変更コンポーネント

**変更レイヤー**:
- [ ] DB スキーマ (`$lib/server/db/`)
- [ ] サービス層 (`$lib/server/services/`)
- [ ] API エンドポイント (`src/routes/api/`)
- [ ] ページ / レイアウト (`src/routes/`)
- [ ] UI コンポーネント (`$lib/ui/`, `$lib/features/`)
- [ ] ドメインモデル (`$lib/domain/`)
- [ ] インフラ (`infra/`)
- [ ] LP サイト (`site/`)
- [x] 設定・CI (`package.json`, `.github/`, `biome.json` 等)

**影響を受ける画面・機能**: なし (アプリ本体のコードパスは 1 行も変更していない)。影響するのは開発者向け gate / CI / test のみ。

新規ファイル:

- `scripts/check-repo-scan-test-declaration.mjs` — repo 走査 test の区分宣言 gate
- `scripts/lib/ci/repo-scan-test-registry.mjs` — 区分宣言 SSOT (repo 18 / bounded 15)
- `tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts` / `check-ss-blob-sha-uniqueness.test.ts` / `check-repo-scan-test-declaration.test.ts` / `pre-ready-step-shape.test.ts`

### #4080 の扱い (#4084 が要求する結論)

PR #4080 は「SS 20 枚 embed / 命名 `develop-*` `pr4080-*` / sha256 全一致」という本 Issue の実データそのものである。本 PR merge 後、#4080 は以下の扱いになる。

1. **現状のままでは fail する** (旧: `SKIP`)。SS 20 枚がある以上「ペア 0 件」は黙って通さない
2. **正しい対処は「命名是正」ではなく「宣言 2 行の追加」**。#4080 の Before / After が同一なのは撮り直し漏れではなく、「JST 00:00〜09:00 の 9 時間帯だけ日付がずれる」修正を差分窓の外 (JST 日中) に撮影したためで、**同一が正しい結果**である。命名だけ規約どおりに直すと今度は偽装として hard-fail する (= 正直に撮った PR が落ちる) ため、命名是正は解にならない
3. よって #4080 の PR body に次の 2 行を追加すれば pass する (撮り直し不要 / 命名変更不要):

```
<!-- ss-pair-prefix: before=develop- after=pr4080- -->
<!-- ss-identical-ok: JST 00:00〜09:00 の窓外 (日中) に撮影したため描画一致が正しい。差分は固定時刻を注入した unit test で実証済み -->
```

この 2 行で 20 枚すべてがペア化され SHA 比較まで進み、同一だった 20 ペアは「理由付きで正当」として出力に列挙されたうえで pass する (握り潰さない)。#4084 が求めた「正直に撮って正直に説明した PR が落ちない経路」がこれで初めて存在する。

### design-doc-check の exempt 列挙漏れ是正 (#3152 同 class 2 例目)

Ready 化した時点で `design-doc-check` が fail した。原因は本 PR の変更内容ではなく **gate の exempt 列挙漏れ**:

- `isAllFilesExempt` は「全変更ファイルが exempt」を要求する
- 本 PR の `src/routes/` 変更は `src/routes/CLAUDE.md` のみ (既存 `CLAUDE.md` matcher で exempt)
- しかし **#4074 AC5 が要求した `.claude/skills/dev-open-pr/SKILL.md`** が `FILE_EXEMPT_MATCHERS` に無く、この 1 file だけで判定が崩れていた

これは #3152 で `tests/` が同じ理由 (列挙漏れによる false fail) で追加されたのと同 class であり、本 PR の主題 (「gate の入力モデルが粗くて誤判定する」) そのものなので、**label で黙らせず構造的に是正**した。

- `.claude/` 全体ではなく **markdown のみ** (`/^.claude/.*.md$/`) を exempt にする。`.claude/hooks/*.mjs` / `.claude/settings.json` は実行される設定・コードなので従来どおり gate 対象に残す
- 回帰テスト 3 件を追加 (exempt 成立 / 誤 fail 回帰 / hooks・settings は非 exempt)。mutation 検証は上表 M5
- `refactor:internal-no-doc-impact` label は使っていない (本 PR body で「意味の違う label で gate を黙らせない」と書いた方針を自分にも適用)


## テスト & 安全装置セルフチェック

- [x] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）
- [x] 追加・変更したテストの概要:
  - `tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts` (新規 7 cases) — 根拠 PR 番号の参照整合 (不一致 / 実在しない番号 / 後方互換 / AC マップ外 / dry-run / 複数列挙 / マップ不在)
  - `tests/unit/scripts/check-ss-blob-sha-uniqueness.test.ts` (新規 13 cases) — 0 ペア fail / 命名非依存ペアリング 3 方式 / 同一 SHA の理由必須宣言 / #2063 PR-2054 sentinel 回帰
  - `tests/unit/scripts/check-repo-scan-test-declaration.test.ts` (新規 9 cases) — 未宣言 / scope 詐称 / timeout 欠落 / stale / 候補 0 件 / timeout 3 形式の解釈
  - `tests/unit/scripts/pre-ready-step-shape.test.ts` (新規 6 cases) — 必須 7 フィールド SSOT / 全 step の shape / 不完全 step の throw / 第 2 registry 廃止
  - `tests/unit/scripts/pre-ready-order-and-base.test.ts` (変更) — `costClass` の取得元を step 定義に変更、`[O6]` に条件付き step の網羅 assert を追加、`[O9]` の期待メッセージを追随
  - repo 走査 18 file (変更) — `vi.setConfig({ testTimeout: 60_000 })` + 理由コメントを file 冒頭に追加 (各 +7 行、ロジック無改変)
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **DynamoDB 実装変更時**（ADR-0010 / #1021）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A (`priority:high` であり `priority:critical` ではない)

### mutation 検証 (実装を commit した後に実施、証跡)

| # | 対象 | 挿入した mutation | 結果 |
|---|---|---|---|
| M1 | `scripts/check-pr-body.mjs` | `checkEvidencePrReferences` 冒頭に `if (true) return null;` | `check-pr-body-evidence-pr-ref.test.ts` **2 failed** / 5 passed |
| M2 | `scripts/check-ss-blob-sha-uniqueness.mjs` | 0 ペア時を `'fail'` → `'skip'` に戻す + `identicalOk.valid` 判定を外す | `check-ss-blob-sha-uniqueness.test.ts` **3 failed** (`[P1]` `[P4]` `[P10]`) / 10 passed |
| M3 | `scripts/check-repo-scan-test-declaration.mjs` | `!declared` / timeout 判定 / 候補 0 件判定を `if (false)` で無効化 | `check-repo-scan-test-declaration.test.ts` **3 failed** (`[R1]` `[R2]` `[R7]`) / 6 passed |
| M4 | `scripts/pre-ready.mjs` | `assertStepShapes` 冒頭に `if (true) return;` | `pre-ready-step-shape.test.ts` `[S4]` `[S5]` + `pre-ready-order-and-base.test.ts` `[O9]` の **3 failed** / 19 passed |
| M5 | `scripts/check-design-doc-sync.mjs` | `.claude/**/*.md` の exempt 行を `/^__MUTATED__$/` に置換 | `check-design-doc-sync.test.ts` **2 failed** / 5 passed |

いずれも mutation 後に `git checkout --` で復元済み。実装は M1 実施前に commit `be90a6a5` として確定させてあるため、revert で実装が消えていない。

### ガードを弱めていない根拠 (ADR-0006)

| 既存ガード | 本 PR での扱い |
|---|---|
| `[K10]` (`buildSteps` 内の `skip:` 直書き禁止、#4018) | **無改変で green**。加えて `[S4]` が skipKind 欠落を step shape 側でも落とす (二重防御) |
| `[O1]` `[O2]` (全 step に有効なコストクラス、#4048) | 不変条件は同一のまま、取得元を「第 2 registry」→「step 定義自身」に変更 (`costClassByName()` が `buildSteps` から導出)。`[O6]` に LP/UI 変更ありの step 集合でも全 step にクラスがある assert を追加し、条件付き step の穴も塞いだ |
| `[O9]` (未登録 step で throw) | throw は維持。指摘先が `STEP_COST_CLASS_BY_NAME` → `costClass` / `buildSteps` に変わったので expect も追随。**検出対象は縮小ではなく拡大** (costClass 欠落だけでなく label / runner / fixHint / skip / skipKind の欠落と costClass の不正値も throw) |
| #2063 SS 偽装検知 (同一 SHA = hard-fail) | 維持。`[P11]` (宣言なし同一 SHA → fail) / `[P12]` (PR-2054 sentinel 4 ペア検出 + `pairBeforeAfter` の従来ペアリング) で固定。**skip 経路を fail に格上げしただけで、fail 経路は 1 つも緩めていない** |
| `refactor:internal-no-doc-impact` exempt (#2063 AC3) | 意味・挙動とも無改変 (`[P3]`)。新設した `ss-identical-ok` は別経路で、理由必須なので label の代替にはならない |
| vitest 既定 timeout (5s) | **全体的な引き上げはしない** (#4085 案 D は不採用)。repo 走査と静的判定された 18 file に限り file scope で 60s を宣言する。本物の hang は 60s で依然落ちる |

## スクリーンショット / ビジュアルデモ

**該当なし (script / test のみ)** — 変更は `scripts/` / `tests/` / `.github/workflows/` / docs のみで、`.svelte` / `.css` / `site/` に差分はなく、描画される画面が存在しない。

**4 スロット添付**（#1740）: 該当なし (script / test のみ)

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | 該当なし (script / test のみ) | 該当なし (script / test のみ) |
| **修正後** | 該当なし (script / test のみ) | 該当なし (script / test のみ) |

**インタラクティブ状態**: N/A

## コード品質セルフレビュー (#1481)

- [x] **SOLID**: gate script は「判定 (純関数) / IO (file 読み込み) / 出力 (main)」を分離し、判定関数は DI (`readFile` / `fetcher` / `registry`) で unit test から実 repo 非依存に検証できる
- [x] **DRY**: `pairBeforeAfter` は既存実装を再利用し `pairScreenshots` が委譲する (既定命名の判定ロジックを二重に書かない)。`isMain` helper (#3969) / `skipStateOf` (#4018) も既存 SSOT を使用。`grep -rn "readdirSync" tests/` で既存の走査 test を全件洗い出し、独自の走査 helper を新設していないことを確認
- [x] **YAGNI**: #4085 は Issue が挙げた 3 案のうち案 C (区分宣言 = 既存 #4048 パターンの横展開) のみを実装し、専用 lane への全件移設 (案 B) は行っていない。#4086 は案 A + 案 B の最小結合で、案 C (チェックリスト化のみ) は ADR-0061 に反するため不採用
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。`checkEvidencePrReferences` はネットワークを呼ばない (自 PR 番号との一致判定のみ) ので gate に外部依存を増やしていない
- [x] **アクセシビリティ**: N/A (UI 変更なし)
- [x] **パフォーマンス**: 新 gate は `tests/**/*.test.ts` を 1 回走査するだけ (実測 1 秒未満)。repo 走査 test への 60s timeout は「実行時間の上限」であり実行時間そのものは増えない

## 横展開・影響波及チェック

**並行実装ペア**:

- [ ] 本番アプリ + デモ版を同期
- [ ] LP ↔ アプリ双方向整合（ADR-0013）
- [ ] 全年齢モード 5 種に横展開
- [ ] ナビゲーション 3 種に反映
- [ ] E2E / ユニットシード + チュートリアルを同期
- [ ] labels SSOT (ADR-0009)
- [x] 設計書同期 (ADR-0001) — `tests/CLAUDE.md` / `src/routes/CLAUDE.md` / `CLAUDE.md` / `docs/codebase-map.md` / `.claude/skills/dev-open-pr/SKILL.md` を同一 PR で更新
- [x] 並行 PR overlap 確認 (#1200) — 下記
- [ ] N/A — 並行実装の影響範囲外

**並行 PR overlap (#1200)**: 同時進行の PR #4094 / #4095 の差分を `gh pr view <N> --json files` で確認した。

| PR | 変更ファイル | 本 PR との重複 |
|---|---|---|
| #4094 (#4083/#4069/#4071/#4076) | `.claude/hooks/heavy-run-{lock,unlock}.mjs` / `scripts/agent-cleanup.mjs` / `scripts/lib/agent-lock*.mjs` / `scripts/lib/heavy-process.mjs` / `docs/sessions/agent-concurrency.md` / `package.json` / `tests/unit/hooks/heavy-run-guard.test.ts` | **重複ファイル 0** |
| #4095 (#4082/#4057/#4075) | `.claude/hooks/{command-execution-tools,gate-approve}.mjs` / `.claude/settings.json` / `scripts/audit-approve-evidence.mjs` / `scripts/lib/gh-command.mjs` / `docs/decisions/0056-*.md` / `tests/unit/helpers/hook-tree-probe.ts` / `tests/unit/hooks/gate-approve-fail-closed.test.ts` | **重複ファイル 0** |

「どちらが先に merge されても壊れない」ことの根拠:

1. **ファイル重複ゼロ**。本 PR は `scripts/check-*.mjs` / `scripts/pre-ready.mjs` / `scripts/lib/ci/` / `tests/unit/scripts/` / `tests/unit/architecture/` / `.github/workflows/ci.yml` を触り、両 PR は `.claude/hooks/` / `scripts/lib/agent-*.mjs` / `scripts/lib/gh-command.mjs` / `tests/unit/hooks/` を触る。テキスト衝突は発生しない
2. **`package.json` を本 PR は変更していない** (#4094 は変更する)。新 gate は `node scripts/check-repo-scan-test-declaration.mjs` を直接実行する形にし npm script を新設していないので、#4094 の `package.json` 差分と競合しない
3. **新 gate の走査対象に両 PR の追加 test が入っても壊れない**。#4094 の `tests/unit/hooks/heavy-run-guard.test.ts` / #4095 の `tests/unit/hooks/gate-approve-fail-closed.test.ts` / `tests/unit/helpers/hook-tree-probe.ts` を本 PR HEAD の gate 判定にかけたところ、いずれも走査 API を使わない (= 候補外) ため registry への追加を要求しない。仮に将来これらが走査を始めても gate は「未宣言」で fail し貼り付け用エントリを出すので、silent には壊れない (これは本 PR が意図した挙動)
4. **`.claude/hooks/` の変更が本 PR の gate に影響しない**。本 PR が追加した検査は `tests/**` と PR body だけを入力に取り、hook の実装には依存しない

**LP / 販促文言変更時** (ADR-0013):

| 変更した文言 | 実装コードパス | Committed/Aspirational |
|------------|---------------|----------------------|
| N/A | N/A | N/A |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**
- [ ] 含まれる → 影響範囲・マイグレーション手順を以下に記載

アプリ本体の挙動は変わらない。開発フローに対しては以下が「今まで通っていたものが通らなくなる」変更にあたるが、いずれも Issue が明示的に要求した是正である。

1. AC 検証マップに他 PR の `--pr <数字>` を書いた PR は fail する (#4074 AC1)
2. SS を embed していてペアが取れない PR は fail する (#4084 AC1)。回避は理由付き宣言
3. repo 走査 test を宣言なしで追加すると fail する (#4085 AC2)
4. `STEP_COST_CLASS_BY_NAME` export は廃止 (#4086)。参照は本 PR 内の test 1 箇所のみで、外部参照は `grep -rn "STEP_COST_CLASS_BY_NAME"` で 0 件を確認済

**レビュー依頼事項・QA**:

- **#4085 の scope 静的判定の線引き**: 「repo root ディレクトリを名指しする文字列リテラル (3 セグメント以下) + 走査 API」を repo 走査と判定する。実走査しない file が `repo` と判定されうる (本 PR では `check-repo-scan-test-declaration.test.ts` 自身が該当) が、誤検出のコストは明示 timeout 1 行なので、判定を緩めるのではなく宣言側を合わせる方針を採った。逆方向 (走査しているのに `bounded` と判定される) は `scope-mismatch` では拾えないため、より深いパスを走査する test が現れたら判定式を広げる必要がある。この線引きの妥当性を見てほしい
- **#4086 で `[O1]`〜`[O9]` の取得元を変更した点**: assertion の意味は同一だが test 側の書き換えを伴うため、「弱体化ではない」ことを上記「ガードを弱めていない根拠」表と mutation M4 で示している。判定を仰ぎたい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A (UI 変更なし)
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A (認証画面の変更なし)
- [x] QA 承認・動作確認が完了している (Dev 完遂宣言)

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

