### PR TITLE
chore: .scratch/ を gitignore し、ローカル作業ファイルの誤コミットを防ぐ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ docs/tickets/
 
 # Temporary files
 tmp/
+.scratch/
 screenshots/
 # LP screenshots are generated at GitHub Pages deploy time (#1157)
 site/screenshots/


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（開発環境の事故防止）。**

`.scratch/` は複数の Claude Code セッションが Issue / PR body の下書き・調査メモの置き場として**既に使っており**（本 PR 時点で 20+ file）、`tmp/` と同じ「ローカル作業ファイル」です。しかし `.gitignore` に無く、**untracked のまま放置**されていました。

オーナーからの指摘（2026-08-02）を受けて実態を確認したところ、**現時点で漏洩はありません**が、`git add -A` で巻き込む事故が起こりうる状態でした。

```
$ git log --all --oneline --diff-filter=A -- ".scratch/*" ".scratch"
(出力なし = 全ブランチの全履歴で「追加された」記録なし)

$ git ls-files ".scratch"
(出力なし = 追跡対象に一度も入っていない)

$ git ls-tree -r origin/main   --name-only | grep -c "^\.scratch/"   → 0
$ git ls-tree -r origin/develop --name-only | grep -c "^\.scratch/"  → 0
```

## 関連 Issue

Issue はありません（オーナー指摘 2026-08-02 の直対応、1 行の予防措置）。

- 参考: `.gitignore` の `tmp/` は同じ役割で既に無視対象になっており、本 PR はその直後に 1 行足すだけです

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `.scratch/` が git の無視対象になる | `git check-ignore -v .scratch/3957.md` | ✅ `.gitignore:87:.scratch/	.scratch/3957.md` |
| AC2 | 過去に `.scratch/` が commit / push されていないことを確認する | `git log --all --diff-filter=A -- '.scratch/*'` / `git ls-files .scratch` / `git ls-tree -r origin/{main,develop}` | ✅ 3 通りとも **0 件**（上記「顧客価値・目的」に出力を掲載） |
| AC3 | 他のファイルを巻き込まない | `git show --stat HEAD` | ✅ `.gitignore` **1 file / +1 行** のみ |
| AC4 | 既存の無視規則を壊さない | `git status --short` で追跡中ファイルが消えていないことを確認 | ✅ 既存の追跡ファイルに変化なし（追加は無視規則 1 行のみで、既に追跡中の file は `.gitignore` の影響を受けない） |

## 変更タイプ

- [x] その他（開発環境設定 / 事故防止）
- [ ] 新機能
- [ ] バグ修正
- [ ] リファクタリング
- [ ] テスト追加・変更
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **既に追跡中のファイルへの影響** | なし。`.gitignore` は**未追跡ファイルにのみ効く**ため、追跡中の file が消えることはない（`.scratch/` は AC2 のとおり一度も追跡されていない） |
| **他のクローンへの波及** | 5 クローン（dev / po / qa / audit / platform）すべてに効く。`.scratch/` は複数ロールのセッションが使うため、repo 側で無視するのが正しい（各自の `.git/info/exclude` に書くと新しいクローンで漏れる） |
| **ビルド / CI への影響** | なし。`.gitignore` はビルド成果物・テスト対象に影響しない |
| **同種の未登録ディレクトリ** | `tmp/` / `screenshots/` / `site/screenshots/` / `docs/screenshots/` / `reports/` は登録済み。`.scratch/` だけが漏れていた |

## テスト・品質セルフチェック

```
$ git check-ignore -v .scratch/3957.md
.gitignore:87:.scratch/        .scratch/3957.md

$ git show --stat HEAD
 .gitignore | 1 +
 1 file changed, 1 insertion(+)
```

- [x] `.gitignore` の 1 行追加のみで、他ファイルを巻き込んでいない
- [x] 追加位置は `tmp/` の直後（同じ「Temporary files」ブロック内）
- [x] 過去の漏洩がないことを 3 通りの方法で確認した
- [x] `npm run pre-ready -- --pr <PR番号>` 全 6 step PASS

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: .gitignore の 1 行追加のみで、アプリケーションコードを 1 行も変更していない。顧客に見える画面は存在しない。 -->

**UI 変更はありません。** 変更は `.gitignore` 1 file / +1 行のみです。

## レビュー依頼事項・破壊的変更

### レビューで見ていただきたい点

1. **`.scratch/` を repo の `.gitignore` に入れる判断**。各自の `.git/info/exclude` に書く選択肢もありますが、**5 クローン運用で新しいクローンを作るたびに漏れる**ため repo 側に置きました。`tmp/` が既に repo 側にあるのと同じ扱いです。

### 破壊的変更

**ありません。** 既に追跡されているファイルは `.gitignore` の影響を受けず、`.scratch/` は一度も追跡されていません。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] 変更が 1 file / +1 行に収まっている
- [x] 過去に `.scratch/` が commit / push されていないことを確認した
- [x] 追跡中ファイルへの影響がないことを確認した
- [x] `npm run pre-ready` 全 step PASS
- [x] `gh pr checks 4217` を確認: **29 pass / 19 skipping**。`unit-test` / `lint-and-test` は **skipping**（`changes` job の paths filter が `.gitignore` を app 変更と見なさないため）。**「skipped でない」を満たしていないことを明示します** — アプリケーションコードを 1 行も変更していないため 本 PR では該当検査が構造的に発火しません。緑を装わず、この事実をもって Ready とします

## QM レビュー結果

<!-- QM が記入 -->
