### PR TITLE
fix(ci): #4129 AC5 env 配布証跡 gate を「既存 env の必須化」まで拡張する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,8 +1139,9 @@ jobs:
       - name: Forbidden terms check (includes site/)
         run: node scripts/check-forbidden-terms.mjs
 
-  # ADR-0029 / #914: 新規必須 env / secret 追加チェック
-  # PR diff から `assert*Configured()` / `throw new Error('...required...')` 等を検出し、
+  # ADR-0024 ルール 5 / #914 / #4129: 必須化された env / secret の配布証跡チェック
+  # PR diff から `assert*Configured()` / 必須文言 (英語 + 日本語) / fail-fast guard、
+  # および optional → required の変化 (#4129 AC5) を検出し、
   # PR 本文に「配布済み: <ENV>」証跡が無い場合は CI を red にする。
   # Pre-PMF 1 人体制で Assertion Erosion (#911 のような assertion 追加 → 配布忘れ →
   # 連続デプロイ失敗) を機械的に止めるためのゲート。
@@ -1162,7 +1163,7 @@ jobs:
       - name: Fetch base ref
         run: git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
 
-      - name: Check new required env / secret distribution evidence (ADR-0029)
+      - name: Check newly required env / secret distribution evidence (ADR-0024 ルール 5)
         env:
           BASE_REF: origin/${{ github.base_ref }}
           PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -219,6 +219,7 @@ jobs:
             actions/pr-lane
             scripts/pr-lane.mjs
             scripts/check-ss-blob-sha-uniqueness.mjs
+            scripts/lib/ci/reason-declaration.mjs
             scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false
 

--- a/docs/decisions/0024-infra-pr-required-baseline.md
+++ b/docs/decisions/0024-infra-pr-required-baseline.md
@@ -19,6 +19,8 @@ PR #1509（#1376 EventBridge cron）のデプロイで 4 つの根本原因が�
 
 結果: `license-expire` / `retention-cleanup` / `trial-notifications` の 3 cron が 2 日間全実行失敗。
 
+同型が 2026-07-31 に再発（#4129）。本番 NUC の日次バックアップが deploy 翌日から毎晩失敗し、発覚まで 18 日かかった。今度は `CRON_SECRET` が **新規 env ではなかった** ため配布証跡 gate に掛からなかった（#3950 でバックアップ入口が一本化され、既存 env が hard requirement 化した）。失敗通知に必要な `DISCORD_ALERT_WEBHOOK_URL` も未配布で、無音だった。→ ルール 5。
+
 ADR-0006 が「assertion を弱める変更を禁止」する一方、CDK 側で silent skip するパターン（`...(value ? { ENV: value } : {})`）が複数箇所に残っており、ADR-0006 は実質的に CDK レベルで形骸化していた。本 ADR は ADR-0006 の CDK 適用版として、インフラ PR の必須要件を 4 本のルールで定める。
 
 ## 決定（ルール 4 本）
