### PR TITLE
fix(auth): #4206 cron dispatcher が認可層で 401 になり本番 cron が 1 ヶ月全滅していたのを塞ぐ

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -373,8 +373,22 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 | `/`, `/auth/**`, `/switch`, `/legal/**` | 全員（認証不要） | — |
 | `/api/health` | 全員（認証不要） | — |
 | `/api/stripe/webhook` | 全員（認証不要、Stripe署名で検証） | — |
+| `/api/cron/**` | 全員（認証不要、**`verifyCronAuth` の共有 secret で検証**、#4206） | — |
 
 認可チェックは `hooks.server.ts` → `authorization.ts` の `authorizeCognito()` で一元実行。ルート × ロール × ライセンス状態の三軸で判定する。
+
+#### 5.2.0 セッションを持たない外部呼び出しの扱い（#4206）
+
+`/api/stripe/webhook` と `/api/cron/**` は **Cognito セッションを持たない外部からの POST** であり、認可層で弾くと handler に到達できない。したがって**認証の担い手を route 側に移す**（認可層の allowlist に載せる ≠ 認証不要）。
+
+| ルート | 呼び出し元 | route 側の認証 |
+|---|---|---|
+| `/api/stripe/webhook` | Stripe | 署名検証 |
+| `/api/cron/**` | cron dispatcher（EventBridge → Lambda → Function URL への HTTP POST） | `verifyCronAuth`（`CRON_SECRET` / `OPS_SECRET_KEY` を `x-cron-secret` または `Authorization: Bearer` で検証） |
+
+**この構成は「全 route が実際に検証している」ことが前提**であり、1 本でも呼び忘れれば無認証で外部公開される。`tests/unit/architecture/cron-route-auth-fitness.test.ts` が `src/routes/api/cron/*/+server.ts` を **FS から列挙**して全件の `verifyCronAuth` 呼び出しを assert し、同時に認可層が cron route を通すこと・`/api/cronjobs` のような前方一致の別 route を巻き込まないことも固定する（除外リストを持たない no-silent-gap 設計）。
+
+`AUTH_MODE` による差の注意: `local` / `anonymous` provider は全ルートを無条件 allow するため、**この欠陥は `cognito`（AWS 本番）でのみ発現する**。NUC / demo で動いていることは本番の保証にならない。
 
 #### 5.2.1 静的ファイル配信の tenant 一致検証（cross-tenant IDOR 防止、#3133）
 

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -102,8 +102,8 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		note: 'src / infra / .github を走査し Stripe webhook 受信口が 1 本かを検査する (#4128)',
 	},
 	'tests/unit/architecture/cron-route-auth-fitness.test.ts': {
-		scope: 'repo',
-		note: 'src/routes/api/cron を走査し、全 cron route が verifyCronAuth を呼ぶことを検査する (#4206)',
+		scope: 'bounded',
+		note: '走査は src/routes/api/cron 配下のみ (再帰だが単一 dir で有界)。全 cron route が verifyCronAuth を呼ぶことを検査する (#4206)',
 	},
 	'tests/unit/architecture/user-content-delivery-headers-fitness.test.ts': {
 		scope: 'repo',

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -101,6 +101,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'src / infra / .github を走査し Stripe webhook 受信口が 1 本かを検査する (#4128)',
 	},
