### PR TITLE
fix(db): #4129 破壊的ローテーションを止め、連続失敗を数え、必須 env を明記する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,9 +44,28 @@ PORT=3000
 # BEDROCK_MODEL_ID=us.anthropic.claude-haiku-4-5-20251001-v1:0
 # BEDROCK_REGION=us-east-1
 
+# ---------------------------------------------------------------
+# NUC 日次バックアップ (#3950 / #4129) — pglite backend では **必須 env が 2 つある**
+# ---------------------------------------------------------------
+# 2026-07-31 の実害: 本番 NUC の `.env` に CRON_SECRET が配られておらず、
+# 日次バックアップが release deploy 後の初回実行から毎晩失敗し続けていた。
+# DISCORD_ALERT_WEBHOOK_URL も未配布だったため通知は 0 通で、18 日間誰も気づかなかった
+# (詳細: Issue #4119)。**pglite backend で backup profile を動かすなら下の 2 つは必須**。
+#
+#   DATA_SOURCE=pglite     # backup コンテナが /api/health の dataSource と照合する。
+#                          # 食い違うと backup を実行せず落ちる (#3967、暗黙 sqlite fallback 廃止)
+#   CRON_SECRET=<32 byte>  # /api/cron/pglite-backup の認証。未設定だと
+#                          # 「CRON_SECRET が未設定です」で毎晩失敗する。OPS_SECRET_KEY でも可
+#
+# 強く推奨 (これが無いと失敗が誰にも届かない):
+#   DISCORD_ALERT_WEBHOOK_URL=<webhook>
+#
 # Backup (optional)
 # BACKUP_DIR=./data/backups
-# BACKUP_RETENTION=10
+# BACKUP_RETENTION=3
+#   ⚠ BACKUP_RETENTION を**引き下げる**と初回実行で複数世代が一括削除されうる。削除は不可逆。
+#     #4129 AC2 の fail-closed guard が「一度に 2 世代以上消す実行」を止めるので、
+#     消えて困る世代を退避してから古い世代を手で削除すること (次回以降は自動で解除される)。
 # BACKUP_POST_HOOK=node scripts/hooks/gdrive-upload.cjs
 # #2519: docker compose --profile backup の cron は backup-db.cjs の後に
 #   verify-backup-restore.cjs を実行し、restore 可能性 (integrity_check /

