### PR TITLE
docs: レビュー時 base ファイル API 取得規律 + unit-test CI 失敗 artifact 調査手順を追記

### DIFF
--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -90,6 +90,17 @@ git ls-remote origin refs/heads/<branch>    # → 返値 SHA を以降の検証�
 node scripts/verify-pr-head.mjs <num> <branch>   # ls-remote と gh pr view の乖離を自動警告
 ```
 
+#### base 側ファイルも API から取得する（working tree 不使用）
+
+レビュー時の SSOT はローカル working tree ではなく API（`gh api` / `git show origin/develop:<path>`）から取得する。QA クローンの working tree は stale になりうる。上記の HEAD SHA 固定規律は PR 側 (headRefOid) の staleness 対策だが、比較対象となる base 側ファイルにも同じ規律を適用する。
+
+QA クローンは Dev と別クローンのため working tree が stale になりやすく、stale な base と PR を比較すると **存在しない矛盾を報告する（false positive）**、**実在する矛盾を見逃す（false negative）**の両方が起きる。false negative の場合は BLOCK すべきものを通してしまう。
+
+```bash
+git show origin/develop:<path>              # base 側ファイルを API 相当で取得（working tree 不参照）
+gh api repos/<owner>/<repo>/contents/<path>?ref=develop   # gh api 経由でも可
+```
+
 ### 手順 1: Issue 照合
 
 ```bash

--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -101,6 +101,8 @@ git show origin/develop:<path>              # base 側ファイルを API 相当
 gh api repos/<owner>/<repo>/contents/<path>?ref=develop   # gh api 経由でも可
 ```
 
+**「無い」と結論する前に、読めているかを確認する。** 検索が 0 件を返したときは「対象が無い」と「読み方が違う」を区別する。API / artifact の形式（flatted / 圧縮 / 参照）を確認してから結論を出す。
+
 ### 手順 1: Issue 照合
 
 ```bash

