### PR TITLE
infra(billing): #4104 staging に Stripe test mode を配備し live 混入を機械で止める

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,31 @@ PORT=3000
 # STRIPE_PRICE_FAMILY_MONTHLY=price_xxxxxxxxxxxxx    # ファミリー月額 ¥780
 
 # ===================================================
+# AWS staging の Stripe test mode (#4104)
+# ===================================================
+# staging (GanbariQuestComputeStaging) には **test mode の資格情報だけ**を配備する。
+# test mode は本番顧客・本番決済・本番 Dashboard に一切影響しないため、
+# 「外部サービス副作用ゼロ」の意図 (本番への副作用を作らない) は保たれる。
+#
+# 配布は GitHub Actions Secrets のみ (ローカル .env には置かない):
+#   gh secret set STRIPE_SECRET_KEY_TEST     --body "sk_test_xxx"  # 登録済 (2026-07-11)
+#   gh secret set STRIPE_WEBHOOK_SECRET_TEST --body "whsec_xxx"    # staging endpoint 登録後
+#
+# deploy-aws-staging.yml が `-c stagingStripeSecretKey` / `-c stagingStripeWebhookSecret`
+# として CDK context 経由で staging Lambda env に注入する。
+#
+# live 混入の機械強制 (2 段、いずれも deploy 前に停止する):
+#   1. deploy-aws-staging.yml `Validate required secrets` — synth 前に prefix を検査
+#   2. compute-stack.ts — `sk_test_` / `rk_test_` 以外を Annotations.addError で synth 停止
+#      (allowlist。denylist だと将来 prefix が増えたとき素通りする)
+#
+# 守れない範囲 (明示): webhook signing secret は test / live とも `whsec_` で prefix が同一のため
+# 文字列から判別できない。形式検査のみで、live 判別は secret key 側の allowlist が担う。
+#
+# price id は staging では注入しない。`USE_LOOKUP_KEY=true` で Stripe API の lookup_key から
+# 解決するため secret 新規登録は不要 (解決失敗時は fallback せず落ちる = silent degradation を作らない)。
+
+# ===================================================
 # Stripe Webhook Shadow Mode — Phase 7 PR-4a (#2713 / ADR-0059)
 # ===================================================
 # Stripe 公式 5 phase migration (setup → discovery → shadow → cutover → retire)

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -9,7 +9,17 @@ name: Deploy to AWS (Staging)
 #   - CDK は `-c stagingEnabled=true` の context gate でのみ staging stack を instantiate する。
 #     本番 deploy.yml の `cdk deploy --all` / `cdk diff --all` (context 無し) は挙動不変。
 #   - staging 3 stack は**明示列挙**で deploy する (`--all` 不使用、本番 6 stack との混線防止)。
-#   - 外部サービス副作用ゼロ: Stripe / Discord / Gemini / SES 系 secret は一切渡さない。
+#   - 外部サービス副作用ゼロ (Stripe は test mode のみ例外、#4104):
+#     Discord / Gemini / SES 系 secret は一切渡さない。**Stripe は test mode の資格情報だけ**を渡す。
+#     なぜ安全か: Stripe の test mode は本番顧客・本番決済・本番 Dashboard に一切影響しない独立空間で、
+#     防ぎたかったもの (本番顧客への副作用) は test mode では原理的に起こらない。逆に secret を一切
+#     渡さない運用は「課金修正が本番に出るまで一度も実 Stripe を通らない」状態を作り、#3958 (初の有料
+#     課金が丸ごと落ちて無通知) と同じ轍を踏む。
+#     live は禁止し、人の注意力ではなく機械で止める (2 段):
+#       (1) 本 workflow の `Validate required secrets` step が synth 前に prefix を検査
+#       (2) ComputeStack が synth 時に allowlist (`sk_test_` / `rk_test_` 以外) を addError で停止
+#     webhook signing secret は test / live とも `whsec_` で **prefix から判別できない**。ここは守れない
+#     範囲として明示する (live 側の実行権限は secret key が握るため secret key の allowlist が防御線)。
 #
 # 責務分界 (docs/design/13-AWSサーバレスアーキテクチャ設計書.md §4.3):
 #   - 本 workflow の責務は「本番 deploy 経路の貫通 + post-deploy health (G-PD AWS 側)」。
@@ -102,6 +112,8 @@ jobs:
           AWS_OIDC_IAMROLE_ARN: ${{ secrets.AWS_OIDC_IAMROLE_ARN }}
           PARENT_GATE_COOKIE_SECRET: ${{ secrets.PARENT_GATE_COOKIE_SECRET }}
           OPS_SECRET_KEY: ${{ secrets.OPS_SECRET_KEY }}
+          STRIPE_SECRET_KEY_TEST: ${{ secrets.STRIPE_SECRET_KEY_TEST }}
+          STRIPE_WEBHOOK_SECRET_TEST: ${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}
         run: |
           missing=0
           for s in AWS_OIDC_IAMROLE_ARN PARENT_GATE_COOKIE_SECRET OPS_SECRET_KEY; do
@@ -116,6 +128,30 @@ jobs:
           if [ $missing -gt 0 ]; then
             echo "::error::$missing required secret(s) missing — aborting staging deploy (#2873)"
             exit 1
+          fi
+
+          # #4104: Stripe は test mode のみ許可。live prefix を synth 前に止める (機械強制 1 段目)。
+          # allowlist 判定 — 既知の test prefix 以外は全て停止する (未知 prefix の素通り防止)。
+          if [ -n "$STRIPE_SECRET_KEY_TEST" ]; then
+            case "$STRIPE_SECRET_KEY_TEST" in
+              sk_test_*|rk_test_*)
+                echo "::notice::STRIPE_SECRET_KEY_TEST is a test mode key" ;;
+              *)
+                echo "::error::STRIPE_SECRET_KEY_TEST is NOT a test mode key (must start with sk_test_ / rk_test_). staging に live key は配備できません (#4104)"
+                exit 1 ;;
+            esac
+          else
+            echo "::warning::STRIPE_SECRET_KEY_TEST 未登録 — staging は Stripe 無効 (isStripeEnabled()=false) で起動します (#4104)"
+          fi
+          if [ -n "$STRIPE_WEBHOOK_SECRET_TEST" ]; then
+            case "$STRIPE_WEBHOOK_SECRET_TEST" in
+              whsec_*) echo "::notice::STRIPE_WEBHOOK_SECRET_TEST format OK" ;;
+              *)
+                echo "::error::STRIPE_WEBHOOK_SECRET_TEST の形式が不正です (whsec_ で始まる必要があります、#4104)"
+                exit 1 ;;
+            esac
+          else
+            echo "::warning::STRIPE_WEBHOOK_SECRET_TEST 未登録 — webhook 受信は検証できません (#4104 S-3 で PO が登録)"
           fi
 
       # Step 4: AWS OIDC 認証 (deploy.yml と同 action / 同 secret)
