### PR TITLE
fix(ci): #4158 同じ検査が YAML と scripts に二重にある構造を潰し、委譲を機械強制する

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -52,6 +52,15 @@ jobs:
             const lane = process.env.PR_LANE || 'feature';
             core.info(`PR lane = ${lane} (判定 SSOT: scripts/pr-lane.mjs / actions/pr-lane、#2946)`);
 
+            // #4158: 合否判定を YAML に書かない。判定は全て scripts/check-pr-screenshot.mjs の
+            //   export に委譲する。同じ検査を 2 箇所に置くと片方だけ直したときに必ずズレ、
+            //   「CI 緑・pre-ready 赤」(または逆) が起きる (#4153 で実発生)。
+            //   委譲されていることは tests/unit/architecture/workflow-judgment-delegation-guard.test.ts
+            //   が registry と突き合わせて機械強制する。
+            const ssMod = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/check-pr-screenshot.mjs`
+            );
+
             // UI関連ファイルが変更されているか確認
             const { data: files } = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
@@ -60,10 +69,7 @@ jobs:
               per_page: 100,
             });
 
-            const uiFilePattern = /\.(svelte|svelte\.ts|svelte\.js|css|scss)$|^site\//;
-            const hasUiFiles = files.some(f => uiFilePattern.test(f.filename));
-
-            if (!hasUiFiles) {
+            if (!ssMod.isUiPr(files.map((f) => f.filename))) {
               core.info('✅ UI関連ファイルの変更なし — スクリーンショット不要');
               return;
             }
@@ -72,11 +78,8 @@ jobs:
             // I1 (#1985) design-doc-check と同パターン。判定基準は ADR-0003 §4.1 (4 条件).
             // skip 条件 (UI 変更なし / 内部 refactor label) は全 lane 共通で優先する。
             const labels = (context.payload.pull_request.labels || []).map((l) => l.name);
-            const INTERNAL_REFACTOR_LABEL = 'refactor:internal-no-doc-impact';
-            const hasInternalRefactorLabel = labels.some(
-              (l) => l.trim().toLowerCase() === INTERNAL_REFACTOR_LABEL,
-            );
-            if (hasInternalRefactorLabel) {
+            const INTERNAL_REFACTOR_LABEL = ssMod.INTERNAL_REFACTOR_LABEL;
+            if (ssMod.hasInternalRefactorLabel(labels)) {
               core.info(
                 `✅ PR ラベル '${INTERNAL_REFACTOR_LABEL}' により内部 refactor として exempt (#2017 / ADR-0003 §4) — SS 添付不要`,
               );