--- a/docs/troubleshoot/github_actions.md
+++ b/docs/troubleshoot/github_actions.md
@@ -640,11 +640,29 @@ gh run view <run-id> --log-failed --job <unit-test-merge-job-id>
 gh run download <run-id> -n vitest-blob-N -D tmp/vitest-blob-N
 ```
 
+#### vitest-blob artifact は flatted 形式 — grep 0 件は「無い」の証拠にならない
+
+vitest の blob artifact (`blob-*.json`) は [flatted](https://github.com/rzanoni/flatted) 形式のフラット配列であり、値が文字列インデックスの参照になっている（`"result":"141095"` は「配列の 141095 番を見ろ」、`{"state":"9244", ...}` は「9244 番が実体」の意味）。**`"fail"` という文字列は文字列プールに 1 個だけ存在し、`state:"fail"` という並びはファイル中に一度も現れない。** `grep '"state":"fail"'` が 0 件を返すのは flatted 形式では正常であり、「失敗 0 件」の証拠にはならない。
+
+参照を解決してから判定する:
+
+```js
+const a = JSON.parse(fs.readFileSync('blob-2-2.json', 'utf8'));
+const failIdx = a.findIndex((x) => x === 'fail');
+const hits = a
+	.map((e, i) => [e, i])
+	.filter(([e]) => e && typeof e === 'object' && String(e.state) === String(failIdx));
+// hits の各 index を .result に持つ task を逆引き → name / errors を解決
+```
+
+**判別法**: `failIdx` が **`-1`** ならプールに `"fail"` 自体が無い = 本当に失敗 0 件。`failIdx` が **実値**（例 `9244`）なら `"fail"` は存在しており、参照を辿っていないだけ。この 1 つの値で「無い」と「読めていない」を区別できる。
+
 ### 再発防止策
 
 - `unit-test (N)` が fail したら、まず `unit-test-merge` job の出力を確認する（ログ推測で終わらせない）
 - 再実行して切り分けるより先に artifact を読む（再実行は 8〜9 分かかり、artifact 精読より遅い）
 - `unit-test-merge` の `digest-mismatch: error`（`actions/download-artifact@v8`）は shard の artifact 自体が
   壊れたサインであり、実装の失敗とは別原因（shard artifact の再アップロード / 再実行で切り分ける）
+- blob artifact を直接 grep して 0 件だった場合、`findIndex` で `"fail"` の参照先が本当に存在しないか（`failIdx === -1`）を確認してから「失敗 0 件」と結論する
 
 **参考**: PR #1534, Issue #1335, CI run 24945001950

--- a/docs/troubleshoot/github_actions.md
+++ b/docs/troubleshoot/github_actions.md
@@ -602,4 +602,49 @@ test.beforeAll(async () => {
 - 残高の絶対値に依存するテストは必ず `beforeAll` で DB 状態を確認・リセットすること
 - `global-setup.ts` の `shop_test_seed` 調整だけでは workers 並列実行には対応できない
 
+---
+
+## TA-011 — unit-test (shard N) 失敗時、失敗内容は job ログに出ず vitest-blob artifact 内にある
+
+| フィールド | 値 |
+|-----------|-----|
+| **発生日** | 2026-07-29 |
+| **PR 番号** | 不明 |
+| **ワークフロー** | CI |
+| **ジョブ名** | unit-test (N) / unit-test-merge |
+| **ステップ名** | Run unit tests (shard) |
+| **ステータス** | resolved |
+
+### エラーメッセージ（原文）
+
+```
+（job ログには失敗した test 名・assertion が一切出力されない。
+ `gh run view <id> --log-failed` / `gh api .../actions/jobs/<job-id>/logs` を grep しても
+ 出るのは artifact upload / git cleanup のログのみ）
+```
+
+### 根本原因
+
+vitest は shard ごとに `vitest-blob-N` という blob artifact をアップロードし、`unit-test-merge` job が
+`actions/download-artifact` で全 shard の blob を集約してから初めてテスト結果（失敗 test 名・assertion）を
+出力する。`unit-test (N)` 単体 job のログには集約前の blob しか残らないため、失敗内容がログに出ない。
+
+### 解決手順
+
+```bash
+# ログ推測ではなく artifact の実物を読む（再実行より速い）
+gh run view <run-id> --log-failed          # → 失敗内容は出ない（artifact upload ログのみ）
+# 1. unit-test-merge job のログを確認する（shard 集約後に失敗 test 名・assertion が出力される）
+gh run view <run-id> --log-failed --job <unit-test-merge-job-id>
+# 2. それでも不足する場合は vitest-blob-N artifact 自体をダウンロードして中身を読む
+gh run download <run-id> -n vitest-blob-N -D tmp/vitest-blob-N
+```
+
+### 再発防止策
+
+- `unit-test (N)` が fail したら、まず `unit-test-merge` job の出力を確認する（ログ推測で終わらせない）
+- 再実行して切り分けるより先に artifact を読む（再実行は 8〜9 分かかり、artifact 精読より遅い）
+- `unit-test-merge` の `digest-mismatch: error`（`actions/download-artifact@v8`）は shard の artifact 自体が
+  壊れたサインであり、実装の失敗とは別原因（shard artifact の再アップロード / 再実行で切り分ける）
+
 **参考**: PR #1534, Issue #1335, CI run 24945001950


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（QA / Dev 双方の運用プロセス）

**解決する課題**: 本日の QM レビューセッションで実際に踏んだ 2 つの罠（working tree の staleness による誤診断リスク / unit-test CI 失敗内容が job ログに出ず artifact 内にある）を、口頭知にせず既存 KB に規律化する。

**期待される効果**: QA クローンの working tree が stale なまま base ファイルを参照して誤診断する事故（存在しない矛盾の報告 / 実在する矛盾の見逃し）を防ぐ。また unit-test shard 失敗時に job ログを何度も読み直す / 無駄な再実行をする代わりに、artifact を直接読む正しい手順に最短で到達できるようにする。

## 関連 Issue

<!-- no-issue-close: オーナー指示による docs 追記。特定 Issue に紐づかない運用規律の追記のため -->

オーナー指示による docs 2 箇所の追記であり、特定の Issue には紐づかない。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `docs/sessions/qa-session.md` の Tier 2 §Authoritative HEAD 検証の直後に、base 側ファイルも working tree ではなく API（`gh api` / `git show origin/develop:<path>`）から取得する規律を追記する | 目視 diff 確認 | HEAD `90f31ee69` / `docs/sessions/qa-session.md:93-101`（「base 側ファイルも API から取得する（working tree 不使用）」節を新設） |
| AC2 | `docs/troubleshoot/github_actions.md` に、unit-test shard 失敗時の失敗内容が job ログに出ず `vitest-blob-N` artifact 内にあること・`unit-test-merge` job 出力を先に見ること・再実行より artifact 精読を優先すること・`digest-mismatch` は shard artifact 破損のサインで実装失敗とは別原因であることを追記する | 目視 diff 確認 + 既存 TA-NNN テンプレート形式踏襲 | HEAD `90f31ee69` / `docs/troubleshoot/github_actions.md:607-644`（TA-011 エントリ新設） |
| AC3 | docs SSOT 原則（`docs/CLAUDE.md` §docs SSOT 原則）に従い、現状の正解のみを端的に記述し経緯 narrative を書かない（Issue 番号参照は出典 pointer として可） | 目視確認 | 両追記とも「何をすべきか」の規律のみを記述。実害は 1-2 行で現状の正解として記載（qa-session.md）。github_actions.md の TA-NNN テンプレートは既存 KB の確立フォーマット（発生日 / PR 番号等のフィールド）を踏襲、本 PR 固有の narrative は追加していない |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**:
なし（`docs/sessions/qa-session.md` と `docs/troubleshoot/github_actions.md` の 2 ファイルのみの追記、UI・コード変更なし）

- [x] N/A — 上記いずれも影響範囲外

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | N/A（docs のみの変更のため、オーナー指示によりローカル heavy 実行は不実施。代替に軽量 doc gate を実行） | N/A |
| doc-code-references | `node scripts/check-doc-code-references.mjs` | PASS（baseline 内、133 件・54 ファイル、新規違反なし） |
| internal-terms | `node scripts/check-internal-terms.mjs` | PASS（新規違反 0 件） |
| pre-push hook | `git push`（rebase drift verify / biome / eslint fast check） | PASS（全 verify chain PASS、対象 file 変更なしで biome/eslint は skip） |

- [x] **SOLID / DRY / YAGNI**: docs 追記のみ、既存 KB フォーマット（TA-NNN テンプレート）を踏襲し独自形式を新設していない
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **A11y・パフォーマンス**: N/A（docs のみ）
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

該当なし（docs のみの変更で UI 変更を含まない）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:
なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: N/A（docs のみ）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

