### PR TITLE
fix(infra): #4167 NUC deploy が CRON_SECRET を配らず日次バックアップを静かに殺すのを塞ぐ

### DIFF
--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -92,8 +92,13 @@ jobs:
           # DISCORD_ALERT_WEBHOOK_URL も無いため alert 0 通で誰も気づかなかった (#4119)。
           # 手で .env に足しても次の deploy で消えるので、必ずこの経路で配る。
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
-          # 通知先。既存の health 通知チャネルを流用する (専用 webhook を増やさない)。
-          DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_HEALTH }}
+          # 通知先は **障害通知チャネル (incident)**。DISCORD_WEBHOOK_HEALTH は
+          # health-check Lambda の heartbeat / 復旧通知を流す**利用者向け**チャネルなので使わない
+          # (バックエンドの障害を利用者向けチャネルに混ぜると、どちらも読まれなくなる)。
+          # 宛先解決の SSOT は src/lib/server/discord-alert.ts:
+          #   DISCORD_ALERT_WEBHOOK_URL ?? DISCORD_WEBHOOK_INCIDENT
+          # なので、incident の値をそのまま ALERT として渡す。
+          DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_INCIDENT }}
           # #3970: off-site 退避先。未設定なら従来どおり ./data/backups (検査も走らない)。
           HOST_BACKUP_DIR: ${{ secrets.HOST_BACKUP_DIR }}
           # #2310 / #2337 / ADR-0050: parent-gate-session.ts は NODE_ENV=production で必須要求。
@@ -121,7 +126,7 @@ jobs:
           # 通知先が無くても deploy は止めない (バックアップ自体は動く) が、
           # **失敗しても誰にも届かない状態**なので警告は必ず出す (#4087 AC1 と同じ立場)。
           if (-not $env:DISCORD_ALERT_WEBHOOK_URL) {
-            Write-Host "::warning::DISCORD_WEBHOOK_HEALTH is not set — バックアップが失敗しても通知が 0 通になります (#4119 の実害と同じ状態)。"
+            Write-Host "::warning::DISCORD_WEBHOOK_INCIDENT is not set — バックアップが失敗しても通知が 0 通になります (#4119 の実害と同じ状態)。"
           }
           # `.env` を毎回 GHA Secrets から再生成（rotate 対応・冪等）。
           # ASCII エンコーディング指定で BOM を避ける (docker compose env_file は BOM を弾く)。

--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -86,6 +86,16 @@ jobs:
       # ここで書き換えない。`.env` は **secret 専用** とし、構成値とは分離する。
       - name: Generate .env from GitHub Secrets
         env:
+          # #4166: バックアップ経路の必須 env。**ここに載っていない env は deploy のたびに
+          # .env から消える** (下の Set-Content が固定リストで全上書きするため)。
+          # 2026-07-31 の実害はこれ: CRON_SECRET が配られず 18 晩バックアップが失敗し、
+          # DISCORD_ALERT_WEBHOOK_URL も無いため alert 0 通で誰も気づかなかった (#4119)。
+          # 手で .env に足しても次の deploy で消えるので、必ずこの経路で配る。
+          CRON_SECRET: ${{ secrets.CRON_SECRET }}
+          # 通知先。既存の health 通知チャネルを流用する (専用 webhook を増やさない)。
+          DISCORD_ALERT_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_HEALTH }}
+          # #3970: off-site 退避先。未設定なら従来どおり ./data/backups (検査も走らない)。
+          HOST_BACKUP_DIR: ${{ secrets.HOST_BACKUP_DIR }}
           # #2310 / #2337 / ADR-0050: parent-gate-session.ts は NODE_ENV=production で必須要求。
           # NUC も NODE_ENV=production で起動するため未注入だと /admin/* cold start で throw して 500。
           # NUC は LAN 内 + AUTH_MODE=local で PIN gate は実際には使われないが、module load 時の
@@ -99,6 +109,20 @@ jobs:
             Write-Host "::error::See docs/decisions/0050-parent-gate-session-cookie-signature.md and infra/CLAUDE.md."
             exit 1
           }
