### PR TITLE
docs(sessions): Agent Teams の取り込み方針を SSOT 化する（ロール別 team / heavy lock の制約）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,9 @@ CI 自動拒否される違反は該当 ADR / script に集約: hex 直書き / 
 - `dev-session.md` — Dev（実装・CI/CD・設計書同期、@docs/sessions/dev-session.md）
 - `qa-session.md` — QA（PR レビュー・品質ゲート、@docs/sessions/qa-session.md）
 
-タスク固有: `.claude/skills/` (11 Skills、オンデマンド発火)
+タスク固有: `.claude/skills/` (オンデマンド発火)
+
+**Agent Teams**: 各ロールが**自分のクローン内で**組む (PO チームの team / Dev チームの team、と別々に構築する)。**ロールを跨いだ team は組まない** — teammate は lead の作業ディレクトリ・gh 認証で動くため ADR-0022 の作成者 ≠ 承認者が空洞化する。**重い検証の並列化には使えない** (`heavy` lock はマシン全体で 1 本)。使ってよい / いけない場面の SSOT → @docs/sessions/agent-teams.md
 
 ## Further Context
 

--- a/docs/sessions/agent-teams.md
+++ b/docs/sessions/agent-teams.md
@@ -1,0 +1,164 @@
+# Agent Teams — 1 ロール内での並列化 SSOT
+
+> **このファイルの位置づけ**: Claude Code の Agent Teams（lead + teammate、共有タスクリスト、mailbox）を本リポジトリでどう使うかの SSOT。**使ってよい場面・使ってはいけない場面・運用規約**を定める。
+>
+> **関連**: [agent-concurrency.md](agent-concurrency.md)（heavy lock）/ [label-mailbox.md](label-mailbox.md)（ロール間の受け渡し）/ [po-session.md](po-session.md) / [dev-session.md](dev-session.md) / [qa-session.md](qa-session.md) / [audit-team.md](audit-team.md) ｜ **関連 ADR**: ADR-0022（作成者 ≠ 承認者）/ ADR-0056（役割分離）/ ADR-0010（Pre-PMF）
+>
+> **公式ドキュメント**: https://code.claude.com/docs/en/agent-teams（experimental。仕様は変わりうるので、判断に迷ったら原典を確認する）
+
+---
+
+## §1 設計背景
+
+本リポジトリの並列化にはこれまで 2 つの手段しかなかった。
+
+| 手段 | 特徴 | 限界 |
+|---|---|---|
+| **subagent**（`Agent` tool） | 呼び出し元にだけ結果を返す | **agent 同士が会話できない**。互いの発見を突き合わせられない |
+| **別クローン・別セッション**（PO / Dev / QM / 監査） | 完全独立 | **セッション間の直接通信手段が無い**。GitHub label を mailbox にして凌いでいる（[label-mailbox.md](label-mailbox.md)） |
+
+**Agent Teams は 3 つ目の手段**で、両者の中間にある。teammate は独立した Claude Code インスタンス（別 context window）でありながら、**共有タスクリストと mailbox で互いに直接メッセージを送れる**。
+
+**この仕組みが無いと困ること**: 「複数の仮説を並列に検証し、互いに反証させる」形の調査ができない。subagent は結果を返すだけで、A の発見を B が引き取って潰す、という往復が起きない。
+
+---
+
+## §2 設計原則
+
+1. **team はロールごとに独立して構築する**（§3.0）。ロールを跨いで team を組まない（§3.1）。ADR-0022 の「作成者 ≠ 承認者」は gh アカウント分離で担保されており、teammate は lead の環境で動くため分離が消える
+2. **重い検証を並列化する目的で使わない**（§3.2）。`heavy` lock はマシン全体で 1 本なので、teammate を増やしても検証は直列化する
+3. **書き込みを伴う teammate には worktree を与える**（§4.2）。同一ファイルの同時編集は silent overwrite になる
+4. **research / review から始める**。並列実装は調整コストが最も高い
+5. **Pre-PMF のコスト意識**（ADR-0010）。teammate 1 人ごとに context window が増え、トークンは線形に増える。3 人チームで約 3〜4 倍
+
+---
+
+## §3 構成と、使ってはいけない場面
+
+### §3.0 構成 — 各ロールが**自分のクローン内で**組む
+
+前提として、**team はロールごとに独立して構築する**。
+
+```
+ganbari-quest-po     → PO の team    （lead = PO セッション）
+ganbari-quest-dev    → Dev の team   （lead = Dev セッション）
+ganbari-quest-qa     → QM の team    （lead = QM セッション）
+ganbari-quest-audit  → 監査の team   （lead = audit-manager）
+```
+
+**4 つの team は互いを知らない。** 相互の受け渡しは引き続き [label-mailbox.md](label-mailbox.md) の `state:*` label で行う。Agent Teams はロール間通信の代替ではなく、**1 ロール内の並列化手段**である。
+
+### §3.1 ロールを跨ぐ team は組まない（最重要）
+
+**Dev lead が QM teammate を spawn する、のような構成を禁止する。**
+
+| 理由 | 内容 |
+|---|---|
+| **gh アカウントが lead のものになる** | teammate は lead の作業ディレクトリ・環境で動く。Dev クローン（`Takenori-Kusaka`）から spawn した teammate は、QM を名乗っても `ganbariquestsupport-lab` にはならない。**PR を作った本人が approve できる状態**が生まれ、ADR-0022 が空洞化する |
+| **permission が lead 継承** | 公式仕様: teammate は lead の permission 設定で起動する。lead が緩い設定なら teammate も緩い |
+| **one team per session** | 1 セッション = 1 team。4 ロールを 1 つの team に束ねることは仕様上できない |
+| **lead 固定** | 主セッションが恒久的に lead。teammate を lead に昇格できない |
+
+**ロール間の受け渡しは引き続き [label-mailbox.md](label-mailbox.md) の `state:*` label で行う。** Agent Teams はその代替ではない。
+
+### §3.2 重い検証の並列化に使わない
+
+[agent-concurrency.md](agent-concurrency.md) §3.1 のとおり、**`heavy` lock はマシン全体で 1 本**である。
+
+```
+heavy = pre-ready / vitest / playwright test / svelte-check / npm run test|check|e2e
+```
+
+**teammate を 5 人にしても、この 5 種は 1 本ずつ順番に流れる。** 残り 4 人は hook に exit 2 で止められて待つだけで、トークンだけ消費する。
+
+「テストを並列で回して速くする」は本リポジトリでは成立しない。速くなるのは **読む・調べる・書く**（lock 対象外）だけ。
+
+### §3.3 その他
+
+- **逐次依存の作業**: 前の変更に次が依存する連鎖。単一セッションが端から端まで推論する方が安く確実
+- **同一ファイルを触る作業**: worktree を分けても merge 時に衝突する。ファイル所有を分けられないなら team にしない
+- **小さい仕事**: 10 分で終わる作業は team にすると 12 分かかって課金は 4 倍
+
+---
+
+## §4 使ってよい場面と運用規約
+
+### §4.1 向いている 4 類型（公式ガイダンス + 本リポジトリの実例）
+
+| 類型 | 本リポジトリでの例 |
+|---|---|
+| **競合仮説の調査** | CI fail の真因調査。第 19 回 run で監査が 4 件の fail を単独で追ったが、**互いに反証させる**形なら anchoring を避けられた |
+| **多観点レビュー** | `ui-defect-hunt` の 8 観点、`audit-team.md` の 8 領域監査。**観点ごとに teammate を割り当てる**のが素直 |
+| **独立した新規モジュール** | ファイル所有が分かれる実装。E3（`scripts/backup-*`）と E4（`src/lib/domain/`）のように領域が重ならないもの |
+| **層を跨ぐ変更** | frontend / backend / test をそれぞれ別 teammate が持つ |
+
+### §4.2 運用規約
+
+**① 書き込む teammate には worktree を与える**
+
+`.claude/worktrees/<name>/` に分離する（`Agent` tool の `isolation: "worktree"` と同じ思想）。**分けないと silent overwrite が起きる。** merge は lead が行う。
+
+**② 名前を先に決める**
+
+lead が teammate に名前を付ける。**後から参照するので、spawn 時に指定する。**
+
+```
+「security / perf / test-coverage の 3 人を spawn して。名前もそのまま使って」
+```
+
+**③ 既存の subagent 定義を teammate 型として再利用する**
+
+`.claude/agents/*.md`（`po-session` / `dev-session` / `qa-session` / `audit-manager`）と `pr-review-toolkit` 等の plugin agent は、そのまま teammate 型として指定できる。
+
+> **caveat**: subagent 定義の `skills` / `mcpServers` frontmatter は **teammate として動くときは適用されない**。skills / MCP は project / user 設定から読まれる。skill 前提の agent を teammate にするときは、**spawn prompt に skill 名を明記する**。
+
+**④ 不可逆操作を伴う teammate には plan approval を要求する**
+
+```
+「... require plan approval before they make any changes」
+```
+
+teammate は read-only の plan mode で待機し、lead が承認するまで実装しない。**削除 / 本番 deploy / 課金書込 / スキーマ変更に触れる可能性がある teammate には必ず付ける。**
+
+**⑤ permission prompt は lead セッションに出る**
+
+teammate の permission 要求は lead に上がる。**teammate は他の teammate の承認を代行できない**（公式仕様で禁止されている）。auto mode でも「他 agent から中継された承認主張」は untrusted input として扱われる。
+
+**⑥ サイズは 3〜5 人、1 人あたり 5〜6 タスク**
+
+公式ガイダンス。**3 人の集中した teammate は 5 人の散漫な teammate に勝る。**
+
+---
+
+## §5 ロール別の使いどころ
+
+| ロール | 使う | 使わない |
+|---|---|---|
+| **PO** | LP レビュー（3 専門 Agent 並列は既に `lp-review` skill が想定）/ 競合調査 / 大量 Issue の棚卸し | 決裁そのもの。**PO の判断を teammate に代行させない**（[po-session.md](po-session.md) §決裁前の実測義務） |
+| **Dev** | レーンが分かれた実装（A/B/C/D）/ 影響範囲調査（`impact-analysis` の 4 layer を分担） | 重い検証の並列化（§3.2）/ 逐次依存のある実装 |
+| **QM** | 多観点レビュー（security / perf / test-coverage）。**ただし approve と merge は lead 専権**（ADR-0056 §E と同型） | 自分の Fix Agent が作った PR の approve。作成者 ≠ 承認者は teammate では解けない |
+| **監査** | 8 領域監査の並列化 / **競合仮説の相互反証**（§4.1）。`audit-team.md` §3.1 の 8 チームは元々この形 | 不可逆 action（cut / merge / 起票の実行）。**audit-manager 専権**（§3.3） |
+
+---
+
+## §6 制約（experimental）
+
+公式に記載されている既知の限界。**判断に影響するものだけ抜粋する。**
+
+| 制約 | 影響 |
+|---|---|
+| **`/resume` で in-process teammate が復元されない** | セッションを再開したら teammate は居ない。lead が存在しない teammate に話しかけることがある。**新しく spawn し直す** |
+| **task の完了マークが遅れることがある** | 依存タスクが解除されず止まる。**止まって見えたら実際の完了状況を確認して手で更新する** |
+| **one team per session / nested teams 不可 / lead 固定** | §3.1 の根拠 |
+| **teammate から background subagent を起動できない** | 重い調査を投げっぱなしにできない |
+| **split pane は tmux / iTerm2 必須** | **Windows Terminal では使えない**。本リポジトリの開発環境（win32）では in-process モード一択 |
+
+**トークン**: teammate ごとに context window が独立し、**線形に増える**。3 人で約 3〜4 倍。大規模チームでは 15 倍に達しうる（公式）。Pre-PMF では **research / review / 新規実装に限って使う**（ADR-0010）。
+
+---
+
+## §7 導入状況
+
+- `~/.claude/settings.json` に `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: "1"` を設定済（2026-08-01、オーナー実施）
+- **本リポジトリでの実運用実績はまだ無い。** 最初は §4.1 の「多観点レビュー」または「競合仮説の調査」から始める
+- 実運用で得た知見（向き / 不向き / 事故）は本ファイルに追記する。**§3 の「使ってはいけない場面」を増やす方向の追記を優先する** — 使える場面は試せば分かるが、使ってはいけない場面は事故ってからでは遅い

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -28,6 +28,24 @@ CronCreate(cron: "47 * * * *", recurring: true, prompt: <label-mailbox.md §4「
 - **per-PR の AC は再判定しない**（QM の領域、§3.4 二重判定回避）
 - **CronCreate はセッション内メモリのみ**（Claude 終了で消滅 / 7 日で失効）。次のセッションでもう一度作る
 
+### §0.1 Agent Teams（1 ロール内の並列化）
+
+**SSOT**: [agent-teams.md](agent-teams.md)
+
+**監査は Agent Teams と最も相性がよい。** §3.1 の 8 チーム構成は元々「独立した観点が並列に調べ、結果を集約する」形であり、teammate への割り当てがそのまま対応する。
+
+さらに §3.6 の全件発露原則に対して、**competing hypotheses（互いの仮説を反証させる）**が効く。単一 agent の逐次調査は anchoring に弱く、最初に見つけた説明で止まる。teammate 同士が直接メッセージを送れるため、**A の仮説を B が潰す往復**が起きる。
+
+**ただし不可逆 action は audit-manager 専権のまま**（§3.3）。teammate に許すのは evidence 生成まで。以下は lead が直接実行する。
+
+- release cut / 統合 PR の発行
+- approve / merge
+- Issue 起票の実行
+
+**adversarial reviewer を teammate 型として spawn できる**（`.claude/skills/adversarial-reviewer`）。ただし subagent 定義の `skills` / `mcpServers` frontmatter は teammate では適用されないため、**spawn prompt に必要な skill 名を明記する**。
+
+**重い検証を並列化しても速くならない** — `heavy` lock はマシン全体で 1 本（[agent-concurrency.md](agent-concurrency.md) §3.1）。最重厚レーンの CI は GitHub Actions 側で走るため teammate 数と無関係。
+
 ## §1 設計背景
 
 main = 本番（push 即 deploy、不変条件）であるにもかかわらず、現状の品質ゲートは「Dev 自己レビュー + QM 毎時レビュー（per-PR の機能正しさ判定）」までで止まっている。

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -30,6 +30,18 @@ Dev が拾うのは **`state:needs-dev`**（PO / QM が着手を渡したもの�
 - **cron の結果で主線を中断しない。** 数分で終わるものだけ差し込み、そうでなければ拾ったことだけ報告して主線に戻る
 - **CronCreate はセッション内メモリのみ**（Claude 終了で消滅 / 7 日で失効 / REPL idle 時のみ発火）。次のセッションでもう一度作る
 
+### Agent Teams（1 ロール内の並列化）
+
+**SSOT**: [agent-teams.md](agent-teams.md)
+
+Dev が使ってよいのは **レーンが分かれた実装**（A 課金 / B データ / C ドメイン / D 装置）と **影響範囲調査**（`impact-analysis` の 4 layer を分担）。
+
+**重い検証の並列化には使えない。** [agent-concurrency.md](agent-concurrency.md) §3.1 の `heavy` lock は**マシン全体で 1 本**であり、`pre-ready` / `vitest` / `playwright test` / `svelte-check` / `npm run test|check|e2e` は teammate を増やしても直列化する。残りの teammate は hook に exit 2 で止められて待つだけで、トークンだけ消費する。**速くなるのは読む・調べる・書く（lock 対象外）だけ。**
+
+**書き込む teammate には worktree を与える**（`.claude/worktrees/<name>/`）。分けないと silent overwrite が起きる。merge は lead が行う。
+
+**不可逆操作に触れうる teammate には plan approval を要求する**（削除 / 本番 deploy / 課金書込 / スキーマ変更）。
+
 ## セッション設計原則
 
 ### 並行セッション前提（CRITICAL）

--- a/docs/sessions/po-session.md
+++ b/docs/sessions/po-session.md
@@ -58,6 +58,14 @@
 - `critical`: 顧客 / 運営が明確に損害（不正検知不能 / 監査ログ欠損 / 課金ずれ / データ喪失）。**本番で動かない / 段階実装で途中までの状態も `critical` 扱い**
 - `high`: 顧客価値劣化、運用回避可能 / `medium`: 内部改善 (DX) / `low`: nice-to-have
 
+### Agent Teams（1 ロール内の並列化）
+
+**SSOT**: [agent-teams.md](agent-teams.md)
+
+PO が使ってよいのは **LP レビュー / 競合調査 / 大量 Issue の棚卸し**。**決裁そのものを teammate に代行させない**（§決裁前の実測義務は PO 本人の義務）。
+
+**ロールを跨いだ team を組まない。** teammate は lead の作業ディレクトリ・gh 認証で動くため、Dev クローンから spawn した「QM teammate」は `ganbariquestsupport-lab` にならず、ADR-0022 の作成者 ≠ 承認者が空洞化する。ロール間の受け渡しは引き続き [label-mailbox.md](label-mailbox.md) の `state:*` label で行う。
+
 ### Pre-PMF バイアスチェック（ADR-0010）
 
 `type:feat` 新規起票時: 「サインアップ 20 名/月（V2MOM Q2）なしで到達できるか」自問。可 → `medium` 以下 / 不可 → `high` 以上で根拠明記。新規機能 Issue 連続時は Growth / Marketing / Activation を 1 本挟む。過剰防衛設計（汎用監査ログ / S3+Athena / WAF / IP ブルートフォース検知）追加禁止。

--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -27,6 +27,18 @@ QM が拾うのは **`state:dev-done`**（レビュー待ち）と **`state:read
 - **approve の依頼は label でなく reviewer request**（`gh pr edit <N> --add-reviewer`）。gate 修理 PR を QM の Fix Agent が作った場合、approve は Dev（ADR-0022 作成者 ≠ 承認者、例外運用は label-mailbox.md §3.2）
 - **CronCreate はセッション内メモリのみ**（Claude 終了で消滅 / 7 日で失効）。次のセッションでもう一度作る
 
+### Agent Teams（1 ロール内の並列化）
+
+**SSOT**: [agent-teams.md](agent-teams.md)
+
+QM が使ってよいのは **多観点レビュー**（security / perf / test-coverage を teammate ごとに分ける）。Tier 2 の per-PR Review Agent を teammate 化する形が素直。
+
+**ただし approve と merge は lead 専権**（ADR-0056 §E と同型。subagent が不可逆 action を肩代わりしないのと同じ）。
+
+**自分の Fix Agent が作った PR の approve は teammate では解けない。** teammate は lead の gh 認証で動くため、作成者 ≠ 承認者の分離が消える。gate 修理 PR の approve は引き続き Dev に reviewer request で渡す（[label-mailbox.md](label-mailbox.md) §3.2 例外運用）。
+
+**重い検証を並列化しても速くならない** — `heavy` lock はマシン全体で 1 本（[agent-concurrency.md](agent-concurrency.md) §3.1）。
+
 ## レビュー対象レーン（git flow 二層、#2858）
 
 QM は PR の **base branch でレーンを判別**し、レーンごとに gate 範囲を変える。


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（PO / Dev / QM / 監査の各セッション）

**解決する課題**: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` を有効化したが、**本リポジトリでどう使うかの方針が無い**。方針なしに使うと、ADR-0022（作成者 ≠ 承認者）の空洞化と、効果の無い並列化によるトークン浪費が起きる。

**期待される効果**: 使ってよい場面・使ってはいけない場面を先に決めることで、**事故る前に止める**。特に「ロールを跨いだ team」は 1 回組むと承認体制が崩れる。

## 関連 Issue

<!-- no-issue-close: 本 PR は運用ドキュメントであり、PO 起票基準「E1〜E5 に属し、かつ顧客の金・データ・法務に接続する場合のみ起票」に照らして専用 Issue を立てていない（docs/sessions/po-session.md §Issue 起票基準）-->

- 関連: #4117（E1）— オーナー代行縮小の文脈。並列化の手段が増えることで、1 ロール内の処理能力が上がる

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | Agent Teams の SSOT が存在し、**使ってよい / いけない場面**が分離して書かれている | 目視 | `docs/sessions/agent-teams.md`（164 行）。§3 = 使ってはいけない場面 / §4 = 使ってよい場面と運用規約 |
| AC2 | **構成が「各ロールが自分のクローン内で組む」**と明記されている | 目視 | §3.0。4 クローン × 4 team の対応表。「Agent Teams はロール間通信の代替ではなく 1 ロール内の並列化手段」と明記 |
| AC3 | **ロール跨ぎ禁止**の理由が、公式仕様の裏付けつきで書かれている | 目視 | §3.1。gh 認証 / permission 継承 / one team per session / lead 固定 の 4 点。ADR-0022 空洞化まで接続 |
| AC4 | **`heavy` lock で並列化が効かない**という本リポジトリ固有の制約が書かれている | `grep -n "heavy" docs/sessions/agent-concurrency.md` で lock 対象を確認 | §3.2。`pre-ready` / `vitest` / `playwright test` / `svelte-check` / `npm run test\|check\|e2e` は**マシン全体で 1 本**。teammate を増やしても直列化する |
| AC5 | 公式ドキュメントの caveat を拾っている | 目視 | §4.2③（subagent 定義の `skills` / `mcpServers` frontmatter は teammate では**適用されない**）/ §6（split pane は Windows Terminal 不可、`/resume` で teammate 復元されない） |
| AC6 | 4 ロールすべての設計書に、**そのロール固有の使いどころ**が追記されている | `git show --stat HEAD` | po=+8 / dev=+12 / qa=+12 / audit=+18 行。共通仕様は `agent-teams.md` に集約し重複させていない |
| AC7 | `CLAUDE.md` に短い指針と SSOT への link がある | `grep -n "Agent Teams" CLAUDE.md` | 1 段落。全文を置かなかったのは、判断規約で分量があり全セッションの context を毎回消費するため |
| AC8 | 実行コード・CI・gate の変更がゼロ | `git show --stat HEAD` | `docs/sessions/*` 5 file + `CLAUDE.md` のみ。+217 / -1 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（`docs/sessions/**` + `CLAUDE.md` のみ）

- [ ] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [ ] **設計書同期** (ADR-0001): 影響する `docs/design/` を同 PR で更新（DB→08 / API→07 / UI→06 / インフラ→13 / セキュリティ→14）
- [ ] **LP ↔ アプリ整合** (ADR-0013): LP 記載が実装と一致。Aspirational を LP に新規追加していない
- [ ] **重量 e2e 敏感領域** (`parallel-implementations.md` §SSOT) に触れる場合、該当 spec のローカル実行ログを本文に貼った
- [x] N/A — 上記いずれも影響範囲外

横展開: 4 ロールすべてに同時反映（AC6 で機械確認）。既存 SSOT との関係も明示した。

| 既存 SSOT | 関係 |
|---|---|
| `agent-concurrency.md` | §3.2 の根拠（`heavy` lock はマシン全体で 1 本） |
| `label-mailbox.md` | Agent Teams は**その代替ではない**。ロール間は引き続き `state:*` label |
| ADR-0022 / ADR-0056 | ロール跨ぎ禁止 / 不可逆 action は lead 専権 の根拠 |

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | Ready 化前に実行 |
| 追加・変更テスト | N/A（ドキュメントのみ、実行コード変更なし） | N/A |

- [x] **SOLID / DRY / YAGNI**: 共通仕様は `agent-teams.md` 1 箇所。各ロール設計書にはそのロール固有の使いどころのみ。**新 label / 新 script / 新 gate をゼロで済ませている**
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。むしろ**認証分離が壊れる構成を明示的に禁止**している
- [x] **A11y・パフォーマンス**: N/A（実行コード変更なし）
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

**該当なし（UI 変更を含まない。`docs/sessions/**` + `CLAUDE.md` のみ）**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **§3.2 の判断が正しいか。** 「`heavy` lock がマシン全体で 1 本だから、teammate を増やしても検証は直列化する」は `agent-concurrency.md` §3.1 の記述からの推論です。**実測していません。** 誤っていれば §3.2 は撤回します（ただし撤回しても「並列化の効果が限定的」という結論は変わらないと見ています）
2. **§5 の QM 欄が ADR-0022 と整合しているか。** 「多観点レビューは teammate に分けてよいが、approve と merge は lead 専権」としました。ADR-0056 §E の subagent 扱いと同型のつもりですが、**teammate は subagent より自律度が高い**ので、同じ扱いでよいか
3. **`CLAUDE.md` に置いた分量が適切か。** 1 段落に絞り、詳細は SSOT へ link しました。ロール跨ぎ禁止だけは CLAUDE.md 側にも書いています（**1 回やると承認体制が壊れるため、link を辿らせたくない**）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` は `~/.claude/settings.json`（ユーザーローカル、git 追跡外）の設定でありリポジトリの env ではありません。§7 に設定済みである旨を記録しています。

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
