### PR TITLE
fix(ci): #4121 check-pr-body の 26 検査を blocking / advisory に分離する

### DIFF
--- a/docs/decisions/0007-static-analysis-tier-policy.md
+++ b/docs/decisions/0007-static-analysis-tier-policy.md
@@ -43,6 +43,7 @@
 **適用実績 (#4121 Wave 2)**:
 
 - `check-lp-plan-sync` を advisory (`continue-on-error`) から **hard-fail に復帰**。類型 2 かつ静的テキスト比較で cheap のため。回帰ガード: `tests/unit/scripts/pre-ready-step-budget.test.ts` [P6] / [P7]
+- **`check-pr-body.mjs` の 26 検査を id 単位で blocking / advisory に分離** (#4121 決裁 4、2026-08-02)。1 本の script に 類型 1 と 類型 3 が同居していたため **script 単位で「pr-body は類型 1」と扱われ、書式検査 19 本が類型 1 の看板で hard-fail に残っていた**（統合 PR #3995 が 60 check 中 57 SUCCESS でありながら書式 gate 2 本で 4 日間 BLOCK された実害の構造）。**hard-fail するのは `BLOCKING_GATES` に明示列挙した 7 件のみ**（証跡の宛先 / close 宣言の着地 / 証跡なき自己申告 / PO 決裁ブリーフ 3 件 / 統合 PR エビデンス表）で、**列挙されていない検査は advisory が既定**。新しい検査を足すときに hard-fail 化を明示的な意思決定にするための向き付け（憲章 §3.4 制約 1 と同型）。advisory は `ADVISORY-IDS <ids>` の 1 行を必ず出し、**2 run 連続で無反応なら削除候補**として棚卸しに上げる（記録用の新装置は作らず CI ログを grep する）。回帰ガード: `tests/unit/scripts/check-pr-body-severity.test.ts`（id タイプミスで gate が無言 advisory 化するのを機械検出）
 - `npm run pre-ready` を **20 step → 6 step** に縮小 (類型 1: pr-body / ss-embed-gate、類型 2 cheap: biome / svelte-check / plan-literals / local-tz-getters)。**外した 14 検査は消していない** — vitest は CI `unit-test`、残りは CI `lint-and-test` / `lp-metrics.yml` / `lp-fallback-check.yml` で hard-fail のまま走る (対応表 SSOT: `npm run pre-ready -- --help`)。`capture` step のみ、検査せずガイダンスを表示するだけ (類型 4 = 参照ゼロ相当) のため撤去
 
 ### 2. 新ツール導入時の判断フロー

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -1300,6 +1300,140 @@ export function resolveLabels(args, fetched) {
  *
  * @type {ReadonlyArray<{ id: string; name: string; issue: string }>}
  */
+/**
+ * hard-fail する検査の一覧 (#4121 決裁 4、ADR-0007 §1-2 判断原則 v2)。
+ *
+ * ## なぜ既定を advisory 側に置くか
+ *
+ * 本 script は 26 の検査を持つが、その大半は **書式・網羅性 (類型 3)** であり、
+ * 判断原則 v2 は「warn 降格 or 撤去」と定めている。にもかかわらず全部が hard-fail だったのは、
+ * **1 本の script に 類型 1 と 類型 3 が同居し、script 単位で「pr-body は類型 1」と
+ * 扱われていた**ため (#4121 Platform 計測)。統合 PR #3995 が 60 check 中 57 SUCCESS で
+ * ありながら書式 gate 2 本により 4 日間 BLOCK された実害はこの構造から出ている。
+ *
+ * そこで **hard-fail する側を明示列挙し、列挙されていない検査は advisory** とする。
+ * 既定を advisory に倒すのは、新しい検査を足すときに **hard-fail 化を明示的な意思決定**に
+ * するため (装置の総数 ratchet と同型の力学、チーム憲章 §3.4 制約 1)。
+ *
+ * ## 各件が hard-fail である理由 (類型 1 = 証跡の真正性 / 不可逆な損失)
+ *
+ * advisory に落ちた検査は **消えていない**。違反は必ず出力され、AI レビュアと QM が読む。
+ * 出力は `formatAdvisoryReport` が安定した 1 行 (`ADVISORY-IDS ...`) を含むため、
+ * CI ログから機械的に拾える (#4121 AC7 の「warn の出口」)。
+ *
+ * ## advisory に落とした検査の多くは、別 job が単独で hard-fail を続ける
+ *
+ * 本 script は「PR body を見る検査」を 1 本に寄せ集めており、**同じ観点を専用 job も持っている**。
+ * その重複分は本 script 側を advisory にしても gate は消えない (二重 gate が 1 本になるだけ):
+ *
+ * | 本 script の id | 引き続き hard-fail する job (script) |
+ * |---|---|
+ * | `missing-required-sections` | `pr-template-gate.yml`「必須セクションの存在確認」(`checkSectionPresence`) |
+ * | `change-type-unselected` | 同「変更タイプの選択」(`checkChangeType`) |
+ * | `ac-map-missing` / `-empty` / `-incomplete` | `pr-ac-verification-check.yml`「Verify AC map in PR body」(`checkPerPrAcMap`) |
+ * | `unchecked-ready-checklist` | `pr-merge-gate.yml`「PR チェックリスト完了確認」(`checkMergeGateChecklist`) |
+ *
+ * 残り (mojibake / placeholder 各種 / forbidden-terms / hotfix env 節 / mergeable-conflicting) は
+ * 本 script が唯一の検出点なので、**真に advisory になる**。うち `mergeable-conflicting` は
+ * GitHub 本体が conflict した PR の merge を拒否するため、gate としては元々冗長だった。
+ */
+export const BLOCKING_GATES = [
+	{
+		id: 'evidence-pr-mismatch',
+		name: 'AC 根拠の PR 番号が自 PR と一致',
+		issue: '#4074',
+		why: '証跡の宛先違い。別 PR / 存在しない番号を指した根拠はその PR を検証した証拠にならない (ADR-0004 が hard-fail 維持と明記)',
+	},
+	{
+		id: 'closes-not-landed',
+		name: '下書きの close 宣言が実 body に着地済み',
+		issue: '#4170',
+		why: '不可逆。閉じてはいけない Issue が main 反映で auto-close されると、後から静かには戻せない',
+	},
+	{
+		id: 'self-review-evidence-missing',
+		name: 'Self-Review の [x] に検証コマンド証跡がある',
+		issue: '#3899',
+		why: '証跡なき PASS は false PASS と同等 (docs/operations/self-review-agent.md §2.4)。自己申告だけで [x] が立つ経路を残さない',
+	},
+	{
+		id: 'po-decision-brief-missing-section',
+		name: 'PO 決裁ブリーフ (見出し)',
+		issue: '#3962',
+		why: '不可逆な変更 (DB schema / Stripe / auth / infra) を PO 決裁を経ずに通す = 自己承認。#3944 / #3956 で 2 回連続再発し ADR-0061 same-class-N→guard で gate 化したばかり',
+	},
+	{
+		id: 'po-decision-brief-missing-diagram',
+		name: 'PO 決裁ブリーフ (mermaid)',
+		issue: '#3962',
+		why: '同上。図が無いブリーフは PO が 5 秒で判断できず、決裁が形骸化する',
+	},
+	{
+		id: 'po-decision-brief-unfilled-placeholder',
+		name: 'PO 決裁ブリーフ (未置換プレースホルダ)',
+		issue: '#3962',
+		why: '同上。`___` が残ったブリーフは「出したが中身が無い」= 証跡の偽装に等しい',
+	},
+	{
+		id: 'integration-evidence-missing',
+		name: '統合 PR のマージ判定エビデンス表',
+		issue: '#2945',
+		why: 'main 反映は不可逆。統合 gate は監査の職掌 (audit-team.md §3.5) であり、本 script の書式整理とは別系統のため現状維持',
+	},
+];
+
+/** @type {ReadonlySet<string>} */
+export const BLOCKING_VIOLATION_IDS = new Set(BLOCKING_GATES.map((g) => g.id));
+
+/**
+ * violations を hard-fail (blocking) と advisory に分ける (#4121 決裁 4)。
+ *
+ * @template {{ id: string }} T
+ * @param {T[]} violations
+ * @returns {{ blocking: T[]; advisory: T[] }}
+ */
+export function partitionBySeverity(violations) {
+	/** @type {T[]} */
+	const blocking = [];
+	/** @type {T[]} */
+	const advisory = [];
+	for (const v of violations) {
+		if (BLOCKING_VIOLATION_IDS.has(v.id)) blocking.push(v);
+		else advisory.push(v);
+	}
+	return { blocking, advisory };
+}
+
+/**
+ * advisory 違反の出力行を組み立てる (#4121 AC7「warn の出口」)。
+ *
+ * **`ADVISORY-IDS` 行を必ず 1 行で出す**。降格した検査が誰にも読まれないまま放置されるのを
+ * 防ぐには「何が何回 warn を出したか」を後から数えられる必要があるが、そのために新しい記録装置を
+ * 作るのは装置 ratchet に反する (チーム憲章 §3.4 制約 1)。既存の CI ログに安定した書式で
+ * 出しておけば、月次棚卸しで `grep ADVISORY-IDS` して数えられる。
+ *
+ * @param {{ id: string; message: string; issue?: string }[]} advisory
+ * @returns {string[]}
+ */
+export function formatAdvisoryReport(advisory) {
+	if (advisory.length === 0) return [];
+	const lines = [
+		`[check-pr-body] ADVISORY — ${advisory.length} 件 (merge は止めません。AI レビュアと QM が読む対象です、#4121)`,
+		`[check-pr-body] ADVISORY-IDS ${advisory.map((v) => v.id).join(',')}`,
+		'',
+	];
+	for (const v of advisory) {
+		lines.push(`⚠ [${v.id}] (${v.issue ?? '-'})`);
+		lines.push(`  ${v.message.split('\n').join('\n  ')}`);
+		lines.push('');
+	}
+	lines.push(
+		'  ※ advisory は「検査していない」ではなく「検出したが merge を止めない」です。',
+		'     2 run 連続で誰も対応しなかった advisory は削除候補として棚卸しに上げてください (#4121 AC7)。',
+	);
+	return lines;
+}
+
 export const READY_ONLY_GATES = [
 	{
 		id: 'unchecked-ready-checklist',
@@ -1724,6 +1858,21 @@ lane による観点の切替 (#4130):
   「マージ判定エビデンス表 + 残 NG 0 件」を検証する (検査を外すのではなく観点を切替える)。
   禁止語 / mojibake / 未置換プレースホルダ / label 条件付き gate は全 lane 共通で効く。
 
+blocking / advisory の切り分け (#4121 決裁 4、ADR-0007 §1-2 判断原則 v2):
+  **merge を止めるのは 類型 1 (証跡の真正性 / 不可逆な損失) の ${BLOCKING_GATES.length} 件だけ**:
+${BLOCKING_GATES.map((g) => `    - ${g.id} (${g.issue}) — ${g.why}`).join('\n')}
+
+  これ以外の検査 (書式・網羅性 = 類型 3) は **advisory**。検出して必ず出力するが exit code に
+  影響させない。「検査していない」のではなく「検出したが merge を止めない」であり、内容の妥当性は
+  AI レビュアと QM が読んで判断する。
+
+  advisory は \`ADVISORY-IDS <id,id,...>\` の 1 行を必ず出す。**2 run 連続で誰も対応しなかった
+  advisory は削除候補**として棚卸しに上げる (#4121 AC7)。記録用の新しい装置は作らない —
+  CI ログを \`grep ADVISORY-IDS\` して数える。
+
+  新しい検査を足すときの既定は advisory。hard-fail にしたいなら BLOCKING_GATES に
+  「何を守るか (類型 1 のどれか)」を書いて明示的に足す。
+
 Draft PR の扱い (#3997):
   Draft PR では Ready 化要件 ${READY_ONLY_GATES.length} 件 (${READY_ONLY_GATES.map((g) => g.id).join(' / ')})
   のみ deferred する。それ以外 (必須セクション / AC 4 列 / 禁止語 / mojibake / 変更タイプ / CONFLICTING /
@@ -2044,22 +2193,29 @@ export async function main(argv = process.argv.slice(2)) {
 		for (const line of formatDraftDeferredGates(deferred, args.pr, reason)) console.log(line);
 	}
 
-	if (violations.length === 0) {
+	// #4121 決裁 4: 類型 1 (証跡の真正性 / 不可逆) のみ merge を止める。
+	// 類型 3 (書式・網羅性) は検出して出力するが exit code に影響させない。
+	const { blocking, advisory } = partitionBySeverity(violations);
+	for (const line of formatAdvisoryReport(advisory)) console.log(line);
+
+	if (blocking.length === 0) {
 		const draftNote = draftState.isDraft
 			? ` (Draft のため Ready 化要件 ${READY_ONLY_GATES.length} 件は deferred)`
 			: args.skipReadyOnly
 				? ` (--skip-ready-only のため Ready 化要件 ${READY_ONLY_GATES.length} 件は未検査)`
 				: '';
+		const advisoryNote =
+			advisory.length > 0 ? ` (advisory ${advisory.length} 件あり — 上記 ⚠ を確認)` : '';
 		console.log(
 			skippedCount > 0
-				? `[check-pr-body] OK (label 条件付き gate ${skippedCount} 件は未検査)${draftNote} — 違反なし`
-				: `[check-pr-body] OK${draftNote} — 違反なし`,
+				? `[check-pr-body] OK (label 条件付き gate ${skippedCount} 件は未検査)${draftNote}${advisoryNote} — blocking 違反なし`
+				: `[check-pr-body] OK${draftNote}${advisoryNote} — blocking 違反なし`,
 		);
 		return 0;
 	}
 
-	console.log(`[check-pr-body] FAIL — ${violations.length} 件の違反:\n`);
-	for (const v of violations) {
+	console.log(`[check-pr-body] FAIL — blocking ${blocking.length} 件の違反:\n`);
+	for (const v of blocking) {
 		console.log(`✗ [${v.id}] (${v.issue})`);
 		console.log(`  ${v.message.split('\n').join('\n  ')}\n`);
 	}

--- a/tests/unit/scripts/check-pr-body-severity.test.ts
+++ b/tests/unit/scripts/check-pr-body-severity.test.ts
@@ -1,0 +1,110 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	BLOCKING_GATES,
+	BLOCKING_VIOLATION_IDS,
+	formatAdvisoryReport,
+	partitionBySeverity,
+} from '../../../scripts/check-pr-body.mjs';
+
+/**
+ * #4121 決裁 4 — check-pr-body の blocking / advisory 切り分け。
+ *
+ * 本 script は 26 の検査を持つが、判断原則 v2 (ADR-0007 §1-2) では大半が
+ * 類型 3 (書式・網羅性) = 「warn 降格 or 撤去」に当たる。1 本の script に 類型 1 と 類型 3 が
+ * 同居していたため script 単位で全部 hard-fail になっていた構造を、id 単位の切り分けに変える。
+ */
+describe('#4121 blocking / advisory 切り分け', () => {
+	const makeViolation = (id: string) => ({ id, message: `${id} の説明`, issue: '#0000' });
+
+	describe('partitionBySeverity', () => {
+		it('BLOCKING_GATES に列挙された id だけが blocking になる', () => {
+			const violations = [
+				makeViolation('evidence-pr-mismatch'),
+				makeViolation('missing-required-sections'),
+				makeViolation('tbd'),
+			];
+			const { blocking, advisory } = partitionBySeverity(violations);
+			expect(blocking.map((v) => v.id)).toEqual(['evidence-pr-mismatch']);
+			expect(advisory.map((v) => v.id)).toEqual(['missing-required-sections', 'tbd']);
+		});
+
+		it('未知の id は advisory に落ちる（新しい検査の既定は advisory）', () => {
+			const { blocking, advisory } = partitionBySeverity([makeViolation('brand-new-check')]);
+			expect(blocking).toHaveLength(0);
+			expect(advisory.map((v) => v.id)).toEqual(['brand-new-check']);
+		});
+
+		it('violations が空なら両方空', () => {
+			expect(partitionBySeverity([])).toEqual({ blocking: [], advisory: [] });
+		});
+
+		it('元の violation オブジェクトを壊さない（message / issue が保たれる）', () => {
+			const v = makeViolation('tbd');
+			const { advisory } = partitionBySeverity([v]);
+			expect(advisory[0]).toBe(v);
+		});
+	});
+
+	describe('formatAdvisoryReport', () => {
+		it('advisory が 0 件なら何も出さない（無音で緩めた印象を作らない代わりに、出す物が無い）', () => {
+			expect(formatAdvisoryReport([])).toEqual([]);
+		});
+
+		it('ADVISORY-IDS 行を 1 行だけ出し、id を カンマ区切りで並べる（#4121 AC7 の集計単位）', () => {
+			const lines = formatAdvisoryReport([makeViolation('tbd'), makeViolation('xxx')]);
+			const idLines = lines.filter((l) => l.includes('ADVISORY-IDS'));
+			expect(idLines).toHaveLength(1);
+			expect(idLines[0]).toContain('ADVISORY-IDS tbd,xxx');
+		});
+
+		it('各 advisory の message を本文に含める（検出内容を握り潰さない）', () => {
+			const lines = formatAdvisoryReport([makeViolation('tbd')]).join('\n');
+			expect(lines).toContain('tbd の説明');
+			expect(lines).toContain('⚠ [tbd]');
+		});
+
+		it('「検査していない」ではなく「止めない」であることを明示する', () => {
+			const text = formatAdvisoryReport([makeViolation('tbd')]).join('\n');
+			expect(text).toContain('検出したが merge を止めない');
+			expect(text).toContain('2 run 連続');
+		});
+	});
+
+	describe('BLOCKING_GATES の健全性（gate が生きているつもりで死んでいる状態を作らない）', () => {
+		const source = readFileSync(resolve(process.cwd(), 'scripts/check-pr-body.mjs'), 'utf-8');
+
+		it('列挙された id は全て check-pr-body.mjs が実際に生成する id である', () => {
+			// id をタイプミスすると **その gate は無言で advisory に落ちる**。
+			// #3969 (gate が生きているつもりで死んでいた) と同 class なので機械で固定する。
+			const producedIds = new Set([...source.matchAll(/\bid:\s*'([a-z0-9-]+)'/g)].map((m) => m[1]));
+			for (const gate of BLOCKING_GATES) {
+				expect(producedIds.has(gate.id), `${gate.id} が実装側に存在しない`).toBe(true);
+			}
+		});
+
+		it('各 gate は「何を守るか」(why) を持つ — 理由なしの hard-fail を作らない', () => {
+			for (const gate of BLOCKING_GATES) {
+				expect(gate.why, `${gate.id} に why がない`).toBeTruthy();
+				expect(gate.why.length, `${gate.id} の why が短すぎる`).toBeGreaterThanOrEqual(20);
+			}
+		});
+
+		it('id が重複していない', () => {
+			expect(BLOCKING_VIOLATION_IDS.size).toBe(BLOCKING_GATES.length);
+		});
+
+		it('証跡の真正性を守る 3 本が blocking から外れていない（降格の巻き戻し検出）', () => {
+			// この 3 本は ADR-0004 / #4170 / #3899 が hard-fail 維持と定めたもの。
+			// 「advisory を増やす」方向の変更でうっかり外れたら落とす。
+			for (const id of [
+				'evidence-pr-mismatch',
+				'closes-not-landed',
+				'self-review-evidence-missing',
+			]) {
+				expect(BLOCKING_VIOLATION_IDS.has(id), `${id} が blocking から外れている`).toBe(true);
+			}
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発基盤）／顧客には Dev の手戻り減少を通じて間接的に届く

**解決する課題**: `check-pr-body.mjs` の 26 検査が**すべて hard-fail** だった。判断原則 v2（ADR-0007 §1-2）は「書式・網羅性 = 類型 3 は warn 降格 or 撤去」と定めているのに、**1 本の script に 類型 1 と 類型 3 が同居し、script 単位で「pr-body は類型 1」と扱われていた**ため、書式検査 19 本が類型 1 の看板で merge を止め続けていた。統合 PR #3995 が 60 check 中 57 SUCCESS でありながら書式 gate 2 本で 4 日間 BLOCK された実害はこの構造から出ている。

**期待される効果**: merge を止めるのは証跡の真正性に関わる 7 件だけになる。書式の不備は**検出されて出力され続ける**が、修正のために merge を止めない。Dev の手戻り 3 指標（#4121 の新しい完了定義）のうち「QM の差し戻し件数」と「PR の往復回数」に直接効く。

## 関連 Issue

<!-- no-issue-close: #4121 は EPIC で、本 PR が消化するのは AC6（類型分離）と AC7（warn の出口）のみ。AC8（check-no-demo-route-duplication 81 行の削除）が未着手のため閉じない -->
#4121 の AC6 / AC7 を消化する。AC8 は未着手のため本 PR では閉じない。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC6 | `check-pr-body.mjs` の 29 検査を類型 1（2〜3 本）と類型 3（26 本）に分離し、類型 3 を warn へ降格する | `node scripts/check-pr-body.mjs --pr 4214 --body-file <書式違反のみの body> --skip-mergeable; echo $?` / `node scripts/check-pr-body.mjs --pr 4214 --body-file <他 PR 番号を含む body> --skip-mergeable; echo $?` | HEAD `4ef71a8b` / **書式違反のみ → `ADVISORY-IDS missing-required-sections,ac-map-missing,unreplaced-placeholder` を出力し exit 0**、**類型 1 違反あり → `FAIL — blocking 1 件の違反: evidence-pr-mismatch` で exit 1**（同時に advisory も `ADVISORY-IDS missing-required-sections` として出る = blocking と advisory が同一 run で両立する）。実 id は重複除去して **26 件**（Issue 本文の「29」は `id:` 出現行数で、`po-decision-brief-*` 3 件と `unchecked-ready-checklist` が 2 箇所ずつ現れる分の重複）。blocking は `BLOCKING_GATES` に **7 件**（`scripts/check-pr-body.mjs:1315-1385`）、advisory は残り **19 件** |
| AC7 | warn の出口を決める — 降格した検査が次の run で何件 warn を出したかを記録し、**2 run 連続で誰も対応しなかった warn は削除候補に上げる** | `npx vitest run tests/unit/scripts/check-pr-body-severity.test.ts` | HEAD `4ef71a8b` / 12 tests passed。`formatAdvisoryReport` が **`ADVISORY-IDS <id,id,...>` を必ず 1 行**出す（`tests/unit/scripts/check-pr-body-severity.test.ts:55-60` が「1 行だけ」を assert）。**記録用の新装置は作らない** — CI ログを `grep ADVISORY-IDS` して月次棚卸しで数える（装置 ratchet、憲章 §3.4 制約 1）。出力には「2 run 連続で誰も対応しなかった advisory は削除候補」の文言を含め、同 test が固定している |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客に見える画面の変更なし。影響は `check-pr-body.mjs` を呼ぶ 3 経路（`npm run pre-ready` Step 9 / `.husky/pre-push` / `pr-merge-gate.yml` の `pr-body-check` job）の **exit code**。

- [x] **並行実装ペア**を同期した — N/A。UI / DB / ラベルに触れていない
- [x] **設計書同期** (ADR-0001): `docs/decisions/0007-static-analysis-tier-policy.md` §1-2 の「適用実績」に本分離を追記（同 §が判断原則 v2 の SSOT）
- [x] **LP ↔ アプリ整合** (ADR-0013): N/A
- [x] **重量 e2e 敏感領域**: N/A
- [ ] N/A — 上記いずれも影響範囲外

### 降格した 19 件のうち 6 件は、別 job が単独で hard-fail を続けます

本 script は「PR body を見る検査」を 1 本に寄せ集めており、**同じ観点を専用 job も持っています**。その重複分は本 script 側を advisory にしても gate は消えません（**二重 gate が 1 本になるだけ**）。

| 本 script の id | 引き続き hard-fail する job（script） |
|---|---|
| `missing-required-sections` | `pr-template-gate.yml`「必須セクションの存在確認」(`checkSectionPresence`) |
| `change-type-unselected` | 同「変更タイプの選択」(`checkChangeType`) |
| `ac-map-missing` / `-empty` / `-incomplete` | `pr-ac-verification-check.yml`「Verify AC map in PR body」(`checkPerPrAcMap`) |
| `unchecked-ready-checklist` | `pr-merge-gate.yml`「PR チェックリスト完了確認」(`checkMergeGateChecklist`) |

残り（mojibake 2 件 / placeholder 系 7 件 / `forbidden-terms` / hotfix env 節 2 件 / `mergeable-conflicting`）は本 script が唯一の検出点なので、**真に advisory になります**。うち `mergeable-conflicting` は **GitHub 本体が conflict した PR の merge を拒否する**ため、gate としては元々冗長でした。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4214` | **ALL PASS（6 step）** — Step 9 Readiness gate / biome / plan-literals / local-tz-getters / svelte-check。Step 11b は UI 変更なしで適用対象外 |
| CI（`gh pr checks 4214`） | `unit-test (1)` / `(2)` / `unit-test-merge` / `lint-and-test` | **全 pass（skipping ではない）** |
| 追加テスト | `npx vitest run tests/unit/scripts/check-pr-body-severity.test.ts` | PASS — 12 tests |
| 既存テスト（退行確認） | `npx vitest run tests/unit/scripts/` | PASS — 55 files / 1106 passed / 1 skipped |
| 型 | `npx svelte-check --tsconfig ./tsconfig.json` | PASS — 8323 files / **0 errors 0 warnings** |
| lint | `npx biome check --error-on-warnings scripts/check-pr-body.mjs` | PASS |

### guard を外すと fail するか（mutation 検証）

**新しい gate は「破ったときに落ちること」が本体**なので、実際に壊して確認しました。

```
BLOCKING_GATES の 'closes-not-landed' を 'closes-not-landedX' に 1 文字変更
  → tests/unit/scripts/check-pr-body-severity.test.ts が 2 件 fail
     「closes-not-landedX が実装側に存在しない: expected false to be true」
  → 変更を戻して 12 tests 全 PASS を再確認
```

これは **id をタイプミスすると、その gate が無言で advisory に落ちる**という失敗モードを塞ぐためのものです（#3969「gate が生きているつもりで死んでいた」と同 class）。

- [x] **SOLID / DRY / YAGNI**: 既存の `READY_ONLY_GATES` / `partitionReadyOnlyViolations` と**同じ idiom**で書き、新しい抽象化を持ち込んでいない。severity 判定を 1 箇所（`partitionBySeverity`）に閉じた
- [x] **Security（OSS 公開前提）**: 秘密情報なし。降格対象に認証・認可・秘密情報を守る検査は含まれない
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — 顧客に見える画面の変更はありません。変更は `scripts/check-pr-body.mjs` / `tests/unit/scripts/` / `docs/decisions/` のみで、`.svelte` / `.css` / `site/` に一切触れていません。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [ ] 含まれない
- [x] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**gate の挙動が変わります。** これまで `check-pr-body.mjs` が exit 1 にしていた 19 件が exit 0 になります（検出と出力は継続）。`pre-ready` Step 9 / `.husky/pre-push` / `pr-merge-gate.yml` の `pr-body-check` job がその影響を受けます。データ移行はありません。復旧は本 PR の revert 1 回です。

**レビュー依頼事項**:

1. **`po-decision-brief-*` 3 件を blocking に残した判断**を確認いただきたいです。PO 決裁は「類型 1 の 2〜3 本のみ hard-fail」でしたが、この 3 件は **#3944 / #3956 で 2 回連続再発したため #3962 で gate 化したばかり**で、降格は ADR-0061 same-class-N→guard と衝突します。類型 1 の定義「証跡の真正性 / **不可逆な損失（偽装・成果物の消失・自己承認）**」のうち **自己承認**に当たると読んで残しました。**PO が「それでも降格」と判断されるなら `BLOCKING_GATES` から 3 行削るだけです**
2. **`integration-evidence-missing` も blocking に残しています。** 統合 PR（develop→main）の gate は監査の職掌（`audit-team.md` §3.5）で、本 PR の書式整理とは別系統のため触りませんでした
3. **AC7 を「新しい記録装置を作らない」形で解釈しています。** Issue の文面は「何件 warn を出したかを記録し」ですが、記録の保存先を作ると装置が 1 本増えます（憲章 §3.4 制約 1）。CI ログに安定書式で出し、月次棚卸しで `grep ADVISORY-IDS` して数える形にしました

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— `git diff` 全 3 ファイルを確認。本 PR は #4208 のブランチに誤って commit していたものを cherry-pick で切り出したもので、#4208 の変更は含まない
- [x] 全 AC が実装済み（未実装・先送りの AC がない）— 本 PR の scope は #4121 の AC6 / AC7 で、両方とも上記 AC 検証マップに実測を記載。AC8 は本 PR の scope 外（`## 関連 Issue` で宣言済み）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A。`.svelte` / `.css` / `site/` に触れていない（pre-ready Step 11b も「UI 変更なし」判定）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A。認証画面に触れていない

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
