### PR TITLE
feat(dx): #4112 長時間セッションで止まる作業継続を、決定的オーケストレーター + 使い捨て worker に分離する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ docs/pr-assets/
 
 
 
+
+# autopilot orchestrator の state / ログ (#4112)
+scripts/.autopilot/

--- a/docs/sessions/autopilot-session.md
+++ b/docs/sessions/autopilot-session.md
@@ -1,0 +1,183 @@
+# Autopilot セッション — 無人で open PR / open issue を消化する
+
+**SSOT**: 実行体 → `scripts/autopilot.ps1` / 1 サイクルの動作定義 → 本ファイル §3 / 並行排他 → [agent-concurrency.md](agent-concurrency.md)
+
+---
+
+## 1. 設計背景
+
+### 解こうとしている問題
+
+Dev セッションで open PR / open issue を継続消化していると、**セッションが長くなるにつれて自動で次のステップへ進まなくなる**。人間が「続けて」と入力すると再開する。権限プロンプトで待っているのではなく、ターンが終了して戻ってこない。
+
+公式ドキュメントに、症状と整合する記述がある:
+
+> If a single file or tool output is so large that context refills immediately after each summary, **Claude Code stops auto-compacting after a few attempts and shows an error instead of looping.**
+> — [How Claude Code works](https://code.claude.com/docs/en/how-claude-code-works)
+
+Anthropic のエンジニアリングブログも、長時間エージェントの典型的失敗として同じ形を挙げている:
+
+> agents tend to attempt comprehensive implementation in a single session, which **exhausts context and leaves half-finished work.**
+> — [Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
+
+### なぜセッション内の継続機構では解けないのか
+
+`/loop` / `ScheduleWakeup` / `CronCreate` は、いずれも **同じ会話・同じ context window の中で次のターンを起こす**機構である。
+
+> **Tasks are session-scoped: they live in the current conversation** and stop when you start a new one.
+> — [Run prompts on a schedule](https://code.claude.com/docs/en/scheduled-tasks)
+
+したがって context 逼迫が原因なら、これらは同じ壁に当たり続ける。新しいセッションを立てるのは Routines（クラウド、最小 1 時間、ローカルファイル不可）か、**外部から `claude -p` を起動する決定的なプロセス**だけである。
+
+### なぜ上位オーケストレーターを LLM にしないのか
+
+**上位を LLM にすると、上位自身が同じ「長時間で止まる」問題を抱える。** 公式ドキュメントがこれを裏付けている。
+
+- Agent teams の lead は通常の Claude Code セッションであり独自の context window を持つ。公式 Troubleshooting に **「lead が作業完了前にシャットダウンを決めてしまうことがある」** が既知問題として記載されている。Best practices にも「無人で長時間放置するとムダな作業のリスクが上がる」とある。加えて experimental / default 無効
+- Dynamic Workflows は「プランをコードに移す」ことでこの問題を回避する設計だが、**セッションを跨げない**（Claude Code を終了すると次のセッションでは最初から）
+- Anthropic 公式の長時間ハーネスは、最上位に LLM を置かない。**Initializer 1 回 + Coding Agent 繰り返し**という決定的な再起動構造を採る
+
+**この判断を覆す前に上記 3 点を再確認すること。** 「lead を Claude にすれば柔軟になる」は一度検討して却下した案である。
+
+---
+
+## 2. 設計原則
+
+### 責務分割
+
+| | 決定的側（`scripts/autopilot.ps1`） | LLM 側（1 サイクル = 1 プロセスの `claude -p`） |
+|---|---|---|
+| 持つもの | セッションのライフサイクル / 上限管理（回数・コスト・時間）/ 停止判定 / 進捗ゼロ検出 / バックオフ / ログ | 次に何をやるかの選択 / 実装 / レビュー判断 / 結果の解釈 |
+| context | **持たない**（だから止まらない） | サイクルごとにゼロにリセットされる |
+
+判断能力を捨てずに、止まらない性質を得るための分割である。
+
+### 状態の SSOT は GitHub
+
+open PR / open issue / label / CI ステータス / レビューコメントが、そのまま state machine として機能する。**ローカルに作業状態を持たない。**
+
+`scripts/autopilot.ps1` が持つローカル state（`state.json`）は、サイクル計数・累計コスト・直近の着手対象・停止フラグのみ。これは「上限判定と反復検出」のためであって、作業内容の引き継ぎではない。
+
+### 自己申告を信じない
+
+各サイクルは、前サイクルの主張ではなく **git の事実と実際にコマンドを走らせた結果**から再開する。Anthropic 公式ハーネスの規律をそのまま採る:
+
+> Start the session by **reading the progress notes file and git commit logs, and run a basic test on the development server to catch any undocumented bugs.**
+
+PR body の「全 step PASS」「対応済み」は自己申告であり、事実ではない。
+
+### 排他は既存 hook に委ねる
+
+重い検証（`pre-ready` / `vitest` / `playwright` / `svelte-check`）のマシン全体排他は `.claude/hooks/heavy-run-lock.mjs` が既に機械強制している。**autopilot は lock を再実装しない。** BLOCK（exit 2）をシグナルとして受け、待たずに別の作業へ切り替える。
+
+`claude -p` で起動した worker も同じ hook を読むため、対話セッションや別クローン（QA チーム）との排他はそのまま維持される。
+
+**`--bare` は絶対に使わない。** hooks / CLAUDE.md / skills をすべてスキップするため、`heavy-run-lock` も `gate-approve` も無効化され、重い検証の二重起動が起きる。
+
+---
+
+## 3. 1 サイクルの動作定義（worker に渡すプロンプト SSOT）
+
+`scripts/autopilot.ps1` は本節の内容を `claude -p` に渡す。**プロンプトの実体は `scripts/autopilot-cycle-prompt.md`** で、本節はその設計意図を記す。
+
+| 手順 | 内容 | なぜ |
+|---|---|---|
+| 1 | `gh pr list` / `gh issue list` / `git log` で**事実**を読む | 前サイクルの主張を信用しない |
+| 2 | **1 件だけ**選ぶ | 全部やろうとして context を使い切り中途半端に終わるのを防ぐ |
+| 3 | 並列可能なものはサブエージェントへ / 重い検証は本体が 1 本ずつ | 並走した検証結果は「通った」も「落ちた」も根拠にならない |
+| 4 | GitHub に記録して終わる | ローカルのメモは次サイクルに引き継がれない |
+
+### 着手優先順位
+
+1. Draft PR で pre-ready 未完走 → 通して Ready 化
+2. Ready PR で QA 未実施 → QA サブエージェントでレビュー、`[must]` があれば修正まで
+3. CI が赤い PR → 切り分けて修正
+4. push 待ちの commit → push
+5. 未着手 Issue（critical / high 優先）
+6. 重複 / 実装済み Issue → 根拠を示して close
+
+### 飛ばしてよいもの（待たない）
+
+- 他セッションが heavy lock を保持している
+- push が別ブランチの lock で BLOCK される
+- `verify-by:owner` / staging 実機検証が要るもの
+
+### PO 決裁の扱い
+
+`po-decision:required` ラベルが付いた PR で人間を待たない。**`PO Session Agent` サブエージェントを起動し、[po-session.md](po-session.md) に基づいて決裁させる**（オーナー判断 2026-07-30）。
+
+### サイクルの終了報告
+
+worker は最終行に以下を出力する。`scripts/autopilot.ps1` が正規表現で読み、反復検出に使う。
+
+```
+AUTOPILOT_RESULT target=<PR#123|ISSUE#456|NONE> action=<ready|fixed|reviewed|closed|pushed|filed|blocked|noop> detail=<40字以内>
+```
+
+---
+
+## 4. 安全弁（5 つすべてが必須）
+
+| # | 安全弁 | 既定値 | 目的 |
+|---|---|---|---|
+| 1 | 停止フラグファイル | `scripts/.autopilot/STOP` | 外部から即座に止める |
+| 2 | サイクル数上限 | 40 | 無限ループ防止 |
+| 3 | 累計コスト上限 | $100 | `claude -p` の `total_cost_usd` を加算して判定 |
+| 4 | 総経過時間上限 | 720 分 | 放置事故の時間的な蓋 |
+| 5 | 進捗ゼロ連続 | 5 回 | 同じ対象を繰り返す / 全候補が blocked のとき人間に返す |
+
+コスト上限は実在の事故を踏まえた必須要件である。30 分間隔ループで prompt cache を外し、1 日で $6,000 を消費した公開事例がある。
+
+### 止め方
+
+```powershell
+# 次のサイクル冒頭で終了する（推奨・安全）
+New-Item -ItemType File scripts\.autopilot\STOP
+
+# 即時停止
+Ctrl+C   # SIGTERM で turn を中断し SessionEnd hook を実行して exit 143
+```
+
+background session が残った場合は `claude daemon stop --any`。
+
+---
+
+## 5. 使い方
+
+```powershell
+# 動作確認（claude を起動せず判定ロジックだけ流す）
+pwsh -File scripts\autopilot.ps1 -DryRun -Once
+
+# 1 サイクルだけ実行して結果を見る
+pwsh -File scripts\autopilot.ps1 -Once
+
+# 通常運用
+pwsh -File scripts\autopilot.ps1
+
+# 上限を明示する
+pwsh -File scripts\autopilot.ps1 -MaxCycles 20 -MaxCostUsd 50 -MaxMinutes 480
+```
+
+ログは `scripts/.autopilot/logs/` に出る（`autopilot.log` = 進行ログ / `cycle-NNN.json` = 各サイクルの raw 出力）。
+
+---
+
+## 6. 既知の制約
+
+| 制約 | 内容 |
+|---|---|
+| **`claude -p` の background subagent 待ち** | デフォルト 10 分で打ち切る。`CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS` で調整（`0` で無制限）。重い検証を subagent 経由で回す場合は要調整 |
+| **サイクル起動コスト** | サイクルごとに CLAUDE.md / skills / MCP をロードし直す |
+| **サイクル間の作業記憶がない** | 設計上の意図。引き継ぎたいことは必ず GitHub に書く |
+| **1 サイクルの長さ設計** | `pre-ready` が 20〜30 分かかるため、`CycleTimeoutMinutes` は最低でもその倍を確保する |
+
+---
+
+## 7. 関連
+
+- [dev-session.md](dev-session.md) — worker が従う Dev ロール定義
+- [po-session.md](po-session.md) — PO 決裁サブエージェントのロール定義
+- [qa-session.md](qa-session.md) — QA レビューサブエージェントのロール定義
+- [agent-concurrency.md](agent-concurrency.md) — 並行排他の運用規約
+- [Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents) — 本設計の下敷き
+- [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents) — 外部メモリによる状態引き継ぎ

--- a/scripts/autopilot-cycle-prompt.md
+++ b/scripts/autopilot-cycle-prompt.md
@@ -37,6 +37,12 @@ CI ステータスが必要なら `gh pr checks <N>` を見てください。
 5. **未着手 Issue** — 実装する（priority:critical / high を優先）
 6. **重複 / 実装済み Issue** — 根拠を示して close する
 
+**絶対に触らないもの**（他チーム管轄・autopilot の scope 外）:
+
+- **統合 PR（`[統合] develop → main`、現 #3995）** — 外部品質監査チーム管轄。body 再生成・approve・merge のいずれも行わない
+- **`refactor/4097-*` 等、他セッションが作業中のブランチ** — lock で BLOCK されたら二重作業なので手を出さない
+- **QA が BLOCK コメントを出している PR の、その指摘への対応以外の変更** — レビュー中の diff を動かさない
+
 **飛ばしてよいもの**（ブロックされたら次へ）:
 
 - 他セッションが heavy lock を保持していて重い検証ができない → **待たずに別の作業へ**
@@ -50,7 +56,8 @@ CI ステータスが必要なら `gh pr checks <N>` を見てください。
 ### 並列化してよいもの（サブエージェントを使う）
 
 - **QA レビュー** → `QA Session Agent` サブエージェント
-- **PO 判断** → `PO Session Agent` サブエージェント（`docs/sessions/po-session.md` 準拠）。`po-decision:required` ラベルが付いた PR は**人間を待たず、PO サブエージェントに決裁させてください**
+- **PO 判断** → `PO Session Agent` サブエージェント（`docs/sessions/po-session.md` 準拠）。`po-decision:required` ラベルが付いた PR は**人間を待たず、PO サブエージェントに決裁させてください**（オーナー判断 2026-07-30）。
+  **ただしこれは「プロダクト判断を代行する」ことであって、`approve` / `merge` の代行ではありません。** approve / merge は lab アカウント専権のまま変わりません（ADR-0022）。 PO サブエージェントの決裁結果は PR body / コメントに残し、merge 判断は QA / 監査に委ねてください
 - **実装 / 修正** → `Dev Session Agent` サブエージェント（worktree 分離）
 
 サブエージェントには**必ず以下を伝えてください**:

--- a/scripts/autopilot-cycle-prompt.md
+++ b/scripts/autopilot-cycle-prompt.md
@@ -1,0 +1,104 @@
+あなたは がんばりクエスト の Dev セッションです。`E:\Github\ganbari-quest-dev\docs\sessions\dev-session.md` に従ってください。
+
+これは**無人オーケストレーターが起動した 1 サイクル**です。前のサイクルの記憶はありません。**それが正常です。** 状態は GitHub にあります。
+
+## このサイクルの目的
+
+**open PR と open issue を 0 件に近づけること。1 サイクルで 1 件だけ前に進めてください。**
+
+全部やろうとしないでください。1 セッションで包括的に実装しようとして context を使い切り、中途半端な作業を残すのが最悪の結果です。
+
+---
+
+## 手順 1: 状態を「事実」から読む（必須・最初にやる）
+
+**前のサイクルの主張は一切読まないでください。** PR body や Issue コメントに書かれた「対応済み」「全 step PASS」は自己申告であり、事実ではありません。以下のコマンドで実際の状態を取得してください。
+
+```bash
+cd E:/Github/ganbari-quest-dev
+git fetch origin develop main --quiet
+gh pr list --state open --limit 30 --json number,isDraft,title,mergeable,statusCheckRollup
+gh issue list --state open --limit 200 --json number,title,labels
+git log --oneline origin/develop -5
+```
+
+CI ステータスが必要なら `gh pr checks <N>` を見てください。
+
+---
+
+## 手順 2: 1 件だけ選ぶ
+
+**優先順位**（上から順に、着手可能な最初の 1 件）:
+
+1. **Draft PR で pre-ready が未実行 / 未完走のもの** — `npm run pre-ready -- --pr <N>` を通して Ready 化する
+2. **Ready PR で QA レビュー未実施のもの** — QA サブエージェントでレビューし、`[must]` があれば修正まで
+3. **CI が赤い PR** — 原因を切り分けて直す
+4. **push できていない commit を持つブランチ** — push する
+5. **未着手 Issue** — 実装する（priority:critical / high を優先）
+6. **重複 / 実装済み Issue** — 根拠を示して close する
+
+**飛ばしてよいもの**（ブロックされたら次へ）:
+
+- 他セッションが heavy lock を保持していて重い検証ができない → **待たずに別の作業へ**
+- push が別ブランチの lock で BLOCK される → **待たずに別の作業へ**
+- `verify-by:owner` ラベル / staging 実機検証が要るもの → **飛ばす**
+
+---
+
+## 手順 3: 実行する
+
+### 並列化してよいもの（サブエージェントを使う）
+
+- **QA レビュー** → `QA Session Agent` サブエージェント
+- **PO 判断** → `PO Session Agent` サブエージェント（`docs/sessions/po-session.md` 準拠）。`po-decision:required` ラベルが付いた PR は**人間を待たず、PO サブエージェントに決裁させてください**
+- **実装 / 修正** → `Dev Session Agent` サブエージェント（worktree 分離）
+
+サブエージェントには**必ず以下を伝えてください**:
+
+> 重いコマンド（`npm run pre-ready` / 引数なしの `vitest run` / `playwright test`）は実行禁止。本体の直列キューでのみ実行する。`git push` は本体が行う。`--no-verify` 禁止。mutation 検証で `git checkout --` を使わない（先に commit する）。approve / merge はしない（ADR-0022）。assertion を弱めない（ADR-0006）。
+
+### 直列必須のもの（サブエージェントに投げない・同時に 1 本だけ）
+
+`npm run pre-ready -- --pr <N>` は**このセッション本体が、1 度に 1 本だけ**実行してください。
+
+- **LP（`site/**`）を変更する PR では `SKIP_SCREENSHOT_EXISTENCE_CHECK=1` を付ける**（`site/screenshots/` は gitignore で CI 生成のため、付けないと必ず偽の赤になる）
+- `heavy-run-lock` に BLOCK されたら**待たない**。手順 2 の「飛ばしてよいもの」に従って別の作業へ移る
+- vitest が `Test timed out in 5000ms` で落ちたら、**それは負荷由来の可能性が高い**。同じ file を単独実行して切り分けること（assertion 失敗なら本物）
+
+---
+
+## 手順 4: 記録して終わる
+
+**GitHub に記録してください。** ローカルのメモは次のサイクルに引き継がれません。
+
+- PR を進めたら PR body / コメントに実測の証跡を書く（step 名・exit code・失敗件数）
+- Issue を close したら根拠（commit / PR / ファイル:行）をコメントに残す
+- 新しく気づいた問題は **follow-up Issue を起票**する（`.claude/skills/issue-triage/SKILL.md` 準拠: 根本原因 5 Whys / AC / AC 検証計画 / 代替案 / Pre-PMF 判定）
+
+### 最終行に必ずこの形式で 1 行出力してください（オーケストレーターが読みます）
+
+```
+AUTOPILOT_RESULT target=<PR#123 または ISSUE#456 または NONE> action=<ready|fixed|reviewed|closed|pushed|filed|blocked|noop> detail=<40字以内>
+```
+
+例:
+```
+AUTOPILOT_RESULT target=PR#4096 action=ready detail=pre-ready 13 step PASS で Ready 化
+AUTOPILOT_RESULT target=NONE action=blocked detail=heavy lock 保持中で全候補が着手不可
+```
+
+---
+
+## 絶対にやらないこと
+
+- **`--bare` を付けて claude を起動する**（hooks が全て無効化され、排他 lock も承認 gate も消える）
+- **他セッションの lock を強制解放する / 他セッションのプロセスを kill する**
+- **`git push --force`（`--force-with-lease` は可）/ 本番デプロイ / DB スキーマ変更 / `.env` の変更 / `rm -rf`**
+- **`--no-verify` で hook を迂回する**
+- **PR の approve / merge**（lab アカウント専権、ADR-0022）
+- **実画面未確認で UI の完了を宣言する / 検証していないことを「検証済み」と書く**
+- **重い検証を並列に走らせる**（並走した結果は「通った」も「落ちた」も根拠にならない）
+
+## 判断に迷ったら
+
+止まらないでください。**飛ばして次の候補に移り、最終行に `action=blocked` で理由を書いてください。** オーケストレーターが次のサイクルで別の切り口を試します。

--- a/scripts/autopilot-cycle-prompt.md
+++ b/scripts/autopilot-cycle-prompt.md
@@ -15,7 +15,7 @@
 **前のサイクルの主張は一切読まないでください。** PR body や Issue コメントに書かれた「対応済み」「全 step PASS」は自己申告であり、事実ではありません。以下のコマンドで実際の状態を取得してください。
 
 ```bash
-cd E:/Github/ganbari-quest-dev
+# カレントは autopilot が渡したリポジトリ (worktree の場合あり)。パスは決め打ちしない。
 git fetch origin develop main --quiet
 gh pr list --state open --limit 30 --json number,isDraft,title,mergeable,statusCheckRollup
 gh issue list --state open --limit 200 --json number,title,labels

--- a/scripts/autopilot.ps1
+++ b/scripts/autopilot.ps1
@@ -38,6 +38,13 @@ param(
     # 進捗ゼロがこの回数連続したら停止する。
     [int]$MaxNoProgress = 5,
 
+    # total_cost_usd を取得できなかったサイクルに計上する保守的な推定額 (USD)。
+    # 0 にすると上限判定が働かなくなるため 0 を許さない。
+    [double]$FallbackCycleCostUsd = 5.0,
+
+    # コストを計測できないサイクルがこの回数連続したら停止する (上限を保証できないため)。
+    [int]$MaxCostUnknownRuns = 3,
+
     # 起動時に 1 サイクルだけ実行して終了する (動作確認用)。
     [switch]$Once,
 
@@ -49,7 +56,7 @@ $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
 # scripts/ 直下に置かれる前提。リポジトリルートは 1 つ上。
-# 別 PC / 別クローンでも動くよう、絶対パスをハードコードしない (#4111)。
+# 別 PC / 別クローンでも動くよう、絶対パスをハードコードしない (#4112)。
 $ScriptDir = $PSScriptRoot
 $RepoDir   = (Resolve-Path (Join-Path $ScriptDir '..')).Path
 $WorkDir   = Join-Path $ScriptDir '.autopilot'
@@ -94,6 +101,7 @@ function Read-State {
         cycle          = 0
         totalCostUsd   = 0.0
         noProgressRuns = 0
+        costUnknownRuns = 0
         recentTargets  = @()
         lastOpenPr     = -1
         lastOpenIssue  = -1
@@ -110,7 +118,7 @@ function Save-State {
 # ---------------------------------------------------------------------------
 
 # gh の JSON 配列を件数にする。
-# 実測 (#4111): `@($json | ConvertFrom-Json).Count` は Windows PowerShell 5.1 で常に 1 を返し、
+# 実測 (#4112): `@($json | ConvertFrom-Json).Count` は Windows PowerShell 5.1 で常に 1 を返し、
 # open PR 11 件 / open issue 118 件を「1 件」と誤認した。-join で 1 本の文字列に正規化してから
 # 変換すると正しく列挙される。件数を誤ると完了判定と進捗ゼロ検出が両方壊れるため関数に固定する。
 function Measure-JsonArray {
@@ -150,7 +158,7 @@ function Invoke-Cycle {
     }
 
     # prompt は stdin から渡す。
-    # 実測 (#4111): `ProcessStartInfo.ArgumentList` は .NET Framework 4.x (Windows PowerShell 5.1)
+    # 実測 (#4112): `ProcessStartInfo.ArgumentList` は .NET Framework 4.x (Windows PowerShell 5.1)
     # に存在せず PropertyNotFoundException になる。長い多行 prompt をコマンドライン引数として
     # quoting するのも壊れやすいため、`claude -p` が stdin から prompt を読む経路を使う。
     #
@@ -176,16 +184,17 @@ function Invoke-Cycle {
     $stdout = if (Test-Path $outFile) { Get-Content $outFile -Raw -Encoding utf8 } else { '' }
 
     $cost = 0.0
+    $costKnown = $false
     $resultText = ''
     # 成否は claude の JSON (`is_error`) を第一の根拠にする。
-    # 実測 (#4111): Start-Process -PassThru の `$proc.ExitCode` は、JSON が
+    # 実測 (#4112): Start-Process -PassThru の `$proc.ExitCode` は、JSON が
     # `is_error:false` / `subtype:success` / `stop_reason:end_turn` を返した成功サイクルでも
     # 非 0 になった。exit code だけを見ると成功を失敗と記録してしまう。
     $okFromJson = $null
     try {
         $json = $stdout | ConvertFrom-Json
         $names = $json.PSObject.Properties.Name
-        if ($names -contains 'total_cost_usd') { $cost = [double]$json.total_cost_usd }
+        if ($names -contains 'total_cost_usd') { $cost = [double]$json.total_cost_usd; $costKnown = $true }
         if ($names -contains 'result')         { $resultText = [string]$json.result }
         if ($names -contains 'is_error')       { $okFromJson = -not [bool]$json.is_error }
     } catch {
@@ -193,8 +202,18 @@ function Invoke-Cycle {
         $resultText = $stdout
     }
 
-    $ok = if ($null -ne $okFromJson) { $okFromJson } else { $proc.ExitCode -eq 0 }
-    return @{ ok = $ok; cost = $cost; result = $resultText; exitCode = $proc.ExitCode }
+    $ok0 = if ($null -ne $okFromJson) { $okFromJson } else { $proc.ExitCode -eq 0 }
+
+    # コスト抽出に失敗したときに 0 として扱わない (fail-open 防止)。
+    # 0 を加算し続けると累計が伸びず `$MaxCostUsd` 判定が永久に成立しないため、
+    # 「コストを計測できない = 上限を保証できない」を保守的な推定値 + 連続失敗カウントで扱う。
+    # 件数バグ (Measure-JsonArray) と同型の「取得失敗が安全側に見える」経路を塞ぐ。
+    if (-not $costKnown) {
+        $cost = $FallbackCycleCostUsd
+        Write-Line ("サイクル $CycleNo の total_cost_usd を取得できませんでした。保守的に `${0:N2} を計上します" -f $FallbackCycleCostUsd) 'WARN'
+    }
+
+    return @{ ok = $ok0; cost = $cost; costKnown = $costKnown; result = $resultText; exitCode = $proc.ExitCode }
 }
 
 function Get-TargetFromResult {
@@ -262,6 +281,19 @@ while ($true) {
     $r = Invoke-Cycle -CycleNo $state.cycle
     $state.totalCostUsd += $r.cost
     $target = Get-TargetFromResult -Text $r.result
+
+    # --- 安全弁 3b: コストを計測できないサイクルが続いたら止める ------------
+    # 上限を保証できない状態で回し続けないため、fail-closed で停止する。
+    if ($r.costKnown) {
+        $state.costUnknownRuns = 0
+    } else {
+        $state.costUnknownRuns++
+        if ($state.costUnknownRuns -ge $MaxCostUnknownRuns) {
+            Save-State $state
+            Write-Line "コストを $MaxCostUnknownRuns 回連続で計測できませんでした。上限を保証できないため終了します" 'STOP'
+            break
+        }
+    }
 
     Write-Line ("cycle $($state.cycle) 終了: ok=$($r.ok) target=$target cost=`${0:N4} 累計=`${1:N2}" -f $r.cost, $state.totalCostUsd)
     if ($r.result) {

--- a/scripts/autopilot.ps1
+++ b/scripts/autopilot.ps1
@@ -1,0 +1,313 @@
+﻿<#
+.SYNOPSIS
+  がんばりクエスト: open PR / open issue を 0 件に向けて消化する無人オーケストレーター。
+
+.DESCRIPTION
+  Anthropic 公式の long-running agent harness パターン
+  (https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
+  に沿った「決定的オーケストレーター + 使い捨て worker」構成。
+
+    - 決定的側 (このスクリプト): セッションの起動・上限管理・停止判定・進捗ゼロ検出
+      → context を持たないので「長時間で止まる」問題が構造的に起きない
+    - LLM 側 (1 サイクル = 1 プロセスの claude -p): 何を next にやるかの判断・実装・レビュー
+      → サイクルごとに context がゼロにリセットされる
+
+  状態の SSOT は GitHub (open PR / open issue / label / CI)。
+  ローカル state はサイクル計数・コスト・反復検出のみ (state.json)。
+
+.NOTES
+  - `--bare` は絶対に使わない。hooks (heavy-run-lock / gate-approve) が無効化されるため。
+  - heavy 検証の排他は既存の PreToolUse hook (machine-wide file lock) がそのまま効く。
+    このスクリプトは lock を再実装しない。
+#>
+
+[CmdletBinding()]
+param(
+    # サイクル数の上限。0 で無制限 (非推奨)。
+    [int]$MaxCycles = 40,
+
+    # 累計コスト上限 (USD)。claude -p の total_cost_usd を加算して判定する。
+    [double]$MaxCostUsd = 100.0,
+
+    # 総経過時間の上限 (分)。
+    [int]$MaxMinutes = 720,
+
+    # 1 サイクルのタイムアウト (分)。pre-ready が 20-30 分かかるため余裕を持たせる。
+    [int]$CycleTimeoutMinutes = 60,
+
+    # 進捗ゼロがこの回数連続したら停止する。
+    [int]$MaxNoProgress = 5,
+
+    # 起動時に 1 サイクルだけ実行して終了する (動作確認用)。
+    [switch]$Once,
+
+    # 実際には claude を起動せず、判定ロジックだけ流す。
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# scripts/ 直下に置かれる前提。リポジトリルートは 1 つ上。
+# 別 PC / 別クローンでも動くよう、絶対パスをハードコードしない (#4111)。
+$ScriptDir = $PSScriptRoot
+$RepoDir   = (Resolve-Path (Join-Path $ScriptDir '..')).Path
+$WorkDir   = Join-Path $ScriptDir '.autopilot'
+
+$PromptFile= Join-Path $ScriptDir 'autopilot-cycle-prompt.md'
+$StateFile = Join-Path $WorkDir 'state.json'
+$StopFile  = Join-Path $WorkDir 'STOP'
+$LogDir    = Join-Path $WorkDir 'logs'
+
+if (-not (Test-Path $WorkDir)) { New-Item -ItemType Directory -Path $WorkDir | Out-Null }
+
+if (-not (Test-Path $LogDir)) { New-Item -ItemType Directory -Path $LogDir | Out-Null }
+if (-not (Test-Path $PromptFile)) { throw "サイクル prompt がありません: $PromptFile" }
+if (-not (Test-Path (Join-Path $RepoDir '.git'))) { throw "git リポジトリではありません: $RepoDir" }
+
+# ---------------------------------------------------------------------------
+# ログ
+# ---------------------------------------------------------------------------
+
+# Windows PowerShell 5.1 の既定コンソール encoding では日本語ログが文字化けするため明示する。
+try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch { }
+
+function Write-Line {
+    param([string]$Message, [string]$Level = 'INFO')
+    $ts = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
+    $line = "[$ts] [$Level] $Message"
+    Write-Host $line
+    Add-Content -Path (Join-Path $LogDir 'autopilot.log') -Value $line -Encoding utf8
+}
+
+# ---------------------------------------------------------------------------
+# state
+# ---------------------------------------------------------------------------
+
+function Read-State {
+    if (Test-Path $StateFile) {
+        try { return Get-Content $StateFile -Raw -Encoding utf8 | ConvertFrom-Json }
+        catch { Write-Line "state.json が壊れています。初期化します: $_" 'WARN' }
+    }
+    return [pscustomobject]@{
+        startedAt      = (Get-Date).ToString('o')
+        cycle          = 0
+        totalCostUsd   = 0.0
+        noProgressRuns = 0
+        recentTargets  = @()
+        lastOpenPr     = -1
+        lastOpenIssue  = -1
+    }
+}
+
+function Save-State {
+    param($State)
+    $State | ConvertTo-Json -Depth 6 | Set-Content -Path $StateFile -Encoding utf8
+}
+
+# ---------------------------------------------------------------------------
+# GitHub の実状態 (完了判定の根拠。worker の自己申告は使わない)
+# ---------------------------------------------------------------------------
+
+# gh の JSON 配列を件数にする。
+# 実測 (#4111): `@($json | ConvertFrom-Json).Count` は Windows PowerShell 5.1 で常に 1 を返し、
+# open PR 11 件 / open issue 118 件を「1 件」と誤認した。-join で 1 本の文字列に正規化してから
+# 変換すると正しく列挙される。件数を誤ると完了判定と進捗ゼロ検出が両方壊れるため関数に固定する。
+function Measure-JsonArray {
+    param([object]$Json)
+    if (-not $Json) { return -1 }
+    try {
+        $parsed = (@($Json) -join "`n") | ConvertFrom-Json
+        if ($null -eq $parsed) { return 0 }
+        return @($parsed).Count
+    } catch {
+        return -1
+    }
+}
+
+function Get-OpenCounts {
+    Push-Location $RepoDir
+    try {
+        $prJson    = & gh pr list --state open --limit 100 --json number 2>$null
+        $issueJson = & gh issue list --state open --limit 300 --json number 2>$null
+        return @{ pr = (Measure-JsonArray $prJson); issue = (Measure-JsonArray $issueJson) }
+    } finally { Pop-Location }
+}
+
+# ---------------------------------------------------------------------------
+# 1 サイクル = claude -p を 1 プロセス起動 (新しい context)
+# ---------------------------------------------------------------------------
+
+function Invoke-Cycle {
+    param([int]$CycleNo)
+
+    $outFile = Join-Path $LogDir ("cycle-{0:D3}.json" -f $CycleNo)
+    $errFile = Join-Path $LogDir ("cycle-{0:D3}.err" -f $CycleNo)
+
+    if ($DryRun) {
+        Write-Line "DryRun: claude は起動しません" 'WARN'
+        return @{ ok = $true; cost = 0.0; result = 'AUTOPILOT_RESULT target=NONE action=noop detail=dry run' }
+    }
+
+    # prompt は stdin から渡す。
+    # 実測 (#4111): `ProcessStartInfo.ArgumentList` は .NET Framework 4.x (Windows PowerShell 5.1)
+    # に存在せず PropertyNotFoundException になる。長い多行 prompt をコマンドライン引数として
+    # quoting するのも壊れやすいため、`claude -p` が stdin から prompt を読む経路を使う。
+    #
+    # --bare は付けない (hooks を殺さないため)。
+    # --permission-mode bypassPermissions は無人実行のため。承認プロンプトで止まらせない。
+    $claudeArgs = '-p --permission-mode bypassPermissions --output-format json'
+
+    $proc = Start-Process -FilePath 'claude' `
+        -ArgumentList $claudeArgs `
+        -WorkingDirectory $RepoDir `
+        -NoNewWindow -PassThru `
+        -RedirectStandardInput $PromptFile `
+        -RedirectStandardOutput $outFile `
+        -RedirectStandardError $errFile
+
+    $timeoutMs = $CycleTimeoutMinutes * 60 * 1000
+    if (-not $proc.WaitForExit($timeoutMs)) {
+        Write-Line "サイクル $CycleNo がタイムアウト ($CycleTimeoutMinutes 分)。プロセスツリーを終了します" 'WARN'
+        try { & taskkill /F /T /PID $proc.Id | Out-Null } catch { Write-Line "taskkill 失敗: $_" 'WARN' }
+        return @{ ok = $false; cost = 0.0; result = 'AUTOPILOT_RESULT target=NONE action=blocked detail=cycle timeout' }
+    }
+
+    $stdout = if (Test-Path $outFile) { Get-Content $outFile -Raw -Encoding utf8 } else { '' }
+
+    $cost = 0.0
+    $resultText = ''
+    # 成否は claude の JSON (`is_error`) を第一の根拠にする。
+    # 実測 (#4111): Start-Process -PassThru の `$proc.ExitCode` は、JSON が
+    # `is_error:false` / `subtype:success` / `stop_reason:end_turn` を返した成功サイクルでも
+    # 非 0 になった。exit code だけを見ると成功を失敗と記録してしまう。
+    $okFromJson = $null
+    try {
+        $json = $stdout | ConvertFrom-Json
+        $names = $json.PSObject.Properties.Name
+        if ($names -contains 'total_cost_usd') { $cost = [double]$json.total_cost_usd }
+        if ($names -contains 'result')         { $resultText = [string]$json.result }
+        if ($names -contains 'is_error')       { $okFromJson = -not [bool]$json.is_error }
+    } catch {
+        Write-Line "サイクル $CycleNo の出力を JSON として解釈できませんでした (exit=$($proc.ExitCode))" 'WARN'
+        $resultText = $stdout
+    }
+
+    $ok = if ($null -ne $okFromJson) { $okFromJson } else { $proc.ExitCode -eq 0 }
+    return @{ ok = $ok; cost = $cost; result = $resultText; exitCode = $proc.ExitCode }
+}
+
+function Get-TargetFromResult {
+    param([string]$Text)
+    if (-not $Text) { return 'NONE' }
+    $m = [regex]::Match($Text, 'AUTOPILOT_RESULT\s+target=(\S+)')
+    if ($m.Success) { return $m.Groups[1].Value }
+    return 'UNPARSED'
+}
+
+# ---------------------------------------------------------------------------
+# メインループ
+# ---------------------------------------------------------------------------
+
+$state = Read-State
+$startTime = [datetime]::Parse($state.startedAt)
+
+Write-Line "=== autopilot 開始 ==="
+Write-Line "上限: cycles=$MaxCycles / cost=`$$MaxCostUsd / minutes=$MaxMinutes / no-progress=$MaxNoProgress"
+Write-Line "停止するには: New-Item '$StopFile' を作成してください"
+
+while ($true) {
+
+    # --- 安全弁 1: 停止フラグ --------------------------------------------
+    if (Test-Path $StopFile) {
+        Write-Line "STOP フラグを検出しました。終了します" 'STOP'
+        Remove-Item $StopFile -Force -ErrorAction SilentlyContinue
+        break
+    }
+
+    # --- 安全弁 2: サイクル数 --------------------------------------------
+    if ($MaxCycles -gt 0 -and $state.cycle -ge $MaxCycles) {
+        Write-Line "サイクル上限 $MaxCycles に到達しました。終了します" 'STOP'
+        break
+    }
+
+    # --- 安全弁 3: 累計コスト --------------------------------------------
+    if ($state.totalCostUsd -ge $MaxCostUsd) {
+        Write-Line ("累計コスト上限に到達しました (`${0:N2} >= `${1:N2})。終了します" -f $state.totalCostUsd, $MaxCostUsd) 'STOP'
+        break
+    }
+
+    # --- 安全弁 4: 総経過時間 --------------------------------------------
+    $elapsed = (Get-Date) - $startTime
+    if ($elapsed.TotalMinutes -ge $MaxMinutes) {
+        Write-Line ("経過時間上限に到達しました ({0:N0} 分)。終了します" -f $elapsed.TotalMinutes) 'STOP'
+        break
+    }
+
+    # --- 完了判定 (GitHub の実状態で判断する) ----------------------------
+    $before = Get-OpenCounts
+    if ($before.pr -eq 0 -and $before.issue -eq 0) {
+        Write-Line "open PR / open issue がともに 0 件になりました。完了です" 'DONE'
+        break
+    }
+    if ($before.pr -lt 0 -or $before.issue -lt 0) {
+        Write-Line "gh から状態を取得できませんでした (認証切れ?)。5 分待って再試行します" 'WARN'
+        Start-Sleep -Seconds 300
+        continue
+    }
+
+    $state.cycle++
+    Write-Line "--- cycle $($state.cycle) 開始 (open PR=$($before.pr) / open issue=$($before.issue)) ---"
+
+    $r = Invoke-Cycle -CycleNo $state.cycle
+    $state.totalCostUsd += $r.cost
+    $target = Get-TargetFromResult -Text $r.result
+
+    Write-Line ("cycle $($state.cycle) 終了: ok=$($r.ok) target=$target cost=`${0:N4} 累計=`${1:N2}" -f $r.cost, $state.totalCostUsd)
+    if ($r.result) {
+        $line = ($r.result -split "`n" | Where-Object { $_ -match 'AUTOPILOT_RESULT' } | Select-Object -Last 1)
+        if ($line) { Write-Line "  $line" }
+    }
+
+    # --- 進捗ゼロ検出 -----------------------------------------------------
+    $after = Get-OpenCounts
+    $progressed = ($after.pr -lt $before.pr) -or ($after.issue -lt $before.issue)
+
+    # 件数が減らなくても「同じ対象を繰り返していない」なら前進とみなす
+    # (Draft→Ready、QA 修正、body 整備は件数を減らさないため)
+    $recent = @($state.recentTargets)
+    $repeating = ($target -ne 'NONE') -and ($recent.Count -ge 2) -and
+                 ($recent[-1] -eq $target) -and ($recent[-2] -eq $target)
+
+    if ($progressed) {
+        $state.noProgressRuns = 0
+    } elseif ($repeating -or $target -eq 'NONE') {
+        $state.noProgressRuns++
+        Write-Line "進捗ゼロ ($($state.noProgressRuns)/$MaxNoProgress): target=$target repeating=$repeating" 'WARN'
+    } else {
+        $state.noProgressRuns = 0
+    }
+
+    $recent += $target
+    if ($recent.Count -gt 6) { $recent = $recent[-6..-1] }
+    $state.recentTargets = $recent
+    $state.lastOpenPr    = $after.pr
+    $state.lastOpenIssue = $after.issue
+    Save-State $state
+
+    # --- 安全弁 5: 進捗ゼロ連続 -------------------------------------------
+    if ($state.noProgressRuns -ge $MaxNoProgress) {
+        Write-Line "進捗ゼロが $MaxNoProgress 回連続しました。人間の判断が要ると判断して終了します" 'STOP'
+        break
+    }
+
+    if ($Once) { Write-Line "-Once が指定されているため 1 サイクルで終了します" 'STOP'; break }
+
+    # --- バックオフ (進捗が無いほど長く待つ = 他セッションの lock 解放を待つ) --
+    $sleepSec = [Math]::Min(60 + ($state.noProgressRuns * 120), 900)
+    Write-Line "次のサイクルまで $sleepSec 秒待機します"
+    Start-Sleep -Seconds $sleepSec
+}
+
+Write-Line "=== autopilot 終了 (cycle=$($state.cycle) / 累計コスト=`$$([Math]::Round($state.totalCostUsd,2))) ==="
+Save-State $state

--- a/tests/unit/scripts/autopilot-syntax.test.ts
+++ b/tests/unit/scripts/autopilot-syntax.test.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * #4111: autopilot オーケストレーターの構造検証。
+ * #4112: autopilot オーケストレーターの構造検証。
  *
  * 本 script は「無人で長時間動く」ことが目的なので、壊れていることに気づくのが遅れる。
  * 起動できない / 安全弁が消えている / 環境依存パスが再混入した、を CI で検出する。
@@ -39,7 +39,7 @@ function powerShellExe(): string {
 	}
 }
 
-describe('autopilot orchestrator (#4111)', () => {
+describe('autopilot orchestrator (#4112)', () => {
 	it('[A1] 実行体・prompt・設計 doc の 3 点が揃っている', () => {
 		expect(existsSync(SCRIPT), `${SCRIPT} が無い`).toBe(true);
 		expect(existsSync(PROMPT), `${PROMPT} が無い`).toBe(true);
@@ -61,7 +61,9 @@ describe('autopilot orchestrator (#4111)', () => {
 		expect(src, 'サイクル数上限が無い').toMatch(/\$state\.cycle\s+-ge\s+\$MaxCycles/);
 		expect(src, '累計コスト上限が無い').toMatch(/\$state\.totalCostUsd\s+-ge\s+\$MaxCostUsd/);
 		expect(src, '経過時間上限が無い').toMatch(/TotalMinutes\s+-ge\s+\$MaxMinutes/);
-		expect(src, '進捗ゼロ連続の上限が無い').toMatch(/\$state\.noProgressRuns\s+-ge\s+\$MaxNoProgress/);
+		expect(src, '進捗ゼロ連続の上限が無い').toMatch(
+			/\$state\.noProgressRuns\s+-ge\s+\$MaxNoProgress/,
+		);
 	});
 
 	it('[A4] --bare を付けて claude を起動していない (hooks を殺さない)', () => {
@@ -87,8 +89,33 @@ describe('autopilot orchestrator (#4111)', () => {
 		expect(prompt, '結果行のフォーマット指定が無い').toContain('AUTOPILOT_RESULT');
 	});
 
+	it('[A9] コスト取得失敗が「コスト 0」に化けない (上限判定の fail-open 防止)', () => {
+		// QA 指摘 (#4113): total_cost_usd の抽出に失敗したとき 0 を加算し続けると、
+		// 累計が伸びず $MaxCostUsd 判定が永久に成立せず無限に回る。
+		// Measure-JsonArray の件数バグと同型の「取得失敗が安全側に見える」経路。
+		const src = readFileSync(SCRIPT, 'utf8');
+		expect(src, '取得成否を追跡していない').toMatch(/\$costKnown\s*=\s*\$true/);
+		expect(src, '取得失敗時に保守的な推定額を計上していない').toMatch(
+			/-not \$costKnown[\s\S]{0,200}\$cost\s*=\s*\$FallbackCycleCostUsd/,
+		);
+		expect(src, '計測不能が続いたときに停止しない').toMatch(
+			/\$state\.costUnknownRuns\s+-ge\s+\$MaxCostUnknownRuns/,
+		);
+	});
+
+	it('[A10] サイクル prompt が他チーム管轄を scope 外として明示している', () => {
+		// QA 指摘 (#4113): 統合 PR は外部品質監査チーム管轄。無人 worker が触れる設計は不可。
+		const prompt = readFileSync(PROMPT, 'utf8');
+		expect(prompt, '統合 PR の除外が無い').toContain('統合 PR');
+		expect(prompt, 'approve / merge の禁止が無い').toMatch(/approve\s*\/\s*merge/);
+		// PO 決裁の代行が approve 代行に読めないこと。
+		expect(prompt, 'PO 決裁と approve の境界が書かれていない').toContain(
+			'approve` / `merge` の代行ではありません',
+		);
+	});
+
 	it('[A7] .ps1 が UTF-8 BOM 付きで保存されている (Windows PowerShell 5.1 の日本語コメント破損回避)', () => {
-		// 実測 (#4111): BOM 無しだと Windows PowerShell 5.1 が ANSI として読み、
+		// 実測 (#4112): BOM 無しだと Windows PowerShell 5.1 が ANSI として読み、
 		// 日本語コメントが壊れて `}` / `)` の対応が崩れ、7 件の parse error になった。
 		// pwsh 7 では再現しないため、BOM の有無自体を不変条件として固定する。
 		const head = readFileSync(SCRIPT).subarray(0, 3);

--- a/tests/unit/scripts/autopilot-syntax.test.ts
+++ b/tests/unit/scripts/autopilot-syntax.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * #4111: autopilot オーケストレーターの構造検証。
+ *
+ * 本 script は「無人で長時間動く」ことが目的なので、壊れていることに気づくのが遅れる。
+ * 起動できない / 安全弁が消えている / 環境依存パスが再混入した、を CI で検出する。
+ *
+ * PowerShell が無い環境 (Linux CI 等) では構文検査のみ skip し、
+ * テキストレベルの不変条件は常に検査する (skip の silent 化を避ける、#4084 教訓)。
+ */
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../..');
+const SCRIPT = resolve(REPO_ROOT, 'scripts/autopilot.ps1');
+const PROMPT = resolve(REPO_ROOT, 'scripts/autopilot-cycle-prompt.md');
+const DOC = resolve(REPO_ROOT, 'docs/sessions/autopilot-session.md');
+
+function hasPowerShell(): boolean {
+	for (const exe of ['pwsh', 'powershell']) {
+		try {
+			execFileSync(exe, ['-NoProfile', '-Command', 'exit 0'], { stdio: 'ignore' });
+			return true;
+		} catch {
+			// 次の候補へ
+		}
+	}
+	return false;
+}
+
+function powerShellExe(): string {
+	try {
+		execFileSync('pwsh', ['-NoProfile', '-Command', 'exit 0'], { stdio: 'ignore' });
+		return 'pwsh';
+	} catch {
+		return 'powershell';
+	}
+}
+
+describe('autopilot orchestrator (#4111)', () => {
+	it('[A1] 実行体・prompt・設計 doc の 3 点が揃っている', () => {
+		expect(existsSync(SCRIPT), `${SCRIPT} が無い`).toBe(true);
+		expect(existsSync(PROMPT), `${PROMPT} が無い`).toBe(true);
+		expect(existsSync(DOC), `${DOC} が無い`).toBe(true);
+	});
+
+	it('[A2] 環境依存の絶対パスをハードコードしていない (別 PC / 別クローンで動く)', () => {
+		const src = readFileSync(SCRIPT, 'utf8');
+		// ドライブレター付きの絶対パス literal を禁止する。
+		const absolutePaths = src.match(/'[A-Za-z]:\\[^']*'/g) ?? [];
+		expect(absolutePaths, `絶対パス literal が残存: ${absolutePaths.join(', ')}`).toEqual([]);
+		expect(src, 'PSScriptRoot 起点でリポジトリを解決していない').toContain('$PSScriptRoot');
+	});
+
+	it('[A3] 安全弁 5 種がすべて実装されている', () => {
+		const src = readFileSync(SCRIPT, 'utf8');
+		// 1 停止フラグ / 2 サイクル数 / 3 累計コスト / 4 経過時間 / 5 進捗ゼロ連続
+		expect(src, '停止フラグ判定が無い').toMatch(/Test-Path\s+\$StopFile/);
+		expect(src, 'サイクル数上限が無い').toMatch(/\$state\.cycle\s+-ge\s+\$MaxCycles/);
+		expect(src, '累計コスト上限が無い').toMatch(/\$state\.totalCostUsd\s+-ge\s+\$MaxCostUsd/);
+		expect(src, '経過時間上限が無い').toMatch(/TotalMinutes\s+-ge\s+\$MaxMinutes/);
+		expect(src, '進捗ゼロ連続の上限が無い').toMatch(/\$state\.noProgressRuns\s+-ge\s+\$MaxNoProgress/);
+	});
+
+	it('[A4] --bare を付けて claude を起動していない (hooks を殺さない)', () => {
+		const src = readFileSync(SCRIPT, 'utf8');
+		// コメント行 (「--bare は使わない」等の説明) は除外して、実引数としての --bare だけを見る。
+		const codeLines = src
+			.split('\n')
+			.filter((l) => !l.trimStart().startsWith('#'))
+			.join('\n');
+		expect(codeLines, "'--bare' を引数に渡している").not.toMatch(/'--bare'/);
+	});
+
+	it('[A5] 完了判定を worker の自己申告ではなく gh の実状態で行っている', () => {
+		const src = readFileSync(SCRIPT, 'utf8');
+		expect(src).toMatch(/gh\s+pr\s+list/);
+		expect(src).toMatch(/gh\s+issue\s+list/);
+	});
+
+	it('[A6] サイクル prompt が「1 件だけ選ぶ」と「事実から読む」を指示している', () => {
+		const prompt = readFileSync(PROMPT, 'utf8');
+		expect(prompt, '1 件だけ進める指示が無い').toContain('1 件だけ');
+		expect(prompt, '前サイクルの主張を読まない指示が無い').toContain('前のサイクルの主張');
+		expect(prompt, '結果行のフォーマット指定が無い').toContain('AUTOPILOT_RESULT');
+	});
+
+	it('[A7] .ps1 が UTF-8 BOM 付きで保存されている (Windows PowerShell 5.1 の日本語コメント破損回避)', () => {
+		// 実測 (#4111): BOM 無しだと Windows PowerShell 5.1 が ANSI として読み、
+		// 日本語コメントが壊れて `}` / `)` の対応が崩れ、7 件の parse error になった。
+		// pwsh 7 では再現しないため、BOM の有無自体を不変条件として固定する。
+		const head = readFileSync(SCRIPT).subarray(0, 3);
+		expect(Array.from(head), 'UTF-8 BOM (EF BB BF) が無い').toEqual([0xef, 0xbb, 0xbf]);
+	});
+
+	it.skipIf(!hasPowerShell())('[A8] PowerShell として構文エラーが無い', () => {
+		const cmd = [
+			'$errs = $null',
+			`$null = [System.Management.Automation.Language.Parser]::ParseFile('${SCRIPT.replace(/'/g, "''")}', [ref]$null, [ref]$errs)`,
+			'if ($errs -and $errs.Count -gt 0) { $errs | ForEach-Object { Write-Output ("line " + $_.Extent.StartLineNumber + ": " + $_.Message) }; exit 1 }',
+			'exit 0',
+		].join('; ');
+		const out = execFileSync(powerShellExe(), ['-NoProfile', '-Command', cmd], {
+			encoding: 'utf8',
+		});
+		expect(out.trim()).toBe('');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**誰の**: このリポジトリで作業する Dev（人・エージェント問わず）と、その進捗を待つオーナー
**どんな状況で**: open PR / open issue を数時間〜数十時間かけて継続消化するとき
**何を得るか**: **人間が「続けて」と入力しなくても作業が進み続ける**こと。

長時間の Dev セッションで、セッションが長くなるにつれて自動で次のステップへ進まなくなる（**2026-07-30 の 1 セッションだけで 3 回発生**）。権限プロンプトで待っているのではなく、`--dangerously-skip-permissions` でも起こる。

継続の制御主体（オーケストレーション）を、作業する当人（LLM）から **context を持たない決定的スクリプト**に移す。

## 関連 Issue

Closes #4112

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 実行体と設計 SSOT をリポジトリに追加し、別 PC / 別クローンで失われないこと（絶対パスのハードコード禁止） | `npx vitest run tests/unit/scripts/autopilot-syntax.test.ts` `[A1]` `[A2]` | HEAD `3b4e5964` / 8 passed / `tests/unit/scripts/autopilot-syntax.test.ts:47-62`。`scripts/autopilot.ps1:24-33` が `$PSScriptRoot` 起点でリポジトリを解決 |
| AC2 | 安全弁 5 種（停止フラグ / サイクル数 / 累計コスト / 経過時間 / 進捗ゼロ連続）をすべて実装 | 同上 `[A3]` | HEAD `3b4e5964` / `scripts/autopilot.ps1:216-247`（5 判定）+ `:299-302`（進捗ゼロ）。test `:64-73` が 5 種の判定式を正規表現で確認 |
| AC3 | `--bare` を使わない（hooks が全無効化され `heavy-run-lock` / `gate-approve` が消えるため） | 同上 `[A4]` | HEAD `3b4e5964` / コメント行を除外した実引数に `'--bare'` 0 件。test `:75-84` |
| AC4 | 完了判定を worker の自己申告ではなく `gh` の実状態で行う | 同上 `[A5]` | HEAD `3b4e5964` / `scripts/autopilot.ps1:124-133` `Get-OpenCounts`。test `:86-90` |
| AC5 | サイクル prompt が「1 件だけ選ぶ」「前サイクルの主張を読まない」「BLOCK されたら待たず別作業へ」を指示 | 同上 `[A6]` | HEAD `3b4e5964` / `scripts/autopilot-cycle-prompt.md:11`（1 件だけ）/ `:21`（前のサイクルの主張）/ `:56-60`（飛ばしてよいもの）。test `:92-97` |
| AC6 | 上記を機械検証する test を置く | `npx vitest run tests/unit/scripts/autopilot-syntax.test.ts` | HEAD `3b4e5964` / **Test Files 1 passed / Tests 8 passed** / Duration 1.67s |
| AC7 | **実弾で 1 サイクル完走し、実際に PR を 1 本前進させる** | `powershell -File scripts/autopilot.ps1 -Once` + `gh pr view 4035 --json isDraft` | **PASS**。ログ `AUTOPILOT_RESULT target=PR#4035 action=ready detail=pre-ready ALL PASS(exit0,vitest8817) で Ready 化` / `gh pr view 4035 --json isDraft` → **`false`** / 32 turns / 25.9 分 / $4.09 |

## 変更タイプ

- [x] 新機能（開発運用ツール）
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・横展開チェック

**追加のみ。既存コードへの変更は `.gitignore` 1 行のみ。**

| ファイル | 役割 |
|---|---|
| `scripts/autopilot.ps1` | 決定的オーケストレーター（起動 / 上限 / 停止判定 / 進捗ゼロ検出）。context を持たない |
| `scripts/autopilot-cycle-prompt.md` | 1 サイクル分の worker 指示 |
| `docs/sessions/autopilot-session.md` | 設計 SSOT。**なぜ上位を LLM にしないか**の公式根拠を含む |
| `tests/unit/scripts/autopilot-syntax.test.ts` | 構造の不変条件を機械検証（8 件） |
| `.gitignore` | `scripts/.autopilot/`（state / ログ）を追跡しない |

**既存機構は改変せず利用する**: `heavy-run-lock`（マシン全体のファイル lock）/ `gate-approve` / `pre-ready` はいずれも触っていない。排他を再実装していないため、対話セッションや別クローン（QA チーム）との競合はそのまま維持される。

## テスト・品質セルフチェック

- [ ] **`npm run pre-ready -- --pr <num>` 全 Step PASS**（#1775 / ADR-0030）— **未実行**。実行しようとした時点で `heavy-run-lock` が別セッション保持（`session=80361a27` / `cwd=E:\Github\ganbari-quest-qa\...`）で BLOCK したため、待たずに中断した（`docs/sessions/agent-concurrency.md` 準拠）。**Ready 化前に取り直す**
- [x] 追加・変更したテストの概要:
  - `tests/unit/scripts/autopilot-syntax.test.ts`（新規 8 件）— ファイル 3 点の存在 / 絶対パス literal 0 件 / 安全弁 5 種の実装 / `--bare` 不在 / `gh` による完了判定 / prompt の必須文言 / **UTF-8 BOM** / PowerShell parse
- [x] **新規 env / secret 追加時**（ADR-0006）: N/A
- [x] **Critical バグ修正の場合**（ADR-0002）: N/A

### dry-run では出ず、実行で初めて壊れた欠陥 4 件（すべて修正 + test 固定）

実弾 1 サイクルを回す前に dry-run は通っていた。**4 件とも dry-run を通過している**ため、実行検証なしに連続運用に入っていたら気づけなかった。

| # | 欠陥 | 影響 | 固定した test |
|---|---|---|---|
| 1 | `.ps1` に UTF-8 BOM が無い | Windows PowerShell 5.1 が ANSI として読み、日本語コメントが壊れて **parse error 7 件**。**pwsh 7 では再現しない** | `[A7]` |
| 2 | `@($json \| ConvertFrom-Json).Count` が常に 1 を返す | **open PR 11 件 / open issue 122 件を「1 件」と誤認**。完了判定と進捗ゼロ検出が両方壊れる | `[A5]` + `Measure-JsonArray` に集約 |
| 3 | `ProcessStartInfo.ArgumentList` を使用 | .NET Framework 4.x（Windows PowerShell 5.1）に存在せず `PropertyNotFoundException`。stdin 経由に変更 | 実行で検出（`[A8]` parse では出ない） |
| 4 | `$proc.ExitCode` を成否の根拠にしていた | JSON が `is_error:false` / `subtype:success` / `stop_reason:end_turn` の**成功サイクルでも非 0**。成功を失敗として記録し続ける | `is_error` を第一根拠に降格変更 |

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: 本 PR は CLI の開発運用ツールのみで UI を一切変更しない。描画される画面が無いため Before / After のペアが原理的に存在しない。挙動の証跡は下記の実行ログと unit test が担う。 -->

**実弾 1 サイクルの実行ログ**（`scripts/.autopilot/logs/autopilot.log`、git 追跡外）:

```
[2026-07-30 12:49:21] [INFO] === autopilot 開始 ===
[2026-07-30 12:49:21] [INFO] 上限: cycles=40 / cost=$20 / minutes=720 / no-progress=5
[2026-07-30 12:49:21] [INFO] 停止するには: New-Item '...\scripts\.autopilot\STOP' を作成してください
[2026-07-30 12:49:23] [INFO] --- cycle 3 開始 (open PR=11 / open issue=122) ---
[2026-07-30 13:15:20] [INFO] cycle 3 終了: target=PR#4035 cost=$4.0870 累計=$4.09
[2026-07-30 13:15:20] [INFO]   AUTOPILOT_RESULT target=PR#4035 action=ready detail=pre-ready ALL PASS(exit0,vitest8817) で Ready 化
[2026-07-30 13:15:21] [STOP] -Once が指定されているため 1 サイクルで終了します
[2026-07-30 13:15:21] [INFO] === autopilot 終了 (cycle=3 / 累計コスト=$4.09) ===
```

**結果の検証**: `gh pr view 4035 --json isDraft` → **`false`**（実際に Ready 化されている）

### コード品質セルフレビュー (#1481)

- 既存機構の再実装を避けた: 排他 lock は `heavy-run-lock.mjs` に委ね、autopilot 側は BLOCK をシグナルとして受けるだけ
- state を新設していない: SSOT は GitHub（open PR / issue / label / CI）。ローカルはサイクル計数・累計コスト・反復検出のみ
- 環境依存を排除: 絶対パスをハードコードせず `$PSScriptRoot` 起点。test `[A2]` で機械強制

### 横展開・影響波及チェック

- **`scripts/` への追加は #1442（使い捨てスクリプト禁止）に抵触しないか**: 抵触しない。恒久の運用ツールであり、`deploy.sh` / `setup-server.sh` と同じ位置づけ。ただし配置に異論があれば `scripts/lib/` 等へ移す
- **既存の対話セッション運用を置換するか**: しない。当面は併存。autopilot は「無人で回したいとき」の選択肢
- **他クローン（QA / audit）との競合**: `heavy-run-lock` がマシン全体のファイル lock として機能することをコード実読で確認済み。`claude -p` で起動した worker も同じ hook を読むため排他は維持される
- **`--bare` の危険性**: 公式が「bare mode never reads them」と明記しており、hooks / CLAUDE.md / skills が全てスキップされる。**本 PR では使わず、test `[A4]` で再混入を防いでいる**

## レビュー依頼事項・破壊的変更

**破壊的変更なし**（追加のみ）。

**とくに見てほしい点**:

1. **安全弁が本当に効くか**。とくに `MaxCostUsd`（`total_cost_usd` の加算）と「進捗ゼロ連続」の判定。実測でサイクル起動コストが $1.12、1 サイクル合計 $4.09 だったため、既定 `-MaxCostUsd 100` は 25 サイクル程度で止まる想定
2. **停止方法が実際に効くか**。停止フラグは「次のサイクル冒頭で終了」なので、走行中のサイクルは止まらない。即時停止は Ctrl+C（SIGTERM で `SessionEnd` hook 実行、exit 143）
3. **worker が暴走しない設計になっているか**。`autopilot-cycle-prompt.md` の「絶対にやらないこと」（`--bare` / 他セッションの lock 強制解放 / `git push --force` / 本番デプロイ / DB スキーマ変更 / `.env` / `rm -rf` / `--no-verify` / approve・merge / 重い検証の並列実行）で足りるか
4. **PO 決裁の扱い**。`po-decision:required` が付いた PR は人間を待たず **PO サブエージェントに決裁させる**方針（オーナー判断 2026-07-30）。これが運用規約と衝突しないか
5. **`ProcessStartInfo.ArgumentList` / BOM / `ConvertFrom-Json` の 3 件は Windows PowerShell 5.1 固有**。pwsh 7 前提に移行すべきかどうか

## 配布済み env / secret (ADR-0006)

N/A（新規 env / secret なし）

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りのまま残っている AC がない）
- [x] Phase 分割した場合: N/A（単一 PR で完結）
- [x] UI 変更時: N/A（UI 変更なし。`ss-pair-none` を宣言済み）
- [x] 認証画面変更時: N/A



## QM レビュー結果

<!-- QM が記入。5 手順の approve body フォーマットは docs/sessions/qa-session.md 参照 -->

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
