### PR TITLE
fix(ci): #4205 close漏れ検知の届け先を PO の受信箱にし、走査を develop に広げる

### DIFF
--- a/.github/workflows/close-leak-report.yml
+++ b/.github/workflows/close-leak-report.yml
@@ -36,10 +36,11 @@ concurrency:
   group: close-leak-report
   cancel-in-progress: false
 
-# report only — issue への書き込みは一切しない (auto-close なし、最小権限)
+# auto-close は一切しない (#3423 選択肢 B 却下)。issues: write は
+# **常設 tracking issue 1 本の upsert のためだけ**に使う (#4205)。検出対象の issue には触らない。
 permissions:
   contents: read
-  issues: read
+  issues: write
 
 jobs:
   report:
@@ -62,7 +63,57 @@ jobs:
       # (GitHub Actions script injection 定石、#3745。shell が $SINCE を展開するため
       #  input 値が shell 構文として解釈されない)
       - name: Detect close leaks (report only)
+        id: detect
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SINCE: ${{ inputs.since || '90 days ago' }}
-        run: node scripts/audit/close-leak-report.mjs --since "$SINCE"
+        run: |
+          node scripts/audit/close-leak-report.mjs --since "$SINCE" > report.md
+          cat report.md
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+          # 「検出: N 件」行から件数を取り出す (report 書式 SSOT は buildCloseLeakReport)
+          COUNT=$(grep -oP '\*\*検出: \K\d+' report.md | head -1)
+          echo "count=${COUNT:-0}" >> "$GITHUB_OUTPUT"
+
+      # #4205: job summary は **どのロールの polling 対象でもない** (チーム憲章 §5.1
+      # 「label のみが通知経路」)。検知は正確に動いていたのに誰にも届いていなかったため、
+      # 常設 tracking issue 1 本へ upsert し `state:needs-po` で PO の受信箱に載せる。
+      #
+      # 毎週 issue を作らず **1 本を更新し続ける** (integration-pr.yml の upsert と同型)。
+      # 検出 0 件のときは issue を作らない / 既存があれば close する (空の受信箱を汚さない)。
+      - name: Deliver to PO mailbox (tracking issue upsert)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COUNT: ${{ steps.detect.outputs.count }}
+          TITLE: 'chore(process): close漏れ候補の週次棚卸し (自動更新)'
+        run: |
+          set -euo pipefail
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --jq "[.[] | select(.title == env.TITLE)] | .[0].number // empty")
+
+          if [ "${COUNT:-0}" = "0" ]; then
+            if [ -n "$EXISTING" ]; then
+              gh issue close "$EXISTING" \
+                --comment "今週の走査では close漏れ候補が 0 件でした。次回検出時に再オープンします (#4205)。"
+              echo "0 件のため tracking issue #$EXISTING を close しました"
+            else
+              echo "0 件 / tracking issue も無し — 何もしません"
+            fi
+            exit 0
+          fi
+
+          {
+            echo "> **この issue は close-leak-report.yml が週次で自動更新します** (#4205)。"
+            echo "> 手で本文を書いても次回の run で上書きされます。棚卸しが済んだら close してください。"
+            echo ""
+            cat report.md
+          } > issue-body.md
+
+          if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --body-file issue-body.md --add-label "state:needs-po"
+            echo "tracking issue #$EXISTING を更新しました ($COUNT 件)"
+          else
+            gh issue create --title "$TITLE" --body-file issue-body.md \
+              --label "state:needs-po" --label "type:docs"
+            echo "tracking issue を新規作成しました ($COUNT 件)"
+          fi

