### PR TITLE
fix(ci): dependabot/renovate gate 判定を actor から PR 作成者に修正

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,13 +3,18 @@ name: Dependabot auto-merge
 # bot lane の SSOT は scripts/pr-lane.mjs の BOT_ACTORS (#2947 / 親 #2942 / EPIC #2861)。
 # 「bot とは誰か」(= dependabot lane の actor 集合) の正準定義は BOT_ACTORS = ['dependabot[bot]',
 # 'renovate[bot]'] に一本化されており、gate workflow の exempt (pr-template-gate.yml 等の
-# `github.actor != 'dependabot[bot]'`) も同 SSOT / classifyLane の dependabot lane 判定を参照する。
+# `github.event.pull_request.user.login != 'dependabot[bot]'`) も同 SSOT / classifyLane の
+# dependabot lane 判定を参照する。
 #
 # ただし下記 auto-merge の発火条件は **dependabot[bot] のみ** で renovate を含まない (現行仕様、
 # #2947 no-go「auto-merge を renovate に拡大しない」)。BOT_ACTORS は「lane = dependabot として
 # exempt / 軽量扱いする actor」の定義であり「auto-merge 対象 actor」とは別概念のため、本 workflow
-# は意図的に actor == 'dependabot[bot]' で即絞る軽量な actor 判定を維持する (composite action
-# actions/pr-lane を挟むと全 PR で checkout+node が走りオーバーヘッドが増えるため不採用、#2947 選択肢 B 却下)。
+# は意図的に軽量な actor 判定を維持する (composite action actions/pr-lane を挟むと全 PR で
+# checkout+node が走りオーバーヘッドが増えるため不採用、#2947 選択肢 B 却下)。
+#
+# #4133: 判定は PR 作成者 (github.event.pull_request.user.login) を見る。github.actor は
+# 「このイベントを起こした人」であり、人間が base 変更や label 付与などで dependabot PR に
+# 触れると actor が人間に変わり、この auto-merge が発火しなくなってしまう (gate 挙動の反転)。
 
 on: pull_request
 
@@ -22,7 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     # auto-merge 対象は dependabot[bot] のみ (renovate は対象外、上記コメント参照)。
     # bot lane SSOT = scripts/pr-lane.mjs の BOT_ACTORS。
-    if: github.actor == 'dependabot[bot]'
+    # PR 作成者で判定する (actor だと人間が触れた瞬間に判定が反転するため、#4133)。
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/pr-ac-verification-check.yml
+++ b/.github/workflows/pr-ac-verification-check.yml
@@ -37,7 +37,10 @@ jobs:
     # #1808 / #2945 AC6: Dependabot / Renovate は依存更新 PR で AC マップを持たないため job レベルで skip。
     # (skip された job は Success を報告し required check は通過する = 従来どおりの挙動不変。
     #  これは dependabot lane の「観点」であり、他レーンは下記 step で必ず実検証する)
-    if: "github.event.pull_request.draft == false && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'"
+    # PR 作成者 (github.event.pull_request.user.login) で判定する。人間が base 変更や label 付与で
+    # dependabot PR に触れると github.actor が変わり gate の挙動が反転するため、actor ではなく
+    # author を見る (発見: #4133)。
+    if: "github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'"
     timeout-minutes: 3
     steps:
       # A-1 lane 判定 SSOT を uses。inline 判定はしない (AC1、#2942 no-go)。

--- a/.github/workflows/pr-author-guard.yml
+++ b/.github/workflows/pr-author-guard.yml
@@ -69,7 +69,10 @@ jobs:
     timeout-minutes: 2
     # Dependabot / Renovate 等 bot PR は #1808 exempt 同等で skip (#2430)。
     # bot は ADR-0022 の役割分離対象外、`pr-template-gate.yml` line 40 と同パターン。
-    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
+    # PR 作成者 (github.event.pull_request.user.login) で判定する。人間が base 変更や label 付与で
+    # dependabot PR に触れると github.actor が変わり gate の挙動が反転するため、actor ではなく
+    # author を見る (発見: #4133)。本 job は pull_request_target のため author は常に取得できる。
+    if: github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'
     steps:
       - name: Verify PR author
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/pr-info.yml
+++ b/.github/workflows/pr-info.yml
@@ -165,7 +165,10 @@ jobs:
   type-label:
     name: title 接頭辞から type:* label 付与
     runs-on: ubuntu-latest
