### PR TITLE
fix(infra): #4174 deploy.yml が discordWebhookIncident を渡さず本番 incident 通知が 0 通なのを塞ぐ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -271,6 +271,26 @@ jobs:
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
 
+      # #4174: incident 通知先 (DISCORD_WEBHOOK_INCIDENT) の配布可否をここで宣言する。
+      # compute-stack.ts は `-c discordWebhookIncident` を読む口を持つが、deploy.yml が
+      # 渡していなかったため env ごと Lambda から落ち、**本番の incident 通知は 0 通**だった。
+      #
+      # 欠落しても deploy は止めない (アプリ本体は動く) が、黙って進むと
+      # 「障害が起きても誰にも届かない」状態が再び不可視になるため必ず警告する
+      # (ADR-0024 ENV silent skip 禁止 / #4167 の任意 env と同じ扱い)。
+      #
+      # 判定結果は post-deploy の実 env 検証 (下記 "Incident webhook env verification") が
+      # 参照する。secret 未登録なら検証を skip、登録済みなのに Lambda env に無ければ配線不良で fail。
+      - name: Incident webhook secret presence (#4174)
+        run: |
+          if [ -z "${{ secrets.DISCORD_WEBHOOK_INCIDENT }}" ]; then
+            echo "INCIDENT_WEBHOOK_CONFIGURED=false" >> $GITHUB_ENV
+            echo "::warning::DISCORD_WEBHOOK_INCIDENT secret が空です。本番 Lambda に incident 通知先が入らず、障害が起きても通知は 0 通になります (#4174 / #4119)"
+          else
+            echo "INCIDENT_WEBHOOK_CONFIGURED=true" >> $GITHUB_ENV
+            echo "::notice::DISCORD_WEBHOOK_INCIDENT secret を検出しました。deploy 後に実 Lambda env を検証します"
+          fi
+
       - name: Resolve DSQL outputs (production)
         run: |
           ENDPOINT=$(aws cloudformation describe-stacks --stack-name GanbariQuestDsql \
@@ -321,6 +341,10 @@ jobs:
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
             -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }} \
+            -c discordWebhookIncident=${{ secrets.DISCORD_WEBHOOK_INCIDENT }} \
+            -c discordWebhookSignup=${{ secrets.DISCORD_WEBHOOK_SIGNUP }} \
+            -c discordWebhookBilling=${{ secrets.DISCORD_WEBHOOK_BILLING }} \
+            -c discordWebhookChurn=${{ secrets.DISCORD_WEBHOOK_CHURN }} \
             ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }} \
             ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }} \
             2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
@@ -348,6 +372,10 @@ jobs:
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
           -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }}
           -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