--- a/scripts/backup-nuc.cjs
+++ b/scripts/backup-nuc.cjs
@@ -60,6 +60,26 @@ const DISCORD_WEBHOOK =
 	process.env.DISCORD_ALERT_WEBHOOK_URL || process.env.DISCORD_WEBHOOK_INCIDENT || '';
 
 /**
+ * 状態ファイルから連続失敗回数を読む (#4129 AC4)。読めなければ null。
+ *
+ * 「今日も失敗した」ではなく「**N 晩続けて失敗している**」を出すために使う。
+ * 毎晩同じ alert が流れるだけだと埋もれる (2026-07-31 の実害は 18 日間気づかれなかった)。
+ *
+ * @returns {number | null}
+ */
+function readConsecutiveFailures() {
+	const backupDir = process.env.BACKUP_DIR || path.join(__dirname, '..', 'data', 'backups');
+	try {
+		const raw = fs.readFileSync(path.resolve(backupDir, 'backup-status-pglite.json'), 'utf-8');
+		const parsed = JSON.parse(raw);
+		return typeof parsed.consecutiveFailures === 'number' ? parsed.consecutiveFailures : null;
+	} catch {
+		// 状態ファイルが無い / 壊れている場合は回数を出さないだけ。元の失敗は握り潰さない。
+		return null;
+	}
+}
+
+/**
  * バックアップ失敗を Discord に通知する。webhook 未設定なら no-op。
  * fail が沈黙しないための最小実装 (verify-backup-restore.cjs と同じ形)。
  *
@@ -70,12 +90,26 @@ async function notifyFailure(detail) {
 		console.error('[backup-nuc] Discord webhook 未設定のため通知を送れません');
 		return;
 	}
+	// #4129 AC4: 連続失敗回数を alert 本文に載せる。1 通ずつ見ると同じに見える alert が、
+	// 回数を持つことで「昨日から続いている」と読めるようになる。
+	const streak = readConsecutiveFailures();
+	const streakNote =
+		streak && streak > 1
+			? `**${streak} 晩連続で失敗しています。** 単発の失敗ではありません。`
+			: null;
 	const embed = {
-		title: '🚨 [CRITICAL] NUC バックアップ 失敗',
-		description: `NUC のバックアップに失敗しました。data 保全リスク。`,
+		title:
+			streak && streak > 1
+				? `🚨 [CRITICAL] NUC バックアップ ${streak} 晩連続失敗`
+				: '🚨 [CRITICAL] NUC バックアップ 失敗',
+		description: streakNote
+			? `NUC のバックアップに失敗しました。data 保全リスク。
+${streakNote}`
+			: `NUC のバックアップに失敗しました。data 保全リスク。`,
 		color: 10038562,
 		fields: [
 			{ name: 'Detail', value: `\`\`\`${detail.slice(0, 800)}\`\`\`` },
+			...(streak !== null ? [{ name: '連続失敗', value: `${streak} 回`, inline: true }] : []),
 			{ name: '対応', value: 'docs/runbooks/pglite-restore-drill.md / backup cron を確認' },
 		],
 		timestamp: new Date().toISOString(),
@@ -183,7 +217,11 @@ async function main() {
 
 main().catch(async (err) => {
 	const message = err instanceof Error ? err.message : String(err);
+	const streak = readConsecutiveFailures();
 	console.error('[backup-nuc] FAILED:', message);
+	if (streak !== null && streak > 1) {
+		console.error(`[backup-nuc] ${streak} 晩連続で失敗しています (単発ではありません、#4129 AC4)`);
+	}
 	await notifyFailure(message);
 	process.exit(1);
 });

--- a/src/lib/server/services/pglite-backup-service.ts
+++ b/src/lib/server/services/pglite-backup-service.ts
@@ -34,6 +34,34 @@ export interface PgliteBackupStatus {
 	lastSuccessDurationMs: number | null;
 	lastFailureAt: string | null;
 	lastFailureMessage: string | null;
+	/**
+	 * 連続失敗回数 (#4129 AC4)。成功で 0 に戻る。
+	 *
+	 * 失敗のたびに alert を 1 通投げるだけだと、**毎晩同じ alert が流れて埋もれる**。
+	 * 2026-07-31 の実害では `CRON_SECRET` 未配布で毎晩失敗していたが 18 日間誰も気づかなかった
+	 * (そのときは webhook も未配布で alert 自体が 0 通だった、#4119)。回数を持てば
+	 * 「今日も失敗した」ではなく「**N 晩続けて失敗している**」を出せる。
+	 */
+	consecutiveFailures: number;
+}
+
+/**
+ * 破壊的ローテーション (一度に複数世代を消す) を検出して止めたことを表すエラー (#4129 AC2)。
+ *
+ * 通常運用では 1 回の実行で溢れる世代は高々 1 件しかない。複数件溢れるのは
+ * **`BACKUP_RETENTION` が引き下げられた直後の初回実行**か、世代名のファイルが外から
+ * 増やされたときだけであり、いずれも「気づかないうちに手持ちが一括で消える」形になる。
+ * 削除は不可逆なので、消す前に止めて人間に退避させる (fail-closed)。
+ */
+export class PgliteBackupRotationGuardError extends Error {
+	constructor(
+		readonly wouldDelete: string[],
+		readonly retention: number,
+		message: string,
+	) {
+		super(message);
+		this.name = 'PgliteBackupRotationGuardError';
+	}
 }
 
 export interface RunPgliteBackupOptions {
@@ -73,6 +101,7 @@ async function readStatus(backupDir: string): Promise<PgliteBackupStatus> {
 		lastSuccessDurationMs: null,
 		lastFailureAt: null,
 		lastFailureMessage: null,
+		consecutiveFailures: 0,
 	};
 	try {
 		const raw = await readFile(join(backupDir, BACKUP_STATUS_FILENAME), 'utf-8');
@@ -132,6 +161,28 @@ export async function runPgliteBackup(
 		// ローテーション: 確定後にのみ削除する。
 		const existing = sortBackupsNewestFirst(await readdir(backupDir));
 		const rotated = existing.slice(retention);
+
+		// #4129 AC2: **一度に 2 世代以上消す実行は止める (fail-closed)**。
+		// 定常運用では、新しい 1 世代が入って古い 1 世代が溢れるだけなので rotated は高々 1 件。
+		// 2 件以上溢れるのは retention 引き下げ直後の初回実行 (#3950 の 7 → 3) か、世代名の
+		// ファイルが外から増えたときで、どちらも「気づかないうちに手持ちが一括で消える」形になる。
+		// 取得した新世代はここまでで確定済みなので、**バックアップは失われず削除だけが止まる**。
+		// 逃げ道 (bypass env) は用意しない — 退避してから手で古い世代を削れば、次回以降は
+		// rotated が 1 件に戻って自然に解除される。env で黙って通せる穴を作らない。
+		if (rotated.length > 1) {
+			throw new PgliteBackupRotationGuardError(
+				rotated,
+				retention,
+				`[pglite-backup] 一度に ${rotated.length} 世代を削除しようとしたため中断しました ` +
+					`(BACKUP_RETENTION=${retention})。削除は不可逆です。` +
+					`対象: ${rotated.join(', ')}。` +
+					'BACKUP_RETENTION を引き下げた直後の初回実行が原因である可能性が高いです。' +
+					'消えて困る世代を退避したうえで、古い世代を手で削除してください ' +
+					'(次回以降は溢れが 1 世代に戻り自動で解除されます)。' +
+					`なお今回取得した新しいバックアップは確定済みで失われていません。`,
+			);
+		}
+
 		for (const stale of rotated) {
 			await rm(join(backupDir, stale), { force: true });
 		}
@@ -144,6 +195,7 @@ export async function runPgliteBackup(
 			lastSuccessFilename: filename,
 			lastSuccessBytes: bytes.byteLength,
 			lastSuccessDurationMs: durationMs,
+			consecutiveFailures: 0,
 		});
 
 		const result: PgliteBackupResult = {
@@ -166,6 +218,7 @@ export async function runPgliteBackup(
 			...previous,
 			lastFailureAt: new Date().toISOString(),
 			lastFailureMessage: message,
+			consecutiveFailures: (previous.consecutiveFailures ?? 0) + 1,
 		}).catch(() => {
 			// 状態ファイルすら書けない場合でも、元の失敗を握り潰さずそのまま投げる。
 		});

--- a/tests/unit/db/pglite-backup-3950.test.ts
+++ b/tests/unit/db/pglite-backup-3950.test.ts
@@ -18,6 +18,15 @@
 //   [BK9] Runbook の退避先 `manual/` が実 FS 上に同居してもローテーションは世代だけを削る
 //         (readdir → フィルタ → rm の実経路。ディレクトリが混ざれば rm が EISDIR で落ちる)
 //
+// #4129 (E3) で追加:
+//   [BK10] **retention 引き下げ後の初回ローテーションで一度に複数世代を消さない** (fail-closed)
+//          — #3950 は BACKUP_RETENTION を 7 → 3 に下げており、初回実行で 4 世代が一括物理削除される
+//          状態だった。削除は不可逆で、退避していなければ過去世代は永久に戻らない。
+//          2026-07-31 時点で未発火だったのは「backup job 自体が CRON_SECRET 未配布で止まっていた」
+//          という幸運によるもの (#4119)。job を直した以上、次に動く回で発火する
+//   [BK11] **連続失敗回数が状態ファイルに積算される** — 失敗が「1 回きりの alert」で埋もれると
+//          毎晩失敗し続けていることに誰も気づけない (2026-07-31 は 18 日間気づかれなかった)
+//
 // [BK2] / [BK3] / [BK5] は「gate を書いたが実は何も落とせていない」を防ぐ実効性検証。
 
 import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -38,6 +47,7 @@ import {
 } from '../../../src/lib/server/db/pglite/backup';
 import {
 	BACKUP_STATUS_FILENAME,
+	PgliteBackupRotationGuardError,
 	runPgliteBackup,
 } from '../../../src/lib/server/services/pglite-backup-service';
 
@@ -306,4 +316,91 @@ describe('#3950 PGlite backup — 復元できることの実証', () => {
 		// 退避先ディレクトリと中身が無傷で残る。
 		expect(readdirSync(join(backupDir, 'manual'))).toEqual([MANUAL_SNAPSHOT_FILENAME]);
 	}, 120_000);
+
+	it('[BK10] retention 引き下げ後の初回ローテーションは abort し、1 世代も削除しない (#4129 AC2)', async () => {
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk10-');
+
+		// retention=7 運用で 7 世代を作る (#3950 引き下げ前の実運用と同じ形)。
+		for (let i = 0; i < 7; i++) {
+			await runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 7,
+				now: new Date(Date.UTC(2026, 6, 10 + i, 3, 0, 0)),
+			});
+		}
+		const before = sortBackupsNewestFirst(readdirSync(backupDir));
+		expect(before).toHaveLength(7);
+
+		// retention を 3 に引き下げた初回実行。旧実装はここで 4 世代を一括削除していた。
+		await expect(
+			runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 3,
+				now: new Date(Date.UTC(2026, 6, 17, 3, 0, 0)),
+			}),
+		).rejects.toBeInstanceOf(PgliteBackupRotationGuardError);
+
+		// **1 世代も消えていないこと** が本テストの主眼 (削除は不可逆)。
+		const after = sortBackupsNewestFirst(readdirSync(backupDir));
+		expect(after).toEqual(expect.arrayContaining(before));
+		expect(after.length).toBeGreaterThanOrEqual(before.length);
+	}, 180_000);
+
+	it('[BK10] 定常運用 (1 世代だけ溢れる) は abort せず従来どおり削除する (#4129 AC2 false-positive 抑止)', async () => {
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk10b-');
+
+		// retention=3 のまま 5 回連続実行しても、毎回溢れるのは 1 世代だけ。
+		for (let i = 0; i < 5; i++) {
+			await runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 3,
+				now: new Date(Date.UTC(2026, 6, 10 + i, 3, 0, 0)),
+			});
+		}
+		expect(sortBackupsNewestFirst(readdirSync(backupDir))).toHaveLength(3);
+	}, 180_000);
+
+	it('[BK11] 連続失敗回数が積算され、成功で 0 に戻る (#4129 AC4)', async () => {
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk11-');
+
+		const brokenMigrations = tempDir('gq-bk11-journal-');
+		mkdirSync(join(brokenMigrations, 'meta'), { recursive: true });
+		writeFileSync(
+			join(brokenMigrations, 'meta', '_journal.json'),
+			JSON.stringify({ entries: [{ idx: 0, when: 9_999_999_999_999, tag: '9999_unapplied' }] }),
+		);
+
+		const readStatus = () =>
+			JSON.parse(readFileSync(join(backupDir, BACKUP_STATUS_FILENAME), 'utf-8')) as Record<
+				string,
+				unknown
+			>;
+
+		// 3 晩連続で失敗する状況 (2026-07-31 に実際に起きた形)。
+		for (let i = 1; i <= 3; i++) {
+			await expect(
+				runPgliteBackup({ client, backupDir, migrationsDir: brokenMigrations, retention: 3 }),
+			).rejects.toThrow();
+			// 「1 回目の alert で埋もれる」を防ぐため、回数そのものを持つ。
+			expect(readStatus().consecutiveFailures).toBe(i);
+		}
+
+		// 成功したらリセットされる (古い連続失敗が残り続けない)。
+		await runPgliteBackup({
+			client,
+			backupDir,
+			migrationsDir: MIGRATIONS_DIR,
+			retention: 3,
+		});
+		expect(readStatus().consecutiveFailures).toBe(0);
+	}, 180_000);
 });


