### PR TITLE
fix(infra): #4204 staging でログインもサインアップもできなかったのを CloudFront 追加で通す

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -357,10 +357,16 @@ jobs:
       # Step 13: ORIGIN / COGNITO_CALLBACK_URL / COGNITO_LOGOUT_URL の解決 (縮退可)。
       # Function URL は synth 時未確定 (自己参照) のため CDK は placeholder を注入している。
       # get-function-url-config で実 URL を取得し、jq read-modify-write で env を merge 更新する。
-      # health / smoke (Step 14-15) は GET のみで ORIGIN 非依存のため、本 step 失敗でも続行する
-      # (continue-on-error)。POST 系 (CSRF origin check) の検証が必要になった時点で必須化を再判断。
-      - name: Resolve ORIGIN from Function URL (best-effort)
-        continue-on-error: true
+      # #4204: **その「再判断する時点」が来た**ので `continue-on-error` を外して必須化する。
+      #
+      # 旧コメント: 「health / smoke (Step 14-15) は GET のみで ORIGIN 非依存のため、本 step 失敗でも
+      # 続行する (continue-on-error)。POST 系 (CSRF origin check) の検証が必要になった時点で必須化を再判断」
+      #
+      # Step 15 に form action の POST smoke を足した以上、**ORIGIN が解決されていないと
+      # SvelteKit の CSRF origin check で 403 になり、smoke の判定が意味を持たなくなる**。
+      # 本 step が黙って失敗したまま smoke が「403 = 認証失敗、想定内」と誤読する経路を塞ぐ
+      # (ADR-0024 ENV silent skip 禁止)。**「再判断する」と書いたまま再判断しないと、コメントが飾りになる。**
+      - name: Resolve ORIGIN from Function URL
         run: |
           FUNCTION_URL=$(aws lambda get-function-url-config \
             --function-name $LAMBDA_FUNCTION \
@@ -429,7 +435,37 @@ jobs:
             echo "::error::Smoke test failed: GET /switch returned $SWITCH (expected 200 or 302)"
             exit 1
           fi
-          echo "::notice::staging smoke test passed (/ and /switch reachable)"
+
+          # #4204: **GET だけの smoke では「フォームが 1 つも送信できない」を検出できない**。
+          #
+          # SvelteKit の名前付き form action は `?/action-name` を使うが、**Lambda Function URL は
+          # クエリ文字列のスラッシュを拒否する** (`InvalidQueryStringException`)。本番は
+          # CloudFront Function `ganbari-quest-query-slash-encode` (network-stack.ts:74-77) が
+          # `?/x` → `?%2Fx` に書き換えて回避しているが、**staging は NetworkStack を deploy しない**
+          # ため、その回避が無い。
+          #
+          # 実害は sign-up だけではない。`/auth/login` にも `/auth/signup` にも default action が無く
+          # 名前付き action しか持たないため、**staging ではログインすらできない**
+          # (= 認証後の画面に到達する手段がゼロ。#4117 の staging 実機検証が始められない)。
+          #
+          # 判定: **400 = 経路が死んでいる**。200 / 303 / 403 は許容 (認証失敗は想定内で、
+          # ここで検証したいのは「フォーム送信がアプリまで届くか」だけ)。
+          # 認証情報は送らない — 届くかどうかだけを見る。
+          FORM=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            --data "email=smoke@example.invalid&password=smoke" \
+            "$BASE/auth/login?/login")
+          echo "POST /auth/login?/login -> $FORM"
+          if [ "$FORM" = "400" ]; then
+            echo "::error::Smoke test failed: POST /auth/login?/login returned 400 — SvelteKit の名前付き form action が Function URL に拒否されています (#4204)。staging ではログインもサインアップもできません。CloudFront の query-slash-encode 相当が要ります"
+            exit 1
+          fi
+          if [ "$FORM" != "200" ] && [ "$FORM" != "303" ] && [ "$FORM" != "403" ]; then
+            echo "::error::Smoke test failed: POST /auth/login?/login returned $FORM (expected 200 / 303 / 403)"
+            exit 1
+          fi
+
+          echo "::notice::staging smoke test passed (/ と /switch が到達、form action が 400 でない)"
 
       # Step 15.5 (#3683、DSQL lane のみ): 実 DSQL staging cluster での並行検証 test を lane 内で自動実行。
       # deploy → migrate → grant → health/smoke green の後、lane が整えた endpoint (GITHUB_ENV の

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -95,10 +95,17 @@ jobs:
     # 想定外 actor による staging stack への任意 deploy を防ぐ。
     if: contains(fromJSON('["Takenori-Kusaka", "ganbariquestsupport-lab"]'), github.actor)
     steps:
-      # Step 1: Checkout。pull_request = 統合 PR の HEAD / workflow_dispatch = develop HEAD。
+      # Step 1: Checkout。pull_request = 統合 PR の HEAD / workflow_dispatch = 選んだ ref。
+      #
+      # #4204: dispatch は `develop` 固定だった。**UI / CLI で branch を選んでも無視され、
+      # 常に develop の中身が deploy される**ため、branch の infra 変更を merge 前に検証できない
+      # (本 Issue の実装を dispatch したところ workflow file だけが branch から読まれ、
+      # `infra/bin/app.ts` は develop のままで「No stacks match GanbariQuestNetworkStaging」で落ちた)。
+      # GitHub は workflow file を dispatch した ref から読むため、**checkout も同じ ref に揃える**のが
+      # 一貫する。actor guard (job の if) で実行者は 2 account に限定済み。
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && 'develop' || github.event.pull_request.head.sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.pull_request.head.sha }}
 
       # Step 2: Node 22
       - uses: actions/setup-node@v7

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -3,8 +3,10 @@ name: Deploy to AWS (Staging)
 # AWS staging 3 stack (#2873 / EPIC #2861 D 系) — 本番 deploy 経路の貫通検証レーン。
 #
 # 設計の核 (prod template 不変条件 / handoff spec 厳守):
-#   - staging = GanbariQuestStorageStaging / GanbariQuestAuthStaging / GanbariQuestComputeStaging
-#     の 3 stack のみ (Network / Ses / Ops 省略、Function URL 直アクセスで検証)。
+#   - staging = Storage / Auth / Compute / Network の 4 stack (Ses / Ops は省略)。
+#     Network (CloudFront) は #4204 で追加 — SvelteKit の名前付き form action (?/action) は
+#     Lambda Function URL がクエリのスラッシュを拒否するため、CloudFront Function
+#     <prefix>-query-slash-encode を通さないと staging でログインもサインアップもできない。
 #   - 同一アカウント・同一リージョン (us-east-1) + 物理名 prefix `ganbari-quest-staging` 分離。
 #   - CDK は `-c stagingEnabled=true` の context gate でのみ staging stack を instantiate する。
 #     本番 deploy.yml の `cdk deploy --all` / `cdk diff --all` (context 無し) は挙動不変。
@@ -75,7 +77,11 @@ env:
   APP_MAJOR_VERSION: "1"
   # staging 3 stack の明示列挙 (--all 禁止)。deploy 順は Storage → Auth → Compute 固定
   # (Auth が SSM cognito param を書き、Compute が deploy-time に解決するため順序依存)。
-  STAGING_STACKS: GanbariQuestStorageStaging GanbariQuestAuthStaging GanbariQuestComputeStaging
+  # #4204: NetworkStaging (CloudFront) を追加。SvelteKit の名前付き form action (?/action) は
+  # Lambda Function URL がクエリのスラッシュを拒否するため、CloudFront Function
+  # <prefix>-query-slash-encode を通さないと staging でログインすらできない。
+  # 依存順に列挙する (Compute の functionUrl を Network が参照する)。
+  STAGING_STACKS: GanbariQuestStorageStaging GanbariQuestAuthStaging GanbariQuestComputeStaging GanbariQuestNetworkStaging
   # DSQL lane 判定 (DoD4 / #3685)。本番 cutover 完遂 (prod=dsql) につき、統合 PR (pull_request) では
   # **常時 dsql lane** を回して「本番構成 = staging 構成」を恒常一致させる。dispatch は手動 opt-in
   # (dsqlEnabled=true) のときのみ。advisory (本 workflow は required check 未登録、infra/CLAUDE.md)。
@@ -366,13 +372,23 @@ jobs:
       # SvelteKit の CSRF origin check で 403 になり、smoke の判定が意味を持たなくなる**。
       # 本 step が黙って失敗したまま smoke が「403 = 認証失敗、想定内」と誤読する経路を塞ぐ
       # (ADR-0024 ENV silent skip 禁止)。**「再判断する」と書いたまま再判断しないと、コメントが飾りになる。**
-      - name: Resolve ORIGIN from Function URL
+      - name: Resolve ORIGIN from CloudFront
         run: |
