### PR TITLE
fix(ops): #4176 バックアップ状態カードを実画面に配線し、二重実装を解消する

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -2813,13 +2813,16 @@ Anti-engagement 原則 (ADR-0012) に従い、子供 UI には CTA を**設置�
 | 判定 | `$lib/domain/backup-health.ts` の純粋関数。component は描画のみ持つ |
 | 表示 | `Alert`（`ok`=success / `warn`=warning / `critical`=danger）+ 最終成功日時 + 連続失敗回数 + 通知経路の有無 |
 | 通知経路の警告 | `notificationMissing` は **`level` と独立に**出す。「取れてはいるが、壊れても届かない」は対処が別だから |
-| 内部 `reason` の非露出 | `reason` enum を画面に出さない。`level` に応じた固定文言のみ（guard trip が 2 回続くと「取得は成功しているのに critical」になる判定の弱点が、家族向け文言として誤解を招くのを避ける。判定側の課題は #4144） |
+| 内部 `reason` の非露出 | **`reason` enum を画面に出さない**（原則は不変）。ただし文言の選択は **`level` + `reason` の 2 軸**で行う — `reason` に応じた**固定文を選ぶ**形であり、enum 値そのものは露出しない |
+| 断定形の禁止（#4162） | **取得が成功している状態で「取れていません」と断定しない**。`rotation-blocked` / `rotation-blocked-critical` は毎晩正常に取れており世代はむしろ増え続けているため、`backupCriticalTitle`（「バックアップが取れていません」）を出すと**診断が真逆**になる。`tests/unit/ui/backup-health-card-wording.test.ts` が機械強制（`[BC3]` が文言そのものを検査） |
+| 見出しを `level` だけで決めない | `level='critical'` でも `reason='rotation-blocked-critical'` なら専用見出しを出す。**level 駆動に戻すと #4173 で差し戻した「7 日後に嘘をつく」を作り直す** |
 | 配置方針 | ADR-0012 anti-engagement に従い、常時表示の煽りにしない設定画面内の静的表示。**子供画面には一切出さない** |
 | testid | `backup-health`（root）+ `data-level` |
 
-- **文言 SSOT**: `SETTINGS_LABELS.{backupSectionTitle, backupOkTitle, backupWarnTitle, backupCriticalTitle, backupLastSuccessLabel, backupNeverSucceeded, backupConsecutiveFailuresLabel, backupNotificationMissing, backupActionHint}`
+- **文言 SSOT**: `SETTINGS_LABELS.{backupSectionTitle, backupOkTitle, backupWarnTitle, backupCriticalTitle, backupRotationBlockedCriticalTitle, backupLastSuccessLabel, backupNeverSucceeded, backupConsecutiveFailuresLabel, backupNotificationMissing, backupActionHint, backupRotationBlockedHint, backupRotationBlockedCriticalHint}`
 - **status file が読めなくても load を落とさない**: バックアップ状態が読めないことと相談フォームが使えることは無関係で、ここで throw すると「バックアップ状態が読めないせいで相談できない」逆転が起きる
-- **SS が撮れない画面**: 描画条件が env 依存で、撮影に使う demo 環境（`DATA_SOURCE=demo`）では出ない。3 状態の見た目は Storybook（`Features/Admin/BackupHealthCard`）で確認する（`src/routes/CLAUDE.md` の `ss-render-impossible` 宣言）。実機確認は #3964
+- **SS が撮れない画面**: 描画条件が env 依存で、撮影に使う demo 環境（`DATA_SOURCE=demo`）では出ない。見た目は Storybook（`Features/Admin/BackupHealthCard`、6 状態）で確認する（`src/routes/CLAUDE.md` の `ss-render-impossible` 宣言）。実機確認は #3964
+- **描画は component 1 箇所に集約する（#4176）**: 実画面が同じ描画を再実装すると、**component だけ直しても家族の画面に届かない**。実際に #4162 の修正が届いていなかった。`tests/unit/architecture/backup-health-card-wiring.test.ts` が配線と二重実装の復活を機械強制
 - **回帰**: `tests/unit/routes/admin-settings-support-backup-health.test.ts`（`[SB1]`〜`[SB4]` = 表示 / dsql 非表示 / status 不読でも load 継続 / level 伝播）
 
 ---