+          -c discordWebhookIncident=${{ secrets.DISCORD_WEBHOOK_INCIDENT }}
+          -c discordWebhookSignup=${{ secrets.DISCORD_WEBHOOK_SIGNUP }}
+          -c discordWebhookBilling=${{ secrets.DISCORD_WEBHOOK_BILLING }}
+          -c discordWebhookChurn=${{ secrets.DISCORD_WEBHOOK_CHURN }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
 
@@ -410,6 +438,37 @@ jobs:
           aws lambda wait function-updated \
             --function-name $LAMBDA_FUNCTION \
             --region $AWS_REGION
+
+      # #4174: **synth の diff ではなく、deploy 済み Lambda の実 env** を読んで検証する。
+      # compute-stack.ts は空値のとき env ごと落とす (`...(x ? {KEY: x} : {})`) ため、
+      # 「context を渡し忘れた」「secret 名を間違えた」のいずれでも **deploy は成功したまま
+      # 通知だけが 0 通**になる。#4119 (NUC で 18 晩 alert 0 通) と同型の failure mode で、
+      # 実 env を見る以外に検出手段がない。
+      #
+      # 判定:
+      #   - secret 未登録 (INCIDENT_WEBHOOK_CONFIGURED=false) → skip (前段で warning 済)
+      #   - secret 登録済 かつ env に存在 → pass
+      #   - secret 登録済 なのに env に無い → **配線不良として hard-fail**
+      #
+      # 本 step の失敗は image rollback を起こさない (rollback は health check 失敗時に限定)。
+      # アプリ本体は健全なので巻き戻す理由がなく、deploy を赤くして配線不良を可視化するのが目的。
+      #
+      # `keys()` で **key 名だけ**を取り出す。webhook URL そのものはシェル変数にも載せない。
+      - name: Incident webhook env verification (production, #4174)
+        run: |
+          if [ "$INCIDENT_WEBHOOK_CONFIGURED" != "true" ]; then
+            echo "::warning::DISCORD_WEBHOOK_INCIDENT secret 未登録のため実 env 検証を skip します (#4174)"
+            exit 0
+          fi
+          KEYS=$(aws lambda get-function-configuration \
+            --function-name "$LAMBDA_FUNCTION" --region "$AWS_REGION" \
+            --query 'keys(Environment.Variables)' --output text | tr '\t' '\n')
+          if echo "$KEYS" | grep -qx "DISCORD_WEBHOOK_INCIDENT"; then
+            echo "::notice::DISCORD_WEBHOOK_INCIDENT が本番 Lambda の実 env に存在します (#4174)"
+          else
+            echo "::error::DISCORD_WEBHOOK_INCIDENT が本番 Lambda の env にありません。secret は登録済のため CDK context の配線不良です (#4174)。障害が起きても通知は 0 通になります"
+            exit 1
+          fi
 
       # ADR-0048 hotfix #6 (2026-05-16): demo Lambda は `latest` タグで CDK 管理されるため
       # CloudFormation が新しい image push を検知できない (production と同じ問題)。

--- a/docs/design/23-Discordサーバー設計書.md
+++ b/docs/design/23-Discordサーバー設計書.md
@@ -188,18 +188,37 @@
 | `DISCORD_WEEKLY_REPORT_WEBHOOK_URL` | Variable | GitHub Settings → Variables | 週次レポート |
 | `FEEDBACK_DISCORD_WEBHOOK_URL` | Secret | GitHub Settings → Secrets | フィードバック送信先 |
 | `DISCORD_WEBHOOK_SUPPORT` | Secret | GitHub Settings → Secrets | サポートメール受信通知 |
+| `DISCORD_WEBHOOK_HEALTH` | Secret | GitHub Settings → Secrets | ヘルスチェック / 稼働状況（利用者向け） |
+| `DISCORD_WEBHOOK_INCIDENT` | Secret | GitHub Settings → Secrets | 障害通知（バックエンド向け。`discord-alert.ts` の宛先） |
+| `DISCORD_WEBHOOK_SIGNUP` / `_BILLING` / `_CHURN` | Secret | GitHub Settings → Secrets | 運用通知チャネル（未登録。登録すれば配布経路は通っている） |
 
 ### 4.4 Lambda 環境変数への伝搬
 
-```
-GitHub Secret: FEEDBACK_DISCORD_WEBHOOK_URL
-  → deploy.yml: -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }}
-  → CDK context → Lambda 環境変数: FEEDBACK_DISCORD_WEBHOOK_URL
+**3 段すべてが揃って初めて Lambda に届く。1 段でも欠けると env ごと落ちるが deploy は成功する**（#4174）:
 
-GitHub Secret: DISCORD_WEBHOOK_SUPPORT
-  → deploy.yml: -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
-  → CDK context → Lambda 環境変数: DISCORD_WEBHOOK_SUPPORT
 ```
+GitHub Secret ─→ deploy.yml の -c <contextKey>=... ─→ CDK context ─→ Lambda 環境変数
+```
+
+| GitHub Secret | CDK context key | Lambda 環境変数 |
+|---|---|---|
+| `FEEDBACK_DISCORD_WEBHOOK_URL` | `feedbackDiscordWebhookUrl` | `FEEDBACK_DISCORD_WEBHOOK_URL` / `DISCORD_WEBHOOK_INQUIRY` |
+| `DISCORD_WEBHOOK_SUPPORT` | `discordWebhookSupport` | (SesStack が受信通知に使用) |
+| `DISCORD_WEBHOOK_INCIDENT` | `discordWebhookIncident` | `DISCORD_WEBHOOK_INCIDENT` |
+| `DISCORD_WEBHOOK_SIGNUP` | `discordWebhookSignup` | `DISCORD_WEBHOOK_SIGNUP` |
+| `DISCORD_WEBHOOK_BILLING` | `discordWebhookBilling` | `DISCORD_WEBHOOK_BILLING` |
+| `DISCORD_WEBHOOK_CHURN` | `discordWebhookChurn` | `DISCORD_WEBHOOK_CHURN` |
+
+`compute-stack.ts` は空値のとき `...(x ? { KEY: x } : {})` で **env ごと落とす**。したがって
+context を渡し忘れても synth も deploy も成功し、**通知だけが 0 通になる**。この穴は 2 層で塞ぐ:
+
+1. `tests/unit/infra/aws-deploy-context-closure.test.ts` — CDK が読む context key が
+   どの workflow からも渡されていなければ CI で fail（`[AD1]`）
+2. deploy.yml の post-deploy step — **deploy 済み Lambda の実 env** を読み、secret 登録済なのに
+   env に無ければ hard-fail（synth の diff では渡し忘れを検出できないため）
+
+チャネルの用途分離（health = 利用者向け / incident = バックエンド障害）は §4.3 の表が SSOT。
+バックエンドの障害を利用者向けチャネルに混ぜると、どちらも読まれなくなる。
 
 ### 4.5 NUC ローカル環境
 

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -121,6 +121,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'src/routes 配下の admin 画面を走査して registry の網羅漏れを検出する (#3134 no-silent-gap)',
 	},
+	'tests/unit/infra/aws-deploy-context-closure.test.ts': {
+		scope: 'repo',
+		note: '.github/workflows と infra/lib を読んで CDK context の配布 closure を検査する (#4174)',
+	},
 	'tests/unit/hooks/agent-lock.test.ts': {
 		scope: 'repo',
 		note: 'repo ツリーは走査しない (temp git fixture + lock dir のみ) が、hook を子プロセスで起動するため静的判定が repo になる。git init / worktree add の分だけ既定 timeout を超え得るので明示 timeout を置く',

--- a/tests/unit/infra/aws-deploy-context-closure.test.ts
+++ b/tests/unit/infra/aws-deploy-context-closure.test.ts
@@ -1,0 +1,244 @@
+// #4174 — AWS deploy が **CDK の読む口に対して context を配り落とさない**ことを機械で固定する。
+//
+// ## 塞ぐ穴
+//
+// CDK は設定値を `this.node.tryGetContext('key') ?? ''` で受け、compute-stack.ts は空値のとき
+// **env ごと Lambda から落とす** (`...(x ? { KEY: x } : {})`)。したがって:
+//
+//   - workflow が `-c key=...` を渡し忘れると、その env は Lambda に存在しない
+//   - それでも **synth も deploy も成功する** (型エラーにも diff にも出ない)
+//   - アプリ側の宛先解決は `A ?? B` で、どちらも無ければ静かに no-op になる
+//
+// 実害: `discordWebhookIncident` は compute-stack.ts が読む口を持ちながら deploy.yml が一度も
+// 渡していなかった。結果として **本番 Lambda で incident 通知が 1 通も飛んでいなかった**。
+// #4119 (NUC で 18 晩バックアップ失敗しても alert 0 通) と同型の failure mode で、NUC 側は
+// #4167 / PR #4168 が `nuc-deploy-env-closure.test.ts` で塞いだ。本 test はその **AWS 側の対**。
+//
+// 人の注意ではなく機械で閉じる (ADR-0061 fitness function / ADR-0024 ENV silent skip 禁止)。
+//
+// ## 何を固定するか
+//
+//   [AD1] CDK が読む context key が、どれかの workflow から実際に渡されている
+//         (渡されないものは「なぜ渡さないか」を CONTEXT_KEYS_NOT_DISTRIBUTED に明示する)
+//   [AD2] 宣言が stale でない (渡すようになった key が免除リストに残り続けない)
+//   [AD3] 本番 compute を触る cdk 呼び出し (diff / deploy) の context 集合が一致している
+//         (diff だけに渡して deploy に渡し忘れる = 差分が出ないまま env が落ちる、を検出)
+//   [AD4] incident 通知先が本番 compute の全 cdk 呼び出しに渡っている
+//   [AD5] secret が空のとき deploy は止めないが必ず警告する
+//   [AD6] deploy 後に **実 Lambda env** を読んで検証し、配線不良なら hard-fail する
+//         (synth の diff では「渡し忘れ」を検出できないため、実 env を見る step が要る)
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: 走査 API + repo root を参照するため gate は scope='repo' と静的判定する。
+// 実測は数十 ms だが、判定を緩めず明示 timeout で合わせる (tests/CLAUDE.md §repo 走査 test)。
+vi.setConfig({ testTimeout: 60_000 });
+
+const ROOT = process.cwd();
+const DEPLOY_WORKFLOW = join(ROOT, '.github', 'workflows', 'deploy.yml');
+const STAGING_WORKFLOW = join(ROOT, '.github', 'workflows', 'deploy-aws-staging.yml');
+const CDK_APP = join(ROOT, 'infra', 'bin', 'app.ts');
+const CDK_LIB_DIR = join(ROOT, 'infra', 'lib');
+
+/**
+ * GitHub Actions の式 `${{ ... }}` を組み立てる。
+ *
+ * リテラルで書くと biome の `noTemplateCurlyInString` に引っかかる (JS の template literal と
+ * 見分けが付かないため)。式であることを明示して組み立てる。
+ */
+function ghaExpr(expression: string): string {
+	return `\${{ ${expression} }}`;
+}
+
+const deployWorkflow = readFileSync(DEPLOY_WORKFLOW, 'utf-8');
+const stagingWorkflow = readFileSync(STAGING_WORKFLOW, 'utf-8');
+
+/**
+ * CDK 側が `tryGetContext` で読む context key の全集合。
+ *
+ * **CDK が SSOT** であり、本 test はそこから要求を読む (workflow 側の一覧を手で写さない)。
+ * `infra/lib` は単一 dir の走査で、stack file を足したら自動で対象に入る。
+ */
+function contextKeysReadByCdk(): Set<string> {
+	const sources = [CDK_APP];
+	for (const name of readdirSync(CDK_LIB_DIR)) {
+		if (name.endsWith('.ts')) sources.push(join(CDK_LIB_DIR, name));
+	}
+	const keys = new Set<string>();
+	for (const path of sources) {
+		const src = readFileSync(path, 'utf-8');
+		for (const m of src.matchAll(/tryGetContext\(\s*['"]([A-Za-z0-9_]+)['"]\s*\)/g)) {
+			const key = m[1];
+			if (typeof key === 'string') keys.add(key);
+		}
+	}
+	return keys;
+}
+
+/** workflow が `-c key=` の形で実際に渡している context key。 */
+function contextKeysPassedBy(workflow: string): Set<string> {
+	const keys = new Set<string>();
+	for (const m of workflow.matchAll(/-c\s+([A-Za-z0-9_]+)=/g)) {
+		const key = m[1];
+		if (typeof key === 'string') keys.add(key);
+	}
+	// `${{ secrets.X && format('-c googleClientId={0}', ...) }}` 形式の条件付き注入も拾う。
+	for (const m of workflow.matchAll(/format\(\s*'-c\s+([A-Za-z0-9_]+)=/g)) {
+		const key = m[1];
+		if (typeof key === 'string') keys.add(key);
+	}
+	return keys;
+}
+
+/**
+ * **渡していないことが正しい** context key と、その理由。
+ *
+ * ここに載せるのは「渡さなくても壊れない」ものだけ。壊れるものは follow-up Issue 番号を
+ * 添えて `followUp` に書き、放置されないようにする (理由なき免除を作らない)。
+ */
+const CONTEXT_KEYS_NOT_DISTRIBUTED: Array<{
+	key: string;
+	why: string;
+	followUp?: string;
+}> = [
+	{
+		key: 'demoDomainName',
+		why: 'default が `demo.<domainName>` (infra/bin/app.ts)。上書きしたいときだけ渡す任意 override で、未指定が正常系',
+	},
+	{
+		key: 'demoCertificateArn',
+		why: 'default が本番 `certificateArn` (infra/bin/app.ts)。wildcard 証明書を共用するため未指定が正常系',
+	},
+	{
+		key: 'opsEmail',
+		why: '未指定だと OpsStack の SNS topic に subscription が 1 件も付かず、全 CloudWatch alarm が宛先なしになる。配布すべき値 (通知先アドレス) が未決のため本 PR では塞げない',
+		followUp: '#4189',
+	},
+];
+
+describe('#4174 AWS deploy の context 配布 closure', () => {
+	const readByCdk = contextKeysReadByCdk();
+	const passed = new Set([
+		...contextKeysPassedBy(deployWorkflow),
+		...contextKeysPassedBy(stagingWorkflow),
+	]);
+	const exempt = new Map(CONTEXT_KEYS_NOT_DISTRIBUTED.map((e) => [e.key, e]));
+
+	it('[AD1] CDK が読む context key はいずれかの workflow から渡されている', () => {
+		// 「読む口はあるが誰も渡さない」= その env は Lambda に存在しない。
+		// deploy は成功するので、この test 以外に検出手段がない。
+		const unaccounted = [...readByCdk].filter((k) => !passed.has(k) && !exempt.has(k));
+		expect(
+			unaccounted,
+			`CDK が tryGetContext で読んでいるのに、どの workflow も -c で渡していない context key があります: ${unaccounted.join(', ')}。` +
+				`workflow に \`-c <key>=${ghaExpr('secrets.X')}\` を足すか、渡さなくてよい理由を CONTEXT_KEYS_NOT_DISTRIBUTED に明示してください。`,
+		).toEqual([]);
+	});
+
+	it('[AD2] 免除リストが stale でない (渡すようになった key が残り続けない)', () => {
+		const stale = CONTEXT_KEYS_NOT_DISTRIBUTED.filter((e) => passed.has(e.key)).map((e) => e.key);
+		expect(
+			stale,
+			`免除リストにあるのに実際は workflow から渡されている key があります: ${stale.join(', ')}。CONTEXT_KEYS_NOT_DISTRIBUTED から削除してください。`,
+		).toEqual([]);
+
+		const unknown = CONTEXT_KEYS_NOT_DISTRIBUTED.filter((e) => !readByCdk.has(e.key)).map(
+			(e) => e.key,
+		);
+		expect(
+			unknown,
+			`免除リストにあるのに CDK が読んでいない key があります: ${unknown.join(', ')}。CDK 側の撤去に合わせて削除してください。`,
+		).toEqual([]);
+
+		for (const entry of CONTEXT_KEYS_NOT_DISTRIBUTED) {
+			expect(entry.why.length, `${entry.key} の免除理由が短すぎます`).toBeGreaterThan(20);
+			if (entry.followUp !== undefined) {
+				// 「壊れているが今は塞げない」ものは追跡先を必ず持つ。理由の非強制を作らない。
+				expect(
+					entry.followUp,
+					`${entry.key} の followUp は Issue 番号 (#NNNN) で書いてください`,
+				).toMatch(/^#\d+$/);
+			}
+		}
+	});
+
+	it('[AD3] 本番 compute を触る cdk diff / deploy の context 集合が一致している', () => {
+		// diff にだけ渡して deploy に渡し忘れると、**diff には差分が出ないのに実 env が落ちる**。
+		// 逆方向 (deploy だけ) も replacement check が実構成とずれるので不可。
+		const steps = productionComputeCdkSteps();
+		expect(steps.length, '本番 compute を触る cdk 呼び出しが見つかりません').toBeGreaterThanOrEqual(
+			2,
+		);
+		const [first, ...rest] = steps;
+		if (!first) throw new Error('unreachable');
+		const baseline = [...contextKeysPassedBy(first.body)].sort();
+		for (const step of rest) {
+			expect(
+				[...contextKeysPassedBy(step.body)].sort(),
+				`cdk 呼び出し間で渡す context が食い違っています ("${first.name}" vs "${step.name}")`,
+			).toEqual(baseline);
+		}
+	});
+
+	it('[AD4] incident 通知先が本番 compute の全 cdk 呼び出しに渡っている', () => {
+		for (const step of productionComputeCdkSteps()) {
+			expect(
+				step.body,
+				`"${step.name}" が discordWebhookIncident を渡していません。本番 Lambda から DISCORD_WEBHOOK_INCIDENT が落ち、障害通知が 0 通になります (#4174)`,
+			).toContain(`-c discordWebhookIncident=${ghaExpr('secrets.DISCORD_WEBHOOK_INCIDENT')}`);
+		}
+	});
+
+	it('[AD5] incident 通知先の secret が空なら警告を出す (黙って進めない)', () => {
+		// 通知先の欠落で deploy を止めるのは過剰 (アプリ本体は動く) だが、
+		// **黙って進むと「障害が起きても誰にも届かない」状態が可視化されない** (ADR-0024)。
+		const step = workflowStep(deployWorkflow, 'Incident webhook secret presence');
+		expect(step).toContain('secrets.DISCORD_WEBHOOK_INCIDENT');
+		expect(step).toContain('::warning::');
+		expect(step).toContain('INCIDENT_WEBHOOK_CONFIGURED');
+	});
+
+	it('[AD6] deploy 後に実 Lambda env を読んで検証し、配線不良なら fail する', () => {
+		// synth の diff では「渡し忘れ」を検出できない (渡し忘れた状態が現状なので差分が出ない)。
+		// deploy 済みの実 env を読む step だけが、配線が生きていることを示せる。
+		const step = workflowStep(deployWorkflow, 'Incident webhook env verification');
+		expect(step).toContain('aws lambda get-function-configuration');
+		expect(step).toContain('Environment.Variables');
+		expect(step).toContain('DISCORD_WEBHOOK_INCIDENT');
+		expect(step, '配線不良を検出しても exit しないなら gate にならない').toContain('exit 1');
+		expect(step).toContain('::error::');
+	});
+});
+
+/** `- name: X` 単位で workflow を切り出し、name に `needle` を含む step の本文を返す。 */
+function workflowStep(workflow: string, needle: string): string {
+	const step = splitWorkflowSteps(workflow).find((s) => s.name.includes(needle));
+	if (!step) throw new Error(`workflow に "${needle}" を含む step が見つかりません`);
+	return step.body;
+}
+
+function splitWorkflowSteps(workflow: string): Array<{ name: string; body: string }> {
+	const steps: Array<{ name: string; body: string }> = [];
+	const starts = [...workflow.matchAll(/^ {6}- name: (.+)$/gm)];
+	for (const [i, m] of starts.entries()) {
+		const name = m[1];
+		if (typeof name !== 'string' || m.index === undefined) continue;
+		const end = starts[i + 1]?.index ?? workflow.length;
+		steps.push({ name: name.trim(), body: workflow.slice(m.index, end) });
+	}
+	return steps;
+}
+
+/**
+ * 本番 compute stack を触る cdk 呼び出し step (diff / deploy)。
+ *
+ * compute stack を含む呼び出しは DSQL endpoint を必ず渡す (compute-stack.ts が未注入で synth error に
+ * する) ため、`-c dsqlEndpoint=` の有無で判別する。Storage 単独 deploy はここに入らない。
+ */
+function productionComputeCdkSteps(): Array<{ name: string; body: string }> {
+	return splitWorkflowSteps(deployWorkflow).filter(
+		(s) => s.body.includes('npx cdk') && s.body.includes('-c dsqlEndpoint='),
+	);
+}


