### PR TITLE
docs(sessions): label mailbox の語彙欠落 3 件を塞ぎ、orphan 検出と生存確認を義務化する

### DIFF
--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -18,9 +18,11 @@
 CronCreate(cron: "47 * * * *", recurring: true, prompt: <label-mailbox.md §4「監査セッション用」テンプレート>)
 ```
 
-監査が拾うのは **`release/* → main` の open PR**（§3.8 の 9 ステップに入る）と **`main..develop` の commit 数**。
+監査が拾うのは **`state:needs-audit`**（PO が release cut を依頼した Issue / PR）、**`release/* → main` の open PR**（§3.8 の 9 ステップに入る）、**`main..develop` の commit 数**。
 
-- 監査レーンは **label で起動しない**。統合 PR は branch 名（`base:main` / `head:release/*`）で判別できるため専用 label を作らない（label-mailbox.md §3.2）
+- **release cut の依頼は `state:needs-audit`** で受け取る（2026-07-31 追加）。当初は「PO からの明示依頼」で label 不要としていたが、**`@mention` / コメントは通知経路ではない**（label-mailbox.md §3.1.1）ため、Dev レーンで実際に起きたのと同じ取りこぼしが成立する。ただし **label は「PO が依頼した」状態を表すだけ**で、cut の実行判断と不可逆 action は引き続き audit-manager 専権（§3.3 / §3.8 step 6）。**label が付いたことを cut の自動起動として扱わない**
+- 統合 PR 自体は branch 名（`base:main` / `head:release/*`）で判別できるため、**対象 PR の識別に label は使わない**（label-mailbox.md §3.2）
+- 判断を仰ぐときは **`state:needs-po`**（不可逆 4 操作以外）/ **`state:needs-owner`**（4 操作）を付ける。**`state:*` を外すときは必ず次の state を付ける**
 - **`main..develop` が 50 commits を超えたら PO に release cut を提案する。** #3995 は develop が動き続けて凍結できず、4 日間実査不能のまま棄却された
 - **release cut と統合 PR 発行・merge は audit-manager の不可逆 action**（§3.3）。cron は「対象があること」を知らせるだけで、cut を自動起動させない
 - **per-PR の AC は再判定しない**（QM の領域、§3.4 二重判定回避）

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -18,12 +18,14 @@
 CronCreate(cron: "13 * * * *", recurring: true, prompt: <label-mailbox.md §4「Dev セッション用」テンプレート>)
 ```
 
-Dev が拾うのは **`state:qm-blocked`**（QM からの差し戻し）と **自分に来た reviewer request**（`review-requested:@me`）。実装完了・CI 全緑・Ready 化したら自分で `state:dev-done` を付けて QM へ渡す。**古い state label を外してから付ける。**
+Dev が拾うのは **`state:needs-dev`**（PO / QM が着手を渡したもの。**Issue と PR の両方**）、**`state:qm-blocked`**（QM からの差し戻し）、**自分に来た reviewer request**（`review-requested:@me`）、そして **ORPHAN**（`state:*` が 1 つも付いていない open）。実装完了・CI 全緑・Ready 化したら自分で `state:dev-done` を付けて QM へ渡す。**古い state label を外してから付ける。**
 
 - **BLOCK 事由は 3 類型のいずれか**（顧客に実害 / 証跡の真正性を弱める / 不可逆）。**症状ではなく事由に対処する** — 「テストが落ちている」は症状であって事由ではない（`#4134` は「commit の主張が HEAD に存在しない」= 証跡の真正性が事由で、落ちた 4 テストはその症状だった）
 - **テストの削除 / skip / assertion 弱体化で赤を消さない**（ADR-0006）。落ちたテストが実装不在を教えてくれている場合、テストを消すと次は誰も気づけない
 - **reviewer request は QM の Fix Agent が作った gate 修理 PR の可能性が高い**（gate 欠陥で Dev が PR を出せない場合の例外運用）。作成者 ≠ 承認者の分離を保つため Dev が approve する。**実 diff を読んでから approve する**
-- **`state:needs-owner` は自分で進めない。** 不可逆 4 操作（削除 = gate / guard / test の削除を含む / 本番 deploy / 課金書込 / スキーマ変更）に気づいたら、Dev からでも label を付けてオーナーへ上げる
+- **判断を仰ぐときは必ず label を付ける。** 不可逆 4 操作（削除 = gate / guard / test の削除を含む / 本番 deploy / 課金書込 / スキーマ変更）→ **`state:needs-owner`**。それ以外の PO 判断（方針 / 優先度 / **repo 設定・ruleset** / 受容判断 / 語彙・ルールの改訂）→ **`state:needs-po`**。「4 操作に当たらないから label を付けない」で終わらせない
+- **`@mention` / Issue コメント / PR body に書いただけでは PO の受信箱に入らない**（label-mailbox.md §3.1.1）。各ロールは label を polling しており本文を読みに行かない。**書いたかどうかではなく、相手の polling クエリに出るかどうかが伝達の成否を決める**（2026-07-31: Dev の判断待ち 2 件が PO に届かず、うち 1 件は PR merge で流れた）
+- **`state:*` を外すときは必ず次の state を付ける。** どの state も付かないと全受信箱から消え、「mailbox 空」と滞留が報告上まったく同じに見える
 - **cron の結果で主線を中断しない。** 数分で終わるものだけ差し込み、そうでなければ拾ったことだけ報告して主線に戻る
 - **CronCreate はセッション内メモリのみ**（Claude 終了で消滅 / 7 日で失効 / REPL idle 時のみ発火）。次のセッションでもう一度作る
 

--- a/docs/sessions/label-mailbox.md
+++ b/docs/sessions/label-mailbox.md
@@ -84,6 +84,16 @@
 
 ### §3.3.1 orphan 検出（どの mailbox にも入っていないものを見つける）
 
+> **orphan の定義（2026-07-31 初回運用で精緻化）**: `state:*` が 1 つも付いていない open のうち、
+> **`status:on-hold` も `epic` label も付いていないもの**。Draft PR は対象外（まだ誰にも渡していない状態）。
+>
+> **backlog を orphan にしない。** 着手順に入っていないものには `status:on-hold` を付ける
+> （凍結・再開トリガー待ち・EPIC 傘下で着手順待ち を同一に扱う）。これをやらないと、
+> **backlog 全件が orphan として毎回報告され、本当に浮いているものが埋もれる**（初回運用で
+> orphan 16 件が出たが、実際に配るべきだったのは 2 件だけだった）。
+>
+> **EPIC 本体は orphan にしない。** EPIC は「傘」であって着手単位ではないため `epic` label で除外する。
+
 label 運用の最大の失敗モードは「**誰の受信箱にも入っていない open 項目**」である。報告上は全員「mailbox 空」になり、**実際は複数件が止まっている**状態と区別がつかない。
 
 各ロールの cron に以下を含める（PO は必須）。
@@ -91,9 +101,9 @@ label 運用の最大の失敗モードは「**誰の受信箱にも入ってい
 ```bash
 # state:* が 1 つも付いていない open Issue / PR
 gh issue list --state open --limit 100 --json number,title,labels \
-  --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN ISSUE #\(.number) \(.title)"'
+  --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN ISSUE #\(.number) \(.title)"'
 gh pr list --state open --limit 50 --json number,title,labels \
-  --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
+  --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
 ```
 
 > **2026-07-31 の実例**: Dev / QM とも「対応事項なし」と報告した時点で、着手すべき Issue が 5 件（`#3950` / `#4087` / `#3970` / `#4117` / `#4139`）滞留していた。全件 `state:*` 未付与だったため、どの mailbox にも現れなかった。
@@ -137,11 +147,11 @@ gh issue list --label "state:needs-dev" --state open --json number,title --jq '.
 gh pr list --label "state:needs-dev" --state open --json number,title --jq '.[]|"着手PR #\(.number) \(.title)"'
 gh pr list --label "state:qm-blocked" --state open --json number,title --jq '.[]|"BLOCKED #\(.number) \(.title)"'
 gh pr list --search "review-requested:@me is:open" --json number,title --jq '.[]|"REVIEW依頼 #\(.number) \(.title)"'
-gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN #\(.number) \(.title)"'
+gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN #\(.number) \(.title)"'
 
 - **判断を仰ぐときは `state:needs-po`（不可逆 4 操作以外）か `state:needs-owner`（4 操作）を必ず付ける。**
   mention / Issue コメント / PR body に書いただけでは PO の受信箱に入らない（§3.1.1）
-- ORPHAN（どの state も付いていない open）が出たら、自分の担当かを判断し、担当なら state:needs-dev を
+- ORPHAN（state:* / status:on-hold / epic のいずれも付いていない open）が出たら、自分の担当かを判断し、担当なら state:needs-dev を
   付けて拾う。他ロールの担当なら該当 state を付けて渡す。**放置しない**
 
 - state:qm-blocked があれば、BLOCK 事由（顧客に実害 / 証跡の真正性 / 不可逆 のどれか）を PR コメントから読み、
@@ -180,8 +190,8 @@ gh pr list --label "state:needs-po" --state open --json number,title --jq '.[]|"
 gh issue list --label "state:needs-owner" --state open --json number,title --jq '.[]|"OWNER #\(.number) \(.title)"'
 gh pr list --label "state:needs-owner" --state open --json number,title --jq '.[]|"OWNER PR #\(.number) \(.title)"'
 gh pr list --label "state:ready-to-merge" --state open --json number,title,mergeStateStatus --jq '.[]|"READY #\(.number) [\(.mergeStateStatus)] \(.title)"'
-gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN #\(.number) \(.title)"'
-gh pr list --state open --limit 50 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
+gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN #\(.number) \(.title)"'
+gh pr list --state open --limit 50 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
 
 - state:needs-owner は、不可逆 4 操作（削除 / 本番 deploy / 課金書込 / スキーマ変更）のどれに
   該当するかを 1 行で示し、判断材料（実 diff / 影響範囲）を添えてオーナーに提示する
@@ -228,9 +238,9 @@ git fetch origin develop main -q && git rev-list --count origin/main..origin/dev
 ```bash
 # 1. orphan — どの受信箱にも入っていない open
 gh issue list --state open --limit 100 --json number,title,labels \
-  --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN #\(.number) \(.title)"'
+  --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN #\(.number) \(.title)"'
 gh pr list --state open --limit 50 --json number,title,labels \
-  --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
+  --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
 
 # 2. 各ロールの受信箱に何件あるか（0 が並ぶこと自体が異常信号）
 for l in needs-dev dev-done qm-blocked ready-to-merge needs-audit needs-po needs-owner; do

--- a/docs/sessions/label-mailbox.md
+++ b/docs/sessions/label-mailbox.md
@@ -38,20 +38,33 @@
 
 | label | 意味 | 付ける人 | 次に動く |
 |---|---|---|---|
+| `state:needs-dev` | PO / QM が Dev に**着手を渡した** | PO / QM | **Dev** |
 | `state:dev-done` | 実装完了・CI 全緑・Ready 化済 | Dev | **QM** |
 | `state:qm-blocked` | BLOCK 3 類型に該当（顧客に実害 / 証跡の真正性 / 不可逆） | QM | **Dev** |
 | `state:ready-to-merge` | QM approve 済 | QM | **QM**（merge を実行） |
-| `state:needs-owner` | **不可逆 4 操作**を含み PO / オーナー判断が要る | 誰でも | **オーナー** |
+| `state:needs-audit` | 統合監査 / release cut を監査チームに渡した | PO | **監査** |
+| `state:needs-po` | **不可逆 4 操作ではない PO 判断**が要る（方針 / 優先度 / repo 設定 / 受容判断 / 語彙・ルールの改訂） | 誰でも | **PO** |
+| `state:needs-owner` | **不可逆 4 操作**（削除 / 本番 deploy / 課金書込 / スキーマ変更）を含む | 誰でも | **オーナー** |
 
-`state:needs-owner` は**誰が気づいても付けてよい**。Dev が実装中に気づいた場合も付ける。
+- `state:needs-po` / `state:needs-owner` は**誰が気づいても付けてよい**。Dev が実装中に気づいた場合も付ける
+- **判断を仰ぐときは必ずどちらかを付ける。** 「不可逆 4 操作に当たらないから `needs-owner` は付けない」で終わらせない — それは判断が要らないという意味ではない。**`needs-po` がその受け皿**
+
+> **§3.1 の欠落で実際に起きたこと（2026-07-31）**: Dev が「ruleset 変更」「node バージョン EBADENGINE」の 2 件を PO 判断待ちとして Issue コメント / PR body に書いたが、**不可逆 4 操作に当たらないため label を付けなかった**。PO はコメントを polling していないため、**どちらも PO の mailbox に入らなかった**。`#4144` の Q1/Q2 が PO に届いたのは、QM が「`po-decision:required` の決裁が GitHub 上に存在しない」として merge を保留したからで、通知経路が機能した結果ではない。
+
+### §3.1.1 mention とコメントは通知経路ではない
+
+**`@mention` / Issue コメント / PR body に書いただけでは、相手の mailbox に入らない。** 各ロールは label を polling しており、本文を読みに行かない。
+
+> **§2 原則 3「付けた側が意味に責任を持つ」の適用**: 自分のレーンから次のレーンへ渡すとき、**渡す側が label を付ける**。書いたかどうかではなく、**相手の polling クエリに出るかどうか**が伝達の成否を決める。
 
 ### §3.2 label で表さないもの（GitHub 標準を使う）
 
 | 用途 | 使うもの | 理由 |
 |---|---|---|
 | **approve の依頼** | `gh pr edit <N> --add-reviewer <user>` | GitHub が reviewer request としてモデル化済。label で二重管理しない |
-| release cut の依頼 | PO → 監査への明示依頼（[audit-team.md](audit-team.md) §3.8 step 6） | cut は監査 orchestrator の不可逆 action。label で自動起動させない |
-| 統合監査の対象 | `base:main head:release/*` の open PR | branch 名で判別できる。label 不要 |
+| 統合監査の**対象 PR** | `base:main head:release/*` の open PR | branch 名で判別できる。label 不要 |
+
+> **release cut の依頼は `state:needs-audit` を使う（2026-07-31 改訂）**。当初は「PO → 監査への明示依頼」で label 不要としていたが、**mention / コメントは通知経路ではない**（§3.1.1）ため、Dev で起きたのと同じ取りこぼしが監査レーンでも成立する。cut を label で**自動起動させない**方針は維持する — `state:needs-audit` は「PO が cut を依頼した」という状態を表すだけで、cut の実行判断と不可逆 action は引き続き audit-manager 専権（[audit-team.md](audit-team.md) §3.3 / §3.8 step 6）。
 
 > **例外運用**: gate 欠陥で Dev が PR を出せない場合に限り QM の Fix Agent が修理 PR を作る。その PR の approve は **Dev** が行う（ADR-0022 作成者 ≠ 承認者）。この受け渡しは **reviewer request** で行い、専用 label を作らない。
 
@@ -61,10 +74,29 @@
 
 | ロール | 拾うもの | コマンド |
 |---|---|---|
-| **Dev** | `state:qm-blocked` / 自分に来た reviewer request | `gh pr list --label "state:qm-blocked" --state open` / `gh pr list --search "review-requested:@me is:open"` |
+| **Dev** | `state:needs-dev` / `state:qm-blocked` / 自分に来た reviewer request | `gh issue list --label "state:needs-dev" --state open` / `gh pr list --label "state:qm-blocked" --state open` / `gh pr list --search "review-requested:@me is:open"` |
 | **QM** | `state:dev-done` / `state:ready-to-merge`（自分が merge） | `gh pr list --label "state:dev-done" --state open` |
-| **PO / オーナー** | `state:needs-owner` | `gh issue list --label "state:needs-owner" --state open` + PR 側も |
-| **監査** | `release/* → main` の open PR | `gh pr list --base main --state open` |
+| **PO** | `state:needs-po` / `state:needs-owner` | `gh issue list --label "state:needs-po" --state open` + `state:needs-owner` + PR 側も |
+| **オーナー** | `state:needs-owner` | 同上 |
+| **監査** | `state:needs-audit` / `release/* → main` の open PR | `gh issue list --label "state:needs-audit" --state open` / `gh pr list --base main --state open` |
+
+**Issue と PR の両方を見る。** `gh pr list --label` は Issue を返さず、`gh issue list --label` は PR を返さない。片方だけ叩くと取りこぼす。
+
+### §3.3.1 orphan 検出（どの mailbox にも入っていないものを見つける）
+
+label 運用の最大の失敗モードは「**誰の受信箱にも入っていない open 項目**」である。報告上は全員「mailbox 空」になり、**実際は複数件が止まっている**状態と区別がつかない。
+
+各ロールの cron に以下を含める（PO は必須）。
+
+```bash
+# state:* が 1 つも付いていない open Issue / PR
+gh issue list --state open --limit 100 --json number,title,labels \
+  --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN ISSUE #\(.number) \(.title)"'
+gh pr list --state open --limit 50 --json number,title,labels \
+  --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
+```
+
+> **2026-07-31 の実例**: Dev / QM とも「対応事項なし」と報告した時点で、着手すべき Issue が 5 件（`#3950` / `#4087` / `#3970` / `#4117` / `#4139`）滞留していた。全件 `state:*` 未付与だったため、どの mailbox にも現れなかった。
 
 ### §3.4 CronCreate の作り方（各セッション起動時に実行）
 
@@ -101,9 +133,16 @@ CronCreate(cron: "<ロールごとにずらした分>", recurring: true, prompt:
 ```
 Dev mailbox チェック。以下を実行して結果を簡潔に報告する（何も無ければ「mailbox 空」の 1 行でよい）:
 
+gh issue list --label "state:needs-dev" --state open --json number,title --jq '.[]|"着手 #\(.number) \(.title)"'
+gh pr list --label "state:needs-dev" --state open --json number,title --jq '.[]|"着手PR #\(.number) \(.title)"'
 gh pr list --label "state:qm-blocked" --state open --json number,title --jq '.[]|"BLOCKED #\(.number) \(.title)"'
 gh pr list --search "review-requested:@me is:open" --json number,title --jq '.[]|"REVIEW依頼 #\(.number) \(.title)"'
-gh issue list --label "state:needs-owner" --state open --json number,title --jq '.[]|"OWNER待ち #\(.number) \(.title)"'
+gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN #\(.number) \(.title)"'
+
+- **判断を仰ぐときは `state:needs-po`（不可逆 4 操作以外）か `state:needs-owner`（4 操作）を必ず付ける。**
+  mention / Issue コメント / PR body に書いただけでは PO の受信箱に入らない（§3.1.1）
+- ORPHAN（どの state も付いていない open）が出たら、自分の担当かを判断し、担当なら state:needs-dev を
+  付けて拾う。他ロールの担当なら該当 state を付けて渡す。**放置しない**
 
 - state:qm-blocked があれば、BLOCK 事由（顧客に実害 / 証跡の真正性 / 不可逆 のどれか）を PR コメントから読み、
   症状ではなく事由に対処する。テストの赤は症状であって事由ではない。
@@ -136,9 +175,13 @@ gh pr list --label "state:ready-to-merge" --state open --json number,title,merge
 ```
 PO mailbox チェック。以下を実行して結果を簡潔に報告する（何も無ければ「mailbox 空」の 1 行でよい）:
 
-gh issue list --label "state:needs-owner" --state open --json number,title --jq '.[]|"ISSUE #\(.number) \(.title)"'
-gh pr list --label "state:needs-owner" --state open --json number,title --jq '.[]|"PR #\(.number) \(.title)"'
+gh issue list --label "state:needs-po" --state open --json number,title --jq '.[]|"PO判断 #\(.number) \(.title)"'
+gh pr list --label "state:needs-po" --state open --json number,title --jq '.[]|"PO判断PR #\(.number) \(.title)"'
+gh issue list --label "state:needs-owner" --state open --json number,title --jq '.[]|"OWNER #\(.number) \(.title)"'
+gh pr list --label "state:needs-owner" --state open --json number,title --jq '.[]|"OWNER PR #\(.number) \(.title)"'
 gh pr list --label "state:ready-to-merge" --state open --json number,title,mergeStateStatus --jq '.[]|"READY #\(.number) [\(.mergeStateStatus)] \(.title)"'
+gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN #\(.number) \(.title)"'
+gh pr list --state open --limit 50 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
 
 - state:needs-owner は、不可逆 4 操作（削除 / 本番 deploy / 課金書込 / スキーマ変更）のどれに
   該当するかを 1 行で示し、判断材料（実 diff / 影響範囲）を添えてオーナーに提示する
@@ -151,6 +194,8 @@ gh pr list --label "state:ready-to-merge" --state open --json number,title,merge
 ```
 監査 mailbox チェック。以下を実行して結果を簡潔に報告する（何も無ければ「統合対象なし」の 1 行でよい）:
 
+gh issue list --label "state:needs-audit" --state open --json number,title --jq '.[]|"CUT依頼 #\(.number) \(.title)"'
+gh pr list --label "state:needs-audit" --state open --json number,title --jq '.[]|"CUT依頼PR #\(.number) \(.title)"'
 gh pr list --base main --state open --json number,title,headRefName --jq '.[]|"統合PR #\(.number) [\(.headRefName)] \(.title)"'
 git fetch origin develop main -q && git rev-list --count origin/main..origin/develop
 
@@ -167,14 +212,62 @@ git fetch origin develop main -q && git rev-list --count origin/main..origin/dev
 | 注意 | 理由 |
 |---|---|
 | **label を付け替えるときは古い state を外す** | 2 つ付いていると「次に誰が動くか」が読めなくなる |
+| **state を外すときは必ず次の state を付ける** | **どの `state:*` も付かない = すべての受信箱から消える。** 報告上は「mailbox 空」になり、滞留と区別がつかない。作業が本当に終わったなら close する。close しないなら次の担当を必ず指す |
+| **判断を仰ぐときは必ず `needs-po` か `needs-owner` を付ける** | 「不可逆 4 操作に当たらないから label を付けない」は、判断が要らないという意味ではない。mention / コメントは通知経路ではない（§3.1.1） |
 | **label は状態であって承認ではない** | `state:ready-to-merge` は「QM が approve した」記録であって、CI 緑の保証ではない |
 | **cron の結果が空でも報告する** | 「mailbox 空」が出ないと、cron が動いているのか死んでいるのか分からない |
+| **「mailbox 空」を「やることが無い」と読まない** | orphan（§3.3.1）を必ず併せて確認する。2026-07-31 に Dev / QM とも「対応事項なし」と報告した時点で 5 件が滞留していた |
+| **「空」が 3 回連続したら生存確認する（§5.1）** | 全員の受信箱が同時に空になるのは、仕事が無いときではなく **渡す経路が壊れているとき**である方が多い |
 | **cron を主線の割り込みにしない** | 拾ったものが数分で終わるなら差し込む。そうでなければ現在の主線を優先し、拾ったことだけ報告する |
 | **セッション終了で cron は消える** | 次のセッション起動時にもう一度作る。§3.4 の制約を参照 |
 
-## §6 現状（2026-07-31 時点）
+### §5.1 「mailbox 空」が 3 回連続したときの生存確認（PO の義務）
 
-- label 4 種は作成済み（QM が作成）
-- 運用開始: `#4134` = `state:qm-blocked` / `#4138` = `state:dev-done`
-- PO セッションの cron は作成済み（`37 * * * *`）
+受信箱が空であることは、**仕事が無いこと**ではなく**渡す経路が壊れていること**の兆候である方が多い。PO は「空」が **3 回連続**したら、次を実行して**誰かが実際に動いているか**を確認する。
+
+```bash
+# 1. orphan — どの受信箱にも入っていない open
+gh issue list --state open --limit 100 --json number,title,labels \
+  --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN #\(.number) \(.title)"'
+gh pr list --state open --limit 50 --json number,title,labels \
+  --jq '.[]|select([.labels[].name]|map(select(startswith("state:")))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
+
+# 2. 各ロールの受信箱に何件あるか（0 が並ぶこと自体が異常信号）
+for l in needs-dev dev-done qm-blocked ready-to-merge needs-audit needs-po needs-owner; do
+  printf "%s: " "$l"
+  echo "issue=$(gh issue list --label "state:$l" --state open --json number --jq 'length') pr=$(gh pr list --label "state:$l" --state open --json number --jq 'length')"
+done
+
+# 3. 直近の活動（人が動いているか）
+gh pr list --state merged --limit 5 --json number,mergedAt,title --jq '.[]|"\(.mergedAt[0:16]) #\(.number) \(.title[0:50])"'
+git fetch origin -q && git rev-list --count origin/main..origin/develop
+
+# 4. EPIC の着手状況（open な EPIC に対して in-flight が 0 でないか）
+gh issue list --state open --label "priority:critical" --json number,title --jq '.[]|"#\(.number) \(.title[0:60])"'
+```
+
+**判定**:
+
+- orphan が 1 件でもある → **渡す経路が壊れている。** 該当する `state:*` を付けて配る
+- 全受信箱 0 かつ merged が数時間停止 → **セッションが落ちているか cron が消えている。** 各ロールに起動確認を求める
+- 全受信箱 0 かつ merged は進んでいる → 正常。ただし **`main..develop` が育っていないか**を併せて見る
+
+> **2026-07-31 の実例**: PO が「mailbox 空」を 4 回連続で報告したあと、Dev / QM 双方が「対応事項なし」と報告した。実際には着手すべき Issue が 5 件滞留し、Dev の判断待ち 2 件が PO に届いていなかった。**全員の受信箱が同時に空になったのは、経路が壊れていたから**である。
+
+## §6 改訂履歴に代えて — 語彙が足りなかった実例
+
+語彙を増やさない原則（§2-5）は維持するが、**渡す経路が存在しない状態は「語彙が足りている」ではない**。以下は 2026-07-31 の実運用 1 日で露見した 2 つの欠落。同種の欠落を疑うときの判断材料として残す。
+
+| 欠落 | 何が起きたか | 追加した語彙 |
+|---|---|---|
+| PO / QM → Dev に**着手を渡す**経路が無い | Dev が拾えるのは QM の差し戻しと reviewer request だけだった。PO が着手順を決めても Dev の受信箱に入らず、**5 件が滞留**したまま Dev は「対応事項なし」と報告した | `state:needs-dev` |
+| **不可逆 4 操作ではない PO 判断**を渡す経路が無い | Dev が「ruleset 変更」「node EBADENGINE」を判断待ちとして書いたが、4 操作に当たらず label を付けられなかった。**PO の mailbox に入らないまま PR が merge されて流れた** | `state:needs-po` |
+| PO → 監査に**release cut を渡す**経路が無い | 「明示依頼で足りる」としていたが、mention / コメントは通知経路ではない。Dev で起きたのと同じ取りこぼしが監査レーンでも成立する | `state:needs-audit` |
+
+**共通の教訓**: 語彙を増やさない原則（§2-5）は、**渡す経路が既にあるとき**にのみ有効。経路が無いまま「増やさない」を守ると、伝達が mention に退化し、mention は誰の受信箱にも入らない。
+
+## §7 現状（2026-07-31 時点）
+
+- label **7 種**（`needs-dev` / `dev-done` / `qm-blocked` / `ready-to-merge` / `needs-audit` / `needs-po` / `needs-owner`）
+- PO セッションの cron は稼働中（`37 * * * *`）
 - **恒久化（GitHub workflow → Discord）は未実施。** 実際に見落としが発生してから作る

--- a/docs/sessions/po-session.md
+++ b/docs/sessions/po-session.md
@@ -181,11 +181,15 @@ Anthropic 公式記事推奨「モデル進化対応: 3-6 ヶ月ごとに設定�
 CronCreate(cron: "37 * * * *", recurring: true, prompt: <label-mailbox.md §4「PO セッション用」テンプレート>)
 ```
 
-PO が拾うのは **`state:needs-owner`**（不可逆 4 操作 = 削除 / 本番 deploy / 課金書込 / スキーマ変更）と、`state:ready-to-merge` の CI 実測確認。
+PO が拾うのは **`state:needs-po`**（不可逆 4 操作**以外**の PO 判断 = 方針 / 優先度 / repo 設定・ruleset / 受容判断 / 語彙・ルールの改訂）、**`state:needs-owner`**（不可逆 4 操作 = 削除 / 本番 deploy / 課金書込 / スキーマ変更）、`state:ready-to-merge` の CI 実測確認、そして **ORPHAN**（`state:*` が 1 つも付いていない open Issue / PR）。**Issue と PR の両方**を見る。
+
+PO が仕事を渡すときは **`state:needs-dev`**（Dev へ着手）/ **`state:needs-audit`**（監査へ release cut 依頼）を付ける。
 
 - **label は状態であって承認ではない。** `state:ready-to-merge` が付いていても CI 緑は自分で確認する（ラベルだけ見て merge 可と判断し、QM が赤を理由に拒否した実例あり）
 - **CronCreate はセッション内メモリのみ**（Claude 終了で消滅 / 7 日で失効 / REPL idle 時のみ発火）。次のセッションでもう一度作る
 - **PO の決定は、指示を出した時点で該当 Issue / PR にコメントとして残す。** セッション上の発言は証跡にならない（PR body の「PO 承認条件」に GitHub 上の出典が無く QM が検証できなかった実例あり、2026-07-31）
+- **決裁したら label を次の担当へ付け替える。外して終わりにしない。** どの `state:*` も付かないと全受信箱から消える
+- **「mailbox 空」が 3 回連続したら生存確認を行う**（label-mailbox.md §5.1）。全員の受信箱が同時に空になるのは、仕事が無いときではなく**渡す経路が壊れているとき**の方が多い。2026-07-31 に Dev / QM とも「対応事項なし」と報告した時点で、着手すべき Issue が 5 件・PO への判断待ちが 2 件滞留していた
 
 ## 技術手順 (`--body-file` 運用 / namespace 重複検査)
 

--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -16,7 +16,9 @@
 CronCreate(cron: "23 * * * *", recurring: true, prompt: <label-mailbox.md §4「QM セッション用」テンプレート>)
 ```
 
-QM が拾うのは **`state:dev-done`**（レビュー待ち）と **`state:ready-to-merge`**（自分が merge を実行）。レビュー完了時は自分で label を付け替える（`state:qm-blocked` → Dev / `state:ready-to-merge` → 自分）。**古い state label を外してから付ける**（2 つ付いていると次に誰が動くか読めない）。
+QM が拾うのは **`state:dev-done`**（レビュー待ち）と **`state:ready-to-merge`**（自分が merge を実行）。レビュー完了時は自分で label を付け替える（`state:qm-blocked` → Dev / `state:ready-to-merge` → 自分）。**古い state label を外してから付ける**（2 つ付いていると次に誰が動くか読めない）。**外すときは必ず次の state を付ける** — どの state も付かないと全受信箱から消え、「mailbox 空」と滞留が報告上まったく同じに見える（2026-07-31 に `#4144` で実際に発生）。
+
+**判断を仰ぐときも label を付ける。** 不可逆 4 操作 → `state:needs-owner` / それ以外の PO 判断（方針・優先度・repo 設定・受容判断）→ **`state:needs-po`**。QM が Dev に着手を渡すときは **`state:needs-dev`**。`@mention` や PR コメントは通知経路ではない（label-mailbox.md §3.1.1）。
 
 - **報告は「CI 個別行の実測（非 pass 行の有無）」を先に書き、結論はその後に置く。** 「BLOCK 3 類型に非該当」は CI 緑を含意しない（結論を先に置いたため PO が merge 可と誤読した実例あり、2026-07-31）
 - **`state:ready-to-merge` でも `gh pr checks` で緑を確認してから merge する。** 赤を跨いだ merge は理由が正当でも外形が admin bypass と区別できない


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（PO / Dev / QM / 監査の各セッション）

**解決する課題**: #4141 で入れた label mailbox を 1 日運用した結果、**渡す経路が存在しない組み合わせが 3 つ**露見した。いずれも「mention / コメントに書いたが相手の受信箱に入らない」形で失われ、**Dev / QM 双方が「対応事項なし」と報告した時点で、着手すべき Issue 5 件と PO への判断待ち 2 件が滞留**していた。

**期待される効果**: 渡す先が無くて失われる伝達をゼロにする。全員の受信箱が同時に空になったとき、それが「仕事が無い」のか「経路が壊れている」のかを機械で切り分けられる。

### 実際に起きたこと（2026-07-31）

| 欠落 | 何が起きたか |
|---|---|
| PO / QM → Dev に**着手を渡す**経路が無い | Dev が拾えるのは QM の差し戻しと reviewer request だけ。PO が着手順を決めても受信箱に入らず、**5 件（#3950 / #4087 / #3970 / #4117 / #4139）が滞留**したまま Dev は「対応事項なし」と報告した |
| **不可逆 4 操作ではない PO 判断**を渡す経路が無い | Dev が「ruleset 変更」「node EBADENGINE」を判断待ちとして Issue コメント / PR body に書いたが、4 操作に当たらず label を付けられなかった。**PO の受信箱に入らないまま PR が merge されて流れた** |
| PO → 監査に **release cut を渡す**経路が無い | 「明示依頼で足りる」としていたが、Dev で起きたのと同じ取りこぼしが監査レーンでも成立する |

**Dev が label を付けなかったのは `state:needs-owner` の定義（不可逆 4 操作）に忠実であり、判断として正しい。定義が不完全だった。**

`#4144` の Q1/Q2 が PO に届いたのは、Dev の通知経路が機能したからではなく、**QM が「`po-decision:required` の決裁が GitHub 上に存在しない」として merge を保留したから**。

## 関連 Issue

<!-- no-issue-close: 本 PR は装置起因（運用ドキュメント）であり、PO 起票基準「E1〜E5 に属し、かつ顧客の金・データ・法務に接続する場合のみ起票」に照らして専用 Issue を立てていない（docs/sessions/po-session.md §Issue 起票基準）-->

- 関連: #4117（E1）— オーナー代行縮小の引き渡し条件 1 の一部
- 前提: #4141（label mailbox の初版）の実運用 1 日で露見した欠落を塞ぐ

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 語彙が 7 種に増え、GitHub 上の label と一致する | `gh label list --search "state:"` | `needs-dev` / `dev-done` / `qm-blocked` / `ready-to-merge` / `needs-audit` / `needs-po` / `needs-owner` の 7 種が実在（作成済） |
| AC2 | `state:needs-po`（不可逆 4 操作以外の PO 判断）が定義され、`needs-owner` との境界が明示されている | 目視 | `label-mailbox.md` §3.1 の表 + 直後の注記「4 操作に当たらないから label を付けない、で終わらせない」 |
| AC3 | `state:needs-audit` が定義され、**cut の自動起動ではない**ことが明示されている | 目視 | `label-mailbox.md` §3.2 の注記 + `audit-team.md` §0 |
| AC4 | 「mention / コメントは通知経路ではない」が独立節として明文化されている | 目視 | `label-mailbox.md` §3.1.1 |
| AC5 | orphan（`state:*` 未付与の open）検出クエリが定義され、各 cron テンプレートに含まれている | `grep -c 'ORPHAN' docs/sessions/label-mailbox.md` | §3.3.1 + Dev / PO の cron テンプレート |
| AC6 | 「空が 3 回連続したら生存確認」が PO の義務として定義され、判定基準まで書かれている | 目視 | `label-mailbox.md` §5.1（4 クエリ + 3 通りの判定） |
| AC7 | 「state を外すときは必ず次の state を付ける」が §5 に入っている | 目視 | `label-mailbox.md` §5 の表 2 行目 |
| AC8 | 4 ロールすべての設計書に反映され、内容が重複していない | `git diff --stat origin/develop origin/docs/label-mailbox-v2` | po=+6 / dev=+6 / qa=+4 / audit=+6 行。共通仕様 +131 行は `label-mailbox.md` に集約 |
| AC9 | orphan の定義が backlog / EPIC 本体 / Draft PR を除外する（**初回運用の実測を反映**） | 目視 + 実測 | commit `7fba8e71`。§3.3.1 の定義注記 + 全 7 箇所のクエリを `status:on-hold` / `epic` 除外に更新。**再検査で ORPHAN 0 件** |

### 追加 commit（初回運用のフィードバック反映）

本 PR は 2 commit で構成される。**2 つ目は本 PR の内容を 1 回運用してみて出た欠陥の修正**である。

- **`2801122a`** — 語彙欠落 3 件（`needs-dev` / `needs-po` / `needs-audit`）+ §3.1.1 / §3.3.1 / §5.1
- **`7fba8e71`** — **orphan の定義を精緻化。** 初回運用で ORPHAN が 16 件出たが、実際に配るべきだったのは 2 件だけだった。残り 14 件は backlog（着手順に入っていない）/ 凍結中（`status:on-hold`）/ EPIC 本体で、毎回報告されると本当に浮いているものが埋もれる

`7fba8e71` を入れなかった場合、**orphan 検出が WIP 上限 4 と真正面から矛盾する**（16 件全部に `state:needs-dev` を付けることになり優先順位が消える）。着手順に入っていないものには `status:on-hold` を付ける運用に切り替え、既存 label のみで解決した（新 label を追加していない）。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（`docs/sessions/**` のみ。実行コード・CI・gate の変更ゼロ）

- [ ] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [ ] **設計書同期** (ADR-0001): 影響する `docs/design/` を同 PR で更新（DB→08 / API→07 / UI→06 / インフラ→13 / セキュリティ→14）
- [ ] **LP ↔ アプリ整合** (ADR-0013): LP 記載が実装と一致。Aspirational を LP に新規追加していない
- [ ] **重量 e2e 敏感領域** (`parallel-implementations.md` §SSOT) に触れる場合、該当 spec のローカル実行ログを本文に貼った
- [x] N/A — 上記いずれも影響範囲外

横展開: 4 ロールの設計書（po / dev / qa / audit）すべてに同時反映済み（AC8 で機械確認）。1 ロールだけ更新して他が取り残される状態を作っていない。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | Ready 化前に実行 |
| 追加・変更テスト | N/A（ドキュメントのみ、実行コード変更なし） | N/A |

- [x] **SOLID / DRY / YAGNI**: 共通仕様は `label-mailbox.md` 1 箇所に集約し、各設計書にはそのロール固有の注意だけを書いて link。語彙追加は**実際に取りこぼしが発生した 3 経路のみ**で、想定だけの label は作っていない
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **A11y・パフォーマンス**: N/A（実行コード変更なし）
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更を含まない。`docs/sessions/**` のみ）**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **`state:needs-audit` が「cut の自動起動」と誤読されないか。** label は「PO が依頼した」状態を表すだけで、cut の実行判断と不可逆 action は audit-manager 専権（`audit-team.md` §3.3 / §3.8 step 6）という切り分けを 2 箇所に書いたが、読んで曖昧に見えないか
2. **`state:needs-po` と `state:needs-owner` の境界が判定可能か。** 「repo 設定・ruleset」を `needs-po` 側に置いたが、ruleset 変更を「不可逆」と読む余地がないか（revert 1 コマンドで戻せるため可逆と判断した）
3. **§5.1 の生存確認が重すぎないか。** 3 回連続空でのみ発火する設計にしたが、毎回の cron に混ぜるべきかどうか
4. **orphan の除外条件（`status:on-hold` / `epic` / Draft PR）が広すぎないか。** 除外を広げるほど「浮いているのに報告されない」リスクが上がる。初回運用の実測（16 件中 配るべきは 2 件）を根拠にしたが、`status:on-hold` に「凍結」「再開トリガー待ち」「EPIC 傘下で着手順待ち」の 3 用途を載せている点が過積載でないか

**語彙を増やさない原則との関係**: §2-5「語彙を増やさない」は**渡す経路が既にあるときにのみ有効**。経路が無いまま守ると伝達が mention に退化し、mention は誰の受信箱にも入らない。§6 に教訓として残した。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