-          FUNCTION_URL=$(aws lambda get-function-url-config \
-            --function-name $LAMBDA_FUNCTION \
+          # #4204: ORIGIN は **CloudFront の URL**。Function URL ではない。
+          # form action は CloudFront Function の query-slash-encode を通らないと届かないため、
+          # 顧客が実際に使う入口 = CloudFront に合わせる。ORIGIN が入口とズレていると
+          # SvelteKit の CSRF origin check が POST を 403 で弾く。
+          CF_DOMAIN=$(aws cloudformation describe-stacks \
+            --stack-name GanbariQuestNetworkStaging \
             --region $AWS_REGION \
-            --query 'FunctionUrl' --output text)
-          ORIGIN="${FUNCTION_URL%/}"
+            --query "Stacks[0].Outputs[?OutputKey=='DistributionDomainName'].OutputValue" \
+            --output text)
+          if [ -z "$CF_DOMAIN" ] || [ "$CF_DOMAIN" = "None" ]; then
+            echo "::error::CloudFront domain を解決できませんでした (GanbariQuestNetworkStaging の DistributionDomainName)"
+            exit 1
+          fi
+          echo "STAGING_BASE=https://$CF_DOMAIN" >> $GITHUB_ENV
+          ORIGIN="https://$CF_DOMAIN"
           echo "Resolved staging ORIGIN: $ORIGIN"
           ENV_JSON=$(aws lambda get-function-configuration \
             --function-name $LAMBDA_FUNCTION \
@@ -414,21 +430,28 @@ jobs:
           echo "::error::staging health check failed after 5 attempts (last status: $STATUS)"
           exit 1
 
-      # Step 15: Smoke test — / と /switch の到達 (200/302) を確認
-      # (deploy-nuc-staging.yml Step 7 と同判定基準)。
+      # Step 15: Smoke test — CloudFront 経由で / と /switch の到達 + form action の到達を確認。
+      #
+      # #4204 で **入口を Function URL から CloudFront に変えた**。顧客が実際に使う入口が
+      # CloudFront であり、Function URL 直では form action が原理的に通らないため。
       - name: Smoke test (staging)
         run: |
-          FUNCTION_URL=$(aws lambda get-function-url-config \
-            --function-name $LAMBDA_FUNCTION \
-            --region $AWS_REGION \
-            --query 'FunctionUrl' --output text)
-          BASE="${FUNCTION_URL%/}"
-          ROOT=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/")
+          BASE="$STAGING_BASE"
+          echo "staging base: $BASE"
+
+          # CloudFront は初回 deploy 直後に伝播待ちがある。GET が通るまで待ってから本題に入る。
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            ROOT=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/")
+            if [ "$ROOT" = "200" ] || [ "$ROOT" = "302" ]; then break; fi
+            echo "GET / -> $ROOT (attempt $i/10, retrying in 15s)"
+            sleep 15
+          done
           echo "GET / -> $ROOT"
           if [ "$ROOT" != "200" ] && [ "$ROOT" != "302" ]; then
             echo "::error::Smoke test failed: GET / returned $ROOT (expected 200 or 302)"
             exit 1
           fi
+
           SWITCH=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/switch")
           echo "GET /switch -> $SWITCH"
           if [ "$SWITCH" != "200" ] && [ "$SWITCH" != "302" ]; then
@@ -439,33 +462,35 @@ jobs:
           # #4204: **GET だけの smoke では「フォームが 1 つも送信できない」を検出できない**。
           #
           # SvelteKit の名前付き form action は `?/action-name` を使うが、**Lambda Function URL は
-          # クエリ文字列のスラッシュを拒否する** (`InvalidQueryStringException`)。本番は
-          # CloudFront Function `ganbari-quest-query-slash-encode` (network-stack.ts:74-77) が
-          # `?/x` → `?%2Fx` に書き換えて回避しているが、**staging は NetworkStack を deploy しない**
-          # ため、その回避が無い。
+          # クエリ文字列のスラッシュを拒否する**。CloudFront Function `<prefix>-query-slash-encode`
+          # が `?/x` → `?%2Fx` に書き換えて初めてアプリまで届く。
           #
           # 実害は sign-up だけではない。`/auth/login` にも `/auth/signup` にも default action が無く
-          # 名前付き action しか持たないため、**staging ではログインすらできない**
+          # 名前付き action しか持たないため、これが無いと **staging ではログインすらできない**
           # (= 認証後の画面に到達する手段がゼロ。#4117 の staging 実機検証が始められない)。
           #
-          # 判定: **400 = 経路が死んでいる**。200 / 303 / 403 は許容 (認証失敗は想定内で、
-          # ここで検証したいのは「フォーム送信がアプリまで届くか」だけ)。
-          # 認証情報は送らない — 届くかどうかだけを見る。
-          FORM=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            --data "email=smoke@example.invalid&password=smoke" \
-            "$BASE/auth/login?/login")
-          echo "POST /auth/login?/login -> $FORM"
-          if [ "$FORM" = "400" ]; then
-            echo "::error::Smoke test failed: POST /auth/login?/login returned 400 — SvelteKit の名前付き form action が Function URL に拒否されています (#4204)。staging ではログインもサインアップもできません。CloudFront の query-slash-encode 相当が要ります"
-            exit 1
-          fi
-          if [ "$FORM" != "200" ] && [ "$FORM" != "303" ] && [ "$FORM" != "403" ]; then
-            echo "::error::Smoke test failed: POST /auth/login?/login returned $FORM (expected 200 / 303 / 403)"
+          # **status code では判定しない。** ログイン失敗は SvelteKit の `fail(400)` / `fail(401)` で
+          # 返るため (src/routes/auth/login/+page.server.ts)、400 は「経路が死んでいる」とも
+          # 「認証情報が違う」とも読めてしまい、判定が意味を持たない。
+          #
+          # 判定は **誰がその応答を作ったか**で行う: `hooks.server.ts` が全レスポンスに付ける
+          # `X-Frame-Options: DENY` があれば「アプリまで届いた」。Lambda Function URL 自身の
+          # 拒否応答にはこのヘッダが無い。
+          #
+          # Origin ヘッダを付けるのは SvelteKit の CSRF origin check を通すため。付けないと
+          # 403 で弾かれ、これも「届いたのに弾かれた」のか「届いていない」のか区別できない。
+          # 認証情報は本物を送らない — 届くかどうかだけを見る。
+          FORM_STATUS=$(curl -s -o /tmp/form-body.txt -D /tmp/form-headers.txt             -w "%{http_code}" -X POST             -H "Content-Type: application/x-www-form-urlencoded"             -H "Origin: $BASE"             --data "email=smoke@example.invalid&password=smoke"             "$BASE/auth/login?/login")
+          echo "POST /auth/login?/login -> $FORM_STATUS"
+          echo "--- response headers ---"
+          cat /tmp/form-headers.txt
+
+          if ! grep -qi '^x-frame-options:' /tmp/form-headers.txt; then
+            echo "::error::Smoke test failed: POST /auth/login?/login (status $FORM_STATUS) の応答がアプリ由来ではありません。SvelteKit の名前付き form action が Function URL に拒否されている可能性が高い (#4204)。staging ではログインもサインアップもできません"
             exit 1
           fi
 
-          echo "::notice::staging smoke test passed (/ と /switch が到達、form action が 400 でない)"
+          echo "::notice::staging smoke test passed (/ と /switch が到達、form action がアプリまで到達 status=$FORM_STATUS)"
 
       # Step 15.5 (#3683、DSQL lane のみ): 実 DSQL staging cluster での並行検証 test を lane 内で自動実行。
       # deploy → migrate → grant → health/smoke green の後、lane が整えた endpoint (GITHUB_ENV の

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -22,6 +22,10 @@ name: Deploy to AWS (Staging)
 #       (2) ComputeStack が synth 時に allowlist (`sk_test_` / `rk_test_` 以外) を addError で停止
 #     webhook signing secret は test / live とも `whsec_` で **prefix から判別できない**。ここは守れない
 #     範囲として明示する (live 側の実行権限は secret key が握るため secret key の allowlist が防御線)。
+#   - **「Discord secret を渡さない」は staging Lambda の話であって、本 workflow 自身の話ではない**
+#     (#4204)。防ぎたいのは「staging のアプリが動いた副作用が実チャネルを汚す」ことであり、
+#     **CI が人間に出す運用アラート**はそれに当たらない。post-deploy の
+#     `Staging PII guard` は Discord へ通知するが、staging Lambda の env には一切注入しない。
 #
 # 責務分界 (docs/design/13-AWSサーバレスアーキテクチャ設計書.md §4.3):
 #   - 本 workflow の責務は「本番 deploy 経路の貫通 + post-deploy health (G-PD AWS 側)」。
@@ -81,6 +85,16 @@ env:
   # Lambda Function URL がクエリのスラッシュを拒否するため、CloudFront Function
   # <prefix>-query-slash-encode を通さないと staging でログインすらできない。
   # 依存順に列挙する (Compute の functionUrl を Network が参照する)。
+  # #4204: staging に登録してよいメールアドレスのドメイン allowlist (**本 env が SSOT**)。
+  #
+  # staging の CloudFront は geoRestriction 無し = **全世界公開**。実在のメールアドレスを
+  # Cognito に登録した時点で「PII を持つ全世界公開環境」が成立する。運用ルール
+  # (使い捨てメールだけを使う) は人の注意力に依存するため、**守られなかったことに気づける**
+  # ようにする (PO 決裁 2026-08-02)。
+  #
+  # **「使い捨てっぽい」の推測判定はしない。** ここに書いたドメインだけを許可する。
+  # 追加したいときは本 env を編集する (docs/runbooks/staging-live-verification.md は本 env を参照する)。
+  STAGING_ALLOWED_EMAIL_DOMAINS: mailinator.com example.invalid example.com
   STAGING_STACKS: GanbariQuestStorageStaging GanbariQuestAuthStaging GanbariQuestComputeStaging GanbariQuestNetworkStaging
   # DSQL lane 判定 (DoD4 / #3685)。本番 cutover 完遂 (prod=dsql) につき、統合 PR (pull_request) では
   # **常時 dsql lane** を回して「本番構成 = staging 構成」を恒常一致させる。dispatch は手動 opt-in
@@ -498,6 +512,68 @@ jobs:
           fi
 
           echo "::notice::staging smoke test passed (/ と /switch が到達、form action がアプリまで到達 status=$FORM_STATUS)"