### PR DESCRIPTION
## 顧客価値・目的

**本番で障害が起きたとき、通知が誰にも届かない状態を塞ぎます。**

`compute-stack.ts` は incident 通知先を CDK context から受ける口を持っていますが、`deploy.yml` が **その context を一度も渡していませんでした**。

```
$ grep -n discordWebhookIncident infra/lib/compute-stack.ts
228:  const discordWebhookIncident = this.node.tryGetContext('discordWebhookIncident') ?? '';
359:  ...(discordWebhookIncident ? { DISCORD_WEBHOOK_INCIDENT: discordWebhookIncident } : {}),

$ grep -n discordWebhookIncident .github/workflows/deploy.yml   # 修正前
（該当なし）
```

`?? ''` で空になり L359 の条件分岐で **env ごと Lambda から落ちます**。宛先解決は `DISCORD_ALERT_WEBHOOK_URL ?? DISCORD_WEBHOOK_INCIDENT` で、どちらも無ければ静かに no-op になるため、**本番 Lambda で incident 通知が一度も飛んでいませんでした**。

#4119（NUC で 18 晩バックアップが失敗し続けても alert 0 通）と同型です。NUC 側は #4167 / PR #4168 で塞ぎましたが、AWS 側は未着手でした。

## 関連 Issue

