### PR TITLE
fix(ci): #4121 E5 Wave 2 — pre-ready を 6 step / 60 秒台にし check-lp-plan-sync を hard-fail に戻す

### DIFF
--- a/.claude/skills/dev-open-pr/SKILL.md
+++ b/.claude/skills/dev-open-pr/SKILL.md
@@ -366,7 +366,7 @@ rm tmp/pr-bodies/<num>-<slug>.md
 | @scripts/check-pr-body.mjs | PR body セルフチェック CLI（#1775 / ADR-0030） |
 | @scripts/check-pr-template-sections-sync.mjs | **#2060: template ↔ SSOT JSON drift 検出 CLI** (`--fix` で JSON 再生成) |
 | @scripts/check-pr-screenshot.mjs | SS 4 スロット / ローカルパス検証 CLI（#1740 / #1741） |
-| @scripts/pre-ready.mjs | pre-ready 全 14 step CLI（#1920 / #2918 で SSOT 検証 step 拡張。一覧 SSOT は `--help`） |
+| @scripts/pre-ready.mjs | pre-ready 全 6 step CLI（#4121 で ADR-0007 §1-2 判断原則 v2 に基づき縮小。外した検査は CI で hard-fail 継続。一覧・対応表 SSOT は `--help`） |
 | @docs/troubleshoot/screenshot_capture.md | SS 撮影 KB（SC-007 screenshots branch 運用 / SC-008 tmp gitignore） |
 | @docs/decisions/0004-review-and-ac-verification.md | AC 検証マップ義務（gate 1） |
 | @docs/decisions/0030-pre-ready-cli.md | pre-ready 全 Step PASS 必須 |

