### PR TITLE
fix(test): #4161 アップグレード CTA の分岐を宣言して検証する + 決済未設定の dead-end を塞ぐ

### DIFF
--- a/scripts/capture-specs/flows/subscription-billing-unavailable-4161.mjs
+++ b/scripts/capture-specs/flows/subscription-billing-unavailable-4161.mjs
@@ -1,0 +1,71 @@
+/**
+ * scripts/capture-specs/flows/subscription-billing-unavailable-4161.mjs
+ *
+ * Issue #4161: 決済が有効でない配備 (STRIPE_SECRET_KEY 未設定 = セルフホスト / 設定不備) で
+ * アップグレード CTA を押したときの before / after SS。
+ *
+ * 撮影する 1 コマ (どちらの build でも同じ操作列):
+ *   「プレミアムへ」CTA を押した直後の /admin/subscription
+ *     - 修正前 (origin/develop, SS_PHASE=before-*): `startCheckout()` に入り 503 で失敗する。
+ *       画面内には何も出ない (checkout の Alert は `{#if stripeEnabled}` の内側にあり
+ *       決済未設定では描画されない) ため、消える Toast だけが手掛かりになる
+ *     - 修正後 (本 PR, SS_PHASE=after-*): 押した時点で理由を in-page banner で提示して打ち切る
+ *
+ * 使用例 (認証が要るので cognito server + standard の storageState を使う):
+ *   SS_PHASE=after BASE_URL=http://localhost:5174 \
+ *     node scripts/capture.mjs \
+ *     --flow subscription-billing-unavailable-4161 \
+ *     --url /admin/subscription \
+ *     --actions scripts/capture-specs/flows/subscription-billing-unavailable-4161.mjs \
+ *     --storage-state playwright/.auth/standard.json \
+ *     --server-mode cognito --presets mobile,desktop --pr 4161
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+const PHASE = process.env.SS_PHASE || 'after';
+// 同一 PR 内で desktop / mobile を撮り分けるときのファイル名衝突を避ける (push 先は flat)
+const VARIANT = process.env.SS_VARIANT ? `-${process.env.SS_VARIANT}` : '';
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	const rafSettle = () =>
+		page.evaluate(
+			() =>
+				new Promise((resolve) =>
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+				),
+		);
+
+	await page.goto(`${BASE_URL}/admin/subscription`, { waitUntil: 'domcontentloaded' });
+
+	// hydration gate: CTA は SSR でも <button> として描画されるため、hydration 前に押すと
+	// onclick 未 attach で空振りし「押しても何も起きない画面」を撮ってしまう。
+	// 確認ダイアログ content は Ark UI <Portal> 配下で client mount 後にのみ DOM に現れる
+	// (前後どちらの build にも存在する) ので、それを gate に使う。
+	await page.getByTestId('portal-confirm-button').waitFor({ state: 'attached', timeout: 60_000 });
+
+	const cta = page.getByTestId('plan-status-family-cta');
+	await cta.waitFor({ state: 'visible', timeout: 30_000 });
+	await cta.click();
+
+	const banner = page.getByTestId('billing-unavailable-alert');
+	if (PHASE.startsWith('after')) {
+		// 修正後 build で banner が出ないまま撮ると「直っていない画面」を後 SS として貼ってしまう。
+		// 握りつぶさず throw して撮影自体を失敗させる (SS 捏造の構造的防止)。
+		await banner.waitFor({ state: 'visible', timeout: 15_000 });
+	} else {
+		// 修正前 build: banner は存在しない。checkout の失敗 Toast (role="alert") が出るまで待つ。
+		// Toast は自動で消えるため、出た直後に撮る。
+		await page
+			.getByRole('alert')
+			.first()
+			.waitFor({ state: 'visible', timeout: 15_000 })
+			.catch(() => {});
+	}
+
+	await rafSettle();
+	await capture(`${PHASE}-subscription-upgrade-cta${VARIANT}`);
+};

--- a/scripts/capture.mjs
+++ b/scripts/capture.mjs
@@ -624,7 +624,13 @@ async function runFlowMode() {
 		if (result.compositePath) {
 			console.log(`合成 WebP: ${result.compositePath}`);
 			console.log(`Markdown: ${path.join(outputDir, `${values.flow}-flow.md`)}`);
-			return { screenshots: [result.compositePath], domFiles: [] };
+			// #4161: 合成シートだけでなく各ステップの PNG と DOM も push 対象にする。
+			// SS embed gate は SS に対応する `.dom.html` を要求し、Before/After 偽装 gate は
+			// ステップ単位のファイル名でペアを取るため、両方を screenshots branch に上げる。
+			return {
+				screenshots: [result.compositePath, ...result.stepPaths],
+				domFiles: result.domPaths,
+			};
 		}
 	} catch (err) {
 		console.error(`\nエラー: ${err.message}`);

--- a/scripts/lib/ci/screenshot-helpers.mjs
+++ b/scripts/lib/ci/screenshot-helpers.mjs
@@ -826,7 +826,7 @@ export class FlowRecorder {
 	 * @param {(page: import('playwright').Page, capture: (label: string) => Promise<string>) => Promise<void>} opts.actions
 	 * @param {'mobile'|'tablet'|'desktop'} [opts.preset='desktop']
 	 * @param {import('playwright').BrowserContextOptions['storageState']} [opts.storageState]
-	 * @returns {Promise<{ stepsDir: string; compositePath: string|null; markdownSnippet: string; stepCount: number }>}
+	 * @returns {Promise<{ stepsDir: string; compositePath: string|null; markdownSnippet: string; stepCount: number; stepPaths: string[]; domPaths: string[] }>}
 	 */
 	async record({ url, flowName, actions, preset = 'desktop', storageState }) {
 		const vp = resolvePreset(preset);
@@ -863,7 +863,7 @@ export class FlowRecorder {
 		}
 		await waitForStablePage(page, { skipNetworkIdle: true });
 
-		/** @type {Array<{ label: string; pngPath: string; stepName: string }>} */
+		/** @type {Array<{ label: string; pngPath: string; stepName: string; domPath: string|null }>} */
 		const steps = [];
 		let stepIndex = 0;
 		const maxSteps = this.#maxSteps;
@@ -903,7 +903,23 @@ export class FlowRecorder {
 				throw new Error(`ステップ ${stepIndex} の PNG が ${blankCheck.reason} です: ${pngPath}`);
 			}
 
-			steps.push({ label, pngPath, stepName });
+			// #4161: flow モードでも DOM スナップショットを併記する。
+			// SS embed gate (check-pr-screenshot.mjs 検証 3) は SS に対応する `.dom.html` を要求するが、
+			// flow モードだけ未対応で「操作を伴う UI 変更は SS を貼れない」状態だった。
+			// 単一 URL モード (ScreenshotCapture) と同じく、撮影直後の同一 page から取得する
+			// (SS と DOM が同一プロセス・同一 page である保証、#1747 AC4 / #1766)。
+			const domPath = resolveDomSnapshotPath(pngPath);
+			const domResult = await captureDomSnapshot(page, domPath);
+			if (!domResult.ok) {
+				console.warn(`[WARN] DOM スナップショットの保存に失敗しました: ${domResult.error.message}`);
+			}
+
+			steps.push({
+				label,
+				pngPath,
+				stepName,
+				domPath: domResult.ok ? domPath : null,
+			});
 			return pngPath;
 		};
 