Refs #4174

<!-- no-issue-close: AC4「意図的に失敗させて通知が届くことを 1 度実証」は本番 deploy を伴うため Dev では実行できません。実機確認の手順を Issue に残し、close 判断は人が行います -->

## AC 検証マップ (ADR-0004)

HEAD SHA: `fc7b187d3`

| AC | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | synth / deploy に `-c discordWebhookIncident=` を渡す | workflow diff + `[AD4]` | **充足**。`cdk diff` / `cdk deploy --all` の両方に追加。`[AD4]` が全 cdk 呼び出しでの存在を assert |
| AC2 | secret が空のとき deploy が黙って進まない | `[AD5]` | **充足**。`::warning::` を出す（ADR-0024。deploy は止めない — アプリ本体は動くため。#4168 の任意 env と同じ扱い） |
| AC3 | 本番 Lambda の env に実際に入ることを deploy 後に **実測**する | post-deploy step + `[AD6]` | **機構は充足 / 実行は未達**。`aws lambda get-function-configuration` で **実 env の key** を読み、secret 登録済なのに無ければ hard-fail する step を追加。**実行は main 反映後の deploy 時**（下記「実測できない範囲」） |
| AC4 | 意図的に失敗させて通知が届くことを 1 度実証する | — | **未達**。本番 deploy と本番での意図的障害誘発が要るため Dev では実行不可。手順を #4174 に残し `state:needs-owner` を付与 |
| AC5 | `tryGetContext` を全件 grep し同型を確認する | grep + `[AD1]` | **充足**。7 件中 3 件が同型。うち 3 チャネル（signup/billing/churn）を本 PR で配線、`opsEmail` は #4189 に分離（下記） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（UI 変更ゼロ）。本番 deploy 時の CDK context と post-deploy 検証のみ。