### PR DESCRIPTION
## 顧客価値・目的

**家族の記録の控えが、気づかないうちに一括で消える経路を塞ぐ。** そして**毎晩失敗し続けていることに人間が気づけるようにする**。

2026-07-31、本番 NUC を実測したところ 2 件が判明した（[#4119 実測報告](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4119#issuecomment-5137096467)）。

1. **日次バックアップが 7/30 の release deploy 後の初回実行から止まっていた** — 原因は `CRON_SECRET` 未配布。`DISCORD_ALERT_WEBHOOK_URL` も未配布で通知は 0 通、**18 日間誰も気づかなかった**
2. **7/12 の PGlite cutover 以降、復元可能な控えが 1 件も存在しなかった** — 日次 backup は更新の止まった SQLite ファイルを 18 世代コピーし続けていた（全世代 1,036,288 bytes で同一）

**この PR で塞ぐのは「次に同じことが起きる経路」です。** 0-a / 0-b（原因特定と初回の論理バックアップ取得）は本 PR とは別に実機で完了済みです。

## 関連 Issue

Refs #4129

<!-- no-issue-close: #4129 の AC2 / AC3 / AC4 を実装。AC1（deploy 前退避の記録）は実機作業として完了済、AC5（ADR-0024 gate 拡張）は PR #4142 で別途実装のため、#4129 は両 PR merge 後に手動 close する -->

## AC 検証マップ (ADR-0004)

HEAD SHA: `b130152ca`

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC2 | 既存世代数 > `BACKUP_RETENTION` のとき初回ローテーションを abort し、退避を促して終了する（fail-closed）。**failing-test-first で示す** | `[BK10]` retention 7 で 7 世代作る → retention 3 で実行 → **1 世代も消えないこと**を assert | **failing-test-first: 実装前に `2 failed | 10 passed`** → 実装後 `12 passed`。**mutation: guard 条件を無効化 → 1 件 fail** |
| AC2 (false-positive 抑止) | 定常運用を壊していないこと | `[BK10b]` retention 3 のまま 5 回連続実行 → 3 世代に収束 | **実装前から緑**（= 定常運用に一切影響していないことの証明） |
| AC3 | NUC の `.env` に `CRON_SECRET` が配布済みであることを確認し、`.env.example` に `DATA_SOURCE` を含む必要 env を明記する | 実機確認 + `.env.example` diff | **配布済**（2026-07-31、PO 承認のうえ実施。`.env.bak-20260731` を取ってから追記 → `up -d` → health 200 復帰を確認）。`.env.example` に必須 2 env + `BACKUP_RETENTION` 引き下げの不可逆性を明記 |
| AC4 | `CRON_SECRET` 未配布時にバックアップが「毎晩失敗し続ける」状態を検知する（**連続失敗回数を閾値に持つ、alert 1 回で埋もれさせない**） | `[BK11]` 3 晩連続失敗 → カウンタが 1→2→3、成功で 0 に戻る | **failing-test-first で先に fail** → 実装後 PASS。**mutation: 積算を固定値 1 に置換 → 1 件 fail** |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客に見える挙動は不変。`/api/health` の `backup` ブロックに `consecutiveFailures` が増える（既存フィールドは不変）。

**AC2 の判定根拠**: 定常運用では 1 回の実行で溢れる世代は**高々 1 件**。2 件以上溢れるのは (a) `BACKUP_RETENTION` 引き下げ直後の初回実行、(b) 世代名のファイルが外から増えたとき、のいずれかで、**どちらも「気づかないうちに手持ちが一括で消える」形**になる。

**取得した新世代を確定した後で止める**ので、バックアップは失われず削除だけが止まります。失敗として status に記録され、AC4 のカウンタにも乗ります。

- [ ] **並行実装ペア**を同期した
- [x] **設計書同期** (ADR-0001): `.env.example` に必須 env と retention 引き下げの不可逆性を明記。テストファイル冒頭の観点一覧に `[BK10]` `[BK11]` を追記
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4144` | **ALL PASS**（vitest **590 files / 9155 passed**、skip 13。LP・UI 変更なしの 5 step は適用対象外で未実行） |
| 追加・変更テスト | `npx vitest run tests/unit/db/pglite-backup-3950.test.ts` | PASS (12 passed) |

**failing-test-first**（ADR-0061）: `[BK10]` `[BK11]` を**実装前に**書いて実行 → **`Tests 2 failed | 10 passed (12)`**。実装後 **12 passed**。

**mutation 検証**（実装を **commit してから** 実施）:

| 壊した箇所 | 落ちたテスト |
|---|---|
| AC2 guard の条件を無効化（`if (false && rotated.length > 1)`） | **1 件** |
| AC4 の積算を固定値に置換（`(previous ?? 0) + 1` → `1`） | **1 件** |

- [x] **SOLID / DRY / YAGNI**: guard はローテーション直前の 1 箇所のみ。専用の閾値 env を増やさず「溢れが 2 件以上か」だけで判定する
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。`.env.example` は値ではなく**必要な env 名と理由**のみ記載
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): N/A（本 PR は `priority:critical` ラベルなし）

## スクリーンショット / ビジュアルデモ

N/A — UI 変更なし（バックアップ機構 / CLI / `.env.example` のみ）。

## レビュー依頼事項・破壊的変更

### bypass env を作らなかった判断

AC2 の guard には**解除用の env を用意していません**。退避したうえで古い世代を手で削れば、次回以降は溢れが 1 世代に戻って**自然に解除**されます。

env で解除できる形にすると、**「とりあえず立てて通す」が可能になり、不可逆削除に対する fail-closed が形骸化します**。今回のように「気づかないうちに手持ちが消える」種類の事故に対しては、逃げ道を用意しないほうが正しいと判断しました。

### AC4 は「push 通知だけでは足りない」ことの土台です

今回の実害は「ジョブが落ちた」形でしたが、**ジョブが起動しなかった場合は、ジョブ内部から投げる push 通知では原理的に検知できません**。

`consecutiveFailures` は push 側（Discord alert の本文に「N 晩連続失敗」と出す）と pull 側（`/api/health` の `backup` ブロックに出る）の**両方に効く土台**です。`lastSuccessAt` の鮮度を外から見る pull 型の検知は #4087 で設計します。**本 PR だけでは「失敗が届く」は完成しません。**

### 実機で確認済みのこと / まだ確認できていないこと

**確認済み**: 0-a の是正（`CRON_SECRET` 配布 → cron 経路 `backup-nuc.cjs` をそのまま実行して成功）と 0-b（復元検証済みバックアップ `pglite-20260730T225306Z.tgz` を取得、V1 59 テーブル / V2 migration 5 件 / V3 journal 5 entry 整合）。

**未確認**: **本 PR の AC2 guard が本番実機で発火する経路は、まだ通していません。** 本番の `data/backups` には現在 pglite 世代が 1 件しかなく（cutover 以降で初めて取れたもの）、retention=3 に対して溢れが発生しないためです。unit test では実 FS 上で 7 世代 → retention 3 の状況を作って検証しています。

## 配布済み env / secret (ADR-0006)

- 配布済み: `CRON_SECRET`（2026-07-31、本番 NUC の `.env` に PO 承認のうえ追記。`.env.bak-20260731` を取得してから実施）
- **未配布**: `DISCORD_ALERT_WEBHOOK_URL` — 本 PR では**あえて配っていません**。push 通知だけでは「ジョブが起動しなかった」を検知できないため、pull 型と 2 本立てで #4087 で設計します

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = #4129 AC2 / AC3 / AC4。AC5 は PR #4142、AC1 は実機作業として完了済であることを body に明示）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢 可逆 — revert で戻る"]
    R2["顧客面: 🟢 見た目・操作は不変"]
    R3["守る対象: 🔴 世代の一括削除は不可逆"]
    R4["本 PR は削除を止める側。増やさない"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 気づかぬ一括削除が止まる"]
    T2["得る: N 晩連続失敗が見える"]
    T3["捨てる: retention 引下げ後に手作業1回"]
  end
  subgraph OBJ["③ 反対理由 (Dev 自己 adversarial)"]
    O1["business: 手作業が要り運用が止まる"]
    O2["UX: 失敗理由が運用者に伝わるか"]
    O3["security: 平文の控えが長く残りうる"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 なし — UI 変更ゼロ"]
    C2["health に項目1つ増えるのみ"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: bypass env 無しでよいか"]
    Q2["Q2: webhook は #4087 送りでよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3 danger
  class T3,O1,O2,O3 warn
  class R1,R2,R4,T1,T2,C1,C2 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠)</summary>

**③ の出所**: **Dev 自身による adversarial pass** であり、ADR-0056 の `adversarial-reviewer` subagent 出力ではありません。`tmp/adversarial-evidence/4144.json` は作っていません（Dev が書いた JSON を QM の approve gate が独立検証の証跡として読むと gate の意味が壊れるため）。独立 dispatch は QM approve 時に実施される前提です。

- **business**: guard が発火すると、退避して古い世代を手で削るまで**その晩のローテーションは止まります**。バックアップ取得自体は成功して確定するので控えは増え続けますが、`BACKUP_RETENTION` を超えた状態が続くとディスクを圧迫します。NUC のディスク制約が retention=3 の根拠だったことを踏まえると、放置されれば別の形で運用を止めかねません。**「止める」判断が「詰まる」に化ける経路**は残っています。
- **UX**: 運用者（非エンジニア）が受け取るのは Discord の alert とコンテナログだけです。guard の message は「退避してから古い世代を手で削れ」と書いてありますが、**それを実行するには SSH とファイル操作が要ります**。エラー文が読めても行動に移せない可能性があり、そこは #4087 の「非エンジニアに届く」設計と合わせないと閉じません。
- **security**: 一括削除を止めるということは、**古い世代がより長く残る**ということです。#3971 で暗号化しない決定をしているため、個人情報を含む控えが想定より長期間 NUC 上に平文で存在する期間が生まれます。運用者自身の機器内である限り受容範囲という整理ですが、NAS / SAMBA に複製している場合は前提が変わります。

**Q1 の背景**: bypass env（例 `BACKUP_ALLOW_BULK_ROTATION=1`）を用意すれば運用は楽になりますが、「とりあえず立てて通す」が可能になり fail-closed が形骸化します。用意しない設計にしていますが、運用負荷とのトレードオフなので確認します。

**Q2 の背景**: `DISCORD_ALERT_WEBHOOK_URL` は本 PR で配っていません。push 通知だけでは「ジョブが起動しなかった」を検知できず、pull 型（`lastSuccessAt` の鮮度）と 2 本立てにする必要があるためです。**その間は失敗が届かない状態が続きます**。先に webhook だけ配る選択肢もあります。

</details>

## QM レビュー結果

<!-- QM が記入 -->
