### PR TITLE
fix(infra): #4189 本番 CloudWatch アラームが宛先ゼロ — opsEmail を配り、宛先が無いと deploy を止める

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,9 +91,14 @@ jobs:
           # #2310 / #2337 / ADR-0050: parent-gate-session.ts が production で必須要求。
           # 未注入だと /admin/* cold start で throw して 500 連発 (PR #2325 で実害発生)。
           PARENT_GATE_COOKIE_SECRET: ${{ secrets.PARENT_GATE_COOKIE_SECRET }}
+          # #4189: CloudWatch アラームの通知先。未登録だと OpsStack の SNS topic に
+          # subscription が 1 件も付かず、**全アラームが宛先ゼロ**で鳴っても誰にも届かない。
+          # 「未設定なら通知しない」を許すと #4119 (18 晩バックアップが失敗して alert 0 通) を
+          # 再現するため、warn ではなく deploy を止める (ADR-0006 / ADR-0024)。
+          OPS_ALERT_EMAIL: ${{ secrets.OPS_ALERT_EMAIL }}
         run: |
           missing=0
-          for s in OPS_SECRET_KEY AWS_OIDC_IAMROLE_ARN STRIPE_SECRET_KEY PARENT_GATE_COOKIE_SECRET; do
+          for s in OPS_SECRET_KEY AWS_OIDC_IAMROLE_ARN STRIPE_SECRET_KEY PARENT_GATE_COOKIE_SECRET OPS_ALERT_EMAIL; do
             val=$(eval echo "\$$s")
             if [ -z "$val" ]; then
               echo "::error::Required GitHub Secret '$s' is missing. Register via 'gh secret set $s --body <value>'"
@@ -268,6 +273,7 @@ jobs:
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
           -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }}
           -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
+          -c opsEmail=${{ secrets.OPS_ALERT_EMAIL }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
 
@@ -342,6 +348,7 @@ jobs:
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
             -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }} \
             -c discordWebhookIncident=${{ secrets.DISCORD_WEBHOOK_INCIDENT }} \
+            -c opsEmail=${{ secrets.OPS_ALERT_EMAIL }} \
             ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }} \
             ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }} \
             2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
@@ -370,6 +377,7 @@ jobs:
           -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }}
           -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
           -c discordWebhookIncident=${{ secrets.DISCORD_WEBHOOK_INCIDENT }}
+          -c opsEmail=${{ secrets.OPS_ALERT_EMAIL }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET && format('-c googleClientSecret={0}', secrets.GOOGLE_OAUTH_CLIENT_SECRET) || '' }}
 
@@ -510,6 +518,43 @@ jobs:
             exit 1
           fi
           echo "::notice::cron-dispatcher smoke test passed"
+
+      # #4189: アラームの**宛先が実在すること**を deploy 後に実物で確認する。
+      #
+      # OpsStack の全 CloudWatch アラーム (Lambda Errors / 5xx / DLQ / Budgets / Health event) は
+      # SNS topic `ganbari-quest-ops-alerts` に送られるが、topic に subscription が 0 件でも
+      # **アラームの作成も deploy も成功する**。実際に本番は subscription 0 件のまま運用されており、
+      # 鳴っても誰にも届かなかった (#4119 では 18 晩バックアップが失敗して alert 0 通)。
+      #
+      # synth では検出できない (context が空でも template は valid に作れる) ため、
+      # #1586 cron-dispatcher smoke と同型で **実 AWS を見る**。
+      #
+      # ⚠️ subscription が 1 件あることは「届く」ことの証明ではない。メール subscription は
+      # 受信者が確認メールの承認リンクを踏むまで PendingConfirmation で、その間は配信されない。
+      # ここでは **Confirmed が 1 件以上あること**まで見る。
+      - name: Ops alert destination smoke test
+        run: |
+          TOPIC_ARN=$(aws sns list-topics --region $AWS_REGION \
+            --query "Topics[?ends_with(TopicArn, ':ganbari-quest-ops-alerts')].TopicArn | [0]" \
+            --output text)
+          if [ -z "$TOPIC_ARN" ] || [ "$TOPIC_ARN" = "None" ]; then
+            echo "::error::SNS topic 'ganbari-quest-ops-alerts' が見つかりません (#4189)"
+            exit 1
+          fi
+          SUBS=$(aws sns list-subscriptions-by-topic --topic-arn "$TOPIC_ARN" --region $AWS_REGION \
+            --query 'Subscriptions[].SubscriptionArn' --output text)
+          echo "subscriptions: ${SUBS:-(none)}"
+          if [ -z "$SUBS" ]; then
+            echo "::error::CloudWatch アラームの宛先が 0 件です。鳴っても誰にも届きません (#4189)。OPS_ALERT_EMAIL を登録して再 deploy してください"
+            exit 1
+          fi
+          # PendingConfirmation は SubscriptionArn がその文字列そのものになる (ARN ではない)。
+          CONFIRMED=$(echo "$SUBS" | tr '\t' '\n' | grep -c '^arn:aws:sns:' || true)
+          if [ "$CONFIRMED" -lt 1 ]; then
+            echo "::error::宛先は登録されていますが全て未承認 (PendingConfirmation) です。確認メールの承認リンクを踏むまでアラームは配信されません (#4189)"
+            exit 1
+          fi
+          echo "::notice::ops alert destination smoke test passed (confirmed subscriptions: $CONFIRMED)"
 
       # ADR-0048 / #2130: demo Lambda post-deploy smoke test
       # PR #2124 (week 4) merge 後 3 件の hotfix (#2127 / #2128 / #2129) が連続発生し、