-    if: "github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'"
+    # PR 作成者 (github.event.pull_request.user.login) で判定する。人間が base 変更や label 付与で
+    # dependabot PR に触れると github.actor が変わり gate の挙動が反転するため、actor ではなく
+    # author を見る (発見: #4133)。
+    if: "github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'"
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -38,7 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     # #1808 / #2945 AC6: Dependabot / Renovate は依存更新 PR で PR template チェックリストを
     # 持たないため job レベルで skip (skip=Success で required check 通過、挙動不変)。
-    if: "github.event.pull_request.draft == false && github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'"
+    # PR 作成者 (github.event.pull_request.user.login) で判定する。github.actor は「このイベントを
+    # 起こした人」であり、人間が base 変更や label 付与などで dependabot PR に触れると actor が
+    # 人間に変わって gate の挙動が反転してしまうため、actor ではなく author を見る (発見: #4133)。
+    if: "github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'"
     timeout-minutes: 3
     steps:
       # A-1 lane 判定 SSOT を uses。inline 判定はしない (AC1、#2942 no-go)。
@@ -113,7 +116,9 @@ jobs:
     name: PR body 検証 (必須セクション / AC 4 列 / 禁止語 / PO 決裁ブリーフ)
     runs-on: ubuntu-latest
     # dependabot / renovate は PR template を持たないため skip (Job 1 と同条件、挙動を揃える)。