@@ -925,7 +941,14 @@ export class FlowRecorder {
 
 		if (steps.length === 0) {
 			if (actionsError) throw actionsError;
-			return { stepsDir, compositePath: null, markdownSnippet: '', stepCount: 0 };
+			return {
+				stepsDir,
+				compositePath: null,
+				markdownSnippet: '',
+				stepCount: 0,
+				stepPaths: [],
+				domPaths: [],
+			};
 		}
 
 		const compositePath = path.join(this.#outputDir, `${flowName}-flow.webp`);
@@ -939,11 +962,18 @@ export class FlowRecorder {
 		this.#printReport(steps, compositePath);
 
 		if (actionsError) throw actionsError;
-		return { stepsDir, compositePath, markdownSnippet, stepCount: steps.length };
+		return {
+			stepsDir,
+			compositePath,
+			markdownSnippet,
+			stepCount: steps.length,
+			stepPaths: steps.map((s) => s.pngPath),
+			domPaths: steps.map((s) => s.domPath).filter((p) => p !== null),
+		};
 	}
 
 	/**
-	 * @param {Array<{ label: string; pngPath: string; stepName: string }>} steps
+	 * @param {Array<{ label: string; pngPath: string; stepName: string; domPath: string|null }>} steps
 	 * @param {string} outputPath
 	 */
 	async #compositeSteps(steps, outputPath) {

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2712,6 +2712,11 @@ export const SUBSCRIPTION_PAGE_LABELS = {
 	// #3204: checkout 失敗時のユーザ向けフィードバック (silent no-op 撲滅)
 	checkoutFailed: '決済を開始できませんでした。時間をおいて再度お試しください',
 	checkoutFailedToastTitle: '決済を開始できませんでした',
+	// #4161: 決済が未設定の配備 (セルフホスト / 設定不備) でアップグレード操作を押したときの説明。
+	// 確認ダイアログを開いてから失敗させる dead-end を作らず、押した時点で理由を提示する。
+	billingUnavailable:
+		'この環境では決済機能が有効になっていないため、プランの変更手続きに進めません',
+	billingUnavailableToastTitle: 'プランの変更手続きに進めません',
 
 	// スタンダードプラン
 	// #1963: atom (PLAN_TERMS / PRICE_TERMS) を terms.ts から参照

--- a/src/lib/features/admin/components/SaasLicensePanel.svelte
+++ b/src/lib/features/admin/components/SaasLicensePanel.svelte
@@ -113,6 +113,10 @@ let selectedTier = $state<'standard' | 'family'>('standard');
 // #3204: 年額は #2719 で廃止確定 (checkout が yearly を reject)。月額固定にし、年額トグル UI を撤去。
 // #3204: checkout 失敗時のエラーメッセージ (silent no-op 撲滅、Toast と併用の in-page banner)
 let checkoutError = $state<string | null>(null);
+// #4161: 決済未設定 (stripeEnabled=false) の配備でアップグレード操作を押したときの説明文。
+// `checkoutError` の Alert は `{#if stripeEnabled}` ブロック内にしか無く、決済未設定時は
+// 画面に何も出ないため、ブロック外に出す専用 state を分けている。
+let billingUnavailable = $state<string | null>(null);
 
 // #771 Portal を開く前の PIN / 確認フレーズ入力
 const DOWNGRADE_CONFIRM_PHRASE = 'プランを変更します';
@@ -248,7 +252,17 @@ async function startCheckout(planId: string) {
 //   - 契約あり   → Stripe 請求管理ページ (プラン変更)。checkout は ALREADY_SUBSCRIBED (409) で
 //                  弾かれるため、上位プランへの変更は Portal 経由が唯一の正しい経路。
 //                  PIN ゲート + 超過リソース確認も requestPortal() が担う。
+//
+// #4161: 決済が有効でない配備 (セルフホスト / STRIPE_SECRET_KEY 未設定の本番) では、
+//   どちらの経路も最後まで到達できない。プラン管理カードは `{#if stripeEnabled}` で
+//   隠れているのに PlanStatusCard の CTA と確認ダイアログはブロックの外にあるため、
+//   放置すると「PIN を入れて確定した末に失敗する」dead-end (#2544 型) が成立する。
+//   押した時点で理由を提示して打ち切る (silent no-op も作らない、#3204 整合)。
 function handlePlanUpgrade(planId: string) {
+	if (!stripeEnabled) {
+		notifyBillingUnavailable();
+		return;
+	}
 	if (hasSubscription) {
 		void requestPortal();
 		return;
@@ -307,8 +321,25 @@ async function executeDowngradeArchive(selection: {
 	}
 }
 
+// #4161: 決済未設定を伝える単一箇所 (Toast + in-page banner の 2 層、ADR-0062 / #3204 整合)
+function notifyBillingUnavailable() {
+	billingUnavailable = SUBSCRIPTION_PAGE_LABELS.billingUnavailable;
+	showToast(
+		SUBSCRIPTION_PAGE_LABELS.billingUnavailableToastTitle,
+		SUBSCRIPTION_PAGE_LABELS.billingUnavailable,
+		'error',
+	);
+}
+
 // #771 + #738: Portal 遷移前ダイアログ
 async function requestPortal() {
+	// #4161: 確認ダイアログは `{#if stripeEnabled}` の外にあるため、requestPortal() を
+	//   呼ぶ全経路 (PlanStatusCard CTA / 請求管理ボタン / ダウングレード選択後) で塞ぐ。
+	if (!stripeEnabled) {
+		notifyBillingUnavailable();
+		return;
+	}
+	billingUnavailable = null;
 	portalPinValue = '';
 	portalConfirmPhrase = '';
 	portalError = null;
@@ -328,6 +359,13 @@ async function requestPortal() {
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: PIN ゲート + Portal 遷移の集中ロジックのため
 async function openPortal() {
 	portalError = null;
+
+	// #4161: ChurnPreventionModal の「解約する」からは requestPortal() を経由せず直接呼ばれる。
+	//   決済未設定の配備で押しても Portal へは行けないため、ここでも同じ理由を返す。
+	if (!stripeEnabled) {
+		notifyBillingUnavailable();
+		return;
+	}
 
 	if (pinConfigured) {
 		if (
@@ -392,7 +430,15 @@ async function openPortal() {
 	<title>{PAGE_TITLES.license}{APP_LABELS.pageTitleSuffix}</title>
 </svelte:head>
 
-<div class="space-y-6" data-testid="saas-license-panel">
+<!-- #4161: アップグレード CTA の分岐を決めるのはこの 2 変数だけ (handlePlanUpgrade)。
+     受け入れテストが「いまどちらの経路を検証しているか」を実際に読んで表明できるよう、
+     DOM に出す (結末を or で並べて、どちらが走ったか誰にも見えない形を作らない)。 -->
+<div
+	class="space-y-6"
+	data-testid="saas-license-panel"
+	data-stripe-enabled={stripeEnabled ? 'true' : 'false'}
+	data-has-subscription={hasSubscription ? 'true' : 'false'}
+>
 	<!-- #3991: 解約 (期末解約) 申請中バナー + 取り消し導線。
 	     「いつまで使えるか」を親が画面で再確認できる唯一の場所であり、
 	     解約完了メールの猶予期限と同じ日付 (Stripe の請求期間終了日) を示す。 -->
@@ -488,6 +534,15 @@ async function openPortal() {
 			onUpgrade={handlePlanUpgrade}
 			upgradeLoading={checkoutLoading || portalLoading}
 		/>
+	{/if}
+
+	<!-- #4161: 決済未設定の配備でアップグレード操作を押したときの理由表示。
+	     `checkoutError` の Alert は `{#if stripeEnabled}` の内側にあり決済未設定時は描画されないため、
+	     ここ (ブロック外) に置く。確認ダイアログは開かない = dead-end を作らない。 -->
+	{#if billingUnavailable}
+		<div data-testid="billing-unavailable-alert">
+			<Alert variant="warning" message={billingUnavailable} />
+		</div>
 	{/if}
 
 	<!-- 無料トライアル -->

--- a/tests/e2e/upgrade-flow.spec.ts
+++ b/tests/e2e/upgrade-flow.spec.ts
@@ -124,6 +124,14 @@ test.describe('#753 PlanStatusCard → /admin/subscription — standard', () => 
 		// 自己リンクでないこと (旧実装は href="/admin/subscription" の <a> だった)
 		await expect(cta).toHaveJSProperty('tagName', 'BUTTON');
 
+		// hydration gate: この CTA は SSR でも <button> として描画されるため、hydration 前に押すと
+		// onclick が未 attach で空振りし、「押しても何も起きない」ではなく「JS 未起動」を測ってしまう
+		// (Vite dev で実測: 初回 fail → retry で PASS)。確認ダイアログの content は Ark UI の
+		// <Portal> 配下で client mount 後にのみ DOM に現れる (閉じていても hidden で存在する) ので、
+		// その出現を hydration の gate に使う (既存 pattern: admin-challenges-delete-confirm.spec.ts)。
+		// checkout は POST を伴うため click 自体の retry はしない (session を二重に作らない)。
+		await expect(page.getByTestId('portal-confirm-button')).toHaveCount(1, { timeout: 30_000 });
+
 		await cta.click();
 
 		if (stripeEnabled === 'true') {

--- a/tests/e2e/upgrade-flow.spec.ts
+++ b/tests/e2e/upgrade-flow.spec.ts
@@ -38,20 +38,19 @@ test.describe('#753 PlanStatusCard → /admin/subscription — free', () => {
 		await expect(freeCta).toBeVisible();
 	});
 
-	test('free プランの PlanStatusCard に「プレミアムへ」CTA がある', async ({ page }) => {
+	// #4161: 旧テストは「family CTA が 0 件なら annotation を積んで return」で、実装
+	//   (`PlanStatusCard.svelte` の `{:else if planTier === 'free'}` 分岐は free CTA のみ)
+	//   では**常に 0 件 = 毎回 return** し、タイトルが主張する内容を一度も検証していなかった。
+	//   実装の事実 (free の次の一歩は standard) を検証する形に直す。
+	test('free プランの PlanStatusCard はアップグレード CTA を 1 本だけ出す (standard への 1 歩)', async ({
+		page,
+	}) => {
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
 
-		const familyCta = page.getByTestId('plan-status-family-cta');
-		const count = await familyCta.count();
-		if (count === 0) {
-			test.info().annotations.push({
-				type: 'skip-reason',
-				description: 'family CTA が PlanStatusCard に存在しないレイアウトのためスキップ',
-			});
-			return;
-		}
-		await expect(familyCta).toBeVisible({ timeout: 10_000 });
-		await expect(familyCta).toContainText(PLAN_TERMS.premium);
+		const freeCta = page.getByTestId('plan-status-free-cta');
+		await expect(freeCta).toBeVisible({ timeout: 10_000 });
+		// free から premium への直行 CTA は出さない (選択肢を 1 本に絞る、Hick's Law)
+		await expect(page.getByTestId('plan-status-family-cta')).toHaveCount(0);
 	});
 });
 
@@ -69,31 +68,55 @@ test.describe('#753 PlanStatusCard → /admin/subscription — standard', () => 
 		const card = page.getByTestId('plan-status-card');
 		await expect(card).toBeVisible({ timeout: 30_000 });
 		await expect(card).toHaveAttribute('data-plan-tier', 'standard');
+		// standard には上位プランへの CTA が出る (テスト名が主張していた当のもの)
+		await expect(page.getByTestId('plan-status-family-cta')).toBeVisible();
 
-		// Portal ボタンまたは plan card 全体非表示 (stripeEnabled=false) のいずれか
-		// #2330 で「決済機能は現在準備中です」placeholder が削除されたため、Portal ボタン visible OR 非表示で skip 検出
+		// #4161: 旧実装は「請求管理ボタンが見えなければ annotation を積んで return」だった。
+		//   このレーンでは契約なしが常なので**毎回 return し、何も検証していなかった**。
+		//   請求管理ボタンの有無を決めるのは契約状態なので、それを読んで対応する側だけを検証する。
+		const hasSubscription = await page
+			.getByTestId('saas-license-panel')
+			.getAttribute('data-has-subscription');
+		expect(['true', 'false']).toContain(hasSubscription);
 		const portalBtn = page.getByTestId('open-portal-button');
-		const isPortalVisible = await portalBtn
-			.waitFor({ state: 'visible', timeout: 10_000 })
-			.then(() => true)
-			.catch(() => false);
-
-		if (!isPortalVisible) {
-			test.info().annotations.push({
-				type: 'skip-reason',
-				description:
-					'Stripe 未設定環境 (stripeEnabled=false で plan card 非表示) のため Portal CTA 不在',
-			});
-			return;
+		if (hasSubscription === 'true') {
+			await expect(portalBtn).toBeVisible();
+		} else {
+			// 契約なしは `{#if hasSubscription}` が false = ボタンごと非描画 (hidden ですらない)
+			await expect(portalBtn).toHaveCount(0);
 		}
 	});
 
 	// #4139: standard → premium のアップグレード CTA が「自ページへのリンク」になっていた
 	// (押しても何も起きない = 収益導線が死ぬ)。CTA が実処理を起動する操作要素であることを固定する。
-	test('standard の「プレミアムへ」CTA が自ページを指さず、押すと何かが起きる (#4139)', async ({
+	//
+	// #4161: 旧実装は「起こりうる結末」を or で並べており、どの環境でどちらの分岐が走るかを
+	//   宣言していなかった。結末を or で並べると、走らなかった側は永久に評価されない死んだ
+	//   部分式として残り、書いた本人にも「どちらが走ったか」が見えない。
+	//   分岐を決める 2 変数 (`stripeEnabled` / `hasSubscription`) を実際に読んで表明し、
+	//   その組み合わせに対応する 1 つの結末だけを検証する。
+	test('standard の「プレミアムへ」CTA が自ページを指さず、宣言した分岐の実処理を起動する (#4139 / #4161)', async ({
 		page,
 	}) => {
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
+
+		// --- どちらの分岐を検証しているかを、推測ではなく画面から読む ---
+		const panel = page.getByTestId('saas-license-panel');
+		await expect(panel).toBeVisible({ timeout: 30_000 });
+		const stripeEnabled = await panel.getAttribute('data-stripe-enabled');
+		const hasSubscription = await panel.getAttribute('data-has-subscription');
+		// 属性が消える / 値が bool 以外になったら、分岐の宣言そのものが壊れているので落とす
+		expect(['true', 'false']).toContain(stripeEnabled);
+		expect(['true', 'false']).toContain(hasSubscription);
+
+		// 本レーン (cognito-dev = AUTH_MODE=cognito + DATA_SOURCE 既定の sqlite) の前提を固定する。
+		// sqlite の auth repo は stub テナントを返し `stripeSubscriptionId` を持たない
+		// (`src/lib/server/db/sqlite/auth-repo.ts:22-32`) ため、**どの plan fixture でも契約なし**になる。
+		// = 契約ありの portal 分岐はこのレーンでは原理的に到達できない。fixture / backend が変わって
+		// ここが true になったら「検証すべき分岐が変わった」という意味で落とし、放置を防ぐ。
+		// 契約あり (portal) 分岐は component 層で決定的に検証している:
+		//   tests/unit/components/saas-license-panel-upgrade-branch.test.ts (b)
+		expect(hasSubscription).toBe('false');
 
 		const cta = page.getByTestId('plan-status-family-cta');
 		await expect(cta).toBeVisible({ timeout: 30_000 });
@@ -101,13 +124,28 @@ test.describe('#753 PlanStatusCard → /admin/subscription — standard', () => 
 		// 自己リンクでないこと (旧実装は href="/admin/subscription" の <a> だった)
 		await expect(cta).toHaveJSProperty('tagName', 'BUTTON');
 
-		// 押下 → 実処理が起動する。契約ありなら Stripe 請求管理ページ確認ダイアログ、
-		// 契約なし / Stripe 無効なら checkout エラー通知が出る。
-		// 旧実装は自ページに再遷移するだけで、どちらも出なかった。
 		await cta.click();
-		await expect(
-			page.getByTestId('portal-confirm-button').or(page.getByRole('alert').first()),
-		).toBeVisible({ timeout: 15_000 });
+
+		if (stripeEnabled === 'true') {
+			// 契約なし + 決済有効 → `startCheckout()` が checkout session を作り離脱する。
+			// **到達先まで検証する**。「/admin/subscription から離れた」だけを合格にすると、
+			// セッション失効 redirect (`/auth/login`) や認可拒否 redirect も等しく PASS してしまう。
+			// origin の完全一致で判定する (prefix 一致は `checkout.stripe.com.example` にも当たる、
+			// CodeQL js/incomplete-url-substring-sanitization)。
+			await page.waitForURL((url) => url.origin === 'https://checkout.stripe.com', {
+				timeout: 30_000,
+			});
+			expect(new URL(page.url()).origin).toBe('https://checkout.stripe.com');
+		} else {
+			// 決済未設定 (fork PR 等で STRIPE_SECRET_KEY_TEST が供給されないレーン) では、
+			// #4161 の是正どおり「理由を出して打ち切る」。PIN 付き確認ダイアログを開いて
+			// 確定させた末に失敗する dead-end (#2544 型) になっていないことも併せて固定する。
+			await expect(page.getByTestId('billing-unavailable-alert')).toBeVisible({
+				timeout: 15_000,
+			});
+			await expect(page.getByTestId('portal-confirm-button')).toBeHidden();
+			expect(new URL(page.url()).pathname).toBe('/admin/subscription');
+		}
 	});
 });
 
@@ -124,21 +162,21 @@ test.describe('#753 PlanStatusCard → /admin/subscription — family', () => {
 		await expect(card).toBeVisible({ timeout: 30_000 });
 		await expect(card).toHaveAttribute('data-plan-tier', 'family');
 
-		// Portal ボタンまたは plan card 全体非表示 (stripeEnabled=false) のいずれか
-		// #2330 で「決済機能は現在準備中です」placeholder が削除されたため、Portal ボタン visible OR 非表示で skip 検出
-		const portalBtn = page.getByTestId('open-portal-button');
-		const isPortalVisible = await portalBtn
-			.waitFor({ state: 'visible', timeout: 10_000 })
-			.then(() => true)
-			.catch(() => false);
+		// #4161: テスト名が主張している当のことを検証する (最上位プランなので上位への CTA は無い)。
+		//   旧実装は請求管理ボタンが見えなければ annotation を積んで return するだけで、
+		//   「CTA が表示されない」を一度も確かめていなかった。
+		await expect(page.getByTestId('plan-status-family-cta')).toHaveCount(0);
+		await expect(page.getByTestId('plan-status-free-cta')).toHaveCount(0);
 
-		if (!isPortalVisible) {
-			test.info().annotations.push({
-				type: 'skip-reason',
-				description:
-					'Stripe 未設定環境 (stripeEnabled=false で plan card 非表示) のため Portal CTA 不在',
-			});
-			return;
+		const hasSubscription = await page
+			.getByTestId('saas-license-panel')
+			.getAttribute('data-has-subscription');
+		expect(['true', 'false']).toContain(hasSubscription);
+		const portalBtn = page.getByTestId('open-portal-button');
+		if (hasSubscription === 'true') {
+			await expect(portalBtn).toBeVisible();
+		} else {
+			await expect(portalBtn).toHaveCount(0);
 		}
 	});
 });
@@ -265,26 +303,24 @@ test.describe('#753 /admin/subscription プラン選択 UI — free', () => {
 	test('free プランで /admin/subscription にプラン選択カードが表示される', async ({ page }) => {
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
 
-		// Stripe 有効環境ではプラン選択カードが表示される。Stripe 無効では plan card 全体非表示 (#2330)
-		// プラン選択カード visible なら通常検証、無ければ Stripe 未設定環境として skip。
+		// #4161: 旧実装は「plan card が見えなければ skip 理由を積んで return」で、
+		//   決済未設定レーンでは何も検証しないまま緑になっていた。
+		//   plan card の有無を決めるのは `stripeEnabled` なので、それを読んで両側を検証する。
+		const stripeEnabled = await page
+			.getByTestId('saas-license-panel')
+			.getAttribute('data-stripe-enabled');
+		expect(['true', 'false']).toContain(stripeEnabled);
+
 		const standardPlanCard = page.getByTestId('standard-plan-card');
-		const isPlanCardVisible = await standardPlanCard
-			.waitFor({ state: 'visible', timeout: 5_000 })
-			.then(() => true)
-			.catch(() => false);
-
-		if (!isPlanCardVisible) {
-			test.info().annotations.push({
-				type: 'skip-reason',
-				description: 'Stripe 未設定環境 (stripeEnabled=false で plan card 非表示) のため skip',
-			});
-			return;
+		if (stripeEnabled === 'true') {
+			// スタンダード / ファミリーの選択カードが表示される
+			await expect(standardPlanCard).toBeVisible({ timeout: 10_000 });
+			await expect(page.getByTestId('family-plan-card')).toBeVisible();
+		} else {
+			// 決済未設定ではプラン管理カードごと非描画 (#2330 で placeholder 削除済)
+			await expect(standardPlanCard).toHaveCount(0);
+			await expect(page.getByTestId('family-plan-card')).toHaveCount(0);
 		}
-
-		// Stripe 有効環境: スタンダード / ファミリーの選択カードが表示される
-		// (preparingText 重複 skip 機構は #2330 で placeholder 削除済のため撤去)
-		await expect(standardPlanCard).toBeVisible();
-		await expect(page.getByTestId('family-plan-card')).toBeVisible();
 
 		// #3204: 年額トグルは撤去 (#2719 年額廃止と UI 整合)。月額固定で年額ボタンは存在しない。
 		await expect(page.getByRole('button', { name: /年額/ })).toHaveCount(0);
@@ -297,25 +333,23 @@ test.describe('#753 /admin/subscription プラン選択 UI — free', () => {
 test.describe('#753 /admin/subscription プラン選択 UI — standard', () => {
 	test.use({ storageState: 'playwright/.auth/standard.json' });
 
-	test('standard プランでは Stripe Portal ボタンが表示される（サブスク有りの場合）', async ({
-		page,
-	}) => {
+	// #4161: 請求管理ボタンの表示条件は「決済有効 かつ 契約あり」の 2 条件。
+	//   旧実装は不在なら return するだけで、条件と描画の対応を一度も確かめていなかった。
+	test('請求管理ボタンの表示が「決済有効 かつ 契約あり」と一致する', async ({ page }) => {
 		await page.goto('/admin/subscription', { waitUntil: 'commit', timeout: 30_000 });
 
-		// standard はサブスクリプション有りなので Portal ボタンが出る、
-		// または Stripe 未設定環境では plan card 全体非表示 (#2330 で placeholder 削除済)
-		const portalBtn = page.getByTestId('open-portal-button');
-		const isPortalVisible = await portalBtn
-			.waitFor({ state: 'visible', timeout: 10_000 })
-			.then(() => true)
-			.catch(() => false);
+		const panel = page.getByTestId('saas-license-panel');
+		await expect(panel).toBeVisible({ timeout: 30_000 });
+		const stripeEnabled = await panel.getAttribute('data-stripe-enabled');
+		const hasSubscription = await panel.getAttribute('data-has-subscription');
+		expect(['true', 'false']).toContain(stripeEnabled);
+		expect(['true', 'false']).toContain(hasSubscription);
 
-		if (!isPortalVisible) {
-			test.info().annotations.push({
-				type: 'skip-reason',
-				description: 'Stripe 未設定環境 (stripeEnabled=false) のため Portal ボタン不在',
-			});
-			return;
+		const portalBtn = page.getByTestId('open-portal-button');
+		if (stripeEnabled === 'true' && hasSubscription === 'true') {
+			await expect(portalBtn).toBeVisible({ timeout: 10_000 });
+		} else {
+			await expect(portalBtn).toHaveCount(0);
 		}
 	});
 });

--- a/tests/unit/components/saas-license-panel-upgrade-branch.test.ts
+++ b/tests/unit/components/saas-license-panel-upgrade-branch.test.ts
@@ -1,0 +1,165 @@
+// tests/unit/components/saas-license-panel-upgrade-branch.test.ts
+// アップグレード CTA の 3 分岐を、分岐を決める 2 変数ごとに固定する (#4161)
+//
+// #4139 の受け入れテスト (upgrade-flow.spec.ts) は「起こりうる結末を or で並べる」形で書かれており、
+// どの環境でどちらの分岐が走るかを宣言していなかった。実測すると cognito-dev レーンでは
+// `hasSubscription` が **常に false** で (sqlite の auth repo が stub テナントを返すため、
+// `src/lib/server/db/sqlite/auth-repo.ts:22-32` — `stripeSubscriptionId` を持たない)、
+// 契約ありの portal 分岐は E2E では原理的に到達できない。
+//
+// そこで分岐の検証は本 component 層に降ろす (ADR-0061 push-down-pyramid)。
+// ここでは env にも secrets にも依存せず、3 分岐すべてが決定的に走る。
+//
+// 分岐 SSOT: SaasLicensePanel.svelte `handlePlanUpgrade`
+//   (a) stripeEnabled=false          → 理由を提示して打ち切る (確認ダイアログを開かない、#4161 AC5)
+//   (b) stripeEnabled=true  + 契約あり → requestPortal() → 請求管理ページ確認ダイアログ
+//   (c) stripeEnabled=true  + 契約なし → startCheckout() → POST /api/stripe/checkout → 離脱
+
+import { cleanup, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SUBSCRIPTION_PLAN } from '../../../src/lib/domain/constants/subscription-plan';
+import { SUBSCRIPTION_STATUS } from '../../../src/lib/domain/constants/subscription-status';
+import { SUBSCRIPTION_PAGE_LABELS } from '../../../src/lib/domain/labels';
+import SaasLicensePanel from '../../../src/lib/features/admin/components/SaasLicensePanel.svelte';
+
+const NOW = '2026-08-01T00:00:00.000Z';
+
+function buildData(options: { stripeEnabled: boolean; hasSubscription: boolean }) {
+	return {
+		license: {
+			plan: 'standard_monthly',
+			status: SUBSCRIPTION_STATUS.ACTIVE,
+			tenantName: 'テスト家族',
+			createdAt: NOW,
+			updatedAt: NOW,
+			// 契約ありの唯一の判定材料 (SaasLicensePanel: `!!license.stripeSubscriptionId`)
+			stripeSubscriptionId: options.hasSubscription ? 'sub_test_4161' : undefined,
+		},
+		stripeEnabled: options.stripeEnabled,
+		planTier: 'standard' as const,
+		planStats: {
+			activityCount: 1,
+			activityMax: null,
+			childCount: 1,
+			childMax: null,
+			retentionDays: 365,
+		},
+		trialStatus: {
+			isTrialActive: false,
+			trialUsed: true,
+			daysRemaining: 0,
+			trialEndDate: null,
+			trialTier: 'standard' as const,
+		},
+		pinConfigured: false,
+		downgradeRetentionDays: 90,
+		cancellation: null,
+		loyaltyInfo: null,
+	};
+}
+
+/**
+ * 請求管理ページの確認ダイアログが「開いている」か。
+ *
+ * Ark UI の Dialog は閉じていても content を DOM に残す (`hidden` + `data-state="closed"`)。
+ * 存在の有無で判定すると、開いていないのに開いた扱いになる / 開いても気付けない、の両方が起きる
+ * (CI で `toBeVisible` が "locator resolved to <button…> unexpected value hidden" と報告していたのと同じ状態)。
+ */
+function isPortalDialogOpen(): boolean {
+	const btn = screen.queryByTestId('portal-confirm-button');
+	const content = btn?.closest('[data-part="content"]');
+	if (!content) return false;
+	return content.getAttribute('data-state') === 'open' && !content.hasAttribute('hidden');
+}
+
+/** プランページ上の「プレミアムへ」CTA (PlanStatusCard 経由で handlePlanUpgrade を呼ぶ唯一の入口) */
+function clickUpgradeCta() {
+	const cta = screen.getByTestId('plan-status-family-cta');
+	expect(cta.tagName).toBe('BUTTON');
+	cta.click();
+}
+
+describe('SaasLicensePanel アップグレード CTA の分岐 (#4161)', () => {
+	beforeEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('分岐を決める 2 変数が DOM に出ている (テストが前提を読める)', () => {
+		render(SaasLicensePanel, {
+			data: buildData({ stripeEnabled: true, hasSubscription: true }),
+		});
+		const panel = screen.getByTestId('saas-license-panel');
+		expect(panel.getAttribute('data-stripe-enabled')).toBe('true');
+		expect(panel.getAttribute('data-has-subscription')).toBe('true');
+	});
+
+	it('(a) 決済未設定: 確認ダイアログを開かず、理由を画面に出す', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+		render(SaasLicensePanel, {
+			data: buildData({ stripeEnabled: false, hasSubscription: true }),
+		});
+
+		clickUpgradeCta();
+
+		// 理由が画面に出る (silent no-op にしない)
+		await waitFor(() => {
+			expect(screen.getByTestId('billing-unavailable-alert').textContent).toContain(
+				SUBSCRIPTION_PAGE_LABELS.billingUnavailable,
+			);
+		});
+		// PIN 付き確認ダイアログは開かない = 確定して失敗する dead-end を作らない (#2544 型)
+		expect(isPortalDialogOpen()).toBe(false);
+		// checkout も叩かない
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('(b) 決済有効 + 契約あり: 請求管理ページの確認ダイアログが開く', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch');
+		render(SaasLicensePanel, {
+			data: buildData({ stripeEnabled: true, hasSubscription: true }),
+		});
+
+		clickUpgradeCta();
+
+		await waitFor(() => {
+			expect(isPortalDialogOpen()).toBe(true);
+		});
+		expect(screen.queryByTestId('billing-unavailable-alert')).toBeNull();
+		// 契約ありは checkout を叩かない (409 ALREADY_SUBSCRIBED になる経路には行かない)
+		expect(fetchSpy).not.toHaveBeenCalledWith(
+			'/api/stripe/checkout',
+			expect.objectContaining({ method: 'POST' }),
+		);
+	});
+
+	it('(c) 決済有効 + 契約なし: checkout session の作成を要求する', async () => {
+		const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+			new Response(JSON.stringify({ url: 'https://checkout.stripe.com/c/pay/cs_test_4161' }), {
+				status: 200,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+		);
+		render(SaasLicensePanel, {
+			data: buildData({ stripeEnabled: true, hasSubscription: false }),
+		});
+
+		clickUpgradeCta();
+
+		await waitFor(() => {
+			expect(fetchSpy).toHaveBeenCalledWith(
+				'/api/stripe/checkout',
+				expect.objectContaining({
+					method: 'POST',
+					body: JSON.stringify({ planId: SUBSCRIPTION_PLAN.FAMILY_MONTHLY }),
+				}),
+			);
+		});
+		// 契約なしで確認ダイアログが開いたら経路違い (portal は 契約ありのみ)
+		expect(isPortalDialogOpen()).toBe(false);
+		expect(screen.queryByTestId('billing-unavailable-alert')).toBeNull();
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / システム全体

**解決する課題**: プラン・課金の受け入れテストが「起こりうる結末を or で並べる」形で書かれており、**どの環境でどちらの分岐が走るかを宣言していなかった**。走らなかった側は永久に評価されない死んだ部分式として残り、書いた本人にも「どちらが走ったか」が見えない。加えて、決済が有効でない配備では「プラン管理カードは隠れているのに PIN 付き確認ダイアログだけ開き、確定すると失敗する」dead-end が成立しうる状態だった。

**期待される効果**: 収益導線（アップグレード）が壊れたとき CI が必ず落ちる。決済未設定の配備で「PIN を入れて確定した末に失敗する」体験がなくなり、押した時点で理由が出る。

## 関連 Issue

<!-- no-issue-close: 実測の結果 Issue #4161 の前提（Stripe 無効 / reachedStripeCheckout が死んだ部分式）が事実と逆だったため、Issue 本文の前提を PO が確認したうえで close 判断してほしい。AC 自体は本 PR で充足している -->
Refs #4161

## 実測で確定した事実（Issue #4161 の前提とは逆）

Issue は「cognito-dev の Stripe は無効 → `reachedStripeCheckout` は CI で一度も評価されない死んだ部分式」を前提にしていた。**実測すると逆だった**。

| Issue の前提 | 実測 | 根拠 |
|---|---|---|
| cognito-dev の Stripe は無効 | **有効** | `.github/workflows/ci.yml:1003` が `secrets.STRIPE_SECRET_KEY_TEST` を e2e-cognito-dev に供給。当該 secret は repo に存在する（`gh secret list` に `STRIPE_SECRET_KEY_TEST` / vars に `STRIPE_PRICE_*_TEST`）。fork PR のみ空 = 無効 |
| 根拠は「503 が両 run で PASS」 | **その test は何も示さない** | 当の test は `expect([401,403,503]).toContain(status)` で、未認証 `request` fixture が返す 401/403 でも PASS する |
| 確認ダイアログが開いた（portal 経路）から 1.4s で緑 | **checkout 経路だった** | `hasSubscription` はこのレーンで**常に false**（`src/lib/server/db/sqlite/auth-repo.ts:22-32` の stub テナントが `stripeSubscriptionId` を持たない）。fail した job 91279227920 のログも `portal-confirm-button` が `hidden` のまま = 未 open |
| 死んでいるのは `reachedStripeCheckout` | **死んでいたのは portal 分岐** | 同上 |

したがって AC4 の「実行されない条件式」は `reachedStripeCheckout` ではなく **portal 分岐**であり、本 PR はそちらを解決している。

## 監査チームの release/2026-08-01 append との関係

監査が `release/2026-08-01`（PR #4152）に append した 3 commit（`11e7799d7` / `83c62658d` / `bb88fb365`）は **develop には入っていない**（`git log origin/develop -- tests/e2e/upgrade-flow.spec.ts` の最新は #4146）。二重修正を避けるため:

- `billing-portal.spec.ts`（vacuous な `nav a[href]` カウント）と `billing-graduation-flow.spec.ts`（旧 URL regex）は **本 PR では触っていない**。監査版が back-merge で develop に入る
- `upgrade-flow.spec.ts` は本 PR が触る。監査版の**実質的な強化（origin 完全一致で到達先を検証する / `role="alert"` を成功条件に入れない）は本 PR の内容に含めた**ため、back-merge の conflict は本 PR 側を採用すれば取りこぼしが出ない

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | テストが `stripeEnabled` と `hasSubscription` を実際に読んで assert し、どちらの分岐を検証しているかが明示される | `npx playwright test --config playwright.cognito-dev.config.ts upgrade-flow --retries=0` + `npx vitest run tests/unit/components/saas-license-panel-upgrade-branch.test.ts` | HEAD `2ab68f327` / 2 変数を `data-stripe-enabled` / `data-has-subscription` として DOM に出し（`SaasLicensePanel.svelte:400-404`）、e2e が `getAttribute` で読んで `expect(['true','false']).toContain(...)` + 組み合わせで分岐（`tests/e2e/upgrade-flow.spec.ts:107-176`）。属性を消す mutation で該当 test が fail（下表 M4） |
| AC2 | portal 経路（契約あり）の検証が cognito-dev で決定的に走る | `npx vitest run tests/unit/components/saas-license-panel-upgrade-branch.test.ts` | **部分充足（理由付き）**。cognito-dev では `hasSubscription` が原理的に true にならない（`src/lib/server/db/sqlite/auth-repo.ts:22-32` が stub テナントを返す固定実装で、fixture では変えられない）。portal 経路は component 層に降ろして**決定的に**検証した（`tests/unit/components/saas-license-panel-upgrade-branch.test.ts:120` (b) / 4 passed）。e2e 側は `expect(hasSubscription).toBe('false')` で前提を表明し、backend / fixture が変わって true になったら落ちる（放置しない） |
| AC3 | checkout 経路（契約なし + Stripe 有効）の検証先を確定する | 同 e2e / CI job 91304285247 | 検証先は **cognito-dev の CI レーン**（staging ではない）。`ci.yml:1003` が test mode key を供給するため checkout 経路が実際に走り、`checkout.stripe.com` への到達まで assert する（`upgrade-flow.spec.ts:151-158`）。fork PR では key 非供給で決済未設定 = else 分岐が走り、そちらも assert する。この事情を spec のコメントに明記した |
| AC4 | 実行されない条件式が残らない | 上記 e2e / component test | 結末の `or` を撤去し、**読んだ 2 変数の組み合わせに対応する 1 つの結末だけ**を検証する形にした。到達不能だった portal 分岐は component 層（env / secrets 非依存）に移して常時実行される。「見えなければ annotation を積んで return」型の**毎回 skip していた 4 件**も条件を読んで両側を検証する形に置換 |
| AC5 | 確認ダイアログが `stripeEnabled` false の環境で開けないことを検証する | `npx vitest run tests/unit/components/saas-license-panel-upgrade-branch.test.ts` / 上記 e2e | `handlePlanUpgrade` / `requestPortal` / `openPortal` の 3 経路すべてで `!stripeEnabled` を弾き、理由を Toast + in-page banner で提示して打ち切る（silent no-op も作らない）。component test (a) が「ダイアログ非 open + 理由表示 + checkout も叩かない」を assert（4 passed）。e2e も決済未設定レーンで同じことを assert（ローカル実測 PASS 2.4s） |
| AC6 | failing-test-first で示す（修正前に落ち、修正後に通る対を固定する） | mutation 検証（下表） | 4 種の mutation すべてで**狙った 1 件だけ**が fail し、戻すと 4 passed に復帰。e2e も AC5 の修正を戻すと fail する（`billing-unavailable-alert` element not found） |

## mutation 検証（vacuous でないことの証拠）

**先に commit してから mutate し、`git stash` + `git stash drop` で復元**した（`git checkout --` は未コミットの実装ごと消すため使わない）。

| # | mutation（製品コードに入れた欠陥） | 実行 | 結果 |
|---|---|---|---|
| M1 | `handlePlanUpgrade` の `!stripeEnabled` guard のみ削除 | `npx vitest run tests/unit/components/saas-license-panel-upgrade-branch.test.ts` | **4 passed（落ちない）** — `requestPortal` 側の guard が残っていて挙動が変わらないため。多重防御が効いていることの確認であり、次の M1b で本来の mutation を実施 |
| M1b | AC5 の修正を**完全に revert**（`handlePlanUpgrade` + `requestPortal` の両 guard 削除） | 同上 | **1 failed / 3 passed** — (a) 決済未設定: 確認ダイアログを開かず、理由を画面に出す |
| M2 | portal 分岐を削除（常に checkout） | 同上 | **1 failed / 3 passed** — (b) 決済有効 + 契約あり |
| M3 | checkout 分岐を削除（常に portal） | 同上 | **1 failed / 3 passed** — (c) 決済有効 + 契約なし |
| M4 | `data-stripe-enabled` / `data-has-subscription` 属性を削除 | 同上 | **1 failed / 3 passed** — 分岐を決める 2 変数が DOM に出ている |
| M1b (e2e) | AC5 の修正を完全に revert | `npx playwright test --config playwright.cognito-dev.config.ts upgrade-flow --retries=0 --grep "宣言した分岐"` | **1 failed** — `getByTestId('billing-unavailable-alert')` element not found。旧 assertion（`portal-confirm OR role="alert"`）はこの状態でも Toast の `role="alert"` で PASS していた = 強化されている（ADR-0006 適合） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `/admin/subscription`（プラン・課金）。決済が有効な配備（本番 / CI e2e レーン）では挙動不変で、変化するのは **`STRIPE_SECRET_KEY` 未設定の配備**（セルフホスト / 設定不備）でアップグレード操作を押したときだけ。

- [ ] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [ ] **設計書同期** (ADR-0001)
- [ ] **LP ↔ アプリ整合** (ADR-0013)
- [x] **重量 e2e 敏感領域**に触れるため、該当 spec のローカル実行ログを本文に貼った（下記）
- [ ] N/A

新規文言は `labels.ts` の SSOT に追加（`SUBSCRIPTION_PAGE_LABELS.billingUnavailable` / `.billingUnavailableToastTitle`）。LP には決済未設定配備の記述が無いため LP 側同期は不要。設計書は「決済未設定時にアップグレード操作を打ち切る」という**既存仕様の穴埋め**であり、UI 仕様の新規追加ではないため 06-UI 設計書の更新対象外と判断した（判断が違えば指摘してほしい）。

**ローカル e2e 実行ログ**（`npx playwright test --config playwright.cognito-dev.config.ts upgrade-flow --retries=0`）:

```
✘ 12 upgrade-flow.spec.ts:201 › #753 /admin/rewards → アップグレード導線 › free プランで「+ 追加」manual (locked) 選択が /admin/subscription へ遷移する
✘ 13 upgrade-flow.spec.ts:226 › #753 /admin/activities AI → アップグレード導線 › free プランで AI パネルの upgrade-cta が /admin/subscription へリンクする
2 failed
19 passed (49.0s)
```

**この 2 件は本 PR の変更対象外で、CI（preview build）では緑**（job 91304285247 のログで両方 `✓`）。ローカル Vite dev の Ark UI Menu hydration race（`admin-activities-add-ux.spec.ts` 冒頭に既知として記述されているもの）で、本 PR 前から同じ 2 件が落ちる。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | PASS |
| 追加・変更テスト | `npx vitest run tests/unit/components/saas-license-panel-upgrade-branch.test.ts` | PASS (4 passed) |
| 追加・変更テスト | `npx playwright test --config playwright.cognito-dev.config.ts upgrade-flow --retries=0` | PASS (19 passed / 既知の local-only 2 件を除く) |
| 回帰 | `npx vitest run tests/unit/components tests/unit/domain` | PASS (1056 passed) |
| 型 | `npx svelte-check --threshold error` | PASS (0 errors) |

- [x] **SOLID / DRY / YAGNI**: 決済未設定の通知は `notifyBillingUnavailable()` の 1 箇所に集約し、3 経路から呼ぶ。新規抽象化なし
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。到達先判定は origin 完全一致（prefix 一致は `checkout.stripe.com.example` にも当たる / CodeQL js/incomplete-url-substring-sanitization）
- [x] **A11y・パフォーマンス**: 追加した banner は既存 `Alert` primitive（`variant="warning"` = `role="status"`）+ Toast（`role="alert"`）の 2 層。新規 N+1 なし
- [x] **Critical バグ修正**(ADR-0002): 該当なし（`priority:high`）

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-prefix: before=01-before- after=01-after- -->

**撮影条件**: `npm run dev:cognito` (AUTH_MODE=cognito、`STRIPE_SECRET_KEY` 未設定 = `stripeEnabled=false`) の
`/admin/subscription` を standard アカウントで開き、**「⭐⭐ プレミアムへ」CTA を押した直後**。
before は `origin/develop` の `SaasLicensePanel.svelte` / `labels.ts` を checkout して同じ操作列で撮影した。

| | モバイル (375px) | PC (1280px) |
|---|---|---|
| **修正前** | ![01-before-subscription-upgrade-cta-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4164/01-before-subscription-upgrade-cta-mobile.png) | ![01-before-subscription-upgrade-cta-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4164/01-before-subscription-upgrade-cta-pc.png) |
| **修正後** | ![01-after-subscription-upgrade-cta-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4164/01-after-subscription-upgrade-cta-mobile.png) | ![01-after-subscription-upgrade-cta-pc](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4164/01-after-subscription-upgrade-cta-pc.png) |

DOM HTML スナップショット (SS と同一 page で取得、#1747 AC4 / #1766):

- [01-before-subscription-upgrade-cta-mobile.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4164/01-before-subscription-upgrade-cta-mobile.dom.html)
- [01-before-subscription-upgrade-cta-pc.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4164/01-before-subscription-upgrade-cta-pc.dom.html)
- [01-after-subscription-upgrade-cta-mobile.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4164/01-after-subscription-upgrade-cta-mobile.dom.html)
- [01-after-subscription-upgrade-cta-pc.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4164/01-after-subscription-upgrade-cta-pc.dom.html)

**読み取り**: 修正前は画面内に何も残らず、数秒で消える Toast だけが手掛かり（checkout の Alert は
`{{#if stripeEnabled}}` の内側にあり決済未設定では描画されない）。修正後は理由が in-page banner として
その場に残る。`DESIGN.md` §9 禁忌 6 点は目視確認済（hex 直書きなし / `Alert` primitive 使用 /
内部コード非露出 / 文言は `labels.ts` SSOT / インラインスタイルなし / `<style>` 追加なし）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる

**レビュー依頼事項**:

1. **AC2 の部分充足**の扱い。cognito-dev で `hasSubscription=true` を作るには sqlite の auth repo stub（`findTenantById` が固定オブジェクトを返す）にテスト専用の分岐を入れるしかなく、製品コードにテスト都合の穴を開けることになるため採らなかった。代わりに component 層で決定的に検証し、e2e では前提を assert して drift を検出する形にしている。この判断でよいか
2. **Issue #4161 の前提が事実と逆だった**件（上記「実測で確定した事実」）。Issue 側の記述を残したままにすると次に読む人が同じ誤解をするため、Issue 本文への追記 or close コメントでの訂正を PO 判断でお願いしたい
3. 決済未設定配備で **CTA 自体を出さない**（押させない）方が #2544 の精神には近いが、`PlanStatusCard` は利用状況表示も兼ねており CTA だけ消すと「なぜ消えたか」が伝わらないため、押したら理由を出す形にした。方針が違えば指摘してほしい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC2 のみ部分充足、理由を上記に明記）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