--- a/scripts/audit/close-leak-report.mjs
+++ b/scripts/audit/close-leak-report.mjs
@@ -1,7 +1,7 @@
 /**
  * scripts/audit/close-leak-report.mjs (#3459 = #3423 AC4)
  *
- * close漏れ取りこぼし検知 report — 「fix は main 反映済だが issue が open のまま」を検出し
+ * close漏れ取りこぼし検知 report — 「fix は反映済だが issue が open のまま」を検出し
  * 一覧 report を出力する補助 job。**auto-close は絶対にしない**（誤爆回避、#3423 選択肢 C 却下と同根拠）。
  *
  * 背景: 0 件化キャンペーン (2026-07-11 監査セッション) で、この class の close漏れが 35+ 件
@@ -26,8 +26,11 @@
  *   node scripts/audit/close-leak-report.mjs --since "30 days ago" # 走査期間変更
  *   node scripts/audit/close-leak-report.mjs --json                # JSON 出力 (機械処理用)
  *
- * CI: .github/workflows/close-leak-report.yml (週次 cron + workflow_dispatch) が実行し
- *     GITHUB_STEP_SUMMARY へ report を書き込む。exit code は常に 0 (report only、gate ではない)。
+ * CI: .github/workflows/close-leak-report.yml (週次 cron + workflow_dispatch) が実行し、
+ *     **常設の tracking issue へ upsert** して `state:needs-po` で PO の受信箱に載せる (#4205)。
+ *     旧実装は GITHUB_STEP_SUMMARY にしか出しておらず、**検知は正確に動いていたのに誰にも届いて
+ *     いなかった** (本リポジトリのロール間伝達は label のみで、job summary は polling 対象ですら
+ *     ない — チーム憲章 §5.1)。exit code は常に 0 (report only、gate ではない)。
  */
 
 import { execFileSync } from 'node:child_process';
@@ -37,8 +40,20 @@ import { isMain as isMainModule } from '../lib/is-main.mjs';
 /** 既定の走査期間 (git approxidate)。週次 cron 運用で直近の close漏れを拾いつつ noise を抑える */
 export const DEFAULT_SINCE = '90 days ago';
 
-/** 既定の走査対象 ref (main 反映済判定の基準) */
-export const DEFAULT_REF = 'origin/main';
+/**
+ * 既定の走査対象 ref (#4205 で `origin/main` → `origin/develop` に変更)。
+ *
+ * develop 二層運用では **merge から main 統合までの間ずっと「作業済みなのに受信箱に居座る」**
+ * 状態になる。統合は週数回なので、main だけを見ていると受信箱は常に実態より深く見える
+ * (実測 #4205: 「28 件残っている」ように見えた backlog のうち **15 件が作業済み**で、
+ *  実装コミットは develop にしか無かった)。
+ *
+ * develop は main の superset として扱える — hotfix (`fix/*` → main 直行) も
+ * `hotfix-back-merge.yml` が develop へ戻すため、develop 走査で main 側も拾える。
+ * その代わり **統合前に revert される可能性がある分の false positive を受け入れる**が、
+ * 本 script は auto-close しない (#3423 選択肢 B 却下) ので実害にならない。
+ */
+export const DEFAULT_REF = 'origin/develop';
 
 /** git log の record / field separator (RS / US 制御文字、コミット本文と衝突しない) */
 const RECORD_SEP = '\u001e';
@@ -203,11 +218,18 @@ export function buildCloseLeakReport(leaks, meta = {}) {
 		'',
 		`- 走査対象: \`${ref}\` の直近コミット (since: ${since})${typeof meta.totalCommits === 'number' ? ` ${meta.totalCommits} 件` : ''}`,
 		`- open issue: ${typeof meta.totalOpen === 'number' ? `${meta.totalOpen} 件` : '(件数不明)'}`,
-		`- **検出: ${leaks.length} 件** (main 反映済コミットが issue 番号を参照しているのに open のまま)`,
+		`- **検出: ${leaks.length} 件** (\`${ref}\` に反映済のコミットが issue 番号を参照しているのに open のまま)`,
 		'',
 		'> **auto-close はしません**。本 report は人間が一覧を見て手動 close (AC gate 経由) するための',
 		'> 棚卸し材料です。EPIC / 進行中 workstream / 部分対応 PR の参照は false positive のため、',
 		'> labels 列と該当コミットを見て判断してください。',
+		...(ref.includes('develop')
+			? [
+					'>',
+					'> 走査対象が `develop` のため、**main 未反映 (統合待ち) のものも含みます** (#4205)。',
+					'> 「作業は終わっているが統合待ち」は close せず、**`state:*` label が実態と合っているか**を見てください。',
+				]
+			: []),
 		'',
 	];
 