--- a/tests/unit/architecture/env-distribution-closure.test.ts
+++ b/tests/unit/architecture/env-distribution-closure.test.ts
@@ -404,13 +404,6 @@ const NOT_DISTRIBUTED: Array<{
 		keys: ['demoCertificateArn'],
 		why: 'default が本番 certificateArn (infra/bin/app.ts)。wildcard 証明書を共用するため未指定が正常系',
 	},
-	{
-		readers: ['cdk-context'],
-		keys: ['opsEmail'],
-		why: '未指定だと OpsStack の SNS topic に subscription が 1 件も付かず、全 CloudWatch alarm が宛先なしになる。配布すべき通知先アドレスが未決のため塞げていない',
-		followUp: '#4189',
-	},
-
 	// ---- NUC 上で動く script ----
 	{
 		readers: ['nuc-script-env'],

--- a/tests/unit/architecture/env-distribution-closure.test.ts
+++ b/tests/unit/architecture/env-distribution-closure.test.ts
@@ -543,9 +543,7 @@ describe('#4191 env / context 配布の closure (経路横断)', () => {
 			'opsEmail が消えると本番 CloudWatch アラームが全系統宛先ゼロになる (#4189)',
 		).toContain('opsEmail');
 		expect(
-			NOT_DISTRIBUTED.find(
-				(e) => e.readers.includes('cdk-context') && e.keys.includes('opsEmail'),
-			),
+			NOT_DISTRIBUTED.find((e) => e.readers.includes('cdk-context') && e.keys.includes('opsEmail')),
 			'opsEmail は配布済なので免除宣言に戻してはいけない (#4189)',
 		).toBeUndefined();
 	});

--- a/tests/unit/architecture/env-distribution-closure.test.ts
+++ b/tests/unit/architecture/env-distribution-closure.test.ts
@@ -535,18 +535,19 @@ describe('#4191 env / context 配布の closure (経路横断)', () => {
 			'discordWebhookIncident が消えると本番 Lambda の incident 通知が 0 通になる (#4174)',
 		).toContain('discordWebhookIncident');
 
-		// opsEmail (#4189) はまだ配れていない。**塞げていないことを追跡できている**ことを pin する
-		// (免除が理由と followUp を持たないまま放置される状態に戻さない)。
-		const opsEmail = NOT_DISTRIBUTED.find(
-			(e) => e.readers.includes('cdk-context') && e.keys.includes('opsEmail'),
-		);
+		// #4189: opsEmail は配布済になったので、免除宣言ではなく**配布経路にあること**を pin する。
+		// これが消えると OpsStack の SNS topic に subscription が 1 件も付かず、
+		// 全 CloudWatch alarm が宛先ゼロに戻る。
 		expect(
-			opsEmail,
-			'opsEmail の宣言が消えています (配れたなら宣言ごと削除してください)',
-		).toBeDefined();
-		expect(opsEmail?.followUp, 'opsEmail は未解決なので followUp Issue を持つ必要があります').toBe(
-			'#4189',
-		);
+			CHANNELS['aws-deploy-context'].keys(),
+			'opsEmail が消えると本番 CloudWatch アラームが全系統宛先ゼロになる (#4189)',
+		).toContain('opsEmail');
+		expect(
+			NOT_DISTRIBUTED.find(
+				(e) => e.readers.includes('cdk-context') && e.keys.includes('opsEmail'),
+			),
+			'opsEmail は配布済なので免除宣言に戻してはいけない (#4189)',
+		).toBeUndefined();
 	});
 });
 