- [x] **並行実装ペア**を同期した: `cdk diff` と `cdk deploy` は同じ context を渡す必要があり、`[AD3]` が両者の集合一致を機械検証する（diff にだけ渡して deploy に渡し忘れると、**diff に差分が出ないまま env が落ちる**）
- [x] **設計書同期** (ADR-0001): `docs/design/23-Discordサーバー設計書.md` §4.3 / §4.4 に「GitHub Secret → `-c` context → Lambda env」の 3 段対応表と、1 段でも欠けると env ごと落ちる構造、2 層 gate を明記
- [ ] **LP ↔ アプリ整合** (ADR-0013): N/A
- [ ] **重量 e2e 敏感領域**: N/A

### AC5 — `tryGetContext` 全件 grep の結果

CDK が読む context key 31 件のうち、**どの workflow からも渡されていなかったのは 7 件**でした。

| context key | 判定 | 対応 |
|---|---|---|
| `discordWebhookIncident` | **同型（本件）** | 本 PR で配線 |
| `discordWebhookSignup` / `discordWebhookBilling` / `discordWebhookChurn` | **同型** | 本 PR で配線。secret 自体は未登録だが、**経路が無いと登録しても届かない**ため塞いだ |
| `opsEmail` | **同型（別 Issue）** | **#4189**。未渡しのため `OpsStack` の SNS topic に subscription が 1 件も付かず、**全 CloudWatch アラームが宛先ゼロ**。配布すべき通知先が未決のため本 PR では塞げない |
| `demoDomainName` / `demoCertificateArn` | 非該当 | `infra/bin/app.ts` に documented default（`demo.<domainName>` / 本番 `certificateArn`）があり、未指定が正常系 |

