### PR TITLE
fix(backup): #4162 rotation guard 発火中の診断が真逆になるのを是正する

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1376,7 +1376,8 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
     "hoursSinceLastSuccess": null,
     "consecutiveFailures": 18,
     "lastFailureMessage": "CRON_SECRET が未設定です (/api/cron/pglite-backup の認証に必要)",
-    "notificationMissing": true
+    "notificationMissing": true,
+    "rotationPendingCount": 0
   }
 }
 ```
@@ -1387,14 +1388,19 @@ backend が不健全 (接続不可 / schema 不在) の場合は **503** + `{"st
 |---|---|
 | 付与条件 | `backup` と同じ（`DATA_SOURCE === 'pglite'` かつ状態ファイルが読めたとき）。読めなければ `backup` ごと省略する |
 | `level` | `ok` / `warn` / `critical`。UI の色分けと通知の強さを 1 箇所で決める |
-| `reason` | `never-succeeded` / `stale-critical` / `stale-warn` / `consecutive-failures-critical` / `last-run-failed` / `no-notification-channel` / `healthy`。**level だけでは人間が行動できない**ため、根拠を持たせる |
+| `reason` | `never-succeeded` / `stale-critical` / `stale-warn` / `consecutive-failures-critical` / `last-run-failed` / `rotation-blocked` / `no-notification-channel` / `healthy`。**level だけでは人間が行動できない**ため、根拠を持たせる |
+| `rotationPendingCount` | ローテーション guard（#4129 AC2）が止めている世代数。0 なら止まっていない。**取得の成否とは独立した事実**（#4162） |
 | `notificationMissing` | 失敗通知の宛先（`DISCORD_ALERT_WEBHOOK_URL` / `DISCORD_WEBHOOK_INCIDENT`）が 1 つも無い状態。**`level` と独立に立つ** — critical のときも「届かない」ことは対処が変わるため独立に伝える |
 | 判定順 | **深刻な方から**。stale（動いていない）を failure（落ちている）より先に見る。**job が起動しなかった場合、job 内から投げる push 通知は原理的に発火しない**ため、鮮度でしか捕まえられない |
 | しきい値 | `BACKUP_STALE_WARN_HOURS = 26` / `BACKUP_STALE_CRITICAL_HOURS = 50` / `BACKUP_CONSECUTIVE_FAILURE_CRITICAL = 2`。日次 03:00 実行前提で「1 回飛んだ」「2 回連続で飛んだ」に対応。1 回で critical にすると再起動のたびに狼少年になる（ADR-0012 整合） |
 
-**既知の限界（#4144 由来、未解消）**: `PgliteBackupRotationGuardError`（**取得自体は成功**しローテーションだけ止めた場合）も通常の失敗と同じ `catch` で `consecutiveFailures` を増やし、`lastSuccessAt` を更新しない。したがって **guard trip が 2 回続くと「取得は成功しているのに critical」**と判定される。`reason` を家族向け UI に出す際は、この誤解を招く表示にならないか確認すること。
+**ローテーション保留は失敗として扱わない（#4162）**: `PgliteBackupRotationGuardError`（**取得自体は成功**しローテーションだけ止めた場合）は、throw の前に「取得は成功」を状態ファイルへ確定させ、`consecutiveFailures` を積まない。止まっている事実は `rotationPendingCount` / `rotationBlockedSince` に**独立した事実として**残す。
 
-回帰は `tests/unit/domain/backup-health.test.ts`（判定）と `tests/unit/routes/health-backup-status.test.ts`（付与条件）が固定する。
+これを 1 つの状態に潰していた旧実装では、判定が `stale-critical`（= 「job が動いていない」）へ倒れ、**診断が真逆**になっていた。実際は毎晩正常に取れており、必要な行動は「古い世代を退避して手で削除する」である。判定を潰すと運用者が job の再起動へ向かい、**guard の意図（不可逆削除を止める）だけが失われる**。
+
+判定順は `rotation-blocked` を stale / 連続失敗より**後**に置く。「取れていない」方が常に重く、「取れているが片付いていない」はその次だからである。guard は自己解除しない（溢れは毎晩 1 ずつ増える）ため、この warn は放置で消える類ではなく**行動を促すもの**として扱う。
+
+回帰は `tests/unit/domain/backup-health.test.ts`（判定）/ `tests/unit/routes/health-backup-status.test.ts`（付与条件）/ `tests/unit/db/pglite-backup-3950.test.ts` `[BK12]` `[BK17]` `[BK18]`（実 status → verdict の経路と保留の解除）が固定する。
 
 #### GET /api/ready
 

--- a/src/lib/domain/backup-health.ts
+++ b/src/lib/domain/backup-health.ts
@@ -29,6 +29,7 @@ export type BackupHealthReason =
 	| 'stale-warn'
 	| 'consecutive-failures-critical'
 	| 'last-run-failed'
+	| 'rotation-blocked'
 	| 'no-notification-channel'
 	| 'healthy';
 
@@ -47,6 +48,16 @@ export interface BackupHealthInput {
 	 * (「通知できないので黙る」を無くす、#4087 AC1)。
 	 */
 	notificationConfigured: boolean;
+	/**
+	 * ローテーション guard (#4129 AC2) が止めている世代数。止まっていなければ 0。
+	 *
+	 * **取得の成否とは独立した事実**である点が本 field の存在理由 (#4162)。guard 発火時は
+	 * 「新世代の確定は成功したが、古い世代の削除だけを意図的に止めた」状態で、
+	 * **バックアップは毎晩正常に増えている**。これを failure として 1 つの状態に潰すと、
+	 * 判定が `stale-critical` (= 「job が動いていない」) に倒れ、**診断が真逆**になる。
+	 * 実際に必要な行動は「古い世代を退避して手で削除する」であって job の再起動ではない。
+	 */
+	rotationPendingCount: number;
 }
 
 export interface BackupHealthVerdict {
@@ -59,6 +70,8 @@ export interface BackupHealthVerdict {
 	lastFailureMessage: string | null;
 	/** 通知経路が無いこと自体の警告。level とは独立に立つ (critical でも同時に出したい)。 */
 	notificationMissing: boolean;
+	/** ローテーション guard が止めている世代数 (#4162)。0 なら止まっていない。 */
+	rotationPendingCount: number;
 }
 
 /** 「1 回飛んだ」と読める閾値 (h)。日次 03:00 + 実行時間 + 余裕。 */
@@ -88,6 +101,7 @@ export function evaluateBackupHealth(input: BackupHealthInput, now: Date): Backu
 		consecutiveFailures: input.consecutiveFailures,
 		lastFailureMessage: input.lastFailureMessage,
 		notificationMissing: !input.notificationConfigured,
+		rotationPendingCount: input.rotationPendingCount,
 	};
 
 	// 一度も成功していない = 「バックアップがある」と言えない状態。
@@ -110,6 +124,16 @@ export function evaluateBackupHealth(input: BackupHealthInput, now: Date): Backu
 
 	if (input.consecutiveFailures > 0) {
 		return { ...base, level: 'warn', reason: 'last-run-failed' };
+	}
+
+	// #4162: ローテーションだけが止まっている状態。**取得は成功し続けている**ので
+	// critical ではなく warn。stale / consecutive-failures より後に見るのは、
+	// 「取れていない」方が常に重いため (取れているが片付いていない、は次に重い)。
+	//
+	// guard は自己解除しない — 溢れは毎晩 1 ずつ増えるので、人が退避して手で削除するまで続く。
+	// したがってこの warn は「放置すれば消える」類ではなく、**行動を促すもの**である。
+	if (input.rotationPendingCount > 0) {
+		return { ...base, level: 'warn', reason: 'rotation-blocked' };
 	}
 
 	// 直近は成功しているが、次に失敗したとき誰にも届かない状態。

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2519,6 +2519,12 @@ export const SETTINGS_LABELS = {
 	backupNotificationMissing:
 		'失敗しても通知が届かない設定です。いま止まっても気づけません (DISCORD_ALERT_WEBHOOK_URL 未設定)。',
 	backupActionHint: 'うまくいっていないときは、下のフォームから相談してください。',
+	// #4162: ローテーション保留だけが起きている状態の案内。
+	// **「取れていない」ではなく「片付いていない」**であることが伝わる文言にする。
+	// 汎用の backupActionHint (相談してください) だけだと、必要な行動が分からないまま
+	// 「job が壊れた」と読まれ、再起動や再インストールに向かってしまう。
+	backupRotationBlockedHint:
+		'バックアップは取れていますが、古い控えが増えすぎたため、自動での削除を止めています。古い控えを別の場所へ移してから、いらないものを消してください。',
 	appInfoSectionTitle: 'ℹ️ アプリ情報',
 	appInfoTermsLink: '📄 利用規約',
 	appInfoPrivacyLink: '🔒 プライバシーポリシー',

--- a/src/lib/features/admin/components/BackupHealthCard.stories.svelte
+++ b/src/lib/features/admin/components/BackupHealthCard.stories.svelte
@@ -23,6 +23,7 @@ const OK: BackupHealthVerdict = {
 	consecutiveFailures: 0,
 	lastFailureMessage: null,
 	notificationMissing: false,
+	rotationPendingCount: 0,
 };
 
 /** 通知経路が無いだけの warn。**取れてはいるが、壊れても届かない**状態 (#4087 AC1)。 */
@@ -33,6 +34,7 @@ const WARN_NO_CHANNEL: BackupHealthVerdict = {
 	consecutiveFailures: 0,
 	lastFailureMessage: null,
 	notificationMissing: true,
+	rotationPendingCount: 0,
 };
 
 /**
@@ -46,6 +48,7 @@ const CRITICAL_REAL_INCIDENT: BackupHealthVerdict = {
 	consecutiveFailures: 18,
 	lastFailureMessage: 'CRON_SECRET が未設定です (/api/cron/pglite-backup の認証に必要)',
 	notificationMissing: true,
+	rotationPendingCount: 0,
 };
 
 /** ジョブが起動しなかったケース。**失敗 0 回でも成功が古ければ critical** (#4087 AC3)。 */
@@ -56,6 +59,21 @@ const CRITICAL_STALE: BackupHealthVerdict = {
 	consecutiveFailures: 0,
 	lastFailureMessage: null,
 	notificationMissing: false,
+	rotationPendingCount: 0,
+};
+/**
+ * ローテーションだけが止まっている状態 (#4162)。
+ * **取得は成功し続けている**ので critical ではなく warn。必要な行動は
+ * 「古い控えを移して消す」であり、job の再起動ではない。
+ */
+const WARN_ROTATION_BLOCKED: BackupHealthVerdict = {
+	level: 'warn',
+	reason: 'rotation-blocked',
+	hoursSinceLastSuccess: 4,
+	consecutiveFailures: 0,
+	lastFailureMessage: null,
+	notificationMissing: false,
+	rotationPendingCount: 4,
 };
 </script>
 
@@ -63,6 +81,7 @@ const CRITICAL_STALE: BackupHealthVerdict = {
 <Story name="WarnNoNotificationChannel" args={{ health: WARN_NO_CHANNEL }} />
 <Story name="CriticalNeverSucceeded" args={{ health: CRITICAL_REAL_INCIDENT }} />
 <Story name="CriticalStale" args={{ health: CRITICAL_STALE }} />
+<Story name="WarnRotationBlocked" args={{ health: WARN_ROTATION_BLOCKED }} />
 
 <Story name="AllStates">
 	<div class="flex flex-col gap-4">
@@ -70,5 +89,6 @@ const CRITICAL_STALE: BackupHealthVerdict = {
 		<BackupHealthCard health={WARN_NO_CHANNEL} />
 		<BackupHealthCard health={CRITICAL_REAL_INCIDENT} />
 		<BackupHealthCard health={CRITICAL_STALE} />
+		<BackupHealthCard health={WARN_ROTATION_BLOCKED} />
 	</div>
 </Story>

--- a/src/lib/features/admin/components/BackupHealthCard.svelte
+++ b/src/lib/features/admin/components/BackupHealthCard.svelte
@@ -67,7 +67,17 @@ const lastSuccessDisplay = $derived(
 
 		{#if health.level !== 'ok'}
 			<p class="mt-3 text-sm text-[var(--color-text-muted)]">
-				{SETTINGS_LABELS.backupActionHint}
+				<!--
+					#4162: ローテーション保留だけのときは専用文言を出す。汎用の「相談してください」
+					だけだと必要な行動が分からず「job が壊れた」と読まれてしまう。
+
+					reason を直接表示するのではなく reason に応じた固定文を選ぶ形は維持する
+					(内部 enum を家族向け UI に露出させない)。#4153 の QM 申し送りが懸念していた
+					「取得は成功しているのに critical」の混在自体が本 Issue で解消済み。
+				-->
+				{health.reason === 'rotation-blocked'
+					? SETTINGS_LABELS.backupRotationBlockedHint
+					: SETTINGS_LABELS.backupActionHint}
 			</p>
 		{/if}
 	</div>

--- a/src/lib/server/services/pglite-backup-service.ts
+++ b/src/lib/server/services/pglite-backup-service.ts
@@ -57,6 +57,16 @@ export interface PgliteBackupStatus {
 	 * まで一緒に見られなくなる**。状態が変わったときだけ通知する。
 	 */
 	lastOffsiteLevel: OffsiteVerdict['level'] | null;
+	/**
+	 * ローテーション guard (#4129 AC2) が止めている世代数 (#4162)。止まっていなければ 0。
+	 *
+	 * **取得の成否とは独立した事実**。guard 発火時は新世代の確定に成功していて
+	 * 削除だけが止まっているため、これを failure に潰すと判定が「job が動いていない」へ
+	 * 倒れて診断が真逆になる。欠損時は 0 扱い (旧 status file との後方互換)。
+	 */
+	rotationPendingCount: number;
+	/** ローテーションが止まり始めた時刻 (ISO 8601)。止まっていなければ null。 */
+	rotationBlockedSince: string | null;
 }
 
 /**
@@ -150,6 +160,8 @@ async function readStatus(backupDir: string): Promise<PgliteBackupStatus> {
 		lastFailureMessage: null,
 		consecutiveFailures: 0,
 		lastOffsiteLevel: null,
+		rotationPendingCount: 0,
+		rotationBlockedSince: null,
 	};
 	try {
 		const raw = await readFile(join(backupDir, BACKUP_STATUS_FILENAME), 'utf-8');
@@ -217,7 +229,28 @@ export async function runPgliteBackup(
 		// 取得した新世代はここまでで確定済みなので、**バックアップは失われず削除だけが止まる**。
 		// 逃げ道 (bypass env) は用意しない — 退避してから手で古い世代を削れば、次回以降は
 		// rotated が 1 件に戻って自然に解除される。env で黙って通せる穴を作らない。
+		// #4162: guard は **throw する前に「取得は成功した」を状態ファイルへ確定させる**。
+		// 新世代は上の rename で既に確定しており、コード自身がそれを知っている
+		// (guard の文言も「今回取得した新しいバックアップは確定済み」と書いている)。
+		// にもかかわらず throw だけすると catch が lastSuccessAt を進めないまま
+		// consecutiveFailures を積み、判定が stale-critical (= 「job が動いていない」) に倒れる。
+		// **実際は毎晩正常に取れており、必要な行動は「古い世代を退避して手で削除」**なので
+		// 診断が真逆になる。取得の成功とローテーションの保留を別々の事実として残す。
 		if (rotated.length > 1) {
+			const previousForGuard = await readStatus(backupDir);
+			await writeStatus(backupDir, {
+				...previousForGuard,
+				lastSuccessAt: new Date().toISOString(),
+				lastSuccessFilename: filename,
+				lastSuccessBytes: bytes.byteLength,
+				lastSuccessDurationMs: Date.now() - startedAt,
+				// 取得は成功しているので連続失敗は 0 に戻す。guard の発火は「失敗」ではない。
+				consecutiveFailures: 0,
+				rotationPendingCount: rotated.length,
+				rotationBlockedSince: previousForGuard.rotationBlockedSince ?? new Date().toISOString(),
+			}).catch(() => {
+				// 状態を書けなくても guard 自体は止める (削除を通してしまう方が重い)。
+			});
 			throw new PgliteBackupRotationGuardError(
 				rotated,
 				retention,
@@ -263,6 +296,11 @@ export async function runPgliteBackup(
 			lastSuccessDurationMs: durationMs,
 			consecutiveFailures: 0,
 			lastOffsiteLevel: offsite.level,
+			// ここまで来た = ローテーションが通った。保留を解除する (#4162)。
+			// 解除を書き忘れると「退避して削除したのに warn が消えない」状態が残り、
+			// 表示が現実から乖離したまま固定される。
+			rotationPendingCount: 0,
+			rotationBlockedSince: null,
 		});
 
 		const result: PgliteBackupResult = {
@@ -283,6 +321,18 @@ export async function runPgliteBackup(
 		});
 		return result;
 	} catch (e) {
+		// #4162: guard の発火は **失敗ではない**。取得は成功しており、削除だけを意図的に
+		// 止めた状態で、その事実は throw の直前に状態ファイルへ書いてある。ここで
+		// consecutiveFailures を積むと判定層が「落ち続けている」と読み、診断が真逆になる。
+		// 状態はもう記録済みなので、そのまま呼び出し側へ投げるだけにする。
+		if (e instanceof PgliteBackupRotationGuardError) {
+			logger.warn('[pglite-backup] rotation blocked (取得は成功)', {
+				service: 'pglite-backup',
+				context: { wouldDelete: e.wouldDelete.length, retention: e.retention },
+			});
+			throw e;
+		}
+
 		const message = e instanceof Error ? e.message : String(e);
 		const previous = await readStatus(backupDir);
 		await writeStatus(backupDir, {

--- a/src/routes/(parent)/admin/settings/support/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/support/+page.server.ts
@@ -46,6 +46,9 @@ async function readBackupHealth(): Promise<BackupHealthVerdict | null> {
 				consecutiveFailures: status.consecutiveFailures,
 				lastFailureMessage: status.lastFailureMessage,
 				notificationConfigured: isBackupNotificationConfigured(process.env),
+				// #4162: guard 発火中は「取得は成功 / ローテーションが保留」。
+				// 欠損時 0 扱いで旧 status file と後方互換。
+				rotationPendingCount: status.rotationPendingCount ?? 0,
 			},
 			new Date(),
 		);

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -65,6 +65,9 @@ export const GET: RequestHandler = async () => {
 					consecutiveFailures: backup.consecutiveFailures,
 					lastFailureMessage: backup.lastFailureMessage,
 					notificationConfigured: isBackupNotificationConfigured(process.env),
+					// #4162: guard 発火中は「取得は成功 / ローテーションが保留」。
+					// 欠損時 0 扱いで旧 status file と後方互換。
+					rotationPendingCount: backup.rotationPendingCount ?? 0,
 				},
 				new Date(),
 			)

--- a/tests/unit/db/pglite-backup-3950.test.ts
+++ b/tests/unit/db/pglite-backup-3950.test.ts
@@ -48,6 +48,7 @@ import {
 } from '../../../src/lib/server/db/pglite/backup';
 import {
 	BACKUP_STATUS_FILENAME,
+	getPgliteBackupStatus,
 	PgliteBackupRotationGuardError,
 	runPgliteBackup,
 } from '../../../src/lib/server/services/pglite-backup-service';
@@ -352,6 +353,89 @@ describe('#3950 PGlite backup — 復元できることの実証', () => {
 		expect(after.length).toBeGreaterThanOrEqual(before.length);
 	}, 180_000);
 
+	it('[BK17] guard 発火時も「取得は成功」を状態ファイルに残す (#4162 診断反転の防止)', async () => {
+		// 旧実装は throw だけして catch が lastFailureAt / consecutiveFailures++ を書いていた。
+		// **新世代は確定しているのに状態ファイルには失敗しか残らない**ため、判定層 (#4148) が
+		// 「job が動いていない」= stale-critical に倒れ、診断が真逆になっていた。
+		// 実際に必要な行動は「古い世代を退避して手で削除」であり job の再起動ではない。
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk17-');
+
+		for (let i = 0; i < 7; i++) {
+			await runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 7,
+				now: new Date(Date.UTC(2026, 6, 10 + i, 3, 0, 0)),
+			});
+		}
+
+		await expect(
+			runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 3,
+				now: new Date(Date.UTC(2026, 6, 17, 3, 0, 0)),
+			}),
+		).rejects.toBeInstanceOf(PgliteBackupRotationGuardError);
+
+		const status = await getPgliteBackupStatus(backupDir);
+		// 取得は成功している = 鮮度判定が「動いていない」に倒れない。
+		expect(status.lastSuccessAt).not.toBeNull();
+		// guard の発火は失敗ではないので連続失敗を積まない。
+		expect(status.consecutiveFailures).toBe(0);
+		// ローテーションが止まっていることは**別の事実として**残る (逆の silent 化を作らない)。
+		expect(status.rotationPendingCount).toBeGreaterThan(1);
+		expect(status.rotationBlockedSince).not.toBeNull();
+	}, 180_000);
+
+	it('[BK18] 退避して溢れが 1 世代に戻れば保留が解除される (#4162)', async () => {
+		// 解除を書き忘れると「片付けたのに warn が消えない」状態が固定され、
+		// 表示が現実から乖離する。
+		const client = await migratedClient();
+		const backupDir = tempDir('gq-bk18-');
+
+		for (let i = 0; i < 7; i++) {
+			await runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 7,
+				now: new Date(Date.UTC(2026, 6, 10 + i, 3, 0, 0)),
+			});
+		}
+		await expect(
+			runPgliteBackup({
+				client,
+				backupDir,
+				migrationsDir: MIGRATIONS_DIR,
+				retention: 3,
+				now: new Date(Date.UTC(2026, 6, 17, 3, 0, 0)),
+			}),
+		).rejects.toBeInstanceOf(PgliteBackupRotationGuardError);
+		expect((await getPgliteBackupStatus(backupDir)).rotationPendingCount).toBeGreaterThan(1);
+
+		// 運用者が古い世代を手で退避 (= 削除) した状況を作る。
+		const generations = sortBackupsNewestFirst(readdirSync(backupDir));
+		for (const stale of generations.slice(3)) {
+			rmSync(join(backupDir, stale));
+		}
+
+		await runPgliteBackup({
+			client,
+			backupDir,
+			migrationsDir: MIGRATIONS_DIR,
+			retention: 3,
+			now: new Date(Date.UTC(2026, 6, 18, 3, 0, 0)),
+		});
+
+		const status = await getPgliteBackupStatus(backupDir);
+		expect(status.rotationPendingCount).toBe(0);
+		expect(status.rotationBlockedSince).toBeNull();
+	}, 180_000);
+
 	it('[BK10] 定常運用 (1 世代だけ溢れる) は abort せず従来どおり削除する (#4129 AC2 false-positive 抑止)', async () => {
 		const client = await migratedClient();
 		const backupDir = tempDir('gq-bk10b-');
@@ -421,9 +505,11 @@ describe('#3950 PGlite backup — 復元できることの実証', () => {
 	// `backup-health.test.ts` は手書きリテラル入力のみ、`health-backup-status.test.ts` は
 	// status を mock する。**実 status → verdict の経路をどのテストも通っていない。**
 	//
-	// 本テストは **現在の挙動を固定する characterization test** である。#4162 で是正する際は
-	// 本テストの期待値も更新が必要になる (= 修正が必ず可視化される)。
-	it('[BK12] guard 発火中は新世代が確定しているのに health が「動いていない」と診断する (#4162 現状固定)', async () => {
+	// 本テストは監査が **現在の挙動を固定する characterization test** として置いたもので、
+	// 「#4162 で是正する際は期待値の更新が必要 (= 修正が必ず可視化される)」と設計されていた。
+	// #4162 の是正に伴い、期待値を **正しい挙動** へ反転させている (assertion の弱体化ではなく
+	// 反転。検証している経路の強度は落としていない — (4) で「戻っていないこと」も固定する)。
+	it('[BK12] guard 発火中は「取得は成功 / ローテーションが保留」と診断する (#4162 是正済)', async () => {
 		const client = await migratedClient();
 		const backupDir = tempDir('gq-bk12-');
 
@@ -431,6 +517,7 @@ describe('#3950 PGlite backup — 復元できることの実証', () => {
 			JSON.parse(readFileSync(join(backupDir, BACKUP_STATUS_FILENAME), 'utf-8')) as {
 				lastSuccessAt: string | null;
 				consecutiveFailures: number;
+				rotationPendingCount?: number;
 			};
 
 		// retention=7 運用で 7 世代を作る (#3950 引き下げ前と同じ形)。
@@ -465,23 +552,32 @@ describe('#3950 PGlite backup — 復元できることの実証', () => {
 		const generationsAfter = sortBackupsNewestFirst(readdirSync(backupDir)).length;
 		expect(generationsAfter).toBe(generationsBefore + 2);
 
-		// (2) それでも状態ファイルは「2 連続失敗」としか記録せず、成功時刻は進んでいない。
+		// (2) 状態ファイルは取得の成功を記録し、成功時刻が進んでいる。
+		//     guard の発火は失敗ではないので連続失敗を積まない。
 		const status = readStatus();
-		expect(status.consecutiveFailures).toBe(2);
-		expect(status.lastSuccessAt).toBe(successAtBeforeGuard);
+		expect(status.consecutiveFailures).toBe(0);
+		expect(status.lastSuccessAt).not.toBe(successAtBeforeGuard);
+		// ローテーションが止まっていることは**別の事実として**残る (逆の silent 化を作らない)。
+		expect(status.rotationPendingCount).toBeGreaterThan(1);
 
-		// (3) その状態を判定層に食わせると「job が動いていない」と読める critical になる。
-		//     直近の世代が実在するにもかかわらず、である (= 本 Issue の核心)。
+		// (3) 判定層は「動いていない」ではなく「片付いていない」と読む。
+		//     必要な行動 (古い世代を退避して手で削除) と診断が一致する。
 		const verdict = evaluateBackupHealth(
 			{
 				lastSuccessAt: status.lastSuccessAt,
 				consecutiveFailures: status.consecutiveFailures,
 				lastFailureMessage: null,
 				notificationConfigured: true,
+				rotationPendingCount: status.rotationPendingCount ?? 0,
 			},
 			new Date(Date.UTC(2026, 6, 19, 3, 5, 0)),
 		);
-		expect(verdict.level).toBe('critical');
-		expect(verdict.reason).toBe('consecutive-failures-critical');
+		expect(verdict.level).toBe('warn');
+		expect(verdict.reason).toBe('rotation-blocked');
+
+		// (4) **本 Issue の核心**: 直近の世代が実在するのに「job が動いていない」と
+		//     読まれる状態に戻っていないこと。stale / 連続失敗のいずれにも倒れない。
+		expect(verdict.reason).not.toBe('stale-critical');
+		expect(verdict.reason).not.toBe('consecutive-failures-critical');
 	}, 180_000);
 });

--- a/tests/unit/domain/backup-health.test.ts
+++ b/tests/unit/domain/backup-health.test.ts
@@ -35,6 +35,7 @@ function healthy(overrides: Partial<BackupHealthInput> = {}): BackupHealthInput 
 		consecutiveFailures: 0,
 		lastFailureMessage: null,
 		notificationConfigured: true,
+		rotationPendingCount: 0,
 		...overrides,
 	};
 }
@@ -120,10 +121,56 @@ describe('#4087 バックアップ状態の判定 (evaluateBackupHealth)', () =>
 				consecutiveFailures: 18,
 				lastFailureMessage: 'CRON_SECRET が未設定です (/api/cron/pglite-backup の認証に必要)',
 				notificationConfigured: false,
+				// 実害時はローテーション以前に取得が 0 件だった (guard は無関係)。
+				rotationPendingCount: 0,
 			},
 			NOW,
 		);
 		expect(v.level).toBe('critical');
+		expect(v.notificationMissing).toBe(true);
+	});
+});
+
+describe('#4162 ローテーション guard 発火中の診断', () => {
+	it('[BH13] 取得は成功していてローテーションだけ止まっているなら warn (critical にしない)', () => {
+		// guard 発火時は新世代の確定に成功しており、**毎晩 1 世代ずつ増え続けている**。
+		// これを critical にすると「job が動いていない」と読まれ、運用者が job の再起動へ
+		// 向かう。実際に必要な行動は「古い世代を退避して手で削除」で、診断が真逆になる。
+		const v = evaluateBackupHealth(healthy({ rotationPendingCount: 3 }), NOW);
+		expect(v.level).toBe('warn');
+		expect(v.reason).toBe('rotation-blocked');
+		expect(v.rotationPendingCount).toBe(3);
+	});
+
+	it('[BH14] 「取れていない」方が常に重い — stale / 連続失敗が rotation-blocked より優先する', () => {
+		// 片付いていないより取れていない方が重い。順序が逆転すると、本当に job が
+		// 止まっているときに warn へ格下げされる。
+		const stale = evaluateBackupHealth(
+			healthy({ lastSuccessAt: hoursAgo(60), rotationPendingCount: 3 }),
+			NOW,
+		);
+		expect(stale.reason).toBe('stale-critical');
+
+		const failing = evaluateBackupHealth(
+			healthy({ consecutiveFailures: 2, rotationPendingCount: 3 }),
+			NOW,
+		);
+		expect(failing.reason).toBe('consecutive-failures-critical');
+	});
+
+	it('[BH15] 保留が解除されたら rotation-blocked を出さない', () => {
+		// 退避して手で削除したのに warn が残り続けると、表示が現実から乖離して固定される。
+		const v = evaluateBackupHealth(healthy({ rotationPendingCount: 0 }), NOW);
+		expect(v.reason).toBe('healthy');
+	});
+
+	it('[BH16] rotation-blocked でも通知経路の欠落は independent に出る', () => {
+		// level と独立に立つ設計 (#4087 AC1) が guard 発火中も維持されること。
+		const v = evaluateBackupHealth(
+			healthy({ rotationPendingCount: 2, notificationConfigured: false }),
+			NOW,
+		);
+		expect(v.reason).toBe('rotation-blocked');
 		expect(v.notificationMissing).toBe(true);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**バックアップの診断が真逆になるのを直します。**

ローテーション guard（#4129 AC2）が発火している間、実際には**毎晩正常にバックアップが取れて世代が増え続けている**のに、health は「job が動いていない」と診断していました。運用者が必要な行動は「古い世代を退避して手で削除する」ですが、診断を信じると **job の再起動や再インストールに向かい、guard の意図（不可逆削除を止める）だけが失われます**。

guard 自身のコメントは「なお今回取得した新しいバックアップは確定済みで失われていません」と書いています。**コードは成功を知っているのに、記録していませんでした。**

## 関連 Issue

Refs #4162

<!-- no-issue-close: AC5 の failing-test-first 対は本 PR で固定したが、実機 (NUC) での guard 発火は再現させていない。Issue の close 判断は実運用での確認を含めて人が行う -->

## AC 検証マップ (ADR-0004)

HEAD SHA: `fde1e26a0`

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | guard 発火時、新世代が確定していることが状態ファイルから読み取れる | `[BK17]` | **充足**。`lastSuccessAt` が進み `consecutiveFailures` が 0 のままであることを実 PGlite + 実 FS で確認 |
| AC2 | `stale-critical` / `consecutive-failures-critical` を返さない | `[BK12]` (4) / `[BH14]` | **充足**。`[BK12]` に「戻っていないこと」の否定 assert を追加。`[BH14]` は逆に「本当に取れていないときは stale が優先」を固定 |
| AC3 | 「ローテーション保留、退避と手動削除が必要」と読める判定を返す | `[BK12]` (3) / `[BH13]` | **充足**。`warn` + `reason='rotation-blocked'`。家族向け UI にも専用文言を出す |
| AC4 | 退避 + 手動削除で溢れが戻れば自動復帰する | `[BK18]` | **充足**。古い世代を実際に削ってから再実行し `rotationPendingCount` が 0 / `rotationBlockedSince` が null に戻ることを確認 |
| AC5 | failing-test-first の対を固定する | mutation 2 種 | **充足**。下記 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 設定 > サポート のバックアップ状態カード（**NUC セルフホスト時のみ**）と `/api/health` の `backupHealth`。**子供画面は不変。クラウド（dsql）では描画されません。**

- [ ] **並行実装ペア**を同期した: N/A
- [x] **設計書同期** (ADR-0001): `docs/design/07-API設計書.md` の `backupHealth` を更新。**「既知の限界（#4144 由来、未解消）」節が本 PR で解消されたので、限界の記述を解消後の仕様に差し替え**ました
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| 判定 + 実経路 | `npx vitest run tests/unit/db/pglite-backup-3950.test.ts tests/unit/domain/backup-health.test.ts` | **27 passed** |
| 付与条件 + 表示 | `npx vitest run tests/unit/routes/health-backup-status.test.ts tests/unit/routes/admin-settings-support-backup-health.test.ts` | **14 passed** |
| 型 | `npx svelte-check` | **0 errors / 8505 files** |
| 綴り | `npm run cspell` | 0 issues |

### mutation 検証 2 種

| mutation | 内容 | 結果 |
|---|---|---|
| **A** | 判定層から `rotation-blocked` の分岐を削除 | `[BH13]` `[BH16]` の **2 件 fail** |
| **B** | service 層の「guard 前の成功記録」を撤去（**旧実装に戻す**） | `[BK12]` `[BK17]` `[BK18]` の **3 件 fail** |

commit 済みの実装に対して行い、復元は `git checkout --` の前に commit してあります。

- [x] **SOLID / DRY / YAGNI**: 判定は `$lib/domain/backup-health.ts`（純粋関数）、記録は service 層、表示は component
- [x] **Security（OSS 公開前提）**: 秘密情報なし
- [x] **A11y・パフォーマンス**: 既存 `Alert` primitive のまま。追加の I/O なし
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:critical` label なし）

## スクリーンショット / ビジュアルデモ

<!-- ss-render-impossible: カードは DATA_SOURCE=pglite かつ backup status file 存在でのみ描画され、SS 撮影に使う demo 環境 (DATA_SOURCE=demo) では原理的に描画されないため -->

**SS を添付していません。** カードは `DATA_SOURCE=pglite` かつ backup status file 存在でのみ描画され、**撮影に使う demo 環境では原理的に描画されません**（#4087 で新設した `ss-render-impossible` 宣言の 2 例目です）。

**Storybook に `WarnRotationBlocked` story を追加しました**（`Features/Admin/BackupHealthCard`）。既存 4 状態に加えて 5 状態目です。実画面確認は #3964 に合流します。

## レビュー依頼事項・破壊的変更

### 案 A（throw を catch の外に出すだけ）を採らなかった理由

`lastSuccessAt` は進みますが、**「ローテーションが止まっている」ことが記録から消えます**。退避が必要なことに誰も気づけなくなる = **逆の silent 化**で、#3950（動いているように見えて無保護）と同型になります。Issue の推奨（案 B）に同意しました。

### `[BK12]` の期待値を反転させました

監査が置いた characterization test で、**「#4162 で是正する際は期待値の更新が必要（= 修正が必ず可視化される）」と設計されていた**ものです。**assertion の弱体化ではなく反転**で、検証している経路の強度は落としていません — (4) として「stale / 連続失敗に戻っていないこと」を新たに固定しています。header コメントにもその旨を残しました。

### 家族向け UI に `reason` を出すかについて（#4153 QM 申し送りへの回答）

**`reason` enum は今回も露出させていません。** `reason === 'rotation-blocked'` のときだけ専用の固定文を選ぶ形です。

申し送りが懸念していた「**guard trip が 2 回続くと『取得は成功しているのに critical』**」という混在自体が、本 PR で解消されています。したがって「片付いていない」という正しい行動を出せるようになりました。汎用の「相談してください」だけだと必要な行動が分からず「job が壊れた」と読まれるため、ここは分けるべきと判断しました。

### 状態ファイルの後方互換

`rotationPendingCount` / `rotationBlockedSince` は**欠損時 0 / null 扱い**です。既存の NUC 上の状態ファイルはそのまま読めます。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1〜AC5 すべて。検証手段を AC 検証マップに明記）
- [x] UI 変更時: SS は原理的に撮れないため `ss-render-impossible` で宣言し、Storybook に 5 状態目を追加
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->