@@ -635,5 +636,33 @@ describe('#4174 AWS deploy は context を渡し忘れたまま緑にならな�
 		expect(step).toContain('DISCORD_WEBHOOK_INCIDENT');
 		expect(step, '配線不良を検出しても exit しないなら gate にならない').toContain('exit 1');
 		expect(step).toContain('::error::');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4189: 「配っている」だけでは足りない — **宛先が実在すること**まで守る
+//
+// opsEmail を deploy.yml に足しても、secret が未登録なら `${{ secrets.X }}` は空文字に落ち、
+// `if (opsEmail)` を通らず subscription 0 件のまま deploy が成功する。これは #4119 (18 晩
+// バックアップ失敗で alert 0 通) と同じ「未設定なら通知しない」の形なので、
+// warn ではなく **deploy を止める** 側に倒す (ADR-0006 / ADR-0024)。
+// ---------------------------------------------------------------------------
+describe('#4189 CloudWatch アラームの宛先', () => {
+	const deployYml = readFileSync('.github/workflows/deploy.yml', 'utf8');
+
+	it('OPS_ALERT_EMAIL 未登録なら deploy を止める (必須 secret 検証に載っている)', () => {
+		const validateStep = deployYml.slice(
+			deployYml.indexOf('name: Validate required secrets'),
+			deployYml.indexOf('name: Configure AWS credentials'),
+		);
+		expect(validateStep).toContain('OPS_ALERT_EMAIL');
+		// for ループの検査対象に入っていること (env に置いただけでは検査されない)
+		expect(validateStep).toMatch(/for s in [^;]*OPS_ALERT_EMAIL/);
+	});
+
+	it('deploy 後に実 SNS topic の subscription を見る smoke がある', () => {
+		expect(deployYml).toContain('list-subscriptions-by-topic');
+		// 「1 件ある」だけで通すと PendingConfirmation (未承認 = 配信されない) を見逃す
+		expect(deployYml).toContain('PendingConfirmation');
 	});
 });


### PR DESCRIPTION
> ## ⚠️ merge 前にオーナー作業が 1 つ必要です
>
> ```bash
> gh secret set OPS_ALERT_EMAIL --body "<通知を受け取るメールアドレス>" --repo Takenori-Kusaka/ganbari-quest
> ```
>
> **未登録のまま merge すると本番 deploy が止まります**（意図的にそうしています。下記「破壊的変更」参照）。
> 登録後、AWS から届く SNS の確認メールの承認リンクを踏むまでアラームは配信されません。

## 顧客価値・目的

**顧客に見える変化はありません（本番障害の検知を機能させる）。**

**本番の CloudWatch アラームは、鳴っても誰にも届きません。** `OpsStack` の全アラーム（Lambda Errors / 5xx / DLQ / Budgets / AWS Health）は SNS topic `ganbari-quest-ops-alerts` に送られますが、この topic に付く subscription は `opsEmail` が渡されたときの 1 件だけで、**`opsEmail` はどの workflow からも渡されていませんでした**。

```
$ grep -rn "opsEmail" .github/workflows/
（該当なし）
```

`props.opsEmail ?? tryGetContext('opsEmail')` が undefined に落ち、`if (opsEmail)` を通らないため、**subscription 0 件の SNS topic に全アラームが流れ込んでいた**状態です。

実害は既に出ています。**#4119 では 18 晩バックアップが失敗し続けて alert が 0 通でした。**

## 関連 Issue

Closes #4189

- #4174（同 class。`discordWebhookIncident` が渡されておらず incident 通知が一度も飛んでいなかった）
- #4167 / #4119（NUC 側の同 class。18 晩バックアップ失敗で alert 0 通）
- ADR-0006（silent skip 禁止）/ ADR-0024（インフラ PR 必須要件 — secrets validation + post-deploy smoke + alarm）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC0** | 配られていないことを failing-test で固定してから直す（ADR-0061） | 免除宣言を外して red を実測 | ✅ **red 実測**: `[EC1]` + `[EC5]` の **2 failed**（`opsEmail` がどの配布経路にも載っていない） |
| **AC1** | 通知先を決めて配布経路に載せる | `deploy.yml` の 3 つの cdk コマンドに `-c opsEmail` を追加 | ✅ メール（`OPS_ALERT_EMAIL`）を採用。**Issue が推奨した案 A**。宛先そのものはオーナーが `gh secret set` で登録（上記） |
| **AC2** | `CONTEXT_KEYS_NOT_DISTRIBUTED` から `opsEmail` を外す | 免除削除 + 反転 assertion | ✅ 「免除が追跡されている」を pin する test を「**配布経路にあること**」を pin する側へ反転。免除宣言に戻すと fail |
| **AC3** | deploy 後に実 SNS topic の subscription が 1 件以上あることを実測する | **手動実測ではなく post-deploy smoke に機械化**した | ✅ `Ops alert destination smoke test` を追加（`aws sns list-subscriptions-by-topic`）。#1586 cron-dispatcher smoke と同型 |
| **AC4** | アラームを 1 度意図的に発火させ、通知が届くことを実証する | — | ⚠️ **未達**。下記「未達の明示」 |

### 「1 件あればよい」ではありません

メール subscription は、**受信者が確認メールの承認リンクを踏むまで `PendingConfirmation`** で、その間は配信されません。「subscription が 1 件ある」だけを見る smoke だと、**未承認のまま「宛先あり」と判定してしまう**（今回直している欠陥と同じ形の穴を新しく作ることになります）。

そのため smoke は **Confirmed が 1 件以上あること**まで見ます（`PendingConfirmation` は `SubscriptionArn` がその文字列そのものになり ARN 形式にならないので判別できます）。

## 変更タイプ

- [x] バグ修正（本番アラームが宛先ゼロ）
- [x] インフラ変更（workflow）
- [x] テスト追加（fitness function）
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **本番 deploy** | **`OPS_ALERT_EMAIL` 未登録だと止まります**（意図的。下記「破壊的変更」） |
| **CDK コード** | **変更なし**。`OpsStack` は元々 `opsEmail` を受ける口を持っており、渡していなかっただけ |
| **staging** | 影響なし。`deploy-aws-staging.yml` は `OpsStack` を deploy しない（4 stack に Ops は含まれない） |
| **NUC** | 無関係（AWS の SNS topic の話） |
| **同 class の残り** | `discordWebhookHealth` は既に配布済（`deploy.yml` の 3 箇所）と実測。**AWS deploy context の免除リストは本 PR で `opsEmail` が消えて残り 1 件**（`demoCertificateArn` = 既定が本番証明書のため未指定が正常系） |
| **通知先の一本化** | Issue の案 B（SNS → Discord）は**採らなかった**。下記「レビュー依頼事項」参照 |

## テスト・品質セルフチェック

```
# 修正前（failing-test-first、ADR-0061）
npx vitest run tests/unit/architecture/env-distribution-closure.test.ts
 × [EC1] cdk-context が読む名前は、どれかの配布経路に載っている
 × [EC5] 実害 4 例の配布が現在も生きている
 Tests  2 failed | 11 passed (13)

# 修正後
 Tests  15 passed (15)

npx biome check --error-on-warnings .   → Found 3 infos（error 0）
npm run cspell                          → Issues found: 0
node scripts/check-repo-scan-test-declaration.mjs → OK（40 件）
```

### mutation 検証（guard が本当に効くか）

**実装を先に commit してから壊しています**（mutation で実装ごと消す事故を避けるため）。

| 壊した内容 | 結果 |
|---|---|
| `-c opsEmail` を **3 箇所すべて**削除 | ✅ `[EC1]` + `[EC5]` の 2 failed |
| `-c opsEmail` を **一部だけ**削除（diff / deploy で不整合） | ✅ 既存 `[AR1]`（context 集合の一致）が red |
| `OPS_ALERT_EMAIL` を必須 secret の検査ループから外す | ✅ 新規 test が red |

- [x] **failing-test-first（ADR-0061）**: 免除を外して red を実測してから配線
- [x] **免除を消すだけで終わらせず、反転 assertion に置き換えた**（「配れた」が「また配らなくなった」に戻るのを検出する）
- [x] **AC3 を手動実測ではなく機械化した**（人の注意力に戻さない）
- [x] **「1 件あればよい」の穴を塞いだ**（PendingConfirmation を fail 扱い）
- [x] `npm run pre-ready -- --pr <PR番号>` 全 6 step PASS

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: CI workflow とテストのみの変更で src/ を 1 行も触っていない。顧客に見える画面が存在しない。 -->

**UI 変更はありません。** 変更は `.github/workflows/deploy.yml` と `tests/unit/architecture/env-distribution-closure.test.ts` の 2 ファイルのみです。

## レビュー依頼事項・破壊的変更

### 破壊的変更: `OPS_ALERT_EMAIL` 未登録だと本番 deploy が止まります

**これは意図した設計です。**

`secrets.OPS_ALERT_EMAIL` が未登録なら `${{ secrets.X }}` は空文字に落ち、`if (opsEmail)` を通らず **subscription 0 件のまま deploy が成功します**。それは今直している欠陥そのものなので、warn ではなく止める側に倒しました（ADR-0006「未設定なら通知しない」の禁止）。

**merge 前に secret を登録してください。** 登録さえすれば以降は普通に通ります。

### 通知先にメールを選んだ理由（Issue の案 A / 案 B）

Issue は案 A（メール）を推奨、案 B（SNS → Discord Lambda）を「Pre-PMF では重い」としていました。**案 A を採りました**が、案 B にも実は追い風があることは記録しておきます。

- `DISCORD_WEBHOOK_INCIDENT` は **2026-08-01 に登録済**（#4174）で、既に読まれるチャネルがある
- Discord に POST する Lambda は **既に repo 内にある**（`infra/lambda/health-check/index.ts` が `DISCORD_WEBHOOK_HEALTH` へ投稿）

つまり案 B は「新規実装 40 行程度 + 既存チャネルに合流」で、当初想定より軽い可能性があります。**ただし本 PR では採りません** — 新規 Lambda は #4189 の scope（宛先ゼロの解消）を超え、まず「届く状態」を最短で作るほうが先だと判断しました。

**通知先をメール 1 本にするか、将来 Discord へ寄せるかは PO 判断**です。寄せる場合の入口として上記 2 点を残します。

### Adversarial review の結果（3 軸、evidence: `tmp/adversarial-evidence/4225.json`）

| 軸 | 指摘 | 対応 |
|---|---|---|
| **business** | **secret 未登録のまま merge されると本番 deploy が全面停止する**。次に `src/` を触った PR が main に入った瞬間に止まり、**hotfix を出したいときに出せない**。「PR body の先頭に書いた」だけでは実行が保証されない | ⚠️ **merge 順序を守っていただく必要があります**（secret 登録 → merge）。**QM / PO への依頼**: 登録が済むまで merge しないでください。Dev 側でこれを機械強制する手段がありません（GitHub Secrets の存在は PR CI からは読めない） |
| **UX** | 宛先が 1 人に固定され、見落とし・不在時に誰も気づけない。全アラームが同じ宛先に流れるため、次に起きるのは「届いたが読まれなかった」 | ⚠️ **未対処**。本 PR の scope は「宛先ゼロの解消」。通知量の観測後に Discord 集約（案 B）を再検討する材料を上記に残しました |
| **security** | `OPS_ALERT_EMAIL` は **CloudFormation template に平文で残る**（SNS Subscription の Endpoint）。GitHub Secrets の秘匿性とは非対称で、AWS 読み取り権限を持つ主体から参照できる。個人アドレスは PII でありフィッシングの標的情報にもなる | ✅ **推奨値を明示**（下記） |

#### 登録するアドレスの推奨

**個人のメールアドレスではなく、運用専用のエイリアスを推奨します。**

`OPS_ALERT_EMAIL` は GitHub Secrets に置きますが、**CDK context → CloudFormation template の `Endpoint` プロパティとして平文で残ります**（`describe-stacks` で読めます）。既に `noreply@ganbari-quest.com` で SES 検証済みドメインを持っているので、`ops@ganbari-quest.com` 等の転送エイリアスを作って登録し、実際の受信は個人メールへ転送するのが安全です。

**後から変えるのは可能**ですが（secret を更新して再 deploy）、旧アドレスの subscription は手動削除が要るので、最初に決めておくほうが安いです。

### 未達の明示（AC4）

**「アラームを 1 度意図的に発火させ、通知が届くことを実証する」は実施していません。**

- 本番でアラームを故意に発火させる（Lambda を意図的にエラーさせる等）必要があり、**本番への副作用を伴います**
- 代わりに **宛先が Confirmed で実在すること**までを post-deploy smoke で機械保証しました
- **「宛先が実在する」≠「届く」** です。配信の実証は残っています

deploy 後に AWS コンソールの SNS topic から「テストメッセージの発行」を 1 回行うのが最も安全な実証だと考えますが、これはオーナー作業です。

## 配布済み env / secret (ADR-0006)

**新規 secret が 1 件あります。**

- **未配布（要登録）**: `OPS_ALERT_EMAIL` → GitHub Actions Secrets（`deploy.yml`）
  - `gh secret set OPS_ALERT_EMAIL --body "<address>" --repo Takenori-Kusaka/ganbari-quest`
  - CDK context `-c opsEmail` 経由で `OpsStack` の SNS EmailSubscription になる
  - **NUC / staging には不要**（`OpsStack` は本番のみ）

## Ready for Review チェックリスト

- [x] failing-test-first で red を実測してから配線した（ADR-0061）
- [x] guard を 3 通りに壊して red を確認した
- [x] **免除を消すだけで終わらせず、逆向きの assertion に置き換えた**
- [x] **AC3 を手動実測ではなく機械化した**
- [x] **未達（AC4 配信の実証）を明示した**
- [x] **merge 前に必要なオーナー作業を本文の先頭に書いた**
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert で戻る"]
    R2["現状: 本番アラーム全系統が宛先ゼロ"]
    R3["🔴 secret 未登録で merge すると本番 deploy 全停止"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 障害が鳴ったら人に届く"]
    T2["負債: 宛先1人 閾値未調整で既読スルー化の恐れ"]
  end
  subgraph OBJ["③ 反対理由 (adversarial 3 軸)"]
    O1["🔴 business: merge順序が人の記憶依存"]
    O2["UX: 1宛先 全アラーム同一先 読まれない恐れ"]
    O3["security: アドレスがCFN templateに平文で残る"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["変化なし src を1行も触らず UI 無し"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 登録アドレスは ops@ エイリアス でよいか"]
    Q2["Q2: secret 登録まで merge を保留できるか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3,O1 danger
  class R2,T2,O2,O3 warn
  class R1,T1,C1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- **Q1**: `OPS_ALERT_EMAIL` は GitHub Secrets に置くが、CDK context → CloudFormation の SNS `Endpoint` として**平文で残る**（`describe-stacks` で読める）。個人アドレスは PII でありフィッシングの標的情報になるため、SES 検証済みドメインの `ops@ganbari-quest.com` 等の転送エイリアスを推奨。後から変更は可能だが旧 subscription の手動削除が要る。
- **Q2**: 未登録のまま merge すると、次に `src/` を触った PR が main に入った時点で本番 deploy が止まる（**hotfix も出せない**）。GitHub Secrets の有無は PR CI から読めないため、**Dev 側で機械強制できない**。順序（登録 → merge）を守っていただく必要がある。
- **fail-closed にした理由**: secret 未登録なら `${{ secrets.X }}` は空文字に落ち、`if (opsEmail)` を通らず subscription 0 件のまま deploy が成功する。それは今直している欠陥そのもの（ADR-0006「未設定なら通知しない」の禁止）。
- **AC4（アラームを発火させて配信を実証）は未達**。本番への副作用を伴うため。deploy 後に SNS コンソールから「テストメッセージの発行」を 1 回行うのが最も安全。
- adversarial evidence: `tmp/adversarial-evidence/4225.json`（3 軸 / 各 100 字以上 / schema PASS）。

</details>
