### PR TITLE
fix(date): #4127 TZ 依存日付導出を「記法の列挙」でなく「欠陥クラス」で lock する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Ready 化前は依然として `npm run pre-ready -- --pr <num>` 全 step PASS �
 
 `npm run pre-ready -- --pr <num>` 一括実行 (ADR-0030 / #1775 / #4121)。**全 6 step** を順次実行し各 fail で即停止 + 修正方針表示。**step 一覧の SSOT は `npm run pre-ready -- --help`**:
 
-1. biome check / 2. svelte-check / 7. check-no-plan-literals (#972) / 7g. check-local-tz-date-getters (#4015, ローカル TZ 日付 getter 禁止 / JST SSOT 強制) / 9. Readiness gate = check-pr-body (PR 番号必須) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail)
+1. biome check / 2. svelte-check / 7. check-no-plan-literals (#972) / 7g. check-local-tz-date-getters (#4015 / #4127, TZ 依存の日付導出禁止 / JST SSOT 強制) / 9. Readiness gate = check-pr-body (PR 番号必須) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail)
 
 **選定基準は ADR-0007 §1-2 判断原則 v2** (#4121): 類型 1 (証跡の真正性 = Step 9 / 11b) と 類型 2 (顧客に見える正しさ = Step 1 / 2 / 7 / 7g) のうち安価なものだけを残す。**外した検査は消していない** — vitest は CI `unit-test`、cspell / hardcoded-strings / license-key-leak / CLI guard 系 / doc-code-references / terminology-coherence / generate-lp-labels --check は CI `lint-and-test`、LP 寸法は `lp-metrics.yml`、LP fallback は `lp-fallback-check.yml` で hard-fail のまま走る (対応表は `--help`)。**`gh pr checks <num>` でこれらが pass (skipped でない) ことを確認してから Ready 化する**。
 

--- a/docs/design/44-チャレンジ設計書.md
+++ b/docs/design/44-チャレンジ設計書.md
@@ -126,7 +126,7 @@ multi-armed bandit / Thompson sampling、BirdBrain 型 ML 難度調整、DDA、�
 | ISO タイムスタンプが指定月キーに属するか | `isInJstMonth(isoTimestamp, monthKey)` | `createdAt` 等 UTC 文字列の月次集計判定 |
 | 日付文字列の N 日後 | `addDaysJST(dateStr, days)` | 期限計算 |
 
-**禁止**: 上記用途に `Date` のローカル日付 getter（`getFullYear` / `getMonth` / `getDate` / `getDay`）を直接使うこと。本番 Lambda と CI runner は TZ 未設定（= UTC）で動くため、**JST 00:00〜09:00 の 9 時間だけ前日/前週/前月として扱われる**。機械強制: `scripts/check-local-tz-date-getters.mjs`（`npm run pre-ready` Step 7g）が新規のローカル TZ getter 使用を検出し、allowlist（理由必須）外は CI で fail する。
+**禁止**: 上記用途で日付をプロセス TZ 任せに導出すること。`Date` のローカル getter（`getFullYear` / `getDate` / `getHours` 等）だけでなく、`toISOString().slice(0, 10)`（UTC の暦日）や `timeZone` 未指定の `toLocaleDateString` も同じ欠陥クラスに含む。本番 Lambda と CI runner は TZ 未設定（= UTC）で動くため、**JST 00:00〜09:00 の 9 時間だけ前日/前週/前月として扱われる**。機械強制: `scripts/check-local-tz-date-getters.mjs`（`npm run pre-ready` Step 7g）が検出し、allowlist（kind ごとに機械検査）外は CI で fail する。振る舞い側は `tests/unit/architecture/tz-invariance.test.ts` が `TZ=UTC` / `TZ=Asia/Tokyo` の 2 環境で JST 暦の期待値と一致することを assert する。
 
 読み書きで基準がずれると次の実害が出る（いずれも実際に発生した）:
 

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -136,7 +136,7 @@ PO セッションが定めた AC を全て満たし、スクラップ&ビルド
 1. `git fetch origin && git pull` で最新化。worktree / clone 直後は refspec に develop 行があるか確認 + branch 作成直後は `node scripts/lib/ci/resolve-base-branch.mjs --verify-base` で基点鮮度を機械検証（stale develop 基点ズレ防止 #2975、SOP SSOT: [branch-strategy.md §3](branch-strategy.md)）
 2. PR / Issue / レビューコメント確認: `gh pr view <num>`, `gh issue view <num>`, `gh api repos/{owner}/{repo}/pulls/{number}/reviews`
 3. レビュー指摘を全件修正（部分対応禁止）
-4. **`npm run pre-ready -- --pr <num>` 全 Step PASS 必須** (ADR-0030 / #1775 / #4121)。**全 6 step** (biome / svelte-check / check-no-plan-literals (#972) / check-local-tz-date-getters (#4015) / Readiness gate = check-pr-body / **SS embed gate (#2918)**) を順次実行、fail で即停止 + 修正方針表示。**一覧・「外した検査の行き先」対応表の SSOT は `npm run pre-ready -- --help`**。E2E / Storybook は別途
+4. **`npm run pre-ready -- --pr <num>` 全 Step PASS 必須** (ADR-0030 / #1775 / #4121)。**全 6 step** (biome / svelte-check / check-no-plan-literals (#972) / check-local-tz-date-getters (#4015 / #4127) / Readiness gate = check-pr-body / **SS embed gate (#2918)**) を順次実行、fail で即停止 + 修正方針表示。**一覧・「外した検査の行き先」対応表の SSOT は `npm run pre-ready -- --help`**。E2E / Storybook は別途
 
    **6 step 以外は消えていない — CI で hard-fail のまま走る (#4121)**。vitest は CI `unit-test`、cspell / hardcoded-strings / license-key-leak / CLI guard 系 / doc-code-references / terminology-coherence / generate-lp-labels --check は CI `lint-and-test`、LP 寸法は `lp-metrics.yml`、LP fallback は `lp-fallback-check.yml`。判定の場所を CI に移しただけなので、**`gh pr checks <num>` でこれらが pass (skipped でない) ことを確認してから Ready 化する**。16 コアを 4 エージェントで共有する運用ではローカルのフルスイートは並走で必ず重なり、その red は PR の欠陥ではなく実行環境の産物になる（同一 HEAD 対照実測: ローカル 1753s / 2 件 timeout ↔ 同 SHA の CI run は 2 shard とも pass）。
 

--- a/infra/lambda/health-check/index.ts
+++ b/infra/lambda/health-check/index.ts
@@ -192,12 +192,26 @@ async function getLastNotifiedStatus(): Promise<NotifiedStatus | null> {
 // Weekly Stats — SSM (#1469)
 // ----------------------------------------------------------------
 
+/**
+ * Date を UTC の暦日文字列 (YYYY-MM-DD) にする。
+ *
+ * `toISOString().slice(0, 10)` を使わないのは、それが「実時刻から UTC の暦日を切り出す」
+ * 形と字面で区別できず、JST 前提の集計に紛れ込む温床になるため (#4127)。ここは週次 ops
+ * 集計の UTC アンカーであることが明示的に必要なので getUTC* から組み立てる。
+ */
+function toUtcDateString(d: Date): string {
+	const y = d.getUTCFullYear();
+	const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+	const day = String(d.getUTCDate()).padStart(2, '0');
+	return `${y}-${m}-${day}`;
+}
+
 // 日曜 00:00 UTC = 月曜 09:00 JST を週の起点とする
 function getSundayWeekStart(date: Date): string {
 	const d = new Date(date);
 	d.setUTCDate(d.getUTCDate() - d.getUTCDay()); // getUTCDay(): 0=Sun
 	d.setUTCHours(0, 0, 0, 0);
-	return d.toISOString().slice(0, 10);
+	return toUtcDateString(d);
 }
 
 async function getWeeklyStats(): Promise<WeeklyStats | null> {
@@ -471,7 +485,7 @@ async function notifyDiscordHeartbeat(stats: WeeklyStats): Promise<void> {
 	const avgResponseMs = stats.total > 0 ? Math.round(stats.totalResponseMs / stats.total) : 0;
 	const weekEndDate = new Date(`${stats.weekStart}T00:00:00Z`);
 	weekEndDate.setUTCDate(weekEndDate.getUTCDate() + 6);
-	const weekRange = `${stats.weekStart} 〜 ${weekEndDate.toISOString().slice(0, 10)}`;
+	const weekRange = `${stats.weekStart} 〜 ${toUtcDateString(weekEndDate)}`;
 
 	const embed = {
 		title: '\u{1F49A} HealthCheck 週次サマリー',

--- a/scripts/check-local-tz-date-getters.mjs
+++ b/scripts/check-local-tz-date-getters.mjs
@@ -131,11 +131,18 @@ export function findUnclassifiedDateMembers() {
 /**
  * TZ 依存だが **他 prototype と名前を共有していて行単位では受け手を判別できない**メンバー。
  *
- * 黙って落とすと #4015 と同じ「気付かれない検出漏れ」になるため、ここに理由付きで宣言し、
- * `findUndeclaredAmbiguousMembers()` が「宣言も走査もされていないメンバー」を検出する。
- * 代わりに `DATE_LITERAL_TO_STRING` で受け手が Date と分かる形だけを拾う。
+ * この宣言は検出を **弱める** ものなので、宣言しただけで通ることがあってはならない
+ * (allowlist の reason を自由文で通していた #4127 残存 3 と同じ失敗形になる)。
+ * そのため `findAmbiguousDeclarationProblems()` が以下を機械検査し、main() で必ず実行する:
+ *
+ *   1. 理由 (`reason`) が非空であること
+ *   2. **補償検出が実在すること** — 宣言したメンバー名が `DATE_RECEIVER_AMBIGUOUS_CALL` の
+ *      source に現れていること (= 受け手が Date と分かる形は必ず拾われる)
+ *   3. 宣言されたメンバーが実際に `Date.prototype` の TZ 依存側にあること (綴り間違いで
+ *      「何も外していないのに外したつもり」になるのを防ぐ)
+ *
+ * @type {Record<string, string>}
  */
-/** @type {Record<string, string>} */
 export const AMBIGUOUS_MEMBERS = {
 	toString:
 		'Object / Number / Buffer 等の toString と同名で、行単位では受け手が Date か判別できない (randomBytes(32).toString("base64url") 等)。受け手が Date と分かる形は DATE_RECEIVER_AMBIGUOUS_CALL で拾う',
@@ -144,18 +151,53 @@ export const AMBIGUOUS_MEMBERS = {
 };
 
 /**
- * 受け手が明らかに Date である曖昧メンバー呼び出し (曖昧回避後の補償検出)。
- * `new Date(...)` リテラル、または `〜At` / `〜Date` / `〜Time` 命名の変数を受け手とする形。
+ * 受け手が Date だと判断できる曖昧メンバー呼び出し (曖昧回避の補償検出)。
+ *
+ * 次のいずれかで拾う:
+ *   - `new Date(...)` リテラルを受け手にする形
+ *   - 日時を示す命名の変数 (`〜At` / `〜Date` / `〜Time` / `〜On` / `〜Since` / `〜Until` /
+ *     `〜Expires` / `〜Timestamp`、`Iso` / `Utc` / `Jst` / `Str` / `Ms` の末尾修飾も許す)
+ *   - 引数に **日時整形オプション** (`dateStyle` / `timeStyle` / `weekday` / `year` / `month` /
+ *     `day` / `hour` / `minute`) を渡している形 — 受け手の命名に頼らず用途で判定する
+ *
+ * **限界の明示**: 命名にも整形オプションにも現れない Date 変数
+ * (`const x = new Date(); x.toLocaleString()`) は行単位では判別できない。これは受け手の型を
+ * 追わない静的検査の構造的限界であり、「取りこぼさない」とは主張しない。振る舞い側は
+ * `tests/unit/architecture/tz-invariance.test.ts` の 2 TZ 実測が担う。
  */
 export const DATE_RECEIVER_AMBIGUOUS_CALL =
-	/(?:new Date\s*\([^)]*\)|\b[A-Za-z_$][\w$]*(?:At|Date|Time)|\b(?:date|time|now|deadline)\b)\s*\.\s*(?:toString|toLocaleString)\s*\(/;
+	/(?:(?:new Date\s*\([^)]*\)|\b[A-Za-z_$][\w$]*(?:At|Date|Time|On|Since|Until|Expires|Timestamp)(?:Iso|Utc|Jst|Str|String|Ms)?|\b(?:date|time|now|deadline|timestamp)\b)\s*\.\s*(?:toString|toLocaleString)\s*\(|\.\s*toLocaleString\s*\([^)]*\b(?:dateStyle|timeStyle|weekday|year|month|day|hour|minute)\s*:)/;
 
-/** 走査も宣言もされていない TZ 依存メンバー (空なら健全) */
-export function findUndeclaredAmbiguousMembers() {
+/**
+ * `AMBIGUOUS_MEMBERS` 宣言自体の健全性検査 (空なら健全)。
+ *
+ * 「宣言を足せば検出から外せる」抜け道を作らないための自己検査。
+ * @returns {Array<{member: string, problem: string}>}
+ */
+export function findAmbiguousDeclarationProblems() {
 	const { dependent } = classifyDateMembers();
-	return dependent.filter(
-		(n) => Object.hasOwn(AMBIGUOUS_MEMBERS, n) && !AMBIGUOUS_MEMBERS[n]?.trim(),
-	);
+	/** @type {Array<{member: string, problem: string}>} */
+	const problems = [];
+	const compensationSource = DATE_RECEIVER_AMBIGUOUS_CALL.source;
+	for (const [member, reason] of Object.entries(AMBIGUOUS_MEMBERS)) {
+		if (typeof reason !== 'string' || reason.trim() === '') {
+			problems.push({ member, problem: '理由 (reason) が空です' });
+		}
+		if (!dependent.includes(member)) {
+			problems.push({
+				member,
+				problem: 'Date.prototype の TZ 依存メンバーではありません (綴り間違い / 既に SAFE 分類)',
+			});
+		}
+		if (!compensationSource.includes(member)) {
+			problems.push({
+				member,
+				problem:
+					'補償検出がありません。DATE_RECEIVER_AMBIGUOUS_CALL に本メンバー名を含めてください (宣言だけで検出を消さない)',
+			});
+		}
+	}
+	return problems;
 }
 
 /** TZ 依存メンバー呼び出しの検出正規表現 (`Date.prototype` から導出) */
@@ -570,6 +612,18 @@ function main() {
 	if (unclassified.length > 0) {
 		console.error(
 			`[check-local-tz-date-getters] ✗ Date.prototype に未分類のメンバーがあります: ${unclassified.join(', ')}`,
+		);
+		process.exit(1);
+	}
+
+	const ambiguousProblems = findAmbiguousDeclarationProblems();
+	if (ambiguousProblems.length > 0) {
+		console.error(
+			`[check-local-tz-date-getters] \u2717 AMBIGUOUS_MEMBERS \u5ba3\u8a00\u304c\u691c\u67fb\u3092\u901a\u308a\u307e\u305b\u3093\u3067\u3057\u305f (${ambiguousProblems.length} \u4ef6):`,
+		);
+		for (const p of ambiguousProblems) console.error(`  ${p.member}: ${p.problem}`);
+		console.error(
+			'\n  \u66d6\u6627\u30e1\u30f3\u30d0\u306e\u5ba3\u8a00\u306f\u691c\u51fa\u3092\u5f31\u3081\u307e\u3059\u3002\u7406\u7531 + \u88dc\u511f\u691c\u51fa (DATE_RECEIVER_AMBIGUOUS_CALL) \u306e\u4e21\u65b9\u304c\u5fc5\u8981\u3067\u3059\u3002',
 		);
 		process.exit(1);
 	}

--- a/scripts/check-local-tz-date-getters.mjs
+++ b/scripts/check-local-tz-date-getters.mjs
@@ -623,7 +623,7 @@ function main() {
 		);
 		for (const p of ambiguousProblems) console.error(`  ${p.member}: ${p.problem}`);
 		console.error(
-			'\n  \u66d6\u6627\u30e1\u30f3\u30d0\u306e\u5ba3\u8a00\u306f\u691c\u51fa\u3092\u5f31\u3081\u307e\u3059\u3002\u7406\u7531 + \u88dc\u511f\u691c\u51fa (DATE_RECEIVER_AMBIGUOUS_CALL) \u306e\u4e21\u65b9\u304c\u5fc5\u8981\u3067\u3059\u3002',
+			'\n  \u66d6\u6627\u30e1\u30f3\u30d0\u30fc\u306e\u5ba3\u8a00\u306f\u691c\u51fa\u3092\u5f31\u3081\u307e\u3059\u3002\u7406\u7531 + \u88dc\u511f\u691c\u51fa (DATE_RECEIVER_AMBIGUOUS_CALL) \u306e\u4e21\u65b9\u304c\u5fc5\u8981\u3067\u3059\u3002',
 		);
 		process.exit(1);
 	}

--- a/scripts/check-local-tz-date-getters.mjs
+++ b/scripts/check-local-tz-date-getters.mjs
@@ -30,7 +30,7 @@
  *      `getTime` / `toISOString` / `toUTCString` / `getTimezoneOffset` 等) を SAFE として列挙し、
  *      **それ以外を全部 TZ 依存として扱う** (deny by default)。`Date.prototype` は言語仕様で
  *      閉じた有限集合なので、これは「記法の列挙」ではなくクラスの表明になる。分類の網羅は
- *      `assertDateMemberClassificationIsTotal()` が自己検査する (将来メンバーが増えたら fail)。
+ *      `findUnclassifiedDateMembers()` が自己検査する (将来メンバーが増えたら fail)。
  *   2. 実時刻から **UTC の暦要素**を切り出す形 (`toISOString()` / `toJSON()` の直後に
  *      `slice` / `substring` / `substr` / `split`) を検出する。TZ 不変でも JST ではないため、
  *      `date-utils.ts` の JST SSOT を経由していない時点で同じクラスの欠陥。

--- a/scripts/check-local-tz-date-getters.mjs
+++ b/scripts/check-local-tz-date-getters.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 /**
- * scripts/check-local-tz-date-getters.mjs (#4015 / ADR-0061 same-class-N → guard)
+ * scripts/check-local-tz-date-getters.mjs (#4015 → #4127 / ADR-0061 same-class-N → guard)
  *
- * ローカル TZ 日付 getter (`getFullYear()` / `getMonth()` / `getDate()` / `getDay()`) の
- * 無秩序な使用を止める CI ガード。
+ * 「日付をプロセス TZ 任せに導出する」欠陥クラスを止める CI ガード。
  *
  * ## なぜ必要か
  *
@@ -12,34 +11,45 @@
  *   - AWS Lambda / CI runner : UTC → JST 00:00〜09:00 の 9 時間、暦日が 1 日前になる
  *   - NUC セルフホスト        : JST → JST と一致する
  *
- * つまりローカル getter は「同じコードが環境ごとに違う日付を返す」。#4003 ではこれで
- * 子供ホームの週次チャレンジが毎週 9 時間まるごと消えた (3 例目)。日付計算の SSOT は
- * `src/lib/domain/date-utils.ts` (JST 基準) 側に既に存在していたが、**違反を検知する手段が
- * 無かったため新規コードに同じ形が入り続けた**。本 gate がその検知手段。
+ * #4003 ではこれで子供ホームの週次チャレンジが毎週 9 時間まるごと消えた。
+ *
+ * ## #4015 版がなぜ 7 箇所を素通ししたか (本 script の設計が変わった理由)
+ *
+ * 初版は検出対象を `getFullYear` / `getMonth` / `getDate` / `getDay` の **4 語の列挙**で
+ * 定義していた。列挙は「今知っている書き方」しか塞げないため、同じ欠陥クラスに属する
+ * 別の書き方がそのまま残った (#4127 の実測):
+ *
+ *   - `recordedAt.getHours()`        → 列挙に無い getter。はやおきボーナスが UTC で 9h ずれる
+ *   - `new Date().toISOString().slice(0,10)` → getter を 1 つも使わずに **UTC の暦日**を作る。
+ *                                     TZ 不変だが JST ではない (`date-utils.ts` が明文で禁じている形)
+ *   - `toLocaleDateString('ja-JP')`  → 表示側の暦日をプロセス TZ (SSR 時は Lambda=UTC) で決める
+ *
+ * そこで本 script は列挙をやめ、**クラスの側から定義**する。
+ *
+ *   1. `Date.prototype` の全メンバーを走査し、TZ 非依存と言い切れるもの (`getUTC*` / `setUTC*` /
+ *      `getTime` / `toISOString` / `toUTCString` / `getTimezoneOffset` 等) を SAFE として列挙し、
+ *      **それ以外を全部 TZ 依存として扱う** (deny by default)。`Date.prototype` は言語仕様で
+ *      閉じた有限集合なので、これは「記法の列挙」ではなくクラスの表明になる。分類の網羅は
+ *      `assertDateMemberClassificationIsTotal()` が自己検査する (将来メンバーが増えたら fail)。
+ *   2. 実時刻から **UTC の暦要素**を切り出す形 (`toISOString()` / `toJSON()` の直後に
+ *      `slice` / `substring` / `substr` / `split`) を検出する。TZ 不変でも JST ではないため、
+ *      `date-utils.ts` の JST SSOT を経由していない時点で同じクラスの欠陥。
+ *   3. `toLocale*` / `Intl.DateTimeFormat` は `timeZone` オプションがあれば SAFE (構造判定)。
  *
  * ## 検査ルール
  *
- * 1. `SEARCH_ROOTS` 配下の `.ts` / `.svelte` を走査し、コメント行以外のローカル getter を数える
- *    (`getUTCFullYear()` 等の UTC getter は TZ 非依存なので対象外)
+ * 1. `SEARCH_ROOTS` (src / infra/lambda / scripts) 配下を走査し、コメント行以外の違反を数える
  * 2. **no-silent-gap**: 検出のあった file が `ALLOWLIST` に無ければ fail
- *    (新規 file で黙って増えることを防ぐ)
  * 3. **ratchet**: allowlist entry の `max` を超えた occurrence 数は fail
- *    (allowlist 済 file の中で新規に増えることも防ぐ)
- * 4. **理由の強制**: `reason` が空 / 未設定の entry があれば、違反 0 件でも fail
- *    (「除外はしたが理由が無い」= #3956 で観測した形骸化を作らない)
+ * 4. **除外理由の機械検証**: allowlist entry は `kind` を持ち、kind ごとに機械検査される。
+ *    自由文の `reason` だけで通ることはない (#4127 残存 3 = 理由が実測と食い違ったまま緑だった)。
  *
- * allowlist に載っているのは #4015 の全数棚卸で **(b) 安全** と判定した箇所のみ。分類基準:
- *
- *   - b1: `YYYY-MM-DD` を `T00:00:00Z` (UTC 深夜) でパースし、そこから加減算する
- *         (UTC+0 以上の TZ では暦要素が一致するため UTC / JST 両 runtime で同結果)
- *   - b2: `YYYY-MM-DD` を `T00:00:00` (ローカル深夜) でパースし、ローカル getter で読む
- *         (パースと読み出しが同じ TZ 系で閉じている)
- *   - b3: `setDate(getDate() + N)` が「N 日後の絶対時刻 (期限)」生成で、暦要素を外に出さない
- *
- * **新しく (a) 相当 (= 実時刻の瞬間からローカル getter で暦要素を取り出す) を書かないこと。**
- * その用途は `date-utils.ts` の `todayDateJST` / `toJSTDateString` / `weekStartJST` /
- * `weekEndJST` / `addDaysJST` / `jstDayOfWeek` / `jstYearMonth` / `monthKeyJST` /
- * `shiftMonthKey` / `monthStartJST` / `monthEndJST` / `isInJstMonth` が担う。
+ *    | kind | 意味 | 機械検査 |
+ *    |---|---|---|
+ *    | `ssot` | JST SSOT の実装本体 | path が `date-utils.ts` であること |
+ *    | `tz-proof` | 2 TZ 実測で不変と確認済 | `proof` が `tz-invariance-cases.mjs` に登録され、fitness test が実測すること |
+ *    | `instant-offset` | 「N 日後の絶対時刻」生成のみ (暦要素を外に出さない) | 全違反行が `setX(getX() ± n)` 構造であること |
+ *    | `non-runtime` | 顧客に見える値を作らない (ビルド道具 / Storybook / demo fixture) | path が `NON_RUNTIME_PATTERNS` に一致すること |
  *
  * 使用法: node scripts/check-local-tz-date-getters.mjs
  * CI: 検出時は exit 1。
@@ -48,154 +58,279 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { hasTzInvarianceCase } from './lib/ci/tz-invariance-cases.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
 
-/** 走査ルート (REPO_ROOT 相対)。tests/ は意図的な時刻固定が多いため対象外 (#4015 No-gos)。 */
-export const SEARCH_ROOTS = ['src'];
+/**
+ * 走査ルート (REPO_ROOT 相対)。
+ *
+ * `infra/lambda` (cron 起動側) と `scripts` は #4015 版では未走査だった。cron の起動時刻と
+ * 「その日」の定義が乖離する変更が silent に入るため #4127 で追加 (AC6)。
+ * `tests/` は意図的な時刻固定が多いため対象外 (#4015 No-gos)。
+ */
+export const SEARCH_ROOTS = ['src', 'infra/lambda', 'scripts'];
 
 /** 走査対象拡張子 */
-export const EXTENSIONS = ['.ts', '.svelte'];
+export const EXTENSIONS = ['.ts', '.svelte', '.mjs', '.js'];
 
 /**
- * ローカル TZ 日付 getter。`getUTC*` は先頭の `.` で自然に除外される
- * (`.getDate(` は `.getUTCDate(` に一致しない)。
+ * `Date.prototype` のうち **TZ 非依存**と言い切れるメンバー。
+ * ここに無いメンバーは自動的に TZ 依存として扱われる (deny by default)。
  */
-export const LOCAL_TZ_GETTER = /\.(getFullYear|getMonth|getDate|getDay)\s*\(\s*\)/;
+export const TZ_SAFE_DATE_MEMBERS = new Set([
+	'constructor',
+	'valueOf',
+	'toJSON',
+	'getTime',
+	'setTime',
+	'getTimezoneOffset', // オフセットそのものを問う API。暦要素を導出しない
+	'toISOString',
+	'toUTCString',
+	'toGMTString',
+	// getUTC* / setUTC* は下の classifyDateMembers() が prefix で自動分類する
+]);
 
 /**
- * allowlist — #4015 の全数棚卸で (b) 安全と判定した箇所のみ。
+ * `Date.prototype` の全メンバーを TZ 安全 / TZ 依存に 2 分する。
+ * 分類は「列挙」ではなく `Date.prototype` の実体から導出するため、
+ * 未知のアクセサが増えても勝手に安全側に落ちない。
+ *
+ * @returns {{ safe: string[], dependent: string[] }}
+ */
+export function classifyDateMembers() {
+	/** @type {string[]} */
+	const safe = [];
+	/** @type {string[]} */
+	const dependent = [];
+	for (const name of Object.getOwnPropertyNames(Date.prototype)) {
+		if (TZ_SAFE_DATE_MEMBERS.has(name) || /^(get|set)UTC/.test(name)) {
+			safe.push(name);
+			continue;
+		}
+		dependent.push(name);
+	}
+	return { safe, dependent };
+}
+
+/**
+ * 分類が `Date.prototype` を網羅していることの自己検査。
+ * 将来 `Date.prototype` にメンバーが増えたときに「分類漏れ = 黙って安全側」を作らない。
+ *
+ * @returns {string[]} 未分類メンバー (空なら健全)
+ */
+export function findUnclassifiedDateMembers() {
+	const { safe, dependent } = classifyDateMembers();
+	const classified = new Set([...safe, ...dependent]);
+	return Object.getOwnPropertyNames(Date.prototype).filter((n) => !classified.has(n));
+}
+
+/**
+ * TZ 依存だが **他 prototype と名前を共有していて行単位では受け手を判別できない**メンバー。
+ *
+ * 黙って落とすと #4015 と同じ「気付かれない検出漏れ」になるため、ここに理由付きで宣言し、
+ * `findUndeclaredAmbiguousMembers()` が「宣言も走査もされていないメンバー」を検出する。
+ * 代わりに `DATE_LITERAL_TO_STRING` で受け手が Date と分かる形だけを拾う。
+ */
+export const AMBIGUOUS_MEMBERS = {
+	toString:
+		'Object / Number / Buffer 等の toString と同名で、行単位では受け手が Date か判別できない (randomBytes(32).toString("base64url") 等)。受け手が Date と分かる形は DATE_RECEIVER_AMBIGUOUS_CALL で拾う',
+	toLocaleString:
+		'Number / Array の toLocaleString と同名で、金額 / ポイントの桁区切り (points.toLocaleString("ja-JP")) が大多数を占める。受け手が Date と分かる形は DATE_RECEIVER_AMBIGUOUS_CALL で拾う',
+};
+
+/**
+ * 受け手が明らかに Date である曖昧メンバー呼び出し (曖昧回避後の補償検出)。
+ * `new Date(...)` リテラル、または `〜At` / `〜Date` / `〜Time` 命名の変数を受け手とする形。
+ */
+export const DATE_RECEIVER_AMBIGUOUS_CALL =
+	/(?:new Date\s*\([^)]*\)|\b[A-Za-z_$][\w$]*(?:At|Date|Time)|\b(?:date|time|now|deadline)\b)\s*\.\s*(?:toString|toLocaleString)\s*\(/;
+
+/** 走査も宣言もされていない TZ 依存メンバー (空なら健全) */
+export function findUndeclaredAmbiguousMembers() {
+	const { dependent } = classifyDateMembers();
+	return dependent.filter(
+		(n) => Object.hasOwn(AMBIGUOUS_MEMBERS, n) && !AMBIGUOUS_MEMBERS[n].trim(),
+	);
+}
+
+/** TZ 依存メンバー呼び出しの検出正規表現 (`Date.prototype` から導出) */
+export function buildTzDependentMemberRegex() {
+	const { dependent } = classifyDateMembers();
+	// 長い名前から並べて部分一致 (getUTCDate が getDate に食われる等) を避ける
+	const alternation = dependent
+		.filter((n) => !Object.hasOwn(AMBIGUOUS_MEMBERS, n))
+		.sort((a, b) => b.length - a.length)
+		.join('|');
+	return new RegExp(`\\.(${alternation})\\s*\\(`);
+}
+
+/** TZ 依存メンバー呼び出し */
+export const TZ_DEPENDENT_MEMBER_CALL = buildTzDependentMemberRegex();
+
+/**
+ * 実時刻から **UTC の暦要素**を切り出す形。
+ * `new Date().toISOString().slice(0, 10)` / `.split('T')[0]` / `.substring(0, 7)` など。
+ * TZ 不変だが JST ではないため、JST SSOT を経由していない時点で同じ欠陥クラス。
+ */
+export const UTC_CALENDAR_SLICE =
+	/\.(toISOString|toJSON)\s*\(\s*\)\s*\.\s*(slice|substring|substr|split)\s*\(/;
+
+/** `Intl.DateTimeFormat` の生成 (timeZone 指定が無ければプロセス TZ 依存) */
+export const INTL_DATE_TIME_FORMAT = /\bIntl\s*\.\s*DateTimeFormat\s*\(/;
+
+/** 同一行に `timeZone` オプションがあるか (構造判定による免除) */
+export const HAS_EXPLICIT_TIME_ZONE = /\btimeZone\s*:/;
+
+/** 「N 日後の絶対時刻」生成 (`d.setDate(d.getDate() + 7)` 形) — kind: instant-offset の機械検査に使う */
+export const INSTANT_OFFSET_PATTERN =
+	/\.set(FullYear|Month|Date|Hours|Minutes|Seconds|Milliseconds)\s*\(\s*[\w.[\]]+\.get\1\s*\(\s*\)\s*[+-]/;
+
+/** `kind: 'non-runtime'` を名乗れる path (顧客に見える値を作らない場所) */
+export const NON_RUNTIME_PATTERNS = [
+	/^scripts\//,
+	/\.stories\.svelte$/,
+	/^src\/lib\/server\/demo\//,
+	/^src\/lib\/server\/debug-plan\.ts$/,
+];
+
+/** allowlist entry が取りうる kind */
+export const ALLOWLIST_KINDS = ['ssot', 'tz-proof', 'instant-offset', 'non-runtime'];
+
+/**
+ * allowlist。
  *
  * `file`: REPO_ROOT 相対 path (`/` 区切り) / `max`: 許容 occurrence 数 (ratchet 上限)
- * `reason`: **必須**。空文字なら本 script 自身が fail する。
+ * `kind`: 上表の 4 種 / `proof`: kind='tz-proof' のとき必須 / `reason`: 必須 (人間向けの説明)
+ *
+ * @type {Array<{file: string, max: number, kind: string, proof?: string, reason: string}>}
  */
 export const ALLOWLIST = [
 	{
-		file: 'src/lib/domain/labels.ts',
-		max: 0,
+		file: 'src/lib/domain/date-utils.ts',
+		max: 20,
+		kind: 'ssot',
 		reason:
-			'(SSOT 化済) 週次チャート曜日は jstDayOfWeek() 経由に置換済。将来の再混入を 0 で pin する',
-	},
-	{
-		file: 'src/lib/server/services/birthday-bonus-service.ts',
-		max: 6,
-		reason:
-			'(b2) 誕生日 / 基準日とも YYYY-MM-DD + T00:00:00 のローカル深夜パースで、ローカル getter による読み出しと同じ TZ 系で閉じている (年齢差分・年判定とも TZ 非依存)',
-	},
-	{
-		file: 'src/lib/server/services/report-service.ts',
-		max: 3,
-		reason:
-			'(b1) `new Date(startDate)` = YYYY-MM-DD の UTC 深夜パースに対する日次ループの ±1 日加算。暦要素の文字列化は toJSTDateString() に委譲済',
-	},
-	{
-		file: 'src/lib/server/services/plan-limit-service.ts',
-		max: 2,
-		reason:
-			'(b1) 保持期間 cutoff (JST 基準の YYYY-MM-DD) を UTC 深夜でパースしてからの -1 日。UTC+0 以上の runtime で同一文字列になる',
-	},
-	{
-		file: 'src/lib/server/services/daily-mission-service.ts',
-		max: 2,
-		reason:
-			'(b2) JST 日付文字列をローカル深夜でパースし、ローカル getter で日数を戻す。パースと読み出しが同じ TZ 系',
-	},
-	{
-		file: 'src/lib/server/services/usage-log-service.ts',
-		max: 4,
-		reason:
-			'(b3) 検索範囲の上下端 / 日次バケット offset として「±N 日後の絶対時刻」を作るのみで、暦要素をローカル getter で外に出していない',
-	},
-	{
-		file: 'src/lib/server/services/child-challenge-service.ts',
-		max: 1,
-		reason: '(b3) 集計入力の「14 日前の絶対時刻」生成のみ。暦要素の露出なし',
-	},
-	{
-		file: 'src/lib/server/services/activity-pin-service.ts',
-		max: 1,
-		reason: '(b3) 使用頻度集計の「N 日前の絶対時刻」生成のみ。暦要素の露出なし',
+			'JST SSOT の実装本体。UTC 算術 + toISOString で JST 暦日を組み立てる唯一の場所であり、ここが違反を持つのは定義上正しい',
 	},
 	{
 		file: 'src/lib/server/services/grace-period-service.ts',
 		max: 1,
-		reason: '(b3) 物理削除猶予期限 = N 日後の絶対時刻を作り ISO で保存するのみ',
+		kind: 'instant-offset',
+		reason: '物理削除猶予期限 = N 日後の絶対時刻を作り ISO で保存するのみ',
 	},
 	{
 		file: 'src/lib/server/services/cloud-export-service.ts',
 		max: 1,
-		reason: '(b3) エクスポート PIN の有効期限 = N 日後の絶対時刻を作り ISO で保存するのみ',
+		kind: 'instant-offset',
+		reason: 'エクスポート PIN の有効期限 = N 日後の絶対時刻を作り ISO で保存するのみ',
 	},
 	{
 		file: 'src/lib/server/services/viewer-token-service.ts',
 		max: 1,
-		reason: '(b3) 閲覧トークン失効時刻 = N 日後の絶対時刻を作り ISO で保存するのみ',
-	},
-	{
-		file: 'src/lib/server/db/demo/daily-mission-repo.ts',
-		max: 1,
-		reason: '(b1) missionDate (YYYY-MM-DD) の UTC 深夜パースからの -1 日',
-	},
-	{
-		file: 'src/lib/server/demo/demo-data.ts',
-		max: 2,
-		reason: '(b1) 固定日付 / 固定瞬間を起点とした -N 日。デモ fixture であり実時刻起点でない',
-	},
-	{
-		file: 'src/lib/server/debug-plan.ts',
-		max: 1,
-		reason:
-			'(b3) DEBUG_TRIAL の擬似終了日を「7 日後の絶対時刻」で作り、暦日化は toJSTDateString() に委譲 (dev 専用、本番ビルド無効)',
-	},
-	{
-		file: 'src/routes/api/v1/admin/tenant/cancel/+server.ts',
-		max: 1,
-		reason: '(b3) 解約猶予期限 = N 日後の絶対時刻を作り ISO で保存するのみ',
+		kind: 'instant-offset',
+		reason: '閲覧トークン失効時刻 = N 日後の絶対時刻を作り ISO で保存するのみ',
 	},
 	{
 		file: 'src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.server.ts',
 		max: 2,
-		reason: '(b3) 履歴取得範囲の「N 日前の絶対時刻」生成のみ。暦日化は toJSTDateString() に委譲済',
-	},
-	{
-		file: 'src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.svelte',
-		max: 3,
-		reason:
-			'(b2) recordedAt 由来の YYYY-MM-DD をローカル深夜パースし、ローカル getter で表示用の月 / 日 / 曜日にする。パースと読み出しが同じ TZ 系',
-	},
-	{
-		file: 'src/routes/(parent)/admin/reports/+page.svelte',
-		max: 1,
-		reason:
-			'(b2) 選択中の月キー文字列からローカルコンストラクタで構築した Date をローカル getter で読む。実時刻由来でない',
-	},
-	{
-		file: 'src/lib/features/admin/components/ChildListCard.svelte',
-		max: 1,
-		reason:
-			'(b1) 誕生日 (YYYY-MM-DD) の UTC 深夜パースを月 / 日の表示に使う。UTC+0 以上の TZ で暦要素が一致',
+		kind: 'instant-offset',
+		reason: '履歴取得範囲の「N 日前の絶対時刻」生成のみ。暦日化は toJSTDateString() に委譲済',
 	},
 	{
 		file: 'src/lib/features/child-home/BabyHomePage.stories.svelte',
-		max: 4,
-		reason:
-			'(dev) Storybook の fixture 生成 (「N ヶ月前生まれ」等の相対誕生日)。本番ビルドに含まれず顧客に見える値を作らない',
+		max: 8,
+		kind: 'non-runtime',
+		reason: 'Storybook の fixture 生成 (「N ヶ月前生まれ」等の相対誕生日)。本番ビルドに含まれない',
 	},
 	{
-		file: 'src/lib/ui/primitives/BirthdayInput.svelte',
+		file: 'src/lib/server/demo/demo-data.ts',
+		max: 6,
+		kind: 'non-runtime',
+		reason: 'デモ fixture の相対日付生成。顧客テナントのデータを作らない',
+	},
+	{
+		file: 'src/lib/server/demo/synthetic-staging-dataset.ts',
+		max: 2,
+		kind: 'non-runtime',
+		reason: 'staging 合成 seed の相対日付生成 (#3412)。顧客テナントのデータを作らない',
+	},
+	{
+		file: 'src/lib/server/debug-plan.ts',
+		max: 2,
+		kind: 'non-runtime',
+		reason: 'DEBUG_TRIAL の擬似終了日 (dev 専用、本番ビルド無効)',
+	},
+	// --- scripts/ (ビルド / CI 道具。顧客に見える日付を作らない) ---
+	{
+		file: 'scripts/ai-evaluation/lib/multi-agent-evaluator.mjs',
 		max: 1,
-		reason:
-			'(b2) 月の日数算出 `new Date(y, m, 0).getDate()` はローカルコンストラクタ + ローカル getter で閉じており、返る日数は TZ 非依存',
+		kind: 'non-runtime',
+		reason: '評価レポートの日付メタ (CI 道具の出力メタデータ)',
+	},
+	{
+		file: 'scripts/ai-evaluation/run-poc.mjs',
+		max: 2,
+		kind: 'non-runtime',
+		reason: 'PoC 出力ファイル名の日付 (CI 道具)',
+	},
+	{
+		file: 'scripts/audit/run-pipeline.mjs',
+		max: 1,
+		kind: 'non-runtime',
+		reason: '監査 run id の日付部 (CI 道具)',
+	},
+	{
+		file: 'scripts/capture-specs/flows/trial-start-error-2941.mjs',
+		max: 4,
+		kind: 'non-runtime',
+		reason: 'SS 撮影用の相対日付 fixture (撮影道具)',
+	},
+	{
+		file: 'scripts/capture.mjs',
+		max: 1,
+		kind: 'non-runtime',
+		reason: 'SS 出力ディレクトリ名の日付 (撮影道具)',
+	},
+	{
+		file: 'scripts/generate-sitemap.mjs',
+		max: 1,
+		kind: 'non-runtime',
+		reason: 'sitemap の lastmod (W3C 日付、UTC で妥当)',
+	},
+	{
+		file: 'scripts/generate-version.ts',
+		max: 1,
+		kind: 'non-runtime',
+		reason: 'ビルド版数の日付部 (JST 補正済の Date を文字列化している)',
+	},
+	{
+		file: 'scripts/security-findings-to-issues.mjs',
+		max: 1,
+		kind: 'non-runtime',
+		reason: 'Issue 本文に載せる検出日 (CI 道具)',
+	},
+	{
+		file: 'scripts/security-scan.mjs',
+		max: 1,
+		kind: 'non-runtime',
+		reason: 'スキャン結果ファイル名の日付 (CI 道具)',
+	},
+	{
+		file: 'scripts/seed-staging.ts',
+		max: 1,
+		kind: 'non-runtime',
+		reason: 'staging seed の anchor 日付 (dev / staging 道具、顧客テナントを作らない)',
 	},
 ];
 
 /**
  * relPath (`/` 区切り) の allowlist entry を返す
  * @param {string} relPath
- * @returns {{file: string, max: number, reason: string} | undefined}
+ * @returns {{file: string, max: number, kind: string, proof?: string, reason: string} | undefined}
  */
 export function findAllowlistEntry(relPath) {
 	const normalized = relPath.replace(/\\/g, '/');
@@ -203,12 +338,78 @@ export function findAllowlistEntry(relPath) {
 }
 
 /**
- * allowlist 自体の健全性検査。`reason` が空 / 空白のみの entry を返す。
- * 「除外したが理由が無い」形骸化を構造的に禁じる (#3956 の教訓)。
- * @returns {Array<{file: string, max: number, reason: string}>}
+ * allowlist 自体の健全性検査 (kind ごとの機械検証)。
+ *
+ * 「理由が書いてあるだけ」で通る除外を作らないための中核。`occurrencesByFile` を渡すと
+ * `instant-offset` の構造検査 (全違反行が `setX(getX() ± n)` か) まで行う。
+ *
+ * @param {Map<string, Array<{file: string, line: number, snippet: string}>>} [occurrencesByFile]
+ * @returns {Array<{file: string, problem: string}>} 問題のある entry (空なら健全)
  */
-export function findAllowlistEntriesWithoutReason() {
-	return ALLOWLIST.filter((e) => typeof e.reason !== 'string' || e.reason.trim() === '');
+export function findAllowlistIntegrityProblems(occurrencesByFile = new Map()) {
+	/** @type {Array<{file: string, problem: string}>} */
+	const problems = [];
+	for (const e of ALLOWLIST) {
+		if (typeof e.reason !== 'string' || e.reason.trim() === '') {
+			problems.push({ file: e.file, problem: 'reason が空です' });
+		}
+		if (!ALLOWLIST_KINDS.includes(e.kind)) {
+			problems.push({
+				file: e.file,
+				problem: `kind が不正です (${String(e.kind)})。許可: ${ALLOWLIST_KINDS.join(' / ')}`,
+			});
+			continue;
+		}
+		if (e.kind === 'ssot' && e.file !== 'src/lib/domain/date-utils.ts') {
+			problems.push({
+				file: e.file,
+				problem: "kind='ssot' は JST SSOT 実装本体 (src/lib/domain/date-utils.ts) 以外に使えません",
+			});
+		}
+		if (e.kind === 'tz-proof') {
+			if (!e.proof) {
+				problems.push({
+					file: e.file,
+					problem: "kind='tz-proof' には proof (実測 case id) が必要です",
+				});
+			} else if (!hasTzInvarianceCase(e.proof)) {
+				problems.push({
+					file: e.file,
+					problem: `proof '${e.proof}' が scripts/lib/ci/tz-invariance-cases.mjs に未登録です`,
+				});
+			}
+		}
+		if (e.kind === 'non-runtime' && !NON_RUNTIME_PATTERNS.some((p) => p.test(e.file))) {
+			problems.push({
+				file: e.file,
+				problem: "kind='non-runtime' を名乗れる path ではありません (NON_RUNTIME_PATTERNS 参照)",
+			});
+		}
+		// stale 検出: 実際には違反の無くなった entry を残さない (allowlist の腐敗防止)。
+		// `max: 0` は「0 で pin する」意思表示なので対象外。
+		if (
+			e.max > 0 &&
+			(occurrencesByFile.get(e.file) ?? []).length === 0 &&
+			occurrencesByFile.size > 0
+		) {
+			problems.push({
+				file: e.file,
+				problem:
+					'違反が 0 件になっています。修正済なら本 entry を削除してください (stale allowlist)',
+			});
+		}
+		if (e.kind === 'instant-offset') {
+			const occurrences = occurrencesByFile.get(e.file) ?? [];
+			const offenders = occurrences.filter((o) => !INSTANT_OFFSET_PATTERN.test(o.snippet));
+			for (const o of offenders) {
+				problems.push({
+					file: e.file,
+					problem: `kind='instant-offset' だが L${o.line} が setX(getX() ± n) 構造ではありません: ${o.snippet}`,
+				});
+			}
+		}
+	}
+	return problems;
 }
 
 /**
@@ -227,40 +428,80 @@ export function isCommentLine(line) {
 }
 
 /**
- * 1 ファイル分の content からローカル TZ getter 行を抽出する (純関数)。
+ * 1 行が違反かを判定する (純関数)。
+ *
+ * `toLocale*` の option object は複数行に分かれることがあるため、`timeZone` の有無は
+ * 続く数行まで見る (`lookahead`)。行単位で切ると整形の差だけで判定が変わってしまう。
+ *
+ * @param {string} line
+ * @param {string} [lookahead] 続く数行を連結したもの (option object の続き)
+ * @returns {{kind: 'tz-dependent-member'|'utc-calendar-slice'|'implicit-locale-tz'} | null}
+ */
+export function classifyLine(line, lookahead = '') {
+	if (isCommentLine(line)) return null;
+	if (UTC_CALENDAR_SLICE.test(line)) return { kind: 'utc-calendar-slice' };
+	const hasTimeZone = HAS_EXPLICIT_TIME_ZONE.test(line) || HAS_EXPLICIT_TIME_ZONE.test(lookahead);
+	if (INTL_DATE_TIME_FORMAT.test(line) && !hasTimeZone) return { kind: 'implicit-locale-tz' };
+	if (DATE_RECEIVER_AMBIGUOUS_CALL.test(line) && !hasTimeZone)
+		return { kind: 'implicit-locale-tz' };
+	if (TZ_DEPENDENT_MEMBER_CALL.test(line)) {
+		// toLocale* は timeZone を明示していれば TZ 非依存 (構造判定)
+		if (/\.toLocale(String|DateString|TimeString)\s*\(/.test(line)) {
+			return hasTimeZone ? null : { kind: 'implicit-locale-tz' };
+		}
+		return { kind: 'tz-dependent-member' };
+	}
+	return null;
+}
+
+/**
+ * 1 ファイル分の content から違反行を抽出する (純関数)。
  * @param {string} relPath REPO_ROOT 相対 path
  * @param {string} content ファイル内容
- * @returns {Array<{file: string, line: number, snippet: string}>}
+ * @returns {Array<{file: string, line: number, snippet: string, kind: string}>}
  */
 export function findOccurrencesInContent(relPath, content) {
-	/** @type {Array<{file: string, line: number, snippet: string}>} */
+	/** @type {Array<{file: string, line: number, snippet: string, kind: string}>} */
 	const out = [];
-	content.split(/\r?\n/).forEach((line, idx) => {
-		if (!LOCAL_TZ_GETTER.test(line)) return;
-		if (isCommentLine(line)) return;
+	const lines = content.split(/\r?\n/);
+	lines.forEach((line, idx) => {
+		// option object が複数行に割れる整形に備え、続く 3 行を lookahead として渡す
+		const hit = classifyLine(line, lines.slice(idx + 1, idx + 4).join('\n'));
+		if (!hit) return;
 		out.push({
 			file: relPath.replace(/\\/g, '/'),
 			line: idx + 1,
-			snippet: line.trim().slice(0, 120),
+			snippet: line.trim().slice(0, 140),
+			kind: hit.kind,
 		});
 	});
 	return out;
 }
 
 /**
- * occurrence 群を allowlist と突き合わせ、違反 (no-silent-gap / ratchet 超過) を返す。
- * @param {Array<{file: string, line: number, snippet: string}>} occurrences
- * @returns {Array<{kind: 'not-allowlisted'|'over-max', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string}>}>}
+ * occurrence を file 別にまとめる
+ * @param {Array<{file: string, line: number, snippet: string, kind: string}>} occurrences
+ * @returns {Map<string, Array<{file: string, line: number, snippet: string, kind: string}>>}
  */
-export function evaluateOccurrences(occurrences) {
-	/** @type {Map<string, Array<{file: string, line: number, snippet: string}>>} */
+export function groupByFile(occurrences) {
+	/** @type {Map<string, Array<{file: string, line: number, snippet: string, kind: string}>>} */
 	const byFile = new Map();
 	for (const o of occurrences) {
 		const list = byFile.get(o.file) ?? [];
 		list.push(o);
 		byFile.set(o.file, list);
 	}
-	/** @type {Array<{kind: 'not-allowlisted'|'over-max', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string}>}>} */
+	return byFile;
+}
+
+/**
+ * occurrence 群を allowlist と突き合わせ、違反 (no-silent-gap / ratchet 超過) を返す。
+ * @param {Array<{file: string, line: number, snippet: string, kind: string}>} occurrences
+ * @returns {Array<{kind: 'not-allowlisted'|'over-max', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string, kind: string}>}>}
+ */
+export function evaluateOccurrences(occurrences) {
+	const byFile = groupByFile(occurrences);
+	/** @type {Array<{kind: 'not-allowlisted'|'over-max', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string, kind: string}>}>} */
 	const violations = [];
 	for (const [file, list] of byFile) {
 		const entry = findAllowlistEntry(file);
@@ -309,10 +550,10 @@ function walk(dir, out = []) {
 /**
  * REPO_ROOT 配下の SEARCH_ROOTS を走査し全 occurrence を返す
  * @param {string} [repoRoot]
- * @returns {Array<{file: string, line: number, snippet: string}>}
+ * @returns {Array<{file: string, line: number, snippet: string, kind: string}>}
  */
 export function findAllOccurrences(repoRoot = REPO_ROOT) {
-	/** @type {Array<{file: string, line: number, snippet: string}>} */
+	/** @type {Array<{file: string, line: number, snippet: string, kind: string}>} */
 	const occurrences = [];
 	for (const root of SEARCH_ROOTS) {
 		for (const file of walk(path.join(repoRoot, root))) {
@@ -324,28 +565,38 @@ export function findAllOccurrences(repoRoot = REPO_ROOT) {
 }
 
 function main() {
-	const noReason = findAllowlistEntriesWithoutReason();
-	if (noReason.length > 0) {
+	const unclassified = findUnclassifiedDateMembers();
+	if (unclassified.length > 0) {
 		console.error(
-			`[check-local-tz-date-getters] ✗ allowlist に理由 (reason) の無い entry が ${noReason.length} 件あります:\n`,
-		);
-		for (const e of noReason) console.error(`  ${e.file}`);
-		console.error(
-			'\n  除外は必ず「なぜ TZ 非依存と言えるか」を reason に書いてください (#4015 / #3956)。',
+			`[check-local-tz-date-getters] ✗ Date.prototype に未分類のメンバーがあります: ${unclassified.join(', ')}`,
 		);
 		process.exit(1);
 	}
 
-	const violations = evaluateOccurrences(findAllOccurrences());
+	const occurrences = findAllOccurrences();
+	const problems = findAllowlistIntegrityProblems(groupByFile(occurrences));
+	if (problems.length > 0) {
+		console.error(
+			`[check-local-tz-date-getters] ✗ allowlist の除外理由が機械検証を通りませんでした (${problems.length} 件):\n`,
+		);
+		for (const p of problems) console.error(`  ${p.file}: ${p.problem}`);
+		console.error(
+			'\n  除外は kind ごとに検査されます (ssot / tz-proof / instant-offset / non-runtime)。',
+		);
+		console.error('  自由文の reason だけでは通りません (#4127)。');
+		process.exit(1);
+	}
+
+	const violations = evaluateOccurrences(occurrences);
 	if (violations.length === 0) {
 		console.log(
-			`[check-local-tz-date-getters] OK — allowlist (${ALLOWLIST.length} file、全件 reason 付き) 外のローカル TZ 日付 getter なし`,
+			`[check-local-tz-date-getters] OK — allowlist (${ALLOWLIST.length} file、全件 kind 検証済) 外の TZ 依存日付導出なし`,
 		);
 		process.exit(0);
 	}
 
 	console.error(
-		`[check-local-tz-date-getters] ✗ ローカル TZ 日付 getter の違反を ${violations.length} file で検出しました (#4015):\n`,
+		`[check-local-tz-date-getters] ✗ TZ 依存の日付導出を ${violations.length} file で検出しました (#4015 / #4127):\n`,
 	);
 	for (const v of violations) {
 		const head =
@@ -353,25 +604,35 @@ function main() {
 				? `${v.file}: ${v.count} 件 (allowlist 未登録)`
 				: `${v.file}: ${v.count} 件 (allowlist 上限 ${v.max} 件を超過)`;
 		console.error(`  ${head}`);
-		for (const s of v.samples) console.error(`    L${s.line}: ${s.snippet}`);
+		for (const s of v.samples) console.error(`    L${s.line} [${s.kind}]: ${s.snippet}`);
 	}
 	console.error('\n修正方針:');
 	console.error(
-		'  - 実時刻 (new Date() / DB timestamp) から暦要素を取り出しているなら **欠陥** です。',
+		'  - [tz-dependent-member] 実時刻から暦要素をローカル TZ で取り出しています。$lib/domain/date-utils.ts の',
 	);
 	console.error(
-		'    $lib/domain/date-utils.ts の JST SSOT (todayDateJST / toJSTDateString / weekStartJST /',
+		'    JST SSOT (todayDateJST / toJSTDateString / jstHour / weekStartJST / weekEndJST / addDaysJST /',
 	);
 	console.error(
-		'    weekEndJST / addDaysJST / jstDayOfWeek / jstYearMonth / monthKeyJST / shiftMonthKey /',
+		'    prevDateJST / jstDayOfWeek / jstYearMonth / monthKeyJST / shiftMonthKey / monthStartJST /',
 	);
-	console.error('    monthStartJST / monthEndJST / isInJstMonth) に置換してください。');
+	console.error('    monthEndJST / isInJstMonth) に置換してください。');
 	console.error(
-		'  - TZ 非依存と言い切れる場合のみ、本 script の ALLOWLIST に file / max / reason を追加します。',
+		'  - [utc-calendar-slice] `toISOString().slice(0, 10)` は **UTC の暦日**です。JST 00:00〜09:00 の',
 	);
 	console.error(
-		'    reason には「なぜ TZ 非依存か」を必ず書いてください (空だと本 gate が落ちます)。',
+		'    9 時間だけ前日になります。todayDateJST() / toJSTDateString() / monthKeyJST() に置換。',
 	);
+	console.error(
+		"  - [implicit-locale-tz] toLocale* / Intl.DateTimeFormat に `timeZone: 'Asia/Tokyo'` を明示するか、",
+	);
+	console.error(
+		'    date-utils.ts の formatJST* を使ってください (SSR は Lambda=UTC で描画されます)。',
+	);
+	console.error(
+		'  - TZ 非依存と言い切れる場合のみ ALLOWLIST に file / max / kind / reason を追加します。kind は',
+	);
+	console.error('    機械検証されます (tz-proof は 2 TZ 実測 case の登録が必要)。');
 	process.exit(1);
 }
 

--- a/scripts/check-local-tz-date-getters.mjs
+++ b/scripts/check-local-tz-date-getters.mjs
@@ -135,6 +135,7 @@ export function findUnclassifiedDateMembers() {
  * `findUndeclaredAmbiguousMembers()` が「宣言も走査もされていないメンバー」を検出する。
  * 代わりに `DATE_LITERAL_TO_STRING` で受け手が Date と分かる形だけを拾う。
  */
+/** @type {Record<string, string>} */
 export const AMBIGUOUS_MEMBERS = {
 	toString:
 		'Object / Number / Buffer 等の toString と同名で、行単位では受け手が Date か判別できない (randomBytes(32).toString("base64url") 等)。受け手が Date と分かる形は DATE_RECEIVER_AMBIGUOUS_CALL で拾う',
@@ -153,7 +154,7 @@ export const DATE_RECEIVER_AMBIGUOUS_CALL =
 export function findUndeclaredAmbiguousMembers() {
 	const { dependent } = classifyDateMembers();
 	return dependent.filter(
-		(n) => Object.hasOwn(AMBIGUOUS_MEMBERS, n) && !AMBIGUOUS_MEMBERS[n].trim(),
+		(n) => Object.hasOwn(AMBIGUOUS_MEMBERS, n) && !AMBIGUOUS_MEMBERS[n]?.trim(),
 	);
 }
 

--- a/scripts/lib/ci/tz-invariance-cases.mjs
+++ b/scripts/lib/ci/tz-invariance-cases.mjs
@@ -1,0 +1,87 @@
+/**
+ * scripts/lib/ci/tz-invariance-cases.mjs (#4127)
+ *
+ * TZ 不変性 proof の登録簿 (SSOT)。
+ *
+ * # なぜ必要か
+ *
+ * #4015 で入れた静的 gate は allowlist の `reason` が**非空かどうか**しか検査していなかった。
+ * その結果「(b2) パースと読み出しが同じ TZ 系なので安全」と書かれた `daily-mission-service`
+ * の `getPreviousDate()` が、実際には TZ=Asia/Tokyo で 2 日前を返していた (#4127 残存 3)。
+ * 理由が実測と食い違っていても緑になる allowlist は、除外の体裁だけがある無検査と同じ。
+ *
+ * 本 registry は「その除外は測って確かめた」と言うための **id 空間**である。
+ *
+ *   - 静的 gate (`scripts/check-local-tz-date-getters.mjs`) の allowlist は
+ *     `kind: 'tz-proof'` のとき `proof` にここの id を要求する (未登録なら fail)
+ *   - fitness test (`tests/unit/architecture/tz-invariance.test.ts`) は、ここの全 id に
+ *     対応する実測 case を持つことを要求し (双方向 no-silent-gap)、各 case を
+ *     `TZ=UTC` と `TZ=Asia/Tokyo` の 2 環境で評価して **JST 暦の期待値と一致する**ことを
+ *     assert する
+ *
+ * つまり allowlist の理由は「文章」ではなく「実行される測定」に紐付く。
+ */
+
+/**
+ * 判定に使う固定の瞬間。
+ *
+ * JST 2026-08-01 00:30 = UTC 2026-07-31 15:30。**UTC 経路だと暦日 / 暦月がどちらも 1 つ前に
+ * なる窓** (JST 00:00〜09:00) の内側にあり、月境界もまたぐため「UTC で導出しているか」と
+ * 「プロセス TZ に依存しているか」を同時に炙り出せる。
+ */
+export const TZ_PROBE_INSTANT_ISO = '2026-07-31T15:30:00.000Z';
+
+/** `TZ_PROBE_INSTANT_ISO` における JST 暦日 */
+export const TZ_PROBE_JST_DATE = '2026-08-01';
+
+/** `TZ_PROBE_INSTANT_ISO` における JST 暦月 */
+export const TZ_PROBE_JST_MONTH = '2026-08';
+
+/** fitness test が評価するプロセス TZ。本番 runtime の 2 種 (Lambda=UTC / NUC=JST) に対応する。 */
+export const TZ_PROBE_TIMEZONES = ['UTC', 'Asia/Tokyo'];
+
+/**
+ * TZ 不変性 proof の登録簿。
+ *
+ * key = proof id (静的 gate の allowlist から参照される) / value.note = 何を測るか。
+ *
+ * @type {Record<string, { note: string }>}
+ */
+export const TZ_INVARIANCE_CASES = {
+	'date-utils/today-date-jst': {
+		note: 'JST SSOT 自身。todayDateJST / monthKeyJST / weekStartJST が 2 TZ で JST 暦と一致する',
+	},
+	'date-utils/jst-hour': {
+		note: 'jstHour() が 2 TZ で JST の時刻を返す (はやおきボーナスの判定入力、#4127 残存 1)',
+	},
+	'date-utils/add-days-jst': {
+		note: 'addDaysJST / prevDateJST が月またぎ・2 TZ で JST 暦日を返す (#4127 残存 3 の置換先)',
+	},
+	'bonus-hook/early-bird-hour': {
+		note: 'evaluateBonusHooks のはやおきボーナスが JST 07:00 の記録に付き JST 15:00 に付かない (#4127 残存 1)',
+	},
+	'usage-log/today-summary-date-key': {
+		note: 'getTodayUsageSummary が JST の暦日で当日ログを引く (#4127 残存 4)',
+	},
+	'usage-log/weekly-summary-buckets': {
+		note: 'getWeeklyUsageSummary の日次バケットが JST 暦日で並ぶ (#4127 残存 4)',
+	},
+	'loyalty/increment-month-key': {
+		note: 'incrementSubscriptionMonth の二重防止キーが JST 月キーになる (#4127 残存 5)',
+	},
+	'rest-days/month-symmetry': {
+		note: 'おやすみ日の GET 既定月 (導出) と POST の上限判定月 (日付由来) が一致する (#4127 残存 6)',
+	},
+};
+
+/** proof id の一覧 */
+export const TZ_INVARIANCE_CASE_IDS = Object.keys(TZ_INVARIANCE_CASES);
+
+/**
+ * proof id が登録済みか
+ * @param {string} id
+ * @returns {boolean}
+ */
+export function hasTzInvarianceCase(id) {
+	return Object.hasOwn(TZ_INVARIANCE_CASES, id);
+}

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -118,7 +118,7 @@ Steps (6 本。番号は既存の識別子を維持 — 実行順は下記「実
   1.  biome check                 — lint (recommended の correctness / suspicious を含む)
   2.  svelte-check                — TS strict 型チェック
   7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972)
-  7g. check-local-tz-date-getters.mjs — ローカル TZ 日付 getter 禁止 / JST SSOT 強制 (#4015)
+  7g. check-local-tz-date-getters.mjs — TZ 依存の日付導出禁止 / JST SSOT 強制 (#4015 / #4127)
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
   11b. check-pr-screenshot.mjs (SS embed gate) — UI 変更 PR の SS embed 未完了を hard-fail (#2918、CI screenshot-check と SSOT 共有)
 

--- a/src/lib/domain/date-utils.ts
+++ b/src/lib/domain/date-utils.ts
@@ -19,11 +19,17 @@
 // 将来 UTC 保存に移行する場合は recorded_at (timestamp) カラムの
 // 新設が必要（#966 コメント 案A 参照）。
 //
-// ## SSOT 宣言 — 日付を決める計算は本 module 経由で行う (#4015)
+// ## SSOT 宣言 — 日付を決める計算は本 module 経由で行う (#4015 / #4127)
 //
-// **「実時刻の瞬間 (`new Date()` / DB timestamp) から暦要素 (年 / 月 / 日 / 曜日) を
-// 取り出す」計算は、必ず本 module の関数を使う。`Date` のローカル TZ getter
-// (`getFullYear()` / `getMonth()` / `getDate()` / `getDay()`) を直接呼ばない。**
+// **「実時刻の瞬間 (`new Date()` / DB timestamp) から暦要素 (年 / 月 / 日 / 時 / 曜日) を
+// 取り出す」計算は、必ず本 module の関数を使う。**禁止されるのはローカル getter だけではない。
+// 同じ欠陥クラスに属する書き方はすべて対象:
+//
+// | 書き方 | なぜ駄目か |
+// |---|---|
+// | `d.getFullYear()` / `getMonth()` / `getDate()` / `getDay()` / `getHours()` 等 | プロセス TZ で結果が変わる |
+// | `new Date().toISOString().slice(0, 10)` / `.split('T')[0]` | TZ 不変だが **UTC の暦日**。JST 00:00〜09:00 が前日になる |
+// | `toLocaleDateString('ja-JP')` (timeZone 未指定) | SSR は Lambda (UTC) で描画されるため暦日がずれる |
 //
 // 理由: 本番 runtime は 2 種類あり、プロセス TZ が一致しない。
 //
@@ -36,8 +42,14 @@
 // これで子供ホームの週次チャレンジが毎週 9 時間まるごと消えた。#966 / ADR-0061
 // (same-class-N → guard) に基づき、本 module を単一の入口とする。
 //
-// 機械強制: `scripts/check-local-tz-date-getters.mjs` が src/ 配下のローカル TZ getter を
-// 検出し、allowlist (理由必須) 外の新規使用を CI で fail させる。
+// 機械強制 (2 層):
+//
+//   - 静的: `scripts/check-local-tz-date-getters.mjs` が src / infra/lambda / scripts を走査し、
+//     上表のクラスを検出する。検出対象は `Date.prototype` の実体から導出しているため
+//     「まだ知らない書き方」も既定で TZ 依存側に落ちる。allowlist は kind ごとに機械検査される
+//   - 振る舞い: `tests/unit/architecture/tz-invariance.test.ts` が `TZ=UTC` (Lambda) と
+//     `TZ=Asia/Tokyo` (NUC) の 2 環境で顧客に見える日付導出を評価し、JST 暦の期待値と
+//     一致することを assert する (記法に依存しない表明)
 //
 // 実装方針: JST の暦日を `toJSTDateString()` で文字列化し、それを **UTC 深夜として
 // 再解釈**してから UTC 算術 (`getUTCDate` / `setUTCDate`) で計算する。以降の計算が

--- a/src/lib/domain/date-utils.ts
+++ b/src/lib/domain/date-utils.ts
@@ -101,6 +101,17 @@ export function jstHour(date: Date = new Date()): number {
 }
 
 /**
+ * JST 暦日 (YYYY-MM-DD) の 00:00 に対応する **UTC の瞬間**を ISO 文字列で返す (#4127)。
+ *
+ * DB に UTC ISO で保存した timestamp を「JST の 1 日」で絞るときの境界値。
+ * `startedAt >= '2026-08-01'` のような UTC 暦日前方一致は、JST 00:00〜09:00 の利用を
+ * 前日側に落としてしまう (保護者画面の「今日の利用時間」が 0 分のままになる)。
+ */
+export function jstDayStartUtcIso(dateStr: string): string {
+	return new Date(new Date(`${dateStr}T00:00:00Z`).getTime() - JST_OFFSET_MS).toISOString();
+}
+
+/**
  * JST 基準の年 / 月 (月は 1-12) を返す。
  * `now.getFullYear()` / `now.getMonth() + 1` の置換先。
  */

--- a/src/lib/domain/date-utils.ts
+++ b/src/lib/domain/date-utils.ts
@@ -90,6 +90,17 @@ export function jstDayOfWeek(date: Date = new Date()): number {
 }
 
 /**
+ * JST 基準の「時」(0-23) を返す。
+ * `date.getHours()` (ローカル TZ) の置換先 (#4127)。
+ *
+ * はやおきボーナスのような「朝 N 時までに記録したか」の判定は、プロセス TZ が UTC の
+ * Lambda 上だと 9 時間ずれ、JST 07:00 の記録には付かず JST 15:00 の記録に付いてしまう。
+ */
+export function jstHour(date: Date = new Date()): number {
+	return new Date(date.getTime() + JST_OFFSET_MS).getUTCHours();
+}
+
+/**
  * JST 基準の年 / 月 (月は 1-12) を返す。
  * `now.getFullYear()` / `now.getMonth() + 1` の置換先。
  */

--- a/src/lib/features/admin/components/ChildListCard.svelte
+++ b/src/lib/features/admin/components/ChildListCard.svelte
@@ -24,8 +24,9 @@ interface Props {
 let { child, isSelected, href, dataTutorial, formatBalance }: Props = $props();
 
 function formatBirthday(dateStr: string): string {
-	const d = new Date(dateStr);
-	return `${d.getMonth() + 1}月${d.getDate()}日`;
+	// YYYY-MM-DD をそのまま整形する (Date 経由の暦要素導出は runtime TZ 依存、#4127)
+	const [, m, d] = dateStr.split('-').map(Number);
+	return `${m ?? 0}月${d ?? 0}日`;
 }
 </script>
 

--- a/src/lib/features/admin/components/ChildProfileCard.svelte
+++ b/src/lib/features/admin/components/ChildProfileCard.svelte
@@ -583,7 +583,7 @@ const avatarSrc = $derived(uploadResult?.avatarUrl ?? generateResult?.filePath ?
 								<span>{log.activityIcon}</span>
 								<span class="logs-item__name">{log.activityName}</span>
 								<span class="logs-item__points">{fmtPts(log.points)}</span>
-								<span class="logs-item__date">{new Date(log.recordedAt).toLocaleDateString('ja-JP')}</span>
+								<span class="logs-item__date">{new Date(log.recordedAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })}</span>
 							</div>
 						{/each}
 					</div>

--- a/src/lib/features/admin/components/SaasLicensePanel.svelte
+++ b/src/lib/features/admin/components/SaasLicensePanel.svelte
@@ -570,7 +570,7 @@ async function openPortal() {
 				<div class="flex items-center justify-between py-2 border-b border-[var(--color-surface-muted)]">
 					<span class="text-sm text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.currentPlanExpiry}</span>
 					<span class="text-sm text-[var(--color-text-primary)]">
-						{new Date(license.planExpiresAt).toLocaleDateString('ja-JP')}
+						{new Date(license.planExpiresAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })}
 					</span>
 				</div>
 			{/if}
@@ -583,7 +583,7 @@ async function openPortal() {
 			<div class="flex items-center justify-between py-2">
 				<span class="text-sm text-[var(--color-text-muted)]">{SUBSCRIPTION_PAGE_LABELS.currentPlanCreatedAt}</span>
 				<span class="text-sm text-[var(--color-text-primary)]">
-					{new Date(license.createdAt).toLocaleDateString('ja-JP')}
+					{new Date(license.createdAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })}
 				</span>
 			</div>
 		</div>

--- a/src/lib/features/certificate/CertificateCard.svelte
+++ b/src/lib/features/certificate/CertificateCard.svelte
@@ -20,6 +20,7 @@ let { certificate, basePath = '/admin/certificates' }: Props = $props();
 
 const formattedDate = $derived(
 	new Date(certificate.issuedAt).toLocaleDateString('ja-JP', {
+		timeZone: 'Asia/Tokyo',
 		year: 'numeric',
 		month: 'short',
 		day: 'numeric',

--- a/src/lib/features/certificate/CertificateTemplate.svelte
+++ b/src/lib/features/certificate/CertificateTemplate.svelte
@@ -21,6 +21,7 @@ let { certificate, watermark = false }: Props = $props();
 
 const formattedDate = $derived(
 	new Date(certificate.issuedAt).toLocaleDateString('ja-JP', {
+		timeZone: 'Asia/Tokyo',
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',

--- a/src/lib/server/db/demo/daily-mission-repo.ts
+++ b/src/lib/server/db/demo/daily-mission-repo.ts
@@ -1,3 +1,4 @@
+import { prevDateJST } from '$lib/domain/date-utils';
 import type { ActivityId, ChildId } from '$lib/domain/ids';
 // Demo IDailyMissionRepo implementation
 // ADR-0048 §決定 §2: stateless Fake (read) + Stub (write) hybrid.
@@ -87,9 +88,7 @@ export async function findPreviousDayMissionIds(
 	date: string,
 	_tenantId: string,
 ): Promise<ActivityId[]> {
-	const prev = new Date(date);
-	prev.setDate(prev.getDate() - 1);
-	const prevDate = prev.toISOString().slice(0, 10);
+	const prevDate = prevDateJST(date);
 	return DEMO_DAILY_MISSIONS.filter((m) => m.childId === childId && m.missionDate === prevDate).map(
 		(m) => m.activityId,
 	);

--- a/src/lib/server/db/dsql/inquiry-repo.ts
+++ b/src/lib/server/db/dsql/inquiry-repo.ts
@@ -15,13 +15,15 @@
 //     throw のまま呼び出し側契約 (service が fail(500) を返す)。
 
 import { sql } from 'drizzle-orm';
+import { todayDateJST } from '$lib/domain/date-utils';
 import type { IInquiryRepo, InquiryRecord } from '../interfaces/inquiry-repo.interface';
 import type { SqlExecutor } from './sql-executor';
 
 /** タイムスタンプベースの ID 採番 (sqlite backend と同形式、INQ-YYYYMMDD-nnnn)。 */
 async function generateInquiryId(): Promise<string> {
 	const now = new Date();
-	const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+	// 問い合わせ番号の日付は顧客に見えるため JST (#4127)
+	const dateStr = todayDateJST().replace(/-/g, '');
 	const seq = String(now.getTime() % 10000).padStart(4, '0');
 	return `INQ-${dateStr}-${seq}`;
 }

--- a/src/lib/server/db/dsql/trial-history-repo.ts
+++ b/src/lib/server/db/dsql/trial-history-repo.ts
@@ -14,6 +14,7 @@
 //     前提の防御。DSQL uuid は全域一意だが IDOR 形状排除のため両述語を維持、sqlite と同 shape)。
 
 import { sql } from 'drizzle-orm';
+import { todayDateJST } from '$lib/domain/date-utils';
 import type {
 	ITrialHistoryRepo,
 	TrialHistoryRow,
@@ -72,7 +73,7 @@ export function createDsqlTrialHistoryRepo(db: SqlExecutor): ITrialHistoryRepo {
 
 		async findActiveTrials() {
 			// endDate が今日以降のトライアル履歴 (cron 通知対象、cross-tenant scan 許容 §11.2)。
-			const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+			const today = todayDateJST();
 			const result = await db.execute(sql`
 				SELECT ${TRIAL_COLUMNS} FROM trial_history WHERE end_date >= ${today}
 			`);

--- a/src/lib/server/db/sqlite/inquiry-repo.ts
+++ b/src/lib/server/db/sqlite/inquiry-repo.ts
@@ -1,6 +1,7 @@
 // SQLite implementation of IInquiryRepo
 // settings テーブルに inquiry: プレフィックスで問い合わせを保存
 
+import { todayDateJST } from '$lib/domain/date-utils';
 import { db } from '../client';
 import type { InquiryRecord } from '../interfaces/inquiry-repo.interface';
 import { settings } from '../schema';
@@ -8,7 +9,8 @@ import { settings } from '../schema';
 /** タイムスタンプベースのID発番（SQLiteモードではアトミックカウンタ不要） */
 export async function generateInquiryId(): Promise<string> {
 	const now = new Date();
-	const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+	// 問い合わせ番号の日付は顧客に見えるため JST (#4127)
+	const dateStr = todayDateJST().replace(/-/g, '');
 	const seq = String(now.getTime() % 10000).padStart(4, '0');
 	return `INQ-${dateStr}-${seq}`;
 }

--- a/src/lib/server/db/sqlite/trial-history-repo.ts
+++ b/src/lib/server/db/sqlite/trial-history-repo.ts
@@ -2,6 +2,7 @@
 // SQLite implementation of ITrialHistoryRepo (#314, #769)
 
 import { and, desc, eq, gte } from 'drizzle-orm';
+import { todayDateJST } from '$lib/domain/date-utils';
 import { db } from '../client';
 import type {
 	InsertTrialHistoryInput,
@@ -27,7 +28,7 @@ export async function findLatestByTenant(tenantId: string): Promise<TrialHistory
 
 /** endDate が今日以降のトライアル履歴を返す（cron 通知対象の取得用） */
 export async function findActiveTrials(): Promise<TrialHistoryRow[]> {
-	const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+	const today = todayDateJST();
 	const rows = await db.select().from(trialHistory).where(gte(trialHistory.endDate, today));
 	return rows.map(toRow);
 }

--- a/src/lib/server/db/sqlite/usage-log-repo.ts
+++ b/src/lib/server/db/sqlite/usage-log-repo.ts
@@ -63,12 +63,14 @@ export async function closeOpenSessions(childId: ChildId, endedAt: string, _tena
 }
 
 /** 本日の使用ログ一覧を取得（テナント全子供） */
-export async function findTodayUsageLogs(tenantId: string, datePrefix: string) {
-	// datePrefix = 'YYYY-MM-DD' でマッチする（ISO8601 prefix）
+export async function findTodayUsageLogs(tenantId: string, startedAtFromIso: string) {
+	// startedAtFromIso = 「その日の始まり」を表す UTC ISO 文字列 (#4127)。
+	// startedAt は UTC ISO で保存されるため、JST の 1 日で絞るには境界を
+	// jstDayStartUtcIso() で作った瞬間で渡す (UTC 暦日の前方一致では 9 時間ずれる)。
 	const rows = db
 		.select()
 		.from(usageLogs)
-		.where(and(eq(usageLogs.tenantId, tenantId), gte(usageLogs.startedAt, datePrefix)))
+		.where(and(eq(usageLogs.tenantId, tenantId), gte(usageLogs.startedAt, startedAtFromIso)))
 		.all();
 	return rows.map(toUsageLog);
 }

--- a/src/lib/server/db/usage-log-repo.ts
+++ b/src/lib/server/db/usage-log-repo.ts
@@ -25,8 +25,8 @@ export async function closeOpenSessions(childId: ChildId, endedAt: string, tenan
 	return sqliteRepo.closeOpenSessions(childId, endedAt, tenantId);
 }
 
-export async function findTodayUsageLogs(tenantId: string, datePrefix: string) {
-	return sqliteRepo.findTodayUsageLogs(tenantId, datePrefix);
+export async function findTodayUsageLogs(tenantId: string, startedAtFromIso: string) {
+	return sqliteRepo.findTodayUsageLogs(tenantId, startedAtFromIso);
 }
 
 export async function findUsageLogsByChildAndDateRange(

--- a/src/lib/server/logger.ts
+++ b/src/lib/server/logger.ts
@@ -2,6 +2,7 @@
 // Structured server-side logger with file output for production
 import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { todayDateJST } from '$lib/domain/date-utils';
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error' | 'critical';
 
@@ -48,7 +49,8 @@ function ensureLogDir() {
 }
 
 function getLogFileName(): string {
-	const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+	// ログのローテーション単位も JST の 1 日に揃える (#4127)
+	const date = todayDateJST();
 	return join(LOG_DIR, `app-${date}.log`);
 }
 

--- a/src/lib/server/services/activity-pin-service.ts
+++ b/src/lib/server/services/activity-pin-service.ts
@@ -1,3 +1,4 @@
+import { addDaysJST, todayDateJST } from '$lib/domain/date-utils';
 import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/activity-pin-service.ts
 // 活動ピン留め・使用頻度ソートサービス
@@ -102,7 +103,5 @@ export async function sortActivitiesWithPreferences<T extends SortableActivity>(
 }
 
 function getSinceDate(days: number): string {
-	const d = new Date();
-	d.setDate(d.getDate() - days);
-	return d.toISOString().split('T')[0] ?? d.toISOString();
+	return addDaysJST(todayDateJST(), -days);
 }

--- a/src/lib/server/services/activity-record-preparation.ts
+++ b/src/lib/server/services/activity-record-preparation.ts
@@ -14,6 +14,7 @@
 // (NOT_FOUND child → NOT_FOUND activity → ALREADY_RECORDED / DAILY_LIMIT_REACHED) は
 // 旧 activity-log-service.ts のインライン実装から変更していない。
 
+import { prevDateJST } from '$lib/domain/date-utils';
 import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 import {
 	calcMasteryBonus,
@@ -221,7 +222,5 @@ async function calculateStreak(
 
 /** Get previous date string (YYYY-MM-DD). */
 function prevDate(dateStr: string): string {
-	const d = new Date(`${dateStr}T00:00:00Z`);
-	d.setUTCDate(d.getUTCDate() - 1);
-	return d.toISOString().slice(0, 10);
+	return prevDateJST(dateStr);
 }

--- a/src/lib/server/services/birthday-bonus-service.ts
+++ b/src/lib/server/services/birthday-bonus-service.ts
@@ -2,7 +2,7 @@ import type { ChildId } from '$lib/domain/ids';
 // src/lib/server/services/birthday-bonus-service.ts
 // 誕生日ボーナスポイントの判定・付与サービス
 
-import { todayDateJST } from '$lib/domain/date-utils';
+import { addDaysJST, todayDateJST } from '$lib/domain/date-utils';
 import { getDefaultUiMode } from '$lib/domain/validation/age-tier';
 import { findChildById, updateChild } from '$lib/server/db/child-repo';
 import { insertPointEntry } from '$lib/server/db/point-repo';
@@ -45,11 +45,11 @@ export interface BirthdayBonusClaimResult {
 
 /** birthDate (YYYY-MM-DD) から年齢を計算 */
 export function calculateAge(birthDate: string, referenceDate: string): number {
-	const birth = new Date(`${birthDate}T00:00:00`);
-	const ref = new Date(`${referenceDate}T00:00:00`);
-	let age = ref.getFullYear() - birth.getFullYear();
-	const monthDiff = ref.getMonth() - birth.getMonth();
-	if (monthDiff < 0 || (monthDiff === 0 && ref.getDate() < birth.getDate())) {
+	// 暦日文字列どうしの比較で完結させる (Date 経由だと runtime TZ で結果が変わりうる、#4127)
+	const [by, bm, bd] = birthDate.split('-').map(Number);
+	const [ry, rm, rd] = referenceDate.split('-').map(Number);
+	let age = (ry ?? 0) - (by ?? 0);
+	if ((rm ?? 0) < (bm ?? 0) || ((rm ?? 0) === (bm ?? 0) && (rd ?? 0) < (bd ?? 0))) {
 		age--;
 	}
 	return Math.max(0, age);
@@ -58,12 +58,9 @@ export function calculateAge(birthDate: string, referenceDate: string): number {
 /** 今日が誕生日当日〜請求期間内かどうか */
 export function isBirthdayWindow(birthDate: string, today: string): boolean {
 	const birthMD = birthDate.slice(5); // "MM-DD"
-	const todayDate = new Date(`${today}T00:00:00Z`);
 
 	for (let i = 0; i < CLAIM_WINDOW_DAYS; i++) {
-		const checkDate = new Date(todayDate);
-		checkDate.setUTCDate(checkDate.getUTCDate() - i);
-		const checkMD = checkDate.toISOString().slice(5, 10);
+		const checkMD = addDaysJST(today, -i).slice(5);
 		if (checkMD === birthMD) {
 			return true;
 		}
@@ -74,11 +71,8 @@ export function isBirthdayWindow(birthDate: string, today: string): boolean {
 /** 誕生日の請求期限日を計算 */
 export function getClaimDeadline(birthDate: string, today: string): string | null {
 	const birthMD = birthDate.slice(5); // "MM-DD"
-	const year = new Date(`${today}T00:00:00Z`).getFullYear();
-	const birthdayThisYear = `${year}-${birthMD}`;
-	const deadline = new Date(`${birthdayThisYear}T00:00:00Z`);
-	deadline.setUTCDate(deadline.getUTCDate() + CLAIM_WINDOW_DAYS - 1);
-	return deadline.toISOString().slice(0, 10);
+	const birthdayThisYear = `${today.slice(0, 4)}-${birthMD}`;
+	return addDaysJST(birthdayThisYear, CLAIM_WINDOW_DAYS - 1);
 }
 
 /** ボーナスポイントを計算 */
@@ -116,7 +110,7 @@ export function checkBirthdayStatus(child: Child, today: string): BirthdayBonusS
 		};
 	}
 
-	const currentYear = new Date(`${today}T00:00:00`).getFullYear();
+	const currentYear = Number(today.slice(0, 4));
 	const alreadyClaimed = child.lastBirthdayBonusYear === currentYear;
 	const inWindow = isBirthdayWindow(child.birthDate, today);
 	const newAge = calculateAge(child.birthDate, today);
@@ -158,7 +152,7 @@ export async function claimBirthdayBonus(
 	const newAge = status.newAge ?? calculateAge(child.birthDate, today);
 	const multiplier = child.birthdayBonusMultiplier ?? 1.0;
 	const totalPoints = calcBirthdayBonus(newAge, multiplier);
-	const currentYear = new Date(`${today}T00:00:00`).getFullYear();
+	const currentYear = Number(today.slice(0, 4));
 
 	// #580: 年齢境界（preschool/elementary/junior/senior）を跨いだ場合、
 	// uiMode も自動的に再計算する。ポリシー: 常に自動上書き（手動設定は誕生日後に再調整）。

--- a/src/lib/server/services/bonus-hook-service.ts
+++ b/src/lib/server/services/bonus-hook-service.ts
@@ -31,7 +31,7 @@ import { asCategoryId } from '$lib/domain/ids';
 // today categories count を使う形式とする。
 
 import { CATEGORY_CODE_TO_ID } from '$lib/domain/categories';
-import { jstDayOfWeek } from '$lib/domain/date-utils';
+import { jstDayOfWeek, jstHour } from '$lib/domain/date-utils';
 import { calcStreakBonus } from '$lib/domain/validation/activity';
 // #2368 (ADR-0052): bonus state SSOT は marketplace strategy 配下に移動済。
 // 本 import は新 SSOT を直接参照 (旧 rule-preset-import-service の re-export 経由を撤去)。
@@ -132,7 +132,9 @@ export async function evaluateBonusHooks(
 			case 'early-bird': {
 				// 朝 8 時までに記録 (JST timezone) で +5
 				// 平日 5 日連続条件は本実装では簡略化 (consecutiveDays ベース)
-				const hour = ctx.recordedAt.getHours();
+				// 「朝 N 時までに記録したか」は JST SSOT 経由 (#4127)。ローカル getter だと
+				// Lambda (UTC) で 9 時間ずれ、JST 07:00 の記録に付かず JST 15:00 に付く。
+				const hour = jstHour(ctx.recordedAt);
 				if (ctx.isFirstToday && hour < 8) {
 					const morning = preset.rules.find((r) => r.title === 'はやおきボーナス');
 					if (morning) {

--- a/src/lib/server/services/child-challenge-service.ts
+++ b/src/lib/server/services/child-challenge-service.ts
@@ -18,7 +18,7 @@ import {
 	CATEGORY_CODES,
 	CATEGORY_NUMERIC_IDS,
 } from '$lib/domain/categories';
-import { todayDateJST, weekStartJST } from '$lib/domain/date-utils';
+import { addDaysJST, todayDateJST, weekStartJST } from '$lib/domain/date-utils';
 import { findAllChildren } from '$lib/server/db/child-repo';
 import { getRepos } from '$lib/server/db/factory';
 import type {
@@ -148,11 +148,8 @@ export async function aggregateCategoryCounts(
 	childId: ChildId,
 	tenantId: string,
 ): Promise<Record<string, number>> {
-	const now = new Date();
-	const twoWeeksAgo = new Date(now);
-	twoWeeksAgo.setDate(twoWeeksAgo.getDate() - 14);
-	const fromDate = twoWeeksAgo.toISOString().slice(0, 10);
-	const toDate = now.toISOString().slice(0, 10);
+	const toDate = todayDateJST();
+	const fromDate = addDaysJST(toDate, -14);
 
 	const { summary } = await aggregateActivityLogsByCategory(childId, tenantId, {
 		from: fromDate,

--- a/src/lib/server/services/daily-mission-service.ts
+++ b/src/lib/server/services/daily-mission-service.ts
@@ -2,7 +2,7 @@ import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/daily-mission-service.ts
 // デイリーミッション — 毎日3つのミッションを自動生成し、達成でボーナス付与
 
-import { todayDateJST } from '$lib/domain/date-utils';
+import { addDaysJST, prevDateJST, todayDateJST } from '$lib/domain/date-utils';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { insertPointLedger } from '$lib/server/db/activity-repo';
 import {
@@ -284,14 +284,12 @@ function shuffle<T>(arr: T[]): T[] {
 	return a;
 }
 
+// 旧実装は「ローカル深夜パース → ローカル setDate → UTC 文字列化」の混在で、
+// TZ=Asia/Tokyo では 1 日ではなく 2 日戻っていた (#4127 残存 3)。JST SSOT に委譲する。
 function getPreviousDate(dateStr: string): string {
-	const d = new Date(`${dateStr}T00:00:00`);
-	d.setDate(d.getDate() - 1);
-	return d.toISOString().slice(0, 10);
+	return prevDateJST(dateStr);
 }
 
 function getNDaysAgo(dateStr: string, n: number): string {
-	const d = new Date(`${dateStr}T00:00:00`);
-	d.setDate(d.getDate() - n);
-	return d.toISOString().slice(0, 10);
+	return addDaysJST(dateStr, -n);
 }

--- a/src/lib/server/services/last-active-touch.ts
+++ b/src/lib/server/services/last-active-touch.ts
@@ -12,6 +12,7 @@
 //     ため、in-memory cache (LRU 風 Map) で十分
 //   - cache は 10000 テナント上限で truncation する (Pre-PMF 想定 << 10000)
 
+import { toJSTDateString } from '$lib/domain/date-utils';
 import { LOCAL_TENANT_UUID } from '$lib/server/auth/local-tenant';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -23,7 +24,7 @@ const lastTouchCache = new Map<string, string>();
 
 /** UTC YYYY-MM-DD を返す */
 function getDayKey(now: Date = new Date()): string {
-	return now.toISOString().slice(0, 10); // 2026-04-27
+	return toJSTDateString(now);
 }
 
 /**

--- a/src/lib/server/services/lifecycle-email-service.ts
+++ b/src/lib/server/services/lifecycle-email-service.ts
@@ -96,6 +96,7 @@ export function daysSinceLastActive(
 function formatExpiresAt(iso: string): string {
 	const d = new Date(iso);
 	return d.toLocaleDateString('ja-JP', {
+		timeZone: 'Asia/Tokyo',
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',

--- a/src/lib/server/services/lifecycle-email-service.ts
+++ b/src/lib/server/services/lifecycle-email-service.ts
@@ -100,7 +100,6 @@ function formatExpiresAt(iso: string): string {
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',
-		timeZone: 'Asia/Tokyo',
 	});
 }
 

--- a/src/lib/server/services/loyalty-service.ts
+++ b/src/lib/server/services/loyalty-service.ts
@@ -1,6 +1,7 @@
 // src/lib/server/services/loyalty-service.ts
 // サブスク継続特典・ロイヤルティシステム
 
+import { monthKeyJST } from '$lib/domain/date-utils';
 import { getSetting, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
 
@@ -163,7 +164,9 @@ export async function incrementSubscriptionMonth(tenantId: string): Promise<{
 	ticketsAwarded: number;
 }> {
 	// 二重インクリメント防止
-	const currentMonth = new Date().toISOString().slice(0, 7); // YYYY-MM
+	// 二重防止キーは JST 月キー。UTC 月キーだと JST 月初 0:00-9:00 に届いた webhook の
+	// 月が前月として記録され、その月の加算がスキップされうる (常に顧客不利、#4127)。
+	const currentMonth = monthKeyJST();
 	const lastIncrement = await getSetting(KEYS.lastIncrementMonth, tenantId);
 	if (lastIncrement === currentMonth) {
 		const months = await getSubscriptionMonths(tenantId);

--- a/src/lib/server/services/loyalty-service.ts
+++ b/src/lib/server/services/loyalty-service.ts
@@ -166,6 +166,13 @@ export async function incrementSubscriptionMonth(tenantId: string): Promise<{
 	// 二重インクリメント防止
 	// 二重防止キーは JST 月キー。UTC 月キーだと JST 月初 0:00-9:00 に届いた webhook の
 	// 月が前月として記録され、その月の加算がスキップされうる (常に顧客不利、#4127)。
+	//
+	// **移行時の既知の残リスク (#4127、PO 判断待ち)**: 旧実装は UTC 月キーで保存していた。
+	// deploy 直前の JST 月初 0:00-9:00 に加算したテナントは前月キーが残るため、同じ JST 月に
+	// 2 通目の invoice.paid (リトライ / 日割り / 支払い方法変更) が届くと再加算されうる。
+	// 保存値だけでは「旧実装が当月分として書いた前月キー」と「正当な前月の加算」を区別できず、
+	// どちらに倒しても片方が誤る (再加算 = 未達チケット付与 / 一律 skip = 正当な加算の取りこぼし)。
+	// 選択は既存データの棚卸しを伴う課金判断のため PO 決裁ブリーフ Q1 に上げている。
 	const currentMonth = monthKeyJST();
 	const lastIncrement = await getSetting(KEYS.lastIncrementMonth, tenantId);
 	if (lastIncrement === currentMonth) {

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -5,7 +5,7 @@ import type { ChildId } from '$lib/domain/ids';
 import { countsTowardActivityQuota } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import type { PlanTier } from '$lib/domain/constants/plan-tier';
-import { todayDateJST } from '$lib/domain/date-utils';
+import { prevDateJST, todayDateJST } from '$lib/domain/date-utils';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { getDebugPlanTier } from '$lib/server/debug-plan';
@@ -221,9 +221,7 @@ export async function hasArchivedData(
 	if (logs.length > 0) return true;
 
 	// 1日前のデータも確認
-	const prevDay = new Date(cutoff);
-	prevDay.setDate(prevDay.getDate() - 1);
-	const prevStr = `${prevDay.getFullYear()}-${String(prevDay.getMonth() + 1).padStart(2, '0')}-${String(prevDay.getDate()).padStart(2, '0')}`;
+	const prevStr = prevDateJST(cutoff);
 	const oldLogs = await repos.activity.findTodayLogsWithCategory(childId, prevStr, tenantId);
 	return oldLogs.length > 0;
 }

--- a/src/lib/server/services/recommendation-service.ts
+++ b/src/lib/server/services/recommendation-service.ts
@@ -2,6 +2,7 @@ import type { ActivityId, CategoryId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/recommendation-service.ts
 // #0264 G2: おすすめ活動の選定ロジック（カテゴリ分散・難易度・日替わり）
 
+import { todayDateJST } from '$lib/domain/date-utils';
 import { getSetting } from '$lib/server/db/settings-repo';
 
 /**
@@ -38,7 +39,7 @@ export async function markFocusModeStart(childId: ChildId, tenantId: string): Pr
 	const key = `focus_mode_start_${childId}`;
 	const existing = await getSetting(key, tenantId);
 	if (!existing) {
-		const today = new Date().toISOString().split('T')[0] ?? '';
+		const today = todayDateJST();
 		await setSetting(key, today, tenantId);
 	}
 }

--- a/src/lib/server/services/report-service.ts
+++ b/src/lib/server/services/report-service.ts
@@ -421,7 +421,7 @@ export async function computeDetailedMonthlyReport(
 	const statuses = await repos.status.findStatuses(childId, tenantId);
 	const totalPoints = statuses.reduce((sum, s) => sum + (s.totalXp ?? 0), 0);
 	const maxLevel = statuses.reduce((max, s) => Math.max(max, s.level ?? 1), 1);
-	const streakDays = await calculateStreak(childId, formatDate(limit), tenantId);
+	const streakDays = await calculateStreak(childId, limit, tenantId);
 	const newAchievements = await countMonthAchievements(childId, startDate, endDate, tenantId);
 
 	return {

--- a/src/lib/server/services/report-service.ts
+++ b/src/lib/server/services/report-service.ts
@@ -2,13 +2,7 @@ import type { ChildId } from '$lib/domain/ids';
 // src/lib/server/services/report-service.ts
 // 月次レポート・成長分析のサービス層
 
-import {
-	addDaysJST,
-	monthEndOfKey,
-	prevDateJST,
-	todayDateJST,
-	toJSTDateString,
-} from '$lib/domain/date-utils';
+import { addDaysJST, monthEndOfKey, prevDateJST, todayDateJST } from '$lib/domain/date-utils';
 import { getRepos } from '$lib/server/db/factory';
 import type { ReportDailySummary } from '$lib/server/db/types';
 import { logger } from '$lib/server/logger';
@@ -472,14 +466,6 @@ export async function computeAllChildrenDetailedReport(
 // ============================================================
 // ヘルパー
 // ============================================================
-
-// 日付文字列化は JST SSOT (date-utils) に委譲する (#4015)。
-// 旧実装はローカル TZ getter で `YYYY-MM-DD` を組み立てており、当月レポートで
-// `formatDate(limit)` (limit = `new Date()` = 実時刻) を通る経路が Lambda (UTC) では
-// JST 00:00〜09:00 に前日を返し、streak 起点が 1 日ずれていた。
-function formatDate(d: Date): string {
-	return toJSTDateString(d);
-}
 
 function getMonthEndDate(yearMonth: string): string {
 	return monthEndOfKey(yearMonth);

--- a/src/lib/server/services/report-service.ts
+++ b/src/lib/server/services/report-service.ts
@@ -2,7 +2,13 @@ import type { ChildId } from '$lib/domain/ids';
 // src/lib/server/services/report-service.ts
 // 月次レポート・成長分析のサービス層
 
-import { monthEndOfKey, toJSTDateString } from '$lib/domain/date-utils';
+import {
+	addDaysJST,
+	monthEndOfKey,
+	prevDateJST,
+	todayDateJST,
+	toJSTDateString,
+} from '$lib/domain/date-utils';
 import { getRepos } from '$lib/server/db/factory';
 import type { ReportDailySummary } from '$lib/server/db/types';
 import { logger } from '$lib/server/logger';
@@ -87,14 +93,14 @@ async function aggregateChildDaily(
 async function calculateStreak(childId: ChildId, date: string, tenantId: string): Promise<number> {
 	const repos = getRepos();
 	let streak = 0;
-	const d = new Date(date);
+	// 日付は JST 暦日の文字列で回す (Date + ローカル setDate は runtime TZ で結果が変わる、#4127)
+	let checkDate = date;
 
 	for (let i = 0; i < 365; i++) {
-		const checkDate = formatDate(d);
 		const logs = await repos.activity.findTodayLogsWithCategory(childId, checkDate, tenantId);
 		if (logs.length === 0) break;
 		streak++;
-		d.setDate(d.getDate() - 1);
+		checkDate = prevDateJST(checkDate);
 	}
 	return streak;
 }
@@ -281,16 +287,12 @@ export async function getSimpleMonthSummary(
 
 	// 集計テーブルがなければリアルタイム計算
 	let totalActivities = 0;
-	const d = new Date(startDate);
-	const end = new Date(endDate);
-	const today = new Date();
-	const limit = end < today ? end : today;
+	const today = todayDateJST();
+	const limit = endDate < today ? endDate : today;
 
-	while (d <= limit) {
-		const dateStr = formatDate(d);
+	for (let dateStr = startDate; dateStr <= limit; dateStr = addDaysJST(dateStr, 1)) {
 		const logs = await repos.activity.findTodayLogsWithCategory(childId, dateStr, tenantId);
 		totalActivities += logs.length;
-		d.setDate(d.getDate() + 1);
 	}
 
 	const statuses = await repos.status.findStatuses(childId, tenantId);
@@ -400,13 +402,10 @@ export async function computeDetailedMonthlyReport(
 	let totalDays = 0;
 	const categoryMap: Record<string, number> = {};
 
-	const d = new Date(startDate);
-	const end = new Date(endDate);
-	const today = new Date();
-	const limit = end < today ? end : today;
+	const today = todayDateJST();
+	const limit = endDate < today ? endDate : today;
 
-	while (d <= limit) {
-		const dateStr = formatDate(d);
+	for (let dateStr = startDate; dateStr <= limit; dateStr = addDaysJST(dateStr, 1)) {
 		const logs = await repos.activity.findTodayLogsWithCategory(childId, dateStr, tenantId);
 		totalDays++;
 		if (logs.length > 0) {
@@ -417,7 +416,6 @@ export async function computeDetailedMonthlyReport(
 				categoryMap[catId] = (categoryMap[catId] ?? 0) + 1;
 			}
 		}
-		d.setDate(d.getDate() + 1);
 	}
 
 	const statuses = await repos.status.findStatuses(childId, tenantId);

--- a/src/lib/server/services/usage-log-service.ts
+++ b/src/lib/server/services/usage-log-service.ts
@@ -6,6 +6,12 @@ import type { ChildId } from '$lib/domain/ids';
 // DATA_SOURCE が 'demo' の場合は no-op fallback で graceful degradation。
 // PMF 後の他 backend 完全実装 roadmap は docs/rationale/07-usage-log-dynamodb-deferred-rationale.md 参照。
 
+import {
+	addDaysJST,
+	jstDayStartUtcIso,
+	todayDateJST,
+	toJSTDateString,
+} from '$lib/domain/date-utils';
 import { getEnv } from '$lib/runtime/env';
 import {
 	closeOpenSessions,
@@ -119,8 +125,9 @@ export async function getTodayUsageSummary(
 		}));
 	}
 	try {
-		const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-		const logs = await findTodayUsageLogs(tenantId, today);
+		// 「今日」は JST 基準。UTC 暦日で絞ると JST 00:00〜09:00 の利用が前日集計に入り、
+		// 保護者画面の「今日の利用時間」が 9 時間ぶん 0 分のままになる (#4127)。
+		const logs = await findTodayUsageLogs(tenantId, jstDayStartUtcIso(todayDateJST()));
 
 		const summaryMap = new Map<ChildId, number>();
 		for (const log of logs) {
@@ -154,40 +161,31 @@ export async function getWeeklyUsageSummary(
 	if (isUsageLogNoopBackend()) {
 		notifyNoopOnce();
 		// 直近 7 日の空エントリを返す (call side が空配列を空 chart として描画する想定)
-		const today = new Date();
+		const today = todayDateJST();
 		const entries: { date: string; durationMin: number }[] = [];
 		for (let i = 6; i >= 0; i--) {
-			const d = new Date(today);
-			d.setDate(d.getDate() - i);
-			entries.push({ date: d.toISOString().slice(0, 10), durationMin: 0 });
+			entries.push({ date: addDaysJST(today, -i), durationMin: 0 });
 		}
 		return entries;
 	}
 	try {
-		const today = new Date();
-		const toDate = new Date(today);
-		toDate.setDate(toDate.getDate() + 1); // tomorrow
-		const fromDate = new Date(today);
-		fromDate.setDate(fromDate.getDate() - 6); // 7 days ago
+		// 範囲も日次バケットも JST 基準で揃える (書き込みは UTC ISO、読み出しは JST 暦日、#4127)
+		const today = todayDateJST();
+		const fromIso = jstDayStartUtcIso(addDaysJST(today, -6));
+		const toIso = jstDayStartUtcIso(addDaysJST(today, 1)); // 翌日 00:00 (JST) 未満
 
-		const fromStr = fromDate.toISOString().slice(0, 10);
-		const toStr = toDate.toISOString().slice(0, 10);
-
-		const logs = await findUsageLogsByChildAndDateRange(childId, tenantId, fromStr, toStr);
+		const logs = await findUsageLogsByChildAndDateRange(childId, tenantId, fromIso, toIso);
 
 		// 日付ごとに集計
 		const dailyMap = new Map<string, number>();
 
 		// 直近7日の空エントリを先に作成
 		for (let i = 6; i >= 0; i--) {
-			const d = new Date(today);
-			d.setDate(d.getDate() - i);
-			const dateStr = d.toISOString().slice(0, 10);
-			dailyMap.set(dateStr, 0);
+			dailyMap.set(addDaysJST(today, -i), 0);
 		}
 
 		for (const log of logs) {
-			const date = log.startedAt.slice(0, 10);
+			const date = toJSTDateString(new Date(log.startedAt));
 			// 直近 7 日のキーのみ集計 (範囲外日付は無視、#2391 PR-2402 flaky 修正)
 			if (!dailyMap.has(date)) continue;
 			const existing = dailyMap.get(date) ?? 0;

--- a/src/lib/server/services/value-preview-service.ts
+++ b/src/lib/server/services/value-preview-service.ts
@@ -13,6 +13,7 @@ import type { CategoryId, ChildId } from '$lib/domain/ids';
  * - Anti-engagement (ADR-0012): 滞在時間延伸 UI ではなく、純粋に進捗の可視化
  */
 
+import { todayDateJST } from '$lib/domain/date-utils';
 import { findActivityLogs } from '$lib/server/db/activity-repo';
 import { findAllChildren } from '$lib/server/db/child-repo';
 
@@ -139,7 +140,7 @@ function computeStreaks(recordedDates: string[]): { current: number; longest: nu
 	const uniqueDates = Array.from(new Set(recordedDates.map(toDateOnly))).sort();
 	if (uniqueDates.length === 0) return { current: 0, longest: 0 };
 
-	const today = new Date().toISOString().slice(0, 10);
+	const today = todayDateJST();
 	return {
 		longest: computeLongestStreak(uniqueDates),
 		current: computeCurrentStreak(uniqueDates, today),
@@ -165,7 +166,7 @@ export async function getTenantValuePreview(tenantId: string): Promise<TenantVal
 		};
 	}
 
-	const todayDate = new Date().toISOString().slice(0, 10);
+	const todayDate = todayDateJST();
 
 	const childPreviews: ChildValuePreview[] = await Promise.all(
 		children.map(async (child) => {

--- a/src/lib/ui/primitives/BirthdayInput.svelte
+++ b/src/lib/ui/primitives/BirthdayInput.svelte
@@ -76,7 +76,8 @@ $effect(() => {
 
 const daysInMonth = $derived.by(() => {
 	if (!yearStr || !monthStr) return 31;
-	return new Date(Number(yearStr), Number(monthStr), 0).getDate();
+	// UTC 算術で月の日数を出す (ローカルコンストラクタ + ローカル getter を避ける、#4127)
+	return new Date(Date.UTC(Number(yearStr), Number(monthStr), 0)).getUTCDate();
 });
 
 const dayOptions = $derived.by(() => {

--- a/src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/(character)/history/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { goto } from '$app/navigation';
+import { jstDayOfWeek, toJSTDateString } from '$lib/domain/date-utils';
 import { asCategoryId } from '$lib/domain/ids';
 import { APP_LABELS, getMilestoneLabel, UI_LABELS } from '$lib/domain/labels';
 import { formatPointValue, formatPointValueWithSign } from '$lib/domain/point-display';
@@ -66,15 +67,16 @@ const logsByDate = $derived(() => {
 });
 
 function formatDate(dateStr: string): string {
-	const d = new Date(`${dateStr}T00:00:00`);
-	const month = d.getMonth() + 1;
-	const day = d.getDate();
-	const weekday = t.weekdays[d.getDay()];
+	// 暦要素は文字列 / JST SSOT から取る (ローカル getter は runtime TZ 依存、#4127)
+	const [, m, dd] = dateStr.split('-').map(Number);
+	const month = m ?? 0;
+	const day = dd ?? 0;
+	const weekday = t.weekdays[jstDayOfWeek(new Date(`${dateStr}T00:00:00Z`))];
 	return `${month}${t.historyCountUnit === 'かい' ? 'がつ' : '月'}${day}${t.historyCountUnit === 'かい' ? 'にち' : '日'}（${weekday}）`;
 }
 
 function formatUnixDate(unix: number): string {
-	return formatDate(new Date(unix).toISOString().slice(0, 10));
+	return formatDate(toJSTDateString(new Date(unix)));
 }
 
 function purchaseStatusLabel(status: string): string {

--- a/src/routes/(parent)/admin/cheer/+page.svelte
+++ b/src/routes/(parent)/admin/cheer/+page.svelte
@@ -312,7 +312,7 @@ $effect(() => {
 							{:else if msg.body}
 								<p class="text-sm font-bold text-[var(--color-text)]">{msg.body}</p>
 							{/if}
-							<p class="text-xs text-[var(--color-text-muted)]">{new Date(msg.sentAt).toLocaleString('ja-JP')}</p>
+							<p class="text-xs text-[var(--color-text-muted)]">{new Date(msg.sentAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}</p>
 						</div>
 						{#if msg.shownAt}
 							<span class="text-xs text-[var(--color-feedback-success-text)]">{CHEER_LABELS.msgRead}</span>

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -306,7 +306,7 @@ const roleLabel = (role: string) => {
 									{roleLabel(member.role)}
 								</span>
 								<span class="text-xs text-[var(--color-text-tertiary)]">
-									{new Date(member.joinedAt).toLocaleDateString('ja-JP')}
+									{new Date(member.joinedAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })}
 								</span>
 							</div>
 						</div>
@@ -472,7 +472,7 @@ const roleLabel = (role: string) => {
 								{roleLabel(invite.role)}
 							</span>
 							<span class="ml-2 text-xs text-[var(--color-text-tertiary)]">
-								{MEMBERS_LABELS.inviteExpiresPrefix}{new Date(invite.expiresAt).toLocaleDateString('ja-JP')}
+								{MEMBERS_LABELS.inviteExpiresPrefix}{new Date(invite.expiresAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })}
 							</span>
 							<!-- #3555 ①: 宛先 email 束縛付き招待の宛先を表示 (タイプミスに owner が気づき
 							     取消し → 再発行できる修正導線) -->
@@ -612,7 +612,7 @@ const roleLabel = (role: string) => {
 									{/if}
 									{#if vt.expiresAt}
 										<span class="text-xs text-[var(--color-text-tertiary)]">
-											{MEMBERS_LABELS.viewerExpiresPrefix}{new Date(vt.expiresAt).toLocaleDateString('ja-JP')}
+											{MEMBERS_LABELS.viewerExpiresPrefix}{new Date(vt.expiresAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })}
 										</span>
 									{:else}
 										<span class="text-xs text-[var(--color-text-tertiary)]">{MEMBERS_LABELS.viewerExpiresNone}</span>

--- a/src/routes/(parent)/admin/points/+page.svelte
+++ b/src/routes/(parent)/admin/points/+page.svelte
@@ -579,7 +579,7 @@ async function handleReceiptFile(event: Event) {
 						<div class="flex items-center justify-between py-3">
 							<div>
 								<p class="text-sm text-[var(--color-text-muted)]">
-									{entry.createdAt ? new Date(entry.createdAt).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' }) : '—'}
+									{entry.createdAt ? new Date(entry.createdAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo', month: 'short', day: 'numeric' }) : '—'}
 								</p>
 							</div>
 							<p class="font-bold text-[var(--color-feedback-warning-text)]">-{fmtBal(Math.abs(entry.amount))}</p>

--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { goto } from '$app/navigation';
+import { shiftMonthKey } from '$lib/domain/date-utils';
 import type { ChildId } from '$lib/domain/ids';
 import { APP_LABELS, PAGE_TITLES, REPORTS_LABELS } from '$lib/domain/labels';
 import ProgressFill from '$lib/ui/components/ProgressFill.svelte';
@@ -43,11 +44,7 @@ function formatMonth(ym: string): string {
 }
 
 function navigateMonth(offset: number) {
-	const parts = data.selectedMonth.split('-').map(Number);
-	const y = parts[0] ?? 2026;
-	const m = parts[1] ?? 1;
-	const d = new Date(y, m - 1 + offset, 1);
-	const newMonth = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+	const newMonth = shiftMonthKey(data.selectedMonth, offset);
 	goto(`?month=${newMonth}`, { replaceState: true });
 }
 

--- a/src/routes/(parent)/admin/rewards/requests/+page.svelte
+++ b/src/routes/(parent)/admin/rewards/requests/+page.svelte
@@ -81,7 +81,7 @@ function closeRejectForm() {
 								</p>
 								<p class="request-date">
 									{ADMIN_REWARDS_REQUESTS_LABELS.requestedAtLabel}:
-									{new Date(req.requestedAt * 1000).toLocaleDateString('ja-JP')}
+									{new Date(req.requestedAt * 1000).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })}
 								</p>
 							</div>
 							<div class="request-actions">

--- a/src/routes/(parent)/admin/settings/account/+page.svelte
+++ b/src/routes/(parent)/admin/settings/account/+page.svelte
@@ -63,6 +63,7 @@ const gracePeriodDeletionDateLabel = $derived.by(() => {
 	const date = new Date(iso);
 	if (Number.isNaN(date.getTime())) return '';
 	return date.toLocaleDateString('ja-JP', {
+		timeZone: 'Asia/Tokyo',
 		year: 'numeric',
 		month: 'long',
 		day: 'numeric',

--- a/src/routes/(parent)/admin/settings/data/+page.svelte
+++ b/src/routes/(parent)/admin/settings/data/+page.svelte
@@ -4,6 +4,7 @@
 
 import { enhance } from '$app/forms';
 import { page } from '$app/stores';
+import { todayDateJST } from '$lib/domain/date-utils';
 import type { ChildId } from '$lib/domain/ids';
 import {
 	APP_LABELS,
@@ -302,8 +303,7 @@ async function handleExport() {
 		const blob = await res.blob();
 		const disposition = res.headers.get('Content-Disposition') ?? '';
 		const filenameMatch = disposition.match(/filename="(.+)"/);
-		const filename =
-			filenameMatch?.[1] ?? `ganbari-quest-backup-${new Date().toISOString().split('T')[0]}.json`;
+		const filename = filenameMatch?.[1] ?? `ganbari-quest-backup-${todayDateJST()}.json`;
 		const url = URL.createObjectURL(blob);
 		const a = document.createElement('a');
 		a.href = url;
@@ -349,7 +349,7 @@ async function handleCloudExport() {
 		}
 		cloudSuccess = SETTINGS_LABELS.cloudExportPinIssued(
 			d.pinCode,
-			new Date(d.expiresAt).toLocaleDateString('ja-JP'),
+			new Date(d.expiresAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' }),
 		);
 		await loadCloudExports();
 	} catch {
@@ -1075,7 +1075,7 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 											</p>
 											<p class="text-xs text-[var(--color-text-muted)]">
 												{SETTINGS_LABELS.cloudStoredExpiry(
-													new Date(exp.expiresAt).toLocaleDateString('ja-JP'),
+													new Date(exp.expiresAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' }),
 												)}
 												· {SETTINGS_LABELS.cloudStoredDownloads(
 													exp.downloadCount,

--- a/src/routes/api/v1/rest-days/[childId]/+server.ts
+++ b/src/routes/api/v1/rest-days/[childId]/+server.ts
@@ -1,4 +1,5 @@
 import { error, json } from '@sveltejs/kit';
+import { monthKeyJST } from '$lib/domain/date-utils';
 import { asChildId } from '$lib/domain/ids';
 import {
 	countRestDaysInMonth,
@@ -21,7 +22,9 @@ export const GET: RequestHandler = async ({ params, url, locals }) => {
 	const childId = asChildId(params.childId);
 	if (!childId) throw error(400, 'Invalid childId');
 
-	const month = url.searchParams.get('month') ?? new Date().toISOString().slice(0, 7);
+	// 既定月は JST。POST 側の上限判定は JST 日付文字列由来の月なので、UTC 月キーだと
+	// JST 月初 0:00-9:00 に GET と POST で別の月を見る (#4127)。
+	const month = url.searchParams.get('month') ?? monthKeyJST();
 	const days = await findRestDays(childId, month, tenantId);
 	const count = await countRestDaysInMonth(childId, month, tenantId);
 

--- a/src/routes/ops/+page.svelte
+++ b/src/routes/ops/+page.svelte
@@ -19,7 +19,7 @@ const adminBypass = $derived(data.adminBypass);
 
 <div class="flex flex-col gap-8">
 	<div class="text-xs text-[var(--color-text-muted)] text-right">
-		{OPS_LABELS.fetchedAt(new Date(kpi.fetchedAt).toLocaleString('ja-JP'))}
+		{OPS_LABELS.fetchedAt(new Date(kpi.fetchedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' }))}
 	</div>
 
 	<!-- KPI カード -->
@@ -132,7 +132,7 @@ const adminBypass = $derived(data.adminBypass);
 			</div>
 		{/if}
 		<div class="text-xs text-[var(--color-text-muted)] mt-3">
-			{OPS_LABELS.triggerEvaluatedAt(new Date(triggerReport.evaluatedAt).toLocaleString('ja-JP'), String(triggerReport.paidUserCount))}
+			{OPS_LABELS.triggerEvaluatedAt(new Date(triggerReport.evaluatedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' }), String(triggerReport.paidUserCount))}
 		</div>
 	</Card>
 
@@ -189,7 +189,7 @@ const adminBypass = $derived(data.adminBypass);
 			</table>
 		{/if}
 		<div class="text-xs text-[var(--color-text-muted)] mt-3">
-			{OPS_LABELS.bypassFetchedAt(new Date(adminBypass.fetchedAt).toLocaleString('ja-JP'))} <a href="https://github.com/Takenori-Kusaka/ganbari-quest/blob/main/docs/decisions/archive/0044-admin-bypass-evidence.md" class="underline">{OPS_LABELS.bypassAdrLink}</a>
+			{OPS_LABELS.bypassFetchedAt(new Date(adminBypass.fetchedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' }))} <a href="https://github.com/Takenori-Kusaka/ganbari-quest/blob/main/docs/decisions/archive/0044-admin-bypass-evidence.md" class="underline">{OPS_LABELS.bypassAdrLink}</a>
 		</div>
 	</Card>
 

--- a/src/routes/ops/analytics/+page.svelte
+++ b/src/routes/ops/analytics/+page.svelte
@@ -74,7 +74,7 @@ function barWidthPct(count: number): number {
 									] ?? step.eventName}
 								</td>
 								<td class="ops-num">
-									{step.count.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}{OPS_ANALYTICS_LABELS.activationFunnelHouseholdSuffix}
+									{step.count.toLocaleString('ja-JP')}{OPS_ANALYTICS_LABELS.activationFunnelHouseholdSuffix}
 								</td>
 								<td class="ops-num">
 									{#if step.step === 1}

--- a/src/routes/ops/analytics/+page.svelte
+++ b/src/routes/ops/analytics/+page.svelte
@@ -38,7 +38,7 @@ function barWidthPct(count: number): number {
 
 <div class="flex flex-col gap-8">
 	<div class="text-xs text-[var(--color-text-muted)] text-right">
-		{OPS_ANALYTICS_LABELS.fetchedAt(new Date(a.fetchedAt).toLocaleString('ja-JP'))}
+		{OPS_ANALYTICS_LABELS.fetchedAt(new Date(a.fetchedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' }))}
 	</div>
 
 	<!-- Activation Funnel (#2285 EPIC #2283: /admin/analytics 撤去で消失する機能を ops 側へ移動) -->
@@ -74,7 +74,7 @@ function barWidthPct(count: number): number {
 									] ?? step.eventName}
 								</td>
 								<td class="ops-num">
-									{step.count.toLocaleString('ja-JP')}{OPS_ANALYTICS_LABELS.activationFunnelHouseholdSuffix}
+									{step.count.toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}{OPS_ANALYTICS_LABELS.activationFunnelHouseholdSuffix}
 								</td>
 								<td class="ops-num">
 									{#if step.step === 1}
@@ -315,7 +315,7 @@ function barWidthPct(count: number): number {
 					{#each a.cancellationReasons.freeTextSamples as sample (sample.id)}
 						<li class="ops-freetext-item">
 							<div class="ops-freetext-meta">
-								<span>{OPS_CANCELLATION_LABELS.freeTextDate(new Date(sample.createdAt).toLocaleDateString('ja-JP'))}</span>
+								<span>{OPS_CANCELLATION_LABELS.freeTextDate(new Date(sample.createdAt).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' }))}</span>
 								<span>{OPS_CANCELLATION_LABELS.freeTextCategory(getCancellationCategoryLabel(sample.category as CancellationCategory))}</span>
 							</div>
 							<p class="ops-freetext-body">{sample.freeText}</p>

--- a/src/routes/ops/business/+page.svelte
+++ b/src/routes/ops/business/+page.svelte
@@ -197,7 +197,7 @@ const progressColor = $derived(
 	</Card>
 
 	<div class="text-xs text-[var(--color-text-muted)] text-right">
-		{OPS_BUSINESS_LABELS.fetchedAt(bep.fetchedAt ? new Date(bep.fetchedAt).toLocaleString('ja-JP') : '-')}
+		{OPS_BUSINESS_LABELS.fetchedAt(bep.fetchedAt ? new Date(bep.fetchedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' }) : '-')}
 	</div>
 </div>
 

--- a/src/routes/ops/cohort/+page.svelte
+++ b/src/routes/ops/cohort/+page.svelte
@@ -148,7 +148,7 @@ function retentionColorClass(value: number | null): string {
 	</Card>
 
 	<div class="text-xs text-[var(--color-text-muted)] text-right">
-		{OPS_COHORT_LABELS.lastFetchedPrefix}{new Date(analysis.fetchedAt).toLocaleString('ja-JP')}
+		{OPS_COHORT_LABELS.lastFetchedPrefix}{new Date(analysis.fetchedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}
 	</div>
 </div>
 

--- a/src/routes/ops/costs/+page.svelte
+++ b/src/routes/ops/costs/+page.svelte
@@ -90,7 +90,7 @@ const diffColorClass = $derived(
 	</Card>
 
 	<div class="text-xs text-[var(--color-text-muted)] text-right">
-		{OPS_COSTS_LABELS.lastFetchedPrefix}{costs.fetchedAt ? new Date(costs.fetchedAt).toLocaleString('ja-JP') : '-'}
+		{OPS_COSTS_LABELS.lastFetchedPrefix}{costs.fetchedAt ? new Date(costs.fetchedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' }) : '-'}
 		{OPS_COSTS_LABELS.cacheNote}
 	</div>
 </div>

--- a/src/routes/ops/revenue/+page.svelte
+++ b/src/routes/ops/revenue/+page.svelte
@@ -210,7 +210,7 @@ const chartPoints = $derived(
 	</Card>
 
 	<div class="text-xs text-[var(--color-text-muted)] text-right">
-		{OPS_REVENUE_LABELS.fetchedAt(current.fetchedAt ? new Date(current.fetchedAt).toLocaleString('ja-JP') : '-')}
+		{OPS_REVENUE_LABELS.fetchedAt(current.fetchedAt ? new Date(current.fetchedAt).toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' }) : '-')}
 		{OPS_REVENUE_LABELS.cacheNote}
 	</div>
 </div>

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -224,7 +224,11 @@ async function handlePinComplete(details: { valueAsString: string }) {
 			pinError = Number.isNaN(unlockTime.getTime())
 				? OYAKAGI_LABELS.lockedError
 				: OYAKAGI_LABELS.gateLockedUntilNotice(
-						unlockTime.toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit' }),
+						unlockTime.toLocaleTimeString('ja-JP', {
+							timeZone: 'Asia/Tokyo',
+							hour: '2-digit',
+							minute: '2-digit',
+						}),
 					);
 		} else if (body.error === 'PIN_FORMAT') {
 			pinError = OYAKAGI_LABELS.gateFormatNotice;

--- a/tests/unit/architecture/tz-invariance.test.ts
+++ b/tests/unit/architecture/tz-invariance.test.ts
@@ -124,7 +124,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-	process.env.TZ = originalTz;
+	// CI は TZ 未設定で走るため、`= undefined` 代入だと文字列 'undefined' が残り
+	// 同一 worker の後続 test を汚染する。未設定だった場合は delete で戻す。
+	if (originalTz === undefined) {
+		delete process.env.TZ;
+	} else {
+		process.env.TZ = originalTz;
+	}
 });
 
 // ---------- cases ----------

--- a/tests/unit/architecture/tz-invariance.test.ts
+++ b/tests/unit/architecture/tz-invariance.test.ts
@@ -71,7 +71,15 @@ vi.mock('$lib/server/db/evaluation-repo', () => ({
 	deleteRestDay: vi.fn(),
 }));
 
-import { addDaysJST, jstHour, monthKeyJST, prevDateJST, todayDateJST, weekStartJST } from '$lib/domain/date-utils';
+import {
+	addDaysJST,
+	jstDayStartUtcIso,
+	jstHour,
+	monthKeyJST,
+	prevDateJST,
+	todayDateJST,
+	weekStartJST,
+} from '$lib/domain/date-utils';
 import { asChildId } from '$lib/domain/ids';
 import { evaluateBonusHooks } from '$lib/server/services/bonus-hook-service';
 import { incrementSubscriptionMonth } from '$lib/server/services/loyalty-service';
@@ -183,7 +191,8 @@ tzCase('bonus-hook/early-bird-hour', async () => {
 tzCase('usage-log/today-summary-date-key', async () => {
 	mockFindTodayUsageLogs.mockResolvedValue([]);
 	await getTodayUsageSummary(TENANT, [{ id: asChildId('1'), nickname: 'たろう' }]);
-	expect(mockFindTodayUsageLogs).toHaveBeenCalledWith(TENANT, TZ_PROBE_JST_DATE);
+	// 「今日」の下限は JST 00:00 に対応する UTC の瞬間 (UTC 暦日の前方一致だと 9 時間ずれる)
+	expect(mockFindTodayUsageLogs).toHaveBeenCalledWith(TENANT, jstDayStartUtcIso(TZ_PROBE_JST_DATE));
 });
 
 tzCase('usage-log/weekly-summary-buckets', async () => {

--- a/tests/unit/architecture/tz-invariance.test.ts
+++ b/tests/unit/architecture/tz-invariance.test.ts
@@ -1,0 +1,247 @@
+// tests/unit/architecture/tz-invariance.test.ts (#4127)
+//
+// # 何を表明する test か
+//
+// 「日付の導出がプロセス TZ に依存しない」ことを、**記法ではなく振る舞いで**表明する
+// fitness function (ADR-0061 原則 2)。
+//
+// #4015 で入れた静的 gate は検出対象を getter 4 語の列挙で定義していたため、同じ欠陥クラスの
+// 別の書き方 (`getHours()` / `toISOString().slice(0,10)` / `toLocaleDateString()`) を素通しした。
+// 列挙を足すだけでは 3 回目が来る。そこで本 test は、顧客に見える日付導出を
+// **`TZ=UTC` (Lambda) と `TZ=Asia/Tokyo` (NUC) の 2 環境で実行し、どちらでも JST 暦の期待値と
+// 一致すること**を assert する。これは書き方に依存しないため、新しい記法にも自動的に効く。
+//
+// 評価の瞬間は `TZ_PROBE_INSTANT_ISO` = JST 2026-08-01 00:30 (= UTC 2026-07-31 15:30)。
+// JST 00:00〜09:00 の窓かつ月境界の内側なので、
+//   - プロセス TZ 依存 (ローカル getter) → 2 TZ で結果が割れる
+//   - UTC 導出 (toISOString().slice) → 2 TZ で一致するが JST 期待値 (2026-08-01 / 2026-08) と割れる
+// の両方が 1 つの assertion で落ちる。
+//
+// registry (`scripts/lib/ci/tz-invariance-cases.mjs`) との対応は双方向に検査する
+// (case を消して registry だけ残す / registry に無い case を足す、のどちらも fail)。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	TZ_INVARIANCE_CASE_IDS,
+	TZ_PROBE_INSTANT_ISO,
+	TZ_PROBE_JST_DATE,
+	TZ_PROBE_JST_MONTH,
+	TZ_PROBE_TIMEZONES,
+} from '../../../scripts/lib/ci/tz-invariance-cases.mjs';
+
+// ---------- mocks (case が触れる I/O のみ) ----------
+
+const mockLoadBonusOverrides = vi.fn();
+vi.mock('$lib/marketplace/strategies/rule-preset/bonus-state', () => ({
+	loadBonusOverrides: (...args: unknown[]) => mockLoadBonusOverrides(...args),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const mockFindTodayUsageLogs = vi.fn();
+const mockFindUsageLogsByChildAndDateRange = vi.fn();
+vi.mock('$lib/server/db/usage-log-repo', () => ({
+	findTodayUsageLogs: (...args: unknown[]) => mockFindTodayUsageLogs(...args),
+	findUsageLogsByChildAndDateRange: (...args: unknown[]) =>
+		mockFindUsageLogsByChildAndDateRange(...args),
+	closeOpenSessions: vi.fn(),
+	insertUsageLog: vi.fn(),
+	updateUsageLogEnd: vi.fn(),
+}));
+
+vi.mock('$lib/runtime/env', () => ({
+	getEnv: () => ({ DATA_SOURCE: 'sqlite' }),
+}));
+
+const mockGetSetting = vi.fn();
+const mockSetSetting = vi.fn();
+vi.mock('$lib/server/db/settings-repo', () => ({
+	getSetting: (...args: unknown[]) => mockGetSetting(...args),
+	setSetting: (...args: unknown[]) => mockSetSetting(...args),
+}));
+
+const mockFindRestDays = vi.fn();
+const mockCountRestDaysInMonth = vi.fn();
+vi.mock('$lib/server/db/evaluation-repo', () => ({
+	findRestDays: (...args: unknown[]) => mockFindRestDays(...args),
+	countRestDaysInMonth: (...args: unknown[]) => mockCountRestDaysInMonth(...args),
+	insertRestDay: vi.fn(async () => ({ ok: true })),
+	deleteRestDay: vi.fn(),
+}));
+
+import { addDaysJST, jstHour, monthKeyJST, prevDateJST, todayDateJST, weekStartJST } from '$lib/domain/date-utils';
+import { asChildId } from '$lib/domain/ids';
+import { evaluateBonusHooks } from '$lib/server/services/bonus-hook-service';
+import { incrementSubscriptionMonth } from '$lib/server/services/loyalty-service';
+import {
+	getTodayUsageSummary,
+	getWeeklyUsageSummary,
+} from '$lib/server/services/usage-log-service';
+import { GET as restDaysGet } from '../../../src/routes/api/v1/rest-days/[childId]/+server';
+
+// ---------- harness ----------
+
+const TENANT = 'tz-invariance-tenant';
+const originalTz = process.env.TZ;
+
+/** 実装済 case の id → 実行関数。registry と双方向に照合される。 */
+const implementedCases: Record<string, () => Promise<void> | void> = {};
+
+/**
+ * case を登録する。`TZ_PROBE_TIMEZONES` の各 TZ で同じ body を実行する
+ * (期待値は JST 暦の固定値なので、TZ 不変性と JST 正しさを同時に見ている)。
+ */
+function tzCase(id: string, body: () => Promise<void> | void): void {
+	implementedCases[id] = body;
+	describe(id, () => {
+		for (const tz of TZ_PROBE_TIMEZONES) {
+			it(`TZ=${tz} で JST 暦の期待値と一致する`, async () => {
+				process.env.TZ = tz;
+				vi.useFakeTimers();
+				vi.setSystemTime(new Date(TZ_PROBE_INSTANT_ISO));
+				try {
+					await body();
+				} finally {
+					vi.useRealTimers();
+				}
+			});
+		}
+	});
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+afterEach(() => {
+	process.env.TZ = originalTz;
+});
+
+// ---------- cases ----------
+
+tzCase('date-utils/today-date-jst', () => {
+	expect(todayDateJST()).toBe(TZ_PROBE_JST_DATE);
+	expect(monthKeyJST()).toBe(TZ_PROBE_JST_MONTH);
+	// 2026-08-01 は土曜。その週の月曜は 2026-07-27
+	expect(weekStartJST()).toBe('2026-07-27');
+});
+
+tzCase('date-utils/jst-hour', () => {
+	// JST 00:30 の記録
+	expect(jstHour()).toBe(0);
+	// JST 07:00 (= UTC 22:00 前日) / JST 15:00 (= UTC 06:00)
+	expect(jstHour(new Date('2026-07-31T22:00:00Z'))).toBe(7);
+	expect(jstHour(new Date('2026-08-01T06:00:00Z'))).toBe(15);
+});
+
+tzCase('date-utils/add-days-jst', () => {
+	expect(prevDateJST(TZ_PROBE_JST_DATE)).toBe('2026-07-31');
+	expect(addDaysJST(TZ_PROBE_JST_DATE, -1)).toBe('2026-07-31');
+	expect(addDaysJST(TZ_PROBE_JST_DATE, 1)).toBe('2026-08-02');
+	expect(addDaysJST('2026-03-01', -1)).toBe('2026-02-28');
+});
+
+tzCase('bonus-hook/early-bird-hour', async () => {
+	const earlyBird = {
+		presetId: 'early-bird',
+		presetName: 'early-bird',
+		presetIcon: '🌅',
+		enabled: true,
+		rules: [
+			{ title: 'はやおきボーナス', pointBonus: 5, description: '', icon: '🌅' },
+			{ title: 'あさかつウィーク', pointBonus: 25, description: '', icon: '🌅' },
+		],
+		importedAt: '2026-05-01T00:00:00Z',
+	};
+	mockLoadBonusOverrides.mockResolvedValue({ presets: [earlyBird] });
+
+	const ctxBase = {
+		childId: asChildId('1'),
+		categoryId: null,
+		consecutiveDays: 1,
+		isFirstToday: true,
+		todayRecordCount: 1,
+	} as unknown as Parameters<typeof evaluateBonusHooks>[0];
+
+	// JST 07:00 の記録 → はやおきボーナスが付く
+	const morning = await evaluateBonusHooks(
+		{ ...ctxBase, recordedAt: new Date('2026-07-31T22:00:00Z') },
+		TENANT,
+	);
+	expect(morning.hits.map((h) => h.ruleTitle)).toContain('はやおきボーナス');
+
+	// JST 15:00 の記録 → 付かない
+	const afternoon = await evaluateBonusHooks(
+		{ ...ctxBase, recordedAt: new Date('2026-08-01T06:00:00Z') },
+		TENANT,
+	);
+	expect(afternoon.hits.map((h) => h.ruleTitle)).not.toContain('はやおきボーナス');
+});
+
+tzCase('usage-log/today-summary-date-key', async () => {
+	mockFindTodayUsageLogs.mockResolvedValue([]);
+	await getTodayUsageSummary(TENANT, [{ id: asChildId('1'), nickname: 'たろう' }]);
+	expect(mockFindTodayUsageLogs).toHaveBeenCalledWith(TENANT, TZ_PROBE_JST_DATE);
+});
+
+tzCase('usage-log/weekly-summary-buckets', async () => {
+	mockFindUsageLogsByChildAndDateRange.mockResolvedValue([
+		// JST 2026-08-01 00:10 の利用 (UTC では 2026-07-31)
+		{ childId: asChildId('1'), startedAt: '2026-07-31T15:10:00.000Z', durationSec: 600 },
+	]);
+	const weekly = await getWeeklyUsageSummary(TENANT, asChildId('1'));
+	expect(weekly.map((e) => e.date)).toEqual([
+		'2026-07-26',
+		'2026-07-27',
+		'2026-07-28',
+		'2026-07-29',
+		'2026-07-30',
+		'2026-07-31',
+		'2026-08-01',
+	]);
+	// JST 00:10 の利用は「今日 (2026-08-01)」に積まれる
+	expect(weekly.find((e) => e.date === TZ_PROBE_JST_DATE)?.durationMin).toBe(10);
+});
+
+tzCase('loyalty/increment-month-key', async () => {
+	mockGetSetting.mockResolvedValue(null);
+	mockSetSetting.mockResolvedValue(undefined);
+	await incrementSubscriptionMonth(TENANT);
+	const monthKeyWrites = mockSetSetting.mock.calls.filter((c) =>
+		String(c[1]).match(/^\d{4}-\d{2}$/),
+	);
+	expect(monthKeyWrites.length).toBeGreaterThan(0);
+	for (const call of monthKeyWrites) expect(call[1]).toBe(TZ_PROBE_JST_MONTH);
+});
+
+tzCase('rest-days/month-symmetry', async () => {
+	mockFindRestDays.mockResolvedValue([]);
+	mockCountRestDaysInMonth.mockResolvedValue(0);
+	const url = new URL('http://localhost/api/v1/rest-days/1');
+	await restDaysGet({
+		params: { childId: '1' },
+		url,
+		locals: { context: { tenantId: TENANT } },
+		// biome-ignore lint/suspicious/noExplicitAny: RequestEvent の未使用フィールドは省略する
+	} as any);
+	// GET の既定月 (導出) が JST 月キーであること = POST 側 (`date.slice(0, 7)` = JST 日付由来) と同じ基準
+	expect(mockFindRestDays).toHaveBeenCalledWith(expect.anything(), TZ_PROBE_JST_MONTH, TENANT);
+});
+
+// ---------- registry との双方向照合 (no-silent-gap) ----------
+
+describe('registry closure', () => {
+	it('registry の全 case が実装されている', () => {
+		const missing = TZ_INVARIANCE_CASE_IDS.filter((id: string) => !(id in implementedCases));
+		expect(missing, `registry にあるが未実装の case: ${missing.join(', ')}`).toEqual([]);
+	});
+
+	it('実装済 case が全て registry に登録されている', () => {
+		const undeclared = Object.keys(implementedCases).filter(
+			(id) => !TZ_INVARIANCE_CASE_IDS.includes(id),
+		);
+		expect(undeclared, `registry 未登録の case: ${undeclared.join(', ')}`).toEqual([]);
+	});
+});

--- a/tests/unit/scripts/check-local-tz-date-getters.test.ts
+++ b/tests/unit/scripts/check-local-tz-date-getters.test.ts
@@ -1,5 +1,5 @@
 /**
- * tests/unit/scripts/check-local-tz-date-getters.test.ts (#4015)
+ * tests/unit/scripts/check-local-tz-date-getters.test.ts (#4015 → #4127)
  *
  * `scripts/check-local-tz-date-getters.mjs` の純関数を検証する。
  *
@@ -7,45 +7,117 @@
  * unit lane では行わない (#4000 / #4051 の判断に整合)。本 test が担うのは
  * **gate のロジックが意図どおり落ちること**の表明:
  *
- *   - allowlist 未登録 file の occurrence を検出する (no-silent-gap)
- *   - allowlist 済 file でも `max` を超えたら検出する (ratchet)
- *   - `reason` が空の allowlist entry を検出する (除外理由の非強制を作らない、#3956 の教訓)
- *   - `getUTC*` / コメント行は検出しない (誤検知しない)
+ *   - #4127 で素通ししていた 3 つの書き方 (getHours / toISOString().slice / toLocale*) を検出する
+ *   - 分類が `Date.prototype` を網羅している (将来メンバーが増えても黙って安全側に落ちない)
+ *   - allowlist 未登録 file / max 超過 / stale entry を検出する (no-silent-gap + ratchet)
+ *   - kind ごとの機械検査が効く (自由文の reason だけでは通らない、#4127 残存 3 の直対処)
+ *   - UTC getter / 数値の桁区切り / timeZone 明示済の toLocale* は検出しない (誤検知しない)
  */
 
 import { describe, expect, it } from 'vitest';
 
 import {
 	ALLOWLIST,
+	ALLOWLIST_KINDS,
+	classifyDateMembers,
+	classifyLine,
 	evaluateOccurrences,
-	findAllowlistEntriesWithoutReason,
 	findAllowlistEntry,
+	findAllowlistIntegrityProblems,
 	findOccurrencesInContent,
+	findUnclassifiedDateMembers,
+	groupByFile,
 	isCommentLine,
-	LOCAL_TZ_GETTER,
+	NON_RUNTIME_PATTERNS,
 } from '../../../scripts/check-local-tz-date-getters.mjs';
 
-describe('check-local-tz-date-getters (#4015)', () => {
-	describe('LOCAL_TZ_GETTER — 検出パターン', () => {
+/** 違反 1 件を作るヘルパ */
+function occ(file: string, line = 1, snippet = 'x', kind = 'tz-dependent-member') {
+	return { file, line, snippet, kind };
+}
+
+describe('check-local-tz-date-getters (#4015 / #4127)', () => {
+	describe('欠陥クラスの検出 — #4127 で素通しした書き方', () => {
 		it.each([
-			'const y = now.getFullYear();',
-			'const m = now.getMonth() + 1;',
-			'const d = now.getDate();',
-			'const w = now.getDay();',
-			'd.setDate(d.getDate() - 1);',
-		])('ローカル TZ getter を検出する: %s', (line) => {
-			expect(LOCAL_TZ_GETTER.test(line)).toBe(true);
+			// #4127 残存 1: 列挙に無かった getter
+			['const hour = ctx.recordedAt.getHours();', 'tz-dependent-member'],
+			['const min = d.getMinutes();', 'tz-dependent-member'],
+			['const s = d.getSeconds();', 'tz-dependent-member'],
+			['const label = d.toDateString();', 'tz-dependent-member'],
+			// #4015 で見ていた 4 語 (回帰)
+			['const y = now.getFullYear();', 'tz-dependent-member'],
+			['const m = now.getMonth() + 1;', 'tz-dependent-member'],
+			['d.setDate(d.getDate() - 1);', 'tz-dependent-member'],
+			['const w = now.getDay();', 'tz-dependent-member'],
+			// #4127 残存 2: getter を 1 つも使わずに UTC の暦日を作る
+			['const today = new Date().toISOString().slice(0, 10);', 'utc-calendar-slice'],
+			['const month = new Date().toISOString().substring(0, 7);', 'utc-calendar-slice'],
+			["const d = new Date().toISOString().split('T')[0];", 'utc-calendar-slice'],
+			['const j = d.toJSON().slice(0, 10);', 'utc-calendar-slice'],
+			// 表示側: プロセス TZ (SSR は Lambda=UTC) で暦日が決まる
+			["{new Date(log.recordedAt).toLocaleDateString('ja-JP')}", 'implicit-locale-tz'],
+			["{new Date(kpi.fetchedAt).toLocaleString('ja-JP')}", 'implicit-locale-tz'],
+			["unlockTime.toLocaleTimeString('ja-JP', { hour: '2-digit' })", 'implicit-locale-tz'],
+			["const f = new Intl.DateTimeFormat('ja-JP', { dateStyle: 'short' });", 'implicit-locale-tz'],
+		])('検出する: %s', (line, kind) => {
+			expect(classifyLine(line)?.kind).toBe(kind);
 		});
 
 		it.each([
+			// UTC getter は TZ 非依存
 			'const y = now.getUTCFullYear();',
-			'const m = now.getUTCMonth() + 1;',
 			'const d = now.getUTCDate();',
-			'const w = now.getUTCDay();',
+			'd.setUTCDate(d.getUTCDate() + 7);',
 			'const t = now.getTime();',
+			'const iso = now.toISOString();',
+			// 数値 / Buffer の同名メソッド (曖昧メンバーの誤検知)
+			"const p = points.toLocaleString('ja-JP');",
+			'const yen = revenue.totalRevenue.toLocaleString();',
+			"const token = randomBytes(32).toString('base64url');",
+			// timeZone を明示していれば TZ 非依存
+			"new Date(x).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })",
+			"new Intl.DateTimeFormat('ja-JP', { timeZone: 'Asia/Tokyo' })",
+			// JST SSOT 経由
+			'const today = todayDateJST();',
 			'const s = toJSTDateString(now).slice(0, 7);',
-		])('UTC getter / 無関係な呼び出しは検出しない: %s', (line) => {
-			expect(LOCAL_TZ_GETTER.test(line)).toBe(false);
+		])('検出しない: %s', (line) => {
+			expect(classifyLine(line)).toBeNull();
+		});
+
+		it('toLocale* の option object が複数行に割れていても timeZone を見つける', () => {
+			const content = [
+				"const s = new Date(x).toLocaleDateString('ja-JP', {",
+				"\ttimeZone: 'Asia/Tokyo',",
+				'});',
+			].join('\n');
+			expect(findOccurrencesInContent('src/x.svelte', content)).toEqual([]);
+		});
+	});
+
+	describe('分類の網羅 — 記法の列挙ではなく Date.prototype から導出する', () => {
+		it('Date.prototype に未分類のメンバーが無い', () => {
+			expect(findUnclassifiedDateMembers()).toEqual([]);
+		});
+
+		it('safe / dependent の和が Date.prototype の全メンバーと一致する', () => {
+			const { safe, dependent } = classifyDateMembers();
+			expect([...safe, ...dependent].sort()).toEqual(
+				Object.getOwnPropertyNames(Date.prototype).sort(),
+			);
+		});
+
+		it('ローカル getter / setter は dependent 側に入る', () => {
+			const { dependent } = classifyDateMembers();
+			for (const name of ['getFullYear', 'getMonth', 'getDate', 'getDay', 'getHours', 'setDate']) {
+				expect(dependent).toContain(name);
+			}
+		});
+
+		it('UTC 系 / 瞬間系は safe 側に入る', () => {
+			const { safe } = classifyDateMembers();
+			for (const name of ['getUTCDate', 'setUTCDate', 'getTime', 'toISOString', 'toUTCString']) {
+				expect(safe).toContain(name);
+			}
 		});
 	});
 
@@ -65,7 +137,7 @@ describe('check-local-tz-date-getters (#4015)', () => {
 	});
 
 	describe('findOccurrencesInContent', () => {
-		it('コード行のみを行番号付きで返す', () => {
+		it('コード行のみを行番号 + kind 付きで返す', () => {
 			const content = [
 				'// getFullYear() の説明コメント',
 				'const a = now.getUTCFullYear();',
@@ -74,7 +146,7 @@ describe('check-local-tz-date-getters (#4015)', () => {
 			const found = findOccurrencesInContent('src/x.ts', content);
 			expect(found).toHaveLength(1);
 			expect(found[0]?.line).toBe(3);
-			expect(found[0]?.file).toBe('src/x.ts');
+			expect(found[0]?.kind).toBe('tz-dependent-member');
 		});
 
 		it('Windows パスは / 区切りに正規化される', () => {
@@ -85,33 +157,25 @@ describe('check-local-tz-date-getters (#4015)', () => {
 
 	describe('evaluateOccurrences — no-silent-gap / ratchet', () => {
 		it('allowlist 未登録 file の occurrence は not-allowlisted で違反になる', () => {
-			const violations = evaluateOccurrences([
-				{ file: 'src/lib/server/services/brand-new-service.ts', line: 10, snippet: 'x' },
-			]);
+			const violations = evaluateOccurrences([occ('src/lib/server/services/brand-new-service.ts')]);
 			expect(violations).toHaveLength(1);
 			expect(violations[0]?.kind).toBe('not-allowlisted');
-			expect(violations[0]?.file).toBe('src/lib/server/services/brand-new-service.ts');
 		});
 
 		it('allowlist 済 file でも max を超えたら over-max で違反になる', () => {
-			const entry = findAllowlistEntry('src/lib/server/services/viewer-token-service.ts');
+			const file = 'src/lib/server/services/grace-period-service.ts';
+			const entry = findAllowlistEntry(file);
 			expect(entry).toBeDefined();
-			const over = Array.from({ length: (entry?.max ?? 0) + 1 }, (_, i) => ({
-				file: 'src/lib/server/services/viewer-token-service.ts',
-				line: i + 1,
-				snippet: 'x',
-			}));
+			const over = Array.from({ length: (entry?.max ?? 0) + 1 }, (_, i) => occ(file, i + 1));
 			const violations = evaluateOccurrences(over);
 			expect(violations).toHaveLength(1);
 			expect(violations[0]?.kind).toBe('over-max');
-			expect(violations[0]?.count).toBe((entry?.max ?? 0) + 1);
 		});
 
 		it('allowlist 済 file が max 以内なら違反にならない', () => {
-			const violations = evaluateOccurrences([
-				{ file: 'src/lib/server/services/viewer-token-service.ts', line: 18, snippet: 'x' },
-			]);
-			expect(violations).toEqual([]);
+			expect(evaluateOccurrences([occ('src/lib/server/services/grace-period-service.ts')])).toEqual(
+				[],
+			);
 		});
 
 		it('occurrence 0 件なら違反 0 件', () => {
@@ -119,30 +183,59 @@ describe('check-local-tz-date-getters (#4015)', () => {
 		});
 	});
 
-	describe('allowlist の健全性 — 除外理由の強制 (#3956 の教訓)', () => {
-		it('現在の allowlist は全 entry が非空の reason を持つ', () => {
-			expect(findAllowlistEntriesWithoutReason()).toEqual([]);
+	describe('allowlist の kind 機械検査 (#4127 — 自由文の reason だけでは通さない)', () => {
+		it('現在の allowlist は kind 検査を全件通る', () => {
+			// occurrencesByFile を空にすると stale 検査が働かない設計 (第 2 引数の意味を固定する)
+			expect(findAllowlistIntegrityProblems()).toEqual([]);
 		});
 
-		it('reason が空 / 空白のみの entry は検出対象である', () => {
-			// 検出関数そのものの表明。実 ALLOWLIST を汚さずロジックを確認する。
-			const probe = [
-				{ file: 'a.ts', max: 1, reason: '' },
-				{ file: 'b.ts', max: 1, reason: '   ' },
-				{ file: 'c.ts', max: 1 },
-				{ file: 'd.ts', max: 1, reason: '理由あり' },
-			];
-			const bad = probe.filter((e) => typeof e.reason !== 'string' || e.reason.trim() === '');
-			expect(bad.map((e) => e.file)).toEqual(['a.ts', 'b.ts', 'c.ts']);
+		it('kind=instant-offset は「setX(getX() ± n)」以外の行を許さない', () => {
+			const file = 'src/lib/server/services/grace-period-service.ts';
+			const problems = findAllowlistIntegrityProblems(
+				groupByFile([occ(file, 12, 'return d.toISOString().slice(0, 10);', 'utc-calendar-slice')]),
+			);
+			expect(problems.map((p) => p.file)).toContain(file);
+			expect(problems.find((p) => p.file === file)?.problem).toMatch(/instant-offset/);
 		});
 
-		it('allowlist entry は file / max / reason を持つ', () => {
+		it('kind=instant-offset は「setX(getX() ± n)」構造なら通る', () => {
+			const file = 'src/lib/server/services/grace-period-service.ts';
+			const problems = findAllowlistIntegrityProblems(
+				groupByFile([occ(file, 12, 'd.setDate(d.getDate() + GRACE_DAYS);')]),
+			).filter((p) => p.file === file);
+			expect(problems).toEqual([]);
+		});
+
+		it('違反が 0 件になった entry は stale として検出される', () => {
+			// 別 file の occurrence だけを渡す = allowlist 済 file の違反が消えた状態
+			const problems = findAllowlistIntegrityProblems(
+				groupByFile([
+					occ('src/lib/server/services/grace-period-service.ts', 12, 'd.setDate(d.getDate() + 1);'),
+				]),
+			);
+			expect(problems.some((p) => p.problem.includes('stale allowlist'))).toBe(true);
+		});
+
+		it('allowlist entry は file / max / kind / reason を持ち、kind は既知の値である', () => {
 			for (const e of ALLOWLIST) {
 				expect(typeof e.file).toBe('string');
-				expect(e.file.startsWith('src/')).toBe(true);
 				expect(typeof e.max).toBe('number');
 				expect(e.max).toBeGreaterThanOrEqual(0);
 				expect(typeof e.reason).toBe('string');
+				expect(e.reason.trim().length).toBeGreaterThan(0);
+				expect(ALLOWLIST_KINDS).toContain(e.kind);
+			}
+		});
+
+		it('kind=non-runtime は非 runtime path のみ (path で機械判定できる)', () => {
+			for (const e of ALLOWLIST.filter((x) => x.kind === 'non-runtime')) {
+				expect(NON_RUNTIME_PATTERNS.some((p) => p.test(e.file))).toBe(true);
+			}
+		});
+
+		it('kind=tz-proof は proof (2 TZ 実測 case) の登録を要求する', () => {
+			for (const e of ALLOWLIST.filter((x) => x.kind === 'tz-proof')) {
+				expect(typeof e.proof).toBe('string');
 			}
 		});
 

--- a/tests/unit/scripts/check-local-tz-date-getters.test.ts
+++ b/tests/unit/scripts/check-local-tz-date-getters.test.ts
@@ -19,11 +19,14 @@ import { describe, expect, it } from 'vitest';
 import {
 	ALLOWLIST,
 	ALLOWLIST_KINDS,
+	AMBIGUOUS_MEMBERS,
 	classifyDateMembers,
 	classifyLine,
+	DATE_RECEIVER_AMBIGUOUS_CALL,
 	evaluateOccurrences,
 	findAllowlistEntry,
 	findAllowlistIntegrityProblems,
+	findAmbiguousDeclarationProblems,
 	findOccurrencesInContent,
 	findUnclassifiedDateMembers,
 	groupByFile,
@@ -118,6 +121,38 @@ describe('check-local-tz-date-getters (#4015 / #4127)', () => {
 			for (const name of ['getUTCDate', 'setUTCDate', 'getTime', 'toISOString', 'toUTCString']) {
 				expect(safe).toContain(name);
 			}
+		});
+	});
+
+	describe('曖昧メンバー宣言の自己検査 (#4127 — 宣言だけで検出を消させない)', () => {
+		it('現在の AMBIGUOUS_MEMBERS 宣言は検査を全件通る', () => {
+			expect(findAmbiguousDeclarationProblems()).toEqual([]);
+		});
+
+		it('宣言した全メンバーに補償検出 (DATE_RECEIVER_AMBIGUOUS_CALL) が存在する', () => {
+			for (const member of Object.keys(AMBIGUOUS_MEMBERS)) {
+				expect(DATE_RECEIVER_AMBIGUOUS_CALL.source).toContain(member);
+			}
+		});
+
+		it.each([
+			// 受け手の命名で Date と分かる形 (末尾修飾込み)
+			"const s = expiresOn.toLocaleString('ja-JP');",
+			"const s = createdAtIso.toLocaleString('ja-JP');",
+			"const s = validUntil.toLocaleString('ja-JP');",
+			// 命名で分からなくても日時整形オプションで分かる形
+			"const s = x.toLocaleString('ja-JP', { dateStyle: 'short' });",
+			"const s = v.toLocaleString('ja-JP', { hour: '2-digit' });",
+		])('曖昧メンバーでも受け手が Date と分かる形は検出する: %s', (line) => {
+			expect(classifyLine(line)?.kind).toBe('implicit-locale-tz');
+		});
+
+		it.each([
+			"const p = points.toLocaleString('ja-JP');",
+			'const yen = revenue.totalRevenue.toLocaleString();',
+			"const n = count.toLocaleString('ja-JP');",
+		])('数値の桁区切りは検出しない: %s', (line) => {
+			expect(classifyLine(line)).toBeNull();
 		});
 	});
 

--- a/tests/unit/services/activity-log-service.test.ts
+++ b/tests/unit/services/activity-log-service.test.ts
@@ -19,12 +19,10 @@ let testDb: TestDb;
 
 // todayDate をモックして日付を制御
 let mockToday = '2026-02-20';
-vi.mock('$lib/domain/date-utils', () => ({
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	// 部分 mock。今日だけを固定し、他の JST ヘルパは実装をそのまま使う (#4127)
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
 	todayDateJST: () => mockToday,
-	toJSTDateString: (date: Date) => {
-		const jst = new Date(date.getTime() + 9 * 60 * 60 * 1000);
-		return jst.toISOString().slice(0, 10);
-	},
 }));
 
 // DB モック: SQLite リポジトリがテスト用インメモリ DB を使うようにする

--- a/tests/unit/services/activity-record-dispatch.test.ts
+++ b/tests/unit/services/activity-record-dispatch.test.ts
@@ -36,12 +36,10 @@ const h = vi.hoisted(() => ({ isDsql: false }));
 
 // todayDate をモックして日付を制御 (既存 activity-log-service.test.ts と同一 pattern)
 const mockToday = '2026-02-20';
-vi.mock('$lib/domain/date-utils', () => ({
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	// 部分 mock。今日だけを固定し、他の JST ヘルパは実装をそのまま使う (#4127)
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
 	todayDateJST: () => mockToday,
-	toJSTDateString: (date: Date) => {
-		const jst = new Date(date.getTime() + 9 * 60 * 60 * 1000);
-		return jst.toISOString().slice(0, 10);
-	},
 }));
 
 // DB モック: SQLite リポジトリがテスト用インメモリ DB を使うようにする

--- a/tests/unit/services/age-recalc-service.test.ts
+++ b/tests/unit/services/age-recalc-service.test.ts
@@ -29,7 +29,9 @@ vi.mock('$lib/server/db/factory', () => ({
 }));
 
 // date-utils モック — 今日の日付を固定
-vi.mock('$lib/domain/date-utils', () => ({
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	// 部分 mock。今日だけを固定し、他の JST ヘルパは実装をそのまま使う (#4127)
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
 	todayDateJST: () => '2026-04-25',
 }));
 

--- a/tests/unit/services/birthday-bonus-service.test.ts
+++ b/tests/unit/services/birthday-bonus-service.test.ts
@@ -21,7 +21,9 @@ vi.mock('$lib/server/db/point-repo', () => ({
 
 // --- date-utils モック — 誕生日計算を固定日付で制御 ---
 let _mockedToday = '2026-04-01';
-vi.mock('$lib/domain/date-utils', () => ({
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	// 部分 mock。今日だけを固定し、他の JST ヘルパは実装をそのまま使う (#4127)
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
 	todayDateJST: () => _mockedToday,
 }));
 

--- a/tests/unit/services/bonus-hook-service.test.ts
+++ b/tests/unit/services/bonus-hook-service.test.ts
@@ -80,11 +80,11 @@ function selfStudyRewardPreset() {
 }
 
 // Fake datetime: 2026-05-13 (水曜) 06:00 JST -> early-bird 発火条件
-const WEDNESDAY_EARLY = new Date('2026-05-13T06:00:00');
+const WEDNESDAY_EARLY = new Date('2026-05-12T21:00:00Z'); // JST 2026-05-13 06:00
 // 土曜 10:00 -> weekend
-const SATURDAY_DAY = new Date('2026-05-16T10:00:00');
+const SATURDAY_DAY = new Date('2026-05-16T01:00:00Z'); // JST 2026-05-16 10:00
 // 平日昼 -> early-bird 不発
-const WEEKDAY_NOON = new Date('2026-05-13T12:00:00');
+const WEEKDAY_NOON = new Date('2026-05-13T03:00:00Z'); // JST 2026-05-13 12:00
 
 beforeEach(() => {
 	vi.clearAllMocks();

--- a/tests/unit/services/daily-mission-service.test.ts
+++ b/tests/unit/services/daily-mission-service.test.ts
@@ -26,7 +26,9 @@ vi.mock('$lib/server/db/client', () => ({
 		return testDb;
 	},
 }));
-vi.mock('$lib/domain/date-utils', () => ({
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	// 部分 mock。今日だけを固定し、他の JST ヘルパは実装をそのまま使う (#4127)
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
 	todayDateJST: () => '2026-03-08',
 }));
 

--- a/tests/unit/services/login-bonus-service.test.ts
+++ b/tests/unit/services/login-bonus-service.test.ts
@@ -32,13 +32,10 @@ vi.mock('$lib/server/db/client', () => ({
 
 // todayDateJST をモックして日付を制御（prevDateJST は実際の計算を使う）
 let mockToday = '2026-03-10';
-vi.mock('$lib/domain/date-utils', () => ({
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	// 部分 mock。今日だけを固定し、他の JST ヘルパは実装をそのまま使う (#4127)
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
 	todayDateJST: () => mockToday,
-	prevDateJST: (dateStr: string) => {
-		const d = new Date(`${dateStr}T00:00:00Z`);
-		d.setUTCDate(d.getUTCDate() - 1);
-		return d.toISOString().slice(0, 10);
-	},
 }));
 
 import {

--- a/tests/unit/services/recommendation-service.test.ts
+++ b/tests/unit/services/recommendation-service.test.ts
@@ -45,7 +45,9 @@ vi.mock('$lib/server/db/activity-repo', () => ({
 		mockInsertPointLedger(...args),
 }));
 
-vi.mock('$lib/domain/date-utils', () => ({
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	// 部分 mock。今日だけを固定し、他の JST ヘルパは実装をそのまま使う (#4127)
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
 	todayDateJST: () => '2026-04-01',
 }));
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供 / 親（管理者） / システム全体

**解決する課題**: #4015 で入れた TZ gate は検出対象を `getFullYear` / `getMonth` / `getDate` / `getDay` の **4 語の列挙**で定義していたため、同じ欠陥クラス（実行環境の TZ 任せに日付が決まる）の別の書き方が本番経路に残存していた。結果、Lambda (UTC) 上で「はやおきボーナスが JST 07:00 の記録に付かず JST 15:00 の記録に付く」「保護者画面の今日の利用時間が JST 00:00〜09:00 の間 0 分のまま」「JST 月初 9 時間に届いた課金 webhook の月がスキップされうる」等が起きていた。

**期待される効果**: 残存 6 箇所が JST 基準に是正され、上記の顧客可視な誤りが消える。さらに gate を「記法の列挙」から「欠陥クラス」に組み替えたため、**次に別の書き方が入っても素通りしない**（3 回目を作らない）。

## 関連 Issue

Refs #4127

<!-- no-issue-close: AC7 の既存データ突合は運用側の確認を含むため、close 判断は PO / QM に委ねる -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | TZ を変えると結果が変わる日付導出を検出する fitness test を追加し、残存が追加前は落ち修正後に通る | `npx vitest run tests/unit/architecture/tz-invariance.test.ts` | 追加時点 (commit `d0c8e5f`) で **9 failed / 9 passed**（bonus-hook はやおき / usage-log 当日・週次 / loyalty 月キー / rest-days 月非対称）。修正後 HEAD で **18 passed**。`tests/unit/architecture/tz-invariance.test.ts:104` の `tzCase` が `TZ=UTC` と `TZ=Asia/Tokyo` の 2 環境で JST 暦の期待値と一致することを assert する |
| AC2 | 残存 1（はやおきボーナス `getHours`）を JST 基準へ是正 | `npx vitest run tests/unit/architecture/tz-invariance.test.ts -t early-bird` | `src/lib/server/services/bonus-hook-service.ts:135` を `jstHour(ctx.recordedAt)` へ。case `bonus-hook/early-bird-hour` が JST 07:00 の記録に付き JST 15:00 に付かないことを 2 TZ で assert（修正前は TZ=UTC のみ fail = TZ 依存の実証） |
| AC3 | 残存 2（service 層の `new Date().toISOString().slice(0,10)` 10 箇所以上）を `todayDateJST()` へ | `node scripts/check-local-tz-date-getters.mjs` | value-preview(2) / last-active-touch / recommendation / loyalty / usage-log(5) / child-challenge(2) / activity-pin(2) / activity-record-preparation / daily-mission(4) / trial-history x2 / inquiry-repo x2 / logger / rest-days / report-service(4) / plan-limit(3) / birthday-bonus(8) / demo daily-mission-repo(2) を是正。gate 出力 `OK — allowlist (19 file、全件 kind 検証済) 外の TZ 依存日付導出なし` |
| AC4 | 残存 3（allowlist の理由と実測の不一致 2 件）を是正し、理由が実測と一致することを機械検証する | `npx vitest run tests/unit/scripts/check-local-tz-date-getters.test.ts` | 不一致だった 2 件（`daily-mission-service` の `getPreviousDate` は TZ=Asia/Tokyo で 2 日前を返していた / `usage-log-service`）は**除外をやめて修正**したため allowlist から消滅。残る allowlist は `kind`（`ssot` / `tz-proof` / `instant-offset` / `non-runtime`）ごとに機械検査され、自由文の reason だけでは通らない（`findAllowlistIntegrityProblems`、52 passed）。違反が 0 件になった stale entry も検出する |
| AC5 | 残存 4 / 5 / 6（利用時間ログの読み書き非対称 / ロイヤルティ月キー / おやすみ日の月非対称）を是正 | `npx vitest run tests/unit/architecture/tz-invariance.test.ts` | 利用時間: 保存は UTC ISO のまま、読み出し境界を `jstDayStartUtcIso()` に統一しバケットを `toJSTDateString()` へ（case `usage-log/today-summary-date-key` / `usage-log/weekly-summary-buckets`）。ロイヤルティ: `monthKeyJST()`（case `loyalty/increment-month-key`）。おやすみ日: GET 既定月を `monthKeyJST()` にし POST（JST 日付由来）と対称化（case `rest-days/month-symmetry`） |
| AC6 | gate の走査対象に `infra/lambda/` と `scripts/` を含める | `node scripts/check-local-tz-date-getters.mjs` | `SEARCH_ROOTS = ['src', 'infra/lambda', 'scripts']`（`scripts/check-local-tz-date-getters.mjs:75`）。`infra/lambda/health-check/index.ts` の 2 箇所は UTC アンカーであることが明示的に必要なため `getUTC*` から組み立てる形に是正。`scripts/` 配下 10 file は `kind: 'non-runtime'`（path で機械判定）で登録 |
| AC7 | 既存データとの突合が壊れないことを確認する | 差分レビュー + 上記 fitness | **保存値の形式と意味は変えていない**（`usage_logs.started_at` は UTC ISO のまま、`recorded_date` は JST YYYY-MM-DD のまま、おやすみ日の `date` も JST 日付のまま）。変更したのは読み出し境界と集計キーのみで、行の書き換え移行は不要。ただし **集計結果（顧客が見る数字）は意図どおり変わる**（JST 00:00〜09:00 の利用が当日側に移る）。`settings.lastIncrementMonth` は UTC 月キー → JST 月キーへ意味が変わるため、**移行月に限り二重加算の余地が残る**（deploy 直前の JST 月初 9 時間に加算したテナントに、同一 JST 月の 2 通目の invoice.paid が届いた場合）。保存値だけでは旧実装の書き込みと正当な前月加算を区別できず、どちらに倒しても片方が誤るため、倒し方を PO 決裁ブリーフ Q1 に上げている（現状は顧客不利に倒さない (a) で実装） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 活動記録のボーナス付与（全年齢モード）/ 保護者画面の利用時間サマリー / ロイヤルティ月数 / おやすみ日 / 月次・週次レポート / 誕生日ボーナス / 各画面の日付表示（SSR 経路）

- [x] **並行実装ペア**を同期した — 日付導出は `src/lib/domain/date-utils.ts` の単一 SSOT に集約しており、labels / 5 年齢モード / ナビ / seed / チュートリアルの並行実装ペアには該当しない
- [x] **設計書同期** (ADR-0001): `src/lib/domain/date-utils.ts` の SSOT 宣言（日付の正典）と `docs/design/44-チャレンジ設計書.md` の禁止記述を欠陥クラス版に更新。DB スキーマ / API / UI 仕様の変更はないため 08 / 07 / 06 は対象外
- [x] **LP ↔ アプリ整合** (ADR-0013): LP 記載に影響なし
- [x] **重量 e2e 敏感領域**: 該当なし（日付導出の内部実装と表示整形の TZ 明示のみ）
- [ ] N/A — 上記いずれも影響範囲外

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4182` | PASS |
| 追加・変更テスト | `npx vitest run tests/unit/architecture/tz-invariance.test.ts tests/unit/scripts/check-local-tz-date-getters.test.ts` | PASS (18 + 52) |
| mutation 検証 | `node scripts/check-local-tz-date-getters.mjs`（旧記法を一時的に再導入） | BLOCK (exit 1) を確認。内訳は下表 |

**mutation で「新しい書き方も捕まる」ことの確認**（commit 済の状態から一時的に mutate し、`git stash push` で復帰）:

| 再導入した書き方 | 旧 gate (#4015) | 新 gate | fitness test |
|---|---|---|---|
| `ctx.recordedAt.getHours()` | 素通り（4 語の列挙外） | `L137 [tz-dependent-member]` で BLOCK | `bonus-hook/early-bird-hour` が TZ=UTC で fail |
| `new Date().toISOString().slice(0, 7)` | 素通り（getter を使わない） | `L169 [utc-calendar-slice]` で BLOCK | `loyalty/increment-month-key` が 2 TZ とも fail |
| `new Date().getMinutes()` | 素通り | `L170 [tz-dependent-member]` で BLOCK | — |
| `new Date().toLocaleDateString('ja-JP')` | 素通り | `L171 [implicit-locale-tz]` で BLOCK | — |
| `new Intl.DateTimeFormat('ja-JP', { dateStyle: 'short' })` | 素通り | `L172 [implicit-locale-tz]` で BLOCK | — |

- [x] **SOLID / DRY / YAGNI**: 日付導出は `date-utils.ts` の単一 SSOT に集約（`jstHour` / `jstDayStartUtcIso` を追加）。gate の検出集合は `Date.prototype` の実体から導出するため重複列挙を持たない
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の追加なし
- [x] **A11y・パフォーマンス**: 表示整形に `timeZone: 'Asia/Tokyo'` を足すのみで DOM 構造・順序は不変。日次ループの Date 生成が文字列演算になり割当が減る
- [x] **Critical バグ修正**(ADR-0002): `priority:critical` ではないため N/A

## スクリーンショット / ビジュアルデモ

`npm run dev:cognito` で `/admin/settings/data`（本 PR で `toLocaleDateString` に `timeZone` を明示した画面の 1 つ）を実ブラウザ描画したもの。DOM HTML を同一 page から併記している (#1747 AC4 / #1766)。

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4182/C--Program-Files-Git-admin-settings-data-mobile.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4182/C--Program-Files-Git-admin-settings-data-desktop.png) |

- [DOM HTML (mobile)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4182/C--Program-Files-Git-admin-settings-data-mobile.dom.html) / [DOM HTML (desktop)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4182/C--Program-Files-Git-admin-settings-data-desktop.dom.html)
- DESIGN.md §9 禁忌 6 点（hex 直書き / プリミティブ再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超）は本 PR の差分で新規に発生していないことを目視確認済

<!-- ss-pair-none: 差分は toLocale* の timeZone option 追加のみで、撮影環境 (JST ブラウザ) では描画結果が原理的に変わらないため Before/After のペアが差分を示さない。ずれるのは SSR が UTC で走る Lambda 経路だけで、その正しさは tests/unit/architecture/tz-invariance.test.ts が TZ=UTC / TZ=Asia/Tokyo の 2 環境実測で担保する -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

`findTodayUsageLogs` / `findUsageLogsByChildAndDateRange` に渡す値の意味を「UTC 暦日の前方一致」から「JST 日境界に対応する UTC ISO の瞬間」に変えたが、repo 実装は `gte` / `lt` の比較のままで、保存データの形式は変更していない。

**レビュー依頼事項**:
1. gate の免除 `kind` 設計（`ssot` / `tz-proof` / `instant-offset` / `non-runtime`）が「理由を書けば通る」抜け道になっていないか。特に `non-runtime` の path 判定（`scripts/` / `*.stories.svelte` / `src/lib/server/demo/` / `debug-plan.ts`）の妥当性
2. `toLocaleString` / `toString` を「曖昧メンバー」として宣言し、受け手が Date と分かる形だけを拾う判断（数値の桁区切りが大多数のため）。宣言は `AMBIGUOUS_MEMBERS` に理由付きで残し、**宣言が抜け道にならないこと**（理由非空 + 補償検出の実在 + Date.prototype 側に実在）を `findAmbiguousDeclarationProblems()` が main() で毎回検査する。受け手の型を追わない静的検査なので取りこぼしゼロは主張せず、限界を doc に明示している
3. AC7 のロイヤルティ月キー変更（UTC 月 → JST 月）の既存データ影響評価

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 → UI の見た目変更を含まないため該当なし（§スクリーンショット に理由を明記）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付 → 認証画面の変更なしのため該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🟢 可逆: revert で全て戻る"]
    R2["顧客面: 子供のボーナス付与と親の利用時間表示が変わる"]
    R3["🔴 DB 移行なし。ただし課金月キーの意味が変わる"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 顧客に見える日付ずれ 6 件の解消"]
    T2["得る: 同クラス 3 回目を静的+実測 2 層で封じる"]
    T3["🟡 捨てる: 69 file 1 PR。回帰時の revert が gate ごと戻る"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: 移行月に課金月キーの二重加算余地"]
    O2["UX: はやおきボーナスが予告なく時間帯移動"]
    O3["security: 曖昧メンバー宣言の抜け道（本 PR で是正済）"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["JST 07 時台の記録にボーナスが戻る（今は 15 時台）"]
    C2["JST 00-09 時の利用が今日側に計上される"]
    C3["🟢 画面レイアウトの変化はなし（値だけ変わる）"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 移行月の課金月キーをどう倒すか"]
    Q2["Q2: ボーナス時間帯の変化を顧客に告知するか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3,O1 danger
  class T3,O2,R2 warn
  class R1,T1,T2,C1,C2,C3,O3 ok
  class Q1,Q2 ask
```

**Q1（要決裁）**: ロイヤルティ継続月数の二重加算防止キーを UTC 月 → JST 月に変えた。deploy 直前の JST 月初 00:00〜09:00 に加算したテナントは前月キーが残るため、同じ JST 月に 2 通目の `invoice.paid`（リトライ / 日割り / 支払い方法変更）が届くと再加算されうる。保存値だけでは「旧実装が当月分として書いた前月キー」と「正当な前月の加算」を区別できないため、どちらに倒しても片方が誤る:

- **(a) 現状の実装（JST 月キーのみで判定）**: 上記条件が重なったテナントで継続月数が 1 多くなり、未達の思い出チケットが 1 枚配られうる（顧客有利側に誤る）
- **(b) 前月キーも「加算済」とみなす**: 上記の再加算は防げるが、その 9 時間の窓に正当な `invoice.paid` が届いたテナントは 1 ヶ月ぶん加算を落とす（顧客不利側に誤る）
- **(c) deploy 前に `settings.lastIncrementMonth` を棚卸しして手で正規化**: 誤りゼロだが本番データ操作を伴う

現状は **(a)** で出している（顧客不利に倒さない方を既定にした）。(b) / (c) を採るなら実装 / 運用手順を追加する。

**Q2（要決裁）**: はやおきボーナスの付与時刻が本番 (Lambda=UTC) で JST 15 時台 → JST 07 時台に移る。これまで「昼に記録すると付いていた」子供にとっては、修正ではなく報酬が消えたように見える。在アプリ告知 / リリースノートを出すか、黙って正す（本来の仕様どおりになるだけ）かの判断。

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- 反対理由 3 軸の全文は `tmp/adversarial-evidence/4182.json`（`.claude/skills/adversarial-reviewer/SKILL.md` の手順で生成）。③ security 軸の指摘（曖昧メンバー宣言が新しい抜け道になっている / 自己検査が空振り / `expiresOn.toLocaleString()` の取りこぼし）は本 PR 内で是正済み（commit `2c0476f`）。`AMBIGUOUS_MEMBERS` に非空理由付きでメンバーを足すと「補償検出がありません」で exit 1 になることを mutation で確認した
- ④ の「画面レイアウトの変化なし」の根拠: `.svelte` の差分は `toLocaleDateString('ja-JP')` への `timeZone` option 追加が主で、JST ブラウザでの描画は同一（§スクリーンショット の `ss-pair-none` 宣言と同じ理由）
- ① の「DB 移行なし」の根拠: `usage_logs.started_at` は UTC ISO のまま / `recorded_date`・おやすみ日は JST 日付のまま。変えたのは読み出し境界と集計キーのみ（AC7 参照）
</details>