+          # #4166: CRON_SECRET も fail-closed にする。無いと日次バックアップが毎晩失敗するが、
+          # **deploy 自体は成功して見える**ため誰も気づかない (2026-07-31 に 18 晩続いた)。
+          # 「deploy は緑、バックアップだけ静かに死ぬ」を作らない。
+          if (-not $env:CRON_SECRET) {
+            Write-Host "::error::CRON_SECRET is not set in GitHub Actions Secrets."
+            Write-Host "::error::/api/cron/pglite-backup の認証に必須。無いと日次バックアップが毎晩失敗します (#4119)。"
+            Write-Host "::error::Register with: gh secret set CRON_SECRET --body <hex> --repo Takenori-Kusaka/ganbari-quest"
+            exit 1
+          }
+          # 通知先が無くても deploy は止めない (バックアップ自体は動く) が、
+          # **失敗しても誰にも届かない状態**なので警告は必ず出す (#4087 AC1 と同じ立場)。
+          if (-not $env:DISCORD_ALERT_WEBHOOK_URL) {
+            Write-Host "::warning::DISCORD_WEBHOOK_HEALTH is not set — バックアップが失敗しても通知が 0 通になります (#4119 の実害と同じ状態)。"
+          }
           # `.env` を毎回 GHA Secrets から再生成（rotate 対応・冪等）。
           # ASCII エンコーディング指定で BOM を避ける (docker compose env_file は BOM を弾く)。
           # ORIGIN: NUC LAN デプロイでは 0.0.0.0 を指定し同一ネットワーク内の全端末を許可。
@@ -110,8 +134,16 @@ jobs:
             "AI_PROVIDER=gemini",
             "ORIGIN=http://0.0.0.0:3000",
             "DATA_SOURCE=pglite",
-            "PGLITE_DATA_DIR=/app/data/pglite"
+            "PGLITE_DATA_DIR=/app/data/pglite",
+            "CRON_SECRET=$env:CRON_SECRET"
           )
+          # 任意 env は設定されているときだけ書く (空値を書くと「設定済みだが空」と区別できない)。
+          if ($env:DISCORD_ALERT_WEBHOOK_URL) {
+            $envLines += "DISCORD_ALERT_WEBHOOK_URL=$env:DISCORD_ALERT_WEBHOOK_URL"
+          }
+          if ($env:HOST_BACKUP_DIR) {
+            $envLines += "HOST_BACKUP_DIR=$env:HOST_BACKUP_DIR"
+          }
           Set-Content -Path .env -Value $envLines -Encoding ASCII
           Write-Host "Wrote .env from GitHub Secrets ($($envLines.Count) lines, secret values masked)"
 

--- a/.github/workflows/deploy-nuc.yml
+++ b/.github/workflows/deploy-nuc.yml
@@ -86,7 +86,7 @@ jobs:
       # ここで書き換えない。`.env` は **secret 専用** とし、構成値とは分離する。
       - name: Generate .env from GitHub Secrets
         env:
-          # #4166: バックアップ経路の必須 env。**ここに載っていない env は deploy のたびに
+          # #4167: バックアップ経路の必須 env。**ここに載っていない env は deploy のたびに
           # .env から消える** (下の Set-Content が固定リストで全上書きするため)。
           # 2026-07-31 の実害はこれ: CRON_SECRET が配られず 18 晩バックアップが失敗し、
           # DISCORD_ALERT_WEBHOOK_URL も無いため alert 0 通で誰も気づかなかった (#4119)。
@@ -109,7 +109,7 @@ jobs:
             Write-Host "::error::See docs/decisions/0050-parent-gate-session-cookie-signature.md and infra/CLAUDE.md."
             exit 1
           }
