### PR TITLE
docs(process): #4187 クローン立ち上げ手順を 1 箇所に置く (AC3/AC4/AC5、AC1/AC2 は PO 決裁で撤回)

### DIFF
--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -56,6 +56,7 @@
 | [docs/decisions/README.md](decisions/README.md) | ADR インベントリ + supersede 関係 (TOP 10 active + archive) |
 | [docs/design/parallel-implementations.md](design/parallel-implementations.md) | 並行実装ペア一覧 (修正前必須チェック: labels / 年齢モード / demo / ナビ / DB / チュートリアル) |
 | [docs/sessions/README.md](sessions/README.md) | チーム憲章 SSOT（ロール境界 / 決定権 DACI / コミュニケーション経路、#4175） |
+| [docs/sessions/clone-setup.md](sessions/clone-setup.md) | クローン立ち上げ手順 SSOT（Node 要件 / `npm ci` 2 段 / gh アカウント / ロール別の起動プロンプトと cron 分、#4187） |
 | [docs/sessions/po-session.md](sessions/po-session.md) | PO 補佐セッション (Issue 起票・優先度・事業判断) |
 | [docs/sessions/dev-session.md](sessions/dev-session.md) | Dev セッション (実装・CI/CD・設計書同期、overall map) |
 | [docs/sessions/dev-process/README.md](sessions/dev-process/README.md) | 開発プロセス運用知 各論 (完遂原則 / アンチパターン / QA fix / 並列 Agent / 調査規律 / 横展開、#2516) |

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -362,6 +362,7 @@ teammate は**自分のクローン内でだけ**組む。**ロールを跨い�
 | [qa-session.md](qa-session.md) | QM の作業手順（PR レビュー / 品質ゲート） |
 | [audit-team.md](audit-team.md) | 監査の役割定義（統合 gate / release cut） |
 | [platform-session.md](platform-session.md) | Platform の作業手順（装置の削減 / 統合 / 自動生成） |
+| [clone-setup.md](clone-setup.md) | **クローンの立ち上げ手順**（Node 要件 / `npm ci` 2 段 / gh アカウント / ロール別の起動プロンプトと cron 分） |
 | [label-mailbox.md](label-mailbox.md) | ロール間の受け渡し（`state:*` label） |
 | [agent-teams.md](agent-teams.md) | 1 ロール内の並列化 |
 | [agent-concurrency.md](agent-concurrency.md) | 重い検証の排他（`heavy` lock） |

--- a/docs/sessions/clone-setup.md
+++ b/docs/sessions/clone-setup.md
@@ -1,0 +1,128 @@
+# クローン立ち上げ手順 — 5 クローン運用の SSOT
+
+> **このファイルの位置づけ**: 新しいクローンを作ってロールセッションを起動するまでの手順。**環境要件と起動プロンプトの場所を 1 箇所にまとめる**。
+>
+> **関連**: [チーム憲章](README.md)（ロール体制）/ [label-mailbox.md](label-mailbox.md)（cron テンプレート）/ [agent-concurrency.md](agent-concurrency.md)（`heavy` lock）｜ **関連 Issue**: #4187 / #4199
+
+---
+
+## §1 設計背景
+
+各ロール（PO / Dev / QM / 監査 / Platform）は**別クローン・別セッション**で動く。クローンを増やす手順は**どこにも書かれていなかった**。`CLAUDE.md` の Build & Test はコマンド一覧であって環境要件ではない。
+
+**新規クローンだけが踏む問題がある。** 既存クローンは `node_modules` を持っており install をやり直さないため、依存の要求が上がっても表面化しない。実際 #4187 では、新しく clone した環境で `npm ci` が EBADENGINE で落ち、`pre-ready` が preflight で止まった。
+
+**このファイルが無いと困ること**: クローンを増やすたびに同じ躓きを繰り返し、しかも**躓いた本人しか原因を知らない**状態になる。
+
+---
+
+## §2 前提 — Node の版
+
+**版の SSOT は `.nvmrc`**（#4199）。`package.json` の `engines` と `.npmrc` の `engine-strict=true` により、**要求を満たさない Node では `npm ci` が明示的に失敗する**。
+
+| 宣言 | 値 | 意味 |
+|---|---|---|
+| `.nvmrc` | `22.23.2` | CI が使う版。exact pin |
+| `package.json` の `engines.node` | `>=22.22.2 <23` | 下限 = `jsdom@30` の要求 / 上限 = `better-sqlite3` の ABI 束縛による major skew 防止 |
+| `.npmrc` の `engine-strict` | `true` | `engines` を**警告でなく install 失敗**にする。**外さない** — 外すと `engines` の宣言が飾りになる |
+
+```bash
+nvm install 22.23.2   # .nvmrc の値
+nvm use 22.23.2
+node -v               # v22.23.2
+```
+
+**PATH に古い node が残っていると、新しい方を隠す。** `nvm` の shim が効かない構成なら実体を確認する:
+
+```bash
+where node            # Windows / Git Bash。複数出たら先頭が使われる
+```
+
+---
+
+## §3 手順
+
+```bash
+# 1. clone（ディレクトリ名はロールごとに固定、§4 の表）
+cd E:/Github
+git clone https://github.com/Takenori-Kusaka/ganbari-quest.git ganbari-quest-<role>
+cd ganbari-quest-<role>
+git checkout develop
+
+# 2. Node を .nvmrc に合わせる（§2）
+nvm use 22.23.2 && node -v
+
+# 3. 依存 install — 2 ステップとも必要
+npm ci
+cd infra && npm ci && cd ..
+#   infra を忘れると tests/unit/infra/ が Cannot find module 'aws-cdk-lib' で落ちる
+#   （prepare script が自動実行するが warning のみで継続するため手動確認する、tests/CLAUDE.md）
+
+# 4. install 結果を確認する
+node -e "require('better-sqlite3'); console.log('bs3 OK', process.versions.node)"
+ls node_modules/valibot node_modules/canvas-confetti infra/node_modules/aws-cdk-lib >/dev/null && echo "deps OK"
+
+# 5. gh アカウントを合わせる（§4 の表）
+gh auth status
+node scripts/check-gh-account-before-pr.mjs   # PR を作るロールはこれが exit 0 になること
+```
+
+### major を切り替えたら必ず `npm ci` をやり直す
+
+`better-sqlite3` は **ABI 束縛**（node-gyp / V8 API）で、major を跨ぐと再ビルドが要る。**忘れると分かりにくい native エラー**（`NODE_MODULE_VERSION` 不一致 / `ERR_DLOPEN_FAILED`）になる。
+
+他の native（`bcrypt` / `bufferutil` / `sharp` / rollup・oxc・lightningcss 等の napi-rs 系）は **N-API（ABI 安定）**なので再ビルド不要。**版を変えて壊れうるのは `better-sqlite3` 1 本だけ。**
+
+**クローンごとに `node_modules` は独立している。** major を切り替えたら**全クローンで `npm ci` が要る**:
+
+```bash
+for d in po dev qa audit platform; do
+  (cd "E:/Github/ganbari-quest-$d" 2>/dev/null && node -e "try{require('better-sqlite3');console.log('OK  '+process.cwd())}catch(e){console.log('NG  '+process.cwd()+' — npm ci が必要')}")
+done
+```
+
+---
+
+## §4 ロール別 — クローン / 起動プロンプト / cron / gh アカウント
+
+| ロール | クローン | 起動プロンプト（SSOT） | mailbox cron | 拾う label |
+|---|---|---|---|---|
+| **PO** | `ganbari-quest-po` | [po-session.md](po-session.md) | `37 * * * *` | `state:needs-po` |
+| **Dev** | `ganbari-quest-dev` | [dev-session.md](dev-session.md) | `13 * * * *` | `state:needs-dev` / `state:qm-blocked` |
+| **QM** | `ganbari-quest-qa` | [qa-session.md](qa-session.md) | `23 * * * *` | `state:dev-done` / `state:ready-to-merge` |
+| **監査** | `ganbari-quest-audit` | [audit-team.md](audit-team.md) | `47 * * * *` | `state:needs-audit` |
+| **Platform** | `ganbari-quest-platform` | [platform-session.md](platform-session.md) | `43 * * * *` | `state:needs-platform` |
+
+**cron の分は SSOT が [label-mailbox.md §3.4](label-mailbox.md)**。同時刻に集中させないため、また `:00` / `:30` を避けるためにずらしてある。**セッション起動直後に 1 本だけ作る**（cron テンプレートは同 §4）。
+
+`CronCreate` は**セッション内メモリのみ**で、Claude 終了で消え、7 日で失効する。**次のセッションでもう一度作る。**
+
+### gh アカウント（ADR-0022）
+
+| 操作 | アカウント |
+|---|---|
+| PR 作成 | **`Takenori-Kusaka`**（`check-gh-account-before-pr.mjs` が exit 1 で止める） |
+| QA approve / merge | **`ganbariquestsupport-lab`** |
+
+**作成者 ≠ 承認者**を保つため。クローンを跨いで同じアカウントで両方やらない。
+
+---
+
+## §5 躓いたときに最初に見るところ
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `npm ci` が **EBADENGINE** で落ちる | 実行中の node が `engines` を満たしていない | §2。`where node` で複数 install を疑う（**上げる必要が無く PATH 順の問題**だった実例が #4187） |
+| `pre-ready` が **preflight FAIL（sentinel 欠落）** | `npm ci` が完了していない | §3 手順 3。`npm ci` 自体が落ちていないか出力末尾を見る |
+| `Cannot find module 'aws-cdk-lib'` | `infra/` の install 漏れ | `cd infra && npm ci`（[tests/CLAUDE.md](../../tests/CLAUDE.md) §テスト環境セットアップ） |
+| `NODE_MODULE_VERSION` 不一致 / `ERR_DLOPEN_FAILED` | node の major を変えた後に `npm ci` していない | §3「major を切り替えたら」 |
+| 重い検証が **exit 2 で止まる** | 他クローンが `heavy` lock を保持中（**マシン全体で 1 本**） | 待たずに別作業へ（[agent-concurrency.md](agent-concurrency.md)） |
+| PR 作成が **PR 起票アカウント検証**で落ちる | gh アカウントが `Takenori-Kusaka` でない | §4。`gh auth switch --user Takenori-Kusaka` |
+
+---
+
+## §6 このファイルの更新ルール
+
+- **Node の版を変えたら §2 の表**を更新する（値の SSOT は `.nvmrc` / `package.json`。ここは参照であって二重管理にしない）
+- **ロールを増やしたら §4 の表**に 1 行足す（クローン名 / 起動プロンプト / cron 分 / 拾う label の 4 つが揃って初めて起動できる）
+- **新規クローンで躓いたら §5 に 1 行足す**。躓いた本人しか知らない状態にしない

--- a/docs/sessions/label-mailbox.md
+++ b/docs/sessions/label-mailbox.md
@@ -152,6 +152,7 @@ CronCreate(cron: "<ロールごとにずらした分>", recurring: true, prompt:
 | Dev | `13 * * * *` |
 | QM | `23 * * * *` |
 | PO | `37 * * * *` |
+| **Platform** | **`43 * * * *`** |
 | 監査 | `47 * * * *` |
 
 #### CronCreate の制約（必ず理解して使う）


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発基盤）／新しくクローンを作る全ロール

**解決する課題**: 5 クローン運用（PO / Dev / QM / 監査 / Platform）に移行したのに、**クローンを増やす手順がどこにも無かった**。`CLAUDE.md` の Build & Test はコマンド一覧であって環境要件ではない。**新規クローンだけが踏む問題**（既存クローンは `node_modules` を持っており install をやり直さないため表面化しない）があり、躓いた本人しか原因を知らない状態になっていた。

**期待される効果**: clone → Node 要件 → `npm ci` 2 段 → gh アカウント → 起動プロンプト → cron までが 1 ファイルに揃う。躓いたときの症状 → 原因 → 対処も同じ場所にあるため、**次に同じ躓きをした人が自力で抜けられる**。

## 関連 Issue

Closes #4187

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `scripts/pre-ready.mjs` の preflight に **node バージョン要件の検査**を追加する | — | **PO 決裁により撤回（2026-08-02、選択肢 B）**。理由は「不要だから」ではなく **「思想は正しいが、#4199 で機械が既に教えるようになったので個別の検査は不要」**。#4187 起票時（08-01）は `package.json` に `engines` が無く、EBADENGINE を出していたのは `jsdom@30` という依存側の宣言だった。#4199 で `engines: ">=22.22.2 <23"` を宣言したことで、**`npm ci` が自リポジトリの要求を名指しして落ちる**ようになっている。加えて新しい検査の追加は憲章 §3.4 制約 1（装置総数は ratchet）の対象で、**原資が無いまま足すと制約を自分で破る**ことになる |
| AC2 | 失敗メッセージに **`where node` / 複数 install の可能性**への言及を含める | — | **AC1 に付随して撤回**（同上）。ただし**内容は失われていない** — `docs/sessions/clone-setup.md` §2 に「PATH に古い node が残っていると新しい方を隠す」と `where node` の使い方を、§5 に「上げる必要が無く PATH 順の問題だった実例（#4187）」を記載した |
| AC3 | **新規クローンの立ち上げ手順**を 1 箇所に置く（clone → node 要件 → `npm ci` → `gh auth` → 起動プロンプト） | `ls docs/sessions/clone-setup.md` / 本文の §3 を実読 | HEAD `50b1a014` / **`docs/sessions/clone-setup.md` を新設**（128 行）。§3 が clone → `nvm use` → `npm ci` → `cd infra && npm ci` → install 結果の確認 → `gh auth status` + `check-gh-account-before-pr.mjs` の順で並ぶ。**`infra` の 2 段目**を明示（忘れると `tests/unit/infra/` が `Cannot find module 'aws-cdk-lib'` で落ちる、`tests/CLAUDE.md` 整合） |
| AC4 | AC3 の手順に、**ロールごとの起動プロンプトの場所**（`docs/sessions/*-session.md`）を含める | 同 §4 の表を実読 | HEAD `50b1a014` / §4 に **5 ロール × 4 列の表**（クローン名 / 起動プロンプト / mailbox cron 分 / 拾う label）。**4 つが揃って初めて起動できる**ことを §6 更新ルールにも明記。gh アカウント（ADR-0022 作成者 ≠ 承認者）も同節に併記 |
| AC5 | `.npmrc` の `engine-strict=true` は**維持する**（外すと `engines` の宣言が飾りになる） | `cat .npmrc` / `node -p "require('./package.json').engines.node"` | HEAD `50b1a014` / `.npmrc` = `engine-strict=true`（**変更なし**）/ `engines.node` = `>=22.22.2 <23`。**#4199 で `engines` を宣言したことで初めて実効化**した。§2 の表に「`engine-strict` は `engines` を警告でなく install 失敗にする。**外さない** — 外すと `engines` の宣言が飾りになる」として位置づけを明文化 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客に見える画面の変更なし。コード変更ゼロ、docs のみ。

- [x] **並行実装ペア**を同期した — N/A。UI / DB / ラベルに触れていない
- [x] **設計書同期** (ADR-0001): 新設ファイルを **`docs/sessions/README.md` §7** と **`docs/codebase-map.md` §3** の両方から link（新規 SSOT 文書追加時の更新ルール、`codebase-map.md` §9 整合）
- [x] **LP ↔ アプリ整合** (ADR-0013): N/A
- [x] **重量 e2e 敏感領域**: N/A
- [ ] N/A — 上記いずれも影響範囲外

### 副産物 — SSOT の欠落を 1 件塞ぎました

**`label-mailbox.md` §3.4 の cron 分表に Platform の行がありませんでした。**

```
| Dev | `13 * * * *` |
| QM  | `23 * * * *` |
| PO  | `37 * * * *` |
| 監査 | `47 * * * *` |     ← Platform (43) が無い
```

`platform-session.md` は「**分は 43**」を指定しているのに、**分の SSOT である `label-mailbox.md` §3.4 の表に載っていない**状態でした。Platform ロール新設時に mailbox 側の更新が落ちたもので、**自分が使う側になって初めて見つかる欠落**です。本 PR で 1 行追加しました。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4221` | **ALL PASS（6 step）** |
| CI（`gh pr checks 4221`） | `unit-test (1)` / `(2)` / `unit-test-merge` / `lint-and-test` | **全 pass（skipping ではない）** |
| doc-code 参照整合 | `node scripts/check-doc-code-references.mjs` | PASS — baseline 内（128 件 / 53 ファイル）、新規違反なし |
| 用語 / 内部語彙 | `node scripts/check-internal-terms.mjs` | PASS — 新規違反 0 件（conn-info 2494 files / self-ref-change 372 files / workflow-lane-coverage 37 本すべて 0 件） |
| スペル | `npm run cspell` | PASS — 1816 files / **Issues found: 0** |
| link 実在確認 | 新設ファイルの相対 link 全 11 件を `[ -e ]` で確認 | PASS — 全件存在（`docs/sessions/*.md` 8 件 / `tests/CLAUDE.md` / `.nvmrc` / `scripts/check-gh-account-before-pr.mjs`） |

- [x] **SOLID / DRY / YAGNI**: **値の SSOT を二重管理していない** — §2 の Node 版は `.nvmrc` / `package.json` を参照する形で書き、値そのものの正本にはしていない（§6 更新ルールに明記）。cron 分も `label-mailbox.md` §3.4 が SSOT であることを §4 に明記
- [x] **Security（OSS 公開前提）**: 秘密情報なし。gh アカウント名（`Takenori-Kusaka` / `ganbariquestsupport-lab`）は ADR-0022 / 既存 docs に既出の公開情報
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

**該当なし（refactor / docs / chore）** — docs のみの変更で、`.svelte` / `.css` / `site/` に一切触れていません。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **AC1 / AC2 は PO 決裁で撤回済み**です（本 PR の scope 外）。撤回理由の表現に注意しています — 「不要」と書くと次に同じ現象が起きたとき「一度不要と判断した」が根拠に使われるため、**「#4199 が別の場所で塞いだのであって思想が否定されたわけではない」**という形で AC 検証マップに記載しました
2. **置き場所を `docs/sessions/` にした判断** — `docs/runbooks/` は本番インシデント対応の運用 runbook が並ぶ場所で、性質が違うと判断しました。AC4 が要求する「ロール別の起動プロンプトの場所」は `docs/sessions/*-session.md` なので、**同じディレクトリに置くほうが辿りやすい**と考えています

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）— `git diff` 全 4 ファイルを確認。コード変更ゼロ、docs のみ
- [x] 全 AC が実装済み（未実装・先送りの AC がない）— AC3 / AC4 / AC5 は実装済み、**AC1 / AC2 は PO 決裁で撤回**（AC 検証マップに撤回理由を記載。先送りではなく決着済み）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A。docs のみ（pre-ready Step 11b も「UI 変更なし」判定）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A。認証画面に触れていない

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qa-session.md` を参照](../docs/sessions/qa-session.md)