+	'tests/unit/architecture/cron-route-auth-fitness.test.ts': {
+		scope: 'repo',
+		note: 'src/routes/api/cron を走査し、全 cron route が verifyCronAuth を呼ぶことを検査する (#4206)',
+	},
 	'tests/unit/architecture/user-content-delivery-headers-fitness.test.ts': {
 		scope: 'repo',
 		note: 'infra + src を走査して配信ヘッダを検査する',

--- a/src/lib/server/auth/authorization.ts
+++ b/src/lib/server/auth/authorization.ts
@@ -140,6 +140,19 @@ function isPublicRoute(path: string): boolean {
 		// #3657: LWA readiness の shallow probe。認証なしで 200 を返せる必要がある
 		path.startsWith('/api/ready') ||
 		path.startsWith('/api/stripe/webhook') ||
+		// #4206: cron dispatcher (EventBridge → Lambda → Function URL への HTTP POST) は
+		// Cognito セッションを持たないため、ここに無いと identity === null で 401 になり
+		// **route の handler に到達する前に**全滅する (本番 AWS で 1 ヶ月継続、成功率 0.8%)。
+		// /api/stripe/webhook と同じ「セッションを持たない外部呼び出し」で、認証は各 route の
+		// verifyCronAuth (CRON_SECRET / OPS_SECRET_KEY) が担う。
+		// **この行は「認証不要」ではなく「認証の担い手が route 側にある」の意**であり、
+		// 全 cron route が verifyCronAuth を呼ぶことは
+		// tests/unit/architecture/cron-route-auth-fitness.test.ts が FS 列挙で機械強制する
+		// (1 本でも呼び忘れれば無認証で外部公開になるため、その guard が唯一の防波堤)。
+		// 境界は `/api/cron/` に限定する — 素朴な startsWith('/api/cron') は
+		// `/api/cronjobs` のような別 route まで巻き込んで公開してしまう。
+		path === '/api/cron' ||
+		path.startsWith('/api/cron/') ||
 		path.startsWith('/legal') ||
 		path.startsWith('/demo') ||
 		path.startsWith('/marketplace') ||

--- a/tests/unit/architecture/cron-route-auth-fitness.test.ts
+++ b/tests/unit/architecture/cron-route-auth-fitness.test.ts
@@ -1,0 +1,116 @@
+// tests/unit/architecture/cron-route-auth-fitness.test.ts
+// #4206: cron route の認証の担い手が route 側にあることを機械強制する fitness function
+//
+// 背景:
+//   #4206 で `/api/cron/` を `isPublicRoute()` の allowlist に追加した。これは
+//   「認証不要」の意味ではなく、「**認証の担い手が認可層ではなく route 側 (verifyCronAuth) にある**」
+//   の意味である。cron dispatcher (EventBridge → Lambda → Function URL への HTTP POST) は
+//   Cognito セッションを持たないため、認可層で弾くと handler に到達できず、本番 AWS で
+//   1 ヶ月・成功率 0.8% の全滅を起こしていた。
+//
+//   したがって allowlist 追加以降、cron route の防御は各 route の `verifyCronAuth`
+//   (CRON_SECRET / OPS_SECRET_KEY 検証) **だけ**になる。1 本でも呼び忘れれば
+//   **無認証で外部公開される**。本 test がその唯一の防波堤である。
+//
+// 検証範囲:
+//   [C1] 母数 — 実 FS 上の src/routes/api/cron/*/+server.ts を列挙する (literal 固定禁止)。
+//        新しい cron route を足した人が本 test を書き換えなくても自動で検査対象に入る。
+//   [C2] 全 route が verifyCronAuth を import し、かつ呼び出していること。
+//        import だけして呼んでいない (= 素通し) を検出するため、import と呼び出しを別々に見る。
+//   [C3] allowlist 側の実装が実際に cron route を公開していること (認可層との突き合わせ)。
+//        allowlist から誤って消された場合、[C3] が fail して #4206 の再発を即検出する。
+//   [C4] 境界 — `/api/cron` に前方一致する**別 route** (`/api/cronjobs` 等) まで
+//        公開していないこと。素朴な startsWith による過剰公開の回帰 guard。
+//
+// no-silent-gap: 除外リストを持たない。cron route は例外なく verifyCronAuth を要求する。
+//   「この route だけは別の認証」が必要になった時点で、本 test を fail させたうえで
+//   除外構造を理由・追跡 Issue 付きで設計すること (schedule-consistency.test.ts の
+//   DOCUMENTED_EXCLUSIONS の作法に倣う)。
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。区分は
+// scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
+
+import { authorizeCognito } from '../../../src/lib/server/auth/authorization';
+
+/** cron endpoint の実体ディレクトリ (母数の SSOT。literal 列挙は禁止) */
+const CRON_ROUTE_DIR = 'src/routes/api/cron';
+
+interface CronRoute {
+	/** endpoint 名 (ディレクトリ名) */
+	name: string;
+	/** repo root からの +server.ts パス */
+	file: string;
+	/** 認可層に渡される path */
+	urlPath: string;
+	source: string;
+}
+
+function collectCronRoutes(): CronRoute[] {
+	const dir = path.resolve(process.cwd(), CRON_ROUTE_DIR);
+	if (!fs.existsSync(dir)) return [];
+
+	return fs
+		.readdirSync(dir, { withFileTypes: true })
+		.filter((entry) => entry.isDirectory())
+		.map((entry) => {
+			const file = path.join(CRON_ROUTE_DIR, entry.name, '+server.ts');
+			return {
+				name: entry.name,
+				file,
+				urlPath: `/api/cron/${entry.name}`,
+				source: fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8'),
+			};
+		})
+		.filter((route) => fs.existsSync(path.resolve(process.cwd(), route.file)));
+}
+
+const cronRoutes = collectCronRoutes();
+
+describe('cron route の認証は route 側が担う (#4206)', () => {
+	it('[C1] 母数: cron route が FS から 1 本以上検出される', () => {
+		// 0 件なら「全部通った」ではなく「1 本も検査していない」。
+		// ディレクトリ移動やリネームで本 test が空振りするのを防ぐ。
+		expect(cronRoutes.length).toBeGreaterThan(0);
+	});
+
+	describe('[C2] 全 route が verifyCronAuth を呼ぶ', () => {
+		for (const route of cronRoutes) {
+			it(`${route.name} が verifyCronAuth を import している`, () => {
+				expect(route.source).toMatch(/import\s*\{[^}]*\bverifyCronAuth\b[^}]*\}/);
+			});
+
+			it(`${route.name} が verifyCronAuth を呼び出している`, () => {
+				// import しただけで呼んでいない = 素通し。import 検査だけでは捕まらない。
+				expect(route.source).toMatch(/\bverifyCronAuth\s*\(/);
+			});
+		}
+	});
+
+	describe('[C3] 認可層は cron route を通す', () => {
+		for (const route of cronRoutes) {
+			it(`${route.urlPath} は Cognito セッション無しでも通過する`, () => {
+				// ここが fail する = allowlist から /api/cron が消えた = #4206 の再発。
+				// 本番 AWS で cron が全滅するが、cron は「動かなくても画面は正常」なので
+				// 顧客からの申告では発覚しない。
+				const result = authorizeCognito(route.urlPath, null, null);
+				expect(result.allowed).toBe(true);
+			});
+		}
+	});
+
+	describe('[C4] 前方一致で別 route を巻き込まない', () => {
+		const notCronPaths = ['/api/cronjobs', '/api/cron-admin', '/api/crontab'];
+
+		for (const notCron of notCronPaths) {
+			it(`${notCron} は公開しない`, () => {
+				const result = authorizeCognito(notCron, null, null);
+				expect(result.allowed).toBe(false);
+			});
+		}
+	});
+});

--- a/tests/unit/architecture/cron-route-auth-fitness.test.ts
+++ b/tests/unit/architecture/cron-route-auth-fitness.test.ts
@@ -41,32 +41,80 @@ import { authorizeCognito } from '../../../src/lib/server/auth/authorization';
 const CRON_ROUTE_DIR = 'src/routes/api/cron';
 
 interface CronRoute {
-	/** endpoint 名 (ディレクトリ名) */
+	/** endpoint 名 (CRON_ROUTE_DIR からの相対パス。入れ子なら 'a/b') */
 	name: string;
 	/** repo root からの +server.ts パス */
 	file: string;
 	/** 認可層に渡される path */
 	urlPath: string;
+	/** 原文 */
 	source: string;
+	/** コメント / 文字列リテラルを除去した実コード (呼び出し検査用) */
+	code: string;
 }
 
-function collectCronRoutes(): CronRoute[] {
-	const dir = path.resolve(process.cwd(), CRON_ROUTE_DIR);
-	if (!fs.existsSync(dir)) return [];
+/**
+ * コメント (`//` / 文末 `/* … *​/`) と文字列リテラル (' " `) を空白に潰す。
+ *
+ * これを挟まないと、**コメントに書かれた関数名が呼び出しとして誤検出される**。
+ * 実測 (#4206 の adversarial review): `src/routes/api/cron/pglite-backup/+server.ts:8` の
+ * 「認証は既存 cron 群と同じ verifyCronAuth (x-cron-secret …)」というコメントだけで
+ * [C2] が緑になり、L33 の実呼び出しを消しても検出できなかった。
+ * **guard が「唯一の防波堤」である以上、コメントで満たせる検査は防波堤ではない。**
+ *
+ * 完全な字句解析ではない (正規表現の限界) が、コメント / 文字列という
+ * 最も現実的なすり抜け経路は閉じる。
+ */
+function stripCommentsAndStrings(source: string): string {
+	return source
+		.replace(/\/\*[\s\S]*?\*\//g, ' ')
+		.replace(/\/\/[^\n]*/g, ' ')
+		.replace(/`(?:\\.|[^`\\])*`/g, ' ')
+		.replace(/'(?:\\.|[^'\\\n])*'/g, ' ')
+		.replace(/"(?:\\.|[^"\\\n])*"/g, ' ');
+}
 
-	return fs
-		.readdirSync(dir, { withFileTypes: true })
-		.filter((entry) => entry.isDirectory())
-		.map((entry) => {
-			const file = path.join(CRON_ROUTE_DIR, entry.name, '+server.ts');
-			return {
-				name: entry.name,
-				file,
-				urlPath: `/api/cron/${entry.name}`,
-				source: fs.readFileSync(path.resolve(process.cwd(), file), 'utf-8'),
-			};
-		})
-		.filter((route) => fs.existsSync(path.resolve(process.cwd(), route.file)));
+/**
+ * `+server.ts` を**再帰的に**集める。
+ *
+ * 認可層の allowlist は `startsWith('/api/cron/')` で**任意深度**を公開するため、
+ * 深さ 1 だけを見る母数収集では「公開されるが検査されない」route が生まれる
+ * (入れ子 route / route group `(group)` / パラメータ route)。母数は公開範囲と一致させる。
+ */
+function collectCronRoutes(): CronRoute[] {
+	const root = path.resolve(process.cwd(), CRON_ROUTE_DIR);
+	if (!fs.existsSync(root)) return [];
+
+	const routes: CronRoute[] = [];
+
+	const walk = (absDir: string, relSegments: string[]): void => {
+		for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+			const abs = path.join(absDir, entry.name);
+
+			if (entry.isDirectory()) {
+				walk(abs, [...relSegments, entry.name]);
+				continue;
+			}
+			if (entry.name !== '+server.ts') continue;
+
+			const source = fs.readFileSync(abs, 'utf-8');
+			const rel = relSegments.join('/');
+			routes.push({
+				name: rel === '' ? '(root)' : rel,
+				file: path.posix.join(CRON_ROUTE_DIR, rel, '+server.ts'),
+				// SvelteKit の route group `(name)` は URL に現れない
+				urlPath: `/api/cron${relSegments
+					.filter((s) => !s.startsWith('('))
+					.map((s) => `/${s}`)
+					.join('')}`,
+				source,
+				code: stripCommentsAndStrings(source),
+			});
+		}
+	};
+
+	walk(root, []);
+	return routes;
 }
 
 const cronRoutes = collectCronRoutes();
@@ -78,15 +126,25 @@ describe('cron route の認証は route 側が担う (#4206)', () => {
 		expect(cronRoutes.length).toBeGreaterThan(0);
 	});
 
-	describe('[C2] 全 route が verifyCronAuth を呼ぶ', () => {
+	describe('[C2] 全 route が verifyCronAuth を呼び、戻り値を捨てない', () => {
 		for (const route of cronRoutes) {
 			it(`${route.name} が verifyCronAuth を import している`, () => {
-				expect(route.source).toMatch(/import\s*\{[^}]*\bverifyCronAuth\b[^}]*\}/);
+				expect(route.code).toMatch(/import\s*\{[^}]*\bverifyCronAuth\b[^}]*\}/);
 			});
 
 			it(`${route.name} が verifyCronAuth を呼び出している`, () => {
 				// import しただけで呼んでいない = 素通し。import 検査だけでは捕まらない。
-				expect(route.source).toMatch(/\bverifyCronAuth\s*\(/);
+				// 判定は code (コメント / 文字列除去済) に対して行う。
+				expect(route.code).toMatch(/\bverifyCronAuth\s*\(/);
+			});
+
+			it(`${route.name} が verifyCronAuth の戻り値を使っている`, () => {
+				// 呼ぶだけで結果を無視する実装 (`verifyCronAuth(request);` の呼び捨て) は
+				// 認証していないのと同じ。代入 (`const e = verifyCronAuth(`) か
+				// 直接分岐 (`if (verifyCronAuth(` / `return verifyCronAuth(`) を要求する。
+				expect(route.code).toMatch(
+					/(?:=|if\s*\(|return|\?\?|&&|\|\|)\s*(?:await\s+)?verifyCronAuth\s*\(/,
+				);
 			});
 		}
 	});

--- a/tests/unit/architecture/cron-route-auth-fitness.test.ts
+++ b/tests/unit/architecture/cron-route-auth-fitness.test.ts
@@ -29,13 +29,12 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
-
-// #4085: repo 走査 test (実行時間が入力サイズに比例する)。区分は
-// scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
-vi.setConfig({ testTimeout: 60_000 });
-
+import { describe, expect, it } from 'vitest';
 import { authorizeCognito } from '../../../src/lib/server/auth/authorization';
+
+// #4085: 走査 test の区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT。
+// 本 test は再帰 walk だが対象が src/routes/api/cron 配下の単一 dir で有界なため
+// scope='bounded' (repo ツリー全走査ではないので明示 timeout は不要)。
 
 /** cron endpoint の実体ディレクトリ (母数の SSOT。literal 列挙は禁止) */
 const CRON_ROUTE_DIR = 'src/routes/api/cron';

--- a/tests/unit/auth/authorization.test.ts
+++ b/tests/unit/auth/authorization.test.ts
@@ -43,6 +43,40 @@ describe('authorizeCognito', () => {
 			});
 		}
 
+		// #4206: cron dispatcher (EventBridge → Lambda → Function URL への HTTP POST) は
+		// Cognito セッションを持たない。allowlist に `/api/cron` が無いと identity === null で
+		// 401 になり、**cron route の handler に到達する前に**認可層で全滅する
+		// (本番 AWS で 1 ヶ月継続、成功率 0.8%)。`/api/stripe/webhook` と同じ
+		// 「セッションを持たない外部呼び出し」であり、認証は各 route の verifyCronAuth
+		// (CRON_SECRET / OPS_SECRET_KEY) が担う。
+		//
+		// この欠陥が `AUTH_MODE=cognito` でしか出ないのは、local / anonymous provider が
+		// 全ルート無条件 allow だから (src/lib/server/auth/providers/local.ts / anonymous.ts)。
+		// NUC と demo Lambda では発現せず、本番だけが落ちていた。
+		describe('cron route (#4206)', () => {
+			// 母数は FS 列挙の fitness function 側 (cron-route-auth-fitness.test.ts) が保証する。
+			// ここは認可層の振る舞いを固定する代表 3 本。
+			const cronPaths = [
+				'/api/cron/export-build',
+				'/api/cron/retention-cleanup',
+				'/api/cron/stripe-webhook-delivery-check',
+			];
+
+			for (const path of cronPaths) {
+				it(`${path} は Cognito セッション無しでも認可層を通過する`, () => {
+					const result = authorizeCognito(path, null, null);
+					expect(result.allowed).toBe(true);
+				});
+			}
+
+			it('/api/cron 配下ではない紛らわしい path まで公開しない', () => {
+				// 素朴な `startsWith('/api/cron')` は `/api/cronjobs` のような別 route まで
+				// 巻き込んで無認証公開する。境界を `/api/cron/` (と完全一致) に限定すること。
+				const result = authorizeCognito('/api/cronjobs', null, null);
+				expect(result.allowed).toBe(false);
+			});
+		});
+
 		it('認証済みで /auth/login → role に応じてリダイレクト（owner → /admin）', () => {
 			const result = authorizeCognito(
 				'/auth/login',


### PR DESCRIPTION
## 顧客価値・目的

**本番 AWS の cron が 1 ヶ月間ほぼ全滅していました（成功率 0.8%）。** 原因は cron の中身ではなく、**cron route の handler に到達する前に認可層が 401 を返していた**ことです。

`isPublicRoute()` の allowlist に `/api/cron` が無いため、Cognito セッションを持たない cron dispatcher（EventBridge → Lambda → Function URL への HTTP POST）が `identity === null` で弾かれていました。

```
1. hooks.server.ts:548        provider.authorize(path, identity, context)
2. CognitoProvider.authorize  → authorizeCognito()
3. authorization.ts:78-86     isPublicRoute('/api/cron/export-build') → false
4. authorization.ts:88-91     identity === null → { allowed: false, status: 401 }
5. hooks.server.ts:550-557    {"error":"認証が必要です"} を 401 で返す
6. cron-dispatcher/index.ts:148  非 2xx → reject → Lambda invocation error
```

**止まっていたのは 6 本**（`export-build` / `retention-cleanup` / `trial-notifications` / `lifecycle-emails` / `stripe-webhook-delivery-check` ほか）。うち `retention-cleanup` は**プラン別の履歴保持期間ポリシー（ADR-0049）の執行**、`stripe-webhook-delivery-check` は**課金 event の取りこぼし検知（EPIC #4117）**であり、どちらも止まっていたことが顧客に見える形では出ません。

### なぜ 1 ヶ月気づかれなかったか（root class）

| 層 | 欠落 |
|---|---|
| **実行時** | CloudWatch アラームは 7/4 から正しく ALARM だったが SNS subscription がゼロ（#4189 / #4174 の担当。本 PR では依存として記録するのみ） |
| **テスト (unit)** | `tests/unit/auth/authorization.test.ts` に `api/cron` の記述が **0 件**。認可層のこの経路は unit test で 1 行もカバーされていなかった |
| **テスト (E2E)** | **`/api/cron` を叩く E2E spec は 11 file 実在する。それでも捕まらなかった** — 既定の `playwright.config.ts` は `AUTH_MODE` を設定せず `local` で動く。`LocalProvider.authorize` は全ルート無条件 allow なので、**この欠陥が構造的に発現しない環境でテストしていた** |
| **環境差** | `local` / `anonymous` provider は**全ルート無条件 allow**（`providers/local.ts:27-30` / `anonymous.ts:52-58`）。**NUC と demo では発現せず、`AUTH_MODE=cognito` の AWS 本番だけが落ちていた** |

「NUC で動いているから大丈夫」が成立しない構造でした。

## 関連 Issue

Closes #4206

- 関連（別 root cause、本 PR では直さない）: #4207（NUC backup コンテナに tzdata が無く `TZ=Asia/Tokyo` が効かない）/ #4189 / #4174（アラーム宛先ゼロ）/ #4033（`age-recalc` / `grace-period-deletion` が AWS で一度も発火しない）

## AC 検証マップ (ADR-0004)

| AC | 内容 | 検証方法 | 結果 |
|---|---|---|---|
| **AC1** | 欠陥を failing-test で固定してから実装する（ADR-0061） | 実装前に commit `1996aabf2` を単独で実行 | ✅ **3 failed / 55 passed** — `/api/cron/{export-build,retention-cleanup,stripe-webhook-delivery-check}` が認可層を通過しないことを実測 |
| **AC2** | cron dispatcher が認可層を通過する | `authorizeCognito('/api/cron/*', null, null)` が `allowed: true` | ✅ 3 files / **119 tests green** |
| **AC3** | 前方一致で別 route を巻き込まない | `/api/cronjobs` / `/api/cron-admin` / `/api/crontab` が公開されないことを assert。境界を `path === '/api/cron' \|\| path.startsWith('/api/cron/')` に限定 | ✅ [C4] 3 件 green |
| **AC4** | allowlist を開けた後も cron route が無認証にならない | FS 列挙の fitness function で全 route の `verifyCronAuth` を機械強制（下記 mutation 検証済） | ✅ 全 10 route が import + 呼び出し + 戻り値使用。mutation 4 通りで red を実測 |
| **AC5** | 設計書同期（ADR-0001） | `14-セキュリティ設計書.md` §5.2 に `/api/cron/**` 行追加 + §5.2.0「セッションを持たない外部呼び出しの扱い」新設 | ✅ |
| **AC6** | アラーム宛先ゼロは本 PR の範囲外であることを明示 | 依存 Issue として記録（#4189 / #4174） | ✅ 本文に記載 |

## 変更タイプ

- [x] バグ修正（本番障害の是正）
- [x] テスト追加（failing-test + fitness function）
- [x] ドキュメント更新（設計書同期、ADR-0001）
- [ ] 新機能
- [ ] リファクタリング
- [ ] インフラ変更

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **挙動が変わる環境** | `AUTH_MODE=cognito`（AWS 本番 / staging）の `/api/cron/**` のみ。`local`（NUC）/ `anonymous`（demo）は元から全 allow なので**挙動不変** |
| **セキュリティ影響** | allowlist に載せた分、認可層の防御が外れる。**代わりに全 10 route の `verifyCronAuth` を fitness function で機械強制**（mutation 検証済）。`verifyCronAuth` は `CRON_SECRET` / `OPS_SECRET_KEY` を `x-cron-secret` / `Authorization: Bearer` の両ヘッダで検証する（`cron-auth.ts:33-56`） |
| **前方一致の巻き込み** | `startsWith('/api/cron')` だと `/api/cronjobs` 等を公開してしまうため `'/api/cron/'` に限定。[C4] で回帰固定 |
| **secret 側は原因ではない** | dispatcher は Bearer を送る（`cron-dispatcher/index.ts:136`）。secret 不一致なら route 側の `{"error":"Unauthorized"}` が返るはずで、実ログの文言「認証が必要です」は repo 全体で `hooks.server.ts:554` の 1 箇所にしか存在しない |
| **既存の cron 整合 gate** | `tests/unit/cron/schedule-consistency.test.ts`（registry / CDK / dispatcher の 3 層照合）は無傷（同時実行で green） |
| **repo 走査 test 登録** | `scripts/lib/ci/repo-scan-test-registry.mjs` に新 fitness を登録（未宣言だと CI が fail する） |
| **直近 30 日の重複変更（ADR-0002）** | `authorization.ts` の直近変更は #4032（settings hub guard、2026-07）で `/api/cron` とは無関係。#4206 に触れた commit は `git log --all --grep=4206` で **0 件** |

## テスト・品質セルフチェック

```
npx vitest run tests/unit/architecture/cron-route-auth-fitness.test.ts \
               tests/unit/auth/authorization.test.ts \
               tests/unit/cron/schedule-consistency.test.ts

 Test Files  3 passed (3)
      Tests  119 passed (119)
```

- [x] **failing-test-first（ADR-0061）**: commit `1996aabf2` で red を実測してから実装
- [x] **fitness function（ADR-0061 same-class→guard）**: 母数を FS から取り、除外リストを持たない no-silent-gap 設計。新しい cron route を足した人が本 test を書き換えなくても自動で検査対象に入る
- [x] **mutation 検証**: guard を 4 通りに壊して全て red を確認
- [x] `npm run pre-ready -- --pr <PR番号>` 全 6 step PASS
- [x] `gh pr checks` で CI 側 hard-fail 検査が pass（skipped でない）

### mutation 検証（guard が本当に効くか）

**「テストが通った」ではなく「壊したら落ちるか」を実測しました。** 実装は先に commit 済で、mutation は `git stash` で退避しています（破棄していません）。

1. **`isPublicRoute` から `/api/cron` の 2 行を削除**（= #4206 の再発そのもの）→ **10 tests failed** ✅
2. **`export-build/+server.ts` の `verifyCronAuth(` 呼び出しをリネーム**（= 認証の呼び忘れ）→ **1 test failed** ✅
3. **`pglite-backup/+server.ts` の実呼び出しを消し、コメントの `verifyCronAuth (…)` だけ残す**（= コメントで検査を満たす）→ **2 tests failed** ✅ ※**guard 強化前はこの mutation が緑のまま通っていました**（下記）
4. **`verifyCronAuth(request);` と呼び捨てにして戻り値を捨てる**（= 呼ぶが弾かない）→ **1 test failed** ✅

### adversarial review の指摘で guard を強化しました（`.claude/skills/adversarial-reviewer`）

**この PR が allowlist を開ける唯一の根拠が fitness function である以上、そこに穴があるなら後回しにできません。** 指摘 2 件を本 PR で塞ぎました。

| 指摘 | 実測 | 対応 |
|---|---|---|
| **正規表現がコメントに一致する** | `pglite-backup/+server.ts:8` の「認証は既存 cron 群と同じ `verifyCronAuth (x-cron-secret …)`」というコメント**だけ**で [C2] が緑になり、L33 の実呼び出しを消しても検出できなかった | コメント（`//` / `/* */`）と文字列リテラル（`'` `"` `` ` ``）を潰してから判定する |
| **母数が公開範囲より狭い** | 収集が深さ 1 の `<dir>/+server.ts` のみ。allowlist は `startsWith('/api/cron/')` で**任意深度**を公開するため、入れ子 route / route group は「公開されるが未検査」 | 再帰 walk に変更（route group `(name)` は URL から除外） |

**あわせて「呼ぶが戻り値を捨てる」を検出する assertion を追加**しました（初版のレビュー依頼事項 3 で自ら挙げた限界のうち、正規表現で塞げる範囲を塞いだ形です）。

### ADR-0002（critical 5 要件）の適用

| 要件 | 対応 |
|---|---|
| E2E 回帰 | **既存 E2E は無力なので unit / fitness に push-down した**（ADR-0061 push-down-pyramid）。`/api/cron` を叩く E2E は 11 file 既にあるが、既定 `playwright.config.ts` は `AUTH_MODE` 未設定 = `local` で動き、`LocalProvider` が全ルート allow するため**この欠陥が原理的に発現しない**。cognito 経路の E2E（`playwright.cognito-dev.config.ts`）に cron を足す案もあるが、認可層の分岐そのものは unit で決定的に固定できるため、重い E2E レーンではなく unit + fitness function に落とした |
| AC 全完了 | 上記 AC 検証マップ参照 |
| 提案全実装 | 調査で挙げた 3 案のうち案 A を採用。案 B（`AuthProvider.authorize` に `Request` を渡す）は 4 provider へのシグネチャ変更で critical の即時修復には広すぎ、案 C（Function URL の IAM 認証）は Function URL が**アプリ本体の公開エントリでもある**ため顧客トラフィックに影響する。**下記「レビュー依頼事項」に不採用理由を記載** |
| 5 年齢モード検証 | **N/A**。サーバ側の認可判定のみで UI 差分ゼロ |
| 直近 30 日重複変更 | 上記「影響範囲」参照（重複なし） |

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: サーバ側の認可判定と test のみの変更で、顧客に見える画面を 1 px も変更しない。UI コンポーネント / route の描画に触れていない。 -->

**UI 変更はありません。** 変更は `src/lib/server/auth/authorization.ts`（認可層）/ `tests/`（2 件）/ `scripts/lib/ci/`（test 登録）/ `docs/design/`（設計書）のみで、`.svelte` を 1 ファイルも触っていません。

## レビュー依頼事項・破壊的変更

### レビューで見ていただきたい点

1. **allowlist に載せる判断そのもの。** これは「認証不要にする」ではなく「認証の担い手を認可層から route 側へ移す」変更です。`/api/stripe/webhook` と同じ構造ですが、**cron は route が 10 本ある**点が webhook（1 本）と違います。だから fitness function を同一 PR で必須にしました。この線引きが妥当かをご確認ください。
2. **fitness function が「除外リストを持たない」設計にした点。** `schedule-consistency.test.ts` は `DOCUMENTED_EXCLUSIONS`（理由 + 追跡 Issue 必須）を持ちますが、本 test は持ちません。cron route に「verifyCronAuth を呼ばない例外」を作った時点で無認証公開になるため、**例外を作れる構造自体を置かない**判断です。将来必要になったら、まず本 test を fail させてから設計してください。
3. **正規表現による検出の残る限界。** コメント / 文字列の除去と「戻り値を使っているか」までは塞ぎましたが、字句解析ではないため完全ではありません（例: 正規表現リテラル内の `/…verifyCronAuth(…/`、動的な間接呼び出し）。AST 解析まで踏み込むかは Pre-PMF のコスト判断（ADR-0010）としてご意見ください。**現時点の判断は「現実的なすり抜け経路（コメント・文字列・呼び捨て・入れ子 route）を閉じたので十分」**です。
4. **`verifyCronAuth` 自体の実装**（本 PR では変更していません）。`cron-auth.ts:52` の secret 比較が `===`（非 timing-safe）で、ADR-0050 が `cookie-signature` を採った先例と不整合です。共有 secret の総当たりは Function URL のレート制限依存になります。**本 PR の scope 外と判断しましたが、別 Issue にすべきかご意見ください。**

### 不採用にした案（ADR-0002「提案全実装」の説明）

- **案 B: `authorizeCognito` 内で「cron secret 保持者のみ」として扱う** — 認可を 1 箇所に集約できる正しい方向ですが、`AuthProvider.authorize` に `Request` を渡すシグネチャ変更が要り、4 provider（cognito / cognito-dev / local / anonymous）と authorize 系 test の全体に波及します。**1 ヶ月止まっている critical の即時修復としては変更面が広すぎる**と判断しました。案 A + fitness function で実効的な安全性は担保できます。
- **案 C: Function URL を `AWS_IAM` 認証 + SigV4 に切り替える** — Function URL は**アプリ本体の公開エントリでもある**ため、authType を変えると全顧客トラフィックが落ちます。cron 専用の Function URL を分離しない限り採れません。共有 secret の廃止として別 Issue 相当です。

### 本 PR で直さないもの（意図的）

- **アラーム宛先ゼロ**（#4189 / #4174）。原因が別（SNS subscription 未設定）で、担当 Issue が既にあります。**「1 ヶ月気づかれなかった」の再発防止はそちら**であり、本 PR は「落ちていた原因」だけを直します。
- **`schedule-registry.ts:7` のコメント**「cronExpression は Asia/Tokyo で解釈される（コンテナ TZ=Asia/Tokyo）」。#4207 がこの前提を否定していますが、**どう是正するかは #4207 の実測結果に依存する**ため先回りしません（`docker-compose.yml` の 3 コンテナすべてが `TZ=Asia/Tokyo` を宣言する一方、repo 内のどの Dockerfile にも `tzdata` の install がありません）。
- **`age-recalc` / `grace-period-deletion` が AWS で一度も発火していない件**（#4033）。物理削除を伴うため有効化に判断が要り、既存 gate の `DOCUMENTED_EXCLUSIONS` に追跡登録済みです。

### 破壊的変更

**ありません。** `AUTH_MODE=cognito` で `/api/cron/**` が通るようになるだけで、他の route の認可判定は不変です。cron が動き出すこと自体は「本来の状態への復帰」です。

### ⚠️ deploy 手順に条件を付けます（adversarial review の指摘を受けて訂正）

初版の本文には「1 ヶ月分の未処理が一気に流れる。ジョブ側は件数上限 + 時間予算で self-limiting する設計（`13-AWS設計書 §3.3`）」と書きましたが、**どちらもコードで裏が取れませんでした。訂正します。**

| 初版の記述 | 実測 |
|---|---|
| `13-AWS設計書 §3.3` に「Cron ジョブ実行時間予算」がある | **無い**。§3.3 の実見出しは「ComputeStack」。この参照は `schedule-registry.ts:10` のコメントが主張しているだけで、**doc 側に実体が無い**（doc-code drift） |
| `retention-cleanup` は件数上限 + 時間予算で self-limiting する | **していない**。`retention-cleanup-service.ts`（227 行）に limit / batch / budget が無く、全 tenant × child を無制限ループする（L120 / L138）。`dsql/activity-repo.ts:586-600` は LIMIT 無しの単発 DELETE |
| 止まっていた通知は「一気に流れる」 | **流れない。永久に失われている**。`trial-notification-service.ts:66-74` は `daysRemaining === 3 / === 1 / === 0` の**完全一致**で発火するキューレス設計。停止中に閾値日を通過した家族には、cron が復活しても遡及送信されない |

**この 3 点目が実害につながります。** トライアル終了の告知を受け取らないまま free に落ちた家族に対し、復活した `retention-cleanup` が**初回実行で保持期間超過の履歴を物理削除**します。順番を誤ると「知らないうちに終了し、知らないうちに履歴が消える」が同時に起きます。

**したがって deploy 手順を以下に固定します（merge 前の合意事項）:**

1. **`retention-cleanup` は初回だけ `{"dryRun": true}` で実行**し、`activityLogsDeleted` / `tenantsProcessed` / `childrenProcessed` を確認する（route は `dryRun` を既に受け付ける — `retention-cleanup/+server.ts:28-42`）
2. 件数が想定内であることを確認してから実削除を有効化する
3. 停止期間（およそ 2026-07-04〜08-02）にトライアル閾値日を通過した tenant の洗い出しと顧客連絡は**別 Issue**（本 PR は削除の順番だけを担保する）

**あわせて注意**: `retention-cleanup` の route は失敗を `errors[]` に格納して **HTTP 200 / `ok: true`** を返します（`+server.ts:52-56`）。dryRun のレスポンスは `ok` ではなく `errors` の中身まで見てください。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。** `CRON_SECRET` / `OPS_SECRET_KEY` は既存で、本 PR は認可層の判定を変えるだけです。

## Ready for Review チェックリスト

- [x] failing-test-first で欠陥を実測してから実装した（ADR-0061）
- [x] guard を壊して red になることを確認した（mutation 検証、証跡を本文に記載）
- [x] 対象 Issue の AC を PR body に転記し、検証方法と結果を明記した
- [x] 設計書を同期した（ADR-0001）
- [x] ADR-0002（critical 5 要件）の各項目に対応 or N/A + 理由を明記した
- [x] 不採用にした案の理由を明記した
- [x] 本 PR で直さないものと、その担当 Issue を明記した
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢 revert で完全に戻る"]
    R2["顧客面: 🔴 復活する retention-cleanup が履歴を物理削除"]
    R3["ロールバック: コードは可逆。削除済データは戻らない"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 1ヶ月止まった本番 cron 6本が動く"]
    T2["捨てる: 認可層の防御。route側 secret 一本になる"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["security: guard に穴2件 → 本PRで塞ぎ済"]
    O2["business: self-limiting の記述が虚偽 → 訂正済"]
    O3["UX: 🔴 失った通知は遡及送信されず永久消失"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["UI 変更ゼロ。cron 復活のみ"]
    C2["🔴 無告知で free 落ちた家族の履歴が消えうる"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 初回 dryRun を deploy 条件にしてよいか"]
    Q2["Q2: 停止中に失った通知の顧客連絡は別Issueでよいか"]
    Q3["Q3: secret 比較の非 timing-safe は別Issueでよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R2,R3,O3,C2 danger
  class T2,O1,O2 warn
  class R1,T1,C1 ok
  class Q1,Q2,Q3 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠)</summary>

**③ の反対理由は `tmp/adversarial-evidence/4216.json` を `.claude/skills/adversarial-reviewer/SKILL.md` の手順で生成してから転記しています。** 3 件とも Dev 側で実物を再確認しました（`pglite-backup/+server.ts:8` のコメント誤検出 / `retention-cleanup-service.ts` に limit・budget 無し / `trial-notification-service.ts:66-74` の完全一致判定）。

**Q1 の背景**: `retention-cleanup` は 1 ヶ月止まっていたため、初回実行の削除対象が通常より多くなります。route は `{"dryRun": true}` を既に受け付けるので、追加実装なしで件数確認できます。

**Q2 の背景**: トライアル終了告知は `daysRemaining` の完全一致で発火するキューレス設計のため、停止中に閾値日を通過した家族には遡及送信されません。**「無告知で終了 → 履歴削除」の順で起きるのが最悪ケース**なので、Q1（削除の順番）は本 PR で担保し、Q2（顧客連絡）は分離できると考えています。

**Q3 の背景**: `cron-auth.ts:52` の secret 比較が `===` で timing-safe ではありません。本 PR は allowlist の追加だけで `verifyCronAuth` の実装を変更していないため scope 外と判断しましたが、allowlist を開けたことでこの secret が唯一の防御になる点は事実です。

</details>