-          # #4166: CRON_SECRET も fail-closed にする。無いと日次バックアップが毎晩失敗するが、
+          # #4167: CRON_SECRET も fail-closed にする。無いと日次バックアップが毎晩失敗するが、
           # **deploy 自体は成功して見える**ため誰も気づかない (2026-07-31 に 18 晩続いた)。
           # 「deploy は緑、バックアップだけ静かに死ぬ」を作らない。
           if (-not $env:CRON_SECRET) {

--- a/tests/unit/infra/nuc-deploy-env-closure.test.ts
+++ b/tests/unit/infra/nuc-deploy-env-closure.test.ts
@@ -76,22 +76,20 @@ const BACKUP_ENV_CONTRACT = [
 describe('#4167 NUC deploy の env 配布 closure', () => {
 	const block = envGenerationBlock();
 
-	it.each(BACKUP_ENV_CONTRACT.filter((e) => e.required))(
-		'[ND1] 必須 env $name が deploy の .env 生成に含まれる',
-		({ name, why }) => {
-			// 「.env に書かれる」= 実際に配られる。env: への宣言だけでは届かない。
-			expect(block, `${name} が .env 生成に含まれていません — ${why}`).toContain(`${name}=`);
-		},
-	);
+	it.each(
+		BACKUP_ENV_CONTRACT.filter((e) => e.required),
+	)('[ND1] 必須 env $name が deploy の .env 生成に含まれる', ({ name, why }) => {
+		// 「.env に書かれる」= 実際に配られる。env: への宣言だけでは届かない。
+		expect(block, `${name} が .env 生成に含まれていません — ${why}`).toContain(`${name}=`);
+	});
 
-	it.each(BACKUP_ENV_CONTRACT.filter((e) => !e.required))(
-		'[ND2] 任意 env $name も配布経路を持つ (無いこと自体は許容)',
-		({ name, why }) => {
-			// 任意でも **配る手段が存在しない** のは別問題。secret 未登録で空になるのは許容するが、
-			// workflow に経路が無ければ「登録しても届かない」= 永久に 0 通になる。
-			expect(block, `${name} の配布経路が workflow にありません — ${why}`).toContain(name);
-		},
-	);
+	it.each(
+		BACKUP_ENV_CONTRACT.filter((e) => !e.required),
+	)('[ND2] 任意 env $name も配布経路を持つ (無いこと自体は許容)', ({ name, why }) => {
+		// 任意でも **配る手段が存在しない** のは別問題。secret 未登録で空になるのは許容するが、
+		// workflow に経路が無ければ「登録しても届かない」= 永久に 0 通になる。
+		expect(block, `${name} の配布経路が workflow にありません — ${why}`).toContain(name);
+	});
 
 	it('[ND3] CRON_SECRET 欠落時は deploy を止める (fail-closed)', () => {
 		// warning で流すと「deploy は緑、バックアップだけ静かに死ぬ」に戻る。
@@ -111,8 +109,12 @@ describe('#4167 NUC deploy の env 配布 closure', () => {
 		// script 側が新しい env を読み始めたのに workflow へ足し忘れる、を検出する。
 		// **script が SSOT** で、本テストはそこから要求を読む。
 		const script = readFileSync(join(ROOT, 'scripts', 'backup-nuc.cjs'), 'utf-8');
-		const referenced = new Set(
-			[...script.matchAll(/process\.env\.([A-Z][A-Z0-9_]*)/g)].map((m) => m[1]),
+		// 正規表現の capture group は型上 `string | undefined` になるため絞り込む
+		// (実行時は必ず存在するが、型を `as` で黙らせない)。
+		const referenced = new Set<string>(
+			[...script.matchAll(/process\.env\.([A-Z][A-Z0-9_]*)/g)]
+				.map((m) => m[1])
+				.filter((n): n is string => typeof n === 'string'),
 		);
 		// script が読むが deploy が配らなくてよい env (compose が直接与える / 派生値)。
 		const suppliedByCompose = new Set([
@@ -122,7 +124,7 @@ describe('#4167 NUC deploy の env 配布 closure', () => {
 			'OPS_SECRET_KEY',
 			'DISCORD_WEBHOOK_INCIDENT',
 		]);
-		const contractNames = new Set(BACKUP_ENV_CONTRACT.map((e) => e.name));
+		const contractNames = new Set<string>(BACKUP_ENV_CONTRACT.map((e) => e.name));
 
 		const unaccounted = [...referenced].filter(
 			(n) => !contractNames.has(n) && !suppliedByCompose.has(n),

--- a/tests/unit/infra/nuc-deploy-env-closure.test.ts
+++ b/tests/unit/infra/nuc-deploy-env-closure.test.ts
@@ -64,7 +64,7 @@ const BACKUP_ENV_CONTRACT = [
 	{
 		name: 'PGLITE_DATA_DIR',
 		required: true,
-		why: '稼働中 PGDATA の場所。取得対象そのもの',
+		why: '稼働中 DB のデータディレクトリの場所。取得対象そのもの',
 	},
 	{
 		name: 'DISCORD_ALERT_WEBHOOK_URL',

--- a/tests/unit/infra/nuc-deploy-env-closure.test.ts
+++ b/tests/unit/infra/nuc-deploy-env-closure.test.ts
@@ -1,0 +1,136 @@
+// #4166 — NUC deploy が **本番で必要な env を配り落とさない**ことを機械で固定する。
+//
+// ## 塞ぐ穴
+//
+// `deploy-nuc.yml` の「Generate .env from GitHub Secrets」step は、`.env` を
+// **固定リストで毎回全上書き**する (`Set-Content`)。したがって:
+//
+//   - リストに載っていない env は **deploy のたびに消える**
+//   - 手で `.env` に足しても次の deploy で消える
+//   - それでも **deploy 自体は成功する** ので、誰も気づかない
+//
+// 2026-07-31 の実害 (#4119) がまさにこれだった。`CRON_SECRET` が配られず日次バックアップが
+// 18 晩失敗し続け、`DISCORD_ALERT_WEBHOOK_URL` も無いため alert は 0 通で、
+// **本番データが 18 日間無保護のまま誰も気づかなかった**。
+//
+// 「deploy は緑、バックアップだけ静かに死ぬ」は #3950 と同型の failure mode である。
+// 人の注意ではなく機械で閉じる (ADR-0061 fitness function)。
+//
+// ## 何を固定するか
+//
+// **本番バックアップ経路が読む env** が、deploy が生成する `.env` に載っていること。
+// env の出所 (`scripts/backup-nuc.cjs` と service 層) から要求を読み、workflow と突き合わせる。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = process.cwd();
+const WORKFLOW_PATH = join(ROOT, '.github', 'workflows', 'deploy-nuc.yml');
+
+const workflow = readFileSync(WORKFLOW_PATH, 'utf-8');
+
+/**
+ * `.env` 生成 step が書き出す行と、その後の条件付き追記をまとめて取り出す。
+ *
+ * `Set-Content -Path .env` までを対象にすることで、「env: に宣言したが `.env` に
+ * 書いていない」= 配られていない、を検出できる (宣言だけでは届かない)。
+ */
+function envGenerationBlock(): string {
+	const start = workflow.indexOf('Generate .env from GitHub Secrets');
+	expect(start).toBeGreaterThan(-1);
+	const end = workflow.indexOf('Set-Content -Path .env', start);
+	expect(end).toBeGreaterThan(start);
+	return workflow.slice(start, end);
+}
+
+/**
+ * 本番 NUC のバックアップ経路が読む env のうち、**欠けると静かに壊れるもの**。
+ *
+ * `required` = 無いと日次バックアップが毎晩失敗する (deploy は成功して見える)。
+ * `optional` = 無くても取得は動くが、**失敗が誰にも届かない / off-site 検査が走らない**。
+ */
+const BACKUP_ENV_CONTRACT = [
+	{
+		name: 'CRON_SECRET',
+		required: true,
+		why: '/api/cron/pglite-backup の認証。無いと毎晩 500 で失敗する (#4119 の直接原因)',
+	},
+	{
+		name: 'DATA_SOURCE',
+		required: true,
+		why: 'backup-nuc.cjs が /api/health の dataSource と照合する。不一致なら実行前に落ちる (#3967)',
+	},
+	{
+		name: 'PGLITE_DATA_DIR',
+		required: true,
+		why: '稼働中 PGDATA の場所。取得対象そのもの',
+	},
+	{
+		name: 'DISCORD_ALERT_WEBHOOK_URL',
+		required: false,
+		why: '失敗通知の宛先。無いと 18 晩失敗しても alert 0 通になる (#4119)',
+	},
+] as const;
+
+describe('#4166 NUC deploy の env 配布 closure', () => {
+	const block = envGenerationBlock();
+
+	it.each(BACKUP_ENV_CONTRACT.filter((e) => e.required))(
+		'[ND1] 必須 env $name が deploy の .env 生成に含まれる',
+		({ name, why }) => {
+			// 「.env に書かれる」= 実際に配られる。env: への宣言だけでは届かない。
+			expect(block, `${name} が .env 生成に含まれていません — ${why}`).toContain(`${name}=`);
+		},
+	);
+
+	it.each(BACKUP_ENV_CONTRACT.filter((e) => !e.required))(
+		'[ND2] 任意 env $name も配布経路を持つ (無いこと自体は許容)',
+		({ name, why }) => {
+			// 任意でも **配る手段が存在しない** のは別問題。secret 未登録で空になるのは許容するが、
+			// workflow に経路が無ければ「登録しても届かない」= 永久に 0 通になる。
+			expect(block, `${name} の配布経路が workflow にありません — ${why}`).toContain(name);
+		},
+	);
+
+	it('[ND3] CRON_SECRET 欠落時は deploy を止める (fail-closed)', () => {
+		// warning で流すと「deploy は緑、バックアップだけ静かに死ぬ」に戻る。
+		// 2026-07-31 はその状態が 18 晩続いた。
+		expect(block).toMatch(/if \(-not \$env:CRON_SECRET\)/);
+		expect(block.slice(block.indexOf('$env:CRON_SECRET'))).toContain('exit 1');
+	});
+
+	it('[ND4] 通知先が無いときは警告を出す (黙って進めない)', () => {
+		// 通知先の欠落で deploy を止めるのは過剰 (取得自体は動く) だが、
+		// **黙って進むと「失敗しても誰にも届かない」状態が可視化されない**。
+		expect(block).toMatch(/if \(-not \$env:DISCORD_ALERT_WEBHOOK_URL\)/);
+		expect(block).toContain('::warning::');
+	});
+
+	it('[ND5] backup-nuc.cjs が読む env が契約に列挙されている (取りこぼし検出)', () => {
+		// script 側が新しい env を読み始めたのに workflow へ足し忘れる、を検出する。
+		// **script が SSOT** で、本テストはそこから要求を読む。
+		const script = readFileSync(join(ROOT, 'scripts', 'backup-nuc.cjs'), 'utf-8');
+		const referenced = new Set(
+			[...script.matchAll(/process\.env\.([A-Z][A-Z0-9_]*)/g)].map((m) => m[1]),
+		);
+		// script が読むが deploy が配らなくてよい env (compose が直接与える / 派生値)。
+		const suppliedByCompose = new Set([
+			'BACKUP_DIR',
+			'BACKUP_RETENTION',
+			'APP_URL',
+			'OPS_SECRET_KEY',
+			'DISCORD_WEBHOOK_INCIDENT',
+		]);
+		const contractNames = new Set(BACKUP_ENV_CONTRACT.map((e) => e.name));
+
+		const unaccounted = [...referenced].filter(
+			(n) => !contractNames.has(n) && !suppliedByCompose.has(n),
+		);
+		expect(
+			unaccounted,
+			`backup-nuc.cjs が読む env のうち、配布契約にも compose にも無いものがあります: ${unaccounted.join(', ')}。` +
+				'BACKUP_ENV_CONTRACT に追加するか、compose 供給分として suppliedByCompose に明示してください。',
+		).toEqual([]);
+	});
+});

--- a/tests/unit/infra/nuc-deploy-env-closure.test.ts
+++ b/tests/unit/infra/nuc-deploy-env-closure.test.ts
@@ -1,4 +1,4 @@
-// #4166 — NUC deploy が **本番で必要な env を配り落とさない**ことを機械で固定する。
+// #4167 — NUC deploy が **本番で必要な env を配り落とさない**ことを機械で固定する。
 //
 // ## 塞ぐ穴
 //
@@ -73,7 +73,7 @@ const BACKUP_ENV_CONTRACT = [
 	},
 ] as const;
 
-describe('#4166 NUC deploy の env 配布 closure', () => {
+describe('#4167 NUC deploy の env 配布 closure', () => {
 	const block = envGenerationBlock();
 
 	it.each(BACKUP_ENV_CONTRACT.filter((e) => e.required))(


### PR DESCRIPTION
## 顧客価値・目的

**家族の記録の控えが、deploy のたびに静かに無保護へ戻る構造を塞ぎます。**

`deploy-nuc.yml` は `.env` を**固定リストで毎回全上書き**します。そのリストに `CRON_SECRET` が無いため、**手で足しても次の deploy で必ず消えます**。しかも **deploy 自体は成功する**ので誰も気づきません。

2026-07-31 の実害（#4119、18 晩失敗 + alert 0 通）は人手で直しましたが、**再発経路は塞がっていませんでした**。

## 関連 Issue

Refs #4167

<!-- no-issue-close: 本 PR は CI 側の再発防止。本番 NUC 側の復旧は実施済だが、次回 deploy で実際に .env が正しく生成されることの確認は main 反映後になるため、close 判断は人が行う -->

## AC 検証マップ (ADR-0004)

HEAD SHA: `63a952810`

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `CRON_SECRET` を Secrets に登録し `.env` に含める | `[ND1]` + 実機 | **充足**。`gh secret set CRON_SECRET` 実行済（`gh secret list` に出現を確認）。workflow の `.env` 生成に追加 |
| AC2 | `CRON_SECRET` 欠落は fail-closed | `[ND3]` | **充足**。`exit 1`。warning にすると「deploy は緑、バックアップだけ静かに死ぬ」に戻る |
| AC3 | 通知先の配布経路を用意し、欠落時は警告 | `[ND2]` / `[ND4]` | **充足**。既存 `DISCORD_WEBHOOK_HEALTH` から配布。欠落で deploy は止めないが `::warning::` を出す |
| AC4 | `HOST_BACKUP_DIR` の配布経路 | workflow diff | **充足**。設定時のみ `.env` へ追記（空値を書くと「設定済みだが空」と区別できないため） |
| AC5 | env 脱落を fitness function で閉じる | `[ND5]` + mutation | **充足**。`backup-nuc.cjs` を SSOT に「script は読むが workflow が配らない env」を検出 |
| AC6 | 本番 NUC で実 cron 経路の成功を実測 | 実機実行 | **充足**。下記ログ |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（UI 変更ゼロ）。NUC deploy の `.env` 生成のみ。

- [ ] **並行実装ペア**を同期した: N/A
- [x] **設計書同期** (ADR-0001): workflow 内コメントに「ここに載っていない env は deploy のたびに消える」構造を明記。`.env.example` は既に #3950 / #4129 系で記載済のため差分なし
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| fitness | `npx vitest run tests/unit/infra/nuc-deploy-env-closure.test.ts` | **7 passed** |
| env 配布 gate | `node scripts/check-new-required-env.mjs` | no newly required env — OK |

### mutation 検証

| mutation | 内容 | 結果 |
|---|---|---|
| A | `.env` 生成から `CRON_SECRET=` の行を削除 | `[ND1]` **1 件 fail** |

### 本番 NUC での実測（read → 復旧 → 再実測）

**失敗の再現**（復旧前、実 cron 経路）:

```
[backup-nuc] POST http://app:3000/api/cron/pglite-backup
[backup-nuc] FAILED: HTTP 500: {"error":"CRON_SECRET not configured"}
[backup-nuc] Discord webhook 未設定のため通知を送れません
```

**復旧後**（Secrets 登録 → `.env` 配備 → 両コンテナ再作成 → 実 cron 経路）:

```
[backup-nuc] backend=pglite (health+env) — DATA_SOURCE=pglite と /api/health dataSource=pglite が一致
[backup-nuc] POST http://app:3000/api/cron/pglite-backup
[backup-nuc] OK: pglite-20260801T063058Z.tgz (5890105 bytes, 5334ms, 保持 3 世代)
[backup-nuc] verification: {"tablesVerified":59,"migrationsApplied":5,
                            "maxAppliedCreatedAt":1784500000002,"journalEntries":5}
```

- [x] **SOLID / DRY / YAGNI**: 契約（どの env が必須か）を test 側の 1 箇所に持ち、workflow と script の双方と突き合わせる
- [x] **Security（OSS 公開前提）**: secret 値は一切コミットしていません。`gh secret set` は stdin 経由で、生成した一時ファイルは削除済
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): `priority:critical` label なし。ただし**顧客データ保全に直結**するため証跡は critical 相当で残しました

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: UI 変更ゼロの deploy workflow / テスト追加で、画面に現れる差分が存在しないため -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 通知先に既存の `DISCORD_WEBHOOK_HEALTH` を流用しました

専用 webhook を新設せず、既存の health 通知チャネルへ相乗りさせています。**別チャネルに分けたい場合は secret 名を変えるだけ**です（workflow の 1 行）。「バックアップ失敗はどこに届くべきか」はご判断ください。

### `[ND5]` が守る範囲

`backup-nuc.cjs` が `process.env.X` で読む env を抽出し、**配布契約にも compose 供給リストにも無いもの**を検出します。script が新しい env を読み始めたのに workflow へ足し忘れる、を捕まえます。逆に「service 層だけが読む env」は対象外なので、そこは今後の穴として残ります。

### 本番 NUC 側は復旧済みです

CI が直っても、**現に動いている NUC は次の deploy まで古い `.env` のまま**です。そのため本 PR とは別に、実機の `.env` へ `CRON_SECRET` を配備し両コンテナを再作成済みです（上記ログ）。**今夜 03:00 の cron は成功します。**

## 配布済み env / secret (ADR-0006)

- [x] `CRON_SECRET` — **GitHub Actions Secrets に登録済**（`gh secret list` で確認）。本番 NUC `.env` へ配備済。値はコミットしていません
- [x] `DISCORD_ALERT_WEBHOOK_URL` — 既存 `DISCORD_WEBHOOK_HEALTH` から配布（新規 secret の登録は不要）
- [x] `HOST_BACKUP_DIR` — 未登録（#3970 AC1 のオーナー判断待ち）。未設定なら従来どおり動作します

## PO 決裁ブリーフ

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert のみで戻る"]
    R2["顧客面: 画面は不変 家庭のデータ保全に効く"]
    R3["🔴deploy が止まりうる 秘密未登録なら fail-closed"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 控えが静かに消える経路を塞ぐ"]
    T2["捨てる: 秘密が欠けると deploy 不可"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: 検査は本番で未発火 過信の恐れ"]
    O2["UX: 通知は運用者向け 家族には届かない"]
    O3["security: 秘密が env ファイルに平文で残る"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["UI 変更ゼロ 失敗が届くようになるだけ"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 秘密欠落で deploy を止めてよいか"]
    Q2["Q2: 障害通知先を incident に寄せてよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3 danger
  class T2,O1,O2,O3 warn
  class R1,R2,T1,C1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい)</summary>

**なぜ決裁が要るか**: `.github/labeler.yml` の `deploy*.yml` glob に一致しており、**NUC 実機の deploy 経路を変える PR** です。label は誤付与ではありません（QM 実測で確認済）。

**Q1 の実体**: `CRON_SECRET` が GitHub Secrets に無いと **deploy を exit 1 で止めます**。warning にすると「deploy は緑、バックアップだけ静かに死ぬ」に戻り、それが 2026-07-31 に 18 晩続いた形です。ただし**秘密の登録漏れで deploy 全体が止まる**副作用があります。秘密は 2026-08-01 に登録済みなので、現状で止まることはありません。

**Q2 の実体**: 障害通知先を `DISCORD_WEBHOOK_HEALTH`（利用者向け）から `DISCORD_WEBHOOK_INCIDENT`（障害用）へ変更しました。PO 指摘に基づく是正です。webhook は登録済みで、**意図的に失敗させて通知が届くことを実証済**（`[backup-nuc] Discord alert sent`）。

**③ の反対理由**は本 PR 向けに `tmp/adversarial-evidence/` を生成していません。**#4159 で生成した 3 軸のうち、本 PR にも当てはまるものを転記しています**（同じバックアップ経路のため）。生成していないことを明示します。

</details>

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A（`ss-pair-none` で宣言）
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->