--- a/.claude/skills/dev-open-pr/ready-gate-checklist.md
+++ b/.claude/skills/dev-open-pr/ready-gate-checklist.md
@@ -15,7 +15,7 @@ Wave 1 (#1969 / #1970 等) で 4 Agent 連続して同じ 4 種類の CI gate �
 | 3 | PR チェックリスト `[x]` 完了確認 | `pr-merge-gate.yml` / `check-pr-body.mjs` | yes | ADR-0030 / #1775 |
 | 4 | screenshot-check (4 スロット) | `pr-quality-gate.yml` | yes (UI 変更時) | #1740 / #1741 / #1747 |
 
-ローカル一括検証: `npm run pre-ready -- --pr <num>` (#1775 / ADR-0030 / #1920 / #2918 で SSOT 検証 step 拡張)。全 14 step、一覧 SSOT は `npm run pre-ready -- --help` (#2929)。Step 9 (`check-pr-body.mjs`) が gate 1〜3 を網羅。Step 11b (SS embed gate #2918) + Step 12 (capture、手動推奨) が gate 4 を補助。
+ローカル一括検証: `npm run pre-ready -- --pr <num>` (#1775 / ADR-0030 / #1920 / #2918 で SSOT 検証 step 拡張)。全 6 step (#4121)、一覧 SSOT は `npm run pre-ready -- --help`。Step 9 (`check-pr-body.mjs`) が gate 1〜3 を網羅。Step 11b (SS embed gate #2918) が gate 4 を担う。6 step 外の検査は CI で hard-fail のまま走るため `gh pr checks <num>` で pass を確認する。
 
 ### hotfix PR (priority:critical / hotfix label) は 4 種 pre-push check 追加必須 (#2343)
 
@@ -357,7 +357,7 @@ npm run dev:open-pr -- --issue <num> --kind default
 
 # 3. ローカル一括検証 (SKILL.md ステップ 3 + 本ファイル gate 1〜3 の機械検証)
 npm run pre-ready -- --pr <num>
-# Step 9 (check-pr-body) で gate 1+2+3 を網羅検出 / Step 11b (SS embed gate #2918) で gate 4 を前倒し検出 (全 14 step、一覧 SSOT は --help)
+# Step 9 (check-pr-body) で gate 1+2+3 を網羅検出 / Step 11b (SS embed gate #2918) で gate 4 を前倒し検出 (全 6 step、一覧 SSOT は --help)
 
 # 4. UI 変更ありなら本ファイル Section 2 で SS 撮影 (gate 4)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,12 +216,12 @@ jobs:
         # 「parser バグ」と「反映漏れ」の両面を捕捉する。
         run: npm run lint:parallel
 
-      - name: LP plan sync check (advisory、#4121 warn 降格)
+      - name: LP plan sync check (#4121 hard-fail 復帰)
         # ADR-0007 §1-2 類型 2 (顧客に見える正しさ = LP にプランの嘘を書かない、ADR-0013)。
-        # 価値はあるが merge を止めるほどではないため hard-fail から warn へ降格した (#4121)。
-        # step 単位の continue-on-error で job 全体を落とさない (job を ci-gate needs から
-        # 外すと同 job の他 check まで advisory になるため、ここは step 単位で降格する)。
-        continue-on-error: true
+        # 類型 2 は「cheap なら hard-fail、重ければ warn」。本検査は静的テキスト比較で数秒なので
+        # hard-fail が正。#4121 で一度 continue-on-error に降格したが、降格すると LP と実装の
+        # プラン齟齬が緑のまま main に入り、顧客が見るページに嘘が残る。
+        # 回帰ガード: tests/unit/scripts/pre-ready-step-budget.test.ts [P6] / [P7]
         run: node scripts/check-lp-plan-sync.mjs --check
 
       - name: No plan/status literal direct write check (#972)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,13 @@ Ready 化前は依然として `npm run pre-ready -- --pr <num>` 全 step PASS �
 
 ### Ready 化前チェック（必須）
 
-`npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #1920 / #2918 で SSOT 検証 step 拡張)。全 20 step (Step 1〜12 + 1b / 7b / 7c / 7d / 7e / 7f / 7g / 11b) を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`** (#2929 で同期):
+`npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #4121)。**全 6 step** を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`**:
 
-1. biome check / 1b. cspell (#3649, CI 同一コマンド) / 2. svelte-check / 3. vitest run / 4. check-hardcoded-strings (#1452) / 5. measure-lp-dimensions (#1163, LP 変更時のみ) / 6. sync-lp-fallback --check (#1945, LP / labels.ts 変更時のみ) / 7. check-no-plan-literals (#972) / 7b. check-license-key-leak (#2836) / 7c. check-cli-entry-guard (#3969) / 7d. check-workflow-sparse-checkout-closure (#3969) / 7e. check-readdir-rotation-guard (#3978) / 7f. check-repo-scan-test-declaration (#4085) / 7g. check-local-tz-date-getters (#4015, ローカル TZ 日付 getter 禁止 / JST SSOT 強制) / 8. generate-lp-labels --check (#1917, labels.ts / terms.ts / age-tier.ts 変更時のみ) / 9. Readiness gate = check-pr-body (PR 番号必須) / 10. check-doc-code-references (#2577) / 11. check-terminology-coherence (#2555) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail) / 12. capture (UI 変更時のみガイダンス)
+1. biome check / 2. svelte-check / 7. check-no-plan-literals (#972) / 7g. check-local-tz-date-getters (#4015, ローカル TZ 日付 getter 禁止 / JST SSOT 強制) / 9. Readiness gate = check-pr-body (PR 番号必須) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail)
 
-**Step 番号は表示上の識別子であり実行順ではない (#4048)**。実行は cheap-fail-first — PR body だけを見る検査 (Step 9) → 静的テキスト検査 (1 / 1b / 4 / 6 / 7 / 7b / 7c / 7d / 7e / 7f / 7g / 8 / 10 / 11) → 型検査 (2) → テスト (3) → ブラウザ実測 (5) → SS 系 (11b / 12) の順。検査の集合・合否条件は番号順実行時と同一。
+**選定基準は ADR-0007 §1-2 判断原則 v2** (#4121): 類型 1 (証跡の真正性 = Step 9 / 11b) と 類型 2 (顧客に見える正しさ = Step 1 / 2 / 7 / 7g) のうち安価なものだけを残す。**外した検査は消していない** — vitest は CI `unit-test`、cspell / hardcoded-strings / license-key-leak / CLI guard 系 / doc-code-references / terminology-coherence / generate-lp-labels --check は CI `lint-and-test`、LP 寸法は `lp-metrics.yml`、LP fallback は `lp-fallback-check.yml` で hard-fail のまま走る (対応表は `--help`)。**`gh pr checks <num>` でこれらが pass (skipped でない) ことを確認してから Ready 化する**。
+
+**Step 番号は表示上の識別子であり実行順ではない (#4048)**。実行は cheap-fail-first — PR body だけを見る検査 (Step 9) → 静的テキスト検査 (1 / 7 / 7g) → 型検査 (2) → SS 系 (11b) の順。
 
 E2E / Storybook は別途 (`npx playwright test` / `npm run test:storybook`)。任意: `npx eslint "src/**/*.ts"` (#977) / `npm run type-coverage` / `npm run knip` (#970)。CI 自動拒否は `.github/workflows/ci.yml` 参照。
 

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -137,7 +137,7 @@
 | `npm run dev` | 開発サーバー (port 5173、local モード) |
 | `npm run dev:cognito` | Cognito 認証画面 (#1026、認証画面 PR Ready 前必須) |
 | `npm run build` | SvelteKit production build |
-| `npm run pre-ready -- --pr <num>` | Ready 化前 全 20 step 検証 (ADR-0030 / #1920 / #2918 / #4015。一覧 SSOT は `--help`。実行順は cheap-fail-first で Step 番号順ではない、#4048) |
+| `npm run pre-ready -- --pr <num>` | Ready 化前 全 6 step 検証 (ADR-0030 / #4121。選定基準は ADR-0007 §1-2 判断原則 v2、外した検査は CI で hard-fail 継続。一覧・対応表 SSOT は `--help`。実行順は cheap-fail-first で Step 番号順ではない、#4048) |
 | `npx biome check .` | Biome lint (Tier T1) |
 | `npx svelte-check` | Svelte 型チェック |
 | `npx vitest run` | unit / integration テスト |

--- a/docs/decisions/0007-static-analysis-tier-policy.md
+++ b/docs/decisions/0007-static-analysis-tier-policy.md
@@ -40,6 +40,11 @@
 
 > 本原則は #4121 で「消すか keep list に入れるかの二択」と書いた誤りの訂正である。二択のままだと、稼働中で価値のある gate に対して消す以外の選択肢が無くなる (実際に `check-recent-deploy-deletion` = 類型 1 と `check-lp-innerhtml-tags` = 類型 2 が削除候補に載った)。
 
+**適用実績 (#4121 Wave 2)**:
+
+- `check-lp-plan-sync` を advisory (`continue-on-error`) から **hard-fail に復帰**。類型 2 かつ静的テキスト比較で cheap のため。回帰ガード: `tests/unit/scripts/pre-ready-step-budget.test.ts` [P6] / [P7]
+- `npm run pre-ready` を **20 step → 6 step** に縮小 (類型 1: pr-body / ss-embed-gate、類型 2 cheap: biome / svelte-check / plan-literals / local-tz-getters)。**外した 14 検査は消していない** — vitest は CI `unit-test`、残りは CI `lint-and-test` / `lp-metrics.yml` / `lp-fallback-check.yml` で hard-fail のまま走る (対応表 SSOT: `npm run pre-ready -- --help`)。`capture` step のみ、検査せずガイダンスを表示するだけ (類型 4 = 参照ゼロ相当) のため撤去
+
 ### 2. 新ツール導入時の判断フロー
 
 ```

--- a/docs/sessions/branch-strategy.md
+++ b/docs/sessions/branch-strategy.md
@@ -101,7 +101,7 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 
 | 判定 | 実行場所 | 内容 |
 |---|---|---|
-| ローカル `pre-ready` | 開発マシン | Step 1〜2 / 4〜12（biome / cspell / svelte-check / 各 SSOT gate / PR body gate）。`--skip-vitest` で Step 3 を CI へ委譲する |
+| ローカル `pre-ready` | 開発マシン | 6 step（biome / svelte-check / plan-literals / local-tz-getters / PR body gate / SS embed gate、#4121）。vitest ほかの検査は CI 側 job で hard-fail のまま走る |
 | フルスイート（vitest） | CI `unit-test`（×2 shard）+ `unit-test-merge` | Ready 判定はこちらを正とする |
 | 単独実行が必要な重い測定 | 開発マシン（排他） | 実行前にチャンネルで一報し、他セッションと重ならない窓を作る |
 

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -102,9 +102,9 @@ PO セッションが定めた AC を全て満たし、スクラップ&ビルド
 1. `git fetch origin && git pull` で最新化。worktree / clone 直後は refspec に develop 行があるか確認 + branch 作成直後は `node scripts/lib/ci/resolve-base-branch.mjs --verify-base` で基点鮮度を機械検証（stale develop 基点ズレ防止 #2975、SOP SSOT: [branch-strategy.md §3](branch-strategy.md)）
 2. PR / Issue / レビューコメント確認: `gh pr view <num>`, `gh issue view <num>`, `gh api repos/{owner}/{repo}/pulls/{number}/reviews`
 3. レビュー指摘を全件修正（部分対応禁止）
-4. **`npm run pre-ready -- --pr <num>` 全 Step PASS 必須** (ADR-0030 / #1775 / #1920 / #2918 で SSOT 検証 step 拡張)。全 14 step (biome / svelte-check / vitest / hardcoded-strings / lp-dimensions / lp-fallback / check-no-plan-literals (#972) / check-license-key-leak (#2836) / generate-lp-labels --check (#1917) / Readiness gate = check-pr-body / doc-code-references (#2577) / terminology-coherence (#2555) / **SS embed gate (#2918)** / capture) を順次実行、fail で即停止 + 修正方針表示。**一覧 SSOT は `npm run pre-ready -- --help`** (#2929)。E2E / Storybook は別途
+4. **`npm run pre-ready -- --pr <num>` 全 Step PASS 必須** (ADR-0030 / #1775 / #4121)。**全 6 step** (biome / svelte-check / check-no-plan-literals (#972) / check-local-tz-date-getters (#4015) / Readiness gate = check-pr-body / **SS embed gate (#2918)**) を順次実行、fail で即停止 + 修正方針表示。**一覧・「外した検査の行き先」対応表の SSOT は `npm run pre-ready -- --help`**。E2E / Storybook は別途
 
-   **vitest (Step 3) の判定は CI `unit-test` へ移す (#4007)**。16 コアを 4 エージェントで共有する運用では、ローカルのフルスイートは並走で必ず重なり、その red は PR の欠陥ではなく実行環境の産物になる（同一 HEAD 対照実測: ローカル 1753s / 2 件 timeout ↔ 同 SHA の CI run は 2 shard とも pass）。`--skip-vitest` は「検証しない」ではなく「判定の場所を CI に移す」意味であり、pre-ready はその旨と確認先 job 名を出力する。
+   **6 step 以外は消えていない — CI で hard-fail のまま走る (#4121)**。vitest は CI `unit-test`、cspell / hardcoded-strings / license-key-leak / CLI guard 系 / doc-code-references / terminology-coherence / generate-lp-labels --check は CI `lint-and-test`、LP 寸法は `lp-metrics.yml`、LP fallback は `lp-fallback-check.yml`。判定の場所を CI に移しただけなので、**`gh pr checks <num>` でこれらが pass (skipped でない) ことを確認してから Ready 化する**。16 コアを 4 エージェントで共有する運用ではローカルのフルスイートは並走で必ず重なり、その red は PR の欠陥ではなく実行環境の産物になる（同一 HEAD 対照実測: ローカル 1753s / 2 件 timeout ↔ 同 SHA の CI run は 2 shard とも pass）。
 
    - **`unit-test` / `unit-test-merge` が skip された PR は Ready にしない（例外なし）**。`gh pr checks <num>` で `unit-test (1)` / `(2)` が **`pass`**（`skipping` ではない）ことを確認してから `gh pr ready`
    - **`ci-gate` green を Ready の根拠にしない**。`ci-gate` は `skipped` を failure として数えない設計（`ci.yml`: `so skipped jobs (via path filter) don't block merges`）なので、job が 1 度も走らなくても green になる
@@ -316,7 +316,7 @@ node scripts/check-no-direct-env-access.mjs
 node scripts/check-new-required-env.mjs
 ```
 
-または `npm run pre-ready -- --pr <num>` で全 14 step 一括 (ADR-0030、一覧 SSOT は `--help`)。Step 9 = `check-pr-body.mjs` で gate 1+2+3 を網羅。**hotfix 緊急時こそ pre-ready を回す**。
+または `npm run pre-ready -- --pr <num>` で全 6 step 一括 (ADR-0030 / #4121、一覧 SSOT は `--help`)。Step 9 = `check-pr-body.mjs` で gate 1+2+3 を網羅。**hotfix 緊急時こそ pre-ready を回す**。
 
 ### hotfix runbook の禁忌
 

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -8,12 +8,13 @@
  * mergeable: CONFLICTING / ローカル biome / svelte-check / vitest 忘れ を、
  * Ready 化前に開発者がローカルで一括検出できるようにする。
  *
- * Issue #1920 で SSOT 検証 3 step を追加 (1 step は既存): check-no-plan-literals (#972 /
- * Phase 5 F1) / sync-lp-fallback (#1945 / Phase 5 F2、既存) / generate-lp-labels --check
- * (#1917 / Phase 1 B1)。F1 #1918 未 merge でも graceful degradation で skip + warning とし、
- * 本 PR を独立に Ready 化可能にする。
+ * #4121 (E5 Wave 2): step が 20 本まで増えて 1 PR が 1 日で回らなくなったため、
+ * **hard-fail は 6 本**に絞った。選定は ADR-0007 §1-2「判断原則 v2」に従い、
+ * 類型 1 (証跡の真正性 / 不可逆な損失) と 類型 2 (顧客に見える正しさ) のうち安価なものだけを残す。
+ * **外した検査は消していない** — CI (ci.yml lint-and-test / unit-test、lp-metrics.yml、
+ * lp-fallback-check.yml) で hard-fail のまま走る。対応表は `--help` を参照。
  *
- * Step 1-10 を順次実行し、各 fail で即 exit 1 + 修正方針を表示する。
+ * 6 step を順次実行し、各 fail で即 exit 1 + 修正方針を表示する。
  * 各 Step は既存の `scripts/*.mjs` / `npm run *` を子プロセスで呼ぶラッパー（独自実装は最小化）。
  *
  * 設計選定 (Issue #1775 / OSS 比較):
@@ -27,7 +28,7 @@
  *
  * Usage:
  *   npm run pre-ready -- --pr 1920
- *   npm run pre-ready -- --pr 1920 --skip-vitest          # vitest 判定を CI unit-test へ委譲 (#4007)
+ *   npm run pre-ready -- --pr 1920 --skip-svelte-check     # 部分確認 (ALL PASS は名乗らない)
  *   npm run pre-ready                                      # PR 未作成時 (PR body / mergeable 検証はスキップ)
  *
  * exit:
@@ -62,25 +63,11 @@ const failOpenNotes = [];
 
 const SKIP_FLAGS = {
 	'--skip-biome': 'skipBiome',
-	'--skip-cspell': 'skipCspell',
 	'--skip-svelte-check': 'skipSvelteCheck',
-	'--skip-vitest': 'skipVitest',
-	'--skip-hardcoded': 'skipHardcoded',
-	'--skip-lp-dimensions': 'skipLpDimensions',
-	'--skip-lp-fallback': 'skipLpFallback',
 	'--skip-plan-literals': 'skipPlanLiterals',
-	'--skip-license-key-leak': 'skipLicenseKeyLeak',
-	'--skip-cli-entry-guard': 'skipCliEntryGuard',
 	'--skip-local-tz-getters': 'skipLocalTzGetters',
-	'--skip-sparse-checkout-closure': 'skipSparseCheckoutClosure',
-	'--skip-readdir-rotation-guard': 'skipReaddirRotationGuard',
-	'--skip-repo-scan-test-declaration': 'skipRepoScanTestDeclaration',
-	'--skip-lp-labels': 'skipLpLabels',
 	'--skip-pr-body': 'skipPrBody',
-	'--skip-doc-code-references': 'skipDocCodeReferences',
-	'--skip-terminology-coherence': 'skipTerminologyCoherence',
 	'--skip-ss-embed-gate': 'skipSsEmbedGate',
-	'--skip-capture': 'skipCapture',
 };
 
 function parseArgs(argv) {
@@ -88,23 +75,10 @@ function parseArgs(argv) {
 		pr: null,
 		skipBiome: false,
 		skipSvelteCheck: false,
-		skipVitest: false,
-		skipHardcoded: false,
-		skipLpDimensions: false,
-		skipLpFallback: false,
 		skipPlanLiterals: false,
-		skipLicenseKeyLeak: false,
-		skipCliEntryGuard: false,
 		skipLocalTzGetters: false,
-		skipSparseCheckoutClosure: false,
-		skipReaddirRotationGuard: false,
-		skipRepoScanTestDeclaration: false,
-		skipLpLabels: false,
 		skipPrBody: false,
-		skipDocCodeReferences: false,
-		skipTerminologyCoherence: false,
 		skipSsEmbedGate: false,
-		skipCapture: false,
 		help: false,
 	};
 	for (let i = 0; i < argv.length; i++) {
@@ -128,66 +102,50 @@ pre-ready — Ready for Review 前のローカル一括セルフチェック (Is
 
 Usage:
   npm run pre-ready -- --pr <number>
-  npm run pre-ready                                # PR 未作成時 (Step 9, 12 はスキップ)
+  npm run pre-ready                                # PR 未作成時 (Step 9 / 11b はスキップ)
 
 Options:
   --pr <num>             GitHub PR 番号 (Step 9 PR body / mergeable 検証用)
   --skip-biome           Step 1 biome check をスキップ
-  --skip-cspell          Step 1b cspell spell check をスキップ
   --skip-svelte-check    Step 2 svelte-check をスキップ
-  --skip-vitest          Step 3 vitest をローカルで実行せず CI job unit-test へ委譲 (#4007)
-                         Ready 化前に gh pr checks <num> で unit-test が pass (skipped でない)
-                         ことを確認すること。ci-gate は skipped を failure として数えないため
-                         ci-gate green は委譲先が走った証拠にならない
-  --skip-hardcoded       Step 4 hardcoded JP text 検査をスキップ
-  --skip-lp-dimensions   Step 5 LP 寸法・禁止語検査をスキップ (LP 変更時のみ自動実行)
-  --skip-lp-fallback     Step 6 LP fallback 同期検査をスキップ (LP / labels.ts 変更時のみ自動実行)
-  --skip-plan-literals   Step 7 plan/status リテラル直書き検査をスキップ (#972 / Phase 5 F1)
-  --skip-license-key-leak Step 7b license key 再導入防止検査をスキップ (#2836 / Phase 7 PR-L4)
-  --skip-cli-entry-guard Step 7c 自前の CLI 直接実行判定 / 手組み file:// URL 検査をスキップ (#3969)
-  --skip-sparse-checkout-closure Step 7d workflow sparse-checkout の import 閉包検査をスキップ (#3969)
-  --skip-readdir-rotation-guard Step 7e readdir の緩い一致 × 破壊的操作の検査をスキップ (#3978)
-  --skip-repo-scan-test-declaration Step 7f repo 走査 test の区分宣言検査をスキップ (#4085)
+  --skip-plan-literals   Step 7 plan/status リテラル直書き検査をスキップ (#972)
   --skip-local-tz-getters Step 7g ローカル TZ 日付 getter 検査をスキップ (#4015 / ADR-0061)
-  --skip-lp-labels       Step 8 LP labels 同期検査をスキップ (labels.ts / terms.ts / age-tier.ts 変更時のみ自動実行、Phase 1 B1)
-  --skip-pr-body         Step 9 PR body 検査をスキップ
-  --skip-doc-code-references Step 10 デッドリンク検査をスキップ
-  --skip-terminology-coherence Step 11 用語不統一・add 経路重複検査をスキップ
+  --skip-pr-body         Step 9 Readiness gate をスキップ
   --skip-ss-embed-gate   Step 11b SS embed gate (UI 変更 PR の SS 未 embed hard-fail、#2918) をスキップ
-  --skip-capture         Step 12 capture (UI 変更時のみ) をスキップ
   --help, -h             このヘルプ
 
-Steps (番号は表示上の識別子。実行順は下記「実行順」を参照 — #4048):
-  1.  biome check                 — lint
-  1b. cspell                      — spell check (CI lint-and-test と同一コマンド、#3649)
+Steps (6 本。番号は既存の識別子を維持 — 実行順は下記「実行順」を参照、#4048 / #4121):
+  1.  biome check                 — lint (recommended の correctness / suspicious を含む)
   2.  svelte-check                — TS strict 型チェック
-  3.  vitest run                  — unit test (storybook 以外)
-  4.  check-hardcoded-strings.mjs — JP ハードコード baseline 監視 (#1452)
-  5.  measure-lp-dimensions.mjs   — LP 寸法 / 禁止語 (LP 変更時のみ)
-  6.  sync-lp-fallback.mjs        — LP fallback テキスト同期検査 (LP / labels.ts 変更時のみ、#1945)
-  7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972 / Phase 5 F1 / #1918)
-  7b. check-license-key-leak.mjs — license key 再導入防止 (#2836 / Phase 7 PR-L4)
-  7c. check-cli-entry-guard.mjs  — 自前の CLI 直接実行判定 / 手組み file:// URL 禁止 (#3969)
-  7d. check-workflow-sparse-checkout-closure.mjs — workflow sparse-checkout の import 閉包検査 (#3969)
-  7e. check-readdir-rotation-guard.mjs — readdir の緩い一致で世代を数える class の検出 (#3978)
-  7f. check-repo-scan-test-declaration.mjs — repo 走査 test の区分宣言 + 明示 timeout 検査 (#4085)
-  7g. check-local-tz-date-getters.mjs — ローカル TZ 日付 getter 禁止 / JST SSOT 強制 (#4015 / ADR-0061)
-  8.  generate-lp-labels --check  — site/shared-labels.js 同期検査 (labels.ts / terms.ts / age-tier.ts 変更時のみ、Phase 1 B1 / #1917)
+  7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972)
+  7g. check-local-tz-date-getters.mjs — ローカル TZ 日付 getter 禁止 / JST SSOT 強制 (#4015)
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
-  10. check-doc-code-references.mjs — ドキュメントのデッドリンク検知 (#2577)
-  11. check-terminology-coherence.ts — 用語不統一・add 経路重複検知 (#2555)
   11b. check-pr-screenshot.mjs (SS embed gate) — UI 変更 PR の SS embed 未完了を hard-fail (#2918、CI screenshot-check と SSOT 共有)
-  12. capture.mjs --pr            — UI 変更検知時のみ撮影 (現状は手動推奨。本 step は実行ガイダンスのみ)
+
+選定基準 (ADR-0007 §1-2 判断原則 v2、#4121):
+  類型 1 (証跡の真正性 / 不可逆な損失) と 類型 2 (顧客に見える正しさ) のうち安価なものだけを
+  pre-ready に残す。残りは CI 側で hard-fail のまま走る。
+    - 類型 1: Step 9 (Ready checklist / AC 証跡 / 禁止語) / Step 11b (SS 証跡)
+    - 類型 2: Step 1 / 2 / 7 / 7g
+
+pre-ready から外した検査の行き先 (**検査を消したわけではない** — CI で hard-fail のまま走る、#4121):
+  cspell / hardcoded-strings / license-key-leak / cli-entry-guard /
+  sparse-checkout-closure / readdir-rotation-guard / repo-scan-test-declaration /
+  doc-code-references / terminology-coherence / generate-lp-labels --check
+                                  → .github/workflows/ci.yml (lint-and-test)
+  vitest                          → .github/workflows/ci.yml (unit-test、2 shard)
+  measure-lp-dimensions           → .github/workflows/lp-metrics.yml
+  sync-lp-fallback --check        → .github/workflows/lp-fallback-check.yml
+  capture (撮影ガイダンス表示のみで検査ではなかった) → 撤去。SS 未 embed は Step 11b が検出する
+  ローカルで個別に回したいときは npm run cspell / npx vitest run 等を直接叩く。
 
 実行順 (cheap-fail-first、#4048):
   Step 番号は PR body / docs / Issue から広く参照されるため変更しない。実行順だけを
   「判定に要する時間と参照する情報の量」で並べ替える。同一クラス内は上記の番号順を保つ。
     1) meta      PR body / メタ情報だけを見る    — Step 9
-    2) static    静的テキスト / 単一ファイル検査 — Step 1 / 1b / 4 / 6 / 7 / 7b / 7c / 7d / 7e / 7f / 7g / 8 / 10 / 11
+    2) static    静的テキスト / 単一ファイル検査 — Step 1 / 7 / 7g
     3) typecheck 型検査                          — Step 2
-    4) test      テスト実行                      — Step 3
-    5) browser   ヘッドレスブラウザ実測          — Step 5
-    6) ui        SS 系                           — Step 11b / 12
+    4) ui        SS 系                           — Step 11b
   検査の集合・合否条件は並べ替えの前後で同一 (tests/unit/scripts/pre-ready-order-and-base.test.ts が固定)。
 
 Exit codes:
@@ -393,35 +351,30 @@ function fetchPrBodyAndLabels(prNumber) {
 
 /**
  * 隔離 worktree (`.claude/worktrees/`) では worktree 生成後に `node_modules` が
- * 自動 install されない。依存欠落のまま pre-ready を回すと Step 2/3 (svelte-check /
- * vitest) が「変更と無関係な」大量 error / spawn 失敗になり、品質ゲートが空振りする
+ * 自動 install されない。依存欠落のまま pre-ready を回すと Step 2 (svelte-check) が
+ * 「変更と無関係な」大量 error / spawn 失敗になり、品質ゲートが空振りする
  * (#3855 / #3856 の 2 agent が共に遭遇)。これを silent に通さず、着手前に明示ガイダンス付きで
  * fail-fast する (ADR-0006 no-silent-fail 整合 / #3857 AC1「依存欠落を silent に pass しない」)。
  *
  * biome の「Checked 0 files」false-negative は本体側 (biome.json の `.claude` ignore を
- * repo 相対 `!.claude` に anchor 化) で根治済み (#3857 Fix B)。本 preflight は残る
- * node_modules 欠落 (Step 2/3 svelte-check/vitest、Step 11 tsx) を対象とする。
+ * repo 相対 `!.claude` に anchor 化) で根治済み (#3857 Fix B)。
  *
  * 検出:
  *   - worktree 判定: `repoRoot/.git` が「ファイル」(linked worktree の gitdir ポインタ) なら worktree。
  *     通常 clone では `.git` はディレクトリなので false。
- *   - 依存欠落判定: pre-ready 各 step が依存する代表 sentinel の存在確認。root `node_modules` に加え、
- *     `infra/node_modules/aws-cdk-lib` も検査する — Step 3 vitest の scope (`tests/unit/**`) には
- *     `tests/unit/infra/*.test.ts` が含まれ aws-cdk-lib (infra 配下) を要求するため (tests/CLAUDE.md)。
- *     `npm ci` の prepare が `cd infra && npm ci` を warn-only で実行する構造上、root だけ入って
- *     infra が欠ける組合せがあり得るので両方を sentinel にする (#3857 で報告された aws-cdk-lib 欠落を捕捉)。
+ *   - 依存欠落判定: pre-ready 各 step が依存する代表 sentinel の存在確認。
+ *     #4121 で 6 step に絞ったため、vitest / tsx / infra の aws-cdk-lib は pre-ready の依存では
+ *     なくなった (それぞれ CI job 側の依存)。sentinel を過剰に要求すると、pre-ready が回せない
+ *     理由を本来不要な install に求めることになるため、残す 6 step が実際に spawn するものだけを見る。
  *
- * pre-ready Step 1/2/3/11 が依存する代表 sentinel。1 つでも欠落したら install 未完了とみなす。
+ * pre-ready Step 1 / 2 が依存する代表 sentinel。1 つでも欠落したら install 未完了とみなす。
  * (export: tests/unit/scripts/pre-ready-preflight.test.ts が root 差替えで検証する)
  */
 export const PREFLIGHT_SENTINELS = [
 	'node_modules', // 本体
-	'node_modules/.bin', // spawn する CLI 群 (svelte-check / vitest / tsx / biome)
+	'node_modules/.bin', // spawn する CLI 群 (svelte-check / biome)
 	'node_modules/svelte-check', // Step 2
-	'node_modules/vitest', // Step 3
-	'node_modules/tsx', // Step 11 (npx tsx check-terminology-coherence.ts)
 	'node_modules/@biomejs/biome', // Step 1
-	'infra/node_modules/aws-cdk-lib', // Step 3 vitest (tests/unit/infra/*.test.ts、tests/CLAUDE.md)
 ];
 
 /**
@@ -611,13 +564,13 @@ export function skipStateOf({
  * console.log を持たない純関数にしてあるのは、AC1〜AC3 (適用対象外のみなら ALL PASS /
  * flag 指定なら PARTIAL PASS / 両者を別行表示) を全 step を回さずに unit test で固定するため。
  *
- * #4007: `delegated` は「未実行」ではなく「判定の場所を CI に移した」step。ALL PASS を妨げないが、
- * 委譲先 job が **実行されて pass した** ことの確認手順を必ず出す (`ci-gate` は skipped を failure
- * として数えないため ci-gate green は委譲先が走った証拠にならない = 沈黙 skip を作らない)。
+ * #4007 / #4121: pre-ready は 6 step に絞り、残りの検査は CI で hard-fail のまま走る。
+ * 「pre-ready ALL PASS = 全部通った」と誤読されると沈黙 skip と同じ害になるため、summary は
+ * 必ず「pre-ready 外で走る検査と、その確認方法」を出す (`ci-gate` は skipped を failure として
+ * 数えないため ci-gate green は委譲先が走った証拠にならない)。
  *
  * @param {{ totalSteps: number; skippedByFlag: string[]; skippedScriptMissing: string[];
  *           skippedPrMissing?: string[]; skippedNotApplicable: string[];
- *           delegated?: { name: string; job: string; howToVerify: string }[];
  *           failOpenCount?: number; pr?: string | null }} input
  * @returns {{ status: 'ALL_PASS' | 'PARTIAL_PASS'; text: string }}
  */
@@ -627,24 +580,20 @@ export function buildSummary({
 	skippedScriptMissing,
 	skippedPrMissing = [],
 	skippedNotApplicable,
-	delegated = [],
 	failOpenCount = 0,
 	pr = null,
 }) {
-	// #4007: CI へ委譲した step の確認手順ブロック (委譲が無ければ空文字)
-	const delegationBlock =
-		delegated.length > 0
-			? `  CI へ委譲した step (${delegated.map((d) => d.name).join(', ')}):\n` +
-				delegated
-					.map(
-						(d) =>
-							`    - ${d.name} → CI job \`${d.job}\`。Ready 化前に **実行されて pass した** ことを確認する:\n` +
-							`        ${d.howToVerify}\n` +
-							`      \`${d.job}\` が skipped の PR は Ready にしない (skipped は pass ではない)。\n` +
-							`      \`ci-gate\` は skipped を failure として数えないため、ci-gate green を根拠にしない。\n`,
-					)
-					.join('')
-			: '';
+	// #4121: pre-ready 外 (CI 側 hard-fail) で走る検査の確認手順。step から外したことと
+	// 検査を消したことは別なので、外した先を必ず名指しする。
+	const ciSideBlock =
+		`  pre-ready 外の検査 (CI で hard-fail、#4121):\n` +
+		`    - unit-test        vitest (2 shard)\n` +
+		`    - lint-and-test    cspell / hardcoded-strings / doc-code-references / terminology-coherence /\n` +
+		`                       license-key-leak / CLI entry guard 系 / generate-lp-labels --check ほか\n` +
+		`    - lp-metrics       LP 寸法・禁止語 (LP 変更時)\n` +
+		`    - lp-fallback-check LP fallback 同期 (LP / labels.ts 変更時)\n` +
+		`    Ready 化前に \`gh pr checks ${pr ?? '<num>'}\` でこれらが **pass (skipped でない)** ことを確認する。\n` +
+		`    \`ci-gate\` は skipped を failure として数えないため、ci-gate green を根拠にしない。\n`;
 	// 適用対象外 (n/a) は「実行しなくてよいので実行していない」であり ALL PASS を妨げない。
 	const notApplicableLine =
 		skippedNotApplicable.length > 0
@@ -669,7 +618,7 @@ export function buildSummary({
 		]
 			.filter(Boolean)
 			.join(' / ');
-		const ran = totalSteps - blocking.length - skippedNotApplicable.length - delegated.length;
+		const ran = totalSteps - blocking.length - skippedNotApplicable.length;
 		return {
 			status: 'PARTIAL_PASS',
 			text:
@@ -678,24 +627,21 @@ export function buildSummary({
 				notApplicableLine +
 				`  これは開発中の部分確認結果であり、Ready 化 (gh pr ready) 判定には\n` +
 				`  skip なしの \`npm run pre-ready -- --pr ${pr ?? '<num>'}\` 全 step PASS が必要です。\n` +
-				delegationBlock,
+				ciSideBlock,
 		};
 	}
 
 	return {
 		status: 'ALL_PASS',
 		text:
-			`\n[pre-ready] ALL PASS${delegated.length > 0 ? ` (${delegated.length} step は CI へ委譲 — 下記を確認)` : ''}${failOpenCount > 0 ? ` (fail-open ${failOpenCount} 件あり — 上記 ⚠ を確認)` : ''} — Ready for Review に進めます。\n` +
+			`\n[pre-ready] ALL PASS (pre-ready 6 step)${failOpenCount > 0 ? ` (fail-open ${failOpenCount} 件あり — 上記 ⚠ を確認)` : ''} — Ready for Review に進めます。\n` +
 			notApplicableLine +
-			delegationBlock +
+			ciSideBlock +
 			`  次の手順:\n` +
 			`    1. node scripts/check-gh-account-before-pr.mjs   # gh アカウント確認 (#1728)\n` +
-			(delegated.length > 0
-				? `    2. gh pr checks ${pr ?? '<num>'}                           # 委譲先 job が pass (skipped でない) ことを確認\n` +
-					`    3. gh pr ready ${pr ?? '<num>'}                            # Ready for Review に変更\n` +
-					`    4. CI 全緑になるまで待機し、QM レビューを依頼\n`
-				: `    2. gh pr ready ${pr ?? '<num>'}                            # Ready for Review に変更\n` +
-					`    3. CI 全緑になるまで待機し、QM レビューを依頼\n`),
+			`    2. gh pr checks ${pr ?? '<num>'}                           # 上記 CI job が pass (skipped でない) ことを確認\n` +
+			`    3. gh pr ready ${pr ?? '<num>'}                            # Ready for Review に変更\n` +
+			`    4. CI 全緑になるまで待機し、QM レビューを依頼\n`,
 	};
 }
 
@@ -710,15 +656,6 @@ export function buildSummary({
  * @param {string[]} changedFiles             base branch との差分ファイル一覧
  */
 export function buildSteps(args, changedFiles) {
-	const lpChanged = changedFiles.some((f) => f.startsWith('site/'));
-	const labelsChanged = changedFiles.some(
-		(f) => f === 'src/lib/domain/labels.ts' || f === 'src/lib/domain/terms.ts',
-	);
-	const ageTierChanged = changedFiles.some((f) => f === 'src/lib/domain/validation/age-tier.ts');
-	// LP fallback 同期は LP / labels.ts どちらかが変わると影響を受ける
-	const lpFallbackTrigger = lpChanged || labelsChanged;
-	// LP labels (site/shared-labels.js) 同期は labels.ts / terms.ts / age-tier.ts いずれかが変わると影響を受ける
-	const lpLabelsTrigger = labelsChanged || ageTierChanged;
 	const uiChanged = changedFiles.some(
 		(f) => /\.(svelte|css|scss)$/.test(f) || f.startsWith('site/'),
 	);
@@ -731,38 +668,21 @@ export function buildSteps(args, changedFiles) {
 		);
 	}
 
-	// graceful degradation: 未実装 / 移動済の検査 script は skip + warning に倒す (Issue #1920 設計判断)
-	const planLiteralsScript = resolve(repoRoot, 'scripts/check-no-plan-literals.mjs');
-	const lpLabelsScript = resolve(repoRoot, 'scripts/generate-lp-labels.mjs');
-	const planLiteralsScriptExists = existsSync(planLiteralsScript);
-	const lpLabelsScriptExists = existsSync(lpLabelsScript);
-	// #2836 (Epic #2525 Phase 7 PR-L4): license key 全廃の再導入防止 gate
-	const licenseKeyLeakScript = resolve(repoRoot, 'scripts/check-license-key-leak.mjs');
-	const licenseKeyLeakScriptExists = existsSync(licenseKeyLeakScript);
-	// #4015: ローカル TZ 日付 getter の再混入を止める gate (ADR-0061 same-class-N → guard)
-	const localTzGetterScript = resolve(repoRoot, 'scripts/check-local-tz-date-getters.mjs');
-	const localTzGetterScriptExists = existsSync(localTzGetterScript);
-	// #3969: 自前の CLI 直接実行判定 / 手組み file:// URL の再混入を止める gate
-	const cliEntryGuardScript = resolve(repoRoot, 'scripts/check-cli-entry-guard.mjs');
-	const cliEntryGuardScriptExists = existsSync(cliEntryGuardScript);
-	// #3969: workflow の sparse-checkout が「実行する script の import 先」まで列挙しているかの検査
-	const sparseClosureScript = resolve(
-		repoRoot,
-		'scripts/check-workflow-sparse-checkout-closure.mjs',
+	// graceful degradation: 検査 script が未配備なら skip + warning に倒す (Issue #1920 設計判断)。
+	// skipKind='script-missing' は ALL PASS を名乗らせないので、gate 不在は summary に必ず残る。
+	const planLiteralsScriptExists = existsSync(
+		resolve(repoRoot, 'scripts/check-no-plan-literals.mjs'),
 	);
-	const sparseClosureScriptExists = existsSync(sparseClosureScript);
-	// #3978: readdir の緩い一致で世代を数え、その結果を破壊的操作の対象にする class の検出
-	const readdirRotationScript = resolve(repoRoot, 'scripts/check-readdir-rotation-guard.mjs');
-	const readdirRotationScriptExists = existsSync(readdirRotationScript);
-	// #4085: repo 走査 test の区分宣言 gate (未宣言 / 明示 timeout 欠落を検出)
-	const repoScanTestScript = resolve(repoRoot, 'scripts/check-repo-scan-test-declaration.mjs');
-	const repoScanTestScriptExists = existsSync(repoScanTestScript);
+	// #4015: ローカル TZ 日付 getter の再混入を止める gate (ADR-0061 same-class-N → guard)
+	const localTzGetterScriptExists = existsSync(
+		resolve(repoRoot, 'scripts/check-local-tz-date-getters.mjs'),
+	);
 
 	return [
 		{
 			name: 'biome',
 			costClass: 'static',
-			label: 'Step 1/12: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)',
+			label: 'Step 1: biome check (--error-on-warnings, CI と整合 — PR #2503 教訓)',
 			...skipStateOf({ byFlag: args.skipBiome }),
 			// #2503 (Issue #2475 14 件目): pre-ready Step 1 は CI .github/workflows/ci.yml
 			// lint-and-test の `npx biome check --error-on-warnings .` と完全一致させる。
@@ -773,80 +693,12 @@ export function buildSteps(args, changedFiles) {
 				'  remaining warning / error は手動で修正してから再実行 (CI は warning=error 扱い)',
 		},
 		{
-			name: 'cspell',
-			costClass: 'static',
-			label: 'Step 1b/12: cspell (CI lint-and-test と同一コマンド — #3649)',
-			...skipStateOf({ byFlag: args.skipCspell }),
-			// #3649: CI lint-and-test の `npm run cspell` (#1432 warning=error) と同一。
-			// pre-ready に本 step が無かった gap により「pre-ready ALL PASS ↔ CI cspell red」の
-			// self-report 乖離が反復 (PR #3647 の Millis 等)。glob は package.json "cspell" が SSOT。
-			runner: () => run('cspell', ['npm', 'run', 'cspell']),
-			fixHint:
-				'  typo なら修正 / 正当な技術語・固有名詞なら .cspell.json の words に追加 (小文字で登録、大文字小文字非依存)',
-		},
-		{
 			name: 'svelte-check',
 			costClass: 'typecheck',
-			label: 'Step 2/12: svelte-check (TS strict)',
+			label: 'Step 2: svelte-check (TS strict)',
 			...skipStateOf({ byFlag: args.skipSvelteCheck }),
 			runner: () => run('svelte-check', ['npx', 'svelte-check', '--tsconfig', './tsconfig.json']),
 			fixHint: '  型エラー箇所を修正。`as any` / `// @ts-expect-error` の追加は禁止 (ADR-0006)。',
-		},
-		{
-			name: 'vitest',
-			costClass: 'test',
-			label: args.skipVitest
-				? 'Step 3/12: vitest run (unit test) — ローカル未実行 / CI unit-test へ委譲 (#4007)'
-				: 'Step 3/12: vitest run (unit test)',
-			// #4018 の skip 分類 (flag / script-missing / pr-missing / n/a) は維持する。
-			// 本 step は `delegatedToCi` を持つため、main() のループが分類より先に委譲へ振り分ける。
-			...skipStateOf({ byFlag: args.skipVitest }),
-			// #4007: `--skip-vitest` は「検証しない」ではなく「判定の場所を CI に移す」。
-			// 16 コアを 4 エージェントで共有する運用ではローカルのフルスイートが並走で落ち、
-			// その red は PR の欠陥ではなく実行環境の産物になる (同一 HEAD 対照実測: ローカル 1753s /
-			// 2 件 timeout ↔ 同 SHA の CI run は 2 shard とも pass)。
-			// ただし委譲先が **実行された** ことの確認は省略できない (skip された job は pass ではない)。
-			delegatedToCi: {
-				job: 'unit-test',
-				howToVerify: 'gh pr checks <num> --watch  # unit-test (1) / (2) が pass であること',
-			},
-			runner: () => run('vitest', ['npx', 'vitest', 'run']),
-			fixHint:
-				'  失敗テストを修正。assertion を弱める変更は禁止 (ADR-0006)。\n' +
-				'  storybook テストは `npm run test:storybook` で別途確認。',
-		},
-		{
-			name: 'hardcoded-strings',
-			costClass: 'static',
-			label: 'Step 4/12: check-hardcoded-strings.mjs (#1452 Phase A)',
-			...skipStateOf({ byFlag: args.skipHardcoded }),
-			runner: () => run('check-hardcoded-strings', ['node', 'scripts/check-hardcoded-strings.mjs']),
-			fixHint:
-				'  baseline (1607 件) より JP ハードコードが増えています。\n' +
-				'  src/lib/domain/labels.ts に定数追加して `data-label` / import 経由に置換 (ADR-0009)。',
-		},
-		{
-			name: 'lp-dimensions',
-			costClass: 'browser',
-			label: `Step 5/12: measure-lp-dimensions.mjs (LP 変更検知: ${lpChanged ? 'YES' : 'NO — skip'})`,
-			...skipStateOf({ byFlag: args.skipLpDimensions, notApplicable: !lpChanged }),
-			runner: () => run('measure-lp-dimensions', ['node', 'scripts/measure-lp-dimensions.mjs']),
-			fixHint:
-				'  LP 寸法 / 禁止語の閾値違反 (#1163 ratchet)。\n' +
-				'  - mobileHeight ≤ 15000px / desktopHeight ≤ 8000px\n' +
-				'  - 禁止語 (ガチャ / 抽選 / コンプリート / git clone 等) を含めない\n' +
-				'  - CTA は 3 種以下',
-		},
-		{
-			name: 'lp-fallback',
-			costClass: 'static',
-			label: `Step 6/12: sync-lp-fallback.mjs --check (LP / labels.ts 変更検知: ${lpFallbackTrigger ? 'YES' : 'NO — skip'})`,
-			...skipStateOf({ byFlag: args.skipLpFallback, notApplicable: !lpFallbackTrigger }),
-			runner: () => run('sync-lp-fallback', ['node', 'scripts/sync-lp-fallback.mjs', '--check']),
-			fixHint:
-				'  site/*.html の data-lp-key fallback テキストが labels.ts と乖離しています (#1945)。\n' +
-				'  修正: `node scripts/sync-lp-fallback.mjs` を実行して fallback を再生成し、\n' +
-				'        生成された site/*.html の差分をコミットしてください。',
 		},
 		// Step 7: check-no-plan-literals (#972 / Phase 5 F1 / #1918)
 		// Issue #1920 graceful degradation: 検査 script が未配備 (F1 #1918 未 merge 等) なら skip + warning。
@@ -855,8 +707,8 @@ export function buildSteps(args, changedFiles) {
 			name: 'plan-literals',
 			costClass: 'static',
 			label: planLiteralsScriptExists
-				? 'Step 7/12: check-no-plan-literals.mjs (#972 / Phase 5 F1)'
-				: 'Step 7/12: check-no-plan-literals.mjs (script 未配備 — skip)',
+				? 'Step 7: check-no-plan-literals.mjs (#972 / Phase 5 F1)'
+				: 'Step 7: check-no-plan-literals.mjs (script 未配備 — skip)',
 			...skipStateOf({ byFlag: args.skipPlanLiterals, scriptMissing: !planLiteralsScriptExists }),
 			runner: () => run('check-no-plan-literals', ['node', 'scripts/check-no-plan-literals.mjs']),
 			fixHint:
@@ -865,126 +717,14 @@ export function buildSteps(args, changedFiles) {
 				"  - 例: 'family-monthly' → SUBSCRIPTION_PLAN.FAMILY_MONTHLY\n" +
 				"  - 例: 'grace_period' → SUBSCRIPTION_STATUS.GRACE_PERIOD",
 		},
-		// Step 7b: check-license-key-leak (#2836 / Epic #2525 Phase 7 PR-L4)
-		// license key 全廃の再導入防止。allowlist 外のコード行に license key 参照を検出したら fail。
-		{
-			name: 'license-key-leak',
-			costClass: 'static',
-			label: licenseKeyLeakScriptExists
-				? 'Step 7b/12: check-license-key-leak.mjs (#2836 / Phase 7 PR-L4)'
-				: 'Step 7b/12: check-license-key-leak.mjs (script 未配備 — skip)',
-			...skipStateOf({
-				byFlag: args.skipLicenseKeyLeak,
-				scriptMissing: !licenseKeyLeakScriptExists,
-			}),
-			runner: () => run('check-license-key-leak', ['node', 'scripts/check-license-key-leak.mjs']),
-			fixHint:
-				'  allowlist 外のコード行に license key 参照を検出しました (#2836)。\n' +
-				'  - LP / メール / ラベル / UI で license key 概念を再導入しないでください。\n' +
-				'  - entitlement は Stripe Subscription (tenant.status=ACTIVE) が唯一 SSOT です。\n' +
-				'  - DB 層 / LEGACY_URL_MAP entry は PR-L5 担当の allowlist (FILE_ALLOWLIST)。',
-		},
-		// Step 7c: check-cli-entry-guard (#3969)
-		// 各 script が自前で書く「直接実行判定」は symlink / junction 経由で必ず false になり、
-		// main() が呼ばれず「何も検査せず exit 0 (= PASS)」になる。判定 SSOT は
-		// scripts/lib/is-main.mjs で、本 step は次の方言が持ち込まれるのを止める。
-		{
-			name: 'cli-entry-guard',
-			costClass: 'static',
-			label: cliEntryGuardScriptExists
-				? 'Step 7c/12: check-cli-entry-guard.mjs (#3969)'
-				: 'Step 7c/12: check-cli-entry-guard.mjs (script 未配備 — skip)',
-			...skipStateOf({ byFlag: args.skipCliEntryGuard, scriptMissing: !cliEntryGuardScriptExists }),
-			runner: () => run('check-cli-entry-guard', ['node', 'scripts/check-cli-entry-guard.mjs']),
-			fixHint:
-				'  自前の CLI 直接実行判定 / 手組み file:// URL を検出しました (#3969)。\n' +
-				"  - 修正: import { isMain } from '<rel>/lib/is-main.mjs' を使い、\n" +
-				'          `if (isMain(import.meta.url)) main();` の形にする\n' +
-				'  - path → URL は node:url の pathToFileURL() を使う (手組みは Windows で常に不一致)\n' +
-				'  - 正当な例外は `allow-argv1: <理由>` / `allow-file-url: <理由>` を当該行か直前行に置く',
-		},
-		// Step 7d: check-workflow-sparse-checkout-closure (#3969)
-		// gate job は sparse-checkout で必要ファイルを個別列挙する。Step 7c が判定 SSOT の利用を
-		// 強制するため、gate script を列挙するたびに helper への import が生え、列挙し忘れると
-		// job が ERR_MODULE_NOT_FOUND で落ちる (#3969 対応時に必須 gate 6 job が同時 fail した)。
-		{
-			name: 'sparse-checkout-closure',
-			costClass: 'static',
-			label: sparseClosureScriptExists
-				? 'Step 7d/12: check-workflow-sparse-checkout-closure.mjs (#3969)'
-				: 'Step 7d/12: check-workflow-sparse-checkout-closure.mjs (script 未配備 — skip)',
-			...skipStateOf({
-				byFlag: args.skipSparseCheckoutClosure,
-				scriptMissing: !sparseClosureScriptExists,
-			}),
-			runner: () =>
-				run('check-workflow-sparse-checkout-closure', [
-					'node',
-					'scripts/check-workflow-sparse-checkout-closure.mjs',
-				]),
-			fixHint:
-				'  workflow の sparse-checkout に import 先の列挙漏れがあります (#3969)。\n' +
-				'  - 修正: 出力された不足パスを当該 sparse-checkout ブロックに追加する\n' +
-				'  - 放置すると当該 job が ERR_MODULE_NOT_FOUND で落ちる (無言 PASS ではなく hard fail)',
-		},
-		// Step 7e: check-readdir-rotation-guard (#3978)
-		// readdir の戻りを prefix / suffix の緩い一致で絞り込み、その結果を削除対象にする class。
-		// 同じ指摘を #3956 / #3978 と 2 度受けたため、3 度目を待たず機械 gate 化した
-		// (docs/sessions/dev-session.md §「QA 指摘の再発防止台帳」#2 / ADR-0061)。
-		{
-			name: 'readdir-rotation-guard',
-			costClass: 'static',
-			label: readdirRotationScriptExists
-				? 'Step 7e/12: check-readdir-rotation-guard.mjs (#3978)'
-				: 'Step 7e/12: check-readdir-rotation-guard.mjs (script 未配備 — skip)',
-			...skipStateOf({
-				byFlag: args.skipReaddirRotationGuard,
-				scriptMissing: !readdirRotationScriptExists,
-			}),
-			runner: () =>
-				run('check-readdir-rotation-guard', ['node', 'scripts/check-readdir-rotation-guard.mjs']),
-			fixHint:
-				'  readdir の緩い一致 (startsWith / endsWith) の結果を破壊的操作の対象にしています (#3978)。\n' +
-				'  - 修正: 命名規則を `*_PATTERN` 名の正規表現 const にし、その完全一致で絞り込む\n' +
-				'  - 生成側にも同じパターンの assert を置く (命名変更で silent に壊れないようにする)\n' +
-				'  - 別 class だと判断した場合のみ `rotation-gate-ok: <理由>` を当該行/直前行に置く',
-		},
-		// Step 7f: check-repo-scan-test-declaration (#4085)
-		// repo 全体を実読する test を既定 timeout (5s) のまま unit lane に置くと、並列実行の負荷で
-		// 落ちる。壊れてはいないので毎回「本物か負荷か」の切り分けが発生し、間違えれば本物の回帰を
-		// 「また負荷だろう」と見逃す。同 class 4 例目で機械 gate 化した (ADR-0061 same-class-N→guard)。
-		//
-		// 本 step は #4086 で step 定義を 1 箇所化した後に追加した最初の step であり、
-		// `costClass` を step 定義に直接書くだけで登録が完結する (第 2 registry への同時登録は不要)。
-		{
-			name: 'repo-scan-test-declaration',
-			costClass: 'static',
-			label: repoScanTestScriptExists
-				? 'Step 7f/12: check-repo-scan-test-declaration.mjs (#4085)'
-				: 'Step 7f/12: check-repo-scan-test-declaration.mjs (script 未配備 — skip)',
-			...skipStateOf({
-				byFlag: args.skipRepoScanTestDeclaration,
-				scriptMissing: !repoScanTestScriptExists,
-			}),
-			runner: () =>
-				run('check-repo-scan-test-declaration', [
-					'node',
-					'scripts/check-repo-scan-test-declaration.mjs',
-				]),
-			fixHint:
-				'  repo 走査 test の区分が未宣言 / 明示 timeout 欠落です (#4085)。\n' +
-				'  - 判定と貼り付け用エントリ: `node scripts/check-repo-scan-test-declaration.mjs --list`\n' +
-				'  - 宣言先: scripts/lib/ci/repo-scan-test-registry.mjs\n' +
-				'  - scope=repo の test には `vi.setConfig({ testTimeout: 60_000 })` 等の明示 timeout を置く',
-		},
 		// Step 7g: check-local-tz-date-getters (#4015 / ADR-0061 same-class-N → guard)
 		// 実時刻からローカル TZ getter で暦要素を取り出す形 (#4003 と同 class) の再混入を止める。
 		{
 			name: 'local-tz-getters',
 			costClass: 'static',
 			label: localTzGetterScriptExists
-				? 'Step 7g/12: check-local-tz-date-getters.mjs (#4015)'
-				: 'Step 7g/12: check-local-tz-date-getters.mjs (script 未配備 — skip)',
+				? 'Step 7g: check-local-tz-date-getters.mjs (#4015)'
+				: 'Step 7g: check-local-tz-date-getters.mjs (script 未配備 — skip)',
 			...skipStateOf({
 				byFlag: args.skipLocalTzGetters,
 				scriptMissing: !localTzGetterScriptExists,
@@ -999,27 +739,6 @@ export function buildSteps(args, changedFiles) {
 				'  - TZ 非依存と言える場合のみ script の ALLOWLIST に file / max / reason を追加します\n' +
 				'    (reason が空だと gate 自身が fail します)。',
 		},
-		// Step 8: generate-lp-labels --check (Phase 1 B1 / #1917)
-		// Issue #1920 graceful degradation: 検査 script が未配備なら skip + warning。
-		// labels.ts / terms.ts / age-tier.ts いずれかの変更検知時のみ実行 (LP shared-labels.js への波及)
-		{
-			name: 'lp-labels',
-			costClass: 'static',
-			label: !lpLabelsScriptExists
-				? 'Step 8/12: generate-lp-labels --check (script 未配備 — skip)'
-				: `Step 8/12: generate-lp-labels --check (labels.ts / terms.ts / age-tier.ts 変更検知: ${lpLabelsTrigger ? 'YES' : 'NO — skip'})`,
-			...skipStateOf({
-				byFlag: args.skipLpLabels,
-				scriptMissing: !lpLabelsScriptExists,
-				notApplicable: !lpLabelsTrigger,
-			}),
-			runner: () =>
-				run('generate-lp-labels --check', ['node', 'scripts/generate-lp-labels.mjs', '--check']),
-			fixHint:
-				'  site/shared-labels.js が labels.ts / terms.ts / age-tier.ts と同期していません (Phase 1 B1 / #1917)。\n' +
-				'  修正: `node scripts/generate-lp-labels.mjs` を実行して再生成し、\n' +
-				'        site/shared-labels.js の差分をコミットしてください。',
-		},
 		{
 			name: 'pr-body',
 			costClass: 'meta',
@@ -1030,8 +749,8 @@ export function buildSteps(args, changedFiles) {
 			// が `check-pr-body.mjs` だけだと「PR body 表面チェック」と誤認され skip されやすい。
 			// ADR-0056 §E (#2632 で新設) 整合の構造的予防。
 			label: args.pr
-				? `Step 9/12: Readiness gate (Ready checklist + AC 4 列 + forbidden-terms + 必須セクション、check-pr-body.mjs --pr ${args.pr})`
-				: 'Step 9/12: Readiness gate (--pr 未指定 — skip、Ready 化前は --pr 必須)',
+				? `Step 9: Readiness gate (Ready checklist + AC 4 列 + forbidden-terms + 必須セクション、check-pr-body.mjs --pr ${args.pr})`
+				: 'Step 9: Readiness gate (--pr 未指定 — skip、Ready 化前は --pr 必須)',
 			...skipStateOf({ byFlag: args.skipPrBody, prMissing: !args.pr }),
 			runner: () => run('check-pr-body', ['node', 'scripts/check-pr-body.mjs', '--pr', args.pr]),
 			fixHint:
@@ -1050,33 +769,6 @@ export function buildSteps(args, changedFiles) {
 				'    - 禁止語は PR で完遂 or Issue 起票して PR から完全除去 (partial PR 禁止)\n' +
 				'    - 詳細は scripts/check-pr-body.mjs --help を参照。',
 		},
-		{
-			name: 'doc-code-references',
-			costClass: 'static',
-			label: 'Step 10/12: check-doc-code-references.mjs (#2577)',
-			...skipStateOf({ byFlag: args.skipDocCodeReferences }),
-			runner: () =>
-				run('check-doc-code-references', ['node', 'scripts/check-doc-code-references.mjs']),
-			fixHint:
-				'  ドキュメント内の実装コードパスが実在しません (デッドリンク)。\n' +
-				'  修正: bare path 表記を Markdown link 形式 `[site/pricing.html L297-301](path/to/file)` に変更するか、\n' +
-				'        意図的な追加なら `node scripts/check-doc-code-references.mjs --update-baseline` を実行してください。',
-		},
-		{
-			name: 'terminology-coherence',
-			costClass: 'static',
-			label: 'Step 11/12: check-terminology-coherence.ts (#2555)',
-			...skipStateOf({ byFlag: args.skipTerminologyCoherence }),
-			runner: () =>
-				run('check-terminology-coherence', [
-					'npx',
-					'tsx',
-					'scripts/check-terminology-coherence.ts',
-				]),
-			fixHint:
-				'  用語の不統一、または add 経路の重複を検知しました。\n' +
-				'  修正: labels.ts の当該箇所を SSOT 用語 (terms.ts) に合わせるか、add 経路を集約してください。',
-		},
 		// Step 11b: SS embed gate (#2918)
 		// UI 変更 PR が「SS は後で push する」未来形のまま / embed 画像なしで Ready 化され、
 		// CI screenshot-check fail → Fix Agent 往復 が 4 件連続 (#2913 / #2914 / #2915 / #2909) した
@@ -1088,8 +780,8 @@ export function buildSteps(args, changedFiles) {
 			costClass: 'ui',
 			label:
 				uiChanged && args.pr
-					? 'Step 11b/12: SS embed gate (check-pr-screenshot.mjs、UI 変更 PR の SS embed 未完了を hard-fail、#2918)'
-					: `Step 11b/12: SS embed gate (${!args.pr ? '--pr 未指定 — skip' : 'UI 変更なし — skip'}、#2918)`,
+					? 'Step 11b: SS embed gate (check-pr-screenshot.mjs、UI 変更 PR の SS embed 未完了を hard-fail、#2918)'
+					: `Step 11b: SS embed gate (${!args.pr ? '--pr 未指定 — skip' : 'UI 変更なし — skip'}、#2918)`,
 			...skipStateOf({
 				byFlag: args.skipSsEmbedGate,
 				prMissing: !args.pr,
@@ -1128,24 +820,6 @@ export function buildSteps(args, changedFiles) {
 				'  UI 変更を含まない PR の場合は PR body に「該当なし（refactor / docs / chore）」と明記、\n' +
 				'  または視覚差分ゼロの内部 refactor なら refactor:internal-no-doc-impact ラベルを付与。',
 		},
-		{
-			name: 'capture',
-			costClass: 'ui',
-			label: `Step 12/12: capture.mjs (UI 変更検知: ${uiChanged ? 'YES' : 'NO — skip'})`,
-			...skipStateOf({ byFlag: args.skipCapture, prMissing: !args.pr, notApplicable: !uiChanged }),
-			runner: async () => {
-				console.log(
-					`[pre-ready] UI 変更を検知しました。スクリーンショット撮影は手動実行を推奨します:\n` +
-						`  MSYS_NO_PATHCONV=1 node scripts/capture.mjs --url <path> --presets mobile,desktop --pr ${args.pr}\n` +
-						`  詳細は docs/sessions/dev-session.md §「Screenshot Agent」を参照。\n` +
-						`  本 Step は実行ガイダンスのみで PASS 扱いとします (実機 dev server 起動を要求しないため)。`,
-				);
-				return 0;
-			},
-			fixHint:
-				'  `npm run capture -- --url <path> --pr <num>` で撮影し PR body に貼り付け。\n' +
-				'  /demo/* は実アプリ検証証跡として禁止 (#1026)。',
-		},
 	];
 }
 
@@ -1161,9 +835,9 @@ async function main() {
 	}
 
 	console.log('[pre-ready] Ready for Review 前のローカル一括セルフチェック (Issue #1775)');
-	console.log(`[pre-ready] PR 番号: ${args.pr ?? '(未指定 — Step 9, 12 はスキップ)'}`);
+	console.log(`[pre-ready] PR 番号: ${args.pr ?? '(未指定 — Step 9 / 11b はスキップ)'}`);
 
-	// #3857: 依存 preflight — 欠落のまま Step 2/3 を回すと変更無関係の false-negative になるため fail-fast
+	// #3857: 依存 preflight — 欠落のまま Step 2 を回すと変更無関係の false-negative になるため fail-fast
 	const pf = preflightWorktreeDeps();
 	if (!pf.ok) {
 		console.error(
@@ -1180,7 +854,7 @@ async function main() {
 			'    cd infra && npm ci   # CDK 単体テスト (cd infra && npx vitest) を回す場合のみ',
 		);
 		console.error(
-			'  (依存欠落のまま Step 2/3 svelte-check / vitest を実行すると変更と無関係な大量 error / spawn 失敗になり、\n' +
+			'  (依存欠落のまま Step 2 svelte-check を実行すると変更と無関係な大量 error / spawn 失敗になり、\n' +
 				'   「pre-ready を回した」証跡が空振りします。ADR-0006 no-silent-fail 整合で着手前に fail-fast します。#3857)',
 		);
 		return 1;
@@ -1219,16 +893,9 @@ async function main() {
 	const skippedPrMissing = [];
 	/** 変更内容が適用対象外の step (#4018: ALL PASS を妨げない) */
 	const skippedNotApplicable = [];
-	/** #4007: skip ではなく「CI の特定 job へ委譲」した step */
-	const delegated = [];
 
 	for (const step of steps) {
 		if (step.skip) {
-			if (step.delegatedToCi) {
-				console.log(`[pre-ready] → ${step.label}`);
-				delegated.push({ name: step.name, ...step.delegatedToCi });
-				continue;
-			}
 			console.log(`[pre-ready] ⊘ ${step.label}`);
 			if (step.skipKind === 'flag') skippedByFlag.push(step.name);
 			else if (step.skipKind === 'script-missing') skippedScriptMissing.push(step.name);
@@ -1262,7 +929,6 @@ async function main() {
 		skippedScriptMissing,
 		skippedPrMissing,
 		skippedNotApplicable,
-		delegated,
 		failOpenCount: failOpenNotes.length,
 		pr: args.pr,
 	});

--- a/tests/unit/scripts/check-license-key-leak.test.ts
+++ b/tests/unit/scripts/check-license-key-leak.test.ts
@@ -151,20 +151,26 @@ describe('check-license-key-leak (#2836)', () => {
 	// ## 外しても検査は失われない (ADR-0006 弱体化ではない)
 	//
 	// 同一の `findAllViolations()` による実 repo 検査は、per-test timeout を持たない専用 lane
-	// で **2 箇所** 走る:
-	//   - `npm run pre-ready` Step 7b (`node scripts/check-license-key-leak.mjs`)
+	// で走る:
 	//   - CI `.github/workflows/ci.yml` の License key re-introduction guard step
 	//
-	// unit lane が担うのは「その配線が消えていないこと」= 下の 3 test。gate が片方の lane から
+	// #4121: pre-ready Step 7b は撤去した (pre-ready の hard-fail を 6 本に絞ったため)。
+	// **gate 自体は CI で hard-fail のまま**であり、消えたのは「ローカルでも重複して回す」ことだけ。
+	// 撤去が silent に起きないよう、pre-ready の `--help` が行き先 (ci.yml) を明示することを下で固定する。
+	//
+	// unit lane が担うのは「その配線が消えていないこと」= 下の 3 test。gate が lane から
 	// 落ちれば unit test が落ちる (「検査していない」が緑に見える状態を作らせない)。
-	describe('実 repo gate の配線 (#4000)', () => {
+	describe('実 repo gate の配線 (#4000 / #4121)', () => {
 		const repoRoot = resolve(__dirname, '../../..');
 		const readRepoFile = (rel: string) => readFileSync(resolve(repoRoot, rel), 'utf8');
 
-		it('pre-ready が check-license-key-leak.mjs を実行する', () => {
-			expect(readRepoFile('scripts/pre-ready.mjs')).toContain(
-				"['node', 'scripts/check-license-key-leak.mjs']",
-			);
+		it('pre-ready から外した事実と行き先 (ci.yml) が --help に明記されている', () => {
+			// pre-ready が実行しなくなったこと自体は問題ないが、**どこで走るのかを書かずに消す**のは
+			// 「検査を消した」と区別が付かなくなる (#4121 の中心的な線引き)。
+			const preReady = readRepoFile('scripts/pre-ready.mjs');
+			expect(preReady).not.toContain("['node', 'scripts/check-license-key-leak.mjs']");
+			expect(preReady).toContain('license-key-leak');
+			expect(preReady).toContain('.github/workflows/ci.yml (lint-and-test)');
 		});
 
 		it('CI が check-license-key-leak.mjs を実行する', () => {

--- a/tests/unit/scripts/pre-ready-order-and-base.test.ts
+++ b/tests/unit/scripts/pre-ready-order-and-base.test.ts
@@ -98,18 +98,19 @@ describe('#4048 実行順が cheap-fail-first であること', () => {
 		expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
 	});
 
-	it('[O4] PR body 検査 (pr-body) が型検査 / テストより先に走る (AC1 の核)', () => {
+	it('[O4] PR body 検査 (pr-body) が静的検査 / 型検査より先に走る (AC1 の核)', () => {
+		// #4121 で vitest step は CI unit-test へ移したため、比較対象は残る最重量 step (svelte-check)。
 		const order = orderedStepNames();
 		expect(order.indexOf('pr-body')).toBeGreaterThanOrEqual(0);
+		expect(order.indexOf('pr-body')).toBeLessThan(order.indexOf('biome'));
 		expect(order.indexOf('pr-body')).toBeLessThan(order.indexOf('svelte-check'));
-		expect(order.indexOf('pr-body')).toBeLessThan(order.indexOf('vitest'));
 	});
 
 	it('[O5] pr-body が実行順の先頭である (ファイルを読まない検査が最初)', () => {
 		expect(orderedStepNames()[0]).toBe('pr-body');
 	});
 
-	it('[O6] 型検査 → テスト → ブラウザ実測 → UI 系 の相対順序を保つ', () => {
+	it('[O6] meta → 静的検査 → 型検査 → UI 系 の相対順序を保つ', () => {
 		const order = orderedStepNames(['site/index.html', 'src/lib/ui/x.svelte']);
 		// LP / UI 変更ありの step 集合でも全 step にクラスが付いていること (旧 [O1] の条件付き step 分)
 		const classes = costClasses();
@@ -119,13 +120,12 @@ describe('#4048 実行順が cheap-fail-first であること', () => {
 			),
 		).toEqual([]);
 		const at = (n: string) => order.indexOf(n);
-		expect(at('svelte-check')).toBeLessThan(at('vitest'));
-		expect(at('vitest')).toBeLessThan(at('lp-dimensions'));
-		expect(at('lp-dimensions')).toBeLessThan(at('ss-embed-gate'));
-		expect(at('ss-embed-gate')).toBeLessThan(at('capture'));
-		// 静的検査は型検査より前
+		// #4121: test / browser クラスの step は CI へ移したため、残る鎖は meta → static → typecheck → ui
+		expect(at('pr-body')).toBeLessThan(at('biome'));
 		expect(at('biome')).toBeLessThan(at('svelte-check'));
-		expect(at('terminology-coherence')).toBeLessThan(at('svelte-check'));
+		expect(at('plan-literals')).toBeLessThan(at('svelte-check'));
+		expect(at('local-tz-getters')).toBeLessThan(at('svelte-check'));
+		expect(at('svelte-check')).toBeLessThan(at('ss-embed-gate'));
 	});
 
 	it('[O7] 並べ替えで step の集合が変わらない (AC2 — 検査を増減させていない)', () => {

--- a/tests/unit/scripts/pre-ready-preflight.test.ts
+++ b/tests/unit/scripts/pre-ready-preflight.test.ts
@@ -76,11 +76,12 @@ describe('preflightWorktreeDeps (#3857 Fix C)', () => {
 		for (const s of sentinels) {
 			mkdirSync(resolve(tmp, s), { recursive: true });
 		}
-		// tsx (Step 11 依存) のみ欠落させる
-		rmSync(resolve(tmp, 'node_modules/tsx'), { recursive: true, force: true });
+		// svelte-check (Step 2 依存) のみ欠落させる
+		// (#4121 で pre-ready を 6 step に絞り、vitest / tsx / aws-cdk-lib は CI 側 job の依存になった)
+		rmSync(resolve(tmp, 'node_modules/svelte-check'), { recursive: true, force: true });
 		const { result } = callPreflight(tmp);
 		expect(result.ok).toBe(false);
-		expect(result.missing).toContain('node_modules/tsx');
+		expect(result.missing).toContain('node_modules/svelte-check');
 	});
 
 	it('.git がファイル (linked worktree の gitdir ポインタ) なら isWorktree:true', () => {

--- a/tests/unit/scripts/pre-ready-skip-classification.test.ts
+++ b/tests/unit/scripts/pre-ready-skip-classification.test.ts
@@ -70,8 +70,11 @@ process.stdout.write(JSON.stringify(steps.map((s) => ({ name: s.name, skip: !!s.
 	return JSON.parse(out) as StepShape[];
 }
 
-/** Readiness gate 系 (`--pr` を前提とする 3 step) */
-const READINESS_GATE_STEPS = ['pr-body', 'ss-embed-gate', 'capture'] as const;
+/**
+ * Readiness gate 系 (`--pr` を前提とする step)。
+ * #4121 で `capture` step (撮影ガイダンス表示のみで検査していなかった) を撤去したため 2 step。
+ */
+const READINESS_GATE_STEPS = ['pr-body', 'ss-embed-gate'] as const;
 
 describe('#4018 skipStateOf — skip 理由の分類', () => {
 	it('[K1] --skip flag が最優先で flag に分類される', () => {

--- a/tests/unit/scripts/pre-ready-step-budget.test.ts
+++ b/tests/unit/scripts/pre-ready-step-budget.test.ts
@@ -1,0 +1,146 @@
+/**
+ * tests/unit/scripts/pre-ready-step-budget.test.ts (#4121 E5 Wave 2)
+ *
+ * 検証対象:
+ *   1. pre-ready の hard-fail step が **6 本ちょうど**であること (ADR-0007 §1-2 判断原則 v2)。
+ *      20 本まで増えた結果 1 PR が 1 日で回らなくなったため、類型 1 (証跡の真正性) と
+ *      類型 2 (顧客に見える正しさ) のうち安価なものだけを残し、残りは CI へ寄せた。
+ *      **「6 本に無い = 検査を消した」ではない**。外した step は CI 側で hard-fail のまま走る。
+ *   2. 外した重量 step (vitest / LP ブラウザ実測) が pre-ready に戻ってこないこと。
+ *      戻ると 300 秒予算が即座に壊れる (vitest 単独でローカル実測 1753s、#4007)。
+ *   3. `check-lp-plan-sync` が CI で hard-fail であること (類型 2 = 顧客に見える正しさ / LP の嘘)。
+ *      #4121 で一度 `continue-on-error: true` に降格したが、cheap な類型 2 は hard-fail が正。
+ *
+ * pre-ready.mjs は plain .mjs のため、.ts test から静的 import すると svelte-check の型 program に
+ * 取り込まれる。既存 pre-ready-*.test.ts と同じく node 子プロセスの dynamic import 経由で呼ぶ。
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), '../../../..');
+const preReadyUrl = pathToFileURL(resolve(repoRoot, 'scripts/pre-ready.mjs')).href;
+
+/**
+ * pre-ready が hard-fail として残す 6 step (#4121)。
+ *
+ * | step             | ADR-0007 §1-2 類型 | 残す理由 |
+ * |------------------|-------------------|----------|
+ * | pr-body          | 1 証跡の真正性     | Ready checklist / AC 証跡 / 禁止語。Ready 化そのものの前提 |
+ * | ss-embed-gate    | 1 証跡の真正性     | UI 変更 PR の SS 証跡。Ready 化後に CI が言っても往復が増えるだけ |
+ * | biome            | 2 顧客に見える正しさ | recommended の correctness / suspicious (noImportCycles 等) を含む。数十秒 |
+ * | svelte-check     | 2 顧客に見える正しさ | 型エラー = 実行時破綻。ローカルで回さないと CI 往復が最も高くつく |
+ * | plan-literals    | 2 顧客に見える正しさ | プラン名・状態の直書き = 顧客に見える誤表示 (ADR-0045) |
+ * | local-tz-getters | 2 顧客に見える正しさ | ローカル TZ 由来の日付ずれ = 顧客に見える誤り (#4015) |
+ */
+const KEEP_STEPS = [
+	'biome',
+	'svelte-check',
+	'plan-literals',
+	'local-tz-getters',
+	'pr-body',
+	'ss-embed-gate',
+] as const;
+
+/** pre-ready から外し、CI 側 hard-fail に委ねた step 名 (pre-ready に戻さない)。 */
+const MOVED_TO_CI = [
+	'cspell',
+	'vitest',
+	'hardcoded-strings',
+	'lp-dimensions',
+	'lp-fallback',
+	'license-key-leak',
+	'cli-entry-guard',
+	'sparse-checkout-closure',
+	'readdir-rotation-guard',
+	'repo-scan-test-declaration',
+	'lp-labels',
+	'doc-code-references',
+	'terminology-coherence',
+] as const;
+
+type StepShape = { name: string; costClass: string; skip: boolean };
+
+function buildStepShapes(args: Record<string, unknown>, changedFiles: string[] = []): StepShape[] {
+	const code = `const m = await import(${JSON.stringify(preReadyUrl)});
+const steps = m.buildSteps(${JSON.stringify(args)}, ${JSON.stringify(changedFiles)});
+process.stdout.write(JSON.stringify(steps.map((s) => ({ name: s.name, costClass: s.costClass, skip: !!s.skip }))));`;
+	return JSON.parse(
+		execFileSync(process.execPath, ['--input-type=module', '-e', code], { encoding: 'utf8' }),
+	) as StepShape[];
+}
+
+describe('#4121 pre-ready の hard-fail step は 6 本', () => {
+	it('[P1] buildSteps がちょうど keep 6 step を返す', () => {
+		const names = buildStepShapes({ pr: '4121' }).map((s) => s.name);
+		expect([...names].sort()).toEqual([...KEEP_STEPS].sort());
+	});
+
+	it('[P2] LP / UI 変更ありの入力でも step が増えない (条件付き step を足し戻していない)', () => {
+		const names = buildStepShapes({ pr: '4121' }, [
+			'site/index.html',
+			'src/lib/domain/labels.ts',
+			'src/lib/domain/validation/age-tier.ts',
+			'src/routes/foo/+page.svelte',
+		]).map((s) => s.name);
+		expect([...names].sort()).toEqual([...KEEP_STEPS].sort());
+	});
+
+	it('[P3] CI へ寄せた step が pre-ready に戻っていない (300 秒予算の回帰ガード)', () => {
+		const names = new Set(buildStepShapes({ pr: '4121' }).map((s) => s.name));
+		expect(MOVED_TO_CI.filter((n) => names.has(n))).toEqual([]);
+	});
+
+	it('[P4] 残す 6 本に重量クラス (test / browser) が含まれない', () => {
+		const heavy = buildStepShapes({ pr: '4121' }, ['site/index.html']).filter((s) =>
+			['test', 'browser'].includes(s.costClass),
+		);
+		expect(heavy).toEqual([]);
+	});
+
+	it('[P5] 6 本すべてが --skip-* flag を持つ (skip 分類を迂回する step がない)', () => {
+		const allSkipped = buildStepShapes(
+			{
+				pr: '4121',
+				skipBiome: true,
+				skipSvelteCheck: true,
+				skipPlanLiterals: true,
+				skipLocalTzGetters: true,
+				skipPrBody: true,
+				skipSsEmbedGate: true,
+			},
+			['src/routes/foo/+page.svelte'],
+		);
+		expect(allSkipped.filter((s) => !s.skip).map((s) => s.name)).toEqual([]);
+	});
+});
+
+describe('#4121 check-lp-plan-sync は CI で hard-fail (ADR-0007 §1-2 類型 2)', () => {
+	/**
+	 * ci.yml から `- name:` 単位で step ブロックを切り出す。
+	 * コメント行 (`#`) は除去する — 判定対象は YAML の directive であり、
+	 * 「なぜ hard-fail なのか」を説明するコメント中の語に反応させない。
+	 */
+	function ciStepBlock(nameFragment: string): string {
+		const yml = readFileSync(resolve(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+		const lines = yml.split('\n');
+		const start = lines.findIndex((l) => /^\s*-\s+name:/.test(l) && l.includes(nameFragment));
+		expect(start, `ci.yml に "${nameFragment}" の step が見つからない`).toBeGreaterThanOrEqual(0);
+		const end = lines.findIndex((l, i) => i > start && /^\s*-\s+name:/.test(l));
+		return lines
+			.slice(start, end === -1 ? lines.length : end)
+			.filter((l) => !/^\s*#/.test(l))
+			.join('\n');
+	}
+
+	it('[P6] LP plan sync check step に continue-on-error directive が無い', () => {
+		expect(ciStepBlock('LP plan sync check')).not.toMatch(/^\s*continue-on-error\s*:/m);
+	});
+
+	it('[P7] check-lp-plan-sync.mjs --check を実際に実行している (空 gate 化していない)', () => {
+		expect(ciStepBlock('LP plan sync check')).toContain('check-lp-plan-sync.mjs --check');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**1 PR が 1 日で回るようにする。** 現状 `npm run pre-ready` は 20 step で、Ready 化のたびに待ち時間が積み上がり、修正 1 回ごとに往復が発生していた。判断原則 v2（ADR-0007 §1-2）で全 step を仕分け、**ローカルで止めるべき 6 本だけを残す**。

**削除行数を稼ぐことが目的ではありません。** 外した 14 step のうち **13 本は CI で hard-fail のまま稼働**しており、完全撤去したのは「何も検査せずガイダンス文を print して常に PASS を返すだけ」の 1 本のみです。

## 関連 Issue

Refs #4121

<!-- no-issue-close: EPIC #4121 (E5) の完了定義は「装置 25,000 行以下 / pre-ready 6 step・300s / 必須 job 8 本」の 3 つ。本 PR は pre-ready 6 step・300s のみを満たすため、EPIC は残り 2 条件の達成後に手動 close する -->

## AC 検証マップ (ADR-0004)

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| 1 | `check-lp-plan-sync` を hard-fail に戻す（類型 2 = 顧客に見える正しさ、PO 判断済） | `ci.yml` から `continue-on-error: true` を削除 → mutation で戻して test が落ちるか | commit `bfce0b707`。**mutation: `continue-on-error: true` を戻すと 1 件 fail**（`[P6]`） |
| 2 | pre-ready を 6 step / 300 秒にする | `npm run pre-ready` の実測 + step 予算 test | **実測 49.9 秒**（`--pr` なし = 4 step 実行）。Step 9 / 11b は `gh` API 数秒なので 6 step でも **60 秒前後**。**mutation: `vitest` step を戻すと 5 件 fail**（`[P1]`〜`[P5]`） |
| 3 | docs の step 数を**同一 PR で**同期（先に数字だけ変えると docs が嘘になる） | `grep` で step 数への言及を全数確認 | `CLAUDE.md` / `docs/codebase-map.md` / `docs/sessions/dev-session.md` / `docs/sessions/branch-strategy.md` / `.claude/skills/dev-open-pr/SKILL.md` / `ready-gate-checklist.md` を同期 |

## 残す 6 step と、外した 14 step の行き先

**step 番号は renumber していません。** `Step 9` / `Step 11b` は `.husky/pre-push` / workflows / skills / ADR-0056 など **24 ファイルから参照**されており、一括改名は本 PR の scope を超えて doc drift を招くためです（番号は「表示上の識別子であり実行順ではない」と既に明記済、#4048）。

### 残す 6 本

| step | 類型 | 残した理由 |
|---|---|---|
| 9 `pr-body`（Readiness gate） | **1 証跡の真正性** | Ready checklist / AC 証跡 / 禁止語。Ready 化そのものの前提 |
| 11b `ss-embed-gate` | **1 証跡の真正性** | UI 変更 PR の SS 証跡 |
| 1 `biome` | 2 | `recommended: true` + `noImportCycles: error` / `noExplicitAny: error` を含み**書式だけではない** |
| 2 `svelte-check` | 2 | 型エラー = 実行時破綻。**CI 往復コストが最も高い** |
| 7 `plan-literals` | 2 | プラン名・状態の直書き = 顧客に見える誤表示 |
| 7g `local-tz-getters` | 2 | ローカル TZ 由来の日付ずれ（PO 見立てどおり hard-fail 維持） |

### 外した 14 本の行き先

| step | 行き先 |
|---|---|
| `vitest` | CI `unit-test`（2 shard）で継続 |
| `cspell` / `hardcoded-strings` / `license-key-leak` / `cli-entry-guard` / `sparse-checkout-closure` / `readdir-rotation-guard` / `repo-scan-test-declaration` / `doc-code-references` / `terminology-coherence` / `generate-lp-labels --check` | CI `ci.yml` lint-and-test で継続 |
| `measure-lp-dimensions` | CI `lp-metrics.yml` で継続 |
| `sync-lp-fallback --check` | CI `lp-fallback-check.yml` で継続 |
| `capture` | **完全撤去**（類型 4 相当）。検査せずガイダンス文を print して常に PASS を返すだけの step で、SS 未 embed は Step 11b が検出する |

この対応表は `npm run pre-ready -- --help` と summary 出力の**両方**に載せ、**「pre-ready ALL PASS = 全部通った」と誤読されないよう `gh pr checks` 確認を促す文言を必ず出す**ようにしています。

### 新規 5 step の ADR-0007 §1-2 類型仕分け (#4121 Wave 2)

| step | 検査内容 | 類型 | 判定 | pre-ready | CI |
|---|---|---|---|---|---|
| 7c `check-cli-entry-guard` (#3969) | 自前の `isMain` 判定 / 手組み `file://` URL を禁止（gate が「何も検査せず exit 0」になる class を止める） | 1 証跡の真正性 | gate は hard-fail 維持。ただし発火は `scripts/` 編集時に限られ CI で同等に hard-fail するため、ローカル重複は外す | 外す | `ci.yml` lint-and-test |
| 7d `check-workflow-sparse-checkout-closure` (#3969) | workflow の sparse-checkout 列挙漏れ検出 | 3 手続きの整合 | 列挙漏れは CI job が `ERR_MODULE_NOT_FOUND` で hard fail するため沈黙しない | 外す | `ci.yml` lint-and-test |
| 7e `check-readdir-rotation-guard` (#3978) | readdir の緩い一致 × 破壊的削除 class の検出 | 1 不可逆な損失 | gate は hard-fail 維持。7c と同じく発火が `scripts/` 編集時に限られるためローカル重複は外す | 外す | `ci.yml` lint-and-test |
| 7f `check-repo-scan-test-declaration` (#4085) | repo 走査 test の区分宣言 + 明示 timeout | 3 書式・網羅性 | test 実行環境の宣言であり顧客に見える正しさではない | 外す | `ci.yml` lint-and-test |
| 7g `check-local-tz-date-getters` (#4015) | ローカル TZ 日付 getter 禁止 / JST SSOT 強制 | **2 顧客に見える正しさ** | 日付ずれは顧客が直接見る誤り。静的検査で数秒 = cheap のため **hard-fail 維持** | **残す** | `ci.yml` lint-and-test |

いずれも **CI 側は hard-fail のまま**であり、**pre-ready から外したことと gate を消すことは別**です。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（顧客に見える挙動は不変）。変更対象は開発者向け CLI と CI 設定、および docs。

- [ ] **並行実装ペア**を同期した
- [x] **設計書同期** (ADR-0001): ADR-0007 に適用実績を追記（139 行で上限内）。step 数に言及する docs 6 ファイルを同一 PR で同期
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| 項目 | 結果 |
|---|---|
| `npm run pre-ready -- --pr 4143` | **ALL PASS (6 step / 50.0 秒)** — Step 9 → 1 → 7 → 7g → 2 の順、Step 11b は UI 変更なしで skip |
| Step 2 svelte-check | 8301 files / **0 errors / 0 warnings** |
| `npm run cspell` | Files checked 1790 / **Issues 0** |
| `npx biome check --error-on-warnings` | 変更 file **0 error** |
| `npx vitest run tests/unit/scripts/` | 53 files / **1002 passed**, 1 skipped |
| `npx vitest run tests/unit/{github,hooks,architecture}/` | 43 files / **708 passed** |

**mutation 検証**（実装 commit **後**に実施、復帰は `git stash`。`git checkout --` は未コミットの実装ごと消すため使用しない）:

| 壊した内容 | 落ちたテスト |
|---|---|
| `ci.yml` の LP plan sync step に `continue-on-error: true` を戻す | **1 件**（`[P6]`） |
| `pre-ready.mjs` に `vitest` step（costClass `test`）を戻す | **5 件**（`[P1]`〜`[P5]`） |

- [x] **SOLID / DRY / YAGNI**: `buildSummary` の `delegated` 機構（#4007）は参照ゼロになったため撤去し、「pre-ready 外で走る CI 検査と確認手順」を常時出力する固定ブロックに置換。**沈黙 skip を作らないという #4007 の意図は維持**
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

N/A — UI 変更なし（CLI / CI / docs のみ）。

## レビュー依頼事項・破壊的変更

**QM に特に見ていただきたい判断が 3 点あります。**

### 1. `biome` を「類型 2」と判定した（類型 3 の余地あり）

純粋な書式検査なら類型 3（warn 降格）ですが、本 repo の `biome.json` は `recommended: true` + `noImportCycles: error` / `noExplicitAny: error` を含み **correctness 検査が入る**ため類型 2 と判定しました。**ここは「類型 3 では」と見る余地があります。**

### 2. 類型 1 の 2 本（`cli-entry-guard` / `readdir-rotation-guard`）を pre-ready から外した

類型 1 は hard-fail が原則です。6 枠の制約下で、**「CI で同等に hard-fail し、かつ発火が `scripts/` 編集時に限られる装置系」より「全 PR で往復コストが出る `svelte-check`」を優先**しました。**gate 自体は CI で hard-fail のまま**で、消してはいません。

### 3. `PREFLIGHT_SENTINELS` から `vitest` / `tsx` / `infra/aws-cdk-lib` を外した

6 step が spawn しない依存を要求し続けると、worktree で不要な `cd infra && npm ci` を強いることになるためです。対応する preflight test は「**別の実在 sentinel（`svelte-check`）を欠落させる**」形に置き換えており、**assertion の強度は同一**です（弱体化していません）。

### 4. ⚠ pre-ready から外した 13 本のうち **2 本は merge を block していません**（本 PR 以前からの状態。直していません）

「CI にある」と「CI で落ちる」は別なので、13 本すべてを **`.github/workflows/*.yml` の step ブロック単位で実測**しました。

**`continue-on-error` は 13 本すべて 0 件**（step 単位 / job 単位とも）。ただし `continue-on-error` を見るだけでは不十分でした。ADR-0007 §4 のとおり required 化の実装点は **`ci-gate` の `needs:` 登録 + branch ruleset の required contexts** なので、そちらも実測しました。

- **`ci-gate` needs**（`ci.yml` L1282〜）: `lint-and-test` / `unit-test` とも登録済 → **11 本は真に merge block**
- **branch ruleset**（`gh api .../rulesets` で実測）:

| ruleset | 対象 | LP 系 required contexts |
|---|---|---|
| `PR_Mearge` | `~DEFAULT_BRANCH` (main) | `Measure LP dimensions and lint forbidden terms` **あり** |
| `develop-light-lane` | `refs/heads/develop` | **無し** |

| 検査 | 状態 |
|---|---|
| `measure-lp-dimensions` | main 向け PR では required。**develop 向け PR では required contexts に無く、red でも merge 可能** |
| `sync-lp-fallback --check` | **どちらの lane でも required contexts に無い**（workflow は赤くなるがブロックしない） |

**この 2 本は本 PR 以前からその状態**で、本 PR が変えたのは「pre-ready のローカル hard-fail を外した」ことだけです。ただし結果として、**develop 向けの LP 変更 PR では 2 本が「どこでも止まらない」状態**になります（`.husky/pre-push` も LP 系は実行していないことを確認済 — 重い検査は CI / pre-ready 委ねの設計）。

**hard-fail 復帰は PO 判断事項のため手を付けていません。** 選択肢:

- **(a)** `develop-light-lane` ruleset に 2 contexts を追加する
- **(b)** 2 本を pre-ready に戻す（6 本 budget を 8 本に）
- **(c)** LP は main 向け統合 PR で止まれば十分と割り切る（`sync-lp-fallback` は (a) でしか塞がらない）

なお `lp-metrics.yml` の `cumulative-lp-metrics` job は `continue-on-error: true` ですが、これは #1840 で warn-only と明記された累積 gate であり、本体の `measure` job とは別物です。

### 据え置いた箇所

`docs/design/billing-redesign/phase7-staging-validation-protocol.md` の「全 10 step PASS」は**据え置き**ました。特定 PR (#2722) の過去の検証記録であり、現在の step 数の主張ではないためです。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（PO 指示 3 点すべて。EPIC #4121 の残り 2 条件は本 PR の scope 外であることを body に明示）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