判定は `CONTEXT_KEYS_NOT_DISTRIBUTED` に理由付きで残し、`[AD2]` が stale 化（渡すようになったのに免除が残る / CDK から消えたのに免除が残る）を検出します。`followUp` は Issue 番号形式を強制し、**理由なき免除を作らせません**。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4190` | PASS |
| 追加・変更テスト | `npx vitest run tests/unit/infra/aws-deploy-context-closure.test.ts` | PASS (6 passed) |
| repo 走査宣言 gate | `node scripts/check-repo-scan-test-declaration.mjs` | PASS (39 件すべて宣言済) |
| env 配布 gate | `node scripts/check-new-required-env.mjs` | PASS (no newly required env) |
| doc-code 参照 gate | `node scripts/check-doc-code-references.mjs` | PASS (baseline 内、新規違反なし) |
| cspell | `npm run cspell` | PASS (1810 files, 0 issues) |

### mutation 検証（**先に commit してから**変更 → `git stash push` で退避）

| mutation | 内容 | 結果 |
|---|---|---|
| A | `cdk diff` から `-c discordWebhookIncident=` を削除 | `[AD3]` `[AD4]` **2 件 fail** |
| B | `-c discordWebhookSupport=` を別名に改変（= 未配布化） | `[AD1]` **1 件 fail**（`discordWebhookSupport` を列挙） |
| C | post-deploy 検証 step から `exit 1` を削除 | `[AD6]` **1 件 fail**（「gate にならない」） |

- [x] **SOLID / DRY / YAGNI**: 契約（CDK が読む key）を **CDK 側 SSOT から読み取り**、workflow と突き合わせる。key の一覧を test 側に手で写していないため、stack file を足せば自動で対象に入る
- [x] **Security（OSS 公開前提）**: secret 値は一切コミットしていません。post-deploy 検証は JMESPath `keys()` で **key 名だけ**を取り出し、webhook URL をシェル変数にも載せません
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): `priority:critical` label なし（`priority:high`）。ただし**障害検知の欠落**に直結するため証跡は critical 相当で残しました

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: UI 変更ゼロの deploy workflow / fitness test / 設計書の変更で、画面に現れる差分が存在しないため -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる

**レビュー依頼事項**:

### 実測できない範囲を明示します（重要）

**Dev は AWS 本番へ deploy できません**（不可逆操作）。したがって以下は**本 PR では実測していません**:

| 未実測 | 誰が / いつ |
|---|---|
| 本番 Lambda の env に `DISCORD_WEBHOOK_INCIDENT` が実際に入ること（AC3） | main 反映後の deploy で post-deploy step が**自動で実測**する。落ちれば deploy が赤くなる |
| 意図的な障害で通知が届くこと（AC4） | オーナーが手動実施。#4174 に手順を残し `state:needs-owner` を付与 |

**「synth の diff ではなく実 env をどう担保するか」**への設計上の回答は、**deploy 自身に実 env を読ませる**ことです。synth の diff は「渡し忘れ」を検出できません — 渡し忘れた状態が現状なので差分が出ないためです。post-deploy step は deploy 済み Lambda の実際の env key を読むため、配線が切れていれば必ず赤くなります。

### post-deploy 検証が hard-fail する条件を限定しています

| 状態 | 挙動 |
|---|---|
| secret 未登録 | skip（前段で `::warning::` 済） |
| secret 登録済 + env にある | pass |
| secret 登録済 + env に無い | **hard-fail**（= 配線不良。#4174 そのもの） |

3 行目でしか落ちないため、false gate になりません。また**この失敗は image rollback を起こしません**（rollback は health check 失敗時に限定）。アプリ本体は健全なので巻き戻す理由がなく、deploy を赤くして配線不良を可視化するのが目的です。

### `-c discordWebhookSignup` / `_BILLING` / `_CHURN` を同時に配線しました

これらの secret は**未登録**です。値が無いので今日の挙動は変わりませんが、**経路が無いと secret を登録しても届かない**ため、同じ穴を残さないよう塞ぎました。「これらのチャネルを持つか」は PO 判断で、本 PR は判断を先取りしていません（未登録なら従来どおり無効）。

### #4189 を切り出しました

`opsEmail` の未配布により **本番 CloudWatch アラームの SNS topic に subscription が 1 件も付いていません**。#4174 と完全に同 class ですが、**どのアドレス / チャネルに送るかが PO 判断**のため本 PR では塞げず、`CONTEXT_KEYS_NOT_DISTRIBUTED` に `followUp: '#4189'` 付きで残しました（`[AD2]` が Issue 番号形式を強制します）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`DISCORD_WEBHOOK_INCIDENT` は #4167 対応時に登録済。本 PR はその配布経路を通しただけ）

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない。AC4 は本番実機が要るため機構ではなく実行が残る旨を上記に明示）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面の変更なし）

## QM レビュー結果

<!-- QM が記入 -->


## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — revert で元に戻る"]
    R2["顧客面: 画面変化なし。運用者の障害検知のみ"]
    R3["ロールバック: データ破壊なし。deploy 設定のみ"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 本番の障害通知が 0 通 → 届く"]
    T2["捨てる: 配線不良で deploy が赤くなる"]
    T3["負債: 未登録 3 チャネルの配線が残る"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: 直るのは incident 1 本のみ"]
    O2["UX: 初回に通知 flood の可能性"]
    O3["security: webhook URL が Lambda env に常駐"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["家族の画面は不変。届く先は運用者のみ"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 障害通知先は Discord でよいか"]
    Q2["Q2: signup/billing/churn を持つか"]
    Q3["Q3: 通知に tenantId を載せてよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1 ok
  class R2,R3 ok
  class T2,T3,O1,O2 warn
  class O3 danger
  class T1,C1 ok
  class Q1,Q2,Q3 ask
```