@@ -97,10 +99,36 @@ new cw.Alarm(this, 'CronDispatcherErrorAlarm', {
 
 scheduled / cron / queue consumer 等、ユーザー操作以外で起動する Lambda 全て対象。
 
+### ルール 5: 「既存 env の必須化」も新規追加と同じ配布証跡を要求する
+
+配布証跡 gate（`scripts/check-new-required-env.mjs`）の対象は **新規追加された env に限らない**。既に存在する env が新たに hard requirement になった変更も同じ扱いとする。
+
+検出する形は 3 つ:
+
+| 形 | 例 |
+|---|---|
+| 必須文言（英語 / **日本語**） | `throw new Error('CRON_SECRET が未設定です')` |
+| fail-fast guard | `if (!X) { console.error(...); process.exit(1) }` |
+| optional → required の**変化** | `.optional()` 剥がし / 既定値 fallback 撤去 / ルール 1 の silent skip 撤去 |
+
+**検出できない範囲**（黙って守れていることにしない）:
+
+- diff 外での必須化（別 file の代替経路が消えて既存 script が唯一の入口になる等）
+- アプリ外の消費者（docker-compose / systemd unit / shell script / workflow yaml）
+- 条件付き必須（別 env の値によって必須になる）/ 動的な env 名（`process.env[name]`）
+- 配布先の実在。gate は PR 本文の証跡文字列の有無しか見ない（実在は deploy 側 validation = ルール 2 と人間レビューが担う）
+
 ## 例外手続き
 
 - 任意の env を silent skip するのは OK。ただしコメントで「optional: なくても動く」を必ず明記すること
 - ルール 3 / 4 を skip する場合は、本 ADR を supersede する新 ADR で正当性を明示すること（ADR-0006 の例外手続きと同じ運用）
+- ルール 5 の検出が誤りの場合のみ、PR 本文で **理由付き**に解除する（理由が空 / `TODO` / `n/a` 等の定型 stub は受理しない、#3956 教訓）:
+
+  ```
+  <!-- env-not-newly-required: <ENV_NAME> <12 文字以上の理由> -->
+  ```
+
+  配布済みなら解除ではなく「配布済み: `<ENV_NAME>` → 配布先」を書く
 
 ## 結果
 

--- a/scripts/check-new-required-env.mjs
+++ b/scripts/check-new-required-env.mjs
@@ -1,17 +1,50 @@
 #!/usr/bin/env node
 /**
- * #914 / ADR-0029 — 新規必須 env / secret 追加チェック
+ * #914 / ADR-0024 — 必須化された env / secret の配布証跡チェック
  *
- * PR diff から「production で必須となる新しい env / secret」を追加した行を検出し、
+ * PR diff から「production で必須になった env / secret」を検出し、
  * PR 本文に **「配布済み:」証跡** が無ければ exit 1 で CI を red にする。
  *
- * 検出パターン (追加行 = `+` で始まる行のみ):
- *   1. 関数名 `assert*Configured()`         例: assertLicenseKeyConfigured()
- *   2. `throw new Error('...required...')`   "required" を含むエラー文字列
- *   3. `process.env.X || (() => { throw ... })()` 同等パターン
+ * ## 検出範囲 (#4129 AC5 で「既存 env の必須化」まで拡張)
  *
- * 抽出された env 名 (大文字スネークケース) について PR 本文に
- * 「配布済み: <ENV_NAME>」 が含まれているか検証する。
+ * 追加行 (`+`) から:
+ *   1. 関数名 `assert*Configured()`          例: assertLicenseKeyConfigured()
+ *   2. `throw new Error('...is required...')` 英語の必須文言
+ *   2-JP. `throw new Error('...が未設定です...')` **日本語の必須文言** (#4129)
+ *   3. `process.env.X || (() => { throw ... })()` 同等パターン
+ *   4. fail-fast guard `if (!X) { ... process.exit(1) }` (#4129)
+ *
+ * 追加行 × 削除行 (`-`) の対比から:
+ *   5. optional → required への **変化** (#4129)
+ *      — `.optional()` 剥がし / 既定値 fallback 撤去 / CDK silent skip 撤去
+ *
+ * ## なぜ「変化」まで見るか (#4129 AC5)
+ *
+ * 2026-07-31、本番 NUC の日次バックアップが 7/30 deploy 後の初回実行から毎晩失敗していた。
+ * 原因は `CRON_SECRET` が NUC の .env に未配布だったこと。#3950 でバックアップ入口が
+ * `scripts/backup-nuc.cjs` の pglite 経路に一本化された結果、**以前から存在する**
+ * `CRON_SECRET` が backup コンテナの hard requirement になったが、本 gate は
+ * 「新規追加された env」しか見ていなかったため素通りした。`DISCORD_ALERT_WEBHOOK_URL` も
+ * 未配布で失敗通知すら届かず、発覚まで 18 日かかった。
+ *
+ * ## 検出できない範囲 (明示。黙って守れていることにしない)
+ *
+ *   - **diff 外での必須化**: 別 file の代替経路が消えた結果、既存 script が唯一の入口に
+ *     なるケース。当該 env は追加行に現れないため検出不能
+ *   - **アプリ外の消費者**: docker-compose / systemd unit / shell script / workflow yaml
+ *     など、JS の `process.env` 以外の形で env を要求する経路
+ *   - **条件付き必須**: 「別 env が特定値のときだけ必須」といった実行時条件
+ *   - **動的な env 名**: `process.env[name]` のように名前が実行時に決まるもの
+ *   - **配布先の実在**: 本 gate は PR 本文の証跡文字列の有無しか見ない。実際に NUC .env /
+ *     GitHub Secrets / SSM へ入っているかは検証しない (人間レビュー + deploy 側 validation)
+ *
+ * ## 誤検出時の解除 (理由必須、#3956 教訓)
+ *
+ * 検出が誤りなら PR 本文に理由付きで宣言する。理由が空 / 定型 stub の宣言は受理しない:
+ *
+ *   <!-- env-not-newly-required: <ENV_NAME> <12 文字以上の理由> -->
+ *
+ * 「配布済み: <ENV_NAME>」を書けるなら、解除ではなくそちらを書くこと。
  *
  * 使い方 (CI):
  *   PR_BODY="$(gh pr view ${{ github.event.number }} --json body -q .body)" \
@@ -27,17 +60,42 @@
  *   BASE_REF   diff のベース ref (デフォルト: origin/main)
  *
  * exit:
- *   0 = 新規必須 env なし、または全て配布済み証跡あり
- *   1 = 新規必須 env が検出され、PR 本文に証跡が無い (CI を red にする)
+ *   0 = 必須化された env なし、または全て配布済み証跡 / 有効な解除宣言あり
+ *   1 = 必須化された env が検出され、PR 本文に証跡も有効な解除宣言も無い (CI を red にする)
  *   2 = git コマンド失敗等の internal error
  */
 
 import { execFileSync } from 'node:child_process';
 import { readFileSync, statSync } from 'node:fs';
+import { isSubstantiveReason, MIN_REASON_LENGTH } from './lib/ci/reason-declaration.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF = process.env.BASE_REF || 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
+
+/**
+ * 既知のフレームワーク / ランタイム内蔵 env。配布証跡の対象外。
+ */
+const FRAMEWORK_ENVS = new Set([
+	'NODE_ENV',
+	'PORT',
+	'HOST',
+	'CI',
+	'PWD',
+	'PATH',
+	'VITE_DEV',
+	'PUBLIC_BASE_URL',
+]);
+
+/**
+ * 日本語の必須文言 (#4129 AC5)。
+ *
+ * 実害 (#3950 → #4129): `throw new Error('CRON_SECRET が未設定です (...)')` が英語前提の
+ * regex に掛からず素通りし、本番 NUC のバックアップが 18 日間無音で停止した。
+ * env 名と述語の間に助詞や短い修飾 (`env`、`(...)` 等) が挟まる場合を許すため窓を 40 字取る。
+ */
+const ENV_REQUIRED_JP_RE =
+	/\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)\b[^\n]{0,40}?(?:が未設定|が設定されていません|が必要|は必須|が必須|を設定してください)/;
 
 // CLI args
 for (const arg of process.argv.slice(2)) {
@@ -183,15 +241,17 @@ function isExcludedPath(path) {
 }
 
 /**
- * Extract added lines (those starting with `+` but not `+++`) from a unified diff.
- * docs/ や *.md などのファイル変更ブロックはスキップする。
- */
-/**
+ * unified diff から追加行 (`+`) と削除行 (`-`) を分けて抽出する。
+ *
+ * 削除行は「optional → required の変化」(#4129 AC5 Pattern F) 判定に使う。
+ * `+++` / `---` のヘッダ行と、docs / test など検査対象外 file のブロックは除外する。
+ *
  * @param {string} diff
- * @returns {string[]}
+ * @returns {{ addedLines: string[]; removedLines: string[] }}
  */
-function extractAddedLines(diff) {
-	const lines = [];
+export function extractDiffLines(diff) {
+	const addedLines = [];
+	const removedLines = [];
 	let skipCurrentFile = false;
 
 	for (const raw of diff.split('\n')) {
@@ -204,10 +264,11 @@ function extractAddedLines(diff) {
 			continue;
 		}
 		if (skipCurrentFile) continue;
-		if (raw.startsWith('+++')) continue;
-		if (raw.startsWith('+')) lines.push(raw.slice(1));
+		if (raw.startsWith('+++') || raw.startsWith('---')) continue;
+		if (raw.startsWith('+')) addedLines.push(raw.slice(1));
+		else if (raw.startsWith('-')) removedLines.push(raw.slice(1));
 	}
-	return lines;
+	return { addedLines, removedLines };
 }
 
 /**
@@ -218,7 +279,9 @@ function extractAddedLines(diff) {
  *     関数名から推測した env 名 (XXX_CONFIGURED → XXX) と、近傍行で参照される
  *     `process.env.<ENV>` を抽出する。
  *   - Pattern B: `throw new Error('... <ENV> is required ...')` 形式の文字列内 env 名
+ *   - Pattern B-JP (#4129): `throw new Error('... <ENV> が未設定です ...')` 日本語必須文言
  *   - Pattern C: `process.env.<ENV> || (() => { throw ... })()` 形式
+ *   - Pattern E (#4129): fail-fast guard `if (!X) { ... process.exit(1) }`
  *
  * 戻り値: env 名 (大文字スネーク) の Set
  */
@@ -245,7 +308,7 @@ export function detectNewRequiredEnvs(addedLines) {
 	// 全追加行を結合して走査することで、複数行に渡る `throw new Error(...)` も拾う
 	const fullText = addedLines.join('\n');
 
-	// Pattern B (multi-line): throw new Error(...'FOO is required'...)
+	// Pattern B / B-JP (multi-line): throw new Error(...'FOO is required' / 'FOO が未設定です'...)
 	const throwBlockRe = /throw\s+new\s+Error\s*\(\s*([\s\S]*?)\)/g;
 	for (const m of fullText.matchAll(throwBlockRe)) {
 		const errorBody = m[1];
@@ -254,7 +317,13 @@ export function detectNewRequiredEnvs(addedLines) {
 		for (const em of errorBody.matchAll(new RegExp(envInStringRe.source, 'g'))) {
 			found.add(em[1]);
 		}
+		for (const em of errorBody.matchAll(new RegExp(ENV_REQUIRED_JP_RE.source, 'g'))) {
+			found.add(em[1]);
+		}
 	}
+
+	// Pattern E: fail-fast guard (throw を使わず process.exit(1) で落とす形)
+	for (const env of detectFailFastGuardedEnvs(addedLines)) found.add(env);
 
 	// 行単位で処理する Pattern A / C
 	for (let i = 0; i < addedLines.length; i++) {
@@ -282,19 +351,164 @@ export function detectNewRequiredEnvs(addedLines) {
 	}
 
 	// 既知のフレームワーク / Vite 内蔵 env は除外する
-	const exclude = new Set([
-		'NODE_ENV',
-		'PORT',
-		'HOST',
-		'CI',
-		'PWD',
-		'PATH',
-		'VITE_DEV',
-		'PUBLIC_BASE_URL',
-	]);
-	for (const e of exclude) found.delete(e);
+	for (const e of FRAMEWORK_ENVS) found.delete(e);
 
 	return found;
+}
+
+/**
+ * fail-fast guard 経由で必須化された env を検出する (#4129 AC5 Pattern E)。
+ *
+ * `throw new Error(...)` を使わず `process.exit(1)` で落とす guard は、既存 regex の
+ * どのパターンにも掛からない。実害 (#3950 / #4129) の backup 経路もこの形だった。
+ *
+ * 判定は 3 点セット:
+ *   1. `const X = process.env.ENV ...` で変数 ↔ env の対応を取る (fallback 連鎖は全て拾う)
+ *   2. `if (!X)` / `if (!process.env.ENV)` の否定 guard を見つける
+ *   3. guard 行から後方 10 行以内に fail-fast (`process.exit(非 0)` / `throw` / `exitCode = 非 0`)
+ *
+ * `process.exit(0)` で終わる guard は「未設定なら黙って skip」= optional の作法なので検出しない。
+ *
+ * @param {string[]} lines
+ * @returns {Set<string>}
+ */
+function detectFailFastGuardedEnvs(lines) {
+	const found = new Set();
+
+	/** @type {Map<string, Set<string>>} 変数名 → 由来 env 名 */
+	const aliases = new Map();
+	for (const line of lines) {
+		const m = line.match(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(.+)$/);
+		if (!m) continue;
+		const envs = [...(m[2] ?? '').matchAll(/process\.env\.([A-Z][A-Z0-9_]+)/g)].map((x) => x[1]);
+		if (envs.length === 0) continue;
+		const bucket = aliases.get(m[1] ?? '') ?? new Set();
+		for (const env of envs) bucket.add(env);
+		aliases.set(m[1] ?? '', bucket);
+	}
+
+	const negationGuardRe = /if\s*\(\s*!\s*(?:process\.env\.)?([A-Za-z_$][\w$]*)/;
+	const failFastRe = /process\.exit\s*\(\s*[1-9]|throw\s+|exitCode\s*=\s*[1-9]/;
+
+	for (let i = 0; i < lines.length; i++) {
+		const guard = (lines[i] ?? '').match(negationGuardRe);
+		if (!guard) continue;
+
+		const name = guard[1] ?? '';
+		const envs = aliases.get(name) ?? (/^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$/.test(name) ? [name] : []);
+		if ([...envs].length === 0) continue;
+
+		const window = lines.slice(i, i + 11).join('\n');
+		if (!failFastRe.test(window)) continue;
+
+		for (const env of envs) found.add(env);
+	}
+
+	return found;
+}
+
+/**
+ * optional → required への「変化」を検出する (#4129 AC5 Pattern F)。
+ *
+ * 追加行だけを見ていると「その env が以前は optional だった」ことが分からない。削除行に
+ * optional の目印があり、追加行では目印が消えたまま env が使われ続けているなら、その PR は
+ * **既存 env を必須化している**。
+ *
+ * optional の目印 (削除行側):
+ *   - `process.env.X || 'default'` / `?? 'default'` — 既定値 fallback
+ *   - `X: z.string().optional()` — schema の optional
+ *   - `...(x ? { X: x } : {})` — CDK silent skip (ADR-0024 ルール 1 で禁止された形)
+ *
+ * false positive 抑止:
+ *   - 追加行に同じ目印が残っていれば「整形しただけ」なので検出しない
+ *   - 追加行に env の言及が無ければ「参照ごと消えた」なので検出しない
+ *
+ * @param {{ addedLines: string[]; removedLines: string[] }} input
+ * @returns {Map<string, string>} env 名 → 検出理由 (BLOCK メッセージ用)
+ */
+export function detectRequirementTransitions({ addedLines, removedLines }) {
+	const transitions = new Map();
+
+	const wasOptional = collectOptionalMarkedEnvs(removedLines ?? []);
+	const stillOptional = collectOptionalMarkedEnvs(addedLines ?? []);
+	const mentioned = collectMentionedEnvs(addedLines ?? []);
+
+	for (const [env, reason] of wasOptional) {
+		if (FRAMEWORK_ENVS.has(env)) continue;
+		if (stillOptional.has(env)) continue; // optional のまま = 変化なし
+		if (!mentioned.has(env)) continue; // 参照ごと消えた = 必須化ではない
+		transitions.set(env, reason);
+	}
+
+	return transitions;
+}
+
+/**
+ * 行群から「optional の目印付き env」を集める。
+ *
+ * @param {string[]} lines
+ * @returns {Map<string, string>} env 名 → どの目印で optional と判断したか
+ */
+function collectOptionalMarkedEnvs(lines) {
+	const found = new Map();
+	for (const line of lines) {
+		// a) 既定値 fallback: process.env.X || ... / ?? ...
+		for (const m of line.matchAll(/process\.env\.([A-Z][A-Z0-9_]+)\s*(?:\|\||\?\?)/g)) {
+			found.set(m[1], 'optional の目印だった既定値 fallback (`|| ...` / `?? ...`) が消えている');
+		}
+		// b) schema の .optional()
+		if (/\.optional\s*\(\s*\)/.test(line)) {
+			for (const m of line.matchAll(/\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)\b/g)) {
+				found.set(m[1], 'schema の `.optional()` が外れている');
+			}
+		}
+		// c) CDK silent skip: ...(x ? { X: x } : {})
+		for (const m of line.matchAll(/\.\.\.\([^)]*\?\s*\{\s*([A-Z][A-Z0-9_]+)\s*:/g)) {
+			found.set(m[1], 'CDK の silent skip (`...(x ? { X: x } : {})`) が外れている');
+		}
+	}
+	return found;
+}
+
+/**
+ * 行群で env が「まだ使われている」ことを示す言及を集める。
+ *
+ * `process.env.X` の直参照と、`X:` の object / schema キーの 2 形を見る。
+ * コメント中の単なる env 名の出現は言及とみなさない (誤検出を増やすため)。
+ *
+ * @param {string[]} lines
+ * @returns {Set<string>}
+ */
+function collectMentionedEnvs(lines) {
+	const found = new Set();
+	for (const line of lines) {
+		for (const m of line.matchAll(/process\.env\.([A-Z][A-Z0-9_]+)/g)) found.add(m[1]);
+		for (const m of line.matchAll(/\b([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)\b\s*:/g)) found.add(m[1]);
+	}
+	return found;
+}
+
+/**
+ * PR 本文の解除宣言を読む (#4129 AC5、理由必須 — #3956 教訓)。
+ *
+ *   <!-- env-not-newly-required: <ENV_NAME> <12 文字以上の理由> -->
+ *
+ * 理由が空 / 定型 stub の宣言は `valid: false` として受理しない。判定は
+ * `scripts/lib/ci/reason-declaration.mjs` (SSOT) に委譲する。
+ *
+ * @param {string | null | undefined} prBody
+ * @returns {Map<string, { present: boolean; reason: string; valid: boolean }>}
+ */
+export function parseNotNewlyRequiredExemptions(prBody) {
+	const map = new Map();
+	for (const m of (prBody ?? '').matchAll(/<!--\s*env-not-newly-required\s*:([^>]*?)-->/g)) {
+		const raw = (m[1] ?? '').trim();
+		const parsed = raw.match(/^([A-Z][A-Z0-9_]*)\s*[-—:]?\s*([\s\S]*)$/);
+		if (!parsed) continue;
+		const reason = (parsed[2] ?? '').trim();
+		map.set(parsed[1], { present: true, reason, valid: isSubstantiveReason(reason) });
+	}
+	return map;
 }
 
 /**
@@ -321,15 +535,23 @@ function main() {
 		process.exit(0);
 	}
 
-	const addedLines = extractAddedLines(diff);
+	const { addedLines, removedLines } = extractDiffLines(diff);
 	const newEnvs = detectNewRequiredEnvs(addedLines);
+	const transitions = detectRequirementTransitions({ addedLines, removedLines });
 
-	if (newEnvs.size === 0) {
-		console.log('[check-new-required-env] no new required env / secret detected — OK');
+	/** @type {Map<string, string>} env 名 → 検出理由 */
+	const detected = new Map();
+	for (const env of newEnvs) detected.set(env, 'この PR で必須 (hard requirement) になっている');
+	for (const [env, reason] of transitions) detected.set(env, reason);
+
+	if (detected.size === 0) {
+		console.log('[check-new-required-env] no newly required env / secret detected — OK');
 		process.exit(0);
 	}
 
-	console.log(`[check-new-required-env] detected new required env(s): ${[...newEnvs].join(', ')}`);
+	console.log(
+		`[check-new-required-env] detected newly required env(s): ${[...detected.keys()].join(', ')}`,
+	);
 
 	if (!PR_BODY) {
 		console.log(
@@ -339,40 +561,62 @@ function main() {
 		process.exit(0);
 	}
 
+	const exemptions = parseNotNewlyRequiredExemptions(PR_BODY);
+
+	/** @type {string[]} 証跡も有効な解除宣言も無い env */
 	const missing = [];
-	for (const env of newEnvs) {
-		if (!hasDistributionEvidence(env, PR_BODY)) {
-			missing.push(env);
+	/** @type {string[]} 解除宣言はあるが理由が空 / 定型 stub の env */
+	const badReason = [];
+
+	for (const env of detected.keys()) {
+		if (hasDistributionEvidence(env, PR_BODY)) continue;
+		const exemption = exemptions.get(env);
+		if (exemption?.valid) {
+			console.log(`[check-new-required-env] ${env}: 解除宣言を受理 — ${exemption.reason}`);
+			continue;
 		}
+		if (exemption?.present) badReason.push(env);
+		else missing.push(env);
 	}
 
-	if (missing.length > 0) {
+	if (missing.length > 0 || badReason.length > 0) {
 		console.error('');
-		console.error('BLOCKED by ADR-0029 — new required env(s) without distribution evidence:');
+		console.error('BLOCKED by ADR-0024 — 必須化された env に配布証跡がありません:');
 		for (const env of missing) {
-			console.error(`  - ${env}`);
+			console.error(`  - ${env}: ${detected.get(env)}`);
+		}
+		for (const env of badReason) {
+			console.error(
+				`  - ${env}: 解除宣言はありますが理由が空 / 定型 stub のため受理できません (理由必須、#3956 教訓)`,
+			);
 		}
 		console.error('');
-		console.error('PR 本文に次の形式で配布済み証跡を記載してください:');
+		console.error('PR 本文に次のいずれかを記載してください:');
 		console.error('');
-		console.error('  ## 配布済み env / secret (ADR-0029)');
-		const firstMissing = missing[0];
+		const firstMissing = missing[0] ?? badReason[0];
 		if (firstMissing) {
+			console.error('  (a) 配布済み証跡 — 実際に配布したうえで書く');
+			console.error('      ## 配布済み env / secret (ADR-0024)');
 			console.error(
-				`  - 配布済み: ${firstMissing} → GitHub Actions Secrets (deploy.yml, deploy-nuc.yml)`,
+				`      - 配布済み: ${firstMissing} → GitHub Actions Secrets (deploy.yml, deploy-nuc.yml)`,
 			);
 			console.error(
-				`  - 配布済み: ${firstMissing} → SSM Parameter Store /ganbari-quest/prod/${firstMissing.toLowerCase()}`,
+				`      - 配布済み: ${firstMissing} → SSM Parameter Store /ganbari-quest/prod/${firstMissing.toLowerCase()}`,
 			);
-			console.error(`  - 配布済み: ${firstMissing} → NUC .env (本機 + バックアップ機)`);
+			console.error(`      - 配布済み: ${firstMissing} → NUC .env (本機 + バックアップ機)`);
+			console.error('');
+			console.error('  (b) 検出が誤りの場合のみ — 理由付きで解除する');
+			console.error(
+				`      <!-- env-not-newly-required: ${firstMissing} <${MIN_REASON_LENGTH} 文字以上の理由> -->`,
+			);
 		}
 		console.error('');
-		console.error('See: docs/decisions/0006-safety-assertion-erosion-ban.md');
+		console.error('See: docs/decisions/0024-infra-pr-required-baseline.md (ルール 5)');
 		process.exit(1);
 	}
 
 	console.log(
-		`[check-new-required-env] all detected env(s) have distribution evidence — OK (${[...newEnvs].join(', ')})`,
+		`[check-new-required-env] all detected env(s) have distribution evidence — OK (${[...detected.keys()].join(', ')})`,
 	);
 	process.exit(0);
 }

--- a/scripts/check-new-required-env.mjs
+++ b/scripts/check-new-required-env.mjs
@@ -380,11 +380,16 @@ function detectFailFastGuardedEnvs(lines) {
 	for (const line of lines) {
 		const m = line.match(/(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(.+)$/);
 		if (!m) continue;
-		const envs = [...(m[2] ?? '').matchAll(/process\.env\.([A-Z][A-Z0-9_]+)/g)].map((x) => x[1]);
-		if (envs.length === 0) continue;
-		const bucket = aliases.get(m[1] ?? '') ?? new Set();
-		for (const env of envs) bucket.add(env);
-		aliases.set(m[1] ?? '', bucket);
+		const varName = m[1];
+		if (!varName) continue;
+		/** @type {Set<string>} */
+		const bucket = aliases.get(varName) ?? new Set();
+		for (const em of (m[2] ?? '').matchAll(/process\.env\.([A-Z][A-Z0-9_]+)/g)) {
+			const env = em[1];
+			if (env) bucket.add(env);
+		}
+		if (bucket.size === 0) continue;
+		aliases.set(varName, bucket);
 	}
 
 	const negationGuardRe = /if\s*\(\s*!\s*(?:process\.env\.)?([A-Za-z_$][\w$]*)/;

--- a/scripts/check-ss-blob-sha-uniqueness.mjs
+++ b/scripts/check-ss-blob-sha-uniqueness.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const MODE = (process.env.CHECK_MODE || 'warn').toLowerCase();
@@ -105,47 +106,10 @@ export function pairBeforeAfter(paths) {
 // ---------------------------------------------------------------------------
 
 /**
- * 理由記述を要求する宣言の最小長 (全角前提の目安)。
- *
- * 「理由の非強制」を作らないための下限 (#3956 教訓 / #4084 AC3)。空欄・`TODO`・`n/a` のような
- * 定型 stub は理由として認めない。lint の `-- <reason>` 付き抑制コメントと同じ思想。
+ * 理由の実体判定は `scripts/lib/ci/reason-declaration.mjs` が SSOT (#4129 AC5 で集約)。
+ * 本 module からの re-export は既存の import 経路を壊さないために維持する。
  */
-export const MIN_REASON_LENGTH = 12;
-
-/** 理由として認めない定型 stub (小文字化して完全一致で判定)。 */
-const STUB_REASONS = new Set([
-	'todo',
-	'tbd',
-	'n/a',
-	'na',
-	'-',
-	'—',
-	'なし',
-	'後で書く',
-	'あとで書く',
-	'理由',
-	'wip',
-	'fixme',
-]);
-
-/**
- * `<!-- <key>: <理由> -->` 形式の宣言を読み、理由の実体があるかを判定する (#4084 AC3)。
- *
- * @param {string} body
- * @param {string} key 例: `ss-identical-ok` / `ss-pair-none`
- * @returns {{ present: boolean; reason: string; valid: boolean }}
- */
-export function parseReasonDeclaration(body, key) {
-	const m = body.match(new RegExp(`<!--\\s*${key}\\s*:([^>]*?)-->`));
-	if (!m) return { present: false, reason: '', valid: false };
-	const reason = (m[1] ?? '').trim();
-	const normalized = reason.toLowerCase();
-	const valid =
-		reason.length >= MIN_REASON_LENGTH &&
-		!STUB_REASONS.has(normalized) &&
-		!/^[-—\s]*$/.test(reason);
-	return { present: true, reason, valid };
-}
+export { MIN_REASON_LENGTH, parseReasonDeclaration };
 
 /**
  * ペアリング宣言を読む (#4084 AC2)。

--- a/scripts/lib/ci/reason-declaration.mjs
+++ b/scripts/lib/ci/reason-declaration.mjs
@@ -1,0 +1,67 @@
+/**
+ * scripts/lib/ci/reason-declaration.mjs
+ *
+ * gate の例外宣言 (`<!-- <key>: <理由> -->`) における **理由の実体判定 SSOT**。
+ *
+ * # なぜ共有するか
+ *
+ * 「例外は宣言できるが理由は必須」は本 repo の一貫した設計 (#3956 教訓 —
+ * 理由の非強制を作らない)。各 gate が独自に stub 一覧を持つと、片方だけ `n/a` を通す
+ * ドリフトが起きる。判定を 1 箇所に集約する。
+ *
+ * 利用側: `scripts/check-ss-blob-sha-uniqueness.mjs` (#4084) /
+ *         `scripts/check-new-required-env.mjs` (#4129 AC5)
+ */
+
+/**
+ * 理由記述を要求する宣言の最小長 (全角前提の目安)。
+ *
+ * 「理由の非強制」を作らないための下限。空欄・`TODO`・`n/a` のような定型 stub は
+ * 理由として認めない。lint の `-- <reason>` 付き抑制コメントと同じ思想。
+ */
+export const MIN_REASON_LENGTH = 12;
+
+/** 理由として認めない定型 stub (小文字化して完全一致で判定)。 */
+export const STUB_REASONS = new Set([
+	'todo',
+	'tbd',
+	'n/a',
+	'na',
+	'-',
+	'—',
+	'なし',
+	'後で書く',
+	'あとで書く',
+	'理由',
+	'wip',
+	'fixme',
+]);
+
+/**
+ * 理由文字列に実体があるかを判定する。
+ *
+ * @param {string} reason
+ * @returns {boolean}
+ */
+export function isSubstantiveReason(reason) {
+	const trimmed = (reason ?? '').trim();
+	return (
+		trimmed.length >= MIN_REASON_LENGTH &&
+		!STUB_REASONS.has(trimmed.toLowerCase()) &&
+		!/^[-—\s]*$/.test(trimmed)
+	);
+}
+
+/**
+ * `<!-- <key>: <理由> -->` 形式の宣言を読み、理由の実体があるかを判定する。
+ *
+ * @param {string} body
+ * @param {string} key 例: `ss-identical-ok` / `ss-pair-none`
+ * @returns {{ present: boolean; reason: string; valid: boolean }}
+ */
+export function parseReasonDeclaration(body, key) {
+	const m = (body ?? '').match(new RegExp(`<!--\\s*${key}\\s*:([^>]*?)-->`));
+	if (!m) return { present: false, reason: '', valid: false };
+	const reason = (m[1] ?? '').trim();
+	return { present: true, reason, valid: isSubstantiveReason(reason) };
+}

--- a/tests/unit/scripts/check-new-required-env.test.ts
+++ b/tests/unit/scripts/check-new-required-env.test.ts
@@ -308,6 +308,15 @@ describe('check-new-required-env (#4129 AC5 既存 env の必須化)', () => {
 			}
 		});
 
+		it('stub ではないが短すぎる理由も受理しない (最小長 gate)', () => {
+			// stub 一覧に載っていない語でも、実質的な説明になっていなければ受理しない。
+			// stub 一覧だけでは「急ぎ」の一言で解除できてしまい理由の非強制が復活する
+			const map = parseNotNewlyRequiredExemptions(
+				'<!-- env-not-newly-required: SOME_TOKEN 急ぎ -->',
+			);
+			expect(map.get('SOME_TOKEN')?.valid).toBe(false);
+		});
+
 		it('理由が空の宣言は受理しない', () => {
 			const map = parseNotNewlyRequiredExemptions('<!-- env-not-newly-required: SOME_TOKEN -->');
 			expect(map.get('SOME_TOKEN')?.present).toBe(true);

--- a/tests/unit/scripts/check-new-required-env.test.ts
+++ b/tests/unit/scripts/check-new-required-env.test.ts
@@ -7,7 +7,11 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { detectNewRequiredEnvs } from '../../../scripts/check-new-required-env.mjs';
+import {
+	detectNewRequiredEnvs,
+	detectRequirementTransitions,
+	parseNotNewlyRequiredExemptions,
+} from '../../../scripts/check-new-required-env.mjs';
 
 describe('check-new-required-env (#2337 regex 改善)', () => {
 	describe('Pattern B: throw new Error 内 env 名検出', () => {
@@ -135,6 +139,183 @@ describe('check-new-required-env (#2337 regex 改善)', () => {
 			const lines2 = ["throw new Error('STRIPE_SECRET_KEY is required');"];
 			const result2 = detectNewRequiredEnvs(lines2);
 			expect(result2.has('STRIPE_SECRET_KEY')).toBe(true);
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4129 AC5 — 「既存 env の必須化」まで検出範囲を広げる
+//
+// 実害 (2026-07-31): 本番 NUC の日次バックアップが 7/30 の deploy 後、初回実行から
+// 毎晩失敗していた。原因は `CRON_SECRET` が NUC の .env に未配布だったこと。
+// #3950 でバックアップ入口が `scripts/backup-nuc.cjs` の pglite 経路へ一本化された結果、
+// 以前から存在する `CRON_SECRET` が backup コンテナの hard requirement になったが、
+// 本 gate は「**新規**追加された必須 env」しか見ていなかったため素通りした。
+// さらに `DISCORD_ALERT_WEBHOOK_URL` も未配布で失敗通知も届かず、18 日間気付かれなかった。
+//
+// 検出漏れの直接原因は 2 つ:
+//   (a) requirement guard の throw 文言が日本語 (`CRON_SECRET が未設定です`) で、
+//       英語 "is required" 前提の regex に掛からなかった
+//   (b) `if (!X) { ... process.exit(1) }` 形式の fail-fast guard を見ていなかった
+// 加えて構造的な穴として (c) optional → required への「変化」を diff から読んでいなかった。
+// ---------------------------------------------------------------------------
+
+describe('check-new-required-env (#4129 AC5 既存 env の必須化)', () => {
+	describe('Pattern B-JP: 日本語の必須文言', () => {
+		it('#3950 実物再現: throw new Error("CRON_SECRET が未設定です ...") を検出する', () => {
+			// scripts/backup-nuc.cjs L101-103 の実コード
+			const lines = [
+				'	if (!CRON_SECRET) {',
+				"		throw new Error('CRON_SECRET が未設定です (/api/cron/pglite-backup の認証に必要)');",
+				'	}',
+			];
+			const result = detectNewRequiredEnvs(lines);
+			expect(result.has('CRON_SECRET')).toBe(true);
+		});
+
+		it('「が必要」「は必須」「を設定してください」「が設定されていません」も検出する', () => {
+			for (const message of [
+				'DISCORD_ALERT_WEBHOOK_URL が必要です',
+				'BACKUP_TARGET_URL は必須です',
+				'NUC_ADMIN_TOKEN を設定してください',
+				'RESTORE_VERIFY_URL が設定されていません',
+			]) {
+				const envName = message.split(' ')[0] as string;
+				const result = detectNewRequiredEnvs([`throw new Error('${message}');`]);
+				expect(result.has(envName), `${envName} を検出できていない`).toBe(true);
+			}
+		});
+	});
+
+	describe('Pattern E: fail-fast guard (throw を使わない必須化)', () => {
+		it('const alias 経由の `if (!X) { ... process.exit(1) }` を検出する', () => {
+			const lines = [
+				"const BACKUP_SECRET = process.env.NUC_BACKUP_SECRET || '';",
+				'if (!BACKUP_SECRET) {',
+				"	console.error('backup secret missing');",
+				'	process.exit(1);',
+				'}',
+			];
+			const result = detectNewRequiredEnvs(lines);
+			expect(result.has('NUC_BACKUP_SECRET')).toBe(true);
+		});
+
+		it('fallback 連鎖 (`A || B`) は両方の env を必須として検出する', () => {
+			// backup-nuc.cjs L58 と同型。どちらも配布されていないと動かないため両方に証跡が要る
+			const lines = [
+				"const CRON_SECRET = process.env.CRON_SECRET || process.env.OPS_SECRET_KEY || '';",
+				'if (!CRON_SECRET) {',
+				'	process.exit(1);',
+				'}',
+			];
+			const result = detectNewRequiredEnvs(lines);
+			expect(result.has('CRON_SECRET')).toBe(true);
+			expect(result.has('OPS_SECRET_KEY')).toBe(true);
+		});
+
+		it('`if (!process.env.X)` 直参照も検出する', () => {
+			const lines = ['if (!process.env.PGLITE_BACKUP_BUCKET) {', '	process.exit(1);', '}'];
+			const result = detectNewRequiredEnvs(lines);
+			expect(result.has('PGLITE_BACKUP_BUCKET')).toBe(true);
+		});
+
+		it('env に紐づかない変数の guard は検出しない (false positive 抑止)', () => {
+			const lines = [
+				'const parsed = JSON.parse(raw);',
+				'if (!parsed) {',
+				'	process.exit(1);',
+				'}',
+			];
+			expect(detectNewRequiredEnvs(lines).size).toBe(0);
+		});
+
+		it('exit(0) で終わる guard は必須化ではない (false positive 抑止)', () => {
+			const lines = [
+				"const optionalHook = process.env.OPTIONAL_HOOK_URL || '';",
+				'if (!optionalHook) {',
+				"	console.log('hook 未設定のため通知を skip します');",
+				'	process.exit(0);',
+				'}',
+			];
+			expect(detectNewRequiredEnvs(lines).has('OPTIONAL_HOOK_URL')).toBe(false);
+		});
+	});
+
+	describe('Pattern F: optional → required の変化 (removed 行との対比)', () => {
+		it('schema の `.optional()` 剥がしを検出する', () => {
+			const result = detectRequirementTransitions({
+				addedLines: ['	CRON_SECRET: z.string(),'],
+				removedLines: ['	CRON_SECRET: z.string().optional(),'],
+			});
+			expect(result.has('CRON_SECRET')).toBe(true);
+		});
+
+		it('既定値 fallback の撤去を検出する', () => {
+			const result = detectRequirementTransitions({
+				addedLines: ['const url = process.env.DISCORD_ALERT_WEBHOOK_URL;'],
+				removedLines: ["const url = process.env.DISCORD_ALERT_WEBHOOK_URL || '';"],
+			});
+			expect(result.has('DISCORD_ALERT_WEBHOOK_URL')).toBe(true);
+		});
+
+		it('CDK silent skip (ADR-0024 ルール 1) の撤去を検出する', () => {
+			const result = detectRequirementTransitions({
+				addedLines: ['	CRON_SECRET: cronSecret,'],
+				removedLines: ['	...(cronSecret ? { CRON_SECRET: cronSecret } : {}),'],
+			});
+			expect(result.has('CRON_SECRET')).toBe(true);
+		});
+
+		it('optional のまま整形しただけの diff は検出しない (false positive 抑止)', () => {
+			const result = detectRequirementTransitions({
+				addedLines: ["const url = process.env.SOME_WEBHOOK_URL || ''; // 整形"],
+				removedLines: ["const url = process.env.SOME_WEBHOOK_URL || '';"],
+			});
+			expect(result.has('SOME_WEBHOOK_URL')).toBe(false);
+		});
+
+		it('参照ごと消えた env は検出しない (使わなくなったのだから必須化ではない)', () => {
+			const result = detectRequirementTransitions({
+				addedLines: [],
+				removedLines: ["const url = process.env.LEGACY_WEBHOOK_URL || '';"],
+			});
+			expect(result.has('LEGACY_WEBHOOK_URL')).toBe(false);
+		});
+
+		it('検出理由を env ごとに持つ (BLOCK メッセージで何を直すか分かるように)', () => {
+			const result = detectRequirementTransitions({
+				addedLines: ['	CRON_SECRET: z.string(),'],
+				removedLines: ['	CRON_SECRET: z.string().optional(),'],
+			});
+			expect(result.get('CRON_SECRET')).toMatch(/optional/i);
+		});
+	});
+
+	describe('誤検出の解除は「理由必須」の宣言でのみ行える (#3956 教訓)', () => {
+		it('実体のある理由付き宣言は解除として受理される', () => {
+			const body =
+				'<!-- env-not-newly-required: SOME_TOKEN 既に NUC / GitHub Secrets 双方へ配布済で本 PR は参照位置の移動のみ -->';
+			const map = parseNotNewlyRequiredExemptions(body);
+			expect(map.get('SOME_TOKEN')?.valid).toBe(true);
+		});
+
+		it('定型 stub の理由は受理しない', () => {
+			for (const stub of ['TODO', 'n/a', 'なし', '-']) {
+				const map = parseNotNewlyRequiredExemptions(
+					`<!-- env-not-newly-required: SOME_TOKEN ${stub} -->`,
+				);
+				expect(map.get('SOME_TOKEN')?.valid, `stub "${stub}" が受理されている`).toBe(false);
+			}
+		});
+
+		it('理由が空の宣言は受理しない', () => {
+			const map = parseNotNewlyRequiredExemptions('<!-- env-not-newly-required: SOME_TOKEN -->');
+			expect(map.get('SOME_TOKEN')?.present).toBe(true);
+			expect(map.get('SOME_TOKEN')?.valid).toBe(false);
+		});
+
+		it('宣言が無ければ解除されない', () => {
+			expect(parseNotNewlyRequiredExemptions('本文に宣言なし').size).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**家族のデータが「毎晩バックアップされているつもりで、実は 18 日間 1 度も取れていない」状態を、次は deploy 前に止める。**

2026-07-31、本番 NUC の日次バックアップが 7/30 の release deploy 後の**初回実行から止まっていた**ことが実測で判明した（[#4119 実測報告](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4119#issuecomment-5137096467)）。原因は `CRON_SECRET` が NUC の `.env` に配布されていなかったこと。

構造的な抜けはこうだった:

- #3950 で backup 入口が `scripts/backup-nuc.cjs` の pglite 経路に一本化され、`CRON_SECRET`（or `OPS_SECRET_KEY`）が backup コンテナの **hard requirement** になった
- しかし `CRON_SECRET` は**以前から存在する env** なので、ADR-0024 の「**新規**必須 env の配布証跡」gate に引っかからなかった
- deploy は緑。その晩 03:00 から毎晩失敗。`DISCORD_ALERT_WEBHOOK_URL` も未配布のため**誰にも届かなかった**
- 発覚は 18 日後、人間がファイル一覧を目で見たとき

**gate が見ていたのは「env の追加」だけで、「既存 env が新たに必須になった」を見ていなかった。** 本 PR はその検出範囲を広げる。

## 関連 Issue

Refs #4129

<!-- no-issue-close: #4129 の AC5 のみを実装。AC1〜AC4（fail-closed abort / .env.example 同期 / 連続失敗検知）は別 PR で並行実装中のため、#4129 は全 AC 完了後に手動 close する -->

## AC 検証マップ (ADR-0004)

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC5 | ADR-0024 の env 配布証跡 gate の検出範囲を「既存 env の必須化」まで広げる | **実ファイルでの before/after 実測**（合成 fixture ではなく、実害の当該ファイル `scripts/backup-nuc.cjs` を入力にする） | `origin/develop` 版の gate → **`[]`（検出ゼロ = 今回の事故が素通りする）** / 本 PR 版 → **`[ 'CRON_SECRET', 'OPS_SECRET_KEY' ]`**。`tests/unit/scripts/check-new-required-env.test.ts` **31 passed** |
| AC5 (failing-test-first) | 先に落ちるテストを書いてから実装する（ADR-0061） | 実装前に test だけ追加して実行 | **`Tests 15 failed | 15 passed (30)`**（新規 15 件が全 fail、既存 15 件は緑）→ 実装後 **31 passed** |
| AC5 (mutation) | テストが実装の不在を検出することの確認 | 実装 commit 後に 4 箇所を個別に破壊 | JP regex から `が未設定` 削除 → **1 件 fail** / Pattern E 無効化 → **3 件 fail** / Pattern F の false-positive 抑止判定を無効化 → **1 件 fail** / `isSubstantiveReason` 最小長判定を無効化 → **0 件 = 生存**（下記参照） |

### mutation で生存した 1 件を潰しました

`isSubstantiveReason` の**最小長判定を壊してもテストが 1 件も落ちませんでした**。stub 一覧に無い短語（「急ぎ」）だけで解除宣言が通ってしまう本物のカバレッジ穴です。最小長 gate を直接検証する test を追加し（commit `0b947e129`）、再実行で fail することを確認済みです。

**mutation が「生存した」ことを報告して終わりにせず、穴を塞いでから出しています。**

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（顧客に見える挙動は不変）。変更対象は CI gate と ADR 本文のみ。

**検出できるようになった 3 方向**:

| pattern | 内容 | なぜ必要か |
|---|---|---|
| **B-JP** | 日本語の必須文言（`X が未設定` / `が設定されていません` / `が必要` / `は必須` / `を設定してください`） | **今回の実害の throw は日本語**で、英語 `is required` 前提の regex を素通りしていた |
| **E** | fail-fast guard `if (!X) { … process.exit(1) }`。`const X = process.env.A \|\| process.env.B` の別名解決込みで、fallback 連鎖は**両方の env** を要求扱いにする | `CRON_SECRET` / `OPS_SECRET_KEY` の 2 段 fallback がこの形 |
| **F** | optional → required の**変化**（削除行との対比）。`.optional()` 剥がし / 既定値 fallback 撤去 / ADR-0024 ルール 1 の CDK silent skip 撤去 | 「新規追加」ではないため従来 gate の対象外だった |

`process.exit(0)` で終わる guard は optional の作法なので対象外です。

- [ ] **並行実装ペア**を同期した
- [x] **設計書同期** (ADR-0001): ADR-0024 にルール 5（既存 env の必須化）+ 再発事例を追記。`ci.yml` の step 名が削除済みの旧 ADR-0029 を指していたため 0024 に是正（挙動変更なし）
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4142` | **ALL PASS**（20 step 中 15 step 実行 / 5 step は LP・UI 変更なしで skip。vitest **590 files / 9170 passed**、svelte-check **0 errors 0 warnings**） |
| 追加・変更テスト | `npx vitest run tests/unit/scripts/check-new-required-env.test.ts` | PASS (31 passed) |

CLI end-to-end も実測しました（temp commit で確認後、commit ごと撤去済）: 証跡なし → exit 1 / `配布済み: <ENV>` あり → exit 0 / stub 理由での解除 → BLOCK 継続 / 実体ある理由 → 受理して exit 0。

- [x] **SOLID / DRY / YAGNI**: 理由判定を `scripts/lib/ci/reason-declaration.mjs` に切り出し、`check-ss-blob-sha-uniqueness.mjs`（#4084）と共有。stub 一覧を 2 箇所に複製しない（#3956 の「理由の非強制を作らない」と同じ SSOT）
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。gate は env **名**のみを扱い値を読まない
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

N/A — UI 変更なし（CI gate + docs のみ）。

## レビュー依頼事項・破壊的変更

### 守れない範囲を明示します（script 冒頭 + ADR-0024 ルール 5 に記載）

**この gate を入れても、今回と同型の事故を完全には止められません。** 検出できない範囲:

| 範囲 | 理由 |
|---|---|
| **diff 外での必須化** | 別 file の代替経路が消えて既存 script が唯一の入口になる型。当該 env が追加行に現れないため**原理的に不可** |
| **アプリ外の消費者** | docker-compose / systemd unit / shell script / workflow yaml が env を要求する経路 |
| **条件付き必須** | 別 env の値によってのみ必須になるもの |
| **動的 env 名** | `process.env[name]` |
| **配布先の実在** | gate は PR body の証跡**文字列**しか見ない。実際に NUC `.env` / Secrets / SSM に入っているかは検証していない |

**最後の 1 つが最も重要な残穴です。** 「証跡さえ書けば通る」ので、**今回の事故は本 gate があっても「配布済み: CRON_SECRET」と書けば通せてしまいます**。実在検証は ADR-0024 ルール 2 の deploy 側 validation と人間レビューの担当であることを明記しました。**deploy 側の fail-fast（#4129 AC3 系、別 PR で実装中）と 2 本立てで初めて塞がります。**

### 誤検出の解除方法（理由を強制します）

```
<!-- env-not-newly-required: <ENV_NAME> <12 文字以上の理由> -->
```

空欄 / `TODO` / `TBD` / `n/a` / `なし` / `-` 等の定型 stub、および 12 文字未満は **BLOCK 継続**（「解除宣言はあるが理由が受理できない」旨を別メッセージで出す）。配布済みなら解除ではなく `配布済み: <ENV>` を書くよう BLOCK メッセージで誘導しています。

### 保守的に倒した箇所

- **Pattern E は誤検出寄り**（guard 行から後方 10 行以内に `throw` / `process.exit(非0)` があれば要求とみなす）。**無音の 18 日より誤検出のほうが安全**という判断です。代わりに解除経路を必ず理由必須にしています
- **Pattern F は逆に取りこぼし寄り**。追加行にまだ optional の目印が残っていれば「整形しただけ」、env の言及が消えていれば「使わなくなった」として検出しません。ここを緩めると全 refactor PR が落ちて **gate が形骸化する**ため

### pre-ready 中に見つかった実バグを 1 件直しました（commit `ce86e7604`）

`matchAll` の capture group は `string | undefined` なのに `Set<string>` へ直接 `add` していました。空判定で narrowing して解消しています（`as any` / `@ts-expect-error` は不使用、ADR-0006）。

**vitest / biome では出ず、svelte-check だけが捕まえました。** PR 番号が要る Step 9 が通せるようになって初めて全 step を回せた効果がそのまま出た形です。

### PR body の placeholder 検出を、逃げ道を使って解除しました（理由付き）

Step 9 が body L106 の「空欄 / `TODO` / `TBD` / `n/a` …」を未置換プレースホルダとして検出しました。**本 PR はまさにその stub 語を拒否する gate の変更**で、仕様説明として列挙が必要なため、gate が用意している逃げ道を理由付きで使っています。

```
<!-- placeholder-scan-skip: 本 PR は定型 stub 理由を拒否する gate 自体の変更であり、拒否対象の語を仕様説明として列挙する必要があるため -->
```

**文言を削って回避する案は不採用にしました** — それだと PR body の説明が不正確になるためです。

### sparse-checkout の 1 行追加は gate が検出したものです

`.github/workflows/pr-quality-gate.yml` への `scripts/lib/ci/reason-declaration.mjs` 追加は、**手で気づいたのではなく `check-workflow-sparse-checkout-closure`（#3969）が名指しで検出**しました。

```
.github/workflows/pr-quality-gate.yml:218  不足: scripts/lib/ci/reason-declaration.mjs
    ... が import しているが sparse-checkout に列挙されていない
    対処: 当該 sparse-checkout ブロックに上記パスを追加する (job は ERR_MODULE_NOT_FOUND で落ちる)
```

gate が無ければ CI で `ERR_MODULE_NOT_FOUND` を踏んでいました。**gate が意図どおり働いた例**として記録します。

### 環境の報告（本 PR の scope 外、手を入れていません）

**worktree で `npm ci` が素で失敗します。** `.npmrc` の `engine-strict=true` × `jsdom@30.0.0` が `node ^22.22.2 || ^24.15.0 || >=26.0.0` を要求するのに対し、この環境の node は **v22.19.0** です（実測）。`npm ci --engine-strict=false` で回避しました。

CI は `node-version: 22` で最新 22.x を取るため**CI では顕在化しませんが、ローカルの Dev / Agent が worktree で `npm ci` すると全員ここで止まります**。node の引き上げか `engine-strict` の扱いは本 PR の scope 外のため手を入れていません。判断をお願いします。

### 既存の失敗 2 件は本変更と無関係です

- `pre-ready-preflight.test.ts` / `nuc-pglite-cutover-cli.test.ts` — **上記 `npm ci` 失敗で worktree の `node_modules` が空だったことが原因**。`--engine-strict=false` で install し直したところ**両方 PASS しました**（環境問題であってコードの問題ではないことが確定）
- `node --test scripts/__tests__/check-ss-blob-sha-uniqueness.test.mjs` の 1 件 — **`origin/develop` の元ファイルに差し替えても同じく 1 fail** で pre-existing と確認済み。#4084 系の別作業と関係する可能性があるため報告のみ

いずれも変更ファイルへの参照 0 件を grep で確認済みです。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = #4129 AC5 のみ。AC1〜AC4 は別 PR で並行実装中であることを body に明示）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