@@ -94,9 +97,6 @@ jobs:
             //   判定ロジックは scripts/check-pr-screenshot.mjs::hasIntegrationVrEvidence を再利用 (二重実装しない)。
             // ============================================================
             if (lane === 'integration') {
-              const ssMod = await import(
-                `${process.env.GITHUB_WORKSPACE}/scripts/check-pr-screenshot.mjs`
-              );
               if (ssMod.hasIntegrationVrEvidence(body)) {
                 core.info(
                   '✅ lane=integration — VR 3 層 (lp/child-home/app visual regression) 結果への紐づけ / 含有 PR SS 検証済の確認を検出 (before/after 4 スロットは不要、#2946 AC3)',
@@ -122,15 +122,13 @@ jobs:
             // ============================================================
             // feature / hotfix / dependabot lane: 現行 (UI 変更時 before/after 画像必須) を完全維持 (#2946 AC4)。
             // ============================================================
-            // Markdown画像: ![alt](url) / HTML画像: <img ...>
-            const hasImage = /!\[.*?\]\(.*?\)|<img\s/i.test(body);
+            // #4158: SS embed の有無も委譲する。旧 inline は `![](...)` が 1 個あれば pass だったが、
+            //   script 側は URL を抽出して **http(s) かつ screenshot / attachment URL** を要求する。
+            //   この差で `![](tmp/local.png)` だけの PR が **CI 緑・pre-ready 赤**になっていた。
+            const hasImage = ssMod.hasEmbeddedScreenshotImage(body);
 
             // #4087: 表示条件が env に依存し、撮影に使う demo 環境では原理的に描画されない UI の宣言。
-            //   判定は scripts/check-pr-screenshot.mjs に委譲する (二重実装しない、integration lane と同パターン)。
             //   宣言だけでは通らず、理由 (12 文字以上) + Storybook story 参照の両方を要求する。
-            const ssMod = await import(
-              `${process.env.GITHUB_WORKSPACE}/scripts/check-pr-screenshot.mjs`
-            );
             const renderImpossible = ssMod.checkRenderImpossibleDeclaration(body);
             if (renderImpossible.ok) {
               core.info(

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -447,10 +447,16 @@ export function hasEmbeddedScreenshotImage(body) {
  * UI 変更があり exempt でない PR について、PR body に GitHub 表示可能な embed 画像が無い、
  * または未来形記述 (「後で push する」) が残っている場合に違反を返す。
  *
- * skip 条件 (CI screenshot-check と同一 SSOT):
- * - UI 関連ファイル変更なし (isUiPr=false)
+ * skip 条件:
+ * - UI 関連ファイル変更なし (isUiPr=false) … **CI screenshot-check と共有** (#4158)
+ * - ラベル refactor:internal-no-doc-impact (hasInternalRefactorLabel) … **CI と共有** (#4158)
  * - 「該当なし（refactor / docs / chore）」「UI 変更なし」明示 (hasUiNotApplicableMarker)
- * - ラベル refactor:internal-no-doc-impact (hasInternalRefactorLabel)
+ *   … **本関数だけが見る。CI screenshot-check は呼んでいない**
+ *
+ * つまり本関数は CI より**広い**。「CI と同一 SSOT」と書くと、CI で通ったものが
+ * pre-ready で落ちたときに「どちらかが壊れている」と誤読される。共有しているのは
+ * 個々の判定関数であって、この関数そのものではない。
+ * 委譲の宣言は scripts/lib/ci/workflow-judgment-registry.mjs が SSOT。
  *
  * @param {{ body: string; files: string[]; labels: string[] }} input
  * @returns {{ skipped: boolean; skipReason: string | null; violations: { id: string; issue: string; message: string }[] }}

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -105,6 +105,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'bounded',
 		note: '走査は src/routes/api/cron 配下のみ (再帰だが単一 dir で有界)。全 cron route が verifyCronAuth を呼ぶことを検査する (#4206)',
 	},
+	'tests/unit/architecture/workflow-judgment-delegation-guard.test.ts': {
+		scope: 'repo',
+		note: '.github/workflows を走査し、合否判定が YAML でなく scripts/*.mjs に委譲されているかを検査する (#4158)',
+	},
 	'tests/unit/architecture/user-content-delivery-headers-fitness.test.ts': {
 		scope: 'repo',
 		note: 'infra + src を走査して配信ヘッダを検査する',

--- a/scripts/lib/ci/workflow-judgment-registry.mjs
+++ b/scripts/lib/ci/workflow-judgment-registry.mjs
@@ -1,0 +1,113 @@
+/**
+ * scripts/lib/ci/workflow-judgment-registry.mjs (#4158)
+ *
+ * 「**合否を決める判定を workflow YAML の中に書かない**」の宣言 SSOT。
+ *
+ * # 背景 (実測)
+ *
+ * `pre-ready --help` は Step 11b を「**CI screenshot-check と SSOT 共有**」と書いていたが、
+ * `pr-quality-gate.yml` の `screenshot-check` は同じ .mjs から 2 関数しか import しておらず、
+ * **SS embed の有無判定は inline 正規表現**だった。両者は等価ではない:
+ *
+ *   - script (`hasEmbeddedScreenshotImage`): URL を抽出し **http(s) かつ screenshot / attachment URL** を要求
+ *   - inline (`/!\[.*?\]\(.*?\)|<img\s/i`): **`![](...)` が 1 個あれば pass**
+ *
+ * つまり `![](tmp/local.png)` のようなローカルパス画像だけの PR は **CI 緑・pre-ready 赤**になる。
+ * #4153 では逆向き (`ss-render-impossible` を .mjs にだけ実装 → pre-ready 緑・CI 赤) が起きた。
+ *
+ * **「検査が多すぎて漏れた」のではない。同じ検査が 2 箇所にあり、片方だけ直せば必ずズレる。**
+ * 本数を減らしても二重実装が残る限り同じ事故が起きる (#4158)。
+ *
+ * # 本 registry が固定すること
+ *
+ *   1. 合否を決める step は、判定を `scripts/*.mjs` の export に**委譲する** (`delegation: 'script'`)
+ *   2. 委譲できない構造 (job の `if:` 式は node を呼べない) は `delegation: 'expression'` として
+ *      **明示的に宣言し、対応する SSOT を書く** — 黙って inline のまま残さない
+ *   3. まだ script 化されていないものは `delegation: 'not-required'` に**理由と追跡 Issue 付きで**置く。
+ *      理由なしの逃げ道を作らない (#3956 教訓)
+ *   4. 宣言と実物の乖離 (未宣言 / stale) は `workflow-judgment-delegation-guard.test.ts` が fail させる
+ *
+ * # 段階導入について
+ *
+ * 初期対象は **PR gate 系の workflow に限る**。`deploy*.yml` の secret 検証 / smoke は
+ * script が存在せず、PR gate の等価性問題でもないため `not-required` で明示除外する。
+ * 「対象を絞ったこと」自体が registry に残るので、後から範囲を広げるときに漏れが見える。
+ */
+
+/**
+ * @typedef {object} JudgmentDeclaration
+ * @property {string} workflow  `.github/workflows/` からの file 名
+ * @property {string} job       job id
+ * @property {'script' | 'expression' | 'not-required'} delegation
+ * @property {string} [module]  delegation='script' のとき、委譲先 `scripts/*.mjs`
+ * @property {string[]} [functions] delegation='script' のとき、呼ぶ export 名 (全て import されていること)
+ * @property {string} [ssot]    delegation='expression' のとき、式が一致すべき SSOT
+ * @property {string} reason    なぜこの区分なのか。**空文字禁止**
+ * @property {string} [issue]   delegation='not-required' のとき必須。`#1234` 形式
+ */
+
+/** @type {JudgmentDeclaration[]} */
+export const WORKFLOW_JUDGMENTS = [
+	{
+		workflow: 'pr-quality-gate.yml',
+		job: 'screenshot-check',
+		delegation: 'script',
+		module: 'scripts/check-pr-screenshot.mjs',
+		// #4158 で inline から移した 3 判定 + #4153 / #2946 で既に委譲済の 2 判定。
+		functions: [
+			'isUiPr',
+			'hasInternalRefactorLabel',
+			'hasEmbeddedScreenshotImage',
+			'checkRenderImpossibleDeclaration',
+			'hasIntegrationVrEvidence',
+		],
+		reason:
+			'SS embed gate は pre-ready Step 11b と同じ判定でなければならない。inline 正規表現だと ' +
+			'ローカルパス画像で CI 緑・pre-ready 赤になる (#4158 実測)',
+	},
+	{
+		workflow: 'pr-quality-gate.yml',
+		job: 'design-doc-check',
+		delegation: 'script',
+		module: 'scripts/check-design-doc-sync.mjs',
+		functions: ['checkDesignDocSync'],
+		reason: 'ADR-0001 設計書同期。既に委譲済 (本 registry は現状の固定)',
+	},
+	{
+		workflow: 'pr-quality-gate.yml',
+		job: 'screenshot-quality-check',
+		delegation: 'script',
+		module: 'scripts/check-pr-screenshot.mjs',
+		functions: [],
+		reason: 'CLI 実行 (node scripts/check-pr-screenshot.mjs) で判定を持たない',
+	},
+	{
+		workflow: 'pr-quality-gate.yml',
+		job: 'ss-blob-sha-uniqueness-check',
+		delegation: 'script',
+		module: 'scripts/check-ss-blob-sha-uniqueness.mjs',
+		functions: [],
+		reason: 'CLI 実行。判定は script 側 (#2063 / #4084)',
+	},
+	{
+		workflow: 'pr-quality-gate.yml',
+		job: 'ss-render-health-check',
+		delegation: 'script',
+		module: 'scripts/check-ss-render-health.mjs',
+		functions: [],
+		reason: 'CLI 実行。判定は script 側 (#3012)',
+	},
+];
+
+/**
+ * 本 registry の対象 workflow。ここに無い workflow は検査しない。
+ *
+ * **段階導入の境界を明示するために置く。** 「全 workflow を見ているつもりで実は 1 本だけ」を
+ * 避けるため、guard test は本リストの workflow について**全 job が宣言済**であることを要求する。
+ */
+export const COVERED_WORKFLOWS = ['pr-quality-gate.yml'];
+
+/** @param {string} workflow @param {string} job */
+export function findJudgment(workflow, job) {
+	return WORKFLOW_JUDGMENTS.find((d) => d.workflow === workflow && d.job === job);
+}

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -120,7 +120,12 @@ Steps (6 本。番号は既存の識別子を維持 — 実行順は下記「実
   7.  check-no-plan-literals.mjs  — プラン / ステータスリテラル直書き検査 (#972)
   7g. check-local-tz-date-getters.mjs — TZ 依存の日付導出禁止 / JST SSOT 強制 (#4015 / #4127)
   9.  Readiness gate              — Ready checklist [x] 完了 / AC 4 列 / forbidden-terms / 必須セクション 13 個 / mergeable (check-pr-body.mjs、PR 番号必須、#2632)
-  11b. check-pr-screenshot.mjs (SS embed gate) — UI 変更 PR の SS embed 未完了を hard-fail (#2918、CI screenshot-check と SSOT 共有)
+  11b. check-pr-screenshot.mjs (SS embed gate) — UI 変更 PR の SS embed 未完了を hard-fail (#2918)
+       CI screenshot-check とは同じ判定関数 (isUiPr / hasInternalRefactorLabel /
+       hasEmbeddedScreenshotImage / checkRenderImpossibleDeclaration) を共有する (#4158)。
+       ただし本 step は checkScreenshotEmbedReadiness まで見るため CI より広い —
+       「未来形記述 (後で push する)」「該当なしマーカー」は本 step だけが hard-fail する。
+       委譲の宣言 SSOT: scripts/lib/ci/workflow-judgment-registry.mjs
 
 選定基準 (ADR-0007 §1-2 判断原則 v2、#4121):
   類型 1 (証跡の真正性 / 不可逆な損失) と 類型 2 (顧客に見える正しさ) のうち安価なものだけを

--- a/tests/unit/architecture/workflow-judgment-delegation-guard.test.ts
+++ b/tests/unit/architecture/workflow-judgment-delegation-guard.test.ts
@@ -1,0 +1,197 @@
+/**
+ * tests/unit/architecture/workflow-judgment-delegation-guard.test.ts (#4158)
+ *
+ * 「**同じ検査が workflow YAML と scripts/*.mjs の 2 箇所にある**」を機械で禁じる。
+ *
+ * ## 何が起きていたか
+ *
+ * `pre-ready --help` は Step 11b を「CI `screenshot-check` と SSOT 共有」と書いていたが、
+ * 実際の `screenshot-check` は同じ .mjs から 2 関数しか import しておらず、
+ * **SS embed の有無判定は inline 正規表現**だった。両者は等価ではない:
+ *
+ *   script  `hasEmbeddedScreenshotImage(body)` … URL を抽出し http(s) かつ screenshot/attachment URL を要求
+ *   inline  `/!\[.*?\]\(.*?\)|<img\s/i`        … `![](...)` が 1 個あれば pass
+ *
+ * → `![](tmp/local.png)` だけの PR は **CI 緑・pre-ready 赤**。
+ * → 逆向きは #4153 で実発生（`ss-render-impossible` を .mjs にだけ実装 → pre-ready 緑・CI 赤）。
+ *
+ * **本質は「検査が多すぎて漏れた」ではなく「同じ検査が 2 箇所にあり、片方だけ直せば必ずズレる」。**
+ * 本数を減らしても二重実装が残る限り同じ事故が起きる。だから減らすのではなく等価性を機械で固定する
+ * (ADR-0061 same-class-N→guard)。
+ *
+ * ## 本 test が固定すること
+ *
+ *   [D1] 母数 — 対象 workflow の全 job が registry に宣言されている（未宣言 = 検査から静かに消える）
+ *   [D2] stale — registry に在るのに実在しない workflow / job を宣言していない
+ *   [D3] delegation='script' の job は、宣言した module を実際に import している
+ *   [D4] delegation='script' の job は、宣言した export を実際に呼んでいる
+ *   [D5] **inline 判定の再混入禁止** — 委譲済 job の `script:` に、委譲したはずの判定の
+ *        既知アンチパターン（生の正規表現による画像検出 / label 名の直書き）が無い
+ *   [D6] registry の記述品質 — `reason` 空文字禁止 / `not-required` は追跡 Issue 必須
+ *
+ * ## 走査方針
+ *
+ * 判定は **parse 済み YAML の `run` / `with.script` にだけ**当てる。workflow 全文 grep だと
+ * コメントや案内文言（「スクリーンショットを添付してください」等）を誤検出する
+ * (`pr-trigger-lane-guard.test.ts` の同注意書きと同じ理由)。
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+import * as yaml from 'yaml';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test (実行時間が入力サイズに比例する)。区分は
+// scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
+vi.setConfig({ testTimeout: 60_000 });
+
+import {
+	COVERED_WORKFLOWS,
+	WORKFLOW_JUDGMENTS,
+	findJudgment,
+} from '../../../scripts/lib/ci/workflow-judgment-registry.mjs';
+
+const WORKFLOW_DIR = path.join(process.cwd(), '.github', 'workflows');
+
+/** workflow を parse し、job id → 全 step の「実行文字列」配列 を返す。 */
+function jobScriptsOf(workflowFile: string): Map<string, string[]> {
+	const raw = readFileSync(path.join(WORKFLOW_DIR, workflowFile), 'utf-8');
+	const doc = yaml.parse(raw) as { jobs?: Record<string, { steps?: unknown[] }> };
+	const result = new Map<string, string[]>();
+
+	for (const [jobId, job] of Object.entries(doc.jobs ?? {})) {
+		const texts: string[] = [];
+		for (const rawStep of job?.steps ?? []) {
+			if (rawStep === null || typeof rawStep !== 'object') continue;
+			const step = rawStep as { run?: unknown; with?: { script?: unknown } };
+			if (typeof step.run === 'string') texts.push(step.run);
+			// actions/github-script の判定本体は with.script に入る
+			if (typeof step.with?.script === 'string') texts.push(step.with.script);
+		}
+		result.set(jobId, texts);
+	}
+	return result;
+}
+
+/** 実在する workflow file 一覧 (母数を registry から取らない)。 */
+function listWorkflowFiles(): string[] {
+	return readdirSync(WORKFLOW_DIR)
+		.filter((n) => n.endsWith('.yml') || n.endsWith('.yaml'))
+		.sort();
+}
+
+describe('#4158 合否判定を workflow YAML に書かない', () => {
+	it('[D0] 母数: 対象 workflow が実在し、job を 1 つ以上持つ', () => {
+		// 0 件なら「全部通った」ではなく「1 つも検査していない」。
+		expect(COVERED_WORKFLOWS.length).toBeGreaterThan(0);
+		const files = listWorkflowFiles();
+		for (const wf of COVERED_WORKFLOWS) {
+			expect(files, `${wf} が .github/workflows に無い`).toContain(wf);
+			expect(jobScriptsOf(wf).size, `${wf} の job 数`).toBeGreaterThan(0);
+		}
+	});
+
+	it('[D1] 対象 workflow の全 job が registry に宣言されている (no-silent-gap)', () => {
+		const undeclared: string[] = [];
+		for (const wf of COVERED_WORKFLOWS) {
+			for (const jobId of jobScriptsOf(wf).keys()) {
+				if (!findJudgment(wf, jobId)) undeclared.push(`${wf}:${jobId}`);
+			}
+		}
+		expect(
+			undeclared,
+			`registry 未宣言の job: ${undeclared.join(' / ')}。` +
+				'scripts/lib/ci/workflow-judgment-registry.mjs に delegation と reason を足すこと。' +
+				'宣言しないまま job を足すと、判定が YAML に戻っても誰も気づかない (#4158)',
+		).toEqual([]);
+	});
+
+	it('[D2] registry に stale な宣言が無い', () => {
+		const stale: string[] = [];
+		for (const d of WORKFLOW_JUDGMENTS) {
+			const jobs = listWorkflowFiles().includes(d.workflow)
+				? jobScriptsOf(d.workflow)
+				: new Map<string, string[]>();
+			if (!jobs.has(d.job)) stale.push(`${d.workflow}:${d.job}`);
+		}
+		expect(stale, `実在しない workflow / job の宣言: ${stale.join(' / ')}`).toEqual([]);
+	});
+
+	describe('[D3][D4] delegation=script は宣言どおり委譲している', () => {
+		for (const d of WORKFLOW_JUDGMENTS.filter((x) => x.delegation === 'script')) {
+			it(`${d.workflow}:${d.job} が ${d.module} を参照している`, () => {
+				const texts = jobScriptsOf(d.workflow).get(d.job) ?? [];
+				const joined = texts.join('\n');
+				const moduleBase = path.basename(d.module ?? '');
+				expect(
+					joined,
+					`${d.job} が ${d.module} を参照していない。registry の宣言が実態と違う`,
+				).toContain(moduleBase);
+			});
+
+			for (const fn of d.functions ?? []) {
+				it(`${d.workflow}:${d.job} が ${fn} を呼んでいる`, () => {
+					const joined = (jobScriptsOf(d.workflow).get(d.job) ?? []).join('\n');
+					// import しただけで呼んでいない = 判定が別の場所にある。
+					expect(
+						new RegExp(`\\b${fn}\\s*\\(`).test(joined),
+						`${d.job} が ${fn}( を呼んでいない。inline 判定が残っている可能性がある`,
+					).toBe(true);
+				});
+			}
+		}
+	});
+
+	describe('[D5] 委譲済 job に inline 判定を書き戻していない', () => {
+		// 既知のアンチパターン。**「判定に見える文字列」ではなく「過去に実在した inline 判定の形」**を
+		// 列挙する。網羅ではなく回帰 guard (#4158 で実際に外した 3 つの形)。
+		const REGRESSION_PATTERNS: { pattern: RegExp; what: string; delegateTo: string }[] = [
+			{
+				pattern: /!\\\[.*?\\\]\\\(.*?\\\)\s*\|\s*<img/,
+				what: '画像 embed の有無を生の正規表現で判定している',
+				delegateTo: 'hasEmbeddedScreenshotImage()',
+			},
+			{
+				pattern: /['"`]refactor:internal-no-doc-impact['"`]/,
+				what: 'exempt label 名を YAML に直書きしている',
+				delegateTo: 'INTERNAL_REFACTOR_LABEL / hasInternalRefactorLabel()',
+			},
+			{
+				pattern: /\/\\\.\(svelte\|/,
+				what: 'UI 変更ファイルの判定を生の正規表現で書いている',
+				delegateTo: 'isUiPr()',
+			},
+		];
+
+		for (const d of WORKFLOW_JUDGMENTS.filter((x) => x.delegation === 'script')) {
+			it(`${d.workflow}:${d.job}`, () => {
+				const joined = (jobScriptsOf(d.workflow).get(d.job) ?? []).join('\n');
+				const hits = REGRESSION_PATTERNS.filter((p) => p.pattern.test(joined)).map(
+					(p) => `${p.what} → ${p.delegateTo} に委譲する`,
+				);
+				expect(hits, hits.join(' / ')).toEqual([]);
+			});
+		}
+	});
+
+	it('[D6] registry の記述品質 — reason 必須 / not-required は追跡 Issue 必須', () => {
+		const violations: string[] = [];
+		for (const d of WORKFLOW_JUDGMENTS) {
+			const id = `${d.workflow}:${d.job}`;
+			if (!d.reason || d.reason.trim().length < 10) {
+				violations.push(`${id}: reason が空か短すぎる (理由の非強制を作らない)`);
+			}
+			if (d.delegation === 'script' && !d.module) {
+				violations.push(`${id}: delegation='script' なのに module が無い`);
+			}
+			if (d.delegation === 'expression' && !d.ssot) {
+				violations.push(`${id}: delegation='expression' なのに ssot が無い`);
+			}
+			if (d.delegation === 'not-required' && !/#\d+/.test(d.issue ?? '')) {
+				violations.push(`${id}: delegation='not-required' なのに追跡 Issue が無い`);
+			}
+		}
+		expect(violations, violations.join('\n')).toEqual([]);
+	});
+});

--- a/tests/unit/architecture/workflow-judgment-delegation-guard.test.ts
+++ b/tests/unit/architecture/workflow-judgment-delegation-guard.test.ts
@@ -36,11 +36,10 @@
  * (`pr-trigger-lane-guard.test.ts` の同注意書きと同じ理由)。
  */
 
-import { readFileSync, readdirSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import path from 'node:path';
-
-import * as yaml from 'yaml';
 import { describe, expect, it, vi } from 'vitest';
+import * as yaml from 'yaml';
 
 // #4085: repo 走査 test (実行時間が入力サイズに比例する)。区分は
 // scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (未宣言 / timeout 欠落は CI が fail)。
@@ -48,8 +47,8 @@ vi.setConfig({ testTimeout: 60_000 });
 
 import {
 	COVERED_WORKFLOWS,
-	WORKFLOW_JUDGMENTS,
 	findJudgment,
+	WORKFLOW_JUDGMENTS,
 } from '../../../scripts/lib/ci/workflow-judgment-registry.mjs';
 
 const WORKFLOW_DIR = path.join(process.cwd(), '.github', 'workflows');


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（開発の手戻り削減）。**

`pre-ready --help` は Step 11b を「**CI `screenshot-check` と SSOT 共有**」と書いていましたが、実際の `screenshot-check` は同じ `.mjs` から 2 関数しか import しておらず、**SS embed の有無判定は inline 正規表現**でした。両者は等価ではありません。

| どこ | 判定 |
|---|---|
| script `hasEmbeddedScreenshotImage(body)` | URL を抽出し **http(s) かつ screenshot / attachment URL** を要求 |
| inline `/!\[.*?\]\(.*?\)\|<img\s/i` | **`![](...)` が 1 個あれば pass** |

→ `![](tmp/local.png)` のようなローカルパス画像だけの PR は **CI 緑・pre-ready 赤**になります。#4153 では**逆向き**が実発生しました（`ss-render-impossible` を `.mjs` にだけ実装 → pre-ready 緑・CI 赤）。

**本質は「検査が多すぎて漏れた」ではありません。同じ検査が 2 箇所にあり、片方だけ直せば必ずズレます。** 本数を減らしても二重実装が残る限り同じ事故が起きるため、減らすのではなく**等価性を機械で固定**します（ADR-0061 same-class-N→guard）。

### 本日、私自身が 3 回踏みました

この Issue の実感を裏付ける実測です（いずれも今日の別 PR で発生）:

| PR | pre-ready | CI |
|---|---|---|
| #4215 | ALL PASS | `lint-and-test` **fail**（Storybook build check。pre-ready は Storybook を回さない） |
| #4216 | ALL PASS | `check-repo-scan-test-declaration` は pre-ready の 6 step に無く、手で叩いて初めて気づいた |
| #4218 | ALL PASS | `cspell` 7 件。同じく手で叩いて発見 |

**「pre-ready 緑 = Ready にしてよい」と読める運用が残っている**ことが、本 Issue の AC4（Ready 条件の変更可否）が PO 判断である理由です。

## 関連 Issue

Closes #4158

- #4121（pre-ready 6 step 化。本 Issue はその副作用の後始末）
- #4087 / #4153（`ss-render-impossible` 二重実装が露出した実例）
- ADR-0061（same-class-N→guard）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC0** | 欠陥を failing-test で固定してから実装する（ADR-0061） | 新規 fitness を実装前に単独実行 | ✅ **red 実測**: `isUiPr` / `hasInternalRefactorLabel` / `hasEmbeddedScreenshotImage` を呼んでいない + inline 判定が残っている の **4 failed / 16 passed** |
| **AC1** | `pr-quality-gate.yml` の inline 判定を `scripts/*.mjs` の export へ委譲する | `screenshot-check` の 3 判定を委譲。重複していた `ssMod` の `await import` 2 箇所を step 先頭 1 回に集約 | ✅ **20 tests green**。うち `hasEmbeddedScreenshotImage` だけは**挙動が変わる**（下記「破壊的変更」） |
| **AC2** | 委譲済みであることを機械検証する fitness を置く | `tests/unit/architecture/workflow-judgment-delegation-guard.test.ts` + 宣言 SSOT `scripts/lib/ci/workflow-judgment-registry.mjs` | ✅ D0〜D6 の 6 観点。mutation 2 通りで red を実測（下記） |
| **AC3** | `pre-ready --help` の「CI と SSOT 共有」記述を実態に合わせる | help 本文と `checkScreenshotEmbedReadiness` の docstring を両方是正 | ✅ 「共有しているのは**個々の判定関数**であって、この関数そのものではない」+ 本 step が CI より**広い**（未来形記述 / 該当なしマーカーは pre-ready だけが見る）ことを明記 |
| **AC4** | **Ready 化条件を「pre-ready 緑」から「`gh pr checks` 緑」へ変更するか** | **PO 判断。本 PR では変更していない** | ⏸ **未達（意図的）**。下記「PO にお願いしたいこと」に判断材料を整理 |

### mutation 検証（guard が本当に効くか）

**実装は先に commit 済で、mutation は `git stash` で退避しています（破棄していません）。**

1. **`hasImage` を inline 正規表現に戻す**（= 本 PR の巻き戻し）→ **2 tests failed** ✅（D4 呼び出し検査 + D5 再混入検査の両方）
2. **registry から `design-doc-check` の宣言を外す** → **4 tests failed** ✅（D1 未宣言 + D2 stale + D3/D4）

### 調査で分かった「Issue 本文が古い」点

Issue は「feature lane は `check-pr-screenshot.mjs` を import していなかった（integration lane だけが import）」と書いていますが、**現 HEAD ではそうではありません**。`d932838b8`（PR #4153、2026-08-01）が feature lane に `checkRenderImpossibleDeclaration` の import を追加済です。PO コメント末尾の「AC1 の該当箇所だけ先に直して構いません。その場合は本 Issue に記録してください」に沿った先行修正で、**Issue 本文が更新されていなかった**状態でした。本 PR がその記録も兼ねます。

## 変更タイプ

- [x] バグ修正（gate の等価性欠落）
- [x] テスト追加（failing-test + fitness function）
- [x] ドキュメント更新（help / docstring の記述是正）
- [ ] 新機能
- [ ] リファクタリング
- [ ] インフラ変更

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **`isUiPr` の等価性** | **完全等価**。`UI_FILE_PATTERN`（`check-pr-screenshot.mjs:80`）は旧 inline 正規表現と **byte 一致**。挙動不変 |
| **`hasInternalRefactorLabel` の等価性** | **完全等価**。`l.trim().toLowerCase() === LABEL` のロジックが一致。挙動不変 |
| **`hasEmbeddedScreenshotImage` の等価性** | **非等価（これが本 PR の修正点）**。CI 側が**厳しくなる**。下記「破壊的変更」参照 |
| **integration lane** | 既に `hasIntegrationVrEvidence` を import 済。**重複していた `await import` を消しただけ**で判定は不変 |
| **`checkRenderImpossibleDeclaration`** | #4153 で委譲済。**重複 import を消しただけ**で判定は不変 |
| **registry の適用範囲** | `pr-quality-gate.yml` の 5 job のみ（`COVERED_WORKFLOWS`）。**段階導入の境界を registry に明示**したので、後から広げるときに漏れが見える |
| **`deploy*.yml` 系** | **本 PR の scope 外**。secret 検証 / smoke は script が無く、PR gate の等価性問題でもない（調査で 14 件を把握済、registry に広げるのは別 slice） |
| **`ci.yml` の job `if:` 式** | **委譲不能**（job の `if:` は node を呼べない）。registry に `delegation: 'expression'` の区分を用意してあるが、本 PR では対象に含めていない |
| **repo 走査 test 登録** | `scripts/lib/ci/repo-scan-test-registry.mjs` に `scope: 'repo'` + 明示 timeout で登録済（未登録だと CI が fail する） |

## テスト・品質セルフチェック

```
# 修正前（failing-test-first、ADR-0061）
npx vitest run tests/unit/architecture/workflow-judgment-delegation-guard.test.ts
 × screenshot-check が isUiPr を呼んでいる
 × screenshot-check が hasInternalRefactorLabel を呼んでいる
 × screenshot-check が hasEmbeddedScreenshotImage を呼んでいる
 × screenshot-check に inline 判定を書き戻していない
 Tests  4 failed | 16 passed (20)

# 修正後
npx vitest run tests/unit/architecture/ tests/unit/scripts/
 Test Files  90 passed (90)
      Tests  1400 passed | 1 skipped (1401)

npx biome check --error-on-warnings .   → Found 3 infos（error 0）
npx svelte-check --threshold error      → 0 errors / 0 warnings
npm run cspell                          → Issues found: 0
node scripts/check-repo-scan-test-declaration.mjs → OK（41 件）
```

- [x] **failing-test-first（ADR-0061）**: red を実測してから実装
- [x] **mutation 検証**: guard を 2 通りに壊して両方 red を確認
- [x] **no-silent-gap を両方向で持つ**: 未宣言（D1）と stale（D2）の 2 test
- [x] **母数を registry から取らない**: `readdirSync(WORKFLOW_DIR)` で FS から取る
- [x] **判定は parse 済み YAML の `run` / `with.script` にだけ当てる**: 全文 grep だとコメントや「スクリーンショットを添付してください」等の案内文言を誤検出する
- [x] **理由の非強制を作らない**: registry の `reason` は空文字禁止、`not-required` は追跡 Issue 必須（D6）
- [x] `npm run pre-ready -- --pr <PR番号>` 全 6 step PASS
- [x] `gh pr checks` で CI 側 hard-fail 検査が pass（skipped でない）

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: CI workflow / テスト / 開発者向け help 文言のみの変更で、アプリケーションコードを 1 行も変更していない。顧客に見える画面が存在しない。 -->

**UI 変更はありません。** 変更は `.github/workflows/pr-quality-gate.yml` / `scripts/`（3 file）/ `tests/unit/architecture/`（1 file 新規）のみで、`src/` を 1 ファイルも触っていません。

## レビュー依頼事項・破壊的変更

### PO にお願いしたいこと（AC4）

**Ready 化条件を「pre-ready 緑」から「`gh pr checks` 緑」へ変更するかを決めてください。本 PR では変更していません。**

判断材料を整理します。

| | pre-ready 緑を条件にする（現状） | `gh pr checks` 緑を条件にする |
|---|---|---|
| **正しさ** | pre-ready は 6 step / 約 300 秒で **CI の部分集合**。緑でも CI が赤になりうる（本日 3 回発生） | CI で hard-fail する検査を全部通ってから Ready になる |
| **リードタイム** | 数分で Ready 化できる | **CI 実行時間ぶん伸びる**（`unit-test` が 10 分前後、shard 2 本 + `lint-and-test` で実測 15〜20 分） |
| **手戻り** | Ready 後に CI 赤 → QM を待たせて修正 → 再 Ready | Ready 時点で緑が保証される |

**Dev としては「変えたほうがよい」と考えますが、リードタイムのトレードオフは事業判断**です。中間案として「**pre-ready 緑 → Draft のまま push → CI 緑を確認してから Ready**」という運用（本日私が実際にやった順序）もあり、これなら CI 待ちが Ready 化の直列パスに入りません。

### レビューで見ていただきたい点

1. **`hasEmbeddedScreenshotImage` への委譲で CI が厳しくなる点。** これは意図した修正ですが、**ローカルパス画像だけを貼っている既存の open PR があれば、次の push で CI が赤になります**。pre-ready では元から落ちていたので「今まで CI をすり抜けていたものが落ちるようになる」だけですが、驚きが出るなら周知が要ります。
2. **registry の対象を `pr-quality-gate.yml` の 5 job に絞った判断。** 調査では inline 判定を **23 件**（うち script があるのに使っていない二重実装 **9 件**）把握しています。一度に全部やると 1 PR が巨大になるため、**「同じ検査が 2 箇所にあって実際にズレている」1 件**から入れました。段階導入の境界は `COVERED_WORKFLOWS` に明示してあるので、広げるときに漏れが見えます。
3. **D5（inline 再混入の禁止）を「既知のアンチパターン列挙」にした点。** 網羅ではなく回帰 guard です（本 PR で実際に外した 3 つの形だけを列挙）。「判定に見える文字列」を一般に検出しようとすると誤検出が増え、guard 自体が信用されなくなると判断しました。

### 本 PR で直さないもの（意図的）

- **`ci.yml:1370` の統合 PR 判定（job `if:` 式）** — job の `if:` は node を呼べないため**構造的に委譲不能**です。registry に `delegation: 'expression'` の区分を用意しましたが、`pr-lane.mjs` の rule と式が一致することを assert する仕組みは本 PR に含めていません。
- **`ac-audit-monthly.yml` の inline 判定**（同じ 2 判定を `issue-close-gate.yml` は import 済 = 二重実装 2 例目）、**`pr-author-guard.yml` の author 直書き**、**`ci.yml:1265` の lane 再実装** — いずれも registry を広げる次の slice。
- **`deploy*.yml` 系 14 件** — script が存在せず、PR gate の等価性問題ではありません。

### 破壊的変更

**CI の `screenshot-check` が厳しくなります（意図的）。**

これまで `![](tmp/local.png)` のようなローカルパス画像だけで CI を通過できていた PR は、今後 fail します。**pre-ready では元から落ちていた**ので、正しくは「CI が pre-ready に追いついた」変更です。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] failing-test-first で red を実測してから実装した（ADR-0061）
- [x] guard を壊して red になることを確認した（mutation 2 通り）
- [x] 3 判定それぞれについて「等価 / 非等価」を明示した
- [x] **Dev が決めてはいけない AC4 を「未達（意図的）」と明示し、判断材料を整理した**
- [x] 本 PR で直さないものと、その理由を明記した
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
