### PR TITLE
fix(ops): #4087 AC2 バックアップ状態を設定 > サポートに出す（component 化 + Storybook 4 状態）

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -125,6 +125,26 @@ jobs:
             // Markdown画像: ![alt](url) / HTML画像: <img ...>
             const hasImage = /!\[.*?\]\(.*?\)|<img\s/i.test(body);
 
+            // #4087: 表示条件が env に依存し、撮影に使う demo 環境では原理的に描画されない UI の宣言。
+            //   判定は scripts/check-pr-screenshot.mjs に委譲する (二重実装しない、integration lane と同パターン)。
+            //   宣言だけでは通らず、理由 (12 文字以上) + Storybook story 参照の両方を要求する。
+            const ssMod = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/check-pr-screenshot.mjs`
+            );
+            const renderImpossible = ssMod.checkRenderImpossibleDeclaration(body);
+            if (renderImpossible.ok) {
+              core.info(
+                '✅ `ss-render-impossible` 宣言 (理由 + Storybook story 参照) を検出 — SS 添付不要 (#4087)',
+              );
+              return;
+            }
+            if (renderImpossible.violation) {
+              core.setFailed(
+                `❌ [${renderImpossible.violation.id}] (${renderImpossible.violation.issue}) ${renderImpossible.violation.message}`,
+              );
+              return;
+            }
+
             if (!hasImage) {
               core.setFailed(
                 [

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -36,6 +36,7 @@ jobs:
             scripts/pr-lane.mjs
             scripts/check-pr-screenshot.mjs
             scripts/lib/is-main.mjs
+            scripts/lib/ci/reason-declaration.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)
@@ -167,6 +168,7 @@ jobs:
             scripts/pr-lane.mjs
             scripts/check-pr-screenshot.mjs
             scripts/lib/is-main.mjs
+            scripts/lib/ci/reason-declaration.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)

--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -2803,6 +2803,25 @@ Anti-engagement 原則 (ADR-0012) に従い、子供 UI には CTA を**設置�
 - **/inquiry/founder は存続**: LP / ライセンスパネルからの公開導線として残す（admin ログイン不要の到達経路）
 - **回帰**: `tests/unit/routes/support-feedback-action.test.ts`（save 成否の surface = #3210）/ `tests/e2e/feedback-form.spec.ts`（感想・要望送信 + 相談切替の段階表示 + 送信完遂）/ `tests/e2e/admin-settings-routes.spec.ts` / `tests/e2e/founder-inquiry.spec.ts`
 
+### 17.8 バックアップ状態カード（NUC セルフホスト時のみ、#4087）
+
+同ページ（`/admin/settings/support`）の先頭に、**バックアップが健全かを家族が自分で見られる**カードを置く。想定運用者は家族（非エンジニア）であり、状態を知る経路が `curl /api/health | jq` しかないと **止まっていることに気づけない**（バックアップが 18 日止まっていた実害 #4119）。
+
+| 要素 | 仕様 |
+|------|------|
+| 描画条件 | `DATA_SOURCE=pglite`（NUC セルフホスト）**かつ** backup status file が読めるときのみ。クラウド（dsql）では返さない（AWS Backup が担う領域で、載せると「自分で見るべきもの」を誤らせる） |
+| 判定 | `$lib/domain/backup-health.ts` の純粋関数。component は描画のみ持つ |
+| 表示 | `Alert`（`ok`=success / `warn`=warning / `critical`=danger）+ 最終成功日時 + 連続失敗回数 + 通知経路の有無 |
+| 通知経路の警告 | `notificationMissing` は **`level` と独立に**出す。「取れてはいるが、壊れても届かない」は対処が別だから |
+| 内部 `reason` の非露出 | `reason` enum を画面に出さない。`level` に応じた固定文言のみ（guard trip が 2 回続くと「取得は成功しているのに critical」になる判定の弱点が、家族向け文言として誤解を招くのを避ける。判定側の課題は #4144） |
+| 配置方針 | ADR-0012 anti-engagement に従い、常時表示の煽りにしない設定画面内の静的表示。**子供画面には一切出さない** |
+| testid | `backup-health`（root）+ `data-level` |
+
+- **文言 SSOT**: `SETTINGS_LABELS.{backupSectionTitle, backupOkTitle, backupWarnTitle, backupCriticalTitle, backupLastSuccessLabel, backupNeverSucceeded, backupConsecutiveFailuresLabel, backupNotificationMissing, backupActionHint}`
+- **status file が読めなくても load を落とさない**: バックアップ状態が読めないことと相談フォームが使えることは無関係で、ここで throw すると「バックアップ状態が読めないせいで相談できない」逆転が起きる
+- **SS が撮れない画面**: 描画条件が env 依存で、撮影に使う demo 環境（`DATA_SOURCE=demo`）では出ない。3 状態の見た目は Storybook（`Features/Admin/BackupHealthCard`）で確認する（`src/routes/CLAUDE.md` の `ss-render-impossible` 宣言）。実機確認は #3964
+- **回帰**: `tests/unit/routes/admin-settings-support-backup-health.test.ts`（`[SB1]`〜`[SB4]` = 表示 / dsql 非表示 / status 不読でも load 継続 / level 伝播）
+
 ---
 
 ## §18 初月価値プレビュー体験（#1600 / ADR-0023 I9）

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -136,6 +136,90 @@ export function detectBeforeAfterLabels(body) {
 	};
 }
 
+import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
+
+/**
+ * `ss-render-impossible` 宣言の検出 (#4087 / PO 決裁 2026-08-01)。
+ *
+ * ## なぜ必要か
+ *
+ * 兄弟 gate の `ss-blob-sha-uniqueness` には理由必須の宣言が 4 種ある (#4084) のに、
+ * **本 gate にだけ「原理的に撮れない」を表す語彙が無かった**。結果、
+ * 「UI は変わるが、その環境では原理的に描画できない」PR に対して、
+ *
+ *   - 「UI 変更なし」と書く   → **虚偽**
+ *   - internal-refactor label → **顧客に見える変更に付けない** (src/routes/CLAUDE.md #4084)
+ *
+ * のどちらかしか道が無く、**label の意味を曲げる方向に退化する**状態だった。
+ * 新機構の追加ではなく **既存 gate の語彙の欠落を埋める** 位置づけ (#4121 E5 と非干渉)。
+ *
+ * ## 実例
+ *
+ * `BackupHealthCard` は `DATA_SOURCE=pglite` かつ backup status file 存在でのみ描画され、
+ * SS 撮影に使う demo 環境 (`DATA_SOURCE=demo`) では原理的に出ない (#4087 AC2)。
+ *
+ * ## 濫用防止
+ *
+ * 宣言だけでは通さない。**Storybook story 参照を同じ body 内に必須**とする
+ * (「原理的に撮れない」は「見た目を確認しなくてよい」ではない)。理由の実体判定は
+ * `scripts/lib/ci/reason-declaration.mjs` (#4084 の 4 宣言と同一 SSOT) に委譲する。
+ *
+ * @param {string} body
+ * @returns {{ ok: boolean; violation?: { id: string; issue: string; message: string } }}
+ */
+export function checkRenderImpossibleDeclaration(body) {
+	const decl = parseReasonDeclaration(body, 'ss-render-impossible');
+	if (!decl.present) return { ok: false };
+
+	if (!decl.valid) {
+		return {
+			ok: false,
+			violation: {
+				id: 'ss-render-impossible-reason-missing',
+				issue: '#4087',
+				message:
+					'`ss-render-impossible` 宣言はありますが理由が受理できません。\n' +
+					`  ${MIN_REASON_LENGTH} 文字以上で、なぜその環境では描画できないのかを書いてください ` +
+					'(空欄 / TODO / n/a 等の定型 stub は受理しません、#3956 教訓)。',
+			},
+		};
+	}
+
+	if (!hasStorybookStoryReference(body)) {
+		return {
+			ok: false,
+			violation: {
+				id: 'ss-render-impossible-story-missing',
+				issue: '#4087',
+				message:
+					'`ss-render-impossible` 宣言には **Storybook story の参照**が必須です。\n' +
+					'  「原理的に撮れない」は「見た目を確認しなくてよい」ではありません。\n' +
+					'  PR body に story のタイトル (例: `Features/Admin/BackupHealthCard`) を書いてください。',
+			},
+		};
+	}
+
+	return { ok: true };
+}
+
+/**
+ * PR body に Storybook story への参照があるか。
+ *
+ * story タイトル (`Foo/Bar/Baz` 形式) か `*.stories.svelte` のパス言及を受理する。
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasStorybookStoryReference(body) {
+	const b = body ?? '';
+	// story ファイルへの言及、または story タイトル (Foo/Bar 形式) の言及を受理する。
+	if (b.includes('.stories.svelte')) return true;
+	return (
+		/(?:Storybook|story|ストーリー)/i.test(b) &&
+		/[A-Za-z][A-Za-z0-9]*\/[A-Za-z][A-Za-z0-9]*/.test(b)
+	);
+}
+
 /**
  * 「該当なし」明示記述の検出。refactor / docs / chore のみで UI 影響がない PR の opt-out 用。
  *
@@ -392,6 +476,21 @@ export function checkScreenshotEmbedReadiness({ body, files, labels }) {
 		};
 	}
 
+	// #4087: 「UI は変わるが、その環境では原理的に描画できない」の宣言 (理由 + story 必須)。
+	const renderImpossible = checkRenderImpossibleDeclaration(body);
+	if (renderImpossible.violation) {
+		violations.push(renderImpossible.violation);
+		return { skipped: false, skipReason: null, violations };
+	}
+	if (renderImpossible.ok) {
+		return {
+			skipped: true,
+			skipReason:
+				'`ss-render-impossible` 宣言 (理由 + Storybook story 参照あり) により exempt (#4087)',
+			violations,
+		};
+	}
+
 	// 未来形記述の検出 (#2918)
 	if (hasFutureTenseScreenshotMarker(body)) {
 		violations.push(buildFutureTenseViolation());
@@ -557,6 +656,17 @@ function main() {
 		skipReason = '「該当なし」明示記述あり';
 	} else if (labelExempt) {
 		skipReason = `PR ラベル '${INTERNAL_REFACTOR_LABEL}' により内部 refactor として exempt (#2017 / ADR-0003 §4)`;
+	}
+
+	// #4087: 宣言に不備があれば violation にし、成立していれば skip する。
+	if (!skipReason && isUi) {
+		const renderImpossible = checkRenderImpossibleDeclaration(PR_BODY);
+		if (renderImpossible.violation) {
+			violations.push(renderImpossible.violation);
+		} else if (renderImpossible.ok) {
+			skipReason =
+				'`ss-render-impossible` 宣言 (理由 + Storybook story 参照あり) により exempt (#4087)';
+		}
 	}
 
 	// #2946 (Phase A/A-4): lane=integration は SS 観点を切替。

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2505,6 +2505,20 @@ export const SETTINGS_LABELS = {
 	feedbackContactSuffix: 'でも受け付けています',
 
 	// アプリ情報
+	// #4087 (E3 / EPIC #4119): バックアップ状態を**家族 (非エンジニア) が見られる場所**に出す。
+	// 2026-07-31 の実害では、バックアップが 18 日止まっていたのに気づく手段が
+	// `curl /api/health | jq` しかなかった。ADR-0012 整合で常時表示の煽りにはせず、
+	// 設定画面内の静的表示に留める (子供画面には一切出さない)。
+	backupSectionTitle: '🗄️ バックアップの状態',
+	backupOkTitle: '正常に取れています',
+	backupWarnTitle: '確認してください',
+	backupCriticalTitle: 'バックアップが取れていません',
+	backupLastSuccessLabel: '最後に成功した日時: ',
+	backupNeverSucceeded: '一度も成功していません',
+	backupConsecutiveFailuresLabel: '連続で失敗した回数: ',
+	backupNotificationMissing:
+		'失敗しても通知が届かない設定です。いま止まっても気づけません (DISCORD_ALERT_WEBHOOK_URL 未設定)。',
+	backupActionHint: 'うまくいっていないときは、下のフォームから相談してください。',
 	appInfoSectionTitle: 'ℹ️ アプリ情報',
 	appInfoTermsLink: '📄 利用規約',
 	appInfoPrivacyLink: '🔒 プライバシーポリシー',

--- a/src/lib/features/admin/components/BackupHealthCard.stories.svelte
+++ b/src/lib/features/admin/components/BackupHealthCard.stories.svelte
@@ -65,12 +65,10 @@ const CRITICAL_STALE: BackupHealthVerdict = {
 <Story name="CriticalStale" args={{ health: CRITICAL_STALE }} />
 
 <Story name="AllStates">
-	{#snippet children()}
-		<div class="flex flex-col gap-4">
-			<BackupHealthCard health={OK} />
-			<BackupHealthCard health={WARN_NO_CHANNEL} />
-			<BackupHealthCard health={CRITICAL_REAL_INCIDENT} />
-			<BackupHealthCard health={CRITICAL_STALE} />
-		</div>
-	{/snippet}
+	<div class="flex flex-col gap-4">
+		<BackupHealthCard health={OK} />
+		<BackupHealthCard health={WARN_NO_CHANNEL} />
+		<BackupHealthCard health={CRITICAL_REAL_INCIDENT} />
+		<BackupHealthCard health={CRITICAL_STALE} />
+	</div>
 </Story>

--- a/src/lib/features/admin/components/BackupHealthCard.stories.svelte
+++ b/src/lib/features/admin/components/BackupHealthCard.stories.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script module lang="ts">
 // #4087 — バックアップ状態カードの 3 状態を Storybook で確認可能にする。
 //
 // 本 component の表示条件は `DATA_SOURCE=pglite` かつ backup status file 存在で、
@@ -6,6 +6,7 @@
 // Storybook なら component 単体で描画できるため、3 状態の見た目を誰も確認できないまま
 // merge される事態を避けられる (PO 決裁 2026-08-01)。
 import { defineMeta } from '@storybook/addon-svelte-csf';
+import type { BackupHealthVerdict } from '$lib/domain/backup-health';
 import BackupHealthCard from './BackupHealthCard.svelte';
 
 const { Story } = defineMeta({
@@ -15,7 +16,7 @@ const { Story } = defineMeta({
 });
 
 /** 正常時。直近成功 + 失敗 0 + 通知経路あり。 */
-const OK = {
+const OK: BackupHealthVerdict = {
 	level: 'ok',
 	reason: 'healthy',
 	hoursSinceLastSuccess: 3,
@@ -25,7 +26,7 @@ const OK = {
 };
 
 /** 通知経路が無いだけの warn。**取れてはいるが、壊れても届かない**状態 (#4087 AC1)。 */
-const WARN_NO_CHANNEL = {
+const WARN_NO_CHANNEL: BackupHealthVerdict = {
 	level: 'warn',
 	reason: 'no-notification-channel',
 	hoursSinceLastSuccess: 5,
@@ -38,7 +39,7 @@ const WARN_NO_CHANNEL = {
  * 2026-07-31 の実害と同じ状態 (#4119)。
  * cutover 以降 1 度も成功せず、18 晩連続で失敗し、通知経路も無かった。
  */
-const CRITICAL_REAL_INCIDENT = {
+const CRITICAL_REAL_INCIDENT: BackupHealthVerdict = {
 	level: 'critical',
 	reason: 'never-succeeded',
 	hoursSinceLastSuccess: null,
@@ -48,7 +49,7 @@ const CRITICAL_REAL_INCIDENT = {
 };
 
 /** ジョブが起動しなかったケース。**失敗 0 回でも成功が古ければ critical** (#4087 AC3)。 */
-const CRITICAL_STALE = {
+const CRITICAL_STALE: BackupHealthVerdict = {
 	level: 'critical',
 	reason: 'stale-critical',
 	hoursSinceLastSuccess: 72,

--- a/src/lib/features/admin/components/BackupHealthCard.stories.svelte
+++ b/src/lib/features/admin/components/BackupHealthCard.stories.svelte
@@ -1,0 +1,75 @@
+<script module>
+// #4087 — バックアップ状態カードの 3 状態を Storybook で確認可能にする。
+//
+// 本 component の表示条件は `DATA_SOURCE=pglite` かつ backup status file 存在で、
+// **SS 撮影に使う demo 環境 (`DATA_SOURCE=demo`) では原理的に描画されない**。
+// Storybook なら component 単体で描画できるため、3 状態の見た目を誰も確認できないまま
+// merge される事態を避けられる (PO 決裁 2026-08-01)。
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import BackupHealthCard from './BackupHealthCard.svelte';
+
+const { Story } = defineMeta({
+	title: 'Features/Admin/BackupHealthCard',
+	component: BackupHealthCard,
+	tags: ['autodocs'],
+});
+
+/** 正常時。直近成功 + 失敗 0 + 通知経路あり。 */
+const OK = {
+	level: 'ok',
+	reason: 'healthy',
+	hoursSinceLastSuccess: 3,
+	consecutiveFailures: 0,
+	lastFailureMessage: null,
+	notificationMissing: false,
+};
+
+/** 通知経路が無いだけの warn。**取れてはいるが、壊れても届かない**状態 (#4087 AC1)。 */
+const WARN_NO_CHANNEL = {
+	level: 'warn',
+	reason: 'no-notification-channel',
+	hoursSinceLastSuccess: 5,
+	consecutiveFailures: 0,
+	lastFailureMessage: null,
+	notificationMissing: true,
+};
+
+/**
+ * 2026-07-31 の実害と同じ状態 (#4119)。
+ * cutover 以降 1 度も成功せず、18 晩連続で失敗し、通知経路も無かった。
+ */
+const CRITICAL_REAL_INCIDENT = {
+	level: 'critical',
+	reason: 'never-succeeded',
+	hoursSinceLastSuccess: null,
+	consecutiveFailures: 18,
+	lastFailureMessage: 'CRON_SECRET が未設定です (/api/cron/pglite-backup の認証に必要)',
+	notificationMissing: true,
+};
+
+/** ジョブが起動しなかったケース。**失敗 0 回でも成功が古ければ critical** (#4087 AC3)。 */
+const CRITICAL_STALE = {
+	level: 'critical',
+	reason: 'stale-critical',
+	hoursSinceLastSuccess: 72,
+	consecutiveFailures: 0,
+	lastFailureMessage: null,
+	notificationMissing: false,
+};
+</script>
+
+<Story name="Ok" args={{ health: OK }} />
+<Story name="WarnNoNotificationChannel" args={{ health: WARN_NO_CHANNEL }} />
+<Story name="CriticalNeverSucceeded" args={{ health: CRITICAL_REAL_INCIDENT }} />
+<Story name="CriticalStale" args={{ health: CRITICAL_STALE }} />
+
+<Story name="AllStates">
+	{#snippet children()}
+		<div class="flex flex-col gap-4">
+			<BackupHealthCard health={OK} />
+			<BackupHealthCard health={WARN_NO_CHANNEL} />
+			<BackupHealthCard health={CRITICAL_REAL_INCIDENT} />
+			<BackupHealthCard health={CRITICAL_STALE} />
+		</div>
+	{/snippet}
+</Story>

--- a/src/lib/features/admin/components/BackupHealthCard.svelte
+++ b/src/lib/features/admin/components/BackupHealthCard.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+// #4087 (E3 / EPIC #4119) — バックアップ状態を家族 (非エンジニア) に見せるカード。
+//
+// ## なぜ component に切り出すか
+//
+// 表示条件が `DATA_SOURCE=pglite` かつ backup status file 存在で、**SS 撮影に使う demo 環境
+// (`DATA_SOURCE=demo`) では原理的に描画されない**。page に直書きすると 3 状態 (ok / warn /
+// critical) の見た目を誰も確認できないまま入ることになる。component 単体なら Storybook で
+// 3 状態とも描画でき、demo 環境に依存しない (PO 決裁 2026-08-01)。
+//
+// ## 表示方針 (ADR-0012 anti-engagement)
+//
+// 常時表示の煽りにはせず、設定画面内の静的表示に留める。**子供画面には一切出さない。**
+// 判定そのものは `$lib/domain/backup-health.ts` (純粋関数) が持ち、本 component は描画のみ。
+
+import type { BackupHealthVerdict } from '$lib/domain/backup-health';
+import { formatCount, SETTINGS_LABELS } from '$lib/domain/labels';
+import Alert from '$lib/ui/primitives/Alert.svelte';
+import Card from '$lib/ui/primitives/Card.svelte';
+
+interface Props {
+	health: BackupHealthVerdict;
+}
+
+let { health }: Props = $props();
+
+// server は判定結果だけを渡すので、表示用の日時は経過時間から復元する。
+// (server 側で文字列整形すると TZ が server 依存になり、#4015 のローカル TZ 事故と同型になる)
+const lastSuccessDisplay = $derived(
+	health.hoursSinceLastSuccess == null
+		? null
+		: new Date(Date.now() - health.hoursSinceLastSuccess * 3_600_000).toLocaleString('ja-JP'),
+);
+</script>
+
+<Card padding="lg">
+	<h3 class="text-lg font-bold text-[var(--color-text)] mb-4">
+		{SETTINGS_LABELS.backupSectionTitle}
+	</h3>
+	<div data-testid="backup-health" data-level={health.level}>
+		{#if health.level === 'ok'}
+			<Alert variant="success" message={SETTINGS_LABELS.backupOkTitle} />
+		{:else if health.level === 'warn'}
+			<Alert variant="warning" message={SETTINGS_LABELS.backupWarnTitle} />
+		{:else}
+			<Alert variant="danger" message={SETTINGS_LABELS.backupCriticalTitle} />
+		{/if}
+
+		<ul class="mt-3 space-y-1 text-sm text-[var(--color-text-muted)]">
+			<li>
+				{SETTINGS_LABELS.backupLastSuccessLabel}{lastSuccessDisplay === null
+					? SETTINGS_LABELS.backupNeverSucceeded
+					: lastSuccessDisplay}
+			</li>
+			{#if health.consecutiveFailures > 0}
+				<li>
+					{SETTINGS_LABELS.backupConsecutiveFailuresLabel}{formatCount(health.consecutiveFailures)}
+				</li>
+			{/if}
+			<!-- level と独立に出す: critical のときも「届かない」ことは対処が変わるため (#4087 AC1) -->
+			{#if health.notificationMissing}
+				<li class="text-[var(--color-feedback-warning-text)]">
+					{SETTINGS_LABELS.backupNotificationMissing}
+				</li>
+			{/if}
+		</ul>
+
+		{#if health.level !== 'ok'}
+			<p class="mt-3 text-sm text-[var(--color-text-muted)]">
+				{SETTINGS_LABELS.backupActionHint}
+			</p>
+		{/if}
+	</div>
+</Card>

--- a/src/routes/(parent)/admin/settings/support/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/support/+page.server.ts
@@ -3,19 +3,55 @@
 // appInfo / founderInquiry は静的なため load 不要。
 
 import { fail } from '@sveltejs/kit';
+import {
+	type BackupHealthVerdict,
+	evaluateBackupHealth,
+	isBackupNotificationConfigured,
+} from '$lib/domain/backup-health';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { generateInquiryId, saveInquiry } from '$lib/server/db/inquiry-repo';
 import { logger } from '$lib/server/logger';
 import { notifyInquiry } from '$lib/server/services/discord-notify-service';
 import { sendInquiryConfirmationEmail } from '$lib/server/services/email-service';
+import { getPgliteBackupStatus } from '$lib/server/services/pglite-backup-service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	// #support-unify: 相談 intent の返信先 hint (「○○ に返信します」) でアカウントメールを提示するため、
 	// cognito 認証時のみ識別子メールを渡す (local モードは null = フォームで明示入力を促す)。
 	const accountEmail = locals.identity?.type === 'cognito' ? locals.identity.email : null;
-	return { accountEmail };
+
+	// #4087 (E3 / EPIC #4119): バックアップ状態を家族 (非エンジニア) が見られる場所に出す。
+	//
+	// NUC セルフホスト (DATA_SOURCE=pglite) のときだけ載せる。クラウド (dsql) のバックアップは
+	// AWS Backup が担っており本画面の対象外で、載せると「自分で見るべきもの」を誤らせる。
+	const backupHealth = process.env.DATA_SOURCE === 'pglite' ? await readBackupHealth() : null;
+
+	return { accountEmail, backupHealth };
 };
+
+/**
+ * バックアップ状態を判定して返す。**画面を落とさない**ことを優先する。
+ *
+ * 状態ファイルが読めないこと自体はサポート画面の主目的 (相談フォーム) と無関係なので、
+ * ここで throw すると「バックアップ状態が読めないせいで相談できない」という逆転が起きる。
+ */
+async function readBackupHealth(): Promise<BackupHealthVerdict | null> {
+	try {
+		const status = await getPgliteBackupStatus();
+		return evaluateBackupHealth(
+			{
+				lastSuccessAt: status.lastSuccessAt,
+				consecutiveFailures: status.consecutiveFailures,
+				lastFailureMessage: status.lastFailureMessage,
+				notificationConfigured: isBackupNotificationConfigured(process.env),
+			},
+			new Date(),
+		);
+	} catch {
+		return null;
+	}
+}
 
 // #support-unify: 1 フォーム統合の検証ロジック。intent (用件 2 軸) + 内容分類を併用する。
 //   - intent='feedback' (感想・要望、返信不要): category = feature|bug|other を併記

--- a/src/routes/(parent)/admin/settings/support/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/support/+page.server.ts
@@ -8,6 +8,7 @@ import {
 	evaluateBackupHealth,
 	isBackupNotificationConfigured,
 } from '$lib/domain/backup-health';
+import { getEnv } from '$lib/runtime/env';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { generateInquiryId, saveInquiry } from '$lib/server/db/inquiry-repo';
 import { logger } from '$lib/server/logger';
@@ -25,7 +26,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 	//
 	// NUC セルフホスト (DATA_SOURCE=pglite) のときだけ載せる。クラウド (dsql) のバックアップは
 	// AWS Backup が担っており本画面の対象外で、載せると「自分で見るべきもの」を誤らせる。
-	const backupHealth = process.env.DATA_SOURCE === 'pglite' ? await readBackupHealth() : null;
+	const backupHealth = getEnv().DATA_SOURCE === 'pglite' ? await readBackupHealth() : null;
 
 	return { accountEmail, backupHealth };
 };

--- a/src/routes/(parent)/admin/settings/support/+page.svelte
+++ b/src/routes/(parent)/admin/settings/support/+page.svelte
@@ -6,8 +6,9 @@
 // founder 直接相談の独立ページ (/inquiry/founder) は LP / ライセンス導線から到達するため存続。
 
 import { enhance } from '$app/forms';
-import { APP_LABELS, PAGE_TITLES, SETTINGS_LABELS } from '$lib/domain/labels';
+import { APP_LABELS, formatCount, PAGE_TITLES, SETTINGS_LABELS } from '$lib/domain/labels';
 import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
+import Alert from '$lib/ui/primitives/Alert.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
@@ -28,6 +29,16 @@ let feedbackEmail = $state('');
 let feedbackInquiryId = $state('');
 let feedbackSuccessIntent = $state<FeedbackIntent>('feedback');
 let feedbackSuccessHadEmail = $state(false);
+
+// #4087: server は判定結果だけを渡すので、表示用の日時は経過時間から復元する。
+// (server 側で文字列整形すると TZ が server 依存になり、#4015 のローカル TZ 事故と同型になる)
+const lastSuccessDisplay = $derived(
+	data.backupHealth?.hoursSinceLastSuccess == null
+		? null
+		: new Date(Date.now() - data.backupHealth.hoursSinceLastSuccess * 3_600_000).toLocaleString(
+				'ja-JP',
+			),
+);
 
 const isConsult = $derived(feedbackIntent === 'consult');
 // 相談 (返信前提) で、かつアカウントメールが無いときのみ返信先を必須にする。
@@ -215,6 +226,52 @@ const successMessage = $derived(
 			{SETTINGS_LABELS.feedbackContactSuffix}
 		</p>
 	</Card>
+
+	<!-- #4087 (E3 / EPIC #4119): バックアップ状態。NUC セルフホスト時のみ表示する。
+	     2026-07-31 の実害では 18 日間バックアップが止まっていたのに、気づく手段が
+	     `curl /api/health | jq` しかなかった。家族 (非エンジニア) が見られる場所に出す。
+	     ADR-0012 整合で常時表示の煽りにはせず、設定画面内の静的表示に留める。 -->
+	{#if data.backupHealth}
+		{@const bh = data.backupHealth}
+		<Card padding="lg">
+			<h3 class="text-lg font-bold text-[var(--color-text)] mb-4">
+				{SETTINGS_LABELS.backupSectionTitle}
+			</h3>
+			<div data-testid="backup-health" data-level={bh.level}>
+				{#if bh.level === 'ok'}
+					<Alert variant="success" message={SETTINGS_LABELS.backupOkTitle} />
+				{:else if bh.level === 'warn'}
+					<Alert variant="warning" message={SETTINGS_LABELS.backupWarnTitle} />
+				{:else}
+					<Alert variant="danger" message={SETTINGS_LABELS.backupCriticalTitle} />
+				{/if}
+
+				<ul class="mt-3 space-y-1 text-sm text-[var(--color-text-muted)]">
+					<li>
+						{SETTINGS_LABELS.backupLastSuccessLabel}{lastSuccessDisplay === null
+							? SETTINGS_LABELS.backupNeverSucceeded
+							: lastSuccessDisplay}
+					</li>
+					{#if bh.consecutiveFailures > 0}
+						<li>
+							{SETTINGS_LABELS.backupConsecutiveFailuresLabel}{formatCount(bh.consecutiveFailures)}
+						</li>
+					{/if}
+					{#if bh.notificationMissing}
+						<li class="text-[var(--color-feedback-warning-text)]">
+							{SETTINGS_LABELS.backupNotificationMissing}
+						</li>
+					{/if}
+				</ul>
+
+				{#if bh.level !== 'ok'}
+					<p class="mt-3 text-sm text-[var(--color-text-muted)]">
+						{SETTINGS_LABELS.backupActionHint}
+					</p>
+				{/if}
+			</div>
+		</Card>
+	{/if}
 
 	<!-- アプリ情報・リンク -->
 	<Card padding="lg">

--- a/src/routes/CLAUDE.md
+++ b/src/routes/CLAUDE.md
@@ -102,10 +102,12 @@ node scripts/capture.mjs --pr <N>            # 修正後 SS を撮り直す
 | 個別に対応を書きたい | `<!-- ss-pair: before=<raw URL or path> after=<raw URL or path> -->` |
 | ペアが原理的に存在しない（新規画面で修正前が無い 等） | `<!-- ss-pair-none: <12 文字以上の理由> -->` |
 | **Before / After が同一なのが正しい** | `<!-- ss-identical-ok: <12 文字以上の理由> -->` |
+| **UI は変わるが、その環境では原理的に描画できない** | `<!-- ss-render-impossible: <12 文字以上の理由> -->` + **Storybook story の参照を同じ body 内に必須** |
 
 - **理由は必須**。空欄 / `TODO` / `n/a` 等の定型 stub は受理されない（理由の非強制を作らない、#3956 教訓）
 - `ss-identical-ok` は「差分が現れる条件の外で撮影したため描画が一致するのが正しい」ケース用（例: JST 00:00〜09:00 だけ日付がずれる修正を JST 日中に撮影した #4080）。**撮り直し漏れの言い訳には使わない**。宣言しても同一だったペアは出力に列挙される
 - `refactor:internal-no-doc-impact` label（視覚差分ゼロの内部 refactor 用）とは意味が違う。**顧客に見える挙動を変える PR には label を付けず、`ss-identical-ok` を使う**
+- `ss-render-impossible` は **`ss-blob-sha-uniqueness` ではなく `check-pr-screenshot.mjs`（SS embed gate / pre-ready Step 11b）** 側の宣言（#4087）。表示条件が env に依存し、撮影に使う demo 環境（`DATA_SOURCE=demo`）では出ない UI がこれに当たる。**宣言だけでは通らない — Storybook story の参照が必須**（「原理的に撮れない」は「見た目を確認しなくてよい」ではない）。実環境での確認は後続 Issue に紐付けること
 
 ## 局所テストコマンド (#2184)
 

--- a/tests/unit/routes/admin-settings-support-backup-health.test.ts
+++ b/tests/unit/routes/admin-settings-support-backup-health.test.ts
@@ -1,0 +1,116 @@
+// tests/unit/routes/admin-settings-support-backup-health.test.ts
+// #4087 (E3 / EPIC #4119) — 設定 > サポート画面にバックアップ状態が配布されることを検証する。
+//
+// 本 Issue の実害は「バックアップが 18 日止まっていたのに、気づく手段が `curl /api/health | jq`
+// しかなかった」。判定ロジック自体は tests/unit/domain/backup-health.test.ts が固定するので、
+// 本テストが固定するのは **判定結果が家族 (非エンジニア) の見る画面まで届く配線**:
+//
+//   [SB1] NUC (DATA_SOURCE=pglite) では backupHealth が load から返る
+//   [SB2] **クラウド (dsql) では返さない** — AWS Backup が担う領域で、載せると
+//         「自分で見るべきもの」を誤らせる
+//   [SB3] 状態ファイルが読めなくても load は落ちない (相談フォームが道連れにならない)
+//   [SB4] 通知経路が無いことが画面まで届く (#4087 AC1「通知できないので黙る」を無くす)
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetPgliteBackupStatus = vi.fn();
+vi.mock('$lib/server/services/pglite-backup-service', () => ({
+	getPgliteBackupStatus: (...args: unknown[]) => mockGetPgliteBackupStatus(...args),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: () => 'tenant-1',
+}));
+vi.mock('$lib/server/db/inquiry-repo', () => ({
+	generateInquiryId: vi.fn(),
+	saveInquiry: vi.fn(),
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('$lib/server/services/discord-notify-service', () => ({ notifyInquiry: vi.fn() }));
+vi.mock('$lib/server/services/email-service', () => ({
+	sendInquiryConfirmationEmail: vi.fn(),
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** 直近成功 + 通知経路あり = ok と判定される状態。 */
+function healthyStatus() {
+	return {
+		lastSuccessAt: new Date(Date.now() - 3_600_000).toISOString(),
+		lastSuccessFilename: 'pglite-20260730T225306Z.tgz',
+		lastSuccessBytes: 5_876_551,
+		lastSuccessDurationMs: 5057,
+		lastFailureAt: null,
+		lastFailureMessage: null,
+		consecutiveFailures: 0,
+	};
+}
+
+async function loadSupportPage() {
+	const mod = await import('../../../src/routes/(parent)/admin/settings/support/+page.server');
+	return mod.load({ locals: { identity: null } } as never);
+}
+
+beforeEach(() => {
+	vi.resetModules();
+	mockGetPgliteBackupStatus.mockReset();
+	process.env.DISCORD_ALERT_WEBHOOK_URL = 'https://discord.example/webhook';
+});
+
+afterEach(() => {
+	process.env = { ...ORIGINAL_ENV };
+});
+
+describe('#4087 設定 > サポート画面へのバックアップ状態の配布', () => {
+	it('[SB1] NUC (pglite) では判定結果が load から返る', async () => {
+		process.env.DATA_SOURCE = 'pglite';
+		mockGetPgliteBackupStatus.mockResolvedValue(healthyStatus());
+
+		const data = (await loadSupportPage()) as { backupHealth: { level: string } | null };
+
+		expect(data.backupHealth).not.toBeNull();
+		expect(data.backupHealth?.level).toBe('ok');
+	});
+
+	it('[SB2] クラウド (dsql) では返さない — AWS Backup の領域と混同させない', async () => {
+		process.env.DATA_SOURCE = 'dsql';
+		mockGetPgliteBackupStatus.mockResolvedValue(healthyStatus());
+
+		const data = (await loadSupportPage()) as { backupHealth: unknown };
+
+		expect(data.backupHealth).toBeNull();
+		// 状態ファイルを読みに行くこと自体をしない (NUC 専用の口を叩かない)。
+		expect(mockGetPgliteBackupStatus).not.toHaveBeenCalled();
+	});
+
+	it('[SB3] 状態ファイルが読めなくても load は落ちない', async () => {
+		// バックアップ状態が読めないことと、相談フォームが使えることは無関係。
+		// ここで throw すると「バックアップ状態が読めないせいで相談できない」逆転が起きる。
+		process.env.DATA_SOURCE = 'pglite';
+		mockGetPgliteBackupStatus.mockRejectedValue(new Error('ENOENT'));
+
+		const data = (await loadSupportPage()) as { backupHealth: unknown; accountEmail: unknown };
+
+		expect(data.backupHealth).toBeNull();
+		expect(data).toHaveProperty('accountEmail');
+	});
+
+	it('[SB4] 通知経路が無いことが画面まで届く (#4087 AC1)', async () => {
+		// 直近は成功していても、次に失敗したとき誰にも届かない状態は warn として出す。
+		// 2026-07-31 の実害では、この状態が 18 日間可視化されていなかった。
+		process.env.DATA_SOURCE = 'pglite';
+		process.env.DISCORD_ALERT_WEBHOOK_URL = '';
+		process.env.DISCORD_WEBHOOK_INCIDENT = '';
+		mockGetPgliteBackupStatus.mockResolvedValue(healthyStatus());
+
+		const data = (await loadSupportPage()) as {
+			backupHealth: { level: string; reason: string; notificationMissing: boolean } | null;
+		};
+
+		expect(data.backupHealth?.level).toBe('warn');
+		expect(data.backupHealth?.reason).toBe('no-notification-channel');
+		expect(data.backupHealth?.notificationMissing).toBe(true);
+	});
+});

--- a/tests/unit/scripts/check-pr-screenshot.test.ts
+++ b/tests/unit/scripts/check-pr-screenshot.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+	checkRenderImpossibleDeclaration,
 	checkScreenshotEmbedReadiness,
 	detectBeforeAfterLabels,
 	detectLocalPaths,
@@ -16,6 +17,7 @@ import {
 	hasEmbeddedScreenshotImage,
 	hasFutureTenseScreenshotMarker,
 	hasIntegrationVrEvidence,
+	hasStorybookStoryReference,
 	hasUiNotApplicableMarker,
 	isScreenshotUrl,
 	isUiPr,
@@ -468,5 +470,60 @@ describe('check-pr-screenshot lane-aware main (#2946)', () => {
 		expect(detectBeforeAfterLabels(fullBody)).toEqual({ hasBefore: true, hasAfter: true });
 		// VR evidence は feature lane では不要 (false でも feature lane は before/after で判定)
 		expect(hasIntegrationVrEvidence(fullBody)).toBe(false);
+	});
+});
+
+describe('ss-render-impossible 宣言 (#4087)', () => {
+	// 「UI は変わるが、その環境では原理的に描画できない」に対する語彙。
+	// 兄弟 gate (ss-blob-sha-uniqueness) には理由必須の宣言が 4 種あるのに本 gate だけ無く、
+	// 「UI 変更なし」と嘘を書くか label の意味を曲げるかしか道が無かった (#4084 / PO 決裁 2026-08-01)。
+	const STORY_REF = 'Storybook の Features/Admin/BackupHealthCard で 4 状態を確認できます';
+
+	it('宣言が無ければ何も起きない (既存 PR に影響しない)', () => {
+		expect(checkRenderImpossibleDeclaration('本文だけ').ok).toBe(false);
+		expect(checkRenderImpossibleDeclaration('本文だけ').violation).toBeUndefined();
+	});
+
+	it('理由 + story 参照が揃えば exempt になる', () => {
+		const body = `<!-- ss-render-impossible: DATA_SOURCE=pglite でのみ描画され demo 環境では出ない -->
+${STORY_REF}`;
+		expect(checkRenderImpossibleDeclaration(body).ok).toBe(true);
+	});
+
+	it('**理由が定型 stub なら受理しない** (理由の非強制を作らない、#3956 教訓)', () => {
+		for (const stub of ['', 'TODO', 'n/a', 'なし']) {
+			const body = `<!-- ss-render-impossible: ${stub} -->
+${STORY_REF}`;
+			const r = checkRenderImpossibleDeclaration(body);
+			expect(r.ok).toBe(false);
+			expect(r.violation?.id).toBe('ss-render-impossible-reason-missing');
+		}
+	});
+
+	it('理由が短すぎれば受理しない', () => {
+		const body = `<!-- ss-render-impossible: 撮れない -->
+${STORY_REF}`;
+		const r = checkRenderImpossibleDeclaration(body);
+		expect(r.ok).toBe(false);
+		expect(r.violation?.id).toBe('ss-render-impossible-reason-missing');
+	});
+
+	it('**story 参照が無ければ宣言だけでは通さない** — 「撮れない」は「見なくてよい」ではない', () => {
+		const body =
+			'<!-- ss-render-impossible: DATA_SOURCE=pglite でのみ描画され demo 環境では出ない -->';
+		const r = checkRenderImpossibleDeclaration(body);
+		expect(r.ok).toBe(false);
+		expect(r.violation?.id).toBe('ss-render-impossible-story-missing');
+	});
+
+	it('story 参照は *.stories.svelte のパス言及でも受理する', () => {
+		const body =
+			'<!-- ss-render-impossible: DATA_SOURCE=pglite でのみ描画され demo 環境では出ない -->\n' +
+			'src/lib/features/admin/components/BackupHealthCard.stories.svelte を追加';
+		expect(checkRenderImpossibleDeclaration(body).ok).toBe(true);
+	});
+
+	it('hasStorybookStoryReference: 無関係な本文では false', () => {
+		expect(hasStorybookStoryReference('ただの説明文です')).toBe(false);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**家族が「バックアップが止まっている」ことに気づける場所を作る。**

2026-07-31 の実害では、バックアップが 18 日止まっていたのに、**気づく手段が `curl /api/health | jq` しかありませんでした**（[#4119 実測](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4119#issuecomment-5137096467)）。想定運用者は家族（非エンジニア）であり、その経路は実質存在しないのと同じです。

## 関連 Issue

Closes #4087

## AC 検証マップ (ADR-0004)

HEAD SHA: `8aea02b1f`

**#4087 の AC 4 項目のうち、本 PR が閉じるのは AC2 だけです。** AC1 / AC3 / AC4 は既に merge 済みで、その根拠を [#4087 のコメント](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4087#issuecomment-5147797554)に実測付きで出しています。

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC2** | バックアップ状態を非エンジニアが見られる場所に出す（ADR-0012 配慮で設定画面内の静的表示） | `[SB1]`〜`[SB4]` + Storybook 4 story | **本 PR で充足**。設定 > サポートにカードを表示。**子供画面には出さない / 常時表示の煽りにしない**。`npx vitest run tests/unit/routes/admin-settings-support-backup-health.test.ts` **4 passed** |
| AC1 | webhook 未設定を可視化（「通知できないので黙る」を無くす） | ローカル pglite で `/api/health` を実測 | **既に充足**（PR #4148）。実出力に `"notificationMissing": true` を確認。`level` と独立に立つ |
| AC3 | 連続失敗の検出（通知手段の有無に関わらずアプリ側で警告） | `[BH2]` / `[BH4]` | **既に充足**（PR #4144 + #4148）。**`consecutiveFailures` だけでは満たしません** — ジョブが起動しなかった場合は失敗回数が増えないため。`lastSuccessAt` の鮮度判定があって初めて成立します |
| AC4 | Pre-PMF で過剰なものは理由を明記して scope 外 | PR #4148 body | **既に充足**（新規通知基盤 / 常時表示バナー / しきい値 env 化の 3 項目を理由付きで scope 外） |

## page 直書きではなく component に切り出しました

**表示条件が `DATA_SOURCE=pglite` かつ backup status file 存在**で、**SS 撮影に使う demo 環境（`DATA_SOURCE=demo`）では原理的に描画されません**。page に直書きすると、**3 状態（ok / warn / critical）の見た目を誰も確認できないまま merge される**ことになります。

component 単体なら Storybook で描画でき、demo 環境に依存しません。story を 4 本置きました。

| story | 状態 |
|---|---|
| `Ok` | 正常時 |
| `WarnNoNotificationChannel` | **取れてはいるが、壊れても届かない**（AC1） |
| `CriticalNeverSucceeded` | **2026-07-31 の実害と同じ入力**（成功 0 件 / 18 晩連続失敗 / 通知経路なし） |
| `CriticalStale` | **ジョブが起動しなかったケース**。失敗 0 回でも成功が古ければ critical（AC3） |

**実害と同じ状態を story に固定したのは、「この画面がどう出るべきだったか」を後から確認できるようにするため**です。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 設定 > サポート（カード 1 枚追加、**NUC セルフホスト時のみ**）。**子供画面は不変。クラウド（dsql）では描画されません。**

- [ ] **並行実装ペア**を同期した
- [x] **設計書同期** (ADR-0001): 判定の根拠・しきい値・push の限界は PR #4148 で `07-API設計書.md` に反映済。本 PR は表示層のみで仕様追加なし
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4153` | **ALL PASS (6 step)** — Step 11b は `ss-render-impossible` 宣言で正当に skip |
| 配線テスト | `npx vitest run tests/unit/routes/admin-settings-support-backup-health.test.ts` | PASS (4 passed) |
| gate 本体 | `npx vitest run tests/unit/scripts/check-pr-screenshot.test.ts` | PASS (**69 passed**、新規 7 件) |

**`[SB2]` が「クラウド（dsql）では返さない」を固定**しています。AWS Backup が担う領域なので、載せると「自分で見るべきもの」を誤らせます。**`[SB3]` は「状態ファイルが読めなくても load が落ちない」** — バックアップ状態が読めないことと相談フォームが使えることは無関係で、ここで throw すると「バックアップ状態が読めないせいで相談できない」逆転が起きます。

- [x] **SOLID / DRY / YAGNI**: 判定は `$lib/domain/backup-health.ts`（純粋関数）が持ち、本 component は描画のみ
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。表示は NUC 内の admin 画面に閉じる
- [x] **A11y・パフォーマンス**: `Alert` primitive（`variant` で success / warning / danger）。`data-testid="backup-health"` + `data-level` で機械検証可能
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

<!-- ss-render-impossible: カードは DATA_SOURCE=pglite かつ backup status file 存在でのみ描画され、SS 撮影に使う demo 環境 (DATA_SOURCE=demo) では原理的に描画されないため -->

**SS を添付していません。** カードは `DATA_SOURCE=pglite` かつ backup status file 存在でのみ描画され、**撮影に使う demo 環境では原理的に描画されません**。

**本 PR で `ss-render-impossible` 宣言を新設し、その 1 例目として使っています**（PO 決裁 2026-08-01）。宣言だけでは通らず、**Storybook story の参照が同じ body 内に必須**です — 「原理的に撮れない」は「見た目を確認しなくてよい」ではないためです。

**代替として Storybook に 4 状態を置きました**（`Features/Admin/BackupHealthCard`）。実画面確認は **#3964（本番実機 1 サイクル）** に合流させます。

**試したうえで打ち切った経緯**（「1 回試して駄目だった」で止めない、という指摘への対応）: `seed-staging.ts` で UUID テナントを作り `AUTH_MODE=local` + `DATA_SOURCE=pglite` の dev server まで立てましたが、`/setup` redirect が解けず撮影に至りませんでした。**判定層が実環境で動くことは確認済み**で、同環境の `/api/health` が `{"level":"critical","reason":"never-succeeded","notificationMissing":true}` を返し、**2026-07-31 の実害と同じ状態を再現**しています。描画できていないのは表示層だけです。時間対効果の観点で PO が打ち切りを決裁しました。

## 本 PR は SS gate の語彙も足しています（PO 決裁 2026-08-01）

`check-pr-screenshot.mjs` に **`ss-render-impossible` 宣言**を追加しました。**新機構の追加ではなく既存 gate の語彙の欠落を埋めるもの**です（#4121 E5 と非干渉）。

兄弟 gate の `ss-blob-sha-uniqueness` には理由必須の宣言が 4 種ある（#4084）のに、**この gate にだけ「原理的に撮れない」を表す語彙が無く**、「UI 変更なし」と虚偽を書くか label の意味を曲げるかしか道がありませんでした。

**濫用防止を 2 段にしています。**

1. **理由必須**。実体判定は `scripts/lib/ci/reason-declaration.mjs`（#4084 の 4 宣言と同一 SSOT）に委譲。空欄 / `TODO` / `n/a` 等の定型 stub は受理しません（#3956 教訓）
2. **Storybook story 参照を同じ body 内に必須**。「原理的に撮れない」は「見た目を確認しなくてよい」ではありません

**宣言だけでは通せないことを test で固定**しています（story 無しは `ss-render-impossible-story-missing` で violation）。**mutation: story 必須判定を無効化すると 1 件 fail** することも確認済みです。

`src/routes/CLAUDE.md` の SS 宣言表に 5 行目として追記し、**どちらの gate の宣言か**（`ss-blob-sha-uniqueness` ではなく `check-pr-screenshot.mjs`）も明記しました。私自身が 2 つの gate を取り違えていたためです。

### あわせて直した自分の欠陥

`+page.server.ts` で `process.env.DATA_SOURCE` を直接参照しており、**CI の `lint-and-test`（ADR-0040 P1 gate）を落としていました**。`getEnv()` 経由に修正済みです。

`pr-quality-gate.yml` の sparse-checkout に `reason-declaration.mjs` の追加も必要でした（`check-workflow-sparse-checkout-closure` が検出。無いと job が `ERR_MODULE_NOT_FOUND` で落ちます）。

### CI の残り赤について（本 PR 起因ではありません）

`unit-test` が赤ですが、**CI blob を解析した結果 `tests/unit/services/ops-service.test.ts:153` の TZ 依存 test**でした。

```
AssertionError: expected +0 to be 2
  at tests/unit/services/ops-service.test.ts:153:43
```

**ローカル（JST）では同 test が 24 passed**、CI（UTC）で落ちます。PO が指摘した「監査が `release/2026-08-01` に append した修正 #1（ops-service `newThisMonth` の TZ 依存）が develop に未反映」と一致します。**develop に back-merge されれば解消する見込み**です。

## レビュー依頼事項・破壊的変更

### 「失敗が届く」の push 側は本 PR でも未着地です

`DISCORD_ALERT_WEBHOOK_URL` は**まだ配っていません**。本 PR で成立するのは **pull 側**（設定画面 + `/api/health`）で、**push 側（Discord alert）は webhook 配布が要ります**。

webhook を配るタイミングは **#3964（実機 1 サイクル）と合わせるのが自然**だと考えていますが、先に配る判断もありえます。#4144 の PO 決裁 Q2 で「#4087 で 2 本立てにする」方針は承認済みです。

### guard trip 混在（#4144 由来、未解消）

`PgliteBackupRotationGuardError`（**取得自体は成功**しローテーションだけ止めた場合）も通常の失敗と同じ `catch` で `consecutiveFailures` を増やすため、**guard trip が 2 回続くと「取得は成功しているのに critical」**と表示されます。

QM 申し送りの「`reason` を家族向け UI に出すときは誤解を招く表示にならないか確認せよ」に対する回答です: **本カードは `reason` を直接表示していません**（`level` に応じた固定文言 + 最終成功日時 + 連続失敗回数 + 通知経路の有無のみ）。したがって `reason` 由来の誤解は生じませんが、**「取得は成功しているのに critical」という判定自体は残ります**。これは #4144 側の課題で、本 PR の scope 外です。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC2 を本 PR で充足。AC1 / AC3 / AC4 は既存 merge 済で、根拠を AC 検証マップに明記）
- [x] UI 変更時: **SS はペアが原理的に取れないため `ss-pair-none` で宣言**。3 状態は Storybook で確認可能。実画面確認は #3964 に合流
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