--- a/src/lib/features/admin/components/BackupHealthCard.stories.svelte
+++ b/src/lib/features/admin/components/BackupHealthCard.stories.svelte
@@ -97,7 +97,13 @@ const CRITICAL_ROTATION_BLOCKED: BackupHealthVerdict = {
 <Story name="WarnRotationBlocked" args={{ health: WARN_ROTATION_BLOCKED }} />
 <Story name="CriticalRotationBlocked" args={{ health: CRITICAL_ROTATION_BLOCKED }} />
 
-<Story name="AllStates">
+<!--
+	args を渡すのは、meta の `component` が指定されている story は args から自動 render される
+	経路があり、`health` が undefined だと `Cannot read properties of undefined (reading 'level')`
+	で落ちるため (#4175 で実測)。`--dangerouslyIgnoreUnhandledErrors` により
+	「passed」に見えていて気づけなかった。
+-->
+<Story name="AllStates" args={{ health: OK }}>
 	<div class="flex flex-col gap-4">
 		<BackupHealthCard health={OK} />
 		<BackupHealthCard health={WARN_NO_CHANNEL} />

--- a/src/lib/features/admin/components/BackupHealthCard.stories.svelte
+++ b/src/lib/features/admin/components/BackupHealthCard.stories.svelte
@@ -100,7 +100,7 @@ const CRITICAL_ROTATION_BLOCKED: BackupHealthVerdict = {
 <!--
 	args を渡すのは、meta の `component` が指定されている story は args から自動 render される
 	経路があり、`health` が undefined だと `Cannot read properties of undefined (reading 'level')`
-	で落ちるため (#4175 で実測)。`--dangerouslyIgnoreUnhandledErrors` により
+	で落ちるため (#4176 で実測)。`--dangerouslyIgnoreUnhandledErrors` により
 	「passed」に見えていて気づけなかった。
 -->
 <Story name="AllStates" args={{ health: OK }}>

--- a/src/routes/(parent)/admin/settings/support/+page.svelte
+++ b/src/routes/(parent)/admin/settings/support/+page.svelte
@@ -233,7 +233,7 @@ const successMessage = $derived(
 	     `curl /api/health | jq` しかなかった。家族 (非エンジニア) が見られる場所に出す。
 	     ADR-0012 整合で常時表示の煽りにはせず、設定画面内の静的表示に留める。
 
-	     #4175: ここは以前 59 行のインライン実装だった。同じ描画が component 側にもあり、
+	     #4176: ここは以前 59 行のインライン実装だった。同じ描画が component 側にもあり、
 	     **component だけを直しても実画面に届かない**状態になっていた (#4162 の
 	     rotation-blocked 文言が実際そうなった)。Storybook が描いていたのも
 	     誰も表示しない component で、SS の代替という主張が成立していなかった。

--- a/src/routes/(parent)/admin/settings/support/+page.svelte
+++ b/src/routes/(parent)/admin/settings/support/+page.svelte
@@ -6,7 +6,8 @@
 // founder 直接相談の独立ページ (/inquiry/founder) は LP / ライセンス導線から到達するため存続。
 
 import { enhance } from '$app/forms';
-import { APP_LABELS, formatCount, PAGE_TITLES, SETTINGS_LABELS } from '$lib/domain/labels';
+import { APP_LABELS, PAGE_TITLES, SETTINGS_LABELS } from '$lib/domain/labels';
+import BackupHealthCard from '$lib/features/admin/components/BackupHealthCard.svelte';
 import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
 import Alert from '$lib/ui/primitives/Alert.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
@@ -230,47 +231,15 @@ const successMessage = $derived(
 	<!-- #4087 (E3 / EPIC #4119): バックアップ状態。NUC セルフホスト時のみ表示する。
 	     2026-07-31 の実害では 18 日間バックアップが止まっていたのに、気づく手段が
 	     `curl /api/health | jq` しかなかった。家族 (非エンジニア) が見られる場所に出す。
-	     ADR-0012 整合で常時表示の煽りにはせず、設定画面内の静的表示に留める。 -->
+	     ADR-0012 整合で常時表示の煽りにはせず、設定画面内の静的表示に留める。
+
+	     #4175: ここは以前 59 行のインライン実装だった。同じ描画が component 側にもあり、
+	     **component だけを直しても実画面に届かない**状態になっていた (#4162 の
+	     rotation-blocked 文言が実際そうなった)。Storybook が描いていたのも
+	     誰も表示しない component で、SS の代替という主張が成立していなかった。
+	     描画は BackupHealthCard 1 箇所に集約する。 -->
 	{#if data.backupHealth}
-		{@const bh = data.backupHealth}
-		<Card padding="lg">
-			<h3 class="text-lg font-bold text-[var(--color-text)] mb-4">
-				{SETTINGS_LABELS.backupSectionTitle}
-			</h3>
-			<div data-testid="backup-health" data-level={bh.level}>
-				{#if bh.level === 'ok'}
-					<Alert variant="success" message={SETTINGS_LABELS.backupOkTitle} />
-				{:else if bh.level === 'warn'}
-					<Alert variant="warning" message={SETTINGS_LABELS.backupWarnTitle} />
-				{:else}
-					<Alert variant="danger" message={SETTINGS_LABELS.backupCriticalTitle} />
-				{/if}
-
-				<ul class="mt-3 space-y-1 text-sm text-[var(--color-text-muted)]">
-					<li>
-						{SETTINGS_LABELS.backupLastSuccessLabel}{lastSuccessDisplay === null
-							? SETTINGS_LABELS.backupNeverSucceeded
-							: lastSuccessDisplay}
-					</li>
-					{#if bh.consecutiveFailures > 0}
-						<li>
-							{SETTINGS_LABELS.backupConsecutiveFailuresLabel}{formatCount(bh.consecutiveFailures)}
-						</li>
-					{/if}
-					{#if bh.notificationMissing}
-						<li class="text-[var(--color-feedback-warning-text)]">
-							{SETTINGS_LABELS.backupNotificationMissing}
-						</li>
-					{/if}
-				</ul>
-
-				{#if bh.level !== 'ok'}
-					<p class="mt-3 text-sm text-[var(--color-text-muted)]">
-						{SETTINGS_LABELS.backupActionHint}
-					</p>
-				{/if}
-			</div>
-		</Card>
+		<BackupHealthCard health={data.backupHealth} />
 	{/if}
 
 	<!-- アプリ情報・リンク -->

--- a/tests/unit/architecture/backup-health-card-wiring.test.ts
+++ b/tests/unit/architecture/backup-health-card-wiring.test.ts
@@ -1,0 +1,96 @@
+// #4175 — 「component は直したが実画面に届いていない」を機械で閉じる。
+//
+// ## 実際に起きたこと
+//
+// #4153 で `BackupHealthCard.svelte` を切り出し、Storybook に 4 状態を置き、
+// **SS を `ss-render-impossible` 宣言で省略した**。根拠は「Storybook で見た目を確認できる」だった。
+//
+// ところが実画面 (`admin/settings/support/+page.svelte`) は **59 行のインライン実装**のままで、
+// **component を import している画面が 1 つも無かった**。つまり:
+//
+//   - Storybook が描いていたのは **誰も表示しない component**
+//   - 「Storybook で確認できるから SS 不要」という主張が成立していなかった (証跡の真正性)
+//   - #4162 で component 側に足した `backupRotationBlockedHint` が
+//     **家族の見る画面に 1 箇所も無い** = 修正が届いていない
+//
+// テストは通り、CI は緑で、PR body には「component 化 + Storybook 4 状態」と書いてあった。
+// **成果物が存在し証跡が揃っているのに顧客経路だけ空**という形で、#3950 と同型である。
+//
+// ## 何を固定するか
+//
+// 描画を 1 箇所に集約したこと。二重実装が復活すれば落ちる。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const PAGE_PATH = join(
+	process.cwd(),
+	'src',
+	'routes',
+	'(parent)',
+	'admin',
+	'settings',
+	'support',
+	'+page.svelte',
+);
+const CARD_PATH = join(
+	process.cwd(),
+	'src',
+	'lib',
+	'features',
+	'admin',
+	'components',
+	'BackupHealthCard.svelte',
+);
+
+const page = readFileSync(PAGE_PATH, 'utf-8');
+const card = readFileSync(CARD_PATH, 'utf-8');
+
+describe('#4175 バックアップ状態カードの配線', () => {
+	it('[BW1] 実画面が BackupHealthCard を使っている', () => {
+		// これが無いと、component をいくら直しても家族の画面は変わらない。
+		expect(page).toContain('BackupHealthCard');
+		expect(page).toMatch(/<BackupHealthCard\s/);
+	});
+
+	it('[BW2] 実画面が状態表示を再実装していない (二重実装の復活を止める)', () => {
+		// level ごとの Alert 出し分けは component の責務。page 側に同じ分岐が生えたら、
+		// 片方だけ直して「直したのに届かない」が再発する。
+		const reimplemented = [
+			'backupOkTitle',
+			'backupWarnTitle',
+			'backupCriticalTitle',
+			'backupLastSuccessLabel',
+			'backupActionHint',
+			'backupRotationBlockedHint',
+		].filter((label) => page.includes(label));
+
+		expect(
+			reimplemented,
+			`実画面が状態表示を再実装しています: ${reimplemented.join(', ')}。` +
+				'描画は BackupHealthCard に集約してください (#4175 の再発)。',
+		).toEqual([]);
+	});
+
+	it('[BW3] component 側が全ての状態文言を持っている (page から移し切れている)', () => {
+		// [BW2] は「page に無いこと」しか見ない。移し先に無ければ**どこにも無い**ので、
+		// 消しただけで通ってしまう。移動先の存在も併せて固定する。
+		for (const label of [
+			'backupOkTitle',
+			'backupWarnTitle',
+			'backupCriticalTitle',
+			'backupLastSuccessLabel',
+			'backupActionHint',
+		]) {
+			expect(card, `${label} が BackupHealthCard にありません`).toContain(label);
+		}
+	});
+
+	it('[BW4] #4162 の rotation-blocked 文言が実際に描画経路へ載っている', () => {
+		// 判定 (domain) → 表示 (component) → 画面 (page) のどこか 1 つでも切れると
+		// 「修正したのに家族には届かない」になる。表示層に到達していることを固定する。
+		expect(card).toContain('backupRotationBlockedHint');
+		expect(card).toContain('rotation-blocked');
+	});
+});

--- a/tests/unit/architecture/backup-health-card-wiring.test.ts
+++ b/tests/unit/architecture/backup-health-card-wiring.test.ts
@@ -1,4 +1,4 @@
-// #4175 — 「component は直したが実画面に届いていない」を機械で閉じる。
+// #4176 — 「component は直したが実画面に届いていない」を機械で閉じる。
 //
 // ## 実際に起きたこと
 //
@@ -47,7 +47,7 @@ const CARD_PATH = join(
 const page = readFileSync(PAGE_PATH, 'utf-8');
 const card = readFileSync(CARD_PATH, 'utf-8');
 
-describe('#4175 バックアップ状態カードの配線', () => {
+describe('#4176 バックアップ状態カードの配線', () => {
 	it('[BW1] 実画面が BackupHealthCard を使っている', () => {
 		// これが無いと、component をいくら直しても家族の画面は変わらない。
 		expect(page).toContain('BackupHealthCard');
@@ -69,7 +69,7 @@ describe('#4175 バックアップ状態カードの配線', () => {
 		expect(
 			reimplemented,
 			`実画面が状態表示を再実装しています: ${reimplemented.join(', ')}。` +
-				'描画は BackupHealthCard に集約してください (#4175 の再発)。',
+				'描画は BackupHealthCard に集約してください (#4176 の再発)。',
 		).toEqual([]);
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**バックアップ状態カードの修正が、家族の見る画面に届いていませんでした。**

`BackupHealthCard.svelte` を **import している画面が 1 つも無く**、実画面は 59 行のインライン実装のままでした。そのため #4162 で component に足した「古い控えが増えすぎたため自動削除を止めています」が実画面に 1 箇所も無く、**家族が見るのは汎用の「相談してください」のまま**でした。

## 関連 Issue

Refs #4176

<!-- no-issue-close: 本 PR は描画の集約と fitness function まで。Storybook を SS 代替とする運用ルール (job が実際に実行されたかの確認) は #4176 の AC に残るため、close 判断は人が行う -->

## AC 検証マップ (ADR-0004)

HEAD SHA: `cdc76311b`

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 実画面のインライン実装を component に置換し描画を 1 箇所に集約 | `[BW1]` `[BW2]` `[BW3]` | **充足**。`<BackupHealthCard health={data.backupHealth} />` に置換。59 行削除 |
| AC2 | `AllStates` story の args 欠落を直す | storybook 実行 | **充足**。`npm run test:storybook` → **213 passed / 39 files**。`reading 'level'` の TypeError が **0 件**（grep で確認） |
| AC3 | 同 class を fitness function で閉じる | `[BW1]`〜`[BW4]` + mutation | **充足**。下記 |
| AC4 | #3964 は本 Issue 解消後に行う | — | **本 PR では扱いません**。#3964 の前提条件として申し送り済（先にやると #4162 修正前の案内が写る） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [x] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 設定 > サポート のバックアップ状態カード（**NUC セルフホスト時のみ**）。**子供画面は不変。クラウド（dsql）では描画されません。**

- [ ] **並行実装ペア**を同期した: **本 PR がその二重実装を解消するもの**です
- [x] **設計書同期** (ADR-0001): `06-UI設計書.md §17.8` を更新。**当初「変更不要」と自己判断したのは誤りでした** — 同じ §17.8 の 3 行下が本日 merge した #4165 / #4173 と矛盾しており、「`level` に応じた固定文言**のみ**」という記述が**分岐条件を誤って伝えて**いました。次に読む人が「見出しは level だけで決めてよい」と判断し、**#4173 で BLOCK された欠陥を作り直します**。断定形の禁止 / 見出しを level だけで決めない / 描画の 1 箇所集約 の 3 行を追加し、解消済の #4144 pointer を撤去
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| 配線 + load | `npx vitest run tests/unit/routes/admin-settings-support-backup-health.test.ts tests/unit/architecture/backup-health-card-wiring.test.ts` | **8 passed** |
| Storybook | `npm run test:storybook` | **213 passed / 39 files** |
| 型 | `npx svelte-check` | 0 errors |

### mutation 検証

| mutation | 内容 | 結果 |
|---|---|---|
| A | 実画面から `<BackupHealthCard>` を外す | `[BW1]` **1 件 fail** |

commit 済みの実装に対して行い、復元は **`git stash push`** を使いました。

### fitness function の設計

`[BW2]` は「page に再実装が生えたら落ちる」検査ですが、**それだけだと「文言を消しただけ」でも通ってしまいます**。移動先に存在することを `[BW3]` で併せて固定しました。

- [x] **SOLID / DRY / YAGNI**: 描画を 1 箇所に集約。判定は domain のまま
- [x] **Security（OSS 公開前提）**: N/A
- [x] **A11y・パフォーマンス**: `data-testid="backup-health"` / `data-level` を component が保持しており、既存 E2E の互換を維持
- [x] **Critical バグ修正**(ADR-0002): `priority:critical` label なし

## スクリーンショット / ビジュアルデモ

<!-- ss-render-impossible: カードは DATA_SOURCE=pglite かつ backup status file 存在でのみ描画され、SS 撮影に使う demo 環境 (DATA_SOURCE=demo) では原理的に描画されないため -->

**SS を添付していません。** カードは `DATA_SOURCE=pglite` かつ backup status file 存在でのみ描画され、撮影に使う demo 環境では原理的に描画されません。

**ただし本 PR は、その宣言の根拠自体を直すものです。** これまで Storybook が描いていたのは**誰も表示しない component** で、「Storybook で確認できるから SS 不要」という主張が成立していませんでした。本 PR で実画面と Storybook が同じ component を描くようになり、宣言が実態に一致します（`Features/Admin/BackupHealthCard`、5 状態）。

## レビュー依頼事項・破壊的変更

### この欠陥は QM チームの棚卸しで発覚しました

Dev 側は気づいていませんでした。**テストは通り、CI は緑で、PR body には「component 化 + Storybook 4 状態」と書いてありました。** 成果物が存在し証跡が揃っているのに顧客経路だけ空という形で、#3950（毎晩成功していたが実データは無保護）と同型です。

### `storybook-test` は develop 向け PR で skip されます

`ci.yml:659` により、本 PR の CI 上でも `storybook-test` は走りません。上記の 213 passed は**ローカル実行**です。**Storybook を SS の代替として使うなら「job が実際に実行されたか」の確認が要る**という運用課題が残ります（#4176 の AC に記載）。

### 削除した 59 行と component の差分

`formatCount` の import が page から不要になったため外しました。それ以外の描画は component 側と同一です（`data-testid` / `data-level` / Alert の variant 出し分け / 各 `<li>` の条件）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC4 は本 PR の scope 外である旨を AC 検証マップに明記）
- [x] UI 変更時: `ss-render-impossible` で宣言 + Storybook（**本 PR でその宣言の根拠が実態に一致するようになりました**）
- [x] 認証画面変更時: N/A

## QM レビュー結果

<!-- QM が記入 -->

