### PR TITLE
fix(ci): #4130 check-pr-body.mjs を lane-aware にし統合 PR の構造的 fail を解消する

### DIFF
--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -1368,6 +1368,36 @@ export function resolveLane(args, fetched) {
 	return { lane: 'feature', source: 'default' };
 }
 
+/**
+ * 「`--pr` があるなら gh を必ず引く」という **配線そのもの**を 1 箇所に固定する (#4130 QA 指摘)。
+ *
+ * `resolveLane` が「取得できた gh を優先する」と正しく書けていても、呼び出し側で
+ * `args.pr && args.lane === null ? fetch(...) : null` のように **申告があるときに fetch を省く**
+ * 配線をすると、gh を引かない → `fetched === null` → 申告採用、となって bypass 経路が生まれる
+ * (本 Issue の実装途中で実際に 1 度この形になった)。fetcher を引数で受けることで、
+ * この 1 行を unit test で pin できるようにする。
+ *
+ * @param {{ pr: string | null; lane: string | null }} args
+ * @param {(pr: string) => 'feature'|'integration'|'hotfix'|'dependabot'|null} fetchLane
+ * @returns {{ lane: string; source: 'gh' | 'flag' | 'default' } | { error: string }}
+ */
+export function resolveLaneWithFetcher(args, fetchLane) {
+	return resolveLane(args, args.pr ? fetchLane(args.pr) : null);
+}
+
+/**
+ * `resolveDraftState` 版の同型 wrapper (#4130 QA 指摘)。
+ * `--draft` 申告で Ready PR の Ready 化要件 (#3997) を外せないことは、
+ * 「`--pr` があるなら isDraft を必ず引く」配線とセットで初めて保証される。
+ *
+ * @param {{ pr: string | null; draft: boolean }} args
+ * @param {(pr: string) => boolean | null} fetchIsDraft
+ * @returns {{ isDraft: boolean; source: 'gh' | 'flag' | 'unresolved' }}
+ */
+export function resolveDraftStateWithFetcher(args, fetchIsDraft) {
+	return resolveDraftState(args, args.pr ? fetchIsDraft(args.pr) : null);
+}
+
 /** @typedef {{ id: string; issue: string; message: string }} Violation */
 
 /**
@@ -1743,7 +1773,7 @@ export async function main(argv = process.argv.slice(2)) {
 
 	// #4130: lane を先に確定する (参照する template / 検証観点が lane で決まるため)。
 	// --pr 指定時は gh の実 lane のみ採用し、未解決は fail-closed で中断する。
-	const resolvedLane = resolveLane(args, args.pr ? fetchPrLane(args.pr) : null);
+	const resolvedLane = resolveLaneWithFetcher(args, fetchPrLane);
 	if ('error' in resolvedLane) {
 		console.error(`[check-pr-body] ERROR: ${resolvedLane.error}`);
 		return 2;
@@ -1797,7 +1827,7 @@ export async function main(argv = process.argv.slice(2)) {
 	for (const line of notes) console.log(line);
 
 	// #3997: Draft PR では Ready 化要件のみ deferred。未解決 (gh 失敗) は Ready 扱いで全 enforce。
-	const draftState = resolveDraftState(args, args.pr ? fetchPrIsDraft(args.pr) : null);
+	const draftState = resolveDraftStateWithFetcher(args, fetchPrIsDraft);
 	// #4121: `--skip-ready-only` は Draft/Ready を問わず Ready 化要件を検査対象から外す
 	// (push レイヤ専用。CI は pr-merge-gate.yml が同 section を検査する)。
 	const deferReadyOnly = draftState.isDraft || args.skipReadyOnly;

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -35,12 +35,65 @@ import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { checkIntegrationEvidenceTable } from './check-ac-verification-map.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
+import { classifyLane } from './pr-lane.mjs';
 import { checkChangeType } from './pr-template-gate-checks.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
-const TEMPLATE_PATH = join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md');
+
+// ---------------------------------------------------------------------------
+// lane-aware 化 (#4130)
+//
+// #4125 が本 CLI を CI (pr-merge-gate.yml / pr-body-check) に配線した時点で、
+// lane-aware な 3 点セット (pr-ac-verification-check.yml / pr-merge-gate.yml /
+// pr-template-gate-checks.mjs) のうち **本 CLI だけが lane 非対応**のまま載った。
+// 統合 PR (release/* → main) は feature 用 template を持たないため
+// `missing-required-sections` / `ac-map-missing` が **body の内容にかかわらず必ず立ち**、
+// 「赤いが無視してよい check」が常設される状態になっていた (実測: PR #4126)。
+//
+// 対処は「統合 PR では job / 検査ごと skip」ではなく **観点の切替**にする
+// (#2942 no-go = required check の空洞化禁止 と同じ方針)。統合 PR の body も
+// 必ず検査対象に残す。
+// ---------------------------------------------------------------------------
+
+/** feature / hotfix / dependabot lane が参照する PR template (従来の唯一の参照先)。 */
+const FEATURE_TEMPLATE_PATH = join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md');
+/** integration lane (統合 PR) が参照する template (#2950 で確定した別系統)。 */
+const INTEGRATION_TEMPLATE_PATH = join(repoRoot, '.github', 'INTEGRATION_PR_TEMPLATE.md');
+
+/** `scripts/pr-lane.mjs` が返す lane の全集合 (typo で gate を空振りさせないための受理集合)。 */
+export const VALID_LANES = Object.freeze(['feature', 'integration', 'hotfix', 'dependabot']);
+
+/**
+ * lane に対応する PR template のパスを返す (#4130 AC1)。
+ *
+ * feature / hotfix / dependabot は従来どおり feature 用 template。
+ * lane を増やす場合はここ 1 箇所で対応付ける (呼び出し側に分岐を散らさない)。
+ *
+ * @param {string} lane
+ * @returns {string}
+ */
+export function templatePathForLane(lane) {
+	return lane === 'integration' ? INTEGRATION_TEMPLATE_PATH : FEATURE_TEMPLATE_PATH;
+}
+
+/**
+ * lane に対応する template を読み、必須セクション見出しを抽出する (#4130 AC1)。
+ *
+ * @param {string} lane
+ * @returns {{ template: string; requiredSections: string[]; path: string }}
+ * @throws {Error} template が存在しない場合 (呼び出し側が exit 2 にする)
+ */
+export function loadTemplateForLane(lane) {
+	const path = templatePathForLane(lane);
+	if (!existsSync(path)) {
+		throw new Error(`PR template が見つかりません: ${path} (lane=${lane})`);
+	}
+	const template = readFileSync(path, 'utf-8');
+	return { template, requiredSections: extractRequiredSections(template), path };
+}
 
 // ---------------------------------------------------------------------------
 // 禁止語 SSOT（Issue 本文 / AC4 dev-session.md と一致させること）