-    if: "github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'"
+    # PR 作成者 (github.event.pull_request.user.login) で判定する。人間が触ると github.actor が
+    # 変わり gate の挙動が反転するため、actor ではなく author を見る (発見: #4133)。
+    if: "github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'renovate[bot]'"
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
> **QM が実装 PR を作成した例外の適用理由 (PO 承認 2026-07-31)**: 本 PR が修理する `github.actor` 判定の欠陥そのものにより、dependabot PR (#4133) の gate が反転して merge 不能になっており、**壊れた gate に阻まれて PR を回せない状態**だった。原則「gate の修理を含め実装は Dev、QM は finding と PR コメントまで」の例外に該当するため QM 側 Fix Agent が作成した。**本 PR の approve は Dev が行う** (ADR-0022 作成者 ≠ 承認者)。

## 顧客価値・目的

**対象ユーザー**: システム全体（CI ゲートの信頼性、開発者・QM 双方に影響）

**解決する課題**: dependabot / renovate PR の CI ゲート skip 判定が `github.actor`（イベントを起こした人）で行われており、PR の作成者ではない。そのため人間が dependabot PR に触れる（base 変更・body 編集・label 付与など、PR の中身は一切変えない操作）だけで `github.actor` が人間に変わり、同じ PR が触られたかどうかで gate の pass/fail が反転していた。

**期待される効果**: 判定を PR 作成者 (`github.event.pull_request.user.login`) に統一することで、無関係なメタデータ編集の有無にかかわらず gate の挙動が一定になる。dependabot PR の body テンプレート不備での誤 fail、および auto-merge の意図しない不発火を防止する。

## 関連 Issue

Refs #4121

<!-- no-issue-close: E5 (#4121) の scope として PO が「単独 Issue は起票しない」と決定 (2026-07-31)。#4121 のコメントに 1 行追加済み。 -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `pr-merge-gate.yml` の 2 job (`checklist-check` / `pr-body-check`) が author 判定に置換されている | `grep -n "github.actor\|github.event.pull_request.user.login" .github/workflows/pr-merge-gate.yml` | HEAD `b8279d30e` / L41, L119 が `github.event.pull_request.user.login` に置換済み（旧 `github.actor` は行 41/119 から消滅） |
| AC2 | `pr-ac-verification-check.yml` の `check` job が author 判定に置換されている | `grep -n "github.event.pull_request.user.login" .github/workflows/pr-ac-verification-check.yml` | HEAD `b8279d30e` / L44 (旧 L40) で置換確認 |
| AC3 | `pr-author-guard.yml` の `enforce-pr-author` job (pull_request_target) が author 判定に置換されている | `grep -n "github.event.pull_request.user.login" .github/workflows/pr-author-guard.yml` | HEAD `b8279d30e` / L76 (旧 L72) で置換確認。同 job は元々 `PR_AUTHOR` 変数でも author を見ており整合 |
| AC4 | `pr-info.yml` の `type-label` job が author 判定に置換されている | `grep -n "github.event.pull_request.user.login" .github/workflows/pr-info.yml` | HEAD `b8279d30e` / L172 (旧 L168) で置換確認 |
| AC5 | `dependabot-auto-merge.yml` の `dependabot` job が author 判定に置換されている（`==` 方向、逆条件） | `grep -n "github.event.pull_request.user.login" .github/workflows/dependabot-auto-merge.yml` | HEAD `b8279d30e` / L32 (旧 L25) で置換確認 |
| AC6 | `deploy-*.yml` の `github.actor`（デプロイ実行者記録用途、PR 作成者判定ではない）は変更していない | `grep -n "github.actor" .github/workflows/*.yml` | HEAD `b8279d30e` / `deploy.yml:1003` / `deploy-aws-staging.yml:80` / `deploy-nuc.yml:54` / `deploy-nuc-staging.yml:86` が unmodified で残存（diff に含まれず） |
| AC7 | 既存の関連 unit test が壊れていない | `npx vitest run tests/unit/github/` | HEAD `b8279d30e` / 62 test files / 1339 passed, 1 skipped, 0 failed |
| AC8 | 全 workflow yml が構文的に有効 | `python3 -c "import yaml; yaml.safe_load(open(f))"` を対象 5 file に実行 | HEAD `b8279d30e` / 5 file 全て parse error なし |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**:
UI 影響なし。CI ワークフロー 5 file (`pr-merge-gate.yml` / `pr-ac-verification-check.yml` / `pr-author-guard.yml` / `pr-info.yml` / `dependabot-auto-merge.yml`) の dependabot/renovate 判定条件のみ。

- [x] N/A — 上記いずれも影響範囲外（並行実装ペア・設計書同期・LP・重量 e2e のいずれにも該当しない、CI ワークフロー定義のみの変更）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | N/A（QM 指示によりこの PR は push まで担当、CI 確認は QM が実施） |
| YAML 構文検証 | `python3 -c "import yaml; yaml.safe_load(open(f))"` (対象 5 file) | PASS |
| 関連 unit test | `npx vitest run tests/unit/github/` | PASS (1339 passed / 1 skipped / 0 failed) |

- [x] **SOLID / DRY / YAGNI**: 単一責任・依存性逆転を満たす / 同一ロジックの重複を `grep` で調査済 / 不要な抽象化なし — 5 file とも既存の if 条件を author 判定に置換するのみ、新規ロジックの追加なし
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし / OWASP Top 10 を境界で検証 / N/A 可 — N/A（CI 条件式の変更のみ）
- [x] **A11y・パフォーマンス**: キーボード操作可 / ARIA 適切 / コントラスト WCAG AA / N+1 なし / N/A 可 — N/A（UI 変更なし）
- [x] **Critical バグ修正**(ADR-0002): 5 要件確認済。該当なければ N/A — N/A（infra/CI 修正であり ADR-0002 の Critical バグ修正定義対象外）

## スクリーンショット / ビジュアルデモ

該当なし（UI 変更を含まない、CI ワークフロー yml の条件式変更のみ）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:
- 対象 job は全て `pull_request` または `pull_request_target` トリガー配下であることを確認済み（`workflow_dispatch` 等で `github.event.pull_request` が空になるケースはなし）。念のため QM 側でも各 job のトリガーを再確認いただきたい
- `dependabot-auto-merge.yml` は `on: pull_request`（デフォルト types = opened/synchronize/reopened）で `github.event.pull_request.user.login` は常に取得可能
- `pr-author-guard.yml` は `pull_request_target` で、既存コードが `PR_AUTHOR: ${{ github.event.pull_request.user.login }}` を使っていたため、skip 条件だけが actor 判定のまま取り残されていた不整合を解消した

## 根本原因

dependabot / renovate PR の CI gate skip 判定に `github.actor`（このイベントを起こした人）を使っていたが、これは PR の作成者ではない。人間が dependabot PR の base 変更・body 編集・label 付与などを行うと、そのイベントの `github.actor` は人間になる。すると `github.actor != 'dependabot[bot]'` の判定が真になり、dependabot PR 本来の skip 対象であるにもかかわらず gate が実行されてしまう（実例: PR #4133 の base を develop に変更したところ `pr-body-check` job が skip されず実行され、dependabot の body に PR template が無いため `[ac-map-missing]` で fail した。同時に `dependabot-auto-merge.yml` の発火条件も成立しなくなる）。同じ PR が無関係なメタデータ編集の有無で pass/fail が変わる状態であり、判定基準を「イベントを起こした人」から「PR を作成した人」(`github.event.pull_request.user.login`) に変更することで、メタデータ編集の有無に依存しない一貫した判定にした。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付 — N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)