@@ -262,6 +298,8 @@ jobs:
             -c stagingEnabled=true $DSQL_CTX \
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
+            -c stagingStripeSecretKey=${{ secrets.STRIPE_SECRET_KEY_TEST }} \
+            -c stagingStripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }} \
             2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
 
       # Step 11: staging 3 stack を明示列挙で deploy (`--all` 禁止 — 本番 6 stack 混線防止)。
@@ -281,7 +319,9 @@ jobs:
             npx cdk deploy "$stack" --require-approval never \
               -c stagingEnabled=true $DSQL_CTX \
               -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
-              -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+              -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
+              -c stagingStripeSecretKey=${{ secrets.STRIPE_SECRET_KEY_TEST }} \
+              -c stagingStripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}
           done
 
       # Step 11.5 (#3646、DSQL lane のみ): アプリ実行 role (app_user) の provisioning。

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,6 +106,17 @@ jobs:
             echo "::error::$missing required secret(s) missing — aborting deploy (#1586)"
             exit 1
           fi
+          # #4104: 本番に test key が入る事故は単体で成立し、しかも無通知で成立する
+          # (顧客の決済がすべて test mode に流れ、決済成功に見えたまま入金されない)。
+          # staging の逆方向と対称に allowlist で止める。denylist (sk_test_ を弾く) だと
+          # 将来 Stripe が prefix を増やしたとき黙って通るため、既知の live prefix 以外を落とす。
+          case "$STRIPE_SECRET_KEY" in
+            sk_live_*|rk_live_*)
+              echo "::notice::STRIPE_SECRET_KEY is a live mode key" ;;
+            *)
+              echo "::error::STRIPE_SECRET_KEY is NOT a live mode key (must start with sk_live_ / rk_live_). 本番に test key は配備できません (#4104)"
+              exit 1 ;;
+          esac
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -533,7 +533,7 @@ export function resolveDemoActive(env: Pick<TypedEnv, 'AUTH_MODE' | 'DATA_SOURCE
 | SSM prefix | `/ganbari-quest/` | `/ganbari-quest-staging/`（`context-token-secret` は workflow が冪等 put） |
 | ECR repo | `ganbari-quest`（maxImageCount:10） | `ganbari-quest-staging` 専用 repo（maxImageCount:3。prod repo 共有は rollback `[-2]` digest 選択 + lifecycle を staging push が侵食するため不採用） |
 | Cognito | custom domain `auth.ganbari-quest.com` + Google IdP | default domain（prefix `ganbari-quest-staging`）。Google IdP / Route53 省略。SSM `cognito/domain` param は default domain 値で必ず書く |
-| 外部サービス env | Stripe / Discord / Gemini / SES 注入 | **非注入**（本番外部サービスへの副作用ゼロ。SES / Cost Explorer の IAM grant も付与しない） |
+| 外部サービス env | Stripe / Discord / Gemini / SES 注入 | Discord / Gemini / SES は**非注入**（SES / Cost Explorer の IAM grant も付与しない）。**Stripe は test mode のみ注入**（#4104。test mode は本番顧客・本番決済に影響しないため「本番への副作用ゼロ」は保たれる。live は 2 段の機械強制で停止 — workflow の synth 前 prefix 検査 + ComputeStack の allowlist `sk_test_`/`rk_test_`。price id は `USE_LOOKUP_KEY=true` で lookup_key 解決に寄せ env を増やさない。webhook signing secret は test/live とも `whsec_` で判別不能なため形式検査のみ = 守れない範囲として明示。手順 SSOT: [runbooks/staging-live-verification.md §9](../runbooks/staging-live-verification.md)） |
 | demo Lambda / cron-dispatcher / log archiving | あり | なし（`enableDemoLambda` / `enableCronDispatcher` / `enableLogArchiving` = false） |
 | RemovalPolicy | RETAIN | DESTROY（使い捨て可能） |
 | trigger | `push: [main]` + tag + dispatch | `pull_request: [main]`（統合 PR、paths filter 付き）+ dispatch（develop HEAD） |

--- a/docs/runbooks/staging-live-verification.md
+++ b/docs/runbooks/staging-live-verification.md
@@ -150,12 +150,69 @@ WHERE family_id = '<検証対象の family uuid>';
 | §6 の psql 接続と UPDATE の実行 | AWS credential（`DbConnectAdmin` 相当）が必要で、リポジトリ内からは検証できない | 実行者が初回実行時に結果を PR に記録し、齟齬があれば本 runbook を修正する |
 | staging Cognito でのサインアップ完了 | SES 非構成のため確認コードの到達性が未確認 | 届かない場合はオーナーに Cognito 側でのユーザー作成を依頼する（admin 権限が必要） |
 | staging DSQL の初期データ | seed 配線が未実施（`docs/design/staging-synthetic-seed.md` §5） | 検証者が sign-up してデータを作る |
-| Stripe 経路 | staging に存在しない（§1） | 本番実測での代替可否をオーナーに確認する |
+| Stripe 経路 | **配線済（#4104）**。ただし webhook endpoint 登録と `STRIPE_WEBHOOK_SECRET_TEST` の登録が未完のため、実往復は未実証 | §10 の手順で endpoint を登録し、S-0〜S-5 を実施する |
 
-## 9. 関連
+## 9. Stripe test mode（#4104）
+
+staging には **test mode の Stripe 資格情報だけ**を配備する。test mode は本番顧客・本番決済・本番 Dashboard に一切影響しない。
+
+### 9.1 secret（GitHub Actions Secrets のみ）
+
+| secret | 状態 | 用途 |
+|---|---|---|
+| `STRIPE_SECRET_KEY_TEST` | 登録済 | staging Lambda の `STRIPE_SECRET_KEY` |
+| `STRIPE_WEBHOOK_SECRET_TEST` | **未登録**（§9.2 で登録） | staging webhook の署名検証 |
+| `STRIPE_PRICE_*` | **不要** | `USE_LOOKUP_KEY=true` で Stripe API の lookup_key から解決するため |
+
+### 9.2 staging webhook endpoint の登録手順（PO 作業、AC4）
+
+**staging の Function URL は初回 deploy まで確定しない**ため、本手順は staging deploy 後に実施する。
+
+1. staging deploy 完了後、Function URL を取得する:
+
+```bash
+aws lambda get-function-url-config --function-name ganbari-quest-staging-app   --region us-east-1 --query FunctionUrl --output text
+```
+
+2. Stripe Dashboard を **test mode** に切り替え、Developers → Webhooks → 「Add endpoint」
+3. Endpoint URL に `<FunctionUrl>api/stripe/webhook` を入力
+4. 購読 event は `docs/design/billing-redesign/` の購読 event 一覧（#3990 で整合済）に合わせる
+5. 発行された signing secret を登録し、staging を再 deploy する:
+
+```bash
+gh secret set STRIPE_WEBHOOK_SECRET_TEST --body "whsec_xxxxxxxx" --repo Takenori-Kusaka/ganbari-quest
+```
+
+### 9.3 live 混入の機械強制（2 段）
+
+| 段 | 実体 | 停止タイミング |
+|---|---|---|
+| 1 | `deploy-aws-staging.yml` の `Validate required secrets` | synth 前 |
+| 2 | `infra/lib/compute-stack.ts` の allowlist（`sk_test_` / `rk_test_` 以外を `Annotations.addError`） | synth 時（deploy に進まない） |
+
+**検証には実 live key を使わない。** `sk_live_` + `0` を 28 個並べた、**prefix だけが本物のダミー文字列**で確認する。判定は prefix の形にのみ依存させてあるため、ダミーで落ちる。**ダミーで落ちなければ実装の欠陥**である。
+
+実 live key を staging env に投入する操作は行わない。万一 hard-fail が効かなかった場合、本番課金鍵が staging に配備された状態が成立し、これは不可逆である。
+
+**守れない範囲（明示）**: webhook signing secret は test / live とも `whsec_` で prefix が同一のため、文字列から判別できない。形式検査のみで、live 判別は secret key 側の allowlist が担う。
+
+### 9.4 検証項目 S-0〜S-5（#4104 の close 条件）
+
+| # | 項目 | 合格条件 |
+|---|---|---|
+| **S-0** | test card で checkout を完了し、**webhook が実際に届き**、**DB の plan が変わり**、**`/admin/subscription` の実画面に反映が出る** | **3 つ全部**。1 つでも欠けたら不合格 |
+| S-1 | Lambda env に Stripe test key が入る | `isStripeEnabled()=true` |
+| S-2 | **ダミー** live prefix で deploy を試み hard-fail する | synth が error で停止（実 live key は使わない） |
+| S-3 | staging webhook endpoint 登録 + 本節の手順が読める | endpoint が test mode に存在する |
+| S-4 | #4081 AC6（webhook 未達時の `success_url` 救済経路） | reconciliation が `applied` を返す |
+| S-5 | #4096 Q2（解約 → 期末まで利用可 → 取り消し） | 各段で契約状態が期待どおり |
+
+**S-0 が通って初めて #4104 を close する。** S-4（救済経路）が通ることは S-0（本線）が通ることの代わりにならない。救済経路は本線が落ちたときのためのものであり、2026-07-26 に落ちたのは本線（webhook 到達）である。
+
+## 10. 関連
 
 - [docs/runbooks/staging-gate-required-checks.md](staging-gate-required-checks.md) — staging deploy gate の required 化手順
 - [docs/design/staging-synthetic-seed.md](../design/staging-synthetic-seed.md) — PII-free 合成 seed の設計と配線状況
 - [docs/runbooks/dsql-restore.md](dsql-restore.md) — DSQL の backup / 復元
 - `.github/workflows/deploy-aws-staging.yml` / `infra/lib/compute-stack.ts` / `infra/lib/auth-stack.ts` / `infra/lib/env-config.ts`
-- Issue #2873（AWS staging stack）/ #3732（invite / members の local 検証不可）/ #4099（本 runbook の初回実行と gap 4 項目の確定）
+- Issue #2873（AWS staging stack）/ #3732（invite / members の local 検証不可）/ #4099（本 runbook の初回実行と gap 4 項目の確定）/ #4104（staging Stripe test mode）/ #4117（EPIC E1）

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -217,9 +217,42 @@ export class ComputeStack extends cdk.Stack {
 		const discordWebhookChurn = this.node.tryGetContext('discordWebhookChurn') ?? '';
 		const discordWebhookIncident = this.node.tryGetContext('discordWebhookIncident') ?? '';
 
+		// --- staging Stripe test mode (#4104) ---
+		// staging に **test mode の** Stripe 資格情報だけを配備する。test mode は本番顧客・本番決済に
+		// 一切影響しないため「外部サービス副作用ゼロ」の意図 (本番への副作用を作らない) は保たれる。
+		//
+		// live 混入の機械強制は **allowlist** で行う (denylist ではない):
+		//   - secret key は `sk_test_` / `rk_test_` 以外を synth error にする。denylist (`sk_live_` を弾く)
+		//     だと将来 Stripe が prefix を増やしたときに素通りするため、既知の test prefix 以外を落とす。
+		//   - webhook signing secret は **test / live とも `whsec_` で prefix が同一**であり、文字列からは
+		//     判別できない。ここは守れない範囲として明示する。live webhook secret 単体では本番への副作用を
+		//     起こせず (署名検証にしか使われない)、live 側の実行権限は secret key が握るため、
+		//     secret key の allowlist が実効的な防御線になる。
+		//   - price id も test / live とも `price_` で判別不能。ただし staging は `USE_LOOKUP_KEY=true` で
+		//     Stripe API の lookup_key から解決するため price env 自体を注入しない (#4104、secret 新規登録ゼロ)。
+		//     lookup_key 解決に失敗したら fallback せず落ちる = silent degradation を作らない。
+		const stagingStripeSecretKey = this.node.tryGetContext('stagingStripeSecretKey') ?? '';
+		const stagingStripeWebhookSecret = this.node.tryGetContext('stagingStripeWebhookSecret') ?? '';
+
+		if (stagingStripeSecretKey && !/^(sk|rk)_test_/.test(stagingStripeSecretKey)) {
+			cdk.Annotations.of(this).addError(
+				'[ComputeStack] stagingStripeSecretKey が test mode の key ではありません (#4104)。' +
+					'staging には `sk_test_` / `rk_test_` で始まる key のみ配備できます。' +
+					'live key の配備は本番顧客への副作用を生むため synth を停止します。',
+			);
+		}
+		if (stagingStripeWebhookSecret && !/^whsec_/.test(stagingStripeWebhookSecret)) {
+			cdk.Annotations.of(this).addError(
+				'[ComputeStack] stagingStripeWebhookSecret の形式が不正です (#4104)。' +
+					'Stripe webhook signing secret は `whsec_` で始まります' +
+					' (test / live は prefix が同一のため、live 判別は secret key 側の allowlist が担う)。',
+			);
+		}
+
 		// --- staging 用 Lambda env (#2873) ---
 		// prod との差分 (handoff spec):
-		//   - Stripe / Discord / Gemini / SES 系 env は注入しない (本番外部サービスへの副作用ゼロ)
+		//   - Discord / Gemini / SES 系 env は注入しない (本番外部サービスへの副作用ゼロ)
+		//   - Stripe は **test mode に限り** 注入する (#4104。live は上の allowlist が synth で止める)
 		//   - CRON_SECRET / OPS_SECRET_KEY 不要 (cron-dispatcher 省略)
 		//   - ORIGIN / COGNITO_CALLBACK_URL / COGNITO_LOGOUT_URL: Function URL は synth 時未確定
 		//     (自己参照) のため placeholder。deploy-aws-staging.yml の ORIGIN resolve step が
@@ -250,6 +283,11 @@ export class ComputeStack extends cdk.Stack {
 			COGNITO_LOGOUT_URL: `${stagingOriginPlaceholder}/auth/login`,
 			CONTEXT_TOKEN_SECRET: contextTokenSecret,
 			MAINTENANCE_MODE: 'false',
+			// #4104: Stripe test mode。未注入なら isStripeEnabled()=false のまま (従来挙動)。
+			// price id は注入せず lookup_key 経路で解決する (USE_LOOKUP_KEY=true)。
+			...(stagingStripeSecretKey ? { STRIPE_SECRET_KEY: stagingStripeSecretKey } : {}),
+			...(stagingStripeWebhookSecret ? { STRIPE_WEBHOOK_SECRET: stagingStripeWebhookSecret } : {}),
+			...(stagingStripeSecretKey ? { USE_LOOKUP_KEY: 'true' } : {}),
 		};
 
 		// --- Lambda: SvelteKit via Lambda Web Adapter ---

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -120,6 +120,24 @@ export class ComputeStack extends cdk.Stack {
 		// --- Stripe 設定（CDK context 経由で GitHub Actions Secrets から取得） ---
 		const stripeSecretKey = this.node.tryGetContext('stripeSecretKey') ?? '';
 		const stripeWebhookSecret = this.node.tryGetContext('stripeWebhookSecret') ?? '';
+
+		// 逆方向 (本番に test key が入る) の allowlist (#4104 PO 指摘 2026-07-31)。
+		// staging に live が入る事故は「live webhook secret を入れる」+「Stripe を live mode に切り替えて
+		// staging の endpoint を登録する」の二重の誤操作を要し、単体では副作用が起きない。
+		// これに対し **本番に test key が入る事故は単体で成立し、しかも無通知**である —
+		// 顧客の決済がすべて test mode に流れ、顧客は払ったつもりで実際には 1 円も入らない
+		// (2026-07-26 の webhook 未達と同じ「誰も気づかないまま課金が成立しない」型)。
+		// 実害が大きいのはこちらのため、prod 側も同じ allowlist 形で止める。
+		// denylist (`sk_test_` を弾く) にしないのは staging 側と同じ理由で、将来 Stripe が prefix を
+		// 増やしたときに黙って通るため。既知の live prefix 以外を落とす。
+		if (stripeSecretKey && !/^(sk|rk)_live_/.test(stripeSecretKey)) {
+			cdk.Annotations.of(this).addError(
+				'[ComputeStack] stripeSecretKey が live mode の key ではありません (#4104)。' +
+					'本番には `sk_live_` / `rk_live_` で始まる key のみ配備できます。' +
+					'test key を本番に配備すると顧客の決済が test mode に流れ、' +
+					'決済成功に見えたまま入金されない状態が無通知で成立するため synth を停止します。',
+			);
+		}
 		// #2719 (Phase 7 PR-3b prerequisite): yearly 4 種 + legacy `stripePriceMonthly` /
 		// `stripePriceYearly` は物理削除済。monthly 2 種のみ Lambda env に inject する。
 		// 過去 yearly 契約者の MRR 表示は `stripe-metrics-service.ts` の `HISTORICAL_YEARLY_AMOUNTS`

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -97,6 +97,37 @@ function buildStagingStacks(extraContext: Record<string, string> = {}): {
 	return { storage, auth, compute };
 }
 
+/**
+ * prod (envConfig 未指定 = 本番) の ComputeStack を任意 context で synth する。
+ * S-5 (#4104 逆方向 allowlist) 用。
+ */
+function buildProdCompute(extraContext: Record<string, string> = {}): ComputeStack {
+	const app = new cdk.App({
+		context: {
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			// prod stack は cron-dispatcher を持つため #1586 fail-close で必須
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+			...extraContext,
+		},
+	});
+	const storage = new StorageStack(app, 'TestStorageProdKeyGuard', { env });
+	return new ComputeStack(app, 'TestComputeProdKeyGuard', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+}
+
 let prodStorage: Template;
 let prodAuth: Template;
 let prodCompute: Template;
@@ -572,6 +603,45 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			// #2716 PR-3b cutover)。staging 側の分岐とは別経路であることを固定する
 			// (staging context を渡しても prod の値は prod の既定のまま)。
 			expect(prodEnv.USE_LOOKUP_KEY).toBe('true');
+		});
+	});
+
+	describe('S-5: 逆方向 — 本番に test key が入るのを止める (#4104 PO 指摘 2026-07-31)', () => {
+		// staging に live が入る事故は二重の誤操作を要し単体では副作用が起きないのに対し、
+		// 本番に test key が入る事故は単体で成立し、しかも無通知で成立する
+		// (顧客の決済がすべて test mode に流れ、決済成功に見えたまま入金されない)。
+		// 実害が大きいのは逆方向のため、prod 側にも同じ allowlist 形の gate を置く。
+		const dummyKey = (prefix: string) => `${prefix}_${'0'.repeat(28)}`;
+
+		it.each([
+			[dummyKey('sk_test'), 'test secret key (ダミー)'],
+			[dummyKey('rk_test'), 'test restricted key (ダミー)'],
+			[dummyKey('pk_live'), 'publishable key (secret ではない)'],
+			['not-a-stripe-key', '未知の形式'],
+		])('本番に非 live prefix (%s) を渡すと synth を停止する: %s', (key) => {
+			const compute = buildProdCompute({ stripeSecretKey: key });
+			Annotations.fromStack(compute as unknown as cdk.Stack).hasError(
+				'*',
+				Match.stringLikeRegexp('live mode の key ではありません'),
+			);
+		});
+
+		it('live prefix の key は synth を通す', () => {
+			const compute = buildProdCompute({ stripeSecretKey: dummyKey('sk_live') });
+			const errors = Annotations.fromStack(compute as unknown as cdk.Stack).findError(
+				'*',
+				Match.anyValue(),
+			);
+			expect(errors).toHaveLength(0);
+		});
+
+		it('stripeSecretKey 未指定 (local synth / staging deploy) は素通しする', () => {
+			const compute = buildProdCompute();
+			const errors = Annotations.fromStack(compute as unknown as cdk.Stack).findError(
+				'*',
+				Match.anyValue(),
+			);
+			expect(errors).toHaveLength(0);
 		});
 	});
 });

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -15,7 +15,7 @@
 // 参考: docs/design/13-AWSサーバレスアーキテクチャ設計書.md §4.3 / infra/lib/env-config.ts
 
 import * as cdk from 'aws-cdk-lib';
