### PR TITLE
fix(infra): #4207 alpine に tzdata が無く TZ が効かないため日次バックアップが真昼に走っていたのを是正する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,20 @@ RUN echo "Build at: ${BUILD_TIMESTAMP}" && mkdir -p data && npm run version:gene
 
 # Stage 3: Runtime (minimal image)
 FROM node:22-alpine AS runtime
+
+# #4207: alpine は tzdata を同梱しない。docker-compose.yml が `TZ=Asia/Tokyo` を渡しても
+# libc がゾーンを解決できず UTC のままになり、**busybox crond が cron 式を UTC で解釈する**。
+# 実害: 深夜 3 時のつもりで登録した日次バックアップ (`0 3 * * *`) が
+# **12:00 JST (= 03:00 UTC) に走っていた** — 家庭向けアプリの本番 DB を、利用者が
+# 起きている真昼にコピーしていた。
+#
+# `printenv TZ` は正しい値を返すため「設定を確認したつもり」になれるうえ、
+# バックアップ自体は成功する (ファイルは毎日でき consecutiveFailures: 0) ので
+# health も alert も何も言わない。目視では気づけない類の欠陥。
+# 回帰は tests/unit/infra/compose-backup-volume.test.ts [TZ1] が compose から
+# TZ 宣言 service を列挙して機械強制する。
+RUN apk add --no-cache tzdata
+
 WORKDIR /app
 
 # Copy built application (flat layout: index.js, handler.js, client/, server/)

--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -18,6 +18,15 @@ RUN npm ci
 
 # Stage 2: Runtime（最小コピー）
 FROM node:22-alpine AS runtime
+
+# #4207: alpine は tzdata を同梱せず、`TZ=Asia/Tokyo` を渡しても解決されない。
+# 本 scheduler は node-cron に `timezone: 'Asia/Tokyo'` を明示指定しており
+# (scripts/scheduler.ts)、node-cron は Node 同梱 ICU を使うため **スケジュール自体は
+# tzdata なしでも正しい**。それでも入れるのは、`date` / ログのタイムスタンプ /
+# 将来 libc 依存の日付処理が入ったときに、3 コンテナで挙動が割れないようにするため。
+# 「この 1 つだけ例外」を残すと、次に読む人が「なぜここだけ無いのか」を毎回調べ直す。
+RUN apk add --no-cache tzdata
+
 WORKDIR /app
 
 # node_modules 全体をコピー（tsx + node-cron が含まれる）

--- a/tests/unit/infra/compose-backup-volume.test.ts
+++ b/tests/unit/infra/compose-backup-volume.test.ts
@@ -153,3 +153,104 @@ describe('#3970 バックアップ保存先の差し替え可能性 (docker-comp
 		}
 	});
 });