**UI 変更なし** — 画面に現れる差分が存在しないため実機 SS はありません（`ss-pair-none` 宣言済）。

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

### ③ の出典

`tmp/adversarial-evidence/4190.json`（`node scripts/verify-adversarial-output.mjs --pr 4190` PASS）。3 軸の全文はそちら。要点のみ:

- **business**: 本 PR が直すのは incident チャネル 1 本のみ。**CloudWatch アラーム全系統は #4189 のとおり宛先ゼロのまま**。「通知は直った」と読んで CloudWatch 側を追わなくなるのが最大の機会損失
- **UX**: 0 通だった状態から届くようになるため、未検出のまま蓄積した失敗条件が deploy 直後に **まとめて発火**しうる。flood はチャネルを「読まれないチャネル」に変える。本 PR は rate limit を足していない
- **security**: webhook URL は bearer 相当で、**認証なしに任意の内容をそのチャネルへ投稿できる**。Lambda env を読める経路が 1 つでも生まれれば、偽の障害通知・偽の復旧手順を投稿する運用者フィッシングが成立する

### 判断依頼の背景

| Q | 背景 |
|---|---|
| **Q1** 障害通知先は Discord でよいか | #4189（CloudWatch アラームの宛先ゼロ）を塞ぐとき、メールにするか Discord に寄せるかで実装が変わります。本 PR は既存設計（`discord-alert.ts` の `DISCORD_ALERT_WEBHOOK_URL ?? DISCORD_WEBHOOK_INCIDENT`）に従っただけで、方針を決めていません |
| **Q2** signup / billing / churn を持つか | secret 未登録のまま**配線だけ**通しました（経路が無いと登録しても届かないため）。持たない方針なら 3 行削除、持つ方針なら secret 登録だけで動きます。**今日の挙動はどちらでも変わりません** |
| **Q3** 通知に tenantId を載せてよいか | `discord-alert.ts` / `discord-notify-service.ts` の payload に家族の識別子が含まれる場合、**外部 SaaS のチャットログに永続化**されます。本 PR も既存設計書もこの点を評価していません。本 PR の scope 外ですが、通知が実際に飛び始めるのは本 PR 以降なので判断時期としては今です |

### security 反対理由が本 PR 固有ではない点

webhook URL の Lambda env 常駐は `FEEDBACK_DISCORD_WEBHOOK_URL` / `DISCORD_WEBHOOK_SUPPORT` で既に存在する既存パターンで、本 PR が新しく作った class ではありません。ただし**「既存だから安全」ではない**ため、Q3 とあわせて判断材料として残します。

### Accepted residual (Pre-PMF)

- 通知の rate limit / 重複抑制は本 PR で足していません（`17b-ログ設計書` §5.3 のバースト抑制はアプリ層の別機構）。初回 flood が実際に起きたら対処する方が、起きるか分からない flood に先回りするより安いと判断しました
- `demoDomainName` / `demoCertificateArn` は documented default があるため未配布のままにしています

</details>
