### PR TITLE
fix(concurrency): #4076 worktree からの push が無関係な branch の lock で止まるのをやめる

### DIFF
--- a/.claude/hooks/heavy-run-lock.mjs
+++ b/.claude/hooks/heavy-run-lock.mjs
@@ -55,32 +55,11 @@ function blockWithHolder(holder, describeHolder) {
 	process.exit(2);
 }
 
-/**
- * 現在の branch 名を返す。取得できなければ null (task lock は諦めて heavy 判定のみ行う)。
- * git 呼び出しは push 系コマンドのときだけ行う — 全 Bash 呼び出しで毎回 spawn すると遅い。
- *
- * `cwd` は **hook payload の値**を優先する。hook プロセスの `process.cwd()` は
- * セッションの起動ディレクトリであり、Buzz エージェントではリポジトリ外
- * (`~/.buzz`) になる。そこで叩くと `git rev-parse` が常に失敗し、task lock が
- * 永久に発火しない (#4013)。
- *
- * @param {string | null} cwd
- */
-async function currentBranch(cwd) {
-	const { spawnSync } = await import('node:child_process');
-	const r = spawnSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-		encoding: 'utf8',
-		cwd: cwd || undefined,
-	});
-	if (r.status !== 0) return null;
-	return (r.stdout || '').trim() || null;
-}
-
 async function main() {
 	// 動的 import。解決に失敗しても catch して exit 2 に倒すため static import にしない (#3999)。
 	const [
 		{ acquire, describeHolder },
-		{ isHeavyCommand, isBranchPublishCommand, extractTarget, taskKeyFromBranch },
+		{ isHeavyCommand, extractTarget },
 		{ resolveSessionOwner },
 	] = await Promise.all([
 		import('../../scripts/lib/agent-lock.mjs'),
@@ -103,8 +82,16 @@ async function main() {
 	const cwd = payload?.cwd ?? process.cwd();
 
 	// 対象コマンドでなければ、プロセス一覧の取得 (spawn 1 回) すら不要。
-	const needsLock = isBranchPublishCommand(command) || isHeavyCommand(command);
-	if (!needsLock) process.exit(0);
+	//
+	// `git push` に対する task lock (branch = Issue 単位の二重作業防止) は #4076 で撤去した。
+	// hook payload の `cwd` は**セッションの起動ディレクトリ**なので、worktree から push しても
+	// main clone の path が来る。そこで `git rev-parse` すると**押す対象と無関係な branch**
+	// (main clone が checkout 中のもの) が取れ、別セッションがその branch の lock を持っている
+	// だけで worktree からの push が全て BLOCK された。押す対象から branch を割り出す精緻化
+	// (refspec 解析 / `git -C` 追跡) は refspec の無い bare `git push` を解決できず穴が残るため、
+	// PO 判断 (2026-07-30) で精緻化ではなく撤去を選ぶ。二重作業の検知は GitHub 側 (同一 branch
+	// への push 競合 / PR の重複) に委ねる。heavy lock (重い検証のマシン全体排他) は維持する。
+	if (!isHeavyCommand(command)) process.exit(0);
 
 	// `process.ppid` は hook 呼び出しごとに変わる短命プロセスなので持ち主にできない (#4013)。
 	// 祖先を辿ってセッションプロセスを取り、解決できなければ PID なし (TTL のみ) で記録する。
@@ -120,27 +107,6 @@ async function main() {
 		sessionId,
 		cwd,
 	};
-
-	// task lock: 同じ branch (= 同じ Issue) を 2 セッションが押すのを止める。
-	if (isBranchPublishCommand(command)) {
-		const branch = await currentBranch(cwd);
-		const key = taskKeyFromBranch(branch);
-		if (key) {
-			const claimed = acquire(key, { ...common, target: branch, ttlMs: 4 * 60 * 60 * 1000 });
-			if (!claimed.ok) {
-				process.stderr.write(
-					`[heavy-run-lock] BLOCK: branch ${branch} は別セッションが作業中です。\n`,
-				);
-				process.stderr.write(`  保持者: ${describeHolder(claimed.holder)}\n`);
-				process.stderr.write(
-					'  対処: 二重作業です。チャンネルで担当を確認し、どちらが進めるかを決めてから再実行してください。\n',
-				);
-				process.exit(2);
-			}
-		}
-	}
-
-	if (!isHeavyCommand(command)) process.exit(0);
 
 	const result = acquire(HEAVY_KEY, { ...common, target: extractTarget(command) });
 	if (result.ok) process.exit(0);

--- a/docs/sessions/agent-concurrency.md
+++ b/docs/sessions/agent-concurrency.md
@@ -40,7 +40,8 @@
 | key | 対象 | 粒度 | TTL |
 |---|---|---|---|
 | `heavy` | `pre-ready` / `vitest` / `playwright test` / `svelte-check` / `npm run test\|check\|e2e` | **マシン全体で 1 本** | 60 分 |
-| `task-<Issue番号>` | `git push` (branch 名から Issue 番号を導出) | Issue 単位 | 4 時間 |
+
+`git push` を branch 単位で排他する `task-<Issue番号>` key は **#4076 で撤去した**。hook が受け取る `cwd` はセッションの起動ディレクトリなので、worktree から push しても main clone の branch が読まれ、押す対象と無関係な branch の lock で全 worktree の push が止まっていた。押す対象から branch を割り出す精緻化は refspec の無い bare `git push` を解決できず穴が残るため、精緻化ではなく撤去を選んでいる (PO 判断 2026-07-30)。二重作業の検知は GitHub 側 (同一 branch への push 競合 / PR の重複) に委ねる。
 
 ### §3.2 保持者の同一性と生存判定
 
@@ -113,14 +114,12 @@ lock ディレクトリが読めない、lock ファイルが壊れている等�
 2. PR 本文整備 / Issue 起票 / レビュー対応など、マシンを占有しない作業に移る
 3. CI で代替できるなら**ローカル実行を諦めて CI を正とする**。ローカル完走が必要なのは「CI に無い gate」を回すときだけ
 
-`task-<n>` で止められた場合は二重作業である。チャンネルで担当を確認し、**どちらが進めるかを決めてから**再実行する。
-
 ## §5 適用範囲と限界
 
 - **worktree 分離は別の層**: ファイルの相互上書きは「チャンネルごとに専用 worktree を使う」ことで防ぐ。lock は**マシン資源と作業の重複**を防ぐもので、両方が要る
 - **hook が効くのは Claude Code 経由の Bash のみ**: 人間が直接ターミナルで叩く分には効かない。オーナーが手で重い検証を回すときは、エージェントが動いていないことを確認する
-- **hook はセッションの設定に登録されて初めて効く**: 本リポジトリの `.claude/settings.json` は **project 設定**なので、リポジトリを起動ディレクトリにしていないセッションには読み込まれない。Buzz エージェントの起動ディレクトリは `~/.buzz` であり、**`~/.buzz/.claude/settings.json` に登録しない限り本 hook は 1 度も走らない** (2026-07-27 実測: Buzz セッションから `git push` しても `task-<n>.lock` が作られなかった)。登録する場合は (a) `command` を絶対パスにする、(b) `matcher` を `"Bash|PowerShell"` にする (PowerShell tool 経由が素通りするため) の 2 点が要る
-- **`gh pr merge` / `gh pr edit` は task lock の対象外**: これらは PR 番号で他人の PR を操作する role (QM / 監査) のコマンドで、自分の branch とは対応しないため。ここを排他するなら PR 単位の別 key が要る (未実装)
+- **hook はセッションの設定に登録されて初めて効く**: 本リポジトリの `.claude/settings.json` は **project 設定**なので、リポジトリを起動ディレクトリにしていないセッションには読み込まれない。Buzz エージェントの起動ディレクトリは `~/.buzz` であり、**`~/.buzz/.claude/settings.json` に登録しない限り本 hook は 1 度も走らない**。登録する場合は (a) `command` を絶対パスにする、(b) `matcher` を `"Bash|PowerShell"` にする (PowerShell tool 経由が素通りするため) の 2 点が要る
+- **`git push` / `gh pr merge` / `gh pr edit` は排他対象ではない**: 誰がどの branch を進めているかの重複検知は lock では行わない (上記 §3.1)
 - **判定は文字列マッチ**: セグメント (`&&` / `;` / `|`) 単位で判定するため無害な前置きでは回避できないが、新しい重量コマンドを足したら `HEAVY_PATTERNS` の更新が要る
 
 ## §6 検証

--- a/scripts/lib/agent-lock-policy.mjs
+++ b/scripts/lib/agent-lock-policy.mjs
@@ -97,40 +97,4 @@ export function extractTarget(command) {
 	return null;
 }
 
-/**
- * branch の成果を公開するコマンドか (`git push`)。
- *
- * ここを task lock の取得点にするのは、**同じ branch を 2 セッションが押す**のが
- * 二重作業の最も分かりやすい形であり、かつ誤爆しにくいからである。`gh pr merge` 等は
- * PR 番号で他人の PR を操作する role (QM / 監査) のコマンドで、自分の branch とは
- * 対応しないため対象にしない。
- *
- * @param {string} command
- * @returns {boolean}
- */
-export function isBranchPublishCommand(command) {
-	const text = String(command ?? '');
-	return text.split(/&&|\|\||;|\|/).some((segment) => {
-		if (READ_ONLY_HEADS.has(headToken(segment))) return false;
-		return /(^|[\s;&|(])git\s+(-C\s+\S+\s+)?push(\s|$)/.test(segment);
-	});
-}
-
-/**
- * branch 名から Issue 番号を取り出し、task lock の key にする。
- *
- * 本リポジトリの branch 命名は `feat/3963-...` / `fix/4001-...` 等
- * (`docs/sessions/branch-strategy.md` §3)。同じ Issue に 2 セッションが着手すると
- * 同じ key になるため、二重着手が機械的に検出できる。
- *
- * @param {string} branch
- * @returns {string | null}
- */
-export function taskKeyFromBranch(branch) {
-	const match = String(branch ?? '').match(
-		/^(?:feat|fix|refactor|design|infra|test|docs|marketing|eval)\/(\d+)[-/]/,
-	);
-	return match ? `task-${match[1]}` : null;
-}
-
-export default { isHeavyCommand, isBranchPublishCommand, extractTarget, taskKeyFromBranch };
+export default { isHeavyCommand, extractTarget };

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -113,6 +113,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'src/routes 配下の admin 画面を走査して registry の網羅漏れを検出する (#3134 no-silent-gap)',
 	},
+	'tests/unit/hooks/agent-lock.test.ts': {
+		scope: 'repo',
+		note: 'repo ツリーは走査しない (temp git fixture + lock dir のみ) が、hook を子プロセスで起動するため静的判定が repo になる。git init / worktree add の分だけ既定 timeout を超え得るので明示 timeout を置く',
+	},
 	'tests/unit/scripts/check-orphan-repos-population.test.ts': {
 		scope: 'repo',
 		note: 'src 配下の repo 実装を走査して orphan を検出する',

--- a/tests/unit/hooks/agent-lock.test.ts
+++ b/tests/unit/hooks/agent-lock.test.ts
@@ -15,18 +15,25 @@
  *   - .claude/hooks/heavy-run-lock.mjs / heavy-run-unlock.mjs
  *
  * cspell 例外 (本 file 限定、.cspell.json への global 追加はしない):
- *   - `pushx`: 「`push` で始まるが push ではない」負例 fixture。前方一致で判定していたら
- *     通ってしまう形を実名で置いている (dev-session §QA 指摘台帳 観点 2 の prefix 一致問題)。
- *     綴りを直すと fixture の意味が失われるため、語そのものを残す
  *   - `sess`: session id の fixture 値 (`sess-1`)
  *   global 辞書に足すと `sess` の打ち間違いが repo 全体で素通りするため、file scope に閉じる。
  */
-// cspell:ignore pushx sess
+// cspell:ignore sess
 
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import {
 	acquire,
@@ -39,12 +46,7 @@ import {
 	release,
 	sameOwner,
 } from '../../../scripts/lib/agent-lock.mjs';
-import {
-	extractTarget,
-	isBranchPublishCommand,
-	isHeavyCommand,
-	taskKeyFromBranch,
-} from '../../../scripts/lib/agent-lock-policy.mjs';
+import { extractTarget, isHeavyCommand } from '../../../scripts/lib/agent-lock-policy.mjs';
 import { resolveSessionOwner } from '../../../scripts/lib/session-owner.mjs';
 
 /** 生存していないことが確実な PID。Windows / POSIX とも未使用値を使う。 */
@@ -108,41 +110,16 @@ describe('extractTarget', () => {
 	});
 });
 
-describe('isBranchPublishCommand', () => {
+describe('push は排他対象ではない (#4076)', () => {
+	// branch 単位の task lock は #4076 で撤去した。policy が push を「排他対象」と
+	// 判定に戻したら、hook が再び branch 名で lock を取り始めるため、ここで固定する。
 	it.each([
 		'git push',
 		'git push -u origin HEAD',
-		'git -C /repo push --force-with-lease',
-	])('push を検出する: %s', (command) => {
-		expect(isBranchPublishCommand(command)).toBe(true);
-	});
-
-	it.each([
-		'git status',
-		'git log --oneline',
-		'gh pr merge 3992',
-		'git pushx',
-	])('push でないものは通す: %s', (command) => {
-		expect(isBranchPublishCommand(command)).toBe(false);
-	});
-
-	it('読み取り専用コマンドの引数に push があっても検出しない', () => {
-		expect(isBranchPublishCommand('grep -rn "git push" docs/')).toBe(false);
-	});
-});
-
-describe('taskKeyFromBranch', () => {
-	it.each([
-		['fix/3963-context-plan-from-db', 'task-3963'],
-		['feat/3438-phase2b-dynamodb-repo-teardown', 'task-3438'],
-		['infra/4004-playwright-shard', 'task-4004'],
-	])('branch %s → %s', (branch, expected) => {
-		expect(taskKeyFromBranch(branch)).toBe(expected);
-	});
-
-	it('Issue 番号を含まない branch は null', () => {
-		expect(taskKeyFromBranch('develop')).toBeNull();
-		expect(taskKeyFromBranch('release/2026-07-27')).toBeNull();
+		'git push --force-with-lease origin fix/4076-worktree-push-no-block',
+		'git -C /repo push',
+	])('push コマンドは重い検証として扱わない: %s', (command) => {
+		expect(isHeavyCommand(command)).toBe(false);
 	});
 });
 
@@ -624,3 +601,100 @@ describe('#4013 readLock は lock レコードのフィールドを検証する'
 		expect(() => readLock('heavy')).toThrow(/壊れています/);
 	});
 });
+
+describe('heavy-run-lock hook: worktree からの push (#4076)', () => {
+	// #4076 の実測再現。main clone が branch A を checkout したまま、worktree の branch B を
+	// push すると、hook が「セッションの cwd = main clone」から branch を解決していたため
+	// **押す対象と無関係な branch A** の lock で BLOCK していた。fixture には当時の実名
+	// (main clone = fix/4017-... / worktree = fix/3980-3981-...) をそのまま置く。
+	// vitest の root は repo root (`vite.config.ts`)。`import.meta.url` は transform 後に
+	// file スキームでなくなることがあるため cwd から解決する。
+	const HOOK = join(process.cwd(), '.claude', 'hooks', 'heavy-run-lock.mjs');
+	const MAIN_BRANCH = 'fix/4017-dependency-review-waiver';
+	const WORKTREE_BRANCH = 'fix/3980-3981-stripe-plan-resolution';
+
+	let root: string;
+	let lockDir: string;
+	let mainClone: string;
+	let worktree: string;
+
+	/** git を temp repo に対して実行する (失敗したら fixture が壊れているので即座に落とす)。 */
+	function git(cwd: string, ...args: string[]): void {
+		const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+		if (r.status !== 0) throw new Error(`git ${args.join(' ')} 失敗: ${r.stderr || r.stdout}`);
+	}
+
+	/** hook を子プロセスで起動し exit code を返す。 */
+	function runHook(command: string, cwd: string): number {
+		const r = spawnSync(process.execPath, [HOOK], {
+			input: JSON.stringify({
+				session_id: 'sess-1',
+				tool_name: 'Bash',
+				tool_input: { command },
+				cwd,
+			}),
+			encoding: 'utf8',
+			env: { ...process.env, AGENT_LOCK_DIR: lockDir },
+		});
+		return r.status ?? -1;
+	}
+
+	beforeAll(() => {
+		root = mkdtempSync(join(tmpdir(), 'wt4076-'));
+		lockDir = join(root, 'locks');
+		mainClone = join(root, 'main-clone');
+		worktree = join(root, 'worktree');
+		mkdirSync(lockDir, { recursive: true });
+		mkdirSync(mainClone, { recursive: true });
+
+		git(root, 'init', '-b', MAIN_BRANCH, mainClone);
+		git(mainClone, 'config', 'user.email', 'test@example.com');
+		git(mainClone, 'config', 'user.name', 'test');
+		writeFileSync(join(mainClone, 'README.md'), '# fixture\n');
+		git(mainClone, 'add', 'README.md');
+		git(mainClone, 'commit', '-m', 'init');
+		git(mainClone, 'worktree', 'add', '-b', WORKTREE_BRANCH, worktree);
+	});
+
+	afterAll(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	/** lock dir に task-*.lock が 1 つでもできていないこと (= branch 単位の lock を取っていない)。 */
+	function taskLocks(): string[] {
+		return readdirSync(lockDir).filter((name) => name.startsWith('task-'));
+	}
+
+	it('main clone が別 branch を checkout していても worktree からの push を通す', () => {
+		// 旧実装はここで cwd (= main clone) の branch を読み `task-4017.lock` を取っていた。
+		expect(runHook(`git push origin ${WORKTREE_BRANCH}`, mainClone)).toBe(0);
+		expect(taskLocks()).toEqual([]);
+	});
+
+	it('worktree を cwd にした push も通す', () => {
+		expect(runHook('git push --force-with-lease', worktree)).toBe(0);
+		expect(taskLocks()).toEqual([]);
+	});
+
+	it('他セッションが同じ branch を触っていても push は止めない', () => {
+		// 「二重作業だから止める」判定そのものを撤去したことの固定 (PO 判断 2026-07-30)。
+		// 生きた別 PID が持つ lock を置いても、push は排他対象ではないので影響しない。
+		writeFileSync(
+			join(lockDir, 'task-3980.lock'),
+			JSON.stringify({ key: 'task-3980', ownerPid: process.pid, startedAt: Date.now() }),
+		);
+		expect(runHook(`git push origin ${WORKTREE_BRANCH}`, worktree)).toBe(0);
+		rmSync(join(lockDir, 'task-3980.lock'));
+	});
+
+	it('重い検証の排他は残っている (撤去しすぎていない)', () => {
+		// heavy lock まで消すと並走した検証結果が根拠にならなくなる。ここが 0 を返し始めたら
+		// 撤去の範囲が広がりすぎている。
+		writeFileSync(
+			join(lockDir, 'heavy.lock'),
+			JSON.stringify({ key: 'heavy', ownerPid: process.pid, startedAt: Date.now() }),
+		);
+		expect(runHook('npx vitest run tests/unit/foo.test.ts', worktree)).toBe(2);
+		rmSync(join(lockDir, 'heavy.lock'));
+	});
+}, 120_000);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（worktree で並列に作業する Dev / QA / 監査セッション）

**解決する課題**: worktree から自分の branch を `git push` すると、`heavy-run-lock` hook が **main clone が checkout 中の branch**（押す対象と無関係）で二重作業判定を行い、その branch の lock を別セッションが持っているだけで push が BLOCK される。実測では main clone の checkout を切り替える以外に回避手段がなく、**並列 Agent 運用そのものが止まっていた**。

**期待される効果**: worktree からの push が、他セッションが何を触っていようと通る。並列運用が hook で止まらなくなる。

## 関連 Issue

Closes #4076

## AC 検証マップ (ADR-0004)

Issue の AC1〜AC3 は「押す対象ブランチで判定する（精緻化）」を前提にしていたが、**PO 判断（2026-07-30）で精緻化ではなく撤去**に変更した。撤去方針での読み替えを併記する。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | worktree 内からの `git push` が、main clone の branch で判定されない<br>（原 AC1「push 対象ブランチで判定」→ 撤去により **branch では判定しない**に読み替え） | `npx vitest run tests/unit/hooks/agent-lock.test.ts`<br>「main clone が別 branch を checkout していても worktree からの push を通す」 | **PASS**（exit 0 かつ `task-*.lock` が 0 件） |
| AC2 | メインクローンが別ブランチを checkout していても、worktree からの push が BLOCK されない | 同上 + 「worktree を cwd にした push も通す」 | **PASS** |
| AC3 | 原文「同一ブランチの二重作業は引き続き BLOCK」→ **PO 判断で撤去**。代わりに<br>**heavy lock（重い検証のマシン全体排他）を弱めていない**ことを固定する | 同 spec「重い検証の排他は残っている (撤去しすぎていない)」 | **PASS**（`heavy.lock` 保持下で `npx vitest run` は exit 2 = BLOCK 継続）<br>二重作業の検知は GitHub 側（同一 branch への push 競合 / PR 重複）に委譲 |
| AC4 | AC1〜AC3 を固定する回帰テスト。fixture に「main clone = branch A / worktree = branch B」を実名で含む | `tests/unit/hooks/agent-lock.test.ts` §「heavy-run-lock hook: worktree からの push (#4076)」 | **PASS**（temp git repo を `git init -b fix/4017-dependency-review-waiver` → `git worktree add -b fix/3980-3981-stripe-plan-resolution` で構成。いずれも #4076 実測時の実名） |
| AC5 | guard を外すと AC4 が落ちることを実行して証跡に残す | 修正前実装を `git show origin/develop:...` で書き戻して同 spec 実行 | **PASS（落ちることを確認）**。下記ログ参照 |

### AC5 mutation 証跡（実装を develop 版に戻して実行）

```console
$ git show 'origin/develop:.claude/hooks/heavy-run-lock.mjs' > .claude/hooks/heavy-run-lock.mjs
$ git show 'origin/develop:scripts/lib/agent-lock-policy.mjs' > scripts/lib/agent-lock-policy.mjs
$ npx vitest run tests/unit/hooks/agent-lock.test.ts -t "worktree"

 FAIL  tests/unit/hooks/agent-lock.test.ts > heavy-run-lock hook: worktree からの push (#4076)
       > 他セッションが同じ branch を触っていても push は止めない
 AssertionError: expected 2 to be +0 // Object.is equality
 - Expected  0
 + Received  2

 Test Files  1 failed (1)
      Tests  3 failed | 2 passed | 64 skipped (69)
```

3 件が fail（残り 1 件 = heavy lock 継続の検査は実装不変なので PASS のまま）。実装を戻すと 69 件すべて PASS。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 設計判断: なぜ「精緻化」ではなく「撤去」か

| 案 | 内容 | 却下 / 採用理由 |
|---|---|---|
| A: 回避運用 | main clone を develop に置いておく | 人が覚えている限りしか効かない。main clone で作業した瞬間に再発（Issue §Alternatives A と同じ） |
| B: 判定の精緻化 | push refspec を読む / `git -C` を追う / worktree を検出して除外 | **refspec の無い bare `git push` を解決できず穴が残る**。hook payload の `cwd` はセッション起動ディレクトリのため、コマンドの実行位置を hook 側から確実に知る手段がない。判定を足すほど「入力を実行文脈から推測する」root class（#4071 / #3969 と同型）を厚くすることになる |
| C: **撤去（採用）** | `git push` に対する branch 単位 task lock をやめる | PO 判断（2026-07-30）。「判定を精緻化せず、worktree では発火させない（撤去）」。二重作業の検知は GitHub 側（同一 branch への push 競合 / PR 重複）に委ねる |

`heavy` lock（`pre-ready` / `vitest` / `playwright` / `svelte-check` のマシン全体排他）は**撤去していない**。並走した検証結果が根拠にならなくなる問題は別物のため。

## 実測: 撤去判断の裏付け（2026-07-30、本 PR 作業中に採取）

本 PR の作業中、着手順どおり次の PR を push しようとした時点で同じ欠陥に当たった。**この機構が守っていたものより、止めていたもののほうが大きい**ことが数字で確定した。

```console
$ git push --force-with-lease origin fix/3991-period-end-cancellation
[heavy-run-lock] BLOCK: branch fix/3991-period-end-cancellation は別セッションが作業中です。
  保持者: pid=33656 / 経過=5968s / session=80361a27-… / target=fix/3991-period-end-cancellation
          / cwd=E:\Github\ganbari-quest-qa\.claude\worktreesgent-a814248f5673af19c
```

| 観測 | 値 |
|---|---|
| `~/.buzz/.locks/` の滞留 `task-*.lock` | **25 本** |
| うち当日の作業対象 branch を塞いでいたもの | `task-3991` / `task-4015` / `task-3958`（着手順 2 / 5 / 6 の全部） |
| BLOCK した lock の経過時間 | 5968s（約 1.7 時間） |
| 保持者 | **別クローン**（`ganbari-quest-qa`）の生存セッション。押そうとした branch とは無関係 |
| 回避手段 | main clone の checkout を切り替えるか、lock を手で消すかの 2 択（どちらも運用の記憶頼み） |

25 本すべてを削除して作業を再開した（オーナー判断）。**「ガードを弱めた」のではなく、「ガードが守るはずだった二重作業を 1 件も検出しないまま、無関係な push を恒久的に止めていた」**というのが実測の結論である。

## 固定する不変条件（PO 明文化 3 点、2026-07-30）

| # | 不変条件 | 本 PR での固定手段 | 結果 |
|---|---|---|---|
| 1 | heavy lock（vitest / pre-ready のマシン全体排他）は維持 | `tests/unit/hooks/agent-lock.test.ts`「重い検証の排他は残っている (撤去しすぎていない)」 | **PASS**（`heavy.lock` 保持下で `npx vitest run` は exit 2） |
| 2 | worktree からの push が「メインクローンの現在ブランチ」を理由に BLOCK されない | 同 spec「main clone が別 branch を checkout していても worktree からの push を通す」/「worktree を cwd にした push も通す」 | **PASS**（exit 0 かつ `task-*.lock` 0 件） |
| 3 | lock の滞留が push を恒久的に止めない（保持者プロセス不在なら無効） | push は lock を取らなくなったため原理的に成立。heavy lock 側は既存の生存判定 + TTL が担保し、`agent-lock.test.ts`「保持者プロセスが死んでいれば奪える (セッション断の回収)」/「TTL を超えていれば奪える」で固定済 | **PASS** |

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（開発時 hook のみ。アプリのランタイム挙動に変更なし）

変更ファイル:

- `.claude/hooks/heavy-run-lock.mjs` — `git push` の task lock 分岐と `currentBranch()` を撤去
- `scripts/lib/agent-lock-policy.mjs` — 未使用になった `isBranchPublishCommand` / `taskKeyFromBranch` を撤去
- `tests/unit/hooks/agent-lock.test.ts` — 撤去分の describe を削除し、hook を子プロセスで起動する回帰 describe を追加
- `scripts/lib/ci/repo-scan-test-registry.mjs` — 上記 test の区分宣言（#4085）
- `docs/sessions/agent-concurrency.md` — lock 表 / 対処手順 / 限界の記述を実装に同期

- [x] **並行実装ペア**を同期した（該当なし。hook / policy / test / 運用 doc の 4 点を同 PR で同期済）
- [x] **設計書同期** (ADR-0001): 運用 SSOT `docs/sessions/agent-concurrency.md` を同 PR で更新
- [x] **LP ↔ アプリ整合** (ADR-0013): N/A（LP 無関係）
- [x] **重量 e2e 敏感領域**: N/A（export/import schema / marketplace / reward 陳列 / DB スキーマ いずれにも触れない）

**残置参照 sweep（撤去系）**: `isBranchPublishCommand` / `taskKeyFromBranch` / `task-<Issue番号>` の残存参照を `grep` で確認。ヒットするのは撤去を説明する 3 箇所のコメント / doc 本文のみで、呼び出し側は 0 件。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4122` | **ALL PASS**（`Test Files 583 passed \| 4 skipped` / `Tests 8980 passed \| 13 skipped`。適用対象外 5 step = lp-fallback / lp-labels / lp-dimensions / ss-embed-gate / capture） |
| 追加・変更テスト | `npx vitest run tests/unit/hooks/agent-lock.test.ts` | **PASS**（69 passed） |
| repo 走査 test 区分宣言 (#4085) | `node scripts/check-repo-scan-test-declaration.mjs` | **PASS**（36 件すべて宣言済） |
| lint | `npx biome check .claude/hooks/heavy-run-lock.mjs scripts/lib/agent-lock-policy.mjs scripts/lib/ci/repo-scan-test-registry.mjs tests/unit/hooks/agent-lock.test.ts` | **PASS** |

- [x] **SOLID / DRY / YAGNI**: 使われなくなった判定関数を残さず撤去した（死んだ抽象を放置しない）
- [x] **Security（OSS 公開前提）**: N/A（秘密情報を扱わない。lock 置き場は従来どおり repo 外）
- [x] **A11y・パフォーマンス**: N/A（UI 非該当）。push ごとの `git rev-parse` spawn が 1 回減る
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:critical` ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（開発時 hook のみの変更で、顧客に見える UI は一切変更していない）**

<!-- ss-pair-none: hook / policy / test / doc のみの変更で描画される画面が存在しない -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない（開発時 hook の挙動のみ。アプリ・CI の合否条件は不変）

**レビュー依頼事項**:

- 「二重作業の機械検知を失う」ことの受容が論点。**Issue の AC3 は「ガードを弱めない」だったが、PO 判断で撤去に変更**しているため、AC の読み替えが妥当かを確認してほしい
- 撤去範囲が `git push` の task lock に限定され、`heavy` lock に及んでいないことを spec（「重い検証の排他は残っている」）で固定している

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1/AC2/AC4/AC5。AC3 は PO 判断で撤去方針に読み替え、上表に明記）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