@@ -217,7 +239,7 @@ export function buildCloseLeakReport(leaks, meta = {}) {
 		return lines.join('\n');
 	}
 
-	lines.push('| Issue | タイトル | labels | main 反映コミット (該当分) |');
+	lines.push(`| Issue | タイトル | labels | \`${ref}\` 反映コミット (該当分) |`);
 	lines.push('|---|---|---|---|');
 	for (const leak of leaks) {
 		const flag = leak.epicLike ? ' ⚠️epic/tracker' : '';

--- a/tests/unit/audit/close-leak-report.test.ts
+++ b/tests/unit/audit/close-leak-report.test.ts
@@ -196,7 +196,7 @@ describe('buildCloseLeakReport', () => {
 });
 
 describe('parseArgs', () => {
-	it('デフォルト値 (since 90 days ago / ref origin/main / limit 500 / json false)', () => {
+	it('デフォルト値 (since 90 days ago / ref origin/develop / limit 500 / json false、#4205)', () => {
 		expect(parseArgs([])).toEqual({
 			since: DEFAULT_SINCE,
 			ref: DEFAULT_REF,
@@ -214,5 +214,43 @@ describe('parseArgs', () => {
 			limit: 100,
 			json: true,
 		});
+	});
+});
+
+describe('#4205 走査対象と report 文言の整合', () => {
+	it('DEFAULT_REF は origin/develop（develop 滞留が見えないと受信箱が実態より深く見える）', () => {
+		expect(DEFAULT_REF).toBe('origin/develop');
+	});
+
+	it('report の見出し / 表ヘッダが ref に追随する（main 固定の文言を残さない）', () => {
+		const md = buildCloseLeakReport(
+			[
+				{
+					number: 1,
+					title: 't',
+					labels: [],
+					epicLike: false,
+					commits: [{ sha: 'abcdef1234', date: '2026-08-01', subject: 's' }],
+				},
+			],
+			{ ref: 'origin/develop', since: '90 days ago', totalOpen: 1, totalCommits: 1 },
+		);
+		expect(md).toContain('`origin/develop` に反映済のコミット');
+		expect(md).toContain('| `origin/develop` 反映コミット (該当分) |');
+		expect(md).not.toContain('main 反映コミット');
+	});
+
+	it('develop 走査のときだけ「main 未反映も含む」注記を出す（誤って close させない）', () => {
+		const dev = buildCloseLeakReport([], { ref: 'origin/develop' });
+		expect(dev).toContain('main 未反映 (統合待ち) のものも含みます');
+
+		const main = buildCloseLeakReport([], { ref: 'origin/main' });
+		expect(main).not.toContain('main 未反映 (統合待ち) のものも含みます');
+	});
+
+	it('workflow が件数を取り出す「**検出: N 件**」の書式を保つ（upsert の分岐条件）', () => {
+		// close-leak-report.yml が grep -oP '\*\*検出: \K\d+' で件数を取る。
+		// 書式を変えると 0 件判定が壊れ、tracking issue が close されなくなる。
+		expect(buildCloseLeakReport([], {})).toMatch(/\*\*検出: 0 件\*\*/);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発基盤）／PO・各ロールの受信箱

**解決する課題**: close漏れ検知（`close-leak-report.yml` / `scripts/audit/close-leak-report.mjs`）は**正常に動いており精度も出ている**のに、**誰にも届いていなかった**。出力先が job summary だけで、本リポジトリのロール間伝達は label のみ（チーム憲章 §5.1）＝ job summary は polling 対象ですらない。加えて走査が `origin/main` 限定のため、develop 二層で「merge 済みだが main 統合待ち」の issue が受信箱に居座り続け、**backlog が常に実態より深く見えていた**。

**期待される効果**: 週次で検出された close漏れ候補が **PO の受信箱（`state:needs-po`）に載る**。走査が develop に広がることで「作業済みなのに label が残っている」が全件見える。PO が手で棚卸しするまで誰も気づけない状態が解消される。

## 関連 Issue

Closes #4205

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 出力先を「誰も開かない job summary」から、**polling 対象に載る場所**へ移す | `node -e "yaml.load('.github/workflows/close-leak-report.yml')"` で step 構成を確認 | HEAD `14dbb14a` / step = `checkout` → `setup-node` → `Detect close leaks (report only)` → **`Deliver to PO mailbox (tracking issue upsert)`**。常設 tracking issue 1 本へ upsert し **`state:needs-po`** を付与する。job summary への出力も従来どおり継続（`cat report.md >> "$GITHUB_STEP_SUMMARY"`） |
| AC2 | 走査が `main` 限定で develop 滞留が見えない状態を解消する | `node scripts/audit/close-leak-report.mjs --ref origin/main --since "90 days ago"` と `--ref origin/develop` を同一窓で比較 | HEAD `14dbb14a` / **`origin/main` 7 件 ↔ `origin/develop` 19 件**。**差の 12 件が「作業済みだが main 未反映」で見えていなかった分**。`DEFAULT_REF` を `origin/develop` に変更（`scripts/audit/close-leak-report.mjs:56`） |
| AC3 | auto-close にしない方針（#3423 選択肢 B 却下）を維持する | `grep -n "issue close\|issue edit\|issue create" .github/workflows/close-leak-report.yml` | HEAD `14dbb14a` / **検出対象の issue には一切書き込まない**。`issues: write` は **tracking issue 1 本の upsert のためだけ**に使う（`gh issue edit "$EXISTING"` / `gh issue create` / 0 件時の `gh issue close "$EXISTING"` はいずれも tracking issue が対象）。report 本文にも「auto-close はしません」の注記を維持 |
| AC4 | 検出ロジックを再実装しない（`scripts/audit/close-leak-report.mjs` は純関数 + unit test 済） | `git diff --stat` | HEAD `14dbb14a` / 検出ロジック（`parseGitLog` / `extractCommitIssueRefs` / `detectCloseLeaks`）は **1 行も変更していない**。変更は `DEFAULT_REF` の値と report 文言の ref 追随のみ |
| AC5 | 新しい検査・新しい workflow を足さない（憲章 §3.4 制約 1） | `ls .github/workflows/ \| wc -l` | HEAD `14dbb14a` / **新規 workflow 0 本 / 新規 script 0 本**。既存 `close-leak-report.yml` に step を 1 つ足しただけ。workflow 本数は 37 本のまま |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客に見える画面の変更なし。影響は週次 `close-leak-report` workflow の出力先と走査 ref。

- [x] **並行実装ペア**を同期した — N/A。UI / DB / ラベルに触れていない
- [x] **設計書同期** (ADR-0001): `scripts/audit/close-leak-report.mjs` の header コメント（同 script の設計 SSOT）を出力先・走査 ref の変更に同期
- [x] **LP ↔ アプリ整合** (ADR-0013): N/A
- [x] **重量 e2e 敏感領域**: N/A
- [ ] N/A — 上記いずれも影響範囲外

### develop 走査で増える false positive の扱い

`origin/develop` は統合前の commit を含むため、**「統合待ち」も検出に混ざります**。auto-close しない設計なので実害はありませんが、読む人が誤って close しないよう **develop 走査のときだけ** report に注記を出します。

```
> 走査対象が `develop` のため、**main 未反映 (統合待ち) のものも含みます** (#4205)。
> 「作業は終わっているが統合待ち」は close せず、**`state:*` label が実態と合っているか**を見てください。
```

`origin/main` を明示した場合はこの注記が出ません（test で固定）。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4219` | **ALL PASS（6 step）** |
| CI（`gh pr checks 4219`） | `unit-test (1)` / `(2)` / `unit-test-merge` / `lint-and-test` | **全 pass（skipping ではない）** |
| 追加・変更テスト | `npx vitest run tests/unit/audit/close-leak-report.test.ts` | PASS — **22 tests**（既存 18 + 追加 4） |
| YAML 構文 + step 構成 | `node -e "yaml.load(...)"` | PASS — parse OK / `permissions: {"contents":"read","issues":"write"}` / step 4 つ |
| 実走査 | `node scripts/audit/close-leak-report.mjs --since "90 days ago"` | PASS — `origin/develop` 19 件を検出、表ヘッダ・注記とも ref 追随を確認 |
| lint | `npx biome check --error-on-warnings` | PASS — 2 files |

### guard を外すと fail するか（mutation 検証）

workflow は `grep -oP '\*\*検出: \K\d+'` で件数を取り、**0 件なら tracking issue を close** します。この書式が静かに変わると 0 件判定が壊れるため、書式を test で固定しました。実際に壊して確認しています。

```
buildCloseLeakReport の `- **検出: N 件**` を `- **検出件数: N**` に変更
  → tests/unit/audit/close-leak-report.test.ts が 3 件 fail
  → 変更を戻して 22 tests 全 PASS を再確認
```

- [x] **SOLID / DRY / YAGNI**: 検出ロジックは再実装せず値と文言だけを変更。upsert は `integration-pr.yml` の既存 idiom を踏襲し、新しい抽象化を持ち込んでいない
- [x] **Security（OSS 公開前提）**: `issues: write` への昇格は tracking issue 1 本の upsert に限定。`workflow_dispatch` input は従来どおり env 経由で渡し `${{ }}` 直展開しない（script injection 定石、#3745）。`$TITLE` は `gh --jq` に `env.TITLE` として渡し、shell 展開経路を作らない
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — 顧客に見える画面の変更はありません。変更は `.github/workflows/` / `scripts/audit/` / `tests/unit/audit/` のみで、`.svelte` / `.css` / `site/` に一切触れていません。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [ ] 含まれない
- [x] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**週次で issue が 1 本作られるようになります。** 検出 0 件の週は作られず、既存があれば close されます。`permissions` が `issues: read` → `issues: write` に上がります。データ移行はありません。復旧は本 PR の revert 1 回です。

**レビュー依頼事項**:

1. **届け先を `state:needs-po` にした判断**を確認いただきたいです。候補は Issue に 3 つ挙がっていました（label mailbox / 週次 report 相乗り / Discord incident webhook）。**label 以外はどのロールの polling にも乗らない**ため mailbox を選びました。`weekly-report.yml` への相乗りも検討しましたが、同 workflow は `fetch-depth: 1` かつ `setup-node` を持たず、close漏れ検知には全 git 履歴が要るため**相乗りすると weekly-report を重くする**（結合も増える）ので見送りました
2. **走査を develop に広げたことで検出が 7 → 19 件に増えます。** 増えた 12 件は「作業済みだが統合待ち」で、**close 対象ではなく label 見直し対象**です。読む側の負荷が上がるのが許容範囲かをご判断ください。noise が多いと感じる場合は `--since` を短くする（既に workflow input で調整可能）か、`origin/main` に戻す選択もあります
3. **初回 run で tracking issue が 19 件のリストとともに作られます。** 中身は現時点の実態そのままです

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— `git diff` 全 3 ファイルを確認。検出ロジック（`parseGitLog` / `extractCommitIssueRefs` / `detectCloseLeaks`）は 1 行も変更していない
- [x] 全 AC が実装済み（未実装・先送りの AC がない）— AC1〜AC5 すべて上記 AC 検証マップに実測を記載
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A。`.svelte` / `.css` / `site/` に触れていない（pre-ready Step 11b も「UI 変更なし」判定）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A。認証画面に触れていない

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
