### PR TITLE
fix(audit): #4170 統合 PR 本文の Closes 宣言が実 PR body に着地しているか機械照合する (AC2)

### DIFF
--- a/.claude/hooks/gate-approve.mjs
+++ b/.claude/hooks/gate-approve.mjs
@@ -665,6 +665,112 @@ export function verifyEvidence(prNumber, cwd = process.cwd()) {
 	return { ok: true };
 }
 
+/**
+ * 統合 PR body の下書きを置く既定パス (#4170 AC2)。
+ *
+ * `gh pr edit --body-file` に渡す下書きをここに置いておくと、approve 直前に本 hook が
+ * 「下書きの `Closes #N` が実 PR body に着地しているか」を自動照合する。
+ *
+ * @param {number} prNumber
+ * @returns {string}
+ */
+export function draftBodyPathForPr(prNumber, cwd = process.cwd()) {
+	return resolve(cwd, 'tmp', 'pr-bodies', `${prNumber}.md`);
+}
+
+/**
+ * approve 直前の Closes 着地確認 (#4170 AC2)。
+ *
+ * ## 何を見るか
+ *
+ * `tmp/pr-bodies/<pr>.md` に下書きがある PR について、その下書きが宣言した `Closes #N` が
+ * **GitHub 上の実 PR body に着地している**かを照合する。下書きだけ編集して `gh pr edit` を
+ * 流し忘れた状態 (第19回統合監査 #4152 で実際に起き、adversarial reviewer が拾うまで
+ * 「追加した」と報告されていた) を approve の手前で落とす。
+ *
+ * ## 下書きが無い PR を block しない理由 (fail-open を選ぶ唯一の箇所であることを明示する)
+ *
+ * 下書きファイルは統合 PR 運用の産物であり、通常の feature PR には存在しない。存在しないことを
+ * block 条件にすると全 approve が止まるので、**照合できなかったことを stderr に必ず出したうえで
+ * 通す**。無言 skip にはしない (ADR-0056 の「skip したことは必ず出力する」と同じ扱い)。
+ * 一方、下書きが**ある**のに照合できない (module 読込失敗 / `gh` 失敗) は「検証不能」なので block する。
+ *
+ * @param {number[]} prNumbers
+ * @param {{ cwd?: string; fetchLiveBody?: (prNumber: number) => string }} [deps] test 用の差し替え口
+ * @returns {Promise<{ ok: true; notes: string[] } | { ok: false; reason: string }>}
+ */
+export async function verifyClosesLandedForApprove(prNumbers, deps = {}) {
+	const cwd = deps.cwd ?? process.cwd();
+	const targets = prNumbers.filter((n) => existsSync(draftBodyPathForPr(n, cwd)));
+	if (targets.length === 0) {
+		return {
+			ok: true,
+			notes: [
+				`[gate-approve] NOTE: Closes 着地確認 (#4170 AC2) は未実施 — ` +
+					`下書き ${prNumbers.map((n) => `tmp/pr-bodies/${n}.md`).join(' / ')} がありません。`,
+				`  統合 PR で \`gh pr edit --body-file\` を使う場合は下書きを同パスに置くと、approve 直前に自動照合されます。`,
+			],
+		};
+	}
+
+	/** @type {typeof import('../../scripts/check-pr-body.mjs')} */
+	let checker;
+	/** @type {(prNumber: number) => string} */
+	let fetchLiveBody;
+	try {
+		// 相対 module は必ず dynamic import (#3999 / #4075 の fail-closed 規約)。
+		checker = await import('../../scripts/check-pr-body.mjs');
+		const cp = await import('node:child_process');
+		fetchLiveBody =
+			deps.fetchLiveBody ??
+			((prNumber) =>
+				cp.execFileSync(
+					'gh',
+					['pr', 'view', String(prNumber), '--json', 'body', '--jq', '.body'],
+					{ encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'] },
+				));
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		return {
+			ok: false,
+			reason:
+				`下書き (${targets.map((n) => `tmp/pr-bodies/${n}.md`).join(' / ')}) はあるが ` +
+				`Closes 着地確認 module を読み込めませんでした: ${msg}\n` +
+				`  検証できないまま approve すると、着地していない \`Closes #N\` を「追加済み」と誤認したまま merge されます (#4170)。`,
+		};
+	}
+
+	const notes = [];
+	for (const prNumber of targets) {
+		const draftPath = draftBodyPathForPr(prNumber, cwd);
+		let liveBody;
+		try {
+			liveBody = fetchLiveBody(prNumber);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			return {
+				ok: false,
+				reason: `PR #${prNumber} の実 body を取得できず Closes 着地確認 (#4170 AC2) が実施できません: ${msg}`,
+			};
+		}
+		const violation = checker.checkClosesLanded(readFileSync(draftPath, 'utf8'), liveBody);
+		if (violation) {
+			return {
+				ok: false,
+				reason:
+					`PR #${prNumber} の Closes 着地確認 (#4170 AC2) fail.\n` +
+					`  ${violation.message.split('\n').join('\n  ')}\n` +
+					`  再確認: node scripts/check-pr-body.mjs --pr ${prNumber} --verify-closes-landed ${draftPath}`,
+			};
+		}
+		notes.push(
+			`[gate-approve] NOTE: PR #${prNumber} の Closes 着地確認 (#4170 AC2) PASS — ` +
+				`下書きの close 宣言は実 body に着地済み`,
+		);
+	}
+	return { ok: true, notes };
+}
+
 async function main() {
 	let payload;
 	try {
@@ -748,6 +854,15 @@ async function main() {
 	}
 	const first = failures.at(0);
 	if (first === undefined) {
+		// #4170 AC2: evidence が揃ったうえで、approve 直前に「下書きの Closes が実 body に着地したか」を見る。
+		// ここに置く理由は監査チームの要望 (「approve 手順に組み込めれば理想。忘れようがなくなる」)。
+		// required CI にはしない (本文修正のたびに最重厚レーンを回すと #4171 の CI 待ちが悪化する)。
+		const closes = await verifyClosesLandedForApprove(prNumbers);
+		if (!closes.ok) {
+			process.stderr.write(`[gate-approve] BLOCK: ${closes.reason}\n`);
+			process.exit(2);
+		}
+		for (const note of closes.notes) process.stderr.write(`${note}\n`);
 		process.exit(0);
 	}
 

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -301,6 +301,20 @@ gh issue view <N> --json body --jq '.body' | grep -c '^- \[ \]'
 
 **実例**: `#4129` を集約に追加しようとしたが、その時点で AC 5 件すべて未チェックで、うち 2 件（`data/backups` の退避記録 / NUC 実機の env 確認）は運用行為だった。しかも `BACKUP_RETENTION` 7→3 の**不可逆削除**を追跡する唯一の tracker であり、auto-close すれば退避を誰も追わないまま削除が走る状態だった。
 
+#### 集約を「書いたつもり」で終わらせない — 下書きの着地確認（#4170 AC2）
+
+同じ `#4129` の一件で、監査は「`Closes #4129` を追加した」と PO に報告したが、**編集したのはローカル下書きだけで実 PR body には存在しなかった**。他のずれ（本文が古い）と違い、`Closes` の欠落は **GitHub の auto-close が発火しない**という副作用を伴い、merge されると main 上の恒久記録になる。
+
+**運用**: 統合 PR body の下書きを **`tmp/pr-bodies/<PR 番号>.md`** に置く。approve 時に `.claude/hooks/gate-approve.mjs` が下書きと実 body の close 宣言を照合し、不一致なら approve を block する（下書きが無い PR は block せず「未実施」を stderr に出す）。手で確認する場合:
+
+```bash
+node scripts/check-pr-body.mjs --pr <N> --verify-closes-landed tmp/pr-bodies/<N>.md
+```
+
+**`grep` で代替しない。** `grep -c "Closes #4129"` は撤回経緯の言及にもヒットする（PR #4152 の実 body で実測 4 件、実際の close 宣言は 0 件）。判定は行頭一致 SSOT（`integration-pr-body.mjs` の `extractClosedIssues`）に委譲されている。
+
+本 gate は **required CI にしない**（本文修正のたびに最重厚レーンを回すと CI 待ちが伸びるため）。本文の state / label 一致・件数照合（#4170 AC1 / AC3 / AC4）は本 gate の対象外で、依然として §3.8 step 7 の目視と adversarial に委ねられている。
+
 ### §3.9 非 critical PR サンプリング監査（complacency 対策、#3862）
 
 `po-decision:required` label（[pr-review SKILL.md](../../.claude/skills/pr-review/SKILL.md) §Step 0 の triage）が付かない非 critical PR は、PO 決裁ブリーフを経由せず QM / 監査チームの判定のみで merge される。この経路を放置すると **PO がプロダクトの実態を知る機会を失う** + **AI レビューへの追認（automation complacency / rubber-stamping）が検知不能になる**ため、抜き取り監査を運用に組み込む。

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -36,6 +36,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { checkIntegrationEvidenceTable } from './check-ac-verification-map.mjs';
+import { extractClosedIssues } from './integration-pr-body.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 import { classifyLane } from './pr-lane.mjs';
 import { checkChangeType } from './pr-template-gate-checks.mjs';
@@ -376,6 +377,126 @@ export function checkEvidencePrReferences(body, prNumber) {
 			`  対応: 根拠欄の番号を ${self} に直し、\`npm run pre-ready -- --pr ${self}\` を実際に実行し直して結果を貼る。\n` +
 			`  番号を書かない形式 (\`--pr <num>\` 等のプレースホルダ) は従来どおり通ります。`,
 	};
+}
+
+// ---------------------------------------------------------------------------
+// Closes 宣言の着地確認 (#4170 AC2)
+//
+// ## 何を検査するのか
+//
+// 手元の下書き body が宣言した `Closes #N` が、**GitHub 上の実 PR body に着地しているか**を
+// 検証する。下書きだけ編集して `gh pr edit --body-file` を流し忘れた状態 (= 書いたつもり) を
+// 機械で落とす。
+//
+// ## なぜ 4 件のうちこれだけを先に入れるのか (実装の優先根拠)
+//
+// 第19回統合監査 (#4152) で統合 PR 本文と GitHub 実態のずれが merge 直前に 4 回出た。
+// うち 3 件は「書いた瞬間は正しく、後で GitHub 側の実態が動いた」= 記述が古いだけ。
+// 本件 (#1) だけは **書いた瞬間から嘘**で、ローカル下書きだけ編集して push しておらず、
+// 実 PR body には最初から存在しなかった。そして監査チームの指摘が決定的だった:
+//
+//   > `Closes` 行は auto-close の実処理に直結し、merge されると main 上の恒久記録になります
+//
+// 違いは**記述の正確さではなく副作用の有無**である。他 3 件は読み手が誤読するだけだが、
+// `Closes` の欠落は **GitHub の実処理が起きない** (閉じるべき Issue が閉じない)。逆に意図せず
+// 存在すれば、閉じてはいけない Issue が閉じる。だから AC1 / AC3 / AC4 より先にこれを入れる。
+//
+// ## 案 C (表の骨格を機械生成) に将来寄せようとする人へ
+//
+//   案 C (表の骨格を機械生成) では「なぜ未解決か / 誰の手にあるか」は生成できない。
+//   #4156 がどの mailbox にも入っていないと気づけたのは、まさにその判断列だった
+//   (監査チーム、2026-08-01)。
+//
+// 機械が生成できるのは番号・state・label まで。「機械生成に寄せれば安全」は成り立たないので、
+// 本 gate を「生成に置き換えれば不要になるもの」と読まないこと。
+//
+// ## grep では代替できない理由 (実測)
+//
+// `grep -c "Closes #4129"` は **撤回経緯の言及にもヒットする**。PR #4152 の実 body で計測すると
+// 素朴な grep は 4 件返すが、実際に auto-close される宣言は 0 件だった (`Closes #4129` は撤回済で、
+// 散文・判定表・mermaid ノードの中にしか残っていない)。したがって判定は **行頭一致 + code fence
+// 除去 + conventional-commit prefix 除外**を行う既存 SSOT (`integration-pr-body.mjs` の
+// `extractClosedIssues`) に委ね、本 file で regex を再実装しない。統合 PR 本文の集約側と本 gate の
+// 検査側で「何が closing 宣言か」の判定が常に一致する (二重実装なし)。
+// ---------------------------------------------------------------------------
+
+/**
+ * body から **実際に auto-close を発火させる** closing 宣言の Issue 番号を取り出す (#4170)。
+ *
+ * 判定は `integration-pr-body.mjs` の `extractClosedIssues` に委譲する (行頭一致 SSOT)。
+ * 同関数は PR 配列を受けて `classifyForContainedList` で back-merge / 統合 PR 自身を除外するため、
+ * ここでは head / label を持たない合成 PR を 1 件渡して body だけを走査させる。
+ *
+ * @param {string} body
+ * @returns {number[]} 昇順・重複排除した Issue 番号
+ */
+export function extractLandedClosingIssues(body) {
+	return extractClosedIssues([{ number: 0, body: typeof body === 'string' ? body : '' }]);
+}
+
+/**
+ * closing keyword を **位置を問わず**拾う素朴な抽出 (#4170)。
+ *
+ * これは判定には使わない。「grep 相当だと何を誤って拾うか」を出力に出して、
+ * 撤回済み言及を close 宣言と読み違える運用ミス自体を可視化するためだけに使う。
+ *
+ * @param {string} body
+ * @returns {number[]} 昇順・重複排除した Issue 番号
+ */
+export function extractClosingKeywordMentions(body) {
+	const src = typeof body === 'string' ? body : '';
+	const found = new Set();
+	for (const m of src.matchAll(
+		/(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)[ \t]*:?[ \t]*[#＃](\d+)/gi,
+	)) {
+		found.add(Number(m[1]));
+	}
+	return [...found].sort((a, b) => a - b);
+}
+
+/**
+ * 下書き body の closing 宣言が GitHub 上の実 PR body に着地しているかを検証する (#4170 AC2)。
+ *
+ * 双方向で見る:
+ *   - **missing** (下書きにあり実 body に無い) = 本 Issue の事故形。`gh pr edit` 流し忘れ。
+ *     閉じるはずの Issue が閉じない
+ *   - **extra** (実 body にあり下書きに無い) = 撤回したつもりの宣言が残っている形。
+ *     閉じてはいけない Issue が閉じる。missing より静かに壊れるので同格で落とす
+ *
+ * @param {string} claimedBody 手元の下書き (`gh pr edit --body-file` に渡すつもりのファイル)
+ * @param {string} liveBody GitHub 上の実 PR body (`gh pr view --json body`)
+ * @returns {{ id: string; message: string } | null}
+ */
+export function checkClosesLanded(claimedBody, liveBody) {
+	const claimed = extractLandedClosingIssues(claimedBody);
+	const landed = extractLandedClosingIssues(liveBody);
+	const missing = claimed.filter((n) => !landed.includes(n));
+	const extra = landed.filter((n) => !claimed.includes(n));
+	if (missing.length === 0 && extra.length === 0) return null;
+
+	const lines = [
+		`下書きの closing 宣言と GitHub 上の実 PR body が一致しません (#4170 AC2)。`,
+		`  下書きの Closes: ${claimed.length === 0 ? '(なし)' : claimed.map((n) => `#${n}`).join(' / ')}`,
+		`  実 body の Closes: ${landed.length === 0 ? '(なし)' : landed.map((n) => `#${n}`).join(' / ')}`,
+	];
+	if (missing.length > 0) {
+		lines.push(
+			`  ✗ 下書きにあるが実 body に無い: ${missing.map((n) => `Closes #${n}`).join(' / ')}`,
+			`    = 下書きだけ編集して \`gh pr edit --body-file\` を流していない状態。このまま merge しても`,
+			`      GitHub の auto-close は発火せず、Issue は開いたまま残ります。`,
+		);
+	}
+	if (extra.length > 0) {
+		lines.push(
+			`  ✗ 実 body にあるが下書きに無い: ${extra.map((n) => `Closes #${n}`).join(' / ')}`,
+			`    = 撤回したつもりの宣言が実 body に残っている状態。merge すると**閉じてはいけない Issue**が`,
+			`      auto-close されます (main 上の恒久記録になり、後から静かに戻せません)。`,
+		);
+	}
+	lines.push(
+		`  対応: 下書きと実 body のどちらが正なのかを決め、\`gh pr edit <PR> --body-file <下書き>\` で揃えてから再実行する。`,
+	);
+	return { id: 'closes-not-landed', message: lines.join('\n') };
 }
 
 // ---------------------------------------------------------------------------
@@ -1485,12 +1606,13 @@ function tryParseStringArg(argv, i, aliases) {
  * @returns {{ pr: string | null; bodyFile: string | null; labels: string | null; lane: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }}
  */
 export function parseArgs(argv) {
-	/** @type {{ pr: string | null; bodyFile: string | null; labels: string | null; lane: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }} */
+	/** @type {{ pr: string | null; bodyFile: string | null; labels: string | null; lane: string | null; verifyClosesLanded: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }} */
 	const args = {
 		pr: null,
 		bodyFile: null,
 		labels: null,
 		lane: null,
+		verifyClosesLanded: null,
 		noLabels: false,
 		skipMergeable: false,
 		draft: false,
@@ -1521,6 +1643,13 @@ export function parseArgs(argv) {
 		if (lane) {
 			args.lane = lane.value;
 			i = lane.nextIndex;
+			continue;
+		}
+		// #4170 AC2: 下書き body の Closes 宣言が実 PR body に着地しているかだけを検査する専用モード
+		const closesLanded = tryParseStringArg(argv, i, ['--verify-closes-landed']);
+		if (closesLanded) {
+			args.verifyClosesLanded = closesLanded.value;
+			i = closesLanded.nextIndex;
 			continue;
 		}
 		const a = argv[i];
@@ -1567,6 +1696,12 @@ Options:
                       --pr 指定時は gh の base/head/author から自動判定され本フラグは無視される
                       (gh が取得できない場合のみ逃げ道として採用される)
   --skip-mergeable    GitHub API 呼び出しをスキップ (オフライン環境用)
+  --verify-closes-landed <path>
+                      【専用モード】手元の下書き <path> の \`Closes #N\` が GitHub 上の実 PR body に
+                      着地しているかだけを検査する (#4170 AC2、--pr 必須)。他の検査は走らない。
+                      下書きだけ編集して \`gh pr edit --body-file\` を流し忘れた状態 (= 書いたつもり)
+                      と、撤回したはずの宣言が実 body に残っている状態の両方を落とす。
+                      required CI には載せない — approve 直前に 1 回叩く手動 gate。
   --help, -h          このヘルプを表示
 
 Detected violations:
@@ -1761,12 +1896,81 @@ export function collectViolations(body, requiredSections, template, args, notes 
 	return violations;
 }
 
+/**
+ * `--verify-closes-landed <下書きパス>` 専用モード (#4170 AC2)。
+ *
+ * 通常の body 検査 (必須セクション / 禁止語 / …) とは問いが違う (「body の中身が正しいか」ではなく
+ * 「手元の下書きが GitHub に着地しているか」) ため、`collectViolations` に混ぜず独立させる。
+ * required CI には載せない — approve 直前に 1 回だけ叩く手動 gate であり、本文修正のたびに
+ * 重量レーンを回すのは監査 run の CI 待ちを悪化させる (#4171、監査チーム判断 2026-08-01)。
+ *
+ * @param {{ pr: string | null; verifyClosesLanded: string | null }} args
+ * @param {(pr: string) => string} fetchBody 実 PR body 取得 (test で差し替え可能)
+ * @returns {number} exit code
+ */
+export function runClosesLandedMode(args, fetchBody = fetchPrBody) {
+	const draftPath = args.verifyClosesLanded ?? '';
+	if (!args.pr) {
+		console.error(
+			'[check-pr-body] ERROR: --verify-closes-landed は --pr <number> と併用してください ' +
+				'(GitHub 上の実 PR body と比較するため)。',
+		);
+		return 2;
+	}
+	if (!existsSync(draftPath)) {
+		console.error(`[check-pr-body] ERROR: 下書きファイルが存在しません: ${draftPath}`);
+		return 2;
+	}
+	const claimedBody = readFileSync(draftPath, 'utf-8');
+	/** @type {string} */
+	let liveBody;
+	try {
+		liveBody = fetchBody(args.pr);
+	} catch (e) {
+		// 取得できないまま pass 側に倒すと「検査したつもり」になる。fail-closed で中断する。
+		const msg = e instanceof Error ? e.message : String(e);
+		console.error(`[check-pr-body] ERROR: PR #${args.pr} の body を取得できませんでした: ${msg}`);
+		return 2;
+	}
+
+	const landed = extractLandedClosingIssues(liveBody);
+	const mentions = extractClosingKeywordMentions(liveBody);
+	const naiveOnly = mentions.filter((n) => !landed.includes(n));
+	console.log(
+		`[check-pr-body] closes-landed: PR #${args.pr} の実 body / 下書き ${draftPath} を比較します`,
+	);
+	// grep 相当との差分を必ず出す。撤回済み言及を close 宣言と読み違える運用ミスを可視化するため
+	// (#4170: 実測で `grep -c "Closes #4129"` は 4 件返すが実 close 宣言は 0 件だった)。
+	console.log(
+		`  実 body の close 宣言 (行頭一致 SSOT): ${landed.length === 0 ? '(なし)' : landed.map((n) => `#${n}`).join(' / ')}`,
+	);
+	console.log(
+		naiveOnly.length === 0
+			? '  grep 相当 (位置を問わない keyword 一致) との差分: なし'
+			: `  grep 相当なら誤って拾う番号: ${naiveOnly.map((n) => `#${n}`).join(' / ')} ` +
+					'(撤回経緯の言及等。auto-close は発火しないので close 宣言ではありません)',
+	);
+
+	const violation = checkClosesLanded(claimedBody, liveBody);
+	if (!violation) {
+		console.log('[check-pr-body] OK — 下書きの closing 宣言は全て GitHub 上の実 body に着地済み');
+		return 0;
+	}
+	console.log(`[check-pr-body] FAIL — 1 件の違反:\n`);
+	console.log(`✗ [${violation.id}] (#4170 AC2)`);
+	console.log(`  ${violation.message.split('\n').join('\n  ')}\n`);
+	return 1;
+}
+
 export async function main(argv = process.argv.slice(2)) {
 	const args = parseArgs(argv);
 	if (args.help) {
 		printHelp();
 		return 0;
 	}
+
+	// #4170 AC2: 下書き vs 実 body の照合は独立した問い。通常の body 検査とは別モードで走る。
+	if (args.verifyClosesLanded !== null) return runClosesLandedMode(args);
 
 	const { body, exitCode } = loadPrBody(args);
 	if (body === null) return exitCode;

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -1603,7 +1603,7 @@ function tryParseStringArg(argv, i, aliases) {
 
 /**
  * @param {string[]} argv
- * @returns {{ pr: string | null; bodyFile: string | null; labels: string | null; lane: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }}
+ * @returns {{ pr: string | null; bodyFile: string | null; labels: string | null; lane: string | null; verifyClosesLanded: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }}
  */
 export function parseArgs(argv) {
 	/** @type {{ pr: string | null; bodyFile: string | null; labels: string | null; lane: string | null; verifyClosesLanded: string | null; noLabels: boolean; skipMergeable: boolean; draft: boolean; skipReadyOnly: boolean; help: boolean }} */

--- a/tests/unit/hooks/gate-approve-closes-landed.test.ts
+++ b/tests/unit/hooks/gate-approve-closes-landed.test.ts
@@ -1,0 +1,93 @@
+/**
+ * tests/unit/hooks/gate-approve-closes-landed.test.ts (#4170 AC2)
+ *
+ * approve 直前に走る Closes 着地確認の wiring を固定する。
+ *
+ * 監査チームの要望 (2026-08-01) は「手で叩くのを忘れるリスクがあるので approve 手順
+ * (`gate-approve` の隣) に組み込めれば理想」。required CI にはしない (本文修正のたびに最重厚
+ * レーンを回すと #4171 の CI 待ちが悪化する) ため、忘却リスクは本 wiring だけが担う。
+ * 「宣言だけの guard」にしないため、着地していない状態で **block されること**を実測で pin する。
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+	draftBodyPathForPr,
+	verifyClosesLandedForApprove,
+} from '../../../.claude/hooks/gate-approve.mjs';
+
+const LIVE_BODY = ['## 関連 Issue', '', 'Closes #4130', 'Closes #4139', ''].join('\n');
+
+const tempDirs: string[] = [];
+
+function makeTree(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'gate-closes-'));
+	tempDirs.push(dir);
+	mkdirSync(join(dir, 'tmp', 'pr-bodies'), { recursive: true });
+	return dir;
+}
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe('#4170 AC2 — approve 直前の Closes 着地確認', () => {
+	it('下書きが無い PR は block しないが、未実施であることを必ず note に出す', async () => {
+		const cwd = makeTree();
+		const result = await verifyClosesLandedForApprove([4152], { cwd, fetchLiveBody: () => LIVE_BODY });
+		expect(result.ok).toBe(true);
+		// 無言 skip にしない (skip したことは必ず出力する、ADR-0056 と同じ扱い)
+		expect(result.ok && result.notes.join('\n')).toContain('未実施');
+	});
+
+	it('下書きの close 宣言が実 body に着地していれば通す', async () => {
+		const cwd = makeTree();
+		writeFileSync(draftBodyPathForPr(4152, cwd), LIVE_BODY, 'utf8');
+		const result = await verifyClosesLandedForApprove([4152], { cwd, fetchLiveBody: () => LIVE_BODY });
+		expect(result.ok).toBe(true);
+		expect(result.ok && result.notes.join('\n')).toContain('PASS');
+	});
+
+	it('下書きだけ編集して push していない状態を block する (#4152 の事故形)', async () => {
+		const cwd = makeTree();
+		writeFileSync(
+			draftBodyPathForPr(4152, cwd),
+			LIVE_BODY.replace('Closes #4130', 'Closes #4129\nCloses #4130'),
+			'utf8',
+		);
+		const result = await verifyClosesLandedForApprove([4152], { cwd, fetchLiveBody: () => LIVE_BODY });
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.reason).toContain('Closes #4129');
+	});
+
+	it('下書きがあるのに実 body を取得できない場合は block する (検証不能を pass に倒さない)', async () => {
+		const cwd = makeTree();
+		writeFileSync(draftBodyPathForPr(4152, cwd), LIVE_BODY, 'utf8');
+		const result = await verifyClosesLandedForApprove([4152], {
+			cwd,
+			fetchLiveBody: () => {
+				throw new Error('gh auth failed');
+			},
+		});
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.reason).toContain('取得できず');
+	});
+
+	it('複数 PR のうち 1 件でも着地していなければ block する', async () => {
+		const cwd = makeTree();
+		writeFileSync(draftBodyPathForPr(4152, cwd), LIVE_BODY, 'utf8');
+		writeFileSync(draftBodyPathForPr(4160, cwd), `${LIVE_BODY}\nCloses #4171\n`, 'utf8');
+		const result = await verifyClosesLandedForApprove([4152, 4160], {
+			cwd,
+			fetchLiveBody: () => LIVE_BODY,
+		});
+		expect(result.ok).toBe(false);
+		expect(!result.ok && result.reason).toContain('#4160');
+	});
+});

--- a/tests/unit/hooks/gate-approve-closes-landed.test.ts
+++ b/tests/unit/hooks/gate-approve-closes-landed.test.ts
@@ -40,7 +40,10 @@ afterEach(() => {
 describe('#4170 AC2 — approve 直前の Closes 着地確認', () => {
 	it('下書きが無い PR は block しないが、未実施であることを必ず note に出す', async () => {
 		const cwd = makeTree();
-		const result = await verifyClosesLandedForApprove([4152], { cwd, fetchLiveBody: () => LIVE_BODY });
+		const result = await verifyClosesLandedForApprove([4152], {
+			cwd,
+			fetchLiveBody: () => LIVE_BODY,
+		});
 		expect(result.ok).toBe(true);
 		// 無言 skip にしない (skip したことは必ず出力する、ADR-0056 と同じ扱い)
 		expect(result.ok && result.notes.join('\n')).toContain('未実施');
@@ -49,7 +52,10 @@ describe('#4170 AC2 — approve 直前の Closes 着地確認', () => {
 	it('下書きの close 宣言が実 body に着地していれば通す', async () => {
 		const cwd = makeTree();
 		writeFileSync(draftBodyPathForPr(4152, cwd), LIVE_BODY, 'utf8');
-		const result = await verifyClosesLandedForApprove([4152], { cwd, fetchLiveBody: () => LIVE_BODY });
+		const result = await verifyClosesLandedForApprove([4152], {
+			cwd,
+			fetchLiveBody: () => LIVE_BODY,
+		});
 		expect(result.ok).toBe(true);
 		expect(result.ok && result.notes.join('\n')).toContain('PASS');
 	});
@@ -61,7 +67,10 @@ describe('#4170 AC2 — approve 直前の Closes 着地確認', () => {
 			LIVE_BODY.replace('Closes #4130', 'Closes #4129\nCloses #4130'),
 			'utf8',
 		);
-		const result = await verifyClosesLandedForApprove([4152], { cwd, fetchLiveBody: () => LIVE_BODY });
+		const result = await verifyClosesLandedForApprove([4152], {
+			cwd,
+			fetchLiveBody: () => LIVE_BODY,
+		});
 		expect(result.ok).toBe(false);
 		expect(!result.ok && result.reason).toContain('Closes #4129');
 	});

--- a/tests/unit/scripts/check-pr-body-closes-landed.test.ts
+++ b/tests/unit/scripts/check-pr-body-closes-landed.test.ts
@@ -1,0 +1,158 @@
+/**
+ * tests/unit/scripts/check-pr-body-closes-landed.test.ts (#4170 AC2)
+ *
+ * 「下書きの `Closes #N` が GitHub 上の実 PR body に着地しているか」を検査する gate の unit test。
+ *
+ * 検査対象の defect は第19回統合監査 (#4152) の実測: 監査 run が `Closes #4129` を「追加した」と
+ * 報告したが、ローカル下書きだけ編集しており実 PR body には存在しなかった。`Closes` 行は
+ * auto-close の実処理に直結し merge されると main 上の恒久記録になるため、記述が古いだけの
+ * 他 3 件とは副作用の有無が違う (監査チーム回答、2026-08-01)。
+ *
+ * 併せて **grep では代替できない**ことを固定する。`grep -c "Closes #4129"` は撤回経緯の言及にも
+ * ヒットし、PR #4152 の実 body では 4 件返すが実際の close 宣言は 0 件だった。判定は行頭一致 SSOT
+ * (`integration-pr-body.mjs` の `extractClosedIssues`) に委譲されている必要がある。
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+	checkClosesLanded,
+	extractClosingKeywordMentions,
+	extractLandedClosingIssues,
+	runClosesLandedMode,
+} from '../../../scripts/check-pr-body.mjs';
+
+/** 実 PR #4152 の構造を最小再現した body (行頭 close 宣言 3 件 + 撤回経緯の言及)。 */
+const LIVE_BODY_4152 = [
+	'## 関連 Issue',
+	'',
+	'**自動クローズ対象 issue:**',
+	'Closes #4130',
+	'Closes #4139',
+	'Closes #4150',
+	'',
+	'### Closes 集約の検証結果',
+	'',
+	'- **#4129 の追加を撤回した理由**: 監査は当初 `Closes #4129` を追加すると判断したが、',
+	'  adversarial reviewer の反証が正しい。open 継続が正しいため撤回した。',
+	'',
+	'| # | 観点 | 結果 |',
+	'|---|---|---|',
+	'| 4 | Closes 集約 | 当初 `Closes #4129` の追加を予告したが撤回 |',
+	'',
+	'| OBJ-1 | 「`Closes #4129` を追加した」と称しているが PR body の実物には存在しない |',
+].join('\n');
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), 'closes-landed-'));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	while (tempDirs.length > 0) {
+		const dir = tempDirs.pop();
+		if (dir) rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe('#4170 AC2 — close 宣言の抽出は行頭一致 SSOT に委譲される', () => {
+	it('行頭の close 宣言だけを auto-close 対象として拾う', () => {
+		expect(extractLandedClosingIssues(LIVE_BODY_4152)).toEqual([4130, 4139, 4150]);
+	});
+
+	it('grep 相当 (位置を問わない keyword 一致) は撤回済みの #4129 を誤って拾う', () => {
+		// この差こそが本 gate を grep で代替できない理由。両者が一致してしまったら
+		// 実装が行頭一致でなくなった (= 撤回経緯を close 宣言と誤認する) ことを意味する。
+		expect(extractClosingKeywordMentions(LIVE_BODY_4152)).toContain(4129);
+		expect(extractLandedClosingIssues(LIVE_BODY_4152)).not.toContain(4129);
+	});
+
+	it('code fence 内の Closes は auto-close されないので拾わない', () => {
+		const body = ['## 関連 Issue', '', '```', 'Closes #999', '```', ''].join('\n');
+		expect(extractLandedClosingIssues(body)).toEqual([]);
+	});
+});
+
+describe('#4170 AC2 — 下書きと実 body の照合', () => {
+	it('一致していれば違反なし', () => {
+		expect(checkClosesLanded(LIVE_BODY_4152, LIVE_BODY_4152)).toBeNull();
+	});
+
+	it('下書きにあり実 body に無い close 宣言を落とす (#4152 の事故形そのもの)', () => {
+		const draft = LIVE_BODY_4152.replace('Closes #4130', 'Closes #4129\nCloses #4130');
+		const violation = checkClosesLanded(draft, LIVE_BODY_4152);
+		expect(violation).not.toBeNull();
+		expect(violation?.id).toBe('closes-not-landed');
+		expect(violation?.message).toContain('下書きにあるが実 body に無い: Closes #4129');
+	});
+
+	it('実 body にあり下書きに無い close 宣言も落とす (撤回したつもりの over-close)', () => {
+		const draft = LIVE_BODY_4152.replace('Closes #4150\n', '');
+		const violation = checkClosesLanded(draft, LIVE_BODY_4152);
+		expect(violation).not.toBeNull();
+		expect(violation?.message).toContain('実 body にあるが下書きに無い: Closes #4150');
+	});
+
+	it('撤回経緯の言及を下書き側に増やしても違反にならない (grep 由来の偽陽性を作らない)', () => {
+		const draft = `${LIVE_BODY_4152}\n\n再掲: 当初 \`Closes #4129\` を足す予定だったが撤回した。`;
+		expect(checkClosesLanded(draft, LIVE_BODY_4152)).toBeNull();
+	});
+});
+
+describe('#4170 AC2 — CLI 専用モード (runClosesLandedMode)', () => {
+	it('一致していれば exit 0', () => {
+		const dir = makeTempDir();
+		const draftPath = join(dir, 'draft.md');
+		writeFileSync(draftPath, LIVE_BODY_4152, 'utf8');
+		const code = runClosesLandedMode(
+			{ pr: '4152', verifyClosesLanded: draftPath },
+			() => LIVE_BODY_4152,
+		);
+		expect(code).toBe(0);
+	});
+
+	it('着地していない close 宣言があれば exit 1', () => {
+		const dir = makeTempDir();
+		const draftPath = join(dir, 'draft.md');
+		writeFileSync(
+			draftPath,
+			LIVE_BODY_4152.replace('Closes #4130', 'Closes #4129\nCloses #4130'),
+			'utf8',
+		);
+		const code = runClosesLandedMode(
+			{ pr: '4152', verifyClosesLanded: draftPath },
+			() => LIVE_BODY_4152,
+		);
+		expect(code).toBe(1);
+	});
+
+	it('--pr が無ければ exit 2 (実 body と比較できないので pass 側に倒さない)', () => {
+		const dir = makeTempDir();
+		const draftPath = join(dir, 'draft.md');
+		writeFileSync(draftPath, LIVE_BODY_4152, 'utf8');
+		expect(runClosesLandedMode({ pr: null, verifyClosesLanded: draftPath }, () => '')).toBe(2);
+	});
+
+	it('下書きファイルが無ければ exit 2', () => {
+		const dir = makeTempDir();
+		expect(
+			runClosesLandedMode({ pr: '4152', verifyClosesLanded: join(dir, 'absent.md') }, () => ''),
+		).toBe(2);
+	});
+
+	it('実 body を取得できなければ exit 2 (取得失敗を「違反なし」にしない)', () => {
+		const dir = makeTempDir();
+		const draftPath = join(dir, 'draft.md');
+		writeFileSync(draftPath, LIVE_BODY_4152, 'utf8');
+		const code = runClosesLandedMode({ pr: '4152', verifyClosesLanded: draftPath }, () => {
+			throw new Error('gh auth failed');
+		});
+		expect(code).toBe(2);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（監査チーム / PO）

**解決する課題**: 統合 PR 本文に `Closes #N` を「追加した」と書いたのに、実際に編集したのはローカル下書きだけで GitHub 上の PR body には存在しない、という状態を人が目視で見つけるしかなかった。第19回統合監査 (#4152) で実際に起き、adversarial reviewer が指摘するまで「追加済み」と PO に報告されていた。

**期待される効果**: approve 直前に機械が照合する。`Closes` 行は auto-close の実処理に直結し merge されると main 上の恒久記録になるため、欠落は「本文が古い」ではなく「閉じるはずの Issue が閉じない」という副作用になる。逆に撤回したつもりの宣言が残っていれば、閉じてはいけない Issue が静かに閉じる。両方向を落とす。

## 関連 Issue

<!-- no-issue-close: AC1 / AC3 / AC4 が残るため close しない。本 PR は監査チーム合意 (2026-08-01) により AC2 のみを scope とする -->
Refs #4170

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC2 | 本文の `Closes #N` 列挙が GitHub 上の PR body に実在することを検証する（ローカル下書きだけ編集した状態を検出する） | `npx vitest run tests/unit/scripts/check-pr-body-closes-landed.test.ts tests/unit/hooks/gate-approve-closes-landed.test.ts` | HEAD `8e321d190` / 17 passed。`scripts/check-pr-body.mjs` `checkClosesLanded()` が missing（下書きにあり実 body に無い）と extra（実 body にあり下書きに無い）を双方向で検出。`tests/unit/scripts/check-pr-body-closes-landed.test.ts:88` が #4152 の事故形（下書きにだけ `Closes #4129` がある状態）で `closes-not-landed` を返すことを pin |
| AC2 (実測) | 判定が `grep` 相当に退化していないこと（撤回経緯の言及を close 宣言と誤認しない） | PR #4152 の実 body を `gh pr view 4152 --json body` で取得し両方式で計測 | 行頭一致 SSOT = `[4130, 4139, 4150]` / grep 相当（位置を問わない keyword 一致）= `[4129, 4130, 4139, 4150]` / `grep -c "Closes #4129"` = **4 件**（実際の close 宣言は 0 件）。`tests/unit/scripts/check-pr-body-closes-landed.test.ts:75` がこの差を assert |
| AC2 (mutation) | gate が宣言だけでなく実際に捕まえること | 実装を 2 通りに壊して test 再実行 | M1「行頭一致を grep 相当に退化」→ 5 test fail / M2「missing 検出を削除（片方向化）」→ 2 test fail。いずれも実装 commit 済の状態から mutate し `git stash push` / `git checkout-index` で復元（`git checkout --` は hook で block されるため不使用） |
| AC2 (approve 配線) | 手で叩くのを忘れても効くこと | `npx vitest run tests/unit/hooks/gate-approve-closes-landed.test.ts` | 5 passed。`.claude/hooks/gate-approve.mjs` が adversarial evidence 検証 PASS 後、`tmp/pr-bodies/<PR>.md` がある PR について照合し不一致で exit 2（block）。下書き不在は block せず「未実施」note を stderr に出す（無言 skip にしない） |
| AC1 / AC3 / AC4 | (本 PR の scope 外) | — | 監査チーム回答 (2026-08-01)「AC2 だけ先に入れて様子を見る形でも構いません」に従い**実装していない**。本文の state / label 一致 (AC1) / 件数と表の行数の照合 (AC3) / hard-fail 化 (AC4) はいずれも本 PR に含まない。#4170 は open のまま残す |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客向け画面への影響なし。`scripts/check-pr-body.mjs`（新しい専用モードを追加、既定の検査経路は不変）と `.claude/hooks/gate-approve.mjs`（approve 直前に 1 検査を追加）。

- [ ] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [x] **設計書同期** (ADR-0001): `docs/sessions/audit-team.md` §3.5.2 に運用（下書きの置き場所・手動確認コマンド・grep で代替しない理由・本 gate の scope 外）を追記
- [ ] **LP ↔ アプリ整合** (ADR-0013): LP 記載が実装と一致。Aspirational を LP に新規追加していない
- [ ] **重量 e2e 敏感領域** (`parallel-implementations.md` §SSOT) に触れる場合、該当 spec のローカル実行ログを本文に貼った
- [ ] N/A — 上記いずれも影響範囲外

**close 宣言の判定を二重実装していない**: 判定は `scripts/integration-pr-body.mjs` の `extractClosedIssues`（統合 PR 本文の集約側と同一 SSOT）に委譲し、本 PR で regex を書き足していない。集約側と検査側で「何が close 宣言か」が食い違わない。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4183` | PASS |
| 追加・変更テスト | `npx vitest run tests/unit/scripts/check-pr-body-closes-landed.test.ts tests/unit/hooks/gate-approve-closes-landed.test.ts` | PASS (17 passed) |
| 既存 regression | `npx vitest run tests/unit/scripts/ tests/unit/hooks/` | PASS (54 files 1056 passed / 6 files 186 passed) |

- [x] **SOLID / DRY / YAGNI**: close 宣言の抽出は既存 SSOT に委譲し再実装なし。新規 script を作らず既存 `check-pr-body.mjs` に追加（#4170 案 B の方針）
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。gate が取得するのは自リポジトリの PR body のみ
- [x] **A11y・パフォーマンス**: N/A（CLI / hook のみ）。hook の追加処理は approve 系コマンド検出後かつ下書きが存在する場合のみ走り、通常の Bash 実行経路には影響しない
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:critical` ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（顧客向け UI の変更を含まない。CLI 出力と PreToolUse hook の stderr のみ）**

参考に、実際の PR #4152 body に対する CLI 出力（下書きにだけ `Closes #4129` を足した事故形の再現）:

```
[check-pr-body] closes-landed: PR #4152 の実 body / 下書き tmp/pr-bodies/4152.md を比較します
  実 body の close 宣言 (行頭一致 SSOT): #4130 / #4139 / #4150
  grep 相当なら誤って拾う番号: #4129 (撤回経緯の言及等。auto-close は発火しないので close 宣言ではありません)
[check-pr-body] FAIL — 1 件の違反:

✗ [closes-not-landed] (#4170 AC2)
  下書きの closing 宣言と GitHub 上の実 PR body が一致しません (#4170 AC2)。
    下書きの Closes: #4129 / #4130 / #4139 / #4150
    実 body の Closes: #4130 / #4139 / #4150
    ✗ 下書きにあるが実 body に無い: Closes #4129
```

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **下書き不在を block しない判断**。`tmp/pr-bodies/<PR>.md` は統合 PR 運用の産物で、通常の feature PR には存在しない。存在しないことを block 条件にすると全 approve が止まるため、「照合できなかったことを stderr に必ず出したうえで通す」形にした。本 PR で fail-open を選んでいる唯一の箇所で、hook のコメントにその旨を明記している。下書きが**ある**のに照合できない（module 読込失敗 / `gh` 失敗）は block 側に倒している。
2. **案 C（表の骨格を機械生成）を将来採らせないための記録**。`scripts/check-pr-body.mjs` の section コメントに、監査チームの指摘（案 C では「なぜ未解決か / 誰の手にあるか」は生成できない。#4156 がどの mailbox にも入っていないと気づけたのはその判断列だった）をそのまま残している。「機械生成に寄せれば安全」と後から判断されるのを止める意図。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR の scope = AC2 のみで、AC1 / AC3 / AC4 は監査チーム合意により本 PR の AC に含まない）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認（UI 変更なしのため N/A）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付（認証画面の変更なしのため N/A）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
