### PR TITLE
fix(ci): #4155 CodeQL の required 非該当を明文化し「PR 由来 new alert 0 件」を機械条件にする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1366,6 +1366,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # #4155: code-scanning alerts API (CodeQL new-alert 検査) の読み取りに必要。
+      security-events: read
     steps:
       - uses: actions/checkout@v7
 
@@ -1381,6 +1383,19 @@ jobs:
         with:
           name: coverage-summary
           path: coverage/
+
+      # #4155: CodeQL は main ruleset の required_status_checks 非該当 (branch-strategy.md §4)。
+      # その代わりに「統合 PR の ref (refs/pull/<N>/merge) 由来の open alert が baseline を
+      # 超えないこと」を機械条件にする。ここでは結果 JSON を出すだけ (--report-only) で、
+      # hard fail は evidence upload 後の enforcement step が行う (evidence を必ず残すため)。
+      - name: CodeQL new-alert 検査 (結果生成、#4155)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          node scripts/audit/check-codeql-alerts.mjs
+          --pr "${{ github.event.pull_request.number }}"
+          --out integration-evidence/codeql-alerts.json
+          --report-only
 
       - name: Generate integration PR evidence (audit-team.md §3.5 #3/#4)
         env:
@@ -1418,8 +1433,15 @@ jobs:
           fi
 
       - name: Upload integration PR evidence
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: integration-pr-evidence-${{ github.run_id }}
           path: integration-evidence/
           retention-days: 30
+
+      # #4155 AC3: 新規 alert 1 件で fail する enforcement (baseline 超過 / ledger 不正 /
+      # 未スキャン・API 取得失敗 = 検査不能 も fail)。advisory と違い continue-on-error にしない。
+      # evidence upload の後段に置き、fail しても artifact は必ず残るようにする。
+      - name: CodeQL new-alert 検査 (enforcement、#4155)
+        run: node scripts/audit/check-codeql-alerts.mjs --input integration-evidence/codeql-alerts.json

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -136,13 +136,23 @@ ADR-0056 §E が定義する「subagent ≠ QM（役割分離 SSOT）」を、�
 
 audit-manager が統合 PR の merge を判定する際に揃えるべき人間可読エビデンス。E 系 sub-issue でこの形式を自動生成するが、ここでは判定に使う仕様を定義する。
 
-**必須エビデンス（4 点 + NG 0 件条件）**:
+**必須エビデンス（4 点 + NG 0 件条件 + CodeQL new-alert 0 件条件）**:
 
 1. **新機能・修正一覧**: 統合 PR に含まれる develop 上の全変更（feature / fix）を 1 行ずつ列挙（出典 PR 番号 / 変更概要 / 対象領域）。
 2. **対応テストケース一覧**: 各変更に対応する unit / integration / E2E / Storybook テストケースを紐付け（変更 × テストの突合表）。
 3. **テスト結果表**: 上記テストの実行結果（pass / fail / skip）を最重厚レーン（[branch-strategy.md](branch-strategy.md) §4）の全 job 横断で集約。
 4. **自動テストカバレッジ**: カバレッジ値 + ratchet 閾値割れがないこと（ADR-0005 整合）。
 5. **NG 0 件エビデンス**: 8 領域 finding のうち severity 閾値以上（§3.6）の未解決 NG が **0 件**であること。残 NG があれば merge しない。
+6. **CodeQL new-alert 0 件エビデンス（#4155）**: `ref=refs/pull/<N>/merge` の open code-scanning alert が baseline（`scripts/audit/codeql-baseline.json`）を **1 件も超えない**こと。`CodeQL` check は main ruleset の required_status_checks 非該当（[branch-strategy.md](branch-strategy.md) §4「CodeQL の扱い」）だが、**その代替として本条件を NG-0 に含める**。「required でないから赤でも通す」を audit-manager が個別判断することを禁じる（外形が admin bypass と区別できないため、ADR-0022 同型）。
+
+   ```bash
+   # 機械取得（CI では ci.yml integration-evidence job が自動実行し evidence.json / job summary に載せる）
+   node scripts/audit/check-codeql-alerts.mjs --pr <N>
+   gh api "repos/Takenori-Kusaka/ganbari-quest/code-scanning/alerts?state=open&ref=refs/pull/<N>/merge"
+   ```
+
+   - 新規 alert 1 件 / baseline ledger 不正（`src/` 混入・`resolutionTrigger` 欠落）/ **未スキャン・API 取得失敗（= 検査不能）** のいずれでも fail する。「検査できなかった」を pass に倒さない
+   - baseline は「受容の記録」であって免罪符ではない。各 entry の `resolutionTrigger`（例: その file を次に触るとき）が解消条件の SSOT
 
 判定可読仕様（表イメージ）:
 
@@ -151,7 +161,7 @@ audit-manager が統合 PR の merge を判定する際に揃えるべき人間�
 | 例: 機能 A（#NNNN） | admin/activities | unit×N / e2e×M | pass | 閾値内 | 0 |
 | 例: 修正 B（#NNNN） | child-home | unit×N / e2e×M | pass | 閾値内 | 0 |
 
-- 全行が pass + 残 NG 合計 0 + カバレッジ閾値割れなし + adversarial evidence の反対理由が解消済、を満たして初めて audit-manager が merge を実行する。
+- 全行が pass + 残 NG 合計 0 + CodeQL new-alert 0 件 + カバレッジ閾値割れなし + adversarial evidence の反対理由が解消済、を満たして初めて audit-manager が merge を実行する。
 - 1 行でも fail / 残 NG > 0 の場合は merge せず、該当を §3.6 の起票/棄却 flow に送る。
 - **#3 / #4 は CI artifact `integration-pr-evidence-<run_id>` が自動生成する**（`ci.yml` `integration-evidence` job、#2874。テスト結果表 = toJSON(needs) 横断 + カバレッジ gap map + API 設計書突合）。**#1 / #2 は B-1（#2950）領域**で、artifact 内 placeholder 行を audit-manager run が記入する。
 - **finding の SARIF 2.1.0 化 + advisory 評価（#2876）**: 各領域 finding は `scripts/audit/to-sarif.mjs` で SARIF 2.1.0 document に変換され、`integration-evidence` job が「NG-0（severity 3-4 + policy_compliant=false が 0）+ カバレッジ ratchet 達成 + 全 job 緑」を **advisory（非 block）** で評価し evidence.md §5 に出す。advisory は merge を block しない（required_status_checks 未登録、continue-on-error）。**NG の最終確定は本表の audit-manager 人間判定が正本**であり、advisory は CI が機械集約できるスナップショットに限る（EPIC 設計原則 1）。

--- a/docs/sessions/branch-strategy.md
+++ b/docs/sessions/branch-strategy.md
@@ -172,7 +172,7 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 | `app-visual-regression.yml` | integration+hotfix（`branches:[main]`）+ push[main] | — | なし（develop PR で skip、VR warn） | 重量 |
 | `deploy-aws-staging.yml` | integration+hotfix（`branches:[main]` PR、paths filter 撤去で常時発火） | —（required 化は段階導入、[runbooks/staging-gate-required-checks.md](../runbooks/staging-gate-required-checks.md)） | なし（main 向け PR で発火、actor allowlist） | 重量 |
 | `deploy-nuc-staging.yml` | integration+hotfix（`branches:[main]` PR） | — | なし（actor allowlist） | 重量 |
-| `codeql.yml` | integration+hotfix（`branches:[main]` PR）+ push[main]+schedule | — | なし（develop PR で skip、main 経路で coverage 維持、#2931） | 重量 |
+| `codeql.yml` | integration+hotfix（`branches:[main]` PR）+ push[main]+schedule | **— required 非該当（代替条件は下記「CodeQL の扱い」）** | なし（develop PR で skip、main 経路で coverage 維持、#2931） | 重量 |
 | `deploy.yml` | N/A（push[main] / tags / dispatch） | — | — | 本番 deploy |
 | `deploy-nuc.yml` | N/A（push[main] / dispatch） | — | — | 本番 deploy |
 | `pages.yml` | N/A（push[main] / dispatch、LP 配信 + SS 撮影） | — | — | 本番 deploy |
@@ -195,6 +195,22 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 > **required context 数 = 10**（★ 印）。`gh api repos/Takenori-Kusaka/ganbari-quest/rulesets/14673945` の `required_status_checks` 配列（`ci-gate` / `screenshot-check` / `Verify AC map in PR body` / `Measure LP dimensions and lint forbidden terms` / `PR チェックリスト完了確認` / `必須セクションの存在確認` / `関連 Issue 番号の記入` / `変更タイプの選択` / `顧客価値・目的の記入` / `テスト実行結果の記入`）が真の SSOT。本表は「どの workflow がどの context を生むか」のマッピングであり、ruleset 変更時は本表も同期する（#2948 no-go: ruleset と乖離させない）。
 >
 > **A-2〜A-5 で lane-aware 化した required gate**: `pr-template-gate.yml`（6 job、#2944 / #3458）/ `pr-ac-verification-check.yml`（#2945）/ `pr-merge-gate.yml`（#2945）/ `pr-quality-gate.yml`（#2946）の 4 workflow（5+1+1+1 = 8 required context）が `actions/pr-lane` 経由で観点切替する。`dependabot-auto-merge.yml`（#2947）は `BOT_ACTORS` SSOT を参照（required ではないが bot lane 判定を共通化）。`ci.yml`（#2874）は inline 式で `pr-lane.mjs` rule 2 と同一判定を行い重量 job を統合 PR で保証発火する。
+
+#### CodeQL の扱い — required 非該当と、その代わりに満たすべき条件（#4155）
+
+`CodeQL` は main ruleset の `required_status_checks` に**含まれない**（上表 ★ 印なし）。ただしこれは「赤でも人の判断で通してよい」という意味では**ない**。required 非該当を維持する代わりに、以下を**機械条件**として課す。
+
+| 項目 | 内容 |
+|---|---|
+| **required 非該当の理由** | 既知 alert が解消されるまで全 PR が止まる（`src/` 外の CI 補助 script 由来のものを含む）。Pre-PMF でリリース全停止に見合わない（ADR-0010） |
+| **代わりに満たすべき条件** | 統合 PR の ref（`refs/pull/<N>/merge`）由来の open alert が **baseline を 1 件も超えない**こと |
+| **検査主体** | `scripts/audit/check-codeql-alerts.mjs`（`ci.yml` `integration-evidence` job で実行、baseline 超過 / ledger 不正 / **未スキャン・API 取得失敗（= 検査不能）** のいずれかで exit 1） |
+| **baseline ledger** | `scripts/audit/codeql-baseline.json`（`tests/e2e/a11y-baseline.json` と同型。`(rule, path)` + `count` で pin、全 entry に `resolutionTrigger` 必須 = 期限なし pin 禁止） |
+| **`src/` の禁止** | **`src/` 配下（顧客経路）の alert を baseline に載せることは禁止**。ledger 検証自体が fail する。顧客経路の alert に「受容」の選択肢を作らない（PO 決裁 2026-08-01） |
+| **解消トリガ** | 日付ではなく「**その file を次に触るとき**」。baseline の各 entry の `resolutionTrigger` が SSOT |
+| **NG-0 条件** | 本検査は [audit-team.md](audit-team.md) §3.5 の NG 0 件条件に組み込まれる（統合 PR の merge 判定材料） |
+
+**やってはいけないこと**: 「required でないから赤でも通す」を人が個別に判断すること。判断が必要になったらそれは baseline / ledger 側の更新（= 差分がレビューに残る形）で行う。
 
 ### 実装状況（§8 step 2、#2931 で実施済み / #2874 で重量レーン拡張）
 

--- a/scripts/audit/check-codeql-alerts.mjs
+++ b/scripts/audit/check-codeql-alerts.mjs
@@ -79,15 +79,6 @@ export function alertKey(rule, path) {
 	return `${rule} ${path}`;
 }
 
-/** キーを人間可読に戻す
- * @param {string} key
- * @returns {{ rule: string, path: string }}
- */
-function splitKey(key) {
-	const [rule, path] = key.split(' ');
-	return { rule, path: path ?? '' };
-}
-
 /**
  * GitHub code-scanning alerts API の生レスポンスを正規化する (pure)。
  *
@@ -215,12 +206,16 @@ export function evaluateCodeqlAlerts({
 	const groups = groupAlerts(normalized);
 	const { errors: baselineErrors } = validateBaseline(baseline);
 
-	/** @type {Map<string, { count: number }>} */
+	/** @type {Map<string, { rule: string, path: string, count: number }>} */
 	const baseMap = new Map();
 	if (Array.isArray(baseline?.entries)) {
 		for (const e of baseline.entries) {
 			if (typeof e?.rule === 'string' && typeof e?.path === 'string') {
-				baseMap.set(alertKey(e.rule, e.path), { count: Number.isInteger(e.count) ? e.count : 0 });
+				baseMap.set(alertKey(e.rule, e.path), {
+					rule: e.rule,
+					path: e.path,
+					count: Number.isInteger(e.count) ? e.count : 0,
+				});
 			}
 		}
 	}
@@ -248,8 +243,7 @@ export function evaluateCodeqlAlerts({
 	const staleEntries = [];
 	for (const [key, v] of baseMap) {
 		if (!groups.has(key)) {
-			const { rule, path } = splitKey(key);
-			staleEntries.push({ rule, path, count: v.count });
+			staleEntries.push({ rule: v.rule, path: v.path, count: v.count });
 		}
 	}
 

--- a/scripts/audit/check-codeql-alerts.mjs
+++ b/scripts/audit/check-codeql-alerts.mjs
@@ -1,0 +1,433 @@
+/**
+ * scripts/audit/check-codeql-alerts.mjs (Issue #4155)
+ *
+ * CodeQL の「PR 由来の new alert 0 件」を **機械条件** にする検査。
+ *
+ * ## なぜ必要か
+ *
+ * `CodeQL` は main ruleset の `required_status_checks` に含まれない
+ * ([branch-strategy.md](../../docs/sessions/branch-strategy.md) §4)。そのため従来は
+ * 「required でないから赤でも merge 可」を **統合監査のたびに人が判断**していた。
+ * これは外形が admin bypass と区別できず (ADR-0022 が禁じている形と同型)、実際に
+ * 統合 PR #4152 では監査自身が入れた `js/incomplete-url-substring-sanitization` を
+ * 判断で流しかけた。
+ *
+ * そこで required 非該当は維持しつつ、その代わりに満たすべき条件を
+ * 「**統合 PR の ref (`refs/pull/<N>/merge`) 由来の open alert が baseline を超えない**」
+ * として機械化する。`tests/e2e/a11y-baseline.json` と同型 (既知違反を rule 単位で pin し、
+ * 新規は 1 件で hard-fail、silent cap 禁止)。
+ *
+ * ## 判定規則
+ *
+ * - baseline (`scripts/audit/codeql-baseline.json`) の entry は `(rule, path)` 組 + `count`。
+ *   observed count ≤ baseline count なら受容、超過分は new alert として fail。
+ * - baseline に無い `(rule, path)` 組の alert は 1 件で fail。
+ * - **`src/` 配下を baseline に載せることは禁止**。顧客経路の alert に「受容」の選択肢を
+ *   作らないため、ledger 検証自体が fail する (PO 決裁 2026-08-01)。
+ * - 全 entry に `resolutionTrigger` を必須とする (期限なし pin = silent cap の禁止、AC4)。
+ * - **「検査できなかった」を pass にしない**: 対象 ref の CodeQL analysis が 0 件、または
+ *   API 取得に失敗した場合は fail する (#4084 で `ss-blob-sha-uniqueness` が
+ *   「ペア 0 件 = skip」で黙って消えた事故と同じ class を作らない)。
+ *
+ * pure function (`validateBaseline` / `groupAlerts` / `evaluateCodeqlAlerts` /
+ * `formatCodeqlMarkdown`) は副作用なし。fetch と fs だけが CLI 側にある。
+ * vitest: tests/unit/audit/check-codeql-alerts.test.ts
+ *
+ * ## Usage
+ *
+ *   # 統合 PR の merge ref を検査し結果 JSON を書き出す (exit は --report-only で抑止)
+ *   node scripts/audit/check-codeql-alerts.mjs --pr 4152 --out integration-evidence/codeql-alerts.json --report-only
+ *
+ *   # 書き出し済み結果を読んで enforcement だけ行う (new alert 1 件で exit 1)
+ *   node scripts/audit/check-codeql-alerts.mjs --input integration-evidence/codeql-alerts.json
+ *
+ *   # 任意 ref / オフライン fixture
+ *   node scripts/audit/check-codeql-alerts.mjs --ref refs/heads/main
+ *   node scripts/audit/check-codeql-alerts.mjs --alerts-file tmp/alerts.json --analysis-count 1
+ *
+ * exit: 0 = 条件充足 / 1 = new alert or ledger 不正 or 検査不能
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isMain as isMainModule } from '../lib/is-main.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** baseline ledger の既定パス */
+export const BASELINE_PATH = join(HERE, 'codeql-baseline.json');
+
+/** 既定の対象リポジトリ */
+export const DEFAULT_REPO = 'Takenori-Kusaka/ganbari-quest';
+
+/**
+ * baseline に載せることを禁止するパス接頭辞 (顧客経路 = production コード)。
+ * PO 決裁 2026-08-01:「`src/` 配下の alert を baseline に載せることを禁止。
+ * 顧客経路の alert に『受容』の選択肢を作らない」。
+ */
+export const FORBIDDEN_BASELINE_PATH_PREFIXES = ['src/'];
+
+/**
+ * `(rule, path)` を 1 本のキーに畳む。
+ * @param {string} rule
+ * @param {string} path
+ * @returns {string}
+ */
+export function alertKey(rule, path) {
+	return `${rule} ${path}`;
+}
+
+/** キーを人間可読に戻す
+ * @param {string} key
+ * @returns {{ rule: string, path: string }}
+ */
+function splitKey(key) {
+	const [rule, path] = key.split(' ');
+	return { rule, path: path ?? '' };
+}
+
+/**
+ * GitHub code-scanning alerts API の生レスポンスを正規化する (pure)。
+ *
+ * @param {Array<any>} rawAlerts
+ * @returns {Array<{ number: number|null, rule: string, path: string, securitySeverity: string, state: string }>}
+ */
+export function normalizeAlerts(rawAlerts) {
+	return (rawAlerts ?? []).map((a) => ({
+		number: typeof a?.number === 'number' ? a.number : null,
+		rule: a?.rule?.id ?? a?.rule_id ?? 'unknown-rule',
+		path: a?.most_recent_instance?.location?.path ?? a?.path ?? 'unknown-path',
+		securitySeverity: a?.rule?.security_severity_level ?? a?.rule?.severity ?? 'unknown',
+		state: a?.state ?? 'open',
+	}));
+}
+
+/**
+ * 正規化済み alert を `(rule, path)` 単位で数える (pure)。
+ *
+ * @param {ReturnType<typeof normalizeAlerts>} alerts
+ * @returns {Map<string, { rule: string, path: string, count: number, securitySeverity: string, numbers: number[] }>}
+ */
+export function groupAlerts(alerts) {
+	/** @type {Map<string, { rule: string, path: string, count: number, securitySeverity: string, numbers: number[] }>} */
+	const groups = new Map();
+	for (const a of alerts ?? []) {
+		const key = alertKey(a.rule, a.path);
+		const cur = groups.get(key);
+		if (cur) {
+			cur.count += 1;
+			if (a.number !== null) cur.numbers.push(a.number);
+		} else {
+			groups.set(key, {
+				rule: a.rule,
+				path: a.path,
+				count: 1,
+				securitySeverity: a.securitySeverity,
+				numbers: a.number !== null ? [a.number] : [],
+			});
+		}
+	}
+	return groups;
+}
+
+/**
+ * baseline ledger 自体の妥当性を検証する (pure)。
+ *
+ * - `entries` は配列であること
+ * - 各 entry に `rule` / `path` / 正の整数 `count` / 非空 `resolutionTrigger` があること
+ *   (resolutionTrigger 欠落 = 期限なし pin = silent cap のため不可、AC4)
+ * - `src/` 配下の path を載せていないこと (顧客経路に受容を作らない)
+ * - `(rule, path)` の重複が無いこと
+ *
+ * @param {any} baseline
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateBaseline(baseline) {
+	/** @type {string[]} */
+	const errors = [];
+	const entries = baseline?.entries;
+	if (!Array.isArray(entries)) {
+		return { valid: false, errors: ['baseline.entries が配列ではありません'] };
+	}
+	const seen = new Set();
+	entries.forEach((e, i) => {
+		const label = `entries[${i}]`;
+		if (typeof e?.rule !== 'string' || e.rule === '') errors.push(`${label}: rule が空です`);
+		if (typeof e?.path !== 'string' || e.path === '') errors.push(`${label}: path が空です`);
+		if (!Number.isInteger(e?.count) || e.count < 1) {
+			errors.push(`${label}: count は 1 以上の整数である必要があります`);
+		}
+		if (typeof e?.resolutionTrigger !== 'string' || e.resolutionTrigger.trim().length < 4) {
+			errors.push(
+				`${label} (${e?.rule} @ ${e?.path}): resolutionTrigger が未記入です。期限なしの pin は作れません (#4155 AC4)`,
+			);
+		}
+		if (
+			typeof e?.path === 'string' &&
+			FORBIDDEN_BASELINE_PATH_PREFIXES.some((p) => e.path.startsWith(p))
+		) {
+			errors.push(
+				`${label} (${e.rule} @ ${e.path}): production コード (${FORBIDDEN_BASELINE_PATH_PREFIXES.join(' / ')}) の alert は baseline に載せられません。即時解消してください`,
+			);
+		}
+		if (typeof e?.rule === 'string' && typeof e?.path === 'string') {
+			const key = alertKey(e.rule, e.path);
+			if (seen.has(key)) errors.push(`${label}: (${e.rule}, ${e.path}) が重複登録されています`);
+			seen.add(key);
+		}
+	});
+	return { valid: errors.length === 0, errors };
+}
+
+/**
+ * observed alert 群を baseline と突き合わせて判定する (pure)。
+ *
+ * @param {{
+ *   alerts?: Array<any>,
+ *   baseline?: any,
+ *   analysisCount?: number | null,
+ *   fetchError?: string | null,
+ *   ref?: string,
+ * }} input
+ * @returns {{
+ *   pass: boolean,
+ *   ref: string,
+ *   observedCount: number,
+ *   newAlerts: Array<{ rule: string, path: string, excess: number, securitySeverity: string, numbers: number[] }>,
+ *   acceptedCount: number,
+ *   staleEntries: Array<{ rule: string, path: string, count: number }>,
+ *   baselineErrors: string[],
+ *   analysisCount: number | null,
+ *   fetchError: string | null,
+ *   reasons: string[],
+ * }}
+ */
+export function evaluateCodeqlAlerts({
+	alerts = [],
+	baseline = null,
+	analysisCount = null,
+	fetchError = null,
+	ref = '',
+} = {}) {
+	const normalized = normalizeAlerts(alerts).filter((a) => a.state === 'open');
+	const groups = groupAlerts(normalized);
+	const { errors: baselineErrors } = validateBaseline(baseline);
+
+	/** @type {Map<string, { count: number }>} */
+	const baseMap = new Map();
+	if (Array.isArray(baseline?.entries)) {
+		for (const e of baseline.entries) {
+			if (typeof e?.rule === 'string' && typeof e?.path === 'string') {
+				baseMap.set(alertKey(e.rule, e.path), { count: Number.isInteger(e.count) ? e.count : 0 });
+			}
+		}
+	}
+
+	/** @type {Array<{ rule: string, path: string, excess: number, securitySeverity: string, numbers: number[] }>} */
+	const newAlerts = [];
+	let acceptedCount = 0;
+	for (const [key, g] of groups) {
+		const allowed = baseMap.get(key)?.count ?? 0;
+		const excess = g.count - allowed;
+		acceptedCount += Math.min(g.count, allowed);
+		if (excess > 0) {
+			newAlerts.push({
+				rule: g.rule,
+				path: g.path,
+				excess,
+				securitySeverity: g.securitySeverity,
+				numbers: g.numbers,
+			});
+		}
+	}
+	newAlerts.sort((a, b) => a.rule.localeCompare(b.rule) || a.path.localeCompare(b.path));
+
+	/** @type {Array<{ rule: string, path: string, count: number }>} */
+	const staleEntries = [];
+	for (const [key, v] of baseMap) {
+		if (!groups.has(key)) {
+			const { rule, path } = splitKey(key);
+			staleEntries.push({ rule, path, count: v.count });
+		}
+	}
+
+	/** @type {string[]} */
+	const reasons = [];
+	if (fetchError) reasons.push(`alert 取得に失敗: ${fetchError} (検査不能 = pass にしない)`);
+	if (analysisCount === 0) {
+		reasons.push(
+			`ref ${ref || '(未指定)'} に CodeQL analysis が 0 件 (未スキャン = pass にしない、#4084 同型)`,
+		);
+	}
+	if (baselineErrors.length > 0)
+		reasons.push(`baseline ledger が不正: ${baselineErrors.length} 件`);
+	if (newAlerts.length > 0) {
+		reasons.push(
+			`baseline 超過の alert ${newAlerts.reduce((s, a) => s + a.excess, 0)} 件 (${newAlerts.map((a) => `${a.rule} @ ${a.path}`).join(', ')})`,
+		);
+	}
+
+	const pass =
+		!fetchError && analysisCount !== 0 && baselineErrors.length === 0 && newAlerts.length === 0;
+
+	return {
+		pass,
+		ref,
+		observedCount: normalized.length,
+		newAlerts,
+		acceptedCount,
+		staleEntries,
+		baselineErrors,
+		analysisCount,
+		fetchError,
+		reasons: pass
+			? [`baseline 内 ${acceptedCount} 件のみ / 新規 0 件 (ref ${ref || '(未指定)'})`]
+			: reasons,
+	};
+}
+
+/**
+ * 判定結果を markdown に整形する (pure)。evidence.md §5 / job summary 用。
+ *
+ * @param {ReturnType<typeof evaluateCodeqlAlerts>} result
+ * @returns {string}
+ */
+export function formatCodeqlMarkdown(result) {
+	const lines = [
+		'### CodeQL new-alert 検査 (#4155)',
+		'',
+		`- 判定: ${result.pass ? '✅ PASS' : '❌ FAIL'}`,
+		`- 対象 ref: ${result.ref || '(未指定)'}`,
+		`- open alert: ${result.observedCount} 件 (baseline 受容 ${result.acceptedCount} 件 / baseline 超過 ${result.newAlerts.length} 組)`,
+		`- CodeQL analysis: ${result.analysisCount === null ? '未確認' : `${result.analysisCount} 件`}`,
+		'',
+		'> `CodeQL` は main ruleset の required_status_checks 非該当。その代わり本検査で',
+		'> 「統合 PR 由来の new alert 0 件」を機械条件にする (branch-strategy.md §4 / audit-team.md §3.5)。',
+	];
+	if (result.newAlerts.length > 0) {
+		lines.push(
+			'',
+			'| rule | path | 超過 | severity | alert # |',
+			'|---|---|---|---|---|',
+			...result.newAlerts.map(
+				(a) =>
+					`| \`${a.rule}\` | \`${a.path}\` | ${a.excess} | ${a.securitySeverity} | ${a.numbers.join(', ') || '—'} |`,
+			),
+		);
+	}
+	if (result.staleEntries.length > 0) {
+		lines.push(
+			'',
+			`- 解消済み baseline entry ${result.staleEntries.length} 件 (ledger から削除してください): ${result.staleEntries
+				.map((e) => `\`${e.rule}\` @ \`${e.path}\``)
+				.join(', ')}`,
+		);
+	}
+	if (!result.pass) {
+		lines.push('', '理由:', ...result.reasons.map((r) => `- ${r}`));
+	}
+	return lines.join('\n');
+}
+
+/** 簡易 argv パーサ
+ * @param {string[]} argv
+ * @param {string} name
+ * @param {string|undefined} [fallback]
+ * @returns {string|undefined}
+ */
+function argOf(argv, name, fallback) {
+	const idx = argv.indexOf(name);
+	return (idx !== -1 ? argv[idx + 1] : undefined) ?? fallback;
+}
+
+/**
+ * `gh api` を叩いて対象 ref の open alert + analysis 件数を取得する (副作用あり)。
+ *
+ * @param {{ repo: string, ref: string }} input
+ * @returns {{ alerts: Array<any>, analysisCount: number | null, fetchError: string | null }}
+ */
+export function fetchCodeqlState({ repo, ref }) {
+	/** @param {string} path */
+	const ghJson = (path) =>
+		JSON.parse(
+			execFileSync('gh', ['api', path], { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 }),
+		);
+	const q = `ref=${encodeURIComponent(ref)}`;
+	try {
+		const alerts = ghJson(`repos/${repo}/code-scanning/alerts?state=open&per_page=100&${q}`);
+		let analysisCount = null;
+		try {
+			const analyses = ghJson(`repos/${repo}/code-scanning/analyses?per_page=1&${q}`);
+			analysisCount = Array.isArray(analyses) ? analyses.length : null;
+		} catch (e) {
+			// analyses だけ落ちた場合も「検査できていない」扱いにする (0 件と同義に倒さない)。
+			return {
+				alerts: Array.isArray(alerts) ? alerts : [],
+				analysisCount: null,
+				fetchError: `analyses 取得失敗: ${e instanceof Error ? e.message : String(e)}`,
+			};
+		}
+		return { alerts: Array.isArray(alerts) ? alerts : [], analysisCount, fetchError: null };
+	} catch (e) {
+		return {
+			alerts: [],
+			analysisCount: null,
+			fetchError: e instanceof Error ? e.message : String(e),
+		};
+	}
+}
+
+/** CLI 本体 (副作用: gh api / fs)
+ * @param {string[]} [argv]
+ * @returns {ReturnType<typeof evaluateCodeqlAlerts>}
+ */
+export function runCli(argv = process.argv.slice(2)) {
+	const inputPath = argOf(argv, '--input');
+	if (inputPath) {
+		// 既に書き出した結果を読んで enforcement だけ行う (CI の 2 step 構成用)。
+		const result = JSON.parse(readFileSync(inputPath, 'utf8'));
+		console.log(formatCodeqlMarkdown(result));
+		return result;
+	}
+
+	const repo = argOf(argv, '--repo', process.env.GITHUB_REPOSITORY || DEFAULT_REPO) ?? DEFAULT_REPO;
+	const pr = argOf(argv, '--pr');
+	const ref = argOf(argv, '--ref', pr ? `refs/pull/${pr}/merge` : 'refs/heads/main') ?? '';
+	const baselinePath = argOf(argv, '--baseline', BASELINE_PATH) ?? BASELINE_PATH;
+	const baseline = existsSync(baselinePath)
+		? JSON.parse(readFileSync(baselinePath, 'utf8'))
+		: { entries: null };
+
+	const alertsFile = argOf(argv, '--alerts-file');
+	const state = alertsFile
+		? {
+				alerts: JSON.parse(readFileSync(alertsFile, 'utf8')),
+				analysisCount: Number(argOf(argv, '--analysis-count', '1')),
+				fetchError: null,
+			}
+		: fetchCodeqlState({ repo, ref });
+
+	const result = evaluateCodeqlAlerts({
+		alerts: state.alerts,
+		baseline,
+		analysisCount: state.analysisCount,
+		fetchError: state.fetchError,
+		ref,
+	});
+
+	const outPath = argOf(argv, '--out');
+	if (outPath) {
+		mkdirSync(dirname(outPath), { recursive: true });
+		writeFileSync(outPath, `${JSON.stringify(result, null, 2)}\n`);
+	}
+	console.log(formatCodeqlMarkdown(result));
+	return result;
+}
+
+if (isMainModule(import.meta.url)) {
+	const reportOnly = process.argv.slice(2).includes('--report-only');
+	const result = runCli();
+	process.exit(reportOnly || result.pass ? 0 : 1);
+}

--- a/scripts/audit/codeql-baseline.json
+++ b/scripts/audit/codeql-baseline.json
@@ -1,0 +1,46 @@
+{
+	"_comment": "#4155 CodeQL baseline ledger — tests/e2e/a11y-baseline.json と同型。CodeQL は main ruleset の required_status_checks 非該当 (branch-strategy.md §4) だが、その代わりに『統合 PR (ref=refs/pull/<N>/merge) 由来の new alert 0 件』を機械条件にする。ここに pin した (rule, path) 組の open alert は count まで受容し、count 超過 / 未登録の組は 1 件で fail する (scripts/audit/check-codeql-alerts.mjs)。baseline は『受容の記録』であって『無期限の免罪符』ではないため、全 entry に resolutionTrigger を必須とする (期限なし pin 禁止)。PO 決裁 2026-08-01: 期限は日付でなくトリガー (『その file を次に触るとき』)。",
+	"_forbiddenPathPrefixes": "src/ 配下の alert を baseline に載せることは禁止 (顧客経路の alert に『受容』の選択肢を作らない)。src/ の entry があれば ledger 検証自体が fail する。",
+	"entries": [
+		{
+			"rule": "js/regex-injection",
+			"path": "scripts/check-recent-deploy-deletion.mjs",
+			"count": 1,
+			"securitySeverity": "high",
+			"note": "alert #43 (2026-07-17)。deploy 削除検知 gate の CI 補助 script。顧客リクエスト経路ではない。",
+			"resolutionTrigger": "scripts/check-recent-deploy-deletion.mjs を次に触るとき"
+		},
+		{
+			"rule": "js/incomplete-sanitization",
+			"path": "scripts/audit/close-leak-report.mjs",
+			"count": 1,
+			"securitySeverity": "high",
+			"note": "alert #42 (2026-07-16)。close漏れ report の CI 補助 script。顧客リクエスト経路ではない。",
+			"resolutionTrigger": "scripts/audit/close-leak-report.mjs を次に触るとき"
+		},
+		{
+			"rule": "js/bad-code-sanitization",
+			"path": "tests/unit/scripts/pre-ready-order-and-base.test.ts",
+			"count": 1,
+			"securitySeverity": "medium",
+			"note": "alert #44 (2026-07-30)。test 内の文字列組立。本番 bundle に載らない。",
+			"resolutionTrigger": "tests/unit/scripts/pre-ready-order-and-base.test.ts を次に触るとき"
+		},
+		{
+			"rule": "js/overly-large-range",
+			"path": "scripts/lib/ci/screenshot-helpers.mjs",
+			"count": 1,
+			"securitySeverity": "medium",
+			"note": "alert #41 (2026-07-16)。SS ヘルパの正規表現文字クラス。CI 補助。",
+			"resolutionTrigger": "scripts/lib/ci/screenshot-helpers.mjs を次に触るとき"
+		},
+		{
+			"rule": "actions/missing-workflow-permissions",
+			"path": ".github/workflows/ci.yml",
+			"count": 3,
+			"securitySeverity": "medium",
+			"note": "alert #6 / #7 / #8 (2026-03-27〜28)。job 単位 permissions 未指定 3 箇所。count 超過 (4 件目) は fail する。",
+			"resolutionTrigger": ".github/workflows/ci.yml の該当 job を次に触るとき"
+		}
+	]
+}

--- a/scripts/audit/evaluate-merge-readiness.mjs
+++ b/scripts/audit/evaluate-merge-readiness.mjs
@@ -97,14 +97,20 @@ export function evaluateCoverageRatchet(coverageGapMap, opts = {}) {
  *
  * - ngCount === 0 (severity 3-4 + policy_compliant=false が 0) かつ
  * - coverage ratchet 割れなし (ratchetOk === true。未取得 null は「評価不能」で advisory pass を出さない)
- * - 全 job 緑 (allGreen === true)
+ * - 全 job 緑 (allGreen === true) かつ
+ * - CodeQL new-alert 0 件 (#4155。`codeqlResult` を渡した場合のみ評価。required 非該当の CodeQL に
+ *   代えて課す機械条件 = `ref=refs/pull/<N>/merge` の open alert が baseline を超えないこと)
  * を満たすと advisory pass。1 つでも欠ければ advisory fail (ただし hard fail させない = 呼び出し側 step が continue-on-error)。
+ *
+ * CodeQL の hard enforcement は `scripts/audit/check-codeql-alerts.mjs` の CLI (exit 1) が担う。
+ * 本 advisory は evidence.md §5 に判定を載せるための集約。
  *
  * @param {{
  *   sarifResults?: Array<any>,
  *   findings?: Array<any>,
  *   coverageGapMap?: any,
  *   allGreen?: boolean,
+ *   codeqlResult?: { pass?: boolean, newAlerts?: Array<any>, reasons?: string[] } | null,
  * }} input
  * @returns {{
  *   advisoryPass: boolean,
@@ -113,6 +119,8 @@ export function evaluateCoverageRatchet(coverageGapMap, opts = {}) {
  *   coverageRatchetOk: boolean | null,
  *   coverageBelowThresholdCount: number,
  *   allGreen: boolean,
+ *   codeqlPass: boolean | null,
+ *   codeqlNewAlertCount: number,
  *   reasons: string[],
  * }}
  */
@@ -121,6 +129,7 @@ export function evaluateMergeReadiness({
 	findings = [],
 	coverageGapMap = null,
 	allGreen = false,
+	codeqlResult = null,
 } = {}) {
 	// finding を優先評価 (severity + policy_compliant)、無ければ SARIF results (level)。
 	const items = (findings?.length ?? 0) > 0 ? findings : sarifResults;
@@ -133,7 +142,18 @@ export function evaluateMergeReadiness({
 	if (cov.ratchetOk === null) reasons.push('coverage 未取得 (評価不能 = advisory pass を出さない)');
 	if (allGreen !== true) reasons.push('最重厚レーン全 job が緑でない');
 
-	const advisoryPass = ng.ngCount === 0 && cov.ratchetOk === true && allGreen === true;
+	// #4155: CodeQL は required 非該当のため「PR 由来 new alert 0 件」を代替条件として集約する。
+	const codeqlPass = codeqlResult == null ? null : codeqlResult.pass === true;
+	const codeqlNewAlertCount = Array.isArray(codeqlResult?.newAlerts)
+		? codeqlResult.newAlerts.length
+		: 0;
+	if (codeqlPass === false) {
+		const detail = codeqlResult?.reasons?.length ? `: ${codeqlResult.reasons.join(' / ')}` : '';
+		reasons.push(`CodeQL new-alert 検査が未達 (#4155)${detail}`);
+	}
+
+	const advisoryPass =
+		ng.ngCount === 0 && cov.ratchetOk === true && allGreen === true && codeqlPass !== false;
 
 	return {
 		advisoryPass,
@@ -142,7 +162,11 @@ export function evaluateMergeReadiness({
 		coverageRatchetOk: cov.ratchetOk,
 		coverageBelowThresholdCount: cov.belowThresholdCount,
 		allGreen: allGreen === true,
-		reasons: advisoryPass ? ['NG 0 + coverage ratchet 達成 + 全 job 緑 (advisory pass)'] : reasons,
+		codeqlPass,
+		codeqlNewAlertCount,
+		reasons: advisoryPass
+			? ['NG 0 + coverage ratchet 達成 + 全 job 緑 + CodeQL new-alert 0 (advisory pass)']
+			: reasons,
 	};
 }
 
@@ -162,6 +186,7 @@ export function formatMergeReadinessMarkdown(result) {
 		`- NG 件数 (severity 3-4 + policy_compliant=false): ${result.ngCount}`,
 		`- coverage ratchet: ${result.coverageRatchetOk === null ? '未取得 (評価不能)' : result.coverageRatchetOk ? '閾値内' : `割れ ${result.coverageBelowThresholdCount} 件`}`,
 		`- 最重厚レーン全 job 緑: ${result.allGreen}`,
+		`- CodeQL new-alert 検査 (#4155): ${result.codeqlPass === null ? '未取得 (評価不能)' : result.codeqlPass ? '新規 0 件' : `新規 ${result.codeqlNewAlertCount} 組`}`,
 		'',
 		`> 本評価は **advisory (先行)** であり merge を block しない (required_status_checks 未登録、`,
 		`> continue-on-error)。NG の最終確定は audit-manager run が統合 PR body §3 に記入する人間判定が正本。`,

--- a/scripts/audit/generate-integration-evidence.mjs
+++ b/scripts/audit/generate-integration-evidence.mjs
@@ -31,6 +31,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { isMain as isMainModule } from '../lib/is-main.mjs';
+import { formatCodeqlMarkdown } from './check-codeql-alerts.mjs';
 import {
 	evaluateMergeReadiness,
 	formatMergeReadinessMarkdown,
@@ -66,6 +67,7 @@ export function buildJobResultTable(needs) {
  *   coverageGapMap: ReturnType<typeof buildCoverageGapMap> | null,
  *   apiCoverageMap: ReturnType<typeof matchEndpointCoverage> | null,
  *   auditFindings?: Array<any>,
+ *   codeqlResult?: any,
  *   runId?: string,
  *   prNumber?: string,
  *   generatedAt?: string,
@@ -77,6 +79,7 @@ export function buildEvidence({
 	coverageGapMap,
 	apiCoverageMap,
 	auditFindings = [],
+	codeqlResult = null,
 	runId = '',
 	prNumber = '',
 	generatedAt = new Date().toISOString(),
@@ -98,6 +101,7 @@ export function buildEvidence({
 		sarifResults,
 		coverageGapMap,
 		allGreen,
+		codeqlResult,
 	});
 
 	const json = {
@@ -120,6 +124,9 @@ export function buildEvidence({
 			errorLevelCount,
 		},
 		mergeReadinessAdvisory: mergeReadiness,
+		// #4155: CodeQL は required 非該当。代わりに「PR 由来 new alert 0 件」を機械条件として
+		// NG-0 条件 (audit-team.md §3.5) に組み込む。hard fail は check-codeql-alerts.mjs CLI が担う。
+		codeql: codeqlResult,
 	};
 
 	const md = [
@@ -165,6 +172,10 @@ export function buildEvidence({
 		'',
 		`- finding → SARIF result: ${sarifResults.length} 件 / rule: ${ruleCount} 件 / level=error: ${errorLevelCount} 件`,
 		'- 完全 SARIF document は attestation artifact (`integration-attestation-<run_id>/sarif.json`) に永続化される (in-toto Release predicate と併せ merge commit に紐付け)',
+		'',
+		codeqlResult
+			? formatCodeqlMarkdown(codeqlResult)
+			: '### CodeQL new-alert 検査 (#4155)\n\n- 判定: ❌ 未取得 (検査結果ファイルなし = 評価不能。pass 扱いにしない)',
 		'',
 		formatMergeReadinessMarkdown(mergeReadiness),
 		'',
@@ -222,11 +233,38 @@ export function runCli(argv = process.argv.slice(2)) {
 	const evidenceDir = argOf(argv, '--audit-evidence', 'tmp/audit-evidence');
 	const auditFindings = internalHelpers.readAuditFindings(evidenceDir);
 
+	// #4155: check-codeql-alerts.mjs が先行 step で書き出した判定結果を取り込む。
+	// **ファイル不在は「検査していない」であって pass ではない**ため、明示的に fail 判定を注入する。
+	const codeqlPath = argOf(argv, '--codeql', 'integration-evidence/codeql-alerts.json');
+	/** @type {any} */
+	let codeqlResult = {
+		pass: false,
+		ref: '',
+		observedCount: 0,
+		newAlerts: [],
+		acceptedCount: 0,
+		staleEntries: [],
+		baselineErrors: [],
+		analysisCount: null,
+		fetchError: null,
+		reasons: [`CodeQL 検査結果 (${codeqlPath}) が無い = 未検査。pass 扱いにしない (#4155)`],
+	};
+	if (existsSync(codeqlPath)) {
+		try {
+			codeqlResult = JSON.parse(readFileSync(codeqlPath, 'utf8'));
+		} catch (e) {
+			codeqlResult.reasons = [
+				`CodeQL 検査結果の parse 失敗: ${e instanceof Error ? e.message : e}`,
+			];
+		}
+	}
+
 	const { json, markdown } = buildEvidence({
 		needs,
 		coverageGapMap,
 		apiCoverageMap,
 		auditFindings,
+		codeqlResult,
 		runId: argOf(argv, '--run-id', process.env.GITHUB_RUN_ID || ''),
 		prNumber: argOf(argv, '--pr', ''),
 	});

--- a/tests/unit/audit/check-codeql-alerts.test.ts
+++ b/tests/unit/audit/check-codeql-alerts.test.ts
@@ -115,9 +115,10 @@ describe('normalizeAlerts / groupAlerts', () => {
 	});
 
 	it('欠損フィールドは unknown に倒して落とさない', () => {
-		const [a] = normalizeAlerts([{}]);
-		expect(a.rule).toBe('unknown-rule');
-		expect(a.path).toBe('unknown-path');
+		const normalized = normalizeAlerts([{}]);
+		expect(normalized).toHaveLength(1);
+		expect(normalized[0]?.rule).toBe('unknown-rule');
+		expect(normalized[0]?.path).toBe('unknown-path');
 	});
 });
 

--- a/tests/unit/audit/check-codeql-alerts.test.ts
+++ b/tests/unit/audit/check-codeql-alerts.test.ts
@@ -1,0 +1,282 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+	BASELINE_PATH,
+	evaluateCodeqlAlerts,
+	formatCodeqlMarkdown,
+	groupAlerts,
+	normalizeAlerts,
+	validateBaseline,
+} from '../../../scripts/audit/check-codeql-alerts.mjs';
+
+/** 2026-08-01 実測の open alert 7 件 (Issue #4155 本文の表と一致)。 */
+const OBSERVED_2026_08_01 = [
+	{
+		number: 43,
+		state: 'open',
+		rule: { id: 'js/regex-injection', security_severity_level: 'high' },
+		most_recent_instance: { location: { path: 'scripts/check-recent-deploy-deletion.mjs' } },
+	},
+	{
+		number: 42,
+		state: 'open',
+		rule: { id: 'js/incomplete-sanitization', security_severity_level: 'high' },
+		most_recent_instance: { location: { path: 'scripts/audit/close-leak-report.mjs' } },
+	},
+	{
+		number: 44,
+		state: 'open',
+		rule: { id: 'js/bad-code-sanitization', security_severity_level: 'medium' },
+		most_recent_instance: {
+			location: { path: 'tests/unit/scripts/pre-ready-order-and-base.test.ts' },
+		},
+	},
+	{
+		number: 41,
+		state: 'open',
+		rule: { id: 'js/overly-large-range', security_severity_level: 'medium' },
+		most_recent_instance: { location: { path: 'scripts/lib/ci/screenshot-helpers.mjs' } },
+	},
+	...[6, 7, 8].map((n) => ({
+		number: n,
+		state: 'open',
+		rule: { id: 'actions/missing-workflow-permissions', security_severity_level: 'medium' },
+		most_recent_instance: { location: { path: '.github/workflows/ci.yml' } },
+	})),
+];
+
+const realBaseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+
+describe('validateBaseline (ledger 自体の健全性)', () => {
+	it('リポジトリの codeql-baseline.json は妥当', () => {
+		const r = validateBaseline(realBaseline);
+		expect(r.errors).toEqual([]);
+		expect(r.valid).toBe(true);
+	});
+
+	it('全 entry に resolutionTrigger がある (期限なし pin を作らない、AC4)', () => {
+		for (const e of realBaseline.entries) {
+			expect(typeof e.resolutionTrigger).toBe('string');
+			expect(e.resolutionTrigger.trim().length).toBeGreaterThan(3);
+		}
+	});
+
+	it('resolutionTrigger 欠落は ledger 不正として検出する', () => {
+		const r = validateBaseline({
+			entries: [{ rule: 'js/foo', path: 'scripts/a.mjs', count: 1 }],
+		});
+		expect(r.valid).toBe(false);
+		expect(r.errors.join('\n')).toMatch(/resolutionTrigger/);
+	});
+
+	it('src/ 配下 (顧客経路) を baseline に載せることを禁止する', () => {
+		const r = validateBaseline({
+			entries: [
+				{
+					rule: 'js/incomplete-url-substring-sanitization',
+					path: 'src/lib/server/stripe/checkout.ts',
+					count: 1,
+					resolutionTrigger: '触るとき',
+				},
+			],
+		});
+		expect(r.valid).toBe(false);
+		expect(r.errors.join('\n')).toMatch(/production コード/);
+	});
+
+	it('(rule, path) の重複登録を検出する', () => {
+		const entry = {
+			rule: 'js/foo',
+			path: 'scripts/a.mjs',
+			count: 1,
+			resolutionTrigger: '触るとき',
+		};
+		const r = validateBaseline({ entries: [entry, { ...entry }] });
+		expect(r.valid).toBe(false);
+		expect(r.errors.join('\n')).toMatch(/重複/);
+	});
+
+	it('entries が配列でない ledger は不正', () => {
+		expect(validateBaseline({}).valid).toBe(false);
+		expect(validateBaseline(null).valid).toBe(false);
+	});
+});
+
+describe('normalizeAlerts / groupAlerts', () => {
+	it('rule.id + location.path を取り出し (rule, path) 単位で数える', () => {
+		const groups = groupAlerts(normalizeAlerts(OBSERVED_2026_08_01));
+		expect(groups.size).toBe(5);
+		expect(groups.get('actions/missing-workflow-permissions .github/workflows/ci.yml')?.count).toBe(
+			3,
+		);
+		expect(groups.get('js/regex-injection scripts/check-recent-deploy-deletion.mjs')?.count).toBe(
+			1,
+		);
+	});
+
+	it('欠損フィールドは unknown に倒して落とさない', () => {
+		const [a] = normalizeAlerts([{}]);
+		expect(a.rule).toBe('unknown-rule');
+		expect(a.path).toBe('unknown-path');
+	});
+});
+
+describe('evaluateCodeqlAlerts (AC5 — baseline 一致で PASS / 1 件追加で FAIL)', () => {
+	it('起票時点の 7 件は baseline に載っており PASS する', () => {
+		const r = evaluateCodeqlAlerts({
+			alerts: OBSERVED_2026_08_01,
+			baseline: realBaseline,
+			analysisCount: 1,
+			ref: 'refs/pull/4155/merge',
+		});
+		expect(r.newAlerts).toEqual([]);
+		expect(r.observedCount).toBe(7);
+		expect(r.acceptedCount).toBe(7);
+		expect(r.staleEntries).toEqual([]);
+		expect(r.pass).toBe(true);
+	});
+
+	it('未登録 rule の alert を 1 件足すと FAIL する', () => {
+		const r = evaluateCodeqlAlerts({
+			alerts: [
+				...OBSERVED_2026_08_01,
+				{
+					number: 99,
+					state: 'open',
+					rule: {
+						id: 'js/incomplete-url-substring-sanitization',
+						security_severity_level: 'high',
+					},
+					most_recent_instance: { location: { path: 'tests/e2e/checkout.spec.ts' } },
+				},
+			],
+			baseline: realBaseline,
+			analysisCount: 1,
+			ref: 'refs/pull/4155/merge',
+		});
+		expect(r.pass).toBe(false);
+		expect(r.newAlerts).toHaveLength(1);
+		expect(r.newAlerts[0]).toMatchObject({
+			rule: 'js/incomplete-url-substring-sanitization',
+			path: 'tests/e2e/checkout.spec.ts',
+			excess: 1,
+		});
+		expect(formatCodeqlMarkdown(r)).toMatch(/❌ FAIL/);
+	});
+
+	it('baseline 済み (rule, path) でも count 超過 (4 件目) は FAIL する', () => {
+		const r = evaluateCodeqlAlerts({
+			alerts: [
+				...OBSERVED_2026_08_01,
+				{
+					number: 100,
+					state: 'open',
+					rule: { id: 'actions/missing-workflow-permissions', security_severity_level: 'medium' },
+					most_recent_instance: { location: { path: '.github/workflows/ci.yml' } },
+				},
+			],
+			baseline: realBaseline,
+			analysisCount: 1,
+		});
+		expect(r.pass).toBe(false);
+		expect(r.newAlerts[0]).toMatchObject({
+			rule: 'actions/missing-workflow-permissions',
+			excess: 1,
+		});
+		// 受容分 3 件は accepted に数え、超過 1 件だけを new として扱う
+		expect(r.acceptedCount).toBe(7);
+	});
+
+	it('closed / fixed な alert は数えない', () => {
+		const r = evaluateCodeqlAlerts({
+			alerts: [
+				...OBSERVED_2026_08_01,
+				{
+					number: 101,
+					state: 'fixed',
+					rule: { id: 'js/new-rule', security_severity_level: 'high' },
+					most_recent_instance: { location: { path: 'scripts/x.mjs' } },
+				},
+			],
+			baseline: realBaseline,
+			analysisCount: 1,
+		});
+		expect(r.pass).toBe(true);
+	});
+
+	it('解消済み baseline entry は stale として報告する (fail はさせない)', () => {
+		const r = evaluateCodeqlAlerts({
+			alerts: OBSERVED_2026_08_01.filter((a) => a.number !== 41),
+			baseline: realBaseline,
+			analysisCount: 1,
+		});
+		expect(r.pass).toBe(true);
+		expect(r.staleEntries).toEqual([
+			{
+				rule: 'js/overly-large-range',
+				path: 'scripts/lib/ci/screenshot-helpers.mjs',
+				count: 1,
+			},
+		]);
+		expect(formatCodeqlMarkdown(r)).toMatch(/解消済み baseline entry/);
+	});
+});
+
+describe('evaluateCodeqlAlerts (検査できなかった状態を PASS にしない)', () => {
+	it('analysis 0 件 (未スキャン) は alert 0 件でも FAIL する', () => {
+		const r = evaluateCodeqlAlerts({
+			alerts: [],
+			baseline: realBaseline,
+			analysisCount: 0,
+			ref: 'refs/pull/4155/merge',
+		});
+		expect(r.pass).toBe(false);
+		expect(r.reasons.join('\n')).toMatch(/analysis が 0 件/);
+	});
+
+	it('fetch 失敗は FAIL する', () => {
+		const r = evaluateCodeqlAlerts({
+			alerts: [],
+			baseline: realBaseline,
+			analysisCount: null,
+			fetchError: 'HTTP 403',
+		});
+		expect(r.pass).toBe(false);
+		expect(r.reasons.join('\n')).toMatch(/取得に失敗/);
+	});
+
+	it('ledger 不正 (src/ 混入) は alert が baseline 内でも FAIL する', () => {
+		const r = evaluateCodeqlAlerts({
+			alerts: [],
+			baseline: {
+				entries: [
+					{
+						rule: 'js/foo',
+						path: 'src/lib/server/x.ts',
+						count: 1,
+						resolutionTrigger: '触るとき',
+					},
+				],
+			},
+			analysisCount: 1,
+		});
+		expect(r.pass).toBe(false);
+		expect(r.baselineErrors.length).toBeGreaterThan(0);
+	});
+});
+
+describe('formatCodeqlMarkdown', () => {
+	it('PASS 時は required 非該当の代替条件であることを明示する', () => {
+		const md = formatCodeqlMarkdown(
+			evaluateCodeqlAlerts({
+				alerts: OBSERVED_2026_08_01,
+				baseline: realBaseline,
+				analysisCount: 1,
+				ref: 'refs/pull/4155/merge',
+			}),
+		);
+		expect(md).toMatch(/✅ PASS/);
+		expect(md).toMatch(/required_status_checks 非該当/);
+		expect(md).toMatch(/refs\/pull\/4155\/merge/);
+	});
+});

--- a/tests/unit/audit/evaluate-merge-readiness.test.ts
+++ b/tests/unit/audit/evaluate-merge-readiness.test.ts
@@ -83,6 +83,35 @@ describe('evaluateMergeReadiness', () => {
 		expect(r.reasons[0]).toContain('advisory pass');
 	});
 
+	it('CodeQL new-alert 検査 FAIL は advisory FAIL にする (#4155 NG-0 条件)', () => {
+		const r = evaluateMergeReadiness({
+			findings: [],
+			coverageGapMap: { total: { lines: { pct: 85 } }, zeroCoverageFiles: [] },
+			allGreen: true,
+			codeqlResult: {
+				pass: false,
+				newAlerts: [{ rule: 'js/regex-injection', path: 'src/lib/x.ts', excess: 1 }],
+				reasons: ['baseline 超過の alert 1 件'],
+			},
+		});
+		expect(r.advisoryPass).toBe(false);
+		expect(r.codeqlPass).toBe(false);
+		expect(r.codeqlNewAlertCount).toBe(1);
+		expect(r.reasons.join('\n')).toMatch(/CodeQL new-alert 検査が未達/);
+	});
+
+	it('CodeQL new-alert 0 件なら他条件充足時に advisory PASS (#4155)', () => {
+		const r = evaluateMergeReadiness({
+			findings: [],
+			coverageGapMap: { total: { lines: { pct: 85 } }, zeroCoverageFiles: [] },
+			allGreen: true,
+			codeqlResult: { pass: true, newAlerts: [], reasons: [] },
+		});
+		expect(r.advisoryPass).toBe(true);
+		expect(r.codeqlPass).toBe(true);
+		expect(formatMergeReadinessMarkdown(r)).toMatch(/CodeQL new-alert 検査 \(#4155\): 新規 0 件/);
+	});
+
 	it('NG 残存 → advisory FAIL', () => {
 		const r = evaluateMergeReadiness({
 			findings: [{ ruleId: 'sec', severity: 4, policy_compliant: false }],

--- a/tests/unit/audit/generate-integration-evidence.test.ts
+++ b/tests/unit/audit/generate-integration-evidence.test.ts
@@ -44,6 +44,32 @@ describe('buildEvidence', () => {
 		expect(markdown).toContain('| e2e-test | failure |');
 	});
 
+	it('CodeQL 検査結果 (#4155) を §5 に含め json.codeql に載せる', () => {
+		const { json, markdown } = buildEvidence({
+			...baseInput,
+			codeqlResult: {
+				pass: true,
+				ref: 'refs/pull/9999/merge',
+				observedCount: 7,
+				acceptedCount: 7,
+				newAlerts: [],
+				staleEntries: [],
+				baselineErrors: [],
+				analysisCount: 1,
+				fetchError: null,
+				reasons: [],
+			},
+		});
+		expect(json.codeql.pass).toBe(true);
+		expect(markdown).toContain('### CodeQL new-alert 検査 (#4155)');
+		expect(markdown).toContain('refs/pull/9999/merge');
+	});
+
+	it('CodeQL 検査結果が無い場合は「未取得 = 評価不能」と明示し pass 扱いにしない (#4155)', () => {
+		const { markdown } = buildEvidence(baseInput);
+		expect(markdown).toContain('未取得 (検査結果ファイルなし = 評価不能。pass 扱いにしない)');
+	});
+
 	it('fail run でも生成され、failedJobCount に集計される (全件発露の入力)', () => {
 		const { json, markdown } = buildEvidence(baseInput);
 		expect(json.failedJobCount).toBe(1);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（品質ゲートの信頼性）

**解決する課題**: `CodeQL` check は main ruleset の required_status_checks に含まれないため、赤になるたびに「required でないから通してよいか」を audit-manager が**毎回人の判断で**決めていた。この形は外形が admin bypass と区別できない（ADR-0022 が禁じている形と同型）。実際に統合 PR #4152 では、監査自身が入れた `js/incomplete-url-substring-sanitization`（high）を判断で流しかけた。CodeQL は正しく動いていたのに、扱いが**どこにも明文化されていない**ことが欠陥だった。

**期待される効果**: required 非該当は維持したまま（既知 alert の解消待ちで全 PR を止めない、ADR-0010）、「統合 PR の ref 由来の new alert 0 件」を**機械条件**にする。判断が入る余地を消し、緩和が必要なら baseline ledger の差分としてレビューに残る形にする。

## 関連 Issue

<!-- no-issue-close: close 判断は人が行うため本 PR では close しない (Refs のみ) -->
Refs #4155

## AC 検証マップ (ADR-0004)

HEAD `19d580c21`。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `branch-strategy.md` §4 の gate 表に `CodeQL` 行を追加し、required 非該当と**その代わりに満たすべき条件**を明記 | 差分目視 + `node scripts/check-internal-terms.mjs`（workflow-lane-coverage group） | `docs/sessions/branch-strategy.md:174`（対応表の `codeql.yml` 行を「required 非該当（代替条件は下記）」に更新）+ 同 `:190-201` に新設した「#### CodeQL の扱い — required 非該当と、その代わりに満たすべき条件（#4155）」（理由 / 代替条件 / 検査主体 / baseline / `src/` 禁止 / 解消トリガ / NG-0 の 7 行表 + 「人が個別に判断しない」明記）。`check-internal-terms` → `workflow-lane-coverage group: workflow 39 本 / 未記載 0 件` / `✓ PASS — 新規違反 0 件` |
| AC2 | 統合監査の NG-0 条件に「`ref=refs/pull/<N>/merge` の open alert が 0 件」を追加（`audit-team.md` §3.5） | 差分目視 + `npx vitest run tests/unit/audit/` | `docs/sessions/audit-team.md:121`（見出しを「4 点 + NG 0 件条件 + CodeQL new-alert 0 件条件」に）/ `:126-134`（必須エビデンス **6.** を新設、`gh api ...code-scanning/alerts?ref=refs/pull/<N>/merge` を明記、「required でないから通す」の個別判断を禁止）/ `:154`（merge 実行条件に「CodeQL new-alert 0 件」を追加）。コード側の NG-0 反映は `scripts/audit/evaluate-merge-readiness.mjs:143-152`（`codeqlPass === false` で `advisoryPass=false`）、test `tests/unit/audit/evaluate-merge-readiness.test.ts:86-113` → `12 passed (12 files) / 181 tests` |
| AC3 | 既存 alert を baseline ledger（`a11y-baseline.json` と同型、rule id + path で pin）に登録し、**新規 alert 1 件で fail** する検査を統合監査の evidence 生成に組み込む | `node scripts/audit/check-codeql-alerts.mjs --ref refs/heads/main`（実 API）+ ci.yml 差分 + `npx vitest run tests/unit/audit/` | ledger = `scripts/audit/codeql-baseline.json`（`(rule, path)` + `count` で 5 entry = 実 alert 7 件）。検査 = `scripts/audit/check-codeql-alerts.mjs`（baseline 超過 / ledger 不正 / **未スキャン・API 取得失敗**のいずれでも exit 1）。evidence 生成への組込 = `.github/workflows/ci.yml` `integration-evidence` job に 2 step（`--report-only` の結果生成 → artifact upload 後の enforcement）+ `permissions: security-events: read`、および `generate-integration-evidence.mjs:176-178`（evidence.md §5 に判定を出力）/ `:127-129`（`evidence.json.codeql`）。**実 API 実行**: `--ref refs/heads/main` → `✅ PASS / open alert: 7 件 (baseline 受容 7 件 / baseline 超過 0 組) / CodeQL analysis: 1 件` `EXIT=0` |
| AC4 | baseline に載せた既存 7 件の解消**トリガー**を明記（期限なしの pin を作らない） | `npx vitest run tests/unit/audit/check-codeql-alerts.test.ts` + ledger 目視 | PO 決裁（2026-08-01）に従い**日付でなくトリガー**を採用。`codeql-baseline.json` の全 5 entry に `resolutionTrigger`（例: `"scripts/check-recent-deploy-deletion.mjs を次に触るとき"`）を記載し、**`resolutionTrigger` 未記入は ledger 不正として fail**（`check-codeql-alerts.mjs` `validateBaseline`）。**`src/` 配下の alert は baseline に載せること自体を禁止**（`FORBIDDEN_BASELINE_PATH_PREFIXES`、顧客経路に「受容」を作らない）。test: 「全 entry に resolutionTrigger がある (期限なし pin を作らない、AC4)」/「resolutionTrigger 欠落は ledger 不正として検出する」/「src/ 配下 (顧客経路) を baseline に載せることを禁止する」→ `17 passed (17)`。**未達点あり**（本文「レビュー依頼事項」参照: トリガー表の Issue **本文**への記載は PO 領域のため行っていない） |
| AC5 | 起票時点の 7 件が baseline に載り、**意図的に 1 件足した状態で検査が fail する**ことを failing-test-first で示す | ① unit test ② 実 API 応答への mutation 実行 | ① `tests/unit/audit/check-codeql-alerts.test.ts`「起票時点の 7 件は baseline に載っており PASS する」（`observedCount=7 / acceptedCount=7 / newAlerts=[] / pass=true`）+「未登録 rule の alert を 1 件足すと FAIL する」+「baseline 済み (rule, path) でも count 超過 (4 件目) は FAIL する」→ `17 passed (17)`。ledger 追加前に検査を書き pass/fail の分岐を先に固定（failing-test-first）。② **実 API 応答に対する mutation**: `gh api ...code-scanning/alerts?ref=refs/heads/main` の生応答 7 件 → `EXIT=0`（PASS）／同応答に `js/incomplete-url-substring-sanitization @ tests/e2e/checkout-mutation.spec.ts` を 1 件注入した 8 件 → `❌ FAIL / baseline 超過 1 組` `EXIT=1`。CI の 2 step 分割も検証（`--report-only` → `EXIT=0` / `--input <result.json>` → `EXIT=1`） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客向け画面の変更なし。影響は統合 PR（`release/*` → `main`）の CI `integration-evidence` job と、統合監査の merge 判定手順のみ。

- [ ] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [x] **設計書同期** (ADR-0001): 影響する SSOT を同 PR で更新（`docs/sessions/branch-strategy.md` §4 gate 表 + CodeQL 節 / `docs/sessions/audit-team.md` §3.5 NG-0 条件）。DB / API / UI / インフラ設計書は変更対象外
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A（LP 記載の変更なし）
- [x] **重量 e2e 敏感領域** (`parallel-implementations.md` §SSOT) に触れる場合、該当 spec のローカル実行ログを本文に貼った → N/A（`ci.yml` の変更は `integration-evidence` job のみで、e2e / 重量 job の定義に触れていない）
- [ ] N/A — 上記いずれも影響範囲外

**判定ロジックの置き場所（#4158 整合）**: 判定は `scripts/audit/check-codeql-alerts.mjs` の export 関数（`validateBaseline` / `groupAlerts` / `evaluateCodeqlAlerts`）に置き、workflow からは CLI 呼び出しのみ。YAML inline script に判定を書いていない。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | PASS |
| 追加・変更テスト | `npx vitest run tests/unit/audit/` | PASS（12 files / 181 tests、うち新規 `check-codeql-alerts.test.ts` 17 + 既存 2 file に 4 追加） |
| 実 API 疎通 + mutation | `node scripts/audit/check-codeql-alerts.mjs --ref refs/heads/main` / 同応答 +1 件 | PASS（exit 0）/ FAIL（exit 1）を両方確認 |
| 静的検査 | `npx biome check .` / `npm run cspell` / `node scripts/check-internal-terms.mjs` / `node scripts/check-workflow-sparse-checkout-closure.mjs` / `node scripts/check-doc-code-references.mjs` / `node scripts/check-repo-scan-test-declaration.mjs` | 全 PASS |

- [x] **SOLID / DRY / YAGNI**: 判定は pure function に分離し CLI と fs / API を分ける（既存 `evaluate-merge-readiness.mjs` と同型）。baseline 機構は `a11y-baseline.json` の既存パターン再利用で新概念を持ち込まない（#4121 E5 整合）。新規依存 0
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。`GH_TOKEN` は `secrets.GITHUB_TOKEN` を job に渡すのみ。job permissions は `contents: read` + `security-events: read`（最小）
- [x] **A11y・パフォーマンス**: N/A（UI 変更なし）。CI 追加コストは `gh api` 2 回のみ
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:critical` ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（顧客向け UI の変更を含まない。変更対象は CI workflow / 検査 script / baseline ledger / 運用 SSOT ドキュメントのみ）**

<!-- ss-pair-none: UI 差分ゼロの CI gate 追加のため修正前後の画面が存在しない -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる

**レビュー依頼事項**:

1. **AC4 の「Issue 本文に明記」は未達**。AC4 の原文は「解消期限を **Issue 本文に**明記」だが、Issue 本文は PO の記述領域のため Dev から編集していない。本 PR では代わりに (a) baseline ledger 各 entry の `resolutionTrigger` フィールド（機械検証付き）、(b) `branch-strategy.md` §4 の「解消トリガ」行、の 2 箇所に記載した。Issue 本文への転記が必要なら PO 側で実施いただきたい。
2. **`integration-evidence` job は `ci-gate` の needs に入っていない**（#2874 の設計「gate ではない」を維持）。したがって本 enforcement step が赤でも `ci-gate` は緑になりうる。本 PR の位置づけは「audit-manager が NG-0 判定で参照する機械証跡を、人の判断ではなく exit code で確定させる」であり、`ci-gate` needs への追加 = 実質 required 化は AC の範囲外（案 A に接近するため）。required 化まで進めるべきかは PO / 監査判断。
3. **stale entry（解消済みの baseline entry）は fail させず報告のみ**にした。ref を絞ったクエリで一部 analysis が欠けた場合に誤検知するため。ledger 掃除は、その file を次に触るとき（= `resolutionTrigger` 発火時）に報告行を見て行う設計。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`GH_TOKEN` は既存の `secrets.GITHUB_TOKEN` を step に渡すのみ）

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない。ただし AC4 の「Issue 本文への記載」のみ上記「レビュー依頼事項 1」の通り Dev 領域外として未実施）
- [x] UI 変更時: N/A
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