@@ -1217,6 +1270,104 @@ export function resolveDraftState(args, fetched) {
 	return { isDraft: false, source: 'unresolved' };
 }
 
+// ---------------------------------------------------------------------------
+// lane 解決 (#4130)
+// ---------------------------------------------------------------------------
+
+/**
+ * `gh pr view --json baseRefName,headRefName,author` の生 JSON から lane 判定入力を取り出す (#4130)。
+ *
+ * 取り出せない形 (パース不能 / field 欠落) は **既定 lane に潰さず `null`**。
+ * 「feature だった」と「読めなかった」を混ぜると、統合 PR を feature 判定して
+ * 本 Issue の恒常赤をそのまま再現してしまう (`extractLabelNames` と同じ方針)。
+ *
+ * lane 判定そのものは `scripts/pr-lane.mjs` の `classifyLane` (SSOT) が行い、
+ * 本関数は入力の取り出しだけを担う (判定の二重実装をしない、#4130 案 B)。
+ *
+ * @param {string} raw
+ * @returns {{ baseRef: string; headRef: string; actor: string } | null}
+ */
+export function extractLaneRefs(raw) {
+	let parsed;
+	try {
+		parsed = JSON.parse(raw.trim() || 'null');
+	} catch {
+		return null;
+	}
+	if (!parsed || typeof parsed !== 'object') return null;
+	const baseRef = typeof parsed.baseRefName === 'string' ? parsed.baseRefName : null;
+	const headRef = typeof parsed.headRefName === 'string' ? parsed.headRefName : null;
+	// PR の lane は「このイベントを起こした人」ではなく **PR 作成者**で決める (#4133 と同じ理由)。
+	const actor = typeof parsed.author?.login === 'string' ? parsed.author.login : null;
+	if (baseRef === null || headRef === null || actor === null) return null;
+	return { baseRef, headRef, actor };
+}
+
+/**
+ * `gh pr view <num> --json baseRefName,headRefName,author` で lane を取得する (#4130)。
+ * `--jq` は使わない (#3962 の Windows cmd.exe 引用問題と同じ理由)。
+ *
+ * @param {string|number|null} prNumber
+ * @returns {'feature'|'integration'|'hotfix'|'dependabot'|null} 取得できなければ null (= 未解決)
+ */
+function fetchPrLane(prNumber) {
+	if (!prNumber) return null;
+	try {
+		const raw = execSync(`gh pr view ${prNumber} --json baseRefName,headRefName,author`, {
+			encoding: 'utf-8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+			timeout: 15_000,
+		});
+		const refs = extractLaneRefs(raw);
+		return refs === null ? null : classifyLane(refs);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * 検査に使う lane を確定する (#4130)。
+ *
+ * - `--pr` 指定時は **gh の実 lane を優先**する (取得できた場合 `--lane` 申告は無視)。
+ *   申告で lane を上書きできると、統合 PR を feature と偽って AC マップ検査を外す /
+ *   feature PR を integration と偽って変更タイプ検査を外す、という bypass 経路になる
+ *   (`resolveDraftState` の `--draft` と同じ方針)。
+ * - `--pr` 指定で未解決 (gh 未認証 / オフライン / 出力形式変化) は、`--lane` 明示があれば
+ *   それを逃げ道として採用し、無ければ **error** にする。
+ *   ここで既定 lane に黙って倒すと、誤った lane で「体裁は緑」の検査結果が出る。
+ *   どちらへ倒しても嘘になるため、無言では pass 側にも fail 側にも倒さない。
+ * - `--pr` なし (`--body-file` dry-run) は `--lane` 申告を採用し、無指定は `feature` (後方互換)。
+ *
+ * @param {{ pr: string | null; lane: string | null }} args
+ * @param {'feature'|'integration'|'hotfix'|'dependabot'|null} fetched `fetchPrLane()` の戻り
+ * @returns {{ lane: string; source: 'gh' | 'flag' | 'default' } | { error: string }}
+ */
+export function resolveLane(args, fetched) {
+	if (args.lane !== null && args.lane !== undefined && !VALID_LANES.includes(args.lane)) {
+		return {
+			error:
+				`--lane の値が不正です: ${JSON.stringify(args.lane)}\n` +
+				`  有効値: ${VALID_LANES.join(' / ')} (判定 SSOT: scripts/pr-lane.mjs)`,
+		};
+	}
+	if (args.pr) {
+		if (fetched !== null) return { lane: fetched, source: 'gh' };
+		// gh から取れなかったときに限り、明示 --lane を逃げ道として認める (オフライン検証用)。
+		// gh が取れているときは申告を無視するので、これは bypass 経路にならない。
+		if (args.lane) return { lane: args.lane, source: 'flag' };
+		return {
+			error:
+				`PR #${args.pr} の lane (base / head / author) を取得できませんでした ` +
+				`(gh 未認証 / オフライン / timeout など)。\n` +
+				`  lane が分からないまま検査すると、統合 PR を feature 用 template で見る (= 恒常赤、#4130) か\n` +
+				`  feature PR を統合 PR 用の観点で見る (= 検査が緩む) かのどちらかになるため中断します。\n` +
+				`  対応: gh auth status を確認して再実行するか、--lane <${VALID_LANES.join('|')}> を明示してください。`,
+		};
+	}
+	if (args.lane) return { lane: args.lane, source: 'flag' };
+	return { lane: 'feature', source: 'default' };
+}
+
 /** @typedef {{ id: string; issue: string; message: string }} Violation */
 
 /**
@@ -1301,14 +1452,15 @@ function tryParseStringArg(argv, i, aliases) {
 
 /**
  * @param {string[]} argv
- * @returns {{ pr: string | null; bodyFile: string | null; labels: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }}
+ * @returns {{ pr: string | null; bodyFile: string | null; labels: string | null; lane: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }}
  */
 export function parseArgs(argv) {
-	/** @type {{ pr: string | null; bodyFile: string | null; labels: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }} */
+	/** @type {{ pr: string | null; bodyFile: string | null; labels: string | null; lane: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }} */
 	const args = {
 		pr: null,
 		bodyFile: null,
 		labels: null,
+		lane: null,
 		noLabels: false,
 		skipMergeable: false,
 		draft: false,
@@ -1332,6 +1484,13 @@ export function parseArgs(argv) {
 		if (labels) {
 			args.labels = labels.value;
 			i = labels.nextIndex;
+			continue;
+		}
+		// #4130: --pr 指定時は gh の実 lane が優先され、本フラグは無視される (bypass 防止)
+		const lane = tryParseStringArg(argv, i, ['--lane']);
+		if (lane) {
+			args.lane = lane.value;
+			i = lane.nextIndex;
 			continue;
 		}
 		const a = argv[i];
@@ -1374,6 +1533,9 @@ Options:
   --skip-ready-only   Ready 化要件 ${READY_ONLY_GATES.length} 件を検査しない (#4121、push レイヤ専用)
                       同 section は pr-merge-gate.yml が CI で検査するため純粋な重複。
                       skip したことは必ず標準出力に出る (無言 skip にしない)
+  --lane <lane>       検査観点の lane (${VALID_LANES.join(' | ')}、#4130)
+                      --pr 指定時は gh の base/head/author から自動判定され本フラグは無視される
+                      (gh が取得できない場合のみ逃げ道として採用される)
   --skip-mergeable    GitHub API 呼び出しをスキップ (オフライン環境用)
   --help, -h          このヘルプを表示
 
@@ -1388,6 +1550,14 @@ Detected violations:
   8. 変更タイプ checkbox 未選択 (\`- [x]\` 1 つ以上必須、CI gate「変更タイプの選択」と同一 SSOT、#3846)
   9. 未置換プレースホルダ (${PLACEHOLDER_PATTERNS.map((p) => p.label).join(' / ')}) が body のどこかに残存 (code fence 内も対象、#4002 / #4029)
      正当にプレースホルダ文字列を書く PR は \`<!-- placeholder-scan-skip: 理由 -->\` を body に 1 行書く (label では通らない)
+
+lane による観点の切替 (#4130):
+  統合 PR (release/* → main、lane=integration) は単一 Issue に紐づかず feature 用 template を
+  持たないため、feature 用の必須セクション / AC 検証マップ / 変更タイプを要求すると
+  **body の内容にかかわらず必ず fail** する (実測: PR #4126)。lane=integration では
+  .github/INTEGRATION_PR_TEMPLATE.md を参照し、AC 検証マップの代わりに
+  「マージ判定エビデンス表 + 残 NG 0 件」を検証する (検査を外すのではなく観点を切替える)。
+  禁止語 / mojibake / 未置換プレースホルダ / label 条件付き gate は全 lane 共通で効く。
 
 Draft PR の扱い (#3997):
   Draft PR では Ready 化要件 ${READY_ONLY_GATES.length} 件 (${READY_ONLY_GATES.map((g) => g.id).join(' / ')})
@@ -1437,13 +1607,16 @@ function loadPrBody(args) {
  * @param {string} body
  * @param {string[]} requiredSections
  * @param {string} template `.github/PULL_REQUEST_TEMPLATE.md` の内容 (#3846 変更タイプ検証で使用)
- * @param {{ pr: string | null; skipMergeable: boolean; labels?: string[] }} args
+ * @param {{ pr: string | null; skipMergeable: boolean; labels?: string[]; lane?: string }} args
  * @param {string[]} notes skip 等の「検査しなかったこと」を呼び出し側で出力するための追記先 (#4029)
  * @returns {{ id: string; issue: string; message: string }[]}
  */
-function collectViolations(body, requiredSections, template, args, notes = []) {
+export function collectViolations(body, requiredSections, template, args, notes = []) {
 	const violations = [];
 	const labels = args.labels ?? [];
+	// #4130: 統合 PR (release/* → main) は単一 Issue に紐づかないため、per-PR AC マップ /
+	// 変更タイプ checkbox を持たない別系統の body になる。観点を切替えるだけで検査は外さない。
+	const isIntegration = args.lane === 'integration';
 
 	const missing = findMissingSections(body, requiredSections);
 	if (missing.length > 0) {
@@ -1474,12 +1647,33 @@ function collectViolations(body, requiredSections, template, args, notes = []) {
 		});
 	}
 
-	const acMap = checkAcMap(body);
-	if (acMap) violations.push({ ...acMap, issue: '#1775 AC2' });
+	if (isIntegration) {
+		// #4130 AC2: per-PR AC マップの代わりに「マージ判定エビデンス表 + 残 NG 0 件」を検証する。
+		// 判定は pr-ac-verification-check.yml と同一 SSOT (scripts/check-ac-verification-map.mjs) を
+		// 再利用し、本 CLI 側に同じ表検証を書かない (#4130 案 C = 別 CLI 新設 を採らない理由)。
+		const evidence = checkIntegrationEvidenceTable(body);
+		if (!evidence.ok) {
+			violations.push({
+				id: 'integration-evidence-missing',
+				issue: '#2945/#4130',
+				message: evidence.error ?? 'マージ判定エビデンス表の検証に失敗しました',
+			});
+		}
+		notes.push(
+			'[check-pr-body] NOTE: lane=integration のため AC 検証マップの代わりに ' +
+				'「マージ判定エビデンス表 + 残 NG 0 件」を検証しました (#4130 AC2)',
+			'  - 変更タイプ checkbox (#3846) は統合 PR template に当該 section が無いため検査対象外です (#4130 AC3)',
+			'  - Ready for Review / 完了チェックリストも統合 PR template に無いため、' +
+				'統合 PR の checklist は pr-merge-gate.yml (## NG 0 件 / カバレッジ宣言) が検査します',
+		);
+	} else {
+		const acMap = checkAcMap(body);
+		if (acMap) violations.push({ ...acMap, issue: '#1775 AC2' });
 
-	// #4074: 根拠欄の `--pr <番号>` が自 PR を指しているか (宛先違いの証跡を通さない)
-	const evidencePrRef = checkEvidencePrReferences(body, args.pr);
-	if (evidencePrRef) violations.push({ ...evidencePrRef, issue: '#4074' });
+		// #4074: 根拠欄の `--pr <番号>` が自 PR を指しているか (宛先違いの証跡を通さない)
+		const evidencePrRef = checkEvidencePrReferences(body, args.pr);
+		if (evidencePrRef) violations.push({ ...evidencePrRef, issue: '#4074' });
+	}
 
 	const unchecked = findUncheckedReadyChecklist(body);
 	if (unchecked.length > 0) {
@@ -1525,9 +1719,13 @@ function collectViolations(body, requiredSections, template, args, notes = []) {
 	if (poDecision) violations.push({ ...poDecision, issue: '#3944/#3956/#3962' });
 
 	// #3846: 変更タイプ checkbox 未選択の shift-left 検出 (CI gate と同一 SSOT を再利用)
-	const changeType = checkChangeTypeSelection(body, template, labels);
-	if (changeType) {
-		violations.push({ ...changeType, issue: '#3835/#3837/#3844/#3846' });
+	// #4130 AC3: 統合 PR template は `## 変更タイプ` を持たないため integration lane では検査しない
+	// (統合 template を渡すと detectChangeTypeHeading が別 section を変更タイプと誤認する)。
+	if (!isIntegration) {
+		const changeType = checkChangeTypeSelection(body, template, labels);
+		if (changeType) {
+			violations.push({ ...changeType, issue: '#3835/#3837/#3844/#3846' });
+		}
 	}
 
 	return violations;
@@ -1543,12 +1741,30 @@ export async function main(argv = process.argv.slice(2)) {
 	const { body, exitCode } = loadPrBody(args);
 	if (body === null) return exitCode;
 
-	if (!existsSync(TEMPLATE_PATH)) {
-		console.error(`[check-pr-body] ERROR: PR template が見つかりません: ${TEMPLATE_PATH}`);
+	// #4130: lane を先に確定する (参照する template / 検証観点が lane で決まるため)。
+	// --pr 指定時は gh の実 lane のみ採用し、未解決は fail-closed で中断する。
+	const resolvedLane = resolveLane(args, args.pr ? fetchPrLane(args.pr) : null);
+	if ('error' in resolvedLane) {
+		console.error(`[check-pr-body] ERROR: ${resolvedLane.error}`);
 		return 2;
 	}
-	const template = readFileSync(TEMPLATE_PATH, 'utf-8');
-	const requiredSections = extractRequiredSections(template);
+	const { lane, source: laneSource } = resolvedLane;
+	console.log(
+		`[check-pr-body] lane=${lane} (判定元: ${laneSource}、SSOT: scripts/pr-lane.mjs) — ` +
+			`参照 template: ${templatePathForLane(lane)
+				.replace(repoRoot, '')
+				.replace(/^[/\\]/, '')}`,
+	);
+
+	/** @type {{ template: string; requiredSections: string[] }} */
+	let loaded;
+	try {
+		loaded = loadTemplateForLane(lane);
+	} catch (e) {
+		console.error(`[check-pr-body] ERROR: ${e instanceof Error ? e.message : String(e)}`);
+		return 2;
+	}
+	const { template, requiredSections } = loaded;
 
 	// #2343: hotfix label 検出のためラベル取得 / #3962: 未解決は fail-closed
 	const needsFetch = args.labels === null && !args.noLabels;
@@ -1575,7 +1791,7 @@ export async function main(argv = process.argv.slice(2)) {
 		body,
 		requiredSections,
 		template,
-		{ ...args, labels },
+		{ ...args, labels, lane },
 		notes,
 	);
 	for (const line of notes) console.log(line);

--- a/tests/fixtures/integration-pr/integration-pr-body.md
+++ b/tests/fixtures/integration-pr/integration-pr-body.md
@@ -1,0 +1,47 @@
+## 統合サマリ
+
+- 対象 develop HEAD: `e593aebc2`
+- 統合対象期間: `2026-07-30` 〜 `2026-07-31` (前回統合 merge 〜 今回)
+- 統合 PR 番号: `#4126`
+
+Closes #4129
+
+## 含有 PR 一覧
+
+| PR | title | type label | 対象領域 |
+|---|---|---|---|
+| #4144 | 破壊的ローテーションを止め、連続失敗を数える | `type:fix` | `scripts/backup` |
+| #4125 | PR body gate を CI に配線する | `type:fix` | `.github/workflows` |
+
+## マージ判定エビデンス表
+
+| 変更（出典 PR） | 対象領域 | 対応テストケース | 結果 | カバレッジ影響 | 残 NG |
+|---|---|---|---|---|---|
+| backup ローテーション（#4144） | scripts/backup | unit×6 | pass | 閾値内 | 0 |
+| PR body gate 配線（#4125） | .github/workflows | unit×3 | pass | 閾値内 | 0 |
+
+残 NG 合計 0 件。
+
+## 監査 run 結果リンク
+
+- audit run evidence: `https://github.com/Takenori-Kusaka/ganbari-quest/actions/runs/1` (run id: `4126-20260731`)
+- adversarial evidence: `tmp/adversarial-evidence/4126.json`
+
+## NG 0 件 / カバレッジ宣言
+
+- 残 NG 合計 0 件 (severity 3-4 + policy_compliant=false の未解決 finding なし)
+- [x] 8 領域 finding のうち severity 閾値以上の未解決 NG が **0 件**である
+- [x] カバレッジ ratchet 閾値割れがない (ADR-0005 整合)
+- [x] 最重厚レーン (branch-strategy.md §4) の全 job が緑である
+- [x] adversarial evidence の反対理由が全件解消済みである
+
+## Accepted residual (Pre-PMF)
+
+| finding (要約) | severity (1-2 のみ) | 受容理由 (Pre-PMF) | 関連 root class |
+|---|---|---|---|
+| reset deleted-count の命名精度 | 2 | dev-only 診断値、ユーザー価値影響なし | reset 完全性 |
+
+## back-merge / drift 状態
+
+- 直近 hotfix back-merge: 該当なし
+- develop⇔main drift: `1` 日 (前回統合 merge からの経過)

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -8,13 +8,15 @@
  * (`XXXY` = 語境界を持たないので XXX として検出されない / `labelish` = PLACEHOLDER 等の
  * token に見えるが該当しない語)。これらは typo ではなく検査対象そのものなので、
  * .cspell.json の辞書 (= 本物の語彙) には入れず file-scoped ignore で閉じる。
+ * (`integratoin` = `--lane` の typo を受理しないことを示す負例。綴りを直すと negative case が消える)
  */
-// cspell:ignore XXXY labelish
+// cspell:ignore XXXY labelish integratoin
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { checkIntegrationEvidenceTable } from '../../../scripts/check-ac-verification-map.mjs';
 import {
 	checkAcMap,
 	checkChangeTypeSelection,
@@ -22,10 +24,12 @@ import {
 	checkPlaceholders,
 	checkPoDecisionBrief,
 	checkSelfReviewEvidence,
+	collectViolations,
 	detectMojibake,
 	extractAcMapSection,
 	extractEnvDistributionSection,
 	extractLabelNames,
+	extractLaneRefs,
 	extractPoDecisionSection,
 	extractRequiredSections,
 	FORBIDDEN_TERMS,
@@ -36,16 +40,20 @@ import {
 	hasHotfixLabel,
 	hasPoDecisionLabel,
 	LABEL_CONDITIONAL_GATES,
+	loadTemplateForLane,
 	PLACEHOLDER_PATTERNS,
 	PO_DECISION_LABEL,
 	parsePlaceholderScanSkip,
 	resolveLabels,
+	resolveLane,
 	scanForbiddenTerms,
 	scanPlaceholders,
 	selectSkippedLabelGates,
 	stripCodeBlocks,
 	stripMarkdownComments,
+	templatePathForLane,
 } from '../../../scripts/check-pr-body.mjs';
+import { classifyLane } from '../../../scripts/pr-lane.mjs';
 
 describe('extractRequiredSections', () => {
 	it('## 見出しを完全一致で抽出する', () => {
@@ -1130,5 +1138,162 @@ describe('未置換プレースホルダ検出 (#4002 / #4029)', () => {
 			expect(p.id).toBeTruthy();
 			expect(p.label).toBeTruthy();
 		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4130: lane-aware 化 (統合 PR で構造上必ず fail する状態の解消)
+//
+// #4125 が check-pr-body.mjs を CI に配線した際、本 CLI だけが lane 非対応
+// (TEMPLATE_PATH = feature 用固定 / checkChangeType の lane = 'feature' 固定) のまま載り、
+// 統合 PR (release/* → main) では missing-required-sections / ac-map-missing が
+// **body の内容にかかわらず必ず立つ**状態になった (実測: PR #4126)。
+//
+// lane 判定は scripts/pr-lane.mjs (SSOT) を、integration lane の観点は
+// scripts/check-ac-verification-map.mjs の checkIntegrationEvidenceTable を再利用する
+// (二重実装しない、#4130 案 B)。
+// ---------------------------------------------------------------------------
+
+describe('lane-aware 化 (#4130)', () => {
+	const INTEGRATION_BODY = readFileSync(
+		resolve(__dirname, '../../fixtures/integration-pr/integration-pr-body.md'),
+		'utf-8',
+	);
+
+	/** collectViolations の呼び出しを 1 行に畳む helper (lane ごとの template 解決込み)。 */
+	function violate(body: string, lane: string) {
+		const { template, requiredSections } = loadTemplateForLane(lane);
+		const notes: string[] = [];
+		const violations = collectViolations(
+			body,
+			requiredSections,
+			template,
+			{ pr: null, skipMergeable: true, labels: [], lane },
+			notes,
+		);
+		return { ids: violations.map((v: { id: string }) => v.id), notes };
+	}
+
+	it('[LN1] integration lane は統合 PR template を参照する (feature 用固定をやめる、AC1)', () => {
+		expect(templatePathForLane('integration')).toMatch(/INTEGRATION_PR_TEMPLATE\.md$/);
+		for (const lane of ['feature', 'hotfix', 'dependabot']) {
+			expect(templatePathForLane(lane)).toMatch(/[/\\]PULL_REQUEST_TEMPLATE\.md$/);
+		}
+	});
+
+	it('[LN2] 統合 PR body が integration lane で構造 violation ゼロになる (#4126 の恒常赤の直因、AC1/AC2)', () => {
+		const { ids } = violate(INTEGRATION_BODY, 'integration');
+		expect(ids).not.toContain('missing-required-sections');
+		expect(ids).not.toContain('ac-map-missing');
+		expect(ids).toEqual([]);
+	});
+
+	it('[LN3] 同じ body を feature lane で見ると従来どおり fail する (lane 差が原因だったことの固定)', () => {
+		const { ids } = violate(INTEGRATION_BODY, 'feature');
+		expect(ids).toContain('missing-required-sections');
+		expect(ids).toContain('ac-map-missing');
+	});
+
+	it('[LN4] integration lane はエビデンス表 section 欠落を検出する (AC マップの代替、検証量を減らさない、AC2)', () => {
+		const noTable = INTEGRATION_BODY.replace(
+			/## マージ判定エビデンス表[\s\S]*?(?=## 監査 run 結果リンク)/,
+			'',
+		);
+		const { ids } = violate(noTable, 'integration');
+		expect(ids).toContain('integration-evidence-missing');
+	});
+
+	it('[LN5] integration lane は「残 NG 0 件」明示欠落を検出する (AC2)', () => {
+		// 注意 (実測): 再利用 SSOT の NG-0 判定は `## NG 0 件 / カバレッジ宣言` という
+		// **見出し文字列自体**にもマッチする (checkIntegrationEvidenceTable の NG_ZERO_PATTERN)。
+		// そのため「本文の宣言だけを消す」入力では落ちない。本 test は本 CLI が SSOT の
+		// NG-0 判定を確かに通していることを、判定が成立し得ない入力で固定する。
+		// SSOT 側の判定強度そのものは本 PR の scope 外 (#2945 の所管)。
+		const noNgZero = INTEGRATION_BODY.replace(/残 NG 合計 0 件/g, '残 NG は監査 run 参照')
+			.replace('## NG 0 件 / カバレッジ宣言', '## NG / カバレッジ宣言')
+			.replace(/未解決 NG が \*\*0 件\*\*である/, '未解決 NG を監査 run 側で確認した');
+		const { ids } = violate(noNgZero, 'integration');
+		expect(ids).toContain('integration-evidence-missing');
+	});
+
+	it('[LN6] integration lane の判定は check-ac-verification-map.mjs と一致する (二重実装しない、AC2)', () => {
+		expect(checkIntegrationEvidenceTable(INTEGRATION_BODY).ok).toBe(true);
+		const broken = INTEGRATION_BODY.replace('| pass | 閾値内 | 0 |', '|  |  |  |');
+		expect(checkIntegrationEvidenceTable(broken).ok).toBe(false);
+		expect(violate(broken, 'integration').ids).toContain('integration-evidence-missing');
+	});
+
+	it('[LN7] integration lane は変更タイプ checkbox を要求しない (統合 template に当該 section がない、AC3)', () => {
+		const { ids, notes } = violate(INTEGRATION_BODY, 'integration');
+		expect(ids).not.toContain('change-type-unselected');
+		// 無言 skip にしない: 何を検査しなかったかを必ず出力に残す
+		expect(notes.join('\n')).toContain('変更タイプ');
+	});
+
+	it('[LN8] feature lane の既存挙動は不変 (AC5 回帰ゼロ)', () => {
+		const featureBody = [
+			'## 変更タイプ',
+			'',
+			'- [ ] feat: 新機能',
+			'- [ ] fix: バグ修正',
+			'- [ ] refactor: リファクタリング',
+			'- [ ] infra: インフラ・CI/CD',
+		].join('\n');
+		const { ids } = violate(featureBody, 'feature');
+		// feature 用 template の必須 section / AC マップ / 変更タイプ が従来どおり全て効く
+		expect(ids).toContain('missing-required-sections');
+		expect(ids).toContain('ac-map-missing');
+		expect(ids).toContain('change-type-unselected');
+	});
+
+	it('[LN9] lane は PR の base/head/author から SSOT (pr-lane.mjs) で決まる', () => {
+		const refs = extractLaneRefs(
+			'{"baseRefName":"main","headRefName":"release/2026-07-31","author":{"login":"Takenori-Kusaka"}}',
+		);
+		expect(refs).toEqual({
+			baseRef: 'main',
+			headRef: 'release/2026-07-31',
+			actor: 'Takenori-Kusaka',
+		});
+		expect(classifyLane(refs as { baseRef: string; headRef: string; actor: string })).toBe(
+			'integration',
+		);
+		expect(extractLaneRefs('not json')).toBeNull();
+		expect(extractLaneRefs('{"baseRefName":"main"}')).toBeNull();
+	});
+
+	it('[LN10] --pr 指定時は gh の実 lane が優先され --lane 申告は無視される (bypass 防止)', () => {
+		expect(resolveLane({ pr: '4126', lane: 'feature' }, 'integration')).toEqual({
+			lane: 'integration',
+			source: 'gh',
+		});
+	});
+
+	it('[LN11] --pr 指定で lane 未解決なら fail-closed (誤 lane で gate を緩めない / 空振りさせない)', () => {
+		const resolved = resolveLane({ pr: '4126', lane: null }, null);
+		expect('error' in resolved).toBe(true);
+		expect((resolved as { error: string }).error).toContain('--lane');
+	});
+
+	it('[LN12] --body-file dry-run は --lane 申告を採用し、既定は feature (後方互換)', () => {
+		expect(resolveLane({ pr: null, lane: 'integration' }, null)).toEqual({
+			lane: 'integration',
+			source: 'flag',
+		});
+		expect(resolveLane({ pr: null, lane: null }, null)).toEqual({
+			lane: 'feature',
+			source: 'default',
+		});
+	});
+
+	it('[LN14] --pr で gh が取れないときだけ --lane を逃げ道として採用する (オフライン検証)', () => {
+		expect(resolveLane({ pr: '4126', lane: 'integration' }, null)).toEqual({
+			lane: 'integration',
+			source: 'flag',
+		});
+	});
+
+	it('[LN13] 未知の lane 値は受理しない (typo で gate が空振りするのを防ぐ)', () => {
+		expect('error' in resolveLane({ pr: null, lane: 'integratoin' }, null)).toBe(true);
 	});
 });

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -14,7 +14,7 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { checkIntegrationEvidenceTable } from '../../../scripts/check-ac-verification-map.mjs';
 import {
@@ -44,8 +44,10 @@ import {
 	PLACEHOLDER_PATTERNS,
 	PO_DECISION_LABEL,
 	parsePlaceholderScanSkip,
+	resolveDraftStateWithFetcher,
 	resolveLabels,
 	resolveLane,
+	resolveLaneWithFetcher,
 	scanForbiddenTerms,
 	scanPlaceholders,
 	selectSkippedLabelGates,
@@ -1295,5 +1297,50 @@ describe('lane-aware 化 (#4130)', () => {
 
 	it('[LN13] 未知の lane 値は受理しない (typo で gate が空振りするのを防ぐ)', () => {
 		expect('error' in resolveLane({ pr: null, lane: 'integratoin' }, null)).toBe(true);
+	});
+
+	// --- 配線の固定 (#4130 QA 指摘) ---
+	// resolveLane / resolveDraftState 単体を正しく書いても、**呼び出し側が「申告があるときは
+	// gh を引かない」形に配線すると申告が勝ってしまう** (実装途中で実際に 1 度その形になった)。
+	// その 1 行を pin するため、fetcher を引数で受ける薄い wrapper を main と共有し、
+	// 「--pr があれば申告の有無にかかわらず fetcher を必ず呼ぶ」ことを spy で固定する。
+	// (main() 自体を execSync mock で回す案は、本 script が vitest の externalized module で
+	//  mock が適用されず実 gh を叩いてしまうため採らない)
+
+	it('[LN15] --pr + --lane でも gh fetcher は必ず呼ばれ、その結果が申告に勝つ (bypass 防止)', () => {
+		const fetcher = vi.fn(() => 'integration' as const);
+		const resolved = resolveLaneWithFetcher({ pr: '4126', lane: 'feature' }, fetcher);
+		expect(fetcher).toHaveBeenCalledWith('4126');
+		expect(resolved).toEqual({ lane: 'integration', source: 'gh' });
+	});
+
+	it('[LN16] --pr + --draft でも isDraft fetcher は必ず呼ばれ、gh=false が申告に勝つ (Ready 化要件を外させない)', () => {
+		const fetcher = vi.fn(() => false);
+		const resolved = resolveDraftStateWithFetcher({ pr: '4147', draft: true }, fetcher);
+		expect(fetcher).toHaveBeenCalledWith('4147');
+		expect(resolved).toEqual({ isDraft: false, source: 'gh' });
+	});
+
+	it('[LN17] gh が Draft と答えたときだけ deferred される / --pr なしでは fetcher を呼ばない', () => {
+		const draftFetcher = vi.fn(() => true);
+		expect(resolveDraftStateWithFetcher({ pr: '4147', draft: false }, draftFetcher)).toEqual({
+			isDraft: true,
+			source: 'gh',
+		});
+
+		// --body-file dry-run では PR が無いので gh を引かない (申告を採用する)
+		const unused = vi.fn(() => false);
+		expect(resolveDraftStateWithFetcher({ pr: null, draft: true }, unused)).toEqual({
+			isDraft: true,
+			source: 'flag',
+		});
+		expect(unused).not.toHaveBeenCalled();
+
+		const laneUnused = vi.fn(() => 'integration' as const);
+		expect(resolveLaneWithFetcher({ pr: null, lane: null }, laneUnused)).toEqual({
+			lane: 'feature',
+			source: 'default',
+		});
+		expect(laneUnused).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**「赤いが無視してよい check」を作らない。**

#4125（E5 Wave 1）が `scripts/check-pr-body.mjs` を CI に配線した際、**この CLI だけが lane 非対応のまま載りました**。結果、統合 PR（`release/* → main`）では **body の内容にかかわらず構造上必ず fail する赤い check** が 1 本立ち続けます。

required check ではないため merge は阻害しませんが、**赤を無視する習慣は本物の赤を見落とす broken-window を作ります**。しかも本 gate 自身が「装置を減らす」文脈（EPIC #4121）で入ったものです。**これは自分たちが作った回帰**なので、装置を増やす方向ではなく、既存 SSOT の再利用で塞ぎます。

## 関連 Issue

Closes #4130

## AC 検証マップ (ADR-0004)

HEAD SHA: `3bdef8301`

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 統合 PR で構造的に必ず fail する状態を解消する | **実在の統合 PR body** で develop 版 / 本 branch を比較 | **#3931**（`release/2026-07-24-4` → main）: develop 版 **FAIL 2 件**（`missing-required-sections` / `ac-map-missing`）→ 本 branch **OK 違反なし**。**#4126**（Issue の検出元）: FAIL 4 件 → **FAIL 2 件**（構造要因 2 件が消滅、残 2 件は内容要因＝§「あえて緩めなかったこと」） |
| AC2 | lane 判定を二重実装しない | 実装 diff | lane 判定は `scripts/pr-lane.mjs` の `classifyLane` を、integration 観点は `scripts/check-ac-verification-map.mjs` の `checkIntegrationEvidenceTable` を**再利用**。新規スクリプトなし（#1442） |
| AC3 | 統合 PR の body が検査対象から外れない（案 A = job skip を採らない） | 実装 diff + §「検出できなくなった範囲」 | job skip は不採用。integration lane では `.github/INTEGRATION_PR_TEMPLATE.md` を参照して検査する |
| — | feature / hotfix lane の挙動が不変 | **pass 側だけでなく fail 側の内訳一致**まで確認 | #4144(feature) OK / #4146(feature Draft) 同一 / **#4002(feature、違反あり) FAIL 内訳完全同一** / **#3947(hotfix、違反あり) FAIL 内訳完全同一**。差分は `lane=… — 参照 template: …` の 1 行が増えるのみ |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（顧客に見える挙動は不変）。変更対象は CI gate の CLI とそのテストのみ。

`.github/workflows/pr-merge-gate.yml` は**変更不要**でした。`pr-body-check` は `--pr <N>` のみを渡しており、lane は gh から自動判定されます（full checkout なので `pr-lane.mjs` / `check-ac-verification-map.mjs` も存在）。

- [ ] **並行実装ペア**を同期した
- [x] **設計書同期** (ADR-0001): N/A（gate の lane 対応であり仕様変更を伴わない。既存の lane-aware 3 点セットと形を揃えただけ）
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4147` | **ALL PASS (6 step)** — svelte-check 8347 files / **0 errors 0 warnings** |
| 追加・変更テスト | `npx vitest run tests/unit/scripts/check-pr-body.test.ts` | PASS (119 passed) |

**failing-test-first**（ADR-0061）: 実装前に fixture と 13 test を先に置いて **`13 failed | 105 passed`** を確認。加えて **CLI 実行でも実装前に統合 fixture が exit 1**（`missing-required-sections` + `ac-map-missing`）になることを確認してから実装に入りました。

**mutation 検証**（実装を **commit してから** 注入、復帰は `git stash push` → `drop`。`git checkout --` は不使用）:

| # | 注入した欠陥 | 落ちたテスト |
|---|---|---|
| M1 | `templatePathForLane` が常に feature template を返す | LN1 / LN2 |
| M2 | integration の evidence 検証結果を violation にしない | LN4 / LN5 / LN6 |
| M3 | 変更タイプ検査を全 lane で skip | LN8（feature 回帰） |
| M4 | lane 未解決時に error でなく feature へ fail-open | LN11 |
| M5 | `extractLaneRefs` が欠落 field でも null を返さない | LN9 |

- [x] **SOLID / DRY / YAGNI**: lane 判定・integration 観点とも既存 SSOT を再利用。新規スクリプト・新規依存ゼロ
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。**lane 未解決は fail-closed（exit 2）**
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

N/A — UI 変更なし（CI gate の CLI + テストのみ）。

## レビュー依頼事項・破壊的変更

### 検出できなくなった範囲（隠さず明記します）

| 範囲 | 理由 | 代替 |
|---|---|---|
| integration lane では**変更タイプ checkbox を検査しない** | 統合 template に当該 section が無い | feature / hotfix では従来どおり検査 |
| integration lane では **Ready checklist（`- [ ]`）を本 CLI が検査しない** | 統合 template に該当 section が無い | `pr-merge-gate.yml`（`## NG 0 件 / カバレッジ宣言`）が担当 |

**上記 2 点は必ず標準出力に NOTE として出します**（無言 skip にしない）。

### 再利用先 SSOT の既知の弱さ（本 PR では直していません）

再利用した `checkIntegrationEvidenceTable`（#2945 所管）に、実測で 2 つの弱さを確認しました。

1. **「残 NG 0 件」判定が `## NG 0 件 / カバレッジ宣言` という見出し文字列自体にマッチする** — 統合 template を使う限り事実上常に満たされます
2. **4 列行の走査が section 内に限定されず body 末尾まで及ぶ** — 他の 4 列表（Accepted residual 等）が行数要件を満たしてしまいます

**本 PR で書き換えると 2 gate 間で判定が分岐する（＝二重実装）ため触っていません。** テストコメントに実測として明記しました。#2945 の所管として扱ってください。

### あえて緩めなかったこと（AC4 は未達です）

**#4126 に残る 2 件を lane で緩めませんでした。**

- `forbidden-terms`（`follow-up` 3 箇所、監査ナラティブの散文）
- `po-decision-brief-missing-diagram`（mermaid ではなく表で記載）

どちらも **body を直せば通る内容要因**で、lane で外すのは検査の弱体化（ADR-0006）です。結果として **Issue の AC4「#4126 が PASS」は未達**ですが、**「統合 PR が構造的に必ず赤」という根本原因は #3931 の fail → pass で決着**しています。

### 判断を仰ぎたい点: template と gate の契約衝突

`INTEGRATION_PR_TEMPLATE.md` 自身の**非コメント行に`自動生成予定`が含まれており**、テンプレどおりに書いた body が `forbidden-terms`（`予定`）で落ちえます。**gate とテンプレが矛盾している**状態です。

テンプレ側を直すのが筋に見えますが、gate の禁止語を緩める案もありえます。**本 PR では触っていません。**

### lane 偽装の経路を作らない設計

lane 未解決は **fail-closed（exit 2）**にしました（既存の label 解決 #3962 と同方針）。gh が使えない場合の逃げ道として `--lane` を受けますが、**gh が取れているときは `--lane` を無視します**。Ready PR で lane を偽って gate を外す経路を作らないためで、`--draft` と同じ扱いです。

### 追加検証: `--lane` / `--draft` で gate を外せないことを固定しました（レビュー指摘対応）

「lane 未解決は fail-closed、gh が使えないときだけ `--lane` を受ける」の保証が **2 箇所に分かれており、テストで固定していたのは 1 箇所だけ**でした。

- **(1)** `resolveLane` — gh が取れたら申告を見ない → `[LN10]` で pin 済
- **(2)** **呼び出し側が gh を必ず引くか** → **無検証**

(2) を `args.pr && args.lane === null ? fetchLane(args.pr) : null` と書くと `fetched === null` になり、(1) の分岐を通って**申告が勝ちます**。**実装途中で実際にこの形を書いていました**（`--lane` 併用時に「gh が取れないので `--lane` を明示してください」と自己矛盾するエラーが出て発覚）。**仮説ではなく一度発生した欠陥**です。

fetcher を引数で受ける薄い wrapper を main と共有し、その 1 行を spy で固定しました（commit `4913323`）。

| test | 固定する内容 |
|---|---|
| `[LN15]` | `--pr` + `--lane feature` でも lane fetcher が**必ず呼ばれ**、gh の `integration` が申告に勝つ |
| `[LN16]` | `--pr` + `--draft` でも isDraft fetcher が**必ず呼ばれ**、gh の `false` が申告に勝つ（Ready PR で #3997 の Ready 化要件を外させない） |
| `[LN17]` | gh=true のときだけ deferred / `--pr` なしでは fetcher を呼ばない（dry-run で無駄に gh を叩かない） |

mutation（commit 後に注入、復帰は `git stash`）: **私が実際に書いたバグそのもの**を注入 → `[LN15]` が fail / draft 側の同型 → `[LN16]` が fail。

**`main()` を execSync mock で回す案は破棄しました。** 本 script は vitest の externalized module のため `vi.mock('node:child_process')` が効かず、**テストが実 gh を叩いて実 PR body を取得していました**（PR #4147 の本文がテスト出力に出て発覚）。network 依存テストを残すのは有害なので、seam を pure 化する方式に変えています。

### 環境の報告（本 PR と無関係。**回避策で解消済み**）

初報で「`node_modules/tsx` 欠落で 5 件 fail / `svelte-check` 212 errors」と報告しましたが、**`npm ci --engine-strict=false` で入れ直したところ全て解消**しました（`nuc-pglite-cutover-cli.test.ts` 12 passed / `pre-ready-preflight.test.ts` pass / `svelte-check` **0 errors**）。**環境起因で確定**し、本 PR に起因する fail は 0 件です。

根本原因は既報の **node v22.19.0 < `jsdom@30` 要求の `^22.22.2`**（`.npmrc` の `engine-strict=true`）で、**今日 2 人が踏んでいます**。node の引き上げか `engine-strict` の扱いは本 PR の scope 外です。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC4 のみ未達。**lane で緩めない判断の結果**であることを body に明示）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->