+
+      # #4204: staging に実在のメールアドレスが登録されていないかを見張る。
+      #
+      # staging の CloudFront は geoRestriction 無し = **全世界公開**。実在アドレスを Cognito に
+      # 登録した時点で「PII を持つ全世界公開環境」が成立する。運用ルール (使い捨てメールだけ)
+      # は人の注意力に依存するため、**守られなかったことに気づける**ようにする (PO 決裁)。
+      #
+      # **deploy は止めない。** 既に登録されているものは既に登録されているので、止めても
+      # 手遅れであり止める意味がない。**気づけること**が目的。
+      #
+      # 判定は allowlist (env STAGING_ALLOWED_EMAIL_DOMAINS) のみ。**「使い捨てっぽい」の推測は
+      # しない** — 推測判定は「知らないドメインを勝手に許す」形で必ず穴になる。
+      #
+      # 出力にメールアドレス本体を出さない (CI ログは repo 参照者が読める)。ドメインと件数だけ出す。
+      #
+      # `continue-on-error` を付けているのは **PO 決裁で advisory と決めたから**であり、
+      # ADR-0024 の「ENV silent skip 禁止」に反する省略ではない。本 step の run は全経路で
+      # exit 0 するため、これが効くのは aws CLI 自体が想定外に失敗したときだけ
+      # (その場合も warning は GitHub Actions のログに残る)。
+      - name: Staging PII guard (registered email domains)
+        continue-on-error: true
+        env:
+          DISCORD_WEBHOOK_INCIDENT: ${{ secrets.DISCORD_WEBHOOK_INCIDENT }}
+        run: |
+          POOL_ID=$(aws cloudformation describe-stacks             --stack-name GanbariQuestAuthStaging --region $AWS_REGION             --query "Stacks[0].Outputs[?OutputKey=='UserPoolId'].OutputValue" --output text)
+          if [ -z "$POOL_ID" ] || [ "$POOL_ID" = "None" ]; then
+            echo "::warning::staging user pool を解決できませんでした (PII guard は判定できていません)"
+            exit 0
+          fi
+
+          EMAILS=$(aws cognito-idp list-users --user-pool-id "$POOL_ID" --region $AWS_REGION \
+            --query "Users[].Attributes[?Name=='email'].Value" --output text | xargs -n1 || true)
+          TOTAL=$(echo "$EMAILS" | sed '/^$/d' | wc -l)
+          echo "registered users: $TOTAL"
+
+          VIOLATIONS=""
+          for e in $EMAILS; do
+            DOMAIN="${e##*@}"
+            OK=0
+            for allowed in $STAGING_ALLOWED_EMAIL_DOMAINS; do
+              if [ "$DOMAIN" = "$allowed" ]; then OK=1; break; fi
+            done
+            if [ "$OK" -eq 0 ]; then
+              VIOLATIONS="$VIOLATIONS $DOMAIN"
+            fi
+          done
+
+          if [ -z "$VIOLATIONS" ]; then
+            echo "::notice::staging PII guard OK (allowlist 外のドメイン 0 件 / 登録 $TOTAL 件)"
+            exit 0
+          fi
+
+          UNIQ=$(echo "$VIOLATIONS" | xargs -n1 | sort -u | xargs)
+          echo "::warning::staging に allowlist 外のメールドメインが登録されています: $UNIQ (#4204)"
+
+          if [ -z "$DISCORD_WEBHOOK_INCIDENT" ]; then
+            echo "::warning::DISCORD_WEBHOOK_INCIDENT 未設定のため通知できませんでした (warning のみ)"
+            exit 0
+          fi
+          MSG="⚠️ staging に allowlist 外のメールドメインが登録されています: ${UNIQ}\nstaging の CloudFront は全世界公開です (#4204)。実在アドレスなら削除を検討してください。\n許可ドメインの SSOT: .github/workflows/deploy-aws-staging.yml の STAGING_ALLOWED_EMAIL_DOMAINS"
+          curl -s -X POST -H "Content-Type: application/json"             -d "{\"content\": \"${MSG}\"}" "$DISCORD_WEBHOOK_INCIDENT" > /dev/null ||             echo "::warning::Discord 通知に失敗しました"
+
 
       # Step 15.5 (#3683、DSQL lane のみ): 実 DSQL staging cluster での並行検証 test を lane 内で自動実行。
       # deploy → migrate → grant → health/smoke green の後、lane が整えた endpoint (GITHUB_ENV の

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -524,11 +524,15 @@ export function resolveDemoActive(env: Pick<TypedEnv, 'AUTH_MODE' | 'DATA_SOURCE
 
 ### 4.3 AWS staging 環境 (Issue #2873 / EPIC #2861 D 系)
 
-本番 deploy 経路 (CDK synth → ECR push → Lambda update → health) そのものを統合 PR で検証するため、本番 6 stack の staging 版を `deploy-aws-staging.yml` で構築する。staging は **3 stack のみ** (`GanbariQuestStorageStaging` / `GanbariQuestAuthStaging` / `GanbariQuestComputeStaging`)。Network / Ses / Ops は省略し Function URL 直アクセスで検証する (CloudFront は geoRestriction JP のため本番 e2e も Function URL 直の実績パターン踏襲)。
+本番 deploy 経路 (CDK synth → ECR push → Lambda update → health) そのものを統合 PR で検証するため、本番 6 stack の staging 版を `deploy-aws-staging.yml` で構築する。staging は **4 stack** (`GanbariQuestStorageStaging` / `GanbariQuestAuthStaging` / `GanbariQuestComputeStaging` / `GanbariQuestNetworkStaging`)。Ses / Ops は省略する。
+
+**Network (CloudFront) は staging にも必要**: SvelteKit の名前付き form action (`?/action`) は Lambda Function URL がクエリ文字列のスラッシュを拒否するため、CloudFront Function `<prefix>-query-slash-encode` を通さないと届かない。`/auth/login` / `/auth/signup` はいずれも default action を持たず名前付き action しかないため、これが無いと staging では**ログインもサインアップもできない** (= 認証後の画面に到達する手段がゼロ)。staging の ORIGIN / post-deploy smoke は CloudFront を入口にする。
 
 | 項目 | 本番 (`deploy.yml`) | AWS staging (`deploy-aws-staging.yml`) |
 |---|---|---|
-| stack | 6 stack (`GanbariQuest{Storage,Auth,Compute,Network,Ses,Ops}`) | 3 stack (`GanbariQuest{Storage,Auth,Compute}Staging`)、明示列挙 deploy (`--all` 不使用) |
+| stack | 6 stack (`GanbariQuest{Storage,Auth,Compute,Network,Ses,Ops}`) | 4 stack (`GanbariQuest{Storage,Auth,Compute,Network}Staging`)、明示列挙 deploy (`--all` 不使用) |
+| CloudFront geoRestriction | JP allowlist | **なし** (post-deploy smoke を回す GitHub runner が日本国外にあるため)。前提 = staging に本番データを入れないこと。入れる運用が生まれたら JP allowlist を戻す |
+| CloudFront 物理名 | `ganbari-quest-query-slash-encode` / `ganbari-quest-error-pages-<account>` | `ganbari-quest-staging-` prefix (同一アカウント・同一リージョンでの衝突回避)。prod 側の名前は不変 (ADR-0019) |
 | 物理名 prefix | `ganbari-quest` | `ganbari-quest-staging`（Lambda `ganbari-quest-staging-app` / log group / pool / bucket / ECR repo） |
 | SSM prefix | `/ganbari-quest/` | `/ganbari-quest-staging/`（`context-token-secret` は workflow が冪等 put） |
 | ECR repo | `ganbari-quest`（maxImageCount:10） | `ganbari-quest-staging` 専用 repo（maxImageCount:3。prod repo 共有は rollback `[-2]` digest 選択 + lifecycle を staging push が侵食するため不採用） |
@@ -537,10 +541,10 @@ export function resolveDemoActive(env: Pick<TypedEnv, 'AUTH_MODE' | 'DATA_SOURCE
 | demo Lambda / cron-dispatcher / log archiving | あり | なし（`enableDemoLambda` / `enableCronDispatcher` / `enableLogArchiving` = false） |
 | RemovalPolicy | RETAIN | DESTROY（使い捨て可能） |
 | trigger | `push: [main]` + tag + dispatch | `pull_request: [main]`（統合 PR、paths filter 付き）+ dispatch（develop HEAD） |
-| ADR-0019 gate | `check-cdk-replacement.mjs` ×2（Storage / all） | 同 script 再利用 ×2（StorageStaging / staging 3 stack） |
-| tag | — | `gq-env=staging`（staging 3 stack に付与） |
+| ADR-0019 gate | `check-cdk-replacement.mjs` ×2（Storage / all） | 同 script 再利用 ×2（StorageStaging / staging 4 stack） |
+| tag | — | `gq-env=staging`（staging 4 stack に付与） |
 
-実装方式: 既存 stack class に optional `envConfig` props（`infra/lib/env-config.ts` の `GqEnvConfig`、default = `PROD_ENV_CONFIG` = 現行 prod 値）を追加。staging 専用 class の複製は二重管理のため不採用。`infra/bin/app.ts` は `-c stagingEnabled=true` の context gate でのみ staging 3 stack を instantiate するため、本番 `cdk deploy --all` / `cdk diff --all` の挙動は不変。
+実装方式: 既存 stack class に optional `envConfig` props（`infra/lib/env-config.ts` の `GqEnvConfig`、default = `PROD_ENV_CONFIG` = 現行 prod 値）を追加。staging 専用 class の複製は二重管理のため不採用。`infra/bin/app.ts` は `-c stagingEnabled=true` の context gate でのみ staging 4 stack を instantiate するため、本番 `cdk deploy --all` / `cdk diff --all` の挙動は不変。
 
 - **prod template 不変 3 重防御**: ① optional props + prod default で diff ゼロ設計 ② `tests/unit/infra/staging-cdk.test.ts` の prod 不変 guard（synth-time、`ganbari-quest` table / `ganbari-quest-app` Fn / `ganbari-quest-users-v2` pool 等の物理名 assert）③ 本番 `deploy.yml` の ADR-0019 gate（deploy-time）。
 - **ORIGIN 解決**: Function URL は synth 時未確定（自己参照）のため CDK は placeholder を注入し、workflow が `get-function-url-config` で解決して jq read-modify-write で `update-function-configuration` する（health / smoke は GET のみで ORIGIN 非依存のため縮退可）。

--- a/docs/runbooks/staging-live-verification.md
+++ b/docs/runbooks/staging-live-verification.md
@@ -3,6 +3,14 @@
 > **対象**: ローカルのどの backend でも実行されない `AUTH_MODE=cognito` + DSQL 経路（課金状態の解決 / entitlement / parent-gate / 招待・メンバー）を、AWS staging（`ganbari-quest-staging-app`）で 1 回通して観測するための手順。
 > **実行主体**: リリース発火 = GQ-Audit / 検証実行と証跡提出 = GQ-Dev / 秘匿値・権限の配置 = オーナー。
 
+## 🚨 staging は全世界公開。実在のメールアドレスを登録しない
+
+**staging の CloudFront には地域制限がない（#4204）。** post-deploy smoke を回す GitHub Actions runner が日本国外にあるため JP allowlist を外してある。したがって **Cognito に実在のメールアドレスを登録した時点で「PII を持つ全世界公開環境」が成立する。**
+
+**sign-up には使い捨てメールだけを使う。** 許可ドメインの SSOT は `.github/workflows/deploy-aws-staging.yml` の `STAGING_ALLOWED_EMAIL_DOMAINS`（本 runbook にリストを複製しない — 複製すると必ずズレる）。
+
+allowlist 外のドメインが登録されると、staging deploy の `Staging PII guard` が Discord の incident チャネルに通知する。**deploy は止まらない**（既に登録されたものは手遅れで、止めても意味がないため）。**気づけることが目的。**
+
 ## ⚠️ ステータス: 未実証（2026-07 時点）
 
 **本 runbook は通しで実行されていない。** 初回実行は Issue [#4099](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4099) で行う（検証主体 = オーナー（AWS SSO 対話ログインが必須）+ GQ-Audit（staging リリース発火））。

--- a/docs/runbooks/staging-live-verification.md
+++ b/docs/runbooks/staging-live-verification.md
@@ -13,6 +13,8 @@
 
 ## 1. 適用範囲
 
+**入口は CloudFront（`GanbariQuestNetworkStaging` の `DistributionDomainName`）。Function URL 直ではない。** SvelteKit の名前付き form action（`?/action`）は Lambda Function URL がクエリ文字列のスラッシュを拒否するため、CloudFront Function `ganbari-quest-staging-query-slash-encode` を通さないとログインもサインアップもできない（#4204）。
+
 ### 本 runbook で検証する
 
 | 対象 | ローカルで実行されない理由 | staging で通る経路 |
@@ -135,7 +137,7 @@ WHERE family_id = '<検証対象の family uuid>';
 
 | 観測点 | 手順 | AC 充足と言える状態 |
 |---|---|---|
-| プラン表示 | staging の Function URL でログイン → `/admin/subscription`（parent-gate PIN を通す） | 表示プラン / 上限が §6.2 (2) で書き込んだ値と一致する |
+| プラン表示 | staging の CloudFront URL でログイン → `/admin/subscription`（parent-gate PIN を通す） | 表示プラン / 上限が §6.2 (2) で書き込んだ値と一致する |
 | 権限（entitlement） | 当該プランでのみ使える機能を 1 つ操作する | プランに応じて許可 / 拒否が切り替わる |
 | サーバ側の解決 | `aws logs tail /aws/lambda/ganbari-quest-staging-app --since 10m` | 例外・fail-closed による 5xx が出ていない |
 
@@ -166,16 +168,16 @@ staging には **test mode の Stripe 資格情報だけ**を配備する。test
 
 ### 9.2 staging webhook endpoint の登録手順（PO 作業、AC4）
 
-**staging の Function URL は初回 deploy まで確定しない**ため、本手順は staging deploy 後に実施する。
+**staging の URL は初回 deploy まで確定しない**ため、本手順は staging deploy 後に実施する。
 
-1. staging deploy 完了後、Function URL を取得する:
+1. staging deploy 完了後、CloudFront の URL を取得する:
 
 ```bash
-aws lambda get-function-url-config --function-name ganbari-quest-staging-app   --region us-east-1 --query FunctionUrl --output text
+aws cloudformation describe-stacks --stack-name GanbariQuestNetworkStaging   --region us-east-1   --query "Stacks[0].Outputs[?OutputKey=='DistributionDomainName'].OutputValue" --output text
 ```
 
 2. Stripe Dashboard を **test mode** に切り替え、Developers → Webhooks → 「Add endpoint」
-3. Endpoint URL に `<FunctionUrl>api/stripe/webhook` を入力
+3. Endpoint URL に `https://<DistributionDomainName>/api/stripe/webhook` を入力
 4. 購読 event は `docs/design/billing-redesign/` の購読 event 一覧（#3990 で整合済）に合わせる
 5. 発行された signing secret を登録し、staging を再 deploy する:
 

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -178,13 +178,14 @@ docker compose logs -f scheduler
 | 項目 | 本番 AWS | AWS staging |
 |---|---|---|
 | workflow | `deploy.yml` | `deploy-aws-staging.yml` |
-| stack | 6 stack (`--all`) | 3 stack (`GanbariQuest{Storage,Auth,Compute}Staging`、明示列挙) |
+| stack | 6 stack (`--all`) | 4 stack (`GanbariQuest{Storage,Auth,Compute,Network}Staging`、明示列挙) |
 | 物理名 prefix | `ganbari-quest` | `ganbari-quest-staging` (Lambda `ganbari-quest-staging-app` / SSM `/ganbari-quest-staging/`) |
 | ECR repo | `ganbari-quest` (maxImageCount:10) | `ganbari-quest-staging` 専用 (maxImageCount:3、prod repo 共有不採用) |
 | 外部サービス | Stripe / Discord / Gemini / SES 注入 | 非注入 (副作用ゼロ。SES / CE の IAM grant も無し) |
 | CDK gate | context 無し (staging stack は instantiate されない) | `-c stagingEnabled=true` (`infra/bin/app.ts` context gate) |
 | trigger | main push | 統合 PR (base=main、paths filter) / dispatch (develop HEAD) |
 | health | `<FunctionUrl>api/health` | `<StagingFunctionUrl>api/health` (200 のみ。schema assert の G-MIG 主担保は NUC staging) |
+| 入口 (ORIGIN / smoke) | CloudFront | **CloudFront** (#4204)。Function URL 直では SvelteKit の名前付き form action (`?/action`) が通らずログインもサインアップもできないため |
 
 - **実装方式**: 既存 stack class に optional `envConfig` props (`infra/lib/env-config.ts`、default = `PROD_ENV_CONFIG`)。prod 不変 guard は `tests/unit/infra/staging-cdk.test.ts`。
 - **ADR-0019 gate**: `scripts/check-cdk-replacement.mjs` を staging diff にも適用 (StorageStaging / staging 3 stack の 2 段)。

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -144,8 +144,11 @@ if (dsqlStagingEnabled) {
 // 本番の `cdk deploy --all` / `cdk diff --all` (deploy.yml) は context 無しで実行されるため
 // 挙動不変 (staging との混線防止)。staging deploy は .github/workflows/deploy-aws-staging.yml が
 // 3 stack を明示列挙して行う (`--all` 不使用)。
-// Network / Ses / Ops は省略: Function URL 直アクセスで検証する (CloudFront は
-// geoRestriction JP のため本番 e2e も Function URL 直の実績パターン踏襲)。
+// Ses / Ops は省略。**Network (CloudFront) は #4204 で staging にも必要**になった:
+// SvelteKit の名前付き form action (`?/action`) は Lambda Function URL がクエリの
+// スラッシュを拒否するため 400 になり、CloudFront Function `<prefix>-query-slash-encode`
+// が `?/x` → `?%2Fx` に書き換えて初めて通る。これが無いと staging では
+// **ログインもサインアップもできない** (= 認証後の画面に到達する手段がゼロ)。
 const stagingEnabled = String(app.node.tryGetContext('stagingEnabled')) === 'true';
 if (stagingEnabled) {
 	const stagingStorage = new StorageStack(app, `${appName}StorageStaging`, {
@@ -170,7 +173,24 @@ if (stagingEnabled) {
 		envConfig: STAGING_ENV_CONFIG,
 	});
 
-	for (const stack of [stagingStorage, stagingAuth, stagingCompute]) {
+	// #4204: staging 用 CloudFront。**custom domain / ACM 証明書は不要** —
+	// `network-stack.ts` の domainNames/certificate は `props.domainName && certificate` の
+	// 条件展開で、未指定なら既定の `*.cloudfront.net` で成立する (Route53 / ACM も同じガード内)。
+	//
+	// geoRestriction は `[]` = 制限なし。post-deploy smoke を回す GitHub Actions runner が
+	// 日本国外にあり、JP allowlist を残すと 403 で smoke が回らないため。
+	// **前提: staging に本番データが入っていないこと** (PO 実測 2026-08-02: 本番 cluster
+	// 1,801,692 bytes に対し staging 1,031,956 bytes = 57%。snapshot コピーなら同等以上になる)。
+	// **staging に本番データを入れる運用が将来生まれたら JP allowlist を戻す** (PO 条件)。
+	const stagingNetwork = new NetworkStack(app, `${appName}NetworkStaging`, {
+		env,
+		description: 'CloudFront for Ganbari Quest (staging, #4204 form action の query slash encode)',
+		functionUrl: stagingCompute.functionUrl,
+		resourcePrefix: STAGING_ENV_CONFIG.resourcePrefix,
+		geoRestrictionCountries: [],
+	});
+
+	for (const stack of [stagingStorage, stagingAuth, stagingCompute, stagingNetwork]) {
 		cdk.Tags.of(stack).add('gq-env', 'staging');
 	}
 }

--- a/infra/lib/network-stack.ts
+++ b/infra/lib/network-stack.ts
@@ -37,6 +37,21 @@ export interface NetworkStackProps extends cdk.StackProps {
 	// 同一 build artifact = content-hash 完全一致を構造的に保証)。未配置のまま flag ON だと
 	// throw する (ADR-0006 silent skip 禁止)。
 	staticAssetsSourceDir?: string;
+	// --- #4204: staging 用 CloudFront ---
+	// 物理名 prefix。既定は 'ganbari-quest' (= PROD_ENV_CONFIG.resourcePrefix) で、
+	// **本番 template は byte 一致のまま**。staging は 'ganbari-quest-staging' を渡して
+	// 同一アカウント・同一リージョンでの物理名衝突を避ける
+	// (error pages bucket / CloudFront Function 名の 2 件がハードコードだった)。
+	resourcePrefix?: string;
+	// CloudFront の地域制限。既定 (未指定) は本番と同じ JP allowlist。
+	// **staging は `[]` を渡して制限を外す** — post-deploy smoke を回す GitHub Actions runner が
+	// 日本国外にあり、制限を残すと 403 で smoke が回らないため。
+	//
+	// ⚠️ staging を全世界公開にできる前提は「**staging に本番データが入っていない**」こと。
+	// PO 実測 (2026-08-02): 本番 cluster 1,801,692 bytes に対し staging 1,031,956 bytes (57%)。
+	// 本番 snapshot をコピーしていれば同等以上になるため、コピーされていないと判断した。
+	// **staging に本番データを入れる運用が将来生まれた場合は JP allowlist を戻すこと** (PO 条件)。
+	geoRestrictionCountries?: string[];
 }
 
 export class NetworkStack extends cdk.Stack {
@@ -48,6 +63,9 @@ export class NetworkStack extends cdk.Stack {
 
 	constructor(scope: Construct, id: string, props: NetworkStackProps) {
 		super(scope, id, props);
+
+		// #4204: 物理名 prefix。既定は本番値なので **prod template は byte 一致**のまま。
+		const prefix = props.resourcePrefix ?? 'ganbari-quest';
 
 		// Parse Lambda Function URL to get the hostname
 		const fnUrlDomain = cdk.Fn.select(2, cdk.Fn.split('/', props.functionUrl.url));
@@ -127,14 +145,14 @@ function handler(event) {
 `;
 
 		const queryFixFn = new cloudfront.Function(this, 'QuerySlashEncodeFn', {
-			functionName: 'ganbari-quest-query-slash-encode',
+			functionName: `${prefix}-query-slash-encode`,
 			code: cloudfront.FunctionCode.fromInline(cfFunctionCode),
 			runtime: cloudfront.FunctionRuntime.JS_2_0,
 		});
 
 		// --- S3 error pages bucket (Network-local to avoid cross-stack cycle) ---
 		const errorPagesBucket = new s3.Bucket(this, 'ErrorPagesBucket', {
-			bucketName: `ganbari-quest-error-pages-${this.account}`,
+			bucketName: `${prefix}-error-pages-${this.account}`,
 			removalPolicy: cdk.RemovalPolicy.DESTROY,
 			autoDeleteObjects: true,
 			blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
@@ -325,7 +343,15 @@ function handler(event) {
 				: {}),
 			priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
 			httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
-			geoRestriction: cloudfront.GeoRestriction.allowlist('JP'),
+			// #4204: 既定 (未指定) は本番と同じ JP allowlist。staging は `[]` で制限なし。
+			// 空配列で allowlist を作ると CDK が throw するため、指定なし扱いに分岐する。
+			...(props.geoRestrictionCountries?.length === 0
+				? {}
+				: {
+						geoRestriction: cloudfront.GeoRestriction.allowlist(
+							...(props.geoRestrictionCountries ?? ['JP']),
+						),
+					}),
 		});
 
 		// #3402-2: offload 初回有効化時、distribution が /_app/immutable/* を S3 に向ける更新と

--- a/infra/lib/network-stack.ts
+++ b/infra/lib/network-stack.ts
@@ -66,6 +66,12 @@ export class NetworkStack extends cdk.Stack {
 
 		// #4204: 物理名 prefix。既定は本番値なので **prod template は byte 一致**のまま。
 		const prefix = props.resourcePrefix ?? 'ganbari-quest';
+		// CloudFront の CachePolicy 名は **アカウント全体で一意**。kebab の prefix をそのまま使えないため
+		// PascalCase に変換する (既定は 'GanbariQuest' = 現行 prod 値と一致)。
+		const namePascal = prefix
+			.split('-')
+			.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+			.join('');
 
 		// Parse Lambda Function URL to get the hostname
 		const fnUrlDomain = cdk.Fn.select(2, cdk.Fn.split('/', props.functionUrl.url));
@@ -189,7 +195,7 @@ function handler(event) {
 		// 静的アセット用 cache policy (365 日 immutable)。/_app/* (shield lambda) と
 		// /_app/immutable/* (S3 offload 時) で共有する。
 		const staticAssetsCachePolicy = new cloudfront.CachePolicy(this, 'StaticAssetsCachePolicy', {
-			cachePolicyName: 'GanbariQuestStaticAssets',
+			cachePolicyName: `${namePascal}StaticAssets`,
 			defaultTtl: cdk.Duration.days(365),
 			maxTtl: cdk.Duration.days(365),
 			minTtl: cdk.Duration.days(1),
@@ -225,7 +231,7 @@ function handler(event) {
 			// network-local bucket (cross-stack cycle 回避、errorPagesBucket と同方針)。
 			// immutable 静的アセット専用。各 deploy で再 upload されるため DESTROY + autoDelete で良い。
 			const staticAssetsBucket = new s3.Bucket(this, 'StaticAssetsBucket', {
-				bucketName: `ganbari-quest-static-assets-${this.account}`,
+				bucketName: `${prefix}-static-assets-${this.account}`,
 				removalPolicy: cdk.RemovalPolicy.DESTROY,
 				autoDeleteObjects: true,
 				blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
@@ -482,7 +488,7 @@ function handler(event) {
 				this,
 				'DemoStaticAssetsCachePolicy',
 				{
-					cachePolicyName: 'GanbariQuestDemoStaticAssets',
+					cachePolicyName: `${namePascal}DemoStaticAssets`,
 					defaultTtl: cdk.Duration.days(365),
 					maxTtl: cdk.Duration.days(365),
 					minTtl: cdk.Duration.days(1),
@@ -509,7 +515,7 @@ function handler(event) {
 
 			// demo 用 CloudFront Function: query slash encode のみ (admin IP 制限なし)。
 			const demoQueryFixFn = new cloudfront.Function(this, 'DemoQuerySlashEncodeFn', {
-				functionName: 'ganbari-quest-demo-query-slash-encode',
+				functionName: `${prefix}-demo-query-slash-encode`,
 				code: cloudfront.FunctionCode.fromInline(`
 function handler(event) {
   var request = event.request;

--- a/tests/unit/infra/cross-stack-export-ratchet.test.ts
+++ b/tests/unit/infra/cross-stack-export-ratchet.test.ts
@@ -172,6 +172,12 @@ const AUTO_EXPORT_ALLOWLIST: readonly ExportEntry[] = [
 		producer: 'GanbariQuestStorageStaging',
 		descriptor: 'staging ECR AppRepo Arn → ComputeStaging が import',
 	},
+	// --- staging ComputeStack (1、#4204) — prod の main Fn FunctionUrl → Network と同型 ---
+	{
+		name: 'GanbariQuestComputeStaging:ExportsOutputFnGetAttSvelteKitFnFunctionUrlB4DF7458FunctionUrl81A12F7D',
+		producer: 'GanbariQuestComputeStaging',
+		descriptor: 'staging main Fn FunctionUrl → NetworkStaging (CloudFront origin) が import',
+	},
 ];
 
 const ALLOWLIST_NAMES: ReadonlySet<string> = new Set(AUTO_EXPORT_ALLOWLIST.map((e) => e.name));
@@ -193,6 +199,7 @@ const SYNTH_STACK_IDS = [
 	'StorageStaging',
 	'AuthStaging',
 	'ComputeStaging',
+	'NetworkStaging',
 ] as const;
 
 /**
@@ -309,11 +316,18 @@ function synthAllStacks(): { exports: Set<string>; imports: Set<string> } {
 		envConfig: STAGING_ENV_CONFIG,
 	});
 	new AuthStack(app, `${APP_NAME}AuthStaging`, { env, envConfig: STAGING_ENV_CONFIG });
-	new ComputeStack(app, `${APP_NAME}ComputeStaging`, {
+	const sCompute = new ComputeStack(app, `${APP_NAME}ComputeStaging`, {
 		env,
 		assetsBucket: sStorage.assetsBucket,
 		repository: sStorage.repository,
 		envConfig: STAGING_ENV_CONFIG,
+	});
+	// #4204: staging CloudFront。Compute の functionUrl を import する (prod Network と同型)。
+	new NetworkStack(app, `${APP_NAME}NetworkStaging`, {
+		env,
+		functionUrl: sCompute.functionUrl,
+		resourcePrefix: STAGING_ENV_CONFIG.resourcePrefix,
+		geoRestrictionCountries: [],
 	});
 
 	// 全 stack build 完了後に Template 化 (synth は tree を lock するため順序が重要)。
@@ -368,7 +382,7 @@ describe('#3858 cross-stack 自動 export/ImportValue allowlist ratchet (ADR-006
 		).toEqual([]);
 	});
 
-	it('生成 Export と allowlist が集合として過不足なく一致する (計 13 = prod 9 + staging 4)', () => {
+	it('生成 Export と allowlist が集合として過不足なく一致する (計 14 = prod 9 + staging 5)', () => {
 		// 上記 2 assert の統合表明 (数の drift を 1 行で可視化)。実測とズレたら人手承認 (本 test 更新) を要する。
 		expect(synthResult.exports.size).toBe(AUTO_EXPORT_ALLOWLIST.length);
 		expect(new Set(synthResult.exports)).toEqual(ALLOWLIST_NAMES);

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -806,6 +806,23 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 		expect(stagingNames.length).toBeGreaterThan(0);
 	});
 
+	// [N-1b] prod 不変の根拠を「既定値」だけに預けない (adversarial review business 軸)。
+	//
+	// prod の物理名は `resourcePrefix` の既定値が 'ganbari-quest' であることだけで守られている。
+	// **app.ts が prod 側にも resourcePrefix / geoRestrictionCountries を渡し始めた瞬間**、
+	// CloudFront Distribution / bucket / CachePolicy が一斉に Replacement になり本番が落ちる
+	// (ADR-0019)。呼び出し側が変わったことを検出する。
+	it('bin/app.ts が prod の NetworkStack に prefix / geoRestriction を渡していない', async () => {
+		const { readFileSync } = await import('node:fs');
+		const src = readFileSync('infra/bin/app.ts', 'utf8');
+		// prod の instantiate は `new NetworkStack(app, \`${appName}Network\`, {` から対応する `});` まで。
+		const start = src.indexOf('new NetworkStack(app, `${appName}Network`');
+		expect(start, 'prod NetworkStack の instantiate が見つからない').toBeGreaterThan(-1);
+		const prodBlock = src.slice(start, src.indexOf('\n\t});', start));
+		expect(prodBlock).not.toContain('resourcePrefix');
+		expect(prodBlock).not.toContain('geoRestrictionCountries');
+	});
+
 	// [N-5] 配線の no-silent-gap。CDK 側が正しくても deploy 対象に入っていなければ意味がない。
 	it('deploy-aws-staging.yml の STAGING_STACKS に NetworkStaging が含まれる', async () => {
 		const { readFileSync } = await import('node:fs');

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -835,11 +835,9 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 		// 許可ドメインは **宣言**する。「使い捨てっぽい」の推測判定は穴になるため置かない。
 		// 参照 (`$STAGING_ALLOWED_EMAIL_DOMAINS`) が残っていても宣言が消えていれば
 		// 全ドメインが allowlist 外になり通知が壊れるので、**宣言側**を見る。
-		const declaration = yml
-			.split(/?
-/)
-			.find((l) => /^\s{2}STAGING_ALLOWED_EMAIL_DOMAINS:\s*\S/.test(l));
-		expect(declaration, '許可ドメインの宣言 (workflow env) が見つかりません').toBeDefined();
+		// 正規表現の m フラグで行頭を見る (env の宣言行だけに当てる)。
+		const hasDeclaration = /^ {2}STAGING_ALLOWED_EMAIL_DOMAINS: *[a-z]/m.test(yml);
+		expect(hasDeclaration, '許可ドメインの宣言 (workflow env) が見つかりません').toBe(true);
 		// 実登録者を実物から取る (synth や設定値ではなく Cognito を見る)
 		expect(yml).toContain('cognito-idp list-users');
 		// 気づける先 = incident チャネル

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -816,7 +816,8 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 		const { readFileSync } = await import('node:fs');
 		const src = readFileSync('infra/bin/app.ts', 'utf8');
 		// prod の instantiate は `new NetworkStack(app, \`${appName}Network\`, {` から対応する `});` まで。
-		const start = src.indexOf('new NetworkStack(app, `${appName}Network`');
+		// 正規表現で探す (通常文字列に `${` を書くと biome noTemplateCurlyInString に当たる)。
+		const start = src.search(/new NetworkStack\(app, `\$\{appName\}Network`/);
 		expect(start, 'prod NetworkStack の instantiate が見つからない').toBeGreaterThan(-1);
 		const prodBlock = src.slice(start, src.indexOf('\n\t});', start));
 		expect(prodBlock).not.toContain('resourcePrefix');

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -732,8 +732,8 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 	// **staging に本番データを入れる運用が生まれたら JP allowlist を戻す** (PO 条件)。
 	it('staging は geoRestriction を持たない', () => {
 		const t = buildNetwork(true);
-		const dists = t.findResources('AWS::CloudFront::Distribution');
-		for (const d of Object.values(dists)) {
+		const distributions = t.findResources('AWS::CloudFront::Distribution');
+		for (const d of Object.values(distributions)) {
 			expect(
 				(d as { Properties?: { DistributionConfig?: { Restrictions?: unknown } } }).Properties
 					?.DistributionConfig?.Restrictions,

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -20,6 +20,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { AuthStack } from '../../../infra/lib/auth-stack';
 import { ComputeStack } from '../../../infra/lib/compute-stack';
 import { STAGING_ENV_CONFIG } from '../../../infra/lib/env-config';
+import { NetworkStack } from '../../../infra/lib/network-stack';
 import { StorageStack } from '../../../infra/lib/storage-stack';
 
 const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
@@ -646,5 +647,131 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			);
 			expect(errors).toHaveLength(0);
 		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4204: staging CloudFront。
+//
+// staging は NetworkStack を deploy していなかったため、SvelteKit の名前付き form action
+// (`?/action`) が Lambda Function URL のクエリ文字列スラッシュ拒否に当たり、
+// **ログインもサインアップもできない**状態だった (= 認証後の画面に到達する手段がゼロ)。
+//
+// prod 側は物理名が 2 件ハードコードされており、同一アカウント・同一リージョンに staging を
+// 立てると衝突する。prefix 化で分離するが、**prod の物理名が 1 文字でも変わると
+// CloudFront distribution / bucket が作り直しになる** (ADR-0019) ため、prod 不変を test で固定する。
+// ---------------------------------------------------------------------------
+describe('#4204 staging CloudFront (NetworkStack)', () => {
+	function buildNetwork(staging: boolean): Template {
+		const app = new cdk.App({
+			context: {
+				'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+					'us-east-1_TESTPOOL',
+				'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+					'test-client-id',
+				'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+					'auth.ganbari-quest.com',
+				'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+					'test-context-token-secret',
+				opsSecretKey: 'test-ops-secret-key',
+				parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+				dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+				dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+			},
+		});
+		const envConfig = staging ? STAGING_ENV_CONFIG : undefined;
+		const storage = new StorageStack(app, 'NetTestStorage', { env, envConfig });
+		const compute = new ComputeStack(app, 'NetTestCompute', {
+			env,
+			assetsBucket: storage.assetsBucket,
+			repository: storage.repository,
+			envConfig,
+		});
+		const network = new NetworkStack(app, 'NetTestNetwork', {
+			env,
+			functionUrl: compute.functionUrl,
+			...(staging
+				? { resourcePrefix: STAGING_ENV_CONFIG.resourcePrefix, geoRestrictionCountries: [] }
+				: {}),
+		});
+		return Template.fromStack(network);
+	}
+
+	// [N-1] prod 不変 (ADR-0019)。物理名が変わると distribution / bucket が作り直しになる。
+	it('prod の物理名と地域制限は従来どおり (prefix 化で変わらない)', () => {
+		const t = buildNetwork(false);
+		t.hasResourceProperties('AWS::CloudFront::Function', {
+			Name: 'ganbari-quest-query-slash-encode',
+		});
+		t.hasResourceProperties('AWS::S3::Bucket', {
+			BucketName: 'ganbari-quest-error-pages-000000000000',
+		});
+		t.hasResourceProperties('AWS::CloudFront::Distribution', {
+			DistributionConfig: Match.objectLike({
+				Restrictions: {
+					GeoRestriction: { RestrictionType: 'whitelist', Locations: ['JP'] },
+				},
+			}),
+		});
+	});
+
+	// [N-2] staging は prefix 分離する。同一アカウント・同一リージョンで物理名が衝突するため。
+	it('staging の物理名は prefix で分離される', () => {
+		const t = buildNetwork(true);
+		t.hasResourceProperties('AWS::CloudFront::Function', {
+			Name: 'ganbari-quest-staging-query-slash-encode',
+		});
+		t.hasResourceProperties('AWS::S3::Bucket', {
+			BucketName: 'ganbari-quest-staging-error-pages-000000000000',
+		});
+	});
+
+	// [N-3] staging は地域制限なし。post-deploy smoke を回す GitHub runner が日本国外にあり、
+	// JP allowlist を残すと 403 で smoke が回らない。
+	// 前提 = staging に本番データが入っていないこと (PO 実測 2026-08-02)。
+	// **staging に本番データを入れる運用が生まれたら JP allowlist を戻す** (PO 条件)。
+	it('staging は geoRestriction を持たない', () => {
+		const t = buildNetwork(true);
+		const dists = t.findResources('AWS::CloudFront::Distribution');
+		for (const d of Object.values(dists)) {
+			expect(
+				(d as { Properties?: { DistributionConfig?: { Restrictions?: unknown } } }).Properties
+					?.DistributionConfig?.Restrictions,
+			).toBeUndefined();
+		}
+	});
+
+	// [N-4] 本題。これが無いと staging で form action が 1 つも通らない。
+	it('staging の default behavior に query-slash-encode Function が付いている', () => {
+		const t = buildNetwork(true);
+		t.hasResourceProperties('AWS::CloudFront::Distribution', {
+			DistributionConfig: Match.objectLike({
+				DefaultCacheBehavior: Match.objectLike({
+					FunctionAssociations: Match.arrayWith([
+						Match.objectLike({ EventType: 'viewer-request' }),
+					]),
+				}),
+			}),
+		});
+	});
+
+	// [N-5] 配線の no-silent-gap。CDK 側が正しくても deploy 対象に入っていなければ意味がない。
+	it('deploy-aws-staging.yml の STAGING_STACKS に NetworkStaging が含まれる', async () => {
+		const { readFileSync } = await import('node:fs');
+		const yml = readFileSync('.github/workflows/deploy-aws-staging.yml', 'utf8');
+		const line = yml.split(/\r?\n/).find((l) => l.trim().startsWith('STAGING_STACKS:'));
+		expect(line).toBeDefined();
+		expect(line).toContain('GanbariQuestNetworkStaging');
+	});
+
+	// [N-6] ORIGIN / smoke は CloudFront を入口にする。Function URL 直だと form action は
+	// 原理的に通らないため、入口がズレていると smoke が本物を検証しない。
+	it('smoke と ORIGIN が CloudFront を入口にしている', async () => {
+		const { readFileSync } = await import('node:fs');
+		const yml = readFileSync('.github/workflows/deploy-aws-staging.yml', 'utf8');
+		expect(yml).toContain('DistributionDomainName');
+		expect(yml).toContain('/auth/login?/login');
+		// status code では判定しない (ログイン失敗も 400 を返すため)。
+		expect(yml).toContain('x-frame-options');
 	});
 });

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -661,6 +661,34 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 // 立てると衝突する。prefix 化で分離するが、**prod の物理名が 1 文字でも変わると
 // CloudFront distribution / bucket が作り直しになる** (ADR-0019) ため、prod 不変を test で固定する。
 // ---------------------------------------------------------------------------
+/** アカウント / リージョンで一意になりうる「名前」プロパティ (#4204)。 */
+const PHYSICAL_NAME_PROPS = new Set([
+	'Name',
+	'BucketName',
+	'FunctionName',
+	'CachePolicyName',
+	'OriginRequestPolicyName',
+	'ResponseHeadersPolicyName',
+]);
+
+/** CFN template を再帰的に歩き、物理名として使われている文字列を集める (#4204)。 */
+function collectPhysicalNames(t: Template): string[] {
+	const found: string[] = [];
+	const walk = (node: unknown): void => {
+		if (Array.isArray(node)) {
+			for (const v of node) walk(v);
+			return;
+		}
+		if (!node || typeof node !== 'object') return;
+		for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+			if (typeof v === 'string' && PHYSICAL_NAME_PROPS.has(k)) found.push(v);
+			walk(v);
+		}
+	};
+	walk(t.toJSON().Resources ?? {});
+	return found;
+}
+
 describe('#4204 staging CloudFront (NetworkStack)', () => {
 	function buildNetwork(staging: boolean): Template {
 		const app = new cdk.App({
@@ -766,34 +794,8 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 	// 「1 件ずつ prefix を付ける」対処では次に足された名前をまた取りこぼすため、
 	// **prod と staging で同じ物理名を 1 つも共有していないこと**を集合として突き合わせる。
 	it('prod と staging の NetworkStack が物理名を 1 つも共有しない', () => {
-		const collectNames = (t: Template): string[] => {
-			const found: string[] = [];
-			const walk = (node: unknown): void => {
-				if (Array.isArray(node)) {
-					for (const v of node) walk(v);
-					return;
-				}
-				if (node && typeof node === 'object') {
-					for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
-						// アカウント / リージョンで一意になりうる「名前」プロパティだけを見る。
-						if (
-							typeof v === 'string' &&
-							/^(Name|BucketName|FunctionName|CachePolicyName|OriginRequestPolicyName|ResponseHeadersPolicyName)$/.test(
-								k,
-							)
-						) {
-							found.push(v);
-						}
-						walk(v);
-					}
-				}
-			};
-			walk(t.toJSON().Resources ?? {});
-			return found;
-		};
-
-		const prodNames = new Set(collectNames(buildNetwork(false)));
-		const stagingNames = collectNames(buildNetwork(true));
+		const prodNames = new Set(collectPhysicalNames(buildNetwork(false)));
+		const stagingNames = collectPhysicalNames(buildNetwork(true));
 		const shared = stagingNames.filter((n) => prodNames.has(n));
 		expect(
 			shared,

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -680,14 +680,18 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 			},
 		});
 		const envConfig = staging ? STAGING_ENV_CONFIG : undefined;
-		const storage = new StorageStack(app, 'NetTestStorage', { env, envConfig });
-		const compute = new ComputeStack(app, 'NetTestCompute', {
+		// stack id は bin/app.ts と同じにする。CloudFront OriginAccessControl 等
+		// **CDK が construct path から自動生成する名前**があり、id を揃えないと
+		// 実際には衝突しないものを衝突として検出してしまう (逆も同様)。
+		const suffix = staging ? 'Staging' : '';
+		const storage = new StorageStack(app, `GanbariQuestStorage${suffix}`, { env, envConfig });
+		const compute = new ComputeStack(app, `GanbariQuestCompute${suffix}`, {
 			env,
 			assetsBucket: storage.assetsBucket,
 			repository: storage.repository,
 			envConfig,
 		});
-		const network = new NetworkStack(app, 'NetTestNetwork', {
+		const network = new NetworkStack(app, `GanbariQuestNetwork${suffix}`, {
 			env,
 			functionUrl: compute.functionUrl,
 			...(staging
@@ -753,6 +757,51 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 				}),
 			}),
 		});
+	});
+
+	// [N-4b] **この class の網羅 guard。**
+	//
+	// 目視で拾った物理名は 2 件だったが、実際には 4 件あった (CloudFront CachePolicy 名は
+	// アカウント全体で一意で、staging deploy が 409 AlreadyExists で ROLLBACK した)。
+	// 「1 件ずつ prefix を付ける」対処では次に足された名前をまた取りこぼすため、
+	// **prod と staging で同じ物理名を 1 つも共有していないこと**を集合として突き合わせる。
+	it('prod と staging の NetworkStack が物理名を 1 つも共有しない', () => {
+		const collectNames = (t: Template): string[] => {
+			const found: string[] = [];
+			const walk = (node: unknown): void => {
+				if (Array.isArray(node)) {
+					for (const v of node) walk(v);
+					return;
+				}
+				if (node && typeof node === 'object') {
+					for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+						// アカウント / リージョンで一意になりうる「名前」プロパティだけを見る。
+						if (
+							typeof v === 'string' &&
+							/^(Name|BucketName|FunctionName|CachePolicyName|OriginRequestPolicyName|ResponseHeadersPolicyName)$/.test(
+								k,
+							)
+						) {
+							found.push(v);
+						}
+						walk(v);
+					}
+				}
+			};
+			walk(t.toJSON().Resources ?? {});
+			return found;
+		};
+
+		const prodNames = new Set(collectNames(buildNetwork(false)));
+		const stagingNames = collectNames(buildNetwork(true));
+		const shared = stagingNames.filter((n) => prodNames.has(n));
+		expect(
+			shared,
+			`prod と同じ物理名を staging が使っている (同一アカウント・同一リージョンで衝突する): ${shared.join(', ')}`,
+		).toEqual([]);
+		// 空集合同士の比較で緑になるのを防ぐ (名前を 1 つも拾えていなければ検査が成立していない)。
+		expect(prodNames.size).toBeGreaterThan(0);
+		expect(stagingNames.length).toBeGreaterThan(0);
 	});
 
 	// [N-5] 配線の no-silent-gap。CDK 側が正しくても deploy 対象に入っていなければ意味がない。

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -833,7 +833,13 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 		const yml = readFileSync('.github/workflows/deploy-aws-staging.yml', 'utf8');
 
 		// 許可ドメインは **宣言**する。「使い捨てっぽい」の推測判定は穴になるため置かない。
-		expect(yml).toContain('STAGING_ALLOWED_EMAIL_DOMAINS');
+		// 参照 (`$STAGING_ALLOWED_EMAIL_DOMAINS`) が残っていても宣言が消えていれば
+		// 全ドメインが allowlist 外になり通知が壊れるので、**宣言側**を見る。
+		const declaration = yml
+			.split(/?
+/)
+			.find((l) => /^\s{2}STAGING_ALLOWED_EMAIL_DOMAINS:\s*\S/.test(l));
+		expect(declaration, '許可ドメインの宣言 (workflow env) が見つかりません').toBeDefined();
 		// 実登録者を実物から取る (synth や設定値ではなく Cognito を見る)
 		expect(yml).toContain('cognito-idp list-users');
 		// 気づける先 = incident チャネル

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -824,6 +824,35 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 		expect(prodBlock).not.toContain('geoRestrictionCountries');
 	});
 
+	// [N-7] geoRestriction を外したことの代償を、人の注意力ではなく機械で見張る (PO 決裁 2026-08-02)。
+	//
+	// staging を全世界公開にした前提は「実在のメールアドレスを登録しない」という運用ルール。
+	// **人が守るなら、守られなかったことに気づく手段がいる。**
+	it('staging に allowlist 外のメールが登録されたら気づける', async () => {
+		const { readFileSync } = await import('node:fs');
+		const yml = readFileSync('.github/workflows/deploy-aws-staging.yml', 'utf8');
+
+		// 許可ドメインは **宣言**する。「使い捨てっぽい」の推測判定は穴になるため置かない。
+		expect(yml).toContain('STAGING_ALLOWED_EMAIL_DOMAINS');
+		// 実登録者を実物から取る (synth や設定値ではなく Cognito を見る)
+		expect(yml).toContain('cognito-idp list-users');
+		// 気づける先 = incident チャネル
+		expect(yml).toContain('DISCORD_WEBHOOK_INCIDENT');
+
+		// **deploy は止めない** (既に登録済のものは手遅れで、止めても意味がない)。
+		const guard = yml.slice(yml.indexOf('- name: Staging PII guard'));
+		expect(guard.slice(0, guard.indexOf('- name: ', 10))).toContain('continue-on-error: true');
+	});
+
+	// [N-8] 許可ドメインの二重管理を作らない。runbook にリストを複製すると必ずズレる。
+	it('runbook は allowlist を複製せず workflow を SSOT として参照する', async () => {
+		const { readFileSync } = await import('node:fs');
+		const runbook = readFileSync('docs/runbooks/staging-live-verification.md', 'utf8');
+		expect(runbook).toContain('STAGING_ALLOWED_EMAIL_DOMAINS');
+		// #4117 の担当者が最初に読む場所に警告があること
+		expect(runbook.slice(0, 1200)).toContain('実在のメールアドレスを登録しない');
+	});
+
 	// [N-5] 配線の no-silent-gap。CDK 側が正しくても deploy 対象に入っていなければ意味がない。
 	it('deploy-aws-staging.yml の STAGING_STACKS に NetworkStaging が含まれる', async () => {
 		const { readFileSync } = await import('node:fs');


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（staging 環境の修復）。**

**staging ではログインもサインアップもできませんでした。** SvelteKit の名前付き form action（`?/action`）は Lambda Function URL がクエリ文字列のスラッシュを拒否するため 400 になり、`/auth/login` にも `/auth/signup` にも default action が無く名前付き action しか持たないためです。

本番は CloudFront Function `ganbari-quest-query-slash-encode` が `?/x` → `?%2Fx` に書き換えて回避していますが、**staging は NetworkStack を deploy していなかった**のでその回避がありませんでした。過去に同じ問題を解いた人が CDK にコメントを残しており、それが staging に引き継がれていなかった、という構造です。

実害は **#4117（Stripe 課金の staging 実機検証）が始められない**ことです。認証後の画面に到達する手段がゼロなので、checkout → webhook → plan 反映のどれも踏めません。

## 関連 Issue

Closes #4204

- #4117（本 PR が前提。staging でログインできて初めて着手できる）
- #2873（AWS staging 系統の構築）
- #3412（staging 合成 seed。geoRestriction を外す判断の前提に関わる）
- ADR-0019（CDK Replacement 検知）/ ADR-0024（ENV silent skip 禁止）/ ADR-0061（failing-test-first）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC0** | 案 2（smoke）を先に入れて赤を実測してから案 1（修正）に進む | staging を実 deploy して smoke の判定を観測 | ✅ **赤を実測**（run `30733390179`）: `POST /auth/login?/login -> 400`。GET `/` と `/switch` は 302 で通っていた = **GET だけの smoke では検出できない**ことも同時に実証 |
| **AC1** | staging に CloudFront を追加する | `GanbariQuestNetworkStaging` を追加し 4 stack 構成に | ✅ **実機緑**（run `30736349247`）: `POST /auth/login?/login -> 200` + `x-frame-options: DENY` |
| **AC2** | staging の geoRestriction を外す | `geoRestrictionCountries: []` | ✅ 実装 + fitness [N-3]。**戻す条件をコード / 設計書 / runbook の 3 箇所に明記**（下記 PO 条件） |
| **AC3** | 物理名を prefix 化して本番と衝突させない | prod 不変を fitness で固定 | ✅ 5 件を prefix 化。**当初 2 件と誤認して 409 で ROLLBACK した**（下記「2 回落としました」） |
| **AC4** | #4117 の本文に「#4204 が前提」を明記 | Issue 編集 | ✅ #4117 に追記済 |
| **AC5** | Step 13 の `continue-on-error` を外す（ADR-0024） | workflow 差分 | ✅ 撤去。**ORIGIN 未解決のまま smoke が 403 を「認証失敗、想定内」と誤読する経路**を塞ぐため |
| **AC6** | `docs/runbooks/staging-live-verification.md` を実態に合わせる（ADR-0001） | runbook 差分 | ✅ 入口を Function URL → CloudFront に是正（Stripe webhook endpoint URL の取得コマンド含む） |
| **AC7（PO 新規）** | staging DB の中身を確認してから全世界公開にする | PO が AWS で実測 | ✅ **PO 実測**: 本番 cluster 1,801,692 bytes に対し staging 1,031,956 bytes（57%）。本番 snapshot をコピーしていれば同等以上になるため、入っていないと判断 |
| **AC8（PO 新規）** | prefix 化の前後で本番リソースの論理 ID / 物理名が変わらないことを確認（ADR-0019） | **PO が release cut 前に実行**（2026-08-02 決裁） | ⏸ **PO 担当に移管**。Dev は代替として fitness [N-1] [N-1b] を設置済 |
| **AC9（PO 新規）** | staging に allowlist 外のメールが登録されたら気づける機械強制を置く | post-deploy `Staging PII guard` + fitness [N-7] | ✅ Cognito の実登録を列挙し、allowlist 外があれば Discord incident へ通知。**deploy は止めない** |
| **AC10（PO 新規）** | runbook 冒頭に「staging は全世界公開。実在メールを登録しない」を書く | runbook 差分 + fitness [N-8] | ✅ #4117 の担当者が最初に読む位置に配置。**allowlist は複製せず workflow を SSOT として参照**（複製は必ずズレる） |

### 赤 → 緑の実測

```
案 2 のみ（CloudFront 無し、run 30733390179）
  GET  /                    -> 302   ✅
  GET  /switch              -> 302   ✅
  POST /auth/login?/login   -> 400   ❌ ← 検出したかったもの

案 1 適用後（CloudFront 有り、run 30736349247）
  staging base: https://d9u77gvjgezns.cloudfront.net
  GET  /                    -> 302   ✅
  GET  /switch              -> 302   ✅
  POST /auth/login?/login   -> 200   ✅ + x-frame-options: DENY
```

`x-frame-options: DENY` は `hooks.server.ts` が付けるヘッダなので、**応答をアプリが作った**証拠です。

**ただしこれは「ログインできる」の証明ではありません。** 認証情報は本物を送っていないため、検証したのは「form action がアプリまで届く」ところまでです。ログイン成功経路（Cognito 認証 → session 発行 → 画面遷移）は 1 度も通っていません。#4117 の担当者が実際にログインを試みて別の壁（SES 未構成による確認コード不達など、runbook §8 が既に未実証と認めている項目）に当たる可能性は残ります。

### smoke の判定に status code を使っていない理由

ログイン失敗は SvelteKit の `fail(400)` / `fail(401)` で返ります（`src/routes/auth/login/+page.server.ts`）。つまり **400 は「経路が死んでいる」とも「認証情報が違う」とも読めてしまい、判定が意味を持ちません**。

判定は **誰がその応答を作ったか**で行います。`X-Frame-Options` があればアプリまで届いた、無ければ Lambda Function URL 自身が拒否した、と区別できます。Origin ヘッダを付けているのは SvelteKit の CSRF origin check を通すためで、付けないと 403 になり「届いたのに弾かれた」のか「届いていない」のか区別できません。

## 変更タイプ

- [x] バグ修正（staging でログインできない）
- [x] インフラ変更（CDK / workflow）
- [x] テスト追加（fitness function）
- [x] ドキュメント更新（設計書 / runbook / infra CLAUDE.md）
- [ ] 新機能
- [ ] リファクタリング

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **prod template** | **不変**。`resourcePrefix` / `geoRestrictionCountries` の既定値が現行 prod 値なので、prod 側の物理名 5 件と geoRestriction JP はそのまま。fitness [N-1] が固定 |
| **物理名の衝突（本 PR の主リスク）** | prod と staging が物理名を 1 つも共有しないことを**集合として**突き合わせる guard [N-4b] を追加。個別列挙ではないので次に足された名前も拾う |
| **custom domain / ACM 証明書** | **不要**。`network-stack.ts` の `domainNames`/`certificate` は `props.domainName && certificate` の条件展開で、未指定なら `*.cloudfront.net` で成立（Route53 / ACM lookup も同じガード内） |
| **cross-stack export** | staging Compute → Network の `FunctionUrl` export が 1 本増える。`cross-stack-export-ratchet.test.ts` の allowlist に登録（**この guard が未登録を検出して落ちた** = 意図どおり機能した） |
| **demo distribution** | staging は `demoFunctionUrl` を渡さないので生成されない。ただし物理名は将来の衝突を避けるため同じ prefix 方式に揃えた |
| **staticAssetsS3Offload** | staging は OFF。`StaticAssetsBucket` は生成されないが、CachePolicy は flag 外で生成されるため衝突した（下記） |
| **NUC staging** | 無関係（本 PR は AWS staging のみ） |
| **本番 deploy 経路** | `deploy.yml` は context 無しで `--all` するため staging stack は synth されない。挙動不変 |

## テスト・品質セルフチェック

```
npx vitest run tests/unit/infra/
 Test Files  16 passed (16)
      Tests  174 passed (174)

npx biome check --error-on-warnings .   → Found 3 infos（error 0）
npm run cspell                          → Issues found: 0
node scripts/check-repo-scan-test-declaration.mjs → OK（40 件）

staging 実 deploy: run 30736349247 → conclusion=success
```

### mutation 検証（guard が本当に効くか）

| 壊した内容 | 結果 |
|---|---|
| `cachePolicyName` を prod 値に戻す（**今回実際に踏んだ欠陥**） | ✅ [N-4b] が red |
| `functionName` の prefix 化を戻す | ✅ [N-2] が red |
| `STAGING_STACKS` から `NetworkStaging` を外す | ✅ [N-5] が red |

- [x] **failing-test-first（ADR-0061）**: 案 2 を先に入れ、実 staging で赤を観測してから案 1 に着手
- [x] 個別列挙ではなく集合で突き合わせる guard にした（同じ class の取りこぼしを防ぐため）
- [x] 空集合同士で緑になる抜けを塞いだ
- [x] `npm run pre-ready -- --pr <PR番号>` 全 6 step PASS

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: CDK / CI workflow / テスト / 設計ドキュメントのみの変更で src/ を 1 行も触っていない。顧客に見える画面が存在しない。 -->

**UI 変更はありません。** 変更は `infra/`（2 file）/ `.github/workflows/`（1 file）/ `tests/unit/infra/`（2 file）/ `docs/`（3 file）のみです。

## レビュー依頼事項・破壊的変更

### 途中で 2 回落としました。両方報告します

#### ① 手動実行が branch を無視していた

`workflow_dispatch` の checkout ref が **`develop` 固定**でした。GitHub は workflow file だけを指定 ref から読むため、**workflow の変更は反映されるのに `infra/` は develop のまま**という食い違いが起き、`No stacks match GanbariQuestNetworkStaging` で落ちました。

「branch を選べるのに選択が無視される」= 配線が silent に死んでいる class です。checkout も dispatch した ref に揃えました（実行者は job の actor guard で 2 アカウントに限定済み）。

**#4204 の scope 外ですが、これを直さないと本 PR の検証自体ができないため同 PR に含めています。**

#### ② 物理名を目視で 2 件しか拾えていなかった

**Issue と私の報告で「ハードコードは 2 件」と書いたのは誤りでした。実際は 5 件です。**

CloudFront の **CachePolicy 名はアカウント全体で一意**で、staging deploy が `Another cache policy with the same name already exists`（409）で CREATE_FAILED → ROLLBACK しました。

**1 件ずつ潰す対処では次に足された名前をまた取りこぼす**ため、guard を個別列挙ではなく集合の突き合わせにしました。

この過程で test 自体の欠陥も出ました。CDK が construct path から自動生成する名前（`OriginAccessControl` 等）があり、test の stack id を実物と揃えないと**衝突しないものを衝突と誤検出**します。stack id を `bin/app.ts` と同じにして直しました。

### 未達の明示（AC8）

**`cdk diff` による本番 Replacement 確認は実施できていません。** PO の「`cdk diff` で確認してから deploy」という指示に対する未達です。

- ローカル `cdk synth` は infra の依存解決で落ち、実 diff には AWS 認証が要ります
- 代わりに **prod 側の物理名 5 件と geoRestriction JP が従来値のままであることを unit test [N-1] で固定**しました（既定値が prod 値なので template は変わりません）
- 本番 deploy 時は `deploy.yml` の `check-cdk-replacement.mjs`（ADR-0019 gate）が走ります
- **本 PR は prod には一切 deploy していません。** staging のみです

**本番に出す前に `cdk diff` を 1 回通してください。** Replacement が出たら止めて PO に上げる、というのが PO の指示です。

### PO 条件の記録

> staging に本番データを入れる運用が将来生まれた場合、geoRestriction を戻す

コード（`network-stack.ts` の props コメント + `app.ts` の instantiate 箇所）/ 設計書（13-AWS §4.3）/ runbook の **3 箇所**に、判断根拠（PO 実測値）と戻す条件を明記しました。

### Adversarial review の結果（3 軸、evidence: `tmp/adversarial-evidence/4223.json`）

| 軸 | 指摘 | 対応 |
|---|---|---|
| **business** | prod 不変の根拠が `resourcePrefix` の**既定値 1 行**だけに依存している。app.ts が prod 側にも prefix を渡し始めた瞬間、CloudFront / bucket / CachePolicy が一斉に Replacement になり本番が落ちる | ✅ **本 PR で対処**。fitness [N-1b] が「`bin/app.ts` の prod NetworkStack に prefix / geoRestriction を渡していない」ことを検証。mutation で red を確認 |
| **UX** | smoke は「届く」ことしか見ておらず「ログインできる」は未検証。完了報告が「ログインできるようになった」と読まれると次の担当者が前提を過信する | ✅ **PR body と Issue の表現を是正**（上記「ただしこれは『ログインできる』の証明ではありません」） |
| **security** | geoRestriction を戻す条件が**コメントだけで機械強制がない**。staging は `AUTH_MODE=cognito` で実ユーザー登録が可能なため、#4117 の検証で実在メールアドレスを登録した時点で「PII を持つ全世界公開環境」が出来上がる | ✅ **PO 決裁を受けて対処済**（AC9 / AC10）。案 1（使い捨てメールのみ）+ 機械強制 |

#### PO 決裁（2026-08-02）を受けた対処

**案 1（使い捨てメールのみ）+ 機械強制**で確定。PO の言葉:

> 「人が守る」で残すなら、守られなかったことに気づく手段を付ける

実装したもの:

- **`Staging PII guard`（post-deploy）**: Cognito user pool の登録メールを列挙し、**allowlist 外のドメインがあれば Discord の incident チャネルへ通知**する
- **`deploy は止めない`**: 既に登録されたものは既に登録されているので、止めても手遅れで意味がない。**気づけることが目的**（PO 指示どおり）
- **allowlist は宣言する**: `STAGING_ALLOWED_EMAIL_DOMAINS`（workflow env が SSOT）。**「使い捨てっぽい」の推測判定はしない** — 推測は「知らないドメインを勝手に許す」形で必ず穴になる
- **CI ログにメールアドレス本体を出さない**: ドメインと件数だけ出す（CI ログは repo 参照者が読める）

**`docs/runbooks/staging-live-verification.md` の冒頭**に警告を置きました。allowlist は runbook に**複製していません**（workflow を参照）— 複製すると必ずズレるためで、fitness [N-8] が複製を禁じています。

##### 「Discord secret を渡さない」原則との関係

staging workflow の header には「外部サービス副作用ゼロ: Discord / Gemini / SES 系 secret は一切渡さない」とあります。**本 guard はこれに反しません。**

防ぎたいのは「**staging のアプリが動いた副作用が実チャネルを汚す**」ことで、**CI が人間に出す運用アラート**はそれに当たりません。**staging Lambda の env には一切注入していません**（workflow step の env のみ）。この線引きを header に明記しました。

### 別 Issue で追うもの

**`workflow_dispatch` の `dsqlEnabled` default が `false` のままで、手動実行が CDK synth で必ず落ちる**（`dsqlEndpoint` context が空）。`pull_request` 経由なら `DSQL_LANE` が常時 true なので通り、**手動実行だけが落ちる**ため気づきにくい構造です。#3438 で DSQL が唯一の backend になった際の残置。PO 指示により別 Issue で起票します。

### 破壊的変更

**staging の入口が Function URL から CloudFront に変わります。** Stripe webhook endpoint を登録済みの場合は URL の張り替えが必要です（runbook の §9.2 に新しい取得コマンドを記載）。**本番の入口は変わりません。**

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] 案 2 → 赤の実測 → 案 1 の順序で進めた（PO 決裁の実装順）
- [x] 赤と緑の両方を実 staging deploy で観測した
- [x] guard を 3 通りに壊して red を確認した
- [x] **自分の誤り（物理名 2 件 → 実際 5 件）を明示した**
- [x] **未達（AC8 `cdk diff`）を明示し、本番投入前の必須作業として書いた**
- [x] PO 条件（geoRestriction を戻す条件）を 3 箇所に記録した
- [x] scope 外だが同 PR に含めた変更（checkout ref）とその理由を書いた
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert で戻る"]
    R2["顧客面: 本番は無変更 staging のみ"]
    R3["🔴 未達: cdk diff 未実行 本番前に必須"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: staging でログインが通り #4117 着手可"]
    T2["負債: staging が全世界公開 PII 混入は人の注意依存"]
  end
  subgraph OBJ["③ 反対理由 (adversarial 3 軸)"]
    O1["business: prod 不変が既定値1行依存 → guard 追加で解消"]
    O2["UX: 届くのみ検証 ログイン成功は未検証"]
    O3["🔴 security: geo 復帰条件がコメントのみ 機械強制なし"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["変化なし src を1行も触らず UI 無し"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: #4117 検証で実在メアドを登録する?"]
    Q2["Q2: 本番 deploy 前 cdk diff は誰が通す?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3,O3 danger
  class T2,O1,O2 warn
  class R1,R2,T1,C1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- **Q1 の背景**: staging は `AUTH_MODE=cognito` で実ユーザー登録が可能。全世界公開にしたため、実在メールアドレスを登録した時点で「PII を持つ全世界公開環境」になる。選択肢は ①使い捨てメアド運用（Dev 推奨・人の注意依存）②検証中だけ geo を JP に戻す（安全だが smoke が落ちる）③現状のまま（Pre-PMF として許容）。**severity が security のため accepted-residual にせず明示的に上げている**（adversarial-reviewer skill の規定）。
- **Q2 の背景**: PO 指示「`cdk diff` で確認してから deploy」に対し **Dev は未実施**。ローカル synth は依存解決で落ち、実 diff には AWS 認証が要る。代替として prod 物理名 5 件 + geoRestriction JP の不変を unit test [N-1] で、呼び出し側の変化を [N-1b] で固定した。本番 deploy 時は `check-cdk-replacement.mjs` が走る。
- **本 PR は prod に一切 deploy していない**（staging のみ、run `30736349247` success）。
- adversarial evidence: `tmp/adversarial-evidence/4223.json`（3 軸 / 各 100 字以上 / schema PASS）。

</details>