+
+// ---------------------------------------------------------------------------
+// #4207 — TZ が「設定されている」ことと「効いている」ことは別
+// ---------------------------------------------------------------------------
+//
+// 本番 NUC の日次バックアップは `0 3 * * *` (深夜 3 時のつもり) で登録されているのに、
+// 実際には **12:00 JST (= 03:00 UTC)** に走っていた。家庭向けアプリの本番 DB を
+// 利用者が起きている真昼にコピーしている状態だった。
+//
+// 原因は tzdata の欠落。`node:22-alpine` は tzdata を同梱しないため、
+// `TZ=Asia/Tokyo` を env で渡しても libc がゾーンを解決できず UTC のままになる。
+// busybox crond はその UTC で `0 3 * * *` を解釈する。
+//
+//   $ docker exec ganbari-quest-backup-1 printenv TZ   → Asia/Tokyo   (設定はされている)
+//   $ docker exec ganbari-quest-backup-1 date          → ... UTC ...  (効いていない)
+//
+// **`printenv TZ` は正しい値を返すので「確認したつもり」になれる**のがこの欠陥の質。
+// しかもバックアップ自体は成功する (ファイルは毎日でき consecutiveFailures: 0) ため、
+// health も alert も何も言わない。#3950 の「取れているつもり」と同型で、
+// 本日 4 件踏んだ「経路はあるが届かない」(#4119 / #4174 / #4189 / #4205) と同じ形。
+//
+//   [TZ1] TZ を宣言する service の Dockerfile が tzdata を install している
+//   [TZ2] cron 式のコメント / 起動ログが実挙動と一致している (「3:00 AM JST」が嘘でない)
+describe('#4207 TZ を宣言したなら、その TZ が実際に効くこと', () => {
+	/** compose の `build:` から、その service がどの Dockerfile で焼かれるかを解決する。 */
+	function dockerfileOf(service: string): string {
+		const raw = readFileSync(COMPOSE_PATH, 'utf-8');
+		const lines = raw.split('\n');
+		const serviceIdx = lines.findIndex((l) => l.trimEnd() === `  ${service}:`);
+		if (serviceIdx < 0) throw new Error(`service '${service}' が docker-compose.yml にありません`);
+
+		const nextIdx = lines.findIndex((l, i) => i > serviceIdx && /^ {2}[a-z][a-z0-9_-]*:\s*$/.test(l));
+		const block = lines.slice(serviceIdx, nextIdx < 0 ? lines.length : nextIdx);
+
+		// `dockerfile: X` の明示があればそれ。無ければ既定の Dockerfile。
+		const explicit = block.find((l) => /^\s+dockerfile:\s*\S+/.test(l));
+		return explicit ? explicit.split(':')[1].trim() : 'Dockerfile';
+	}
+
+	/** TZ env を宣言している service を compose から列挙する (母数を literal 固定しない)。 */
+	function servicesDeclaringTz(): string[] {
+		const raw = readFileSync(COMPOSE_PATH, 'utf-8');
+		const lines = raw.split('\n');
+		return lines
+			.map((l, i) => (/^ {2}[a-z][a-z0-9_-]*:\s*$/.test(l) ? { name: l.trim().slice(0, -1), i } : null))
+			.filter((s): s is { name: string; i: number } => s !== null)
+			.filter(({ name }) => environmentLinesOf(name).some((e) => e.startsWith('TZ=')));
+	}
+
+	const tzServices = servicesDeclaringTz();
+
+	it('[TZ0] 母数: TZ を宣言する service が 1 つ以上ある', () => {
+		// 0 件なら「全部通った」ではなく「1 つも検査していない」。
+		expect(tzServices.length).toBeGreaterThan(0);
+	});
+
+	it('[TZ1] TZ を宣言する service の Dockerfile が tzdata を install している', () => {
+		const missing: string[] = [];
+
+		for (const { name } of tzServices) {
+			const dockerfile = dockerfileOf(name);
+			const content = readFileSync(join(process.cwd(), dockerfile), 'utf-8');
+			// alpine 以外 (debian 系) は tzdata 同梱なので、alpine を使う場合だけ要求する。
+			const usesAlpine = /^FROM\s+\S*alpine/m.test(content);
+			if (!usesAlpine) continue;
+			if (!/apk\s+add[^\n]*\btzdata\b/.test(content)) {
+				missing.push(`${name} (${dockerfile})`);
+			}
+		}
+
+		expect(
+			missing,
+			`TZ を env で渡しているが tzdata が無いため TZ が解決されない service: ${missing.join(' / ')}。` +
+				'alpine は tzdata を同梱しないので `RUN apk add --no-cache tzdata` が要る。' +
+				'これが無いと printenv TZ は正しい値を返すのに date は UTC を返す (#4207)。',
+		).toEqual([]);
+	});
+
+	it('[TZ2] backup の cron 式と、コメント / 起動ログの時刻表記が一致している', () => {
+		const raw = readFileSync(COMPOSE_PATH, 'utf-8');
+
+		// crontab に登録している時刻を実体から取る。
+		const cronLine = raw.split('\n').find((l) => l.includes('crontab -'));
+		expect(cronLine, 'backup の crontab 登録行が見つからない').toBeDefined();
+		const hour = cronLine?.match(/echo\s+"(\d+)\s+(\d+)\s+\*\s+\*\s+\*/)?.[2];
+		expect(hour, `cron 式から時が読めない: ${cronLine}`).toBeDefined();
+
+		// その時刻を JST として説明している文言が、cron 式の時と一致すること。
+		// 「3:00 AM JST」と書いてあるのに `0 12 * * *` を登録している、の逆パターンも捕まえる。
+		const claims = raw.split('\n').filter((l) => /(\d+):00 AM JST|daily .*JST/.test(l));
+		expect(claims.length, 'cron の時刻を JST で説明している行が無い').toBeGreaterThan(0);
+		for (const claim of claims) {
+			const claimed = claim.match(/(\d+):00 AM JST/)?.[1];
+			if (!claimed) continue;
+			expect(
+				Number(claimed),
+				`「${claim.trim()}」が cron 式 (${hour} 時) と一致しない。文言か cron 式のどちらかが嘘になっている`,
+			).toBe(Number(hour));
+		}
+	});
+});

--- a/tests/unit/infra/compose-backup-volume.test.ts
+++ b/tests/unit/infra/compose-backup-volume.test.ts
@@ -1,3 +1,8 @@
+// cspell:ignore tzdata libc btzdata
+//   tzdata / libc = alpine の TZ 解決に必要な実在のパッケージ名・ライブラリ名 (#4207)。
+//   btzdata = 検査用の正規表現 `\btzdata\b` を cspell が語として拾ったもの。
+//   いずれも file scope に閉じる — global 辞書に足すと repo 全体で綴り誤りが素通りする
+//   (tests/CLAUDE.md §「負例 fixture と cspell」)。
 // tests/unit/infra/compose-backup-volume.test.ts
 // #3970 (E3 / EPIC #4119) — バックアップの保存先を compose を書き換えずに差し替えられること。
 //
@@ -190,20 +195,22 @@ describe('#4207 TZ を宣言したなら、その TZ が実際に効くこと', 
 		const block = lines.slice(serviceIdx, nextIdx < 0 ? lines.length : nextIdx);
 
 		// `dockerfile: X` の明示があればそれ。無ければ既定の Dockerfile。
-		const explicit = block.find((l) => /^\s+dockerfile:\s*\S+/.test(l));
-		return explicit ? explicit.split(':')[1].trim() : 'Dockerfile';
+		const explicit = block
+			.map((l) => l.match(/^\s+dockerfile:\s*(\S+)/)?.[1])
+			.find((v): v is string => v !== undefined);
+		return explicit ?? 'Dockerfile';
 	}
 
-	/** TZ env を宣言している service を compose から列挙する (母数を literal 固定しない)。 */
+	/** TZ env を宣言している service 名を compose から列挙する (母数を literal 固定しない)。 */
 	function servicesDeclaringTz(): string[] {
 		const raw = readFileSync(COMPOSE_PATH, 'utf-8');
-		const lines = raw.split('\n');
-		return lines
-			.map((l, i) =>
-				/^ {2}[a-z][a-z0-9_-]*:\s*$/.test(l) ? { name: l.trim().slice(0, -1), i } : null,
-			)
-			.filter((s): s is { name: string; i: number } => s !== null)
-			.filter(({ name }) => environmentLinesOf(name).some((e) => e.startsWith('TZ=')));
+		const names: string[] = [];
+		for (const line of raw.split('\n')) {
+			if (!/^ {2}[a-z][a-z0-9_-]*:\s*$/.test(line)) continue;
+			const name = line.trim().slice(0, -1);
+			if (environmentLinesOf(name).some((e) => e.startsWith('TZ='))) names.push(name);
+		}
+		return names;
 	}
 
 	const tzServices = servicesDeclaringTz();
@@ -216,7 +223,7 @@ describe('#4207 TZ を宣言したなら、その TZ が実際に効くこと', 
 	it('[TZ1] TZ を宣言する service の Dockerfile が tzdata を install している', () => {
 		const missing: string[] = [];
 
-		for (const { name } of tzServices) {
+		for (const name of tzServices) {
 			const dockerfile = dockerfileOf(name);
 			const content = readFileSync(join(process.cwd(), dockerfile), 'utf-8');
 			// alpine 以外 (debian 系) は tzdata 同梱なので、alpine を使う場合だけ要求する。

--- a/tests/unit/infra/compose-backup-volume.test.ts
+++ b/tests/unit/infra/compose-backup-volume.test.ts
@@ -184,7 +184,9 @@ describe('#4207 TZ を宣言したなら、その TZ が実際に効くこと', 
 		const serviceIdx = lines.findIndex((l) => l.trimEnd() === `  ${service}:`);
 		if (serviceIdx < 0) throw new Error(`service '${service}' が docker-compose.yml にありません`);
 
-		const nextIdx = lines.findIndex((l, i) => i > serviceIdx && /^ {2}[a-z][a-z0-9_-]*:\s*$/.test(l));
+		const nextIdx = lines.findIndex(
+			(l, i) => i > serviceIdx && /^ {2}[a-z][a-z0-9_-]*:\s*$/.test(l),
+		);
 		const block = lines.slice(serviceIdx, nextIdx < 0 ? lines.length : nextIdx);
 
 		// `dockerfile: X` の明示があればそれ。無ければ既定の Dockerfile。
@@ -197,7 +199,9 @@ describe('#4207 TZ を宣言したなら、その TZ が実際に効くこと', 
 		const raw = readFileSync(COMPOSE_PATH, 'utf-8');
 		const lines = raw.split('\n');
 		return lines
-			.map((l, i) => (/^ {2}[a-z][a-z0-9_-]*:\s*$/.test(l) ? { name: l.trim().slice(0, -1), i } : null))
+			.map((l, i) =>
+				/^ {2}[a-z][a-z0-9_-]*:\s*$/.test(l) ? { name: l.trim().slice(0, -1), i } : null,
+			)
 			.filter((s): s is { name: string; i: number } => s !== null)
 			.filter(({ name }) => environmentLinesOf(name).some((e) => e.startsWith('TZ=')));
 	}


### PR DESCRIPTION
## 顧客価値・目的

**家庭向けアプリの本番 DB を、利用者が起きている真昼にバックアップしていました。**

`docker-compose.yml` も起動ログも「daily 3:00 AM JST」と言っているのに、実際に走っていたのは **12:00 JST（= 03:00 UTC）** です。

原因は **tzdata の欠落**でした。`node:22-alpine` は tzdata を同梱しないため、`TZ=Asia/Tokyo` を env で渡しても libc がゾーンを解決できず UTC のままになり、busybox crond がその UTC で `0 3 * * *` を解釈します。

```
$ docker exec ganbari-quest-backup-1 printenv TZ   → Asia/Tokyo   ← 設定はされている
$ docker exec ganbari-quest-backup-1 date          → ... UTC ...  ← 効いていない
```

### #3950 の証跡に、この欠陥がそのまま写っていました

本 PR の作業中、#3950 に貼られた「バックアップ復元リハーサル」の証跡を読んで気づきました。

```
pglite-20260731T030000Z.tgz   LastWriteTime = 2026/07/31 12:00:05
```

**ファイル名は `03:00:00Z`（UTC 3 時）、実際に書かれたのは JST 12:00。** バックアップが正常に取れたことを示す証跡が、同時にスケジュールがずれていることの証拠にもなっていました。

### なぜ気づけなかったか（root class）

**`printenv TZ` は正しい値を返すので「設定を確認したつもり」になれます。** しかもバックアップ自体は成功する（ファイルは毎日でき `consecutiveFailures: 0`）ため、health も alert も何も言いません。

「設定したつもりが効いていない + 成功しているので誰も疑わない」は、直近 4 件（#4119 / #4174 / #4189 / #4205）と同じ「経路はあるが届かない」class です。

## 関連 Issue

Closes #4207

- 発見の起点: #3950（PGlite 日次バックアップ実装。復元リハーサルの証跡に本欠陥が写っていた）
- 同 class: #4119 / #4174 / #4189 / #4205（経路はあるが届かない）
- 親 EPIC: #4119（データを失わない）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 意図する時刻を決める（家庭の利用時間帯を避ける当初意図を確認） | cron 式・コメント・起動ログの三者を突合。**当初意図（深夜 3 時 JST）を維持**し、文言ではなく実挙動を合わせる方向で確定 | ✅ `0 3 * * *` と「daily 3:00 AM JST」を**どちらも変更せず**、tzdata を入れて記述が事実になるようにした |
| AC2 | 決めた時刻で実際に発火することを**本番 NUC で実測** | `docker exec <backup> date` が JST を返すこと + 次回実行のファイル名 / mtime | ⚠️ **未達（Dev では実施不可）**。本 PR は NUC 実機に載る経路を持たない。**deploy 後にオーナー確認が必要** — 下記「レビュー依頼事項」に手順を記載 |
| AC3 | `docker-compose.yml` のコメントと起動ログを実挙動と一致させる | `[TZ2]` が cron 式の「時」と「N:00 AM JST」表記の一致を機械照合 | ✅ 変更不要だった。**tzdata を入れることで既存の「3:00 AM JST」が真になる**（文言を 12:00 に書き換えるのは意図を捨てることになるので採らない） |
| AC4 | 同じ取り違えを機械で止める（既存 test に相乗り、新規 script なし） | `tests/unit/infra/compose-backup-volume.test.ts` に `[TZ0]`〜`[TZ2]` を追加。compose から TZ 宣言 service を**列挙**して母数とする | ✅ 修正前 **1 failed / 8 passed** → 修正後 **9 passed**。新規 script は作っていない |
| AC5 | 他 2 コンテナで同じ問題が起きていないか確認し、影響があれば同時是正 | `[TZ1]` の失敗出力が該当 service を列挙 | ✅ **3 service すべて該当**（`app` / `backup` / `scheduler`）。全部同時に是正した |

## 変更タイプ

- [x] バグ修正（本番の挙動が意図とずれていた）
- [x] テスト追加（failing-test + 機械強制）
- [x] インフラ変更（Dockerfile 2 件）
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **アプリの日付処理への影響** | **なし**。アプリは JST SSOT ヘルパ（`src/lib/domain/date-utils.ts`）で日付を導出し、システム TZ に依存しない設計で、`tests/unit/architecture/tz-invariance.test.ts` が `TZ=UTC` と `TZ=Asia/Tokyo` の 2 環境で同値を assert する。本 PR で同 test が green であることを確認済 |
| **backup health の staleness 判定** | **影響なし（実数値で確認）**。`BACKUP_STALE_WARN_HOURS = 26` / `BACKUP_STALE_CRITICAL_HOURS = 50`（`src/lib/domain/backup-health.ts:88,90`）は `lastSuccessAt` からの**経過時間**で判定するため、何時に走るかに依存しない。移行時の 1 回だけ間隔が変わるが、12:00 JST → 翌 03:00 JST = **15 時間**で warn 閾値 26 時間を下回るため誤検知しない |
| **世代ローテーション** | **影響なし**。`BACKUP_RETENTION`（既定 3、`src/lib/server/db/pglite/backup.ts:43`）は**世代数**で切るため実行時刻に依存しない |
| **scheduler の cron スケジュール** | **元から正しかった**。`scripts/scheduler.ts` は node-cron に `timezone: 'Asia/Tokyo'` を明示指定しており、node-cron は Node 同梱 ICU を使うため tzdata 非依存。それでも tzdata を入れたのは、`date` / ログのタイムスタンプを 3 コンテナで揃え、「ここだけ例外」を残さないため |
| **AWS 側 cron** | **無関係**。EventBridge は `utcCronExpression` を明示定義しており TZ 解決に依存しない（`src/lib/server/cron/schedule-registry.ts`） |
| **image サイズ** | `tzdata` は数 MB。`--no-cache` 付きで layer を残さない |

## テスト・品質セルフチェック

```
# 修正前（failing-test-first、ADR-0061）
npx vitest run tests/unit/infra/compose-backup-volume.test.ts
 × [TZ1] TZ を宣言する service の Dockerfile が tzdata を install している
   → app (Dockerfile) / backup (Dockerfile) / scheduler (Dockerfile.scheduler)
 Tests  1 failed | 8 passed (9)

# 修正後
npx vitest run tests/unit/infra/
 Test Files  16 passed (16)
      Tests  167 passed (167)

npx vitest run tests/unit/architecture/tz-invariance.test.ts   → green（アプリの TZ 非依存を確認）
npx biome check --error-on-warnings .                          → Found 3 infos（error 0）
```

- [x] **failing-test-first（ADR-0061）**: commit で red を実測してから実装
- [x] **母数を literal 固定しない**: `[TZ1]` は compose から TZ 宣言 service を列挙するため、TZ を宣言する service を足した人が test を書き換えなくても検査対象に入る
- [x] **`[TZ0]` で母数 0 件を fail させる**: 「全部通った」と「1 つも検査していない」を区別する
- [x] AC4 のとおり**新規 script を作らず**、既存 `compose-backup-volume.test.ts` に相乗りした
- [x] `npm run pre-ready -- --pr <PR番号>` 全 6 step PASS
- [x] `gh pr checks` で CI 側 hard-fail 検査が pass（skipped でない）

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: Dockerfile 2 件とテスト 1 件の変更で、アプリケーションの画面を 1 px も変更しない。顧客に見える UI は存在しない。 -->

**UI 変更はありません。** 変更は `Dockerfile` / `Dockerfile.scheduler` / `tests/unit/infra/compose-backup-volume.test.ts` の 3 file です。

## レビュー依頼事項・破壊的変更

### ⚠️ AC2（本番 NUC での実測）は deploy 後にオーナー確認が必要です

**本 PR では実施できません。** base=develop の PR は NUC 実機に載る経路を持たないためです。**「直したつもり」で終わらせないため、確認手順を明記します。**

deploy 後、本番 NUC で以下を実行してください。

```bash
# 1. TZ が実際に効いているか（これが本 PR の直接の検証）
docker exec ganbari-quest-backup-1 date
#   → "JST" を含む時刻が返れば OK（修正前は "UTC" だった）

# 2. 次回のバックアップが深夜に走ったか（翌日確認）
ls -la C:\Docker\ganbari-quest\data\backups\
#   → 新しい pglite-*.tgz の mtime が JST 03:00 前後であること
#   → ファイル名の UTC 表記は 18:00Z 前後になる（03:00 JST = 前日 18:00 UTC）
```

**ファイル名が `T030000Z` のまま mtime が 12:00 なら、直っていません。**

### レビューで見ていただきたい点

1. **文言ではなく実挙動を合わせた判断。** AC3 は「コメントと起動ログを実挙動と一致させる」ですが、実挙動（12:00）に文言を合わせると**「利用時間帯を避ける」という当初意図を捨てる**ことになります。tzdata を入れて既存の「3:00 AM JST」を真にする方向を選びました。この解釈で合っているかご確認ください。
2. **`scheduler` にも入れた判断。** scheduler は node-cron の `timezone` 明示指定で**元から正しく動いていました**（ICU 依存で tzdata 不要）。機能上は不要ですが、「3 コンテナのうち 1 つだけ tzdata が無い」状態を残すと次に読む人が毎回理由を調べ直すため、揃えました。過剰なら外します。
3. **`[TZ1]` が alpine のときだけ tzdata を要求する点。** debian 系ベースイメージは tzdata を同梱するため、`FROM *alpine` の場合のみ検査しています。将来ベースイメージを変えたときに検査が黙って消えないか、という観点でご確認ください。

### 破壊的変更

**ありません。**

**ただし、バックアップの実行時刻が 12:00 JST → 03:00 JST に変わります**（これが本 PR の目的です）。移行時の 1 回だけ間隔が 15 時間になりますが、staleness の warn 閾値 26 時間を下回るため誤検知しません（上記「影響範囲」参照）。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。** `TZ=Asia/Tokyo` は既に `docker-compose.yml` で全 3 service に配布済みで、本 PR はそれが**解決されるようにする**だけです。

## Ready for Review チェックリスト

- [x] failing-test-first で欠陥を実測してから実装した（ADR-0061）
- [x] AC5（他コンテナへの波及）を機械で列挙し、全件是正した
- [x] アプリの日付処理に影響しないことを `tz-invariance.test.ts` で確認した
- [x] staleness 閾値・世代ローテーションへの影響を実数値で確認した
- [x] **Dev では実施できない AC2 を「未達」と明示し、確認手順を書いた**
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