-import { Match, Template } from 'aws-cdk-lib/assertions';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { AuthStack } from '../../../infra/lib/auth-stack';
 import { ComputeStack } from '../../../infra/lib/compute-stack';
@@ -66,7 +66,7 @@ function buildProdStacks(): {
  * 意図的に cronSecret / opsSecretKey を context に渡さない —
  * #1586 guard が enableCronDispatcher 分岐内に移動したことの実証 (#2873 handoff spec)。
  */
-function buildStagingStacks(): {
+function buildStagingStacks(extraContext: Record<string, string> = {}): {
 	storage: StorageStack;
 	auth: AuthStack;
 	compute: ComputeStack;
@@ -77,6 +77,7 @@ function buildStagingStacks(): {
 			// #3438 Phase 2B: staging も prod と同型で無条件 DSQL (dual-mode 廃止)。endpoint は必須 (fail-close)。
 			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
 			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+			...extraContext,
 		},
 	});
 	const storage = new StorageStack(app, 'TestStorageStaging', {
@@ -381,7 +382,7 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			});
 		});
 
-		it('外部サービス env (Stripe / Discord / Gemini / SES / cron secret) を一切注入しない (副作用ゼロ)', () => {
+		it('外部サービス env (Discord / Gemini / SES / cron secret / Stripe price) を一切注入しない (副作用ゼロ)', () => {
 			const functions = stagingCompute.findResources('AWS::Lambda::Function', {
 				Properties: { FunctionName: 'ganbari-quest-staging-app' },
 			});
@@ -391,12 +392,13 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			};
 			const envVars = fnDef.Properties.Environment?.Variables ?? {};
 
+			// #4104: Stripe は test mode 限定で注入する例外になったため本リストから外した
+			// (test mode は本番顧客・本番決済に影響しない)。context 未注入の本 fixture では
+			// 結果的に STRIPE_* が付かないことを下の「未注入なら env に付かない」test が固定する。
+			// Discord / Gemini / SES / cron secret は従来どおり一切注入しない。
 			const forbiddenEnvKeys = [
-				'STRIPE_SECRET_KEY',
-				'STRIPE_WEBHOOK_SECRET',
 				'STRIPE_PRICE_STANDARD_MONTHLY',
 				'STRIPE_PRICE_FAMILY_MONTHLY',
-				'USE_LOOKUP_KEY',
 				'STRIPE_WEBHOOK_SHADOW_MODE',
 				'STRIPE_WEBHOOK_SECRET_TEST',
 				'GEMINI_API_KEY',
@@ -447,6 +449,129 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			// buildStagingStacks() が context に cronSecret / opsSecretKey を渡していないのに
 			// beforeAll で synth が成功していること自体が実証。ここでは明示再構築で assert する。
 			expect(() => buildStagingStacks()).not.toThrow();
+		});
+	});
+
+	describe('S-4: staging Stripe test mode (#4104) — test key のみ配備 / live は synth で停止', () => {
+		/** staging Lambda の env Variables を取り出す。 */
+		function stagingEnvOf(template: Template): Record<string, unknown> {
+			const functions = template.findResources('AWS::Lambda::Function', {
+				Properties: { FunctionName: 'ganbari-quest-staging-app' },
+			});
+			const fnDef = Object.values(functions)[0] as {
+				Properties: { Environment?: { Variables?: Record<string, unknown> } };
+			};
+			return fnDef.Properties.Environment?.Variables ?? {};
+		}
+
+		it('test key を渡すと STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET / USE_LOOKUP_KEY が注入される', () => {
+			const staging = buildStagingStacks({
+				stagingStripeSecretKey: 'sk_test_0000000000000000000000000000',
+				stagingStripeWebhookSecret: 'whsec_0000000000000000000000000000',
+			});
+			const env = stagingEnvOf(Template.fromStack(staging.compute as unknown as cdk.Stack));
+
+			expect(env.STRIPE_SECRET_KEY).toBe('sk_test_0000000000000000000000000000');
+			expect(env.STRIPE_WEBHOOK_SECRET).toBe('whsec_0000000000000000000000000000');
+			// price id は lookup_key 経路で解決するため env を増やさない (#4104、secret 新規登録ゼロ)
+			expect(env.USE_LOOKUP_KEY).toBe('true');
+			expect(env.STRIPE_PRICE_STANDARD_MONTHLY).toBeUndefined();
+			expect(env.STRIPE_PRICE_FAMILY_MONTHLY).toBeUndefined();
+		});
+
+		it('context 未注入なら STRIPE_* は env に付かない (従来どおり Stripe 無効で起動)', () => {
+			const env = stagingEnvOf(stagingCompute);
+			expect(env.STRIPE_SECRET_KEY).toBeUndefined();
+			expect(env.STRIPE_WEBHOOK_SECRET).toBeUndefined();
+			expect(env.USE_LOOKUP_KEY).toBeUndefined();
+		});
+
+		// #4104 条件 2 (PO): **実 live key は使わない**。prefix だけが本物のダミー文字列で検証する。
+		// 判定を prefix の形にのみ依存させているのはこのため (Stripe API 疎通で実在性を見る実装にすると
+		// ダミーで検証できなくなり、実証の代償が「live key を staging に配備する」= 不可逆になる)。
+		// GitHub push protection はダミーでも Stripe key の「形」を検出して push を止めるため、
+		// prefix と body を分けて組み立てる (file 上に完成形の文字列を置かない)。
+		const dummyKey = (prefix: string) => `${prefix}_${'0'.repeat(28)}`;
+
+		it.each([
+			[dummyKey('sk_live'), 'live secret key (ダミー)'],
+			[dummyKey('rk_live'), 'live restricted key (ダミー)'],
+			[dummyKey('pk_test'), 'publishable key (secret ではない)'],
+			['not-a-stripe-key', '未知の形式'],
+		])('live / 非 test prefix (%s) は synth を停止する: %s', (key) => {
+			const staging = buildStagingStacks({ stagingStripeSecretKey: key });
+			// Annotations.addError は deploy 前 (cdk synth) に error として集約され deploy に進ませない。
+			Annotations.fromStack(staging.compute as unknown as cdk.Stack).hasError(
+				'*',
+				Match.stringLikeRegexp('test mode の key ではありません'),
+			);
+		});
+
+		it('webhook secret が whsec_ 以外なら synth を停止する', () => {
+			const staging = buildStagingStacks({
+				stagingStripeSecretKey: 'sk_test_0000000000000000000000000000',
+				stagingStripeWebhookSecret: 'bogus_secret',
+			});
+			Annotations.fromStack(staging.compute as unknown as cdk.Stack).hasError(
+				'*',
+				Match.stringLikeRegexp('webhook signing secret'),
+			);
+		});
+
+		it('test key のみ (正常系) では synth error が出ない', () => {
+			const staging = buildStagingStacks({
+				stagingStripeSecretKey: 'sk_test_0000000000000000000000000000',
+				stagingStripeWebhookSecret: 'whsec_0000000000000000000000000000',
+			});
+			const errors = Annotations.fromStack(staging.compute as unknown as cdk.Stack).findError(
+				'*',
+				Match.anyValue(),
+			);
+			expect(errors).toHaveLength(0);
+		});
+
+		it('prod (envConfig 未指定) には staging Stripe context が影響しない (prod 不変)', () => {
+			// staging 用 context を渡しても prod stack の env は従来の stripeSecretKey 経路のまま。
+			const app = new cdk.App({
+				context: {
+					'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+						'us-east-1_TESTPOOL',
+					'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+						'test-client-id',
+					'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+						'auth.ganbari-quest.com',
+					'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+						'test-context-token-secret',
+					opsSecretKey: 'test-ops-secret-key',
+					parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+					dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+					dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+					// staging 専用 context (prod では読まれない)
+					stagingStripeSecretKey: 'sk_test_0000000000000000000000000000',
+				},
+			});
+			const storage = new StorageStack(app, 'TestStorageProdInvariant', { env });
+			const compute = new ComputeStack(app, 'TestComputeProdInvariant', {
+				env,
+				assetsBucket: storage.assetsBucket,
+				repository: storage.repository,
+			});
+			const template = Template.fromStack(compute as unknown as cdk.Stack);
+			const functions = template.findResources('AWS::Lambda::Function', {
+				Properties: { FunctionName: 'ganbari-quest-app' },
+			});
+			const fnDef = Object.values(functions)[0] as {
+				Properties: { Environment?: { Variables?: Record<string, unknown> } };
+			};
+			const prodEnv = fnDef.Properties.Environment?.Variables ?? {};
+			// prod は stripeSecretKey context 未指定なので Stripe secret env は付かない (従来挙動)。
+			// staging 用 context (stagingStripeSecretKey) が prod 側に漏れていないことの確認。
+			expect(prodEnv.STRIPE_SECRET_KEY).toBeUndefined();
+			expect(prodEnv.STRIPE_WEBHOOK_SECRET).toBeUndefined();
+			// USE_LOOKUP_KEY は prod では従来から `useLookupKey` context 由来で入る (既定 'true'、
+			// #2716 PR-3b cutover)。staging 側の分岐とは別経路であることを固定する
+			// (staging context を渡しても prod の値は prod の既定のまま)。
+			expect(prodEnv.USE_LOOKUP_KEY).toBe('true');
 		});
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

課金まわりを修正する Dev と、それを本番に出す判断をする PO / オーナーが、**Stripe と往復する変更を本番に触らずに検証できる**ようにする。

いま staging は Stripe secret を一切配備しない方針のため、課金修正が**本番に出すまで一度も実 Stripe を通らない**。ローカルは `isStripeEnabled()=false` で原理的に検証不能、staging も secret 無しで不能、という二重の穴になっている。2026-07-26 の本番障害は webhook 到達そのものが落ちた事象で、local のどの backend でも再現できない。

本 PR は**配線と機械強制まで**を入れる。実 deploy を要する AC は次回 staging バッチで消化する（下記 AC 検証マップ参照）。

## 関連 Issue

Refs #4104

<!-- no-issue-close: 実 deploy を要する AC1 / AC4 / AC6 / AC7 が本 PR では未検証。#4104 は 2026-07-30 に EPIC #4117 へ畳み込み済 (NOT_PLANNED + duplicate) のため再 open せず、S-0〜S-5 の結果は #4117 に貼る -->

## AC 検証マップ (ADR-0004)

HEAD SHA: `8795726b`

| AC | 検証手段 | 結果 | 状態 |
|---|---|---|---|
| AC1 (test mode secret 配備) | `infra/lib/compute-stack.ts` の `stagingEnvironment` に `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` / `USE_LOOKUP_KEY` を条件付き注入。`deploy-aws-staging.yml` が `-c stagingStripeSecretKey` / `-c stagingStripeWebhookSecret` を diff / deploy 双方に渡す | 配線は unit test で確認 (`tests/unit/infra/staging-cdk.test.ts` 29 passed)。**実 Lambda env での `isStripeEnabled()=true` は未検証** | 🟡 配線のみ |
| AC2 (live 混入の機械強制) | `infra/lib/compute-stack.ts:1054-1069` の allowlist (`sk_test_` / `rk_test_` 以外を `cdk.Annotations.addError`) + `deploy-aws-staging.yml` の `Validate required secrets` prefix 検査 (2 段) | `tests/unit/infra/staging-cdk.test.ts` の `S-4` describe が 4 種のダミー key (`sk_live` / `rk_live` / `pk_test` / 非 Stripe 形式) で synth が error 停止することを assert。**29 passed** | ✅ 本 PR で充足 |
| AC3 (workflow 記述の改訂) | `.github/workflows/deploy-aws-staging.yml:12` の diff | 「外部サービス副作用ゼロ」→「Stripe は test mode のみ例外」に改訂し、**なぜ安全か**（test mode は本番顧客・本番決済に影響しない / live は 2 段で機械的に停止）を同じ場所に併記 | ✅ 本 PR で充足 |
| AC4 (webhook endpoint 登録 + runbook) | `docs/runbooks/staging-live-verification.md` §9.2 | 手順を記載（Function URL 取得 → Stripe Dashboard test mode で endpoint 追加 → `gh secret set STRIPE_WEBHOOK_SECRET_TEST` → 再 deploy）。**Function URL は初回 deploy まで確定しないため、登録自体は未実施** | 🟡 手順のみ |
| **逆方向: 本番に test key**（PO 指摘 2026-07-31、AC 外の追加） | `deploy.yml` の `Validate required secrets` で `sk_live_` / `rk_live_` allowlist + `compute-stack.ts` の同 allowlist を `addError` で synth 停止（2 段） | `tests/unit/infra/staging-cdk.test.ts` の `S-5` describe が非 live prefix 4 種で synth 停止 / live prefix は通過 / 未指定は素通し を assert。**35 passed**。新 guard を無効化した状態で **4 failed / 31 passed** を確認済 | ✅ 本 PR で充足 |
| AC5 (Discord / Gemini / SES は現状維持) | `infra/lib/compute-stack.ts` の `stagingEnvironment` diff | Stripe 2 key + `USE_LOOKUP_KEY` のみ追加。`forbiddenEnvKeys` から外したのもこの 3 つだけで、Discord / Gemini / SES は禁止のまま test が守る | ✅ 本 PR で充足 |
| AC6 (#4081 AC6 を staging で 1 回通す) | staging 実機 | **未実施**（S-4 として次回バッチ） | 🔴 未検証 |
| AC7 (#4096 Q2 を staging で消化) | staging 実機 | **未実施**（S-5 として次回バッチ） | 🔴 未検証 |

**完了の扱い**: #4104 は 2026-07-30 に EPIC #4117 へ畳み込み済（`NOT_PLANNED` + `duplicate` = 未着手を意味する close）で、**再 open しない**。S-0〜S-5 の結果は **#4117 に貼る**。#4117 の完了定義「staging Stripe で checkout → webhook → plan 反映 → 実画面が 1 回通る」が **S-0 の合格条件そのもの**である。S-4（救済経路）が通ることは S-0（本線）が通ることの代わりにならない。2026-07-26 に落ちたのは本線である。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（顧客に見える挙動は不変）。変更対象は AWS staging 環境の Lambda env と、その deploy 経路のガードのみ。本番 (`prodEnvironment`) は無改変で、unit test が prod 側の Stripe env 不変を assert している。

- [ ] **並行実装ペア**を同期した
- [x] **設計書同期** (ADR-0001): `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §4.3 の staging 差分表（外部サービス env 行）と `docs/runbooks/staging-live-verification.md` §8 / §9 を同 PR で更新
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A（LP 記載の変更なし）
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4134` | **ALL PASS** (適用対象外 5 step は変更内容が検査対象を含まないため未実行、#4018) |
| 追加・変更テスト | `npx vitest run tests/unit/infra/staging-cdk.test.ts` | PASS (35 passed) |

**mutation 検証（テストが実装の不在を検出することの確認）**: ① staging 側 — 実装を commit したうえで `git checkout HEAD~1 -- infra/lib/compute-stack.ts` して同 test を実行 → **`Tests 6 failed | 23 passed (29)`**。② 逆方向 (prod) 側 — 新 guard の条件を無効化して実行 → **`Tests 4 failed | 31 passed (35)`**。いずれも実装を戻して全 PASS に復帰。

- [x] **SOLID / DRY / YAGNI**: 判定は 1 箇所（`ComputeStack` の allowlist）に閉じる。workflow 側は同じ判定を synth 前に前倒しするだけで、判定ロジックの二重実装ではない
- [x] **Security（OSS 公開前提）**: **実 live key は使っていない**。ダミーは prefix だけ本物にし、GitHub push protection がダミーでも「形」を検出するため file 上には完成形の文字列を置かず runtime で組み立てている。secret 値は GitHub Actions Secrets からのみ渡し、repo にも CDK context のデフォルトにも置かない
- [x] **A11y・パフォーマンス**: N/A（UI 変更なし）
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

N/A — UI 変更なし（infra + docs のみ）。

## レビュー依頼事項・破壊的変更

**守れない範囲を明示する（AC2 の限界）**: webhook signing secret は **test / live とも `whsec_`** で prefix が同一のため、文字列から live を判別できない。形式検査しかできず、live 判別は **secret key 側の allowlist が担う**。この非対称性はコード・workflow・test・runbook・`.env.example` の 5 箇所に明記した。

**price id を注入しなかった判断**: `USE_LOOKUP_KEY=true` のとき `getPriceId()` は Stripe API の `lookup_key` から解決し、env の `STRIPE_PRICE_*` は kill-switch 的な fallback にすぎない（`src/lib/server/stripe/config.ts`）。staging で env を持たせると解決失敗が黙って fallback に吸われるため、あえて注入せず**失敗が表に出る**ようにした。

**PO 承認条件の履行**: ① `Closes` を使わず `Refs #4104`（本 PR では close しない）② 検証に実 live key を使わない ③ S-0（本線）をテスト計画に追加 — 3 点とも本 body に反映済み。

## 配布済み env / secret (ADR-0006)

- 配布済み: `STRIPE_SECRET_KEY_TEST`（2026-07-11 に repo secret へ登録済、`gh secret list` で確認）
- **未配布**: `STRIPE_WEBHOOK_SECRET_TEST` — staging の Function URL が初回 deploy まで確定せず、endpoint 登録が先行できないため。§9.2 の手順どおり deploy 後に登録する。未登録の間は workflow が `::warning::` を出し、Stripe env を注入せずに deploy を続行する（`isStripeEnabled()=false` の現状維持）

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み — **この PR で書けるコード・手順はすべて入っている**。残る AC1 / AC4 / AC6 / AC7 は「未実装」ではなく **staging deploy の実行 / Stripe Dashboard 操作 / 実測**で、コードとして先送りしたものは無い（上記 AC 検証マップに 🟡 / 🔴 で個別に明示。#4104 は close せず、S-0〜S-5 の実施後に手動 close する）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢 可逆 — revert で元に戻る"]
    R2["顧客面: 🟢 変化なし — staging 限定"]
    R3["不可逆になる唯一の筋: 🔴 live 鍵混入"]
    R4["→ 2 段 gate で停止 + 実 live 鍵は不使用"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 課金経路を本番前に実測できる"]
    T2["捨てる: staging の外部副作用ゼロ原則"]
    T3["負債: whsec_ は test/live 判別不能"]
  end
  subgraph OBJ["③ 反対理由 (Dev 自己 adversarial)"]
    O1["business: 検証環境が本番の代役に見える"]
    O2["UX: staging 課金画面を実挙動と誤認"]
    O3["security: 鍵の置き場が 1 つ増える"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 なし — 本番 env は無改変"]
    C2["unit test が prod 側不変を assert"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: staging に test 鍵配備を許可するか"]
    Q2["Q2: whsec_ 判別不能を残すことを許容か"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3 danger
  class T2,T3,O1,O2,O3 warn
  class R1,R2,R4,T1,C1,C2 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠)</summary>

**③ の出所について**: これは **Dev 自身による adversarial pass** であり、ADR-0056 の `adversarial-reviewer` subagent 出力ではない。`tmp/adversarial-evidence/4134.json` は**あえて作っていない**（Dev が書いた JSON を QM の approve gate が独立検証の証跡として読んでしまうと、gate の意味が壊れるため）。独立した adversarial-reviewer の dispatch は QM approve 時に実施される前提。

- **business**: staging で Stripe が通るようになると「staging で確認したから本番も大丈夫」という代役扱いが起きうる。staging は DSQL / Cognito / Function URL いずれも本番と別実体で、test mode の Stripe も本番アカウントの price / 税設定を共有しない。「staging 緑 = 本番安全」と読み替えられた瞬間、2026-07-26 と同型の見落としが再発する。runbook §8「保証できない点」を残してあるのはこのため。
- **UX**: staging の `/admin/subscription` が実際に課金状態を出すようになるため、検証者が staging の画面を本番挙動と同一視しやすくなる。特に trial / 期末解約の日付は test clock の影響を受けるので、画面上の日付を根拠に本番仕様を判断すると誤る。
- **security**: 鍵の保管場所が 1 つ増える（repo secret に test 鍵 2 本）。test 鍵でも Stripe API を叩けるため、漏れれば test 環境の顧客データ（合成 seed）と Stripe test アカウントの操作は可能になる。live との差は「本番決済に届かない」ことであって「無害」ではない。2 段 gate は live 混入を止めるが、test 鍵そのものの取扱いは通常の secret 同様に扱う必要がある。

**Q1 の背景**: 本 PR 起票自体は 2026-07-30 に承認済み（条件 3 点付き）。ここで改めて Q1 を置いているのは、merge = staging に鍵が実際に載る最初の一歩になるため。
**Q2 の背景**: webhook signing secret は test / live とも `whsec_` で、文字列から live を判別できない。形式検査までしかできず、live 判別は secret key 側の allowlist に依存する。この非対称性を残したまま進めてよいかの確認。

</details>

## QM レビュー結果

<!-- QM が記入 -->
