### PR TITLE
docs(process): #4180 宛先 label を用件から切り離し 6 ロール分そろえる（QM 宛の経路が無かった）

### DIFF
--- a/.claude/agents/platform-session.md
+++ b/.claude/agents/platform-session.md
@@ -26,7 +26,7 @@ Dev の**外在的認知負荷**を下げる。装置を増やして人に守ら
 
 ## セッション起動時
 
-`state:needs-platform` を拾う mailbox cron を 1 本作る（分は **43**、他ロールと重ならない値）。テンプレートは [platform-session.md §mailbox cron](../../docs/sessions/platform-session.md)。実装完了・CI 全緑・Ready 化したら `state:needs-platform` を外して **`state:dev-done`** を付け QM へ渡す。
+`state:needs-platform` を拾う mailbox cron を 1 本作る（分は **43**、他ロールと重ならない値）。テンプレートは [platform-session.md §mailbox cron](../../docs/sessions/platform-session.md)。実装完了・CI 全緑・Ready 化したら `state:needs-platform` を外して **`state:dev-done`** を付け QM へ渡す。**完成前に QM へ相談したいときは `state:needs-qm`**（#4180。`dev-done` は「実装完了・CI 全緑・Ready 化済」を含意するので完成前に付けない）。
 
 ## やってはいけないこと
 

--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -305,10 +305,13 @@ PO ──state:needs-dev──▶ Dev ──state:dev-done──▶ QM ──sta
                          ▲                       │
                          └──state:qm-blocked─────┘
 
-PO ──state:needs-audit──▶ 監査
+誰でも ──state:needs-qm──▶ QM        （**問い合わせ・見解確認**。完成していなくても送れる）
+誰でも ──state:needs-audit──▶ 監査    （cut 依頼 / 問い合わせ）
 誰でも ──state:needs-po──▶ PO        （不可逆 4 操作**以外**の判断）
 誰でも ──state:needs-owner──▶ オーナー （不可逆 4 操作）
 ```
+
+**宛先 label（6 ロール分）は「誰に用があるか」だけを表し、用件を含意しない。** 何の用かは Issue / PR のコメントに書く。工程 label（`dev-done` / `qm-blocked` / `ready-to-merge`）だけが前提条件（実装完了・BLOCK 判定・approve 済）を含意する（#4180、[label-mailbox.md](label-mailbox.md) §3.1）。
 
 **守るべきことは 3 つだけ。**
 
@@ -317,6 +320,8 @@ PO ──state:needs-audit──▶ 監査
 3. **受け取った側は、対応が終わったら次の state に移す**（復路。[label-mailbox.md](label-mailbox.md) §3.1.1 の遷移表）
 
 > **Platform には `state:needs-platform` で渡す。** 復路（Platform が対応を終えたら何に移すか）は [label-mailbox.md](label-mailbox.md) §3.1.1 の遷移表。
+>
+> **問い合わせは往復である。** `state:needs-qm` に答えたら**問い合わせ元の state に戻す**。戻さないと送り手は「返ってこない」だけを観測する。**どのロールからどのロールへ渡せるか**の全数は [label-mailbox.md §3.3.1 経路マトリクス](label-mailbox.md)（空欄 = 経路の欠落）。
 
 ### §5.2 判断を仰ぐとき
 

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -20,9 +20,11 @@
 CronCreate(cron: "47 * * * *", recurring: true, prompt: <label-mailbox.md §4「監査セッション用」テンプレート>)
 ```
 
-監査が拾うのは **`state:needs-audit`**（PO が release cut を依頼した Issue / PR）、**`release/* → main` の open PR**（§3.8 の 9 ステップに入る）、**`main..develop` の commit 数**。
+監査が拾うのは **`state:needs-audit`**（**監査チームに用がある** Issue / PR。release cut 依頼だけでなく、仕様の問い合わせ / 見解確認を含む。**付与者は誰でも**、#4180）、**`release/* → main` の open PR**（§3.8 の 9 ステップに入る）、**`main..develop` の commit 数**。
 
-- **release cut の依頼は `state:needs-audit`** で受け取る（2026-07-31 追加）。当初は「PO からの明示依頼」で label 不要としていたが、**`@mention` / コメントは通知経路ではない**（label-mailbox.md §3.1.1）ため、Dev レーンで実際に起きたのと同じ取りこぼしが成立する。ただし **label は「PO が依頼した」状態を表すだけ**で、cut の実行判断と不可逆 action は引き続き audit-manager 専権（§3.3 / §3.8 step 6）。**label が付いたことを cut の自動起動として扱わない**
+- **`state:needs-audit` は cut 依頼専用ではない**（#4180 で定義を緩和）。**宛先 label は「誰に用があるか」だけを表し、用件を含意しない**（label-mailbox.md §3.1）。用件は Issue / PR の本文を読む。**cut 依頼と問い合わせを label で区別しない** — 区別のために語彙を増やさない
+- **監査から他ロールへ渡す経路**: QM に用があれば **`state:needs-qm`**、Dev に着手を渡すなら **`state:needs-dev`**（#4180 以前は監査発の横方向が空いており、`needs-po` 経由で PO がボトルネックになっていた）
+- **release cut の依頼も `state:needs-audit`** で受け取る（2026-07-31 追加）。当初は「PO からの明示依頼」で label 不要としていたが、**`@mention` / コメントは通知経路ではない**（label-mailbox.md §3.1.1）ため、Dev レーンで実際に起きたのと同じ取りこぼしが成立する。ただし **label は「PO が依頼した」状態を表すだけ**で、cut の実行判断と不可逆 action は引き続き audit-manager 専権（§3.3 / §3.8 step 6）。**label が付いたことを cut の自動起動として扱わない**
 - 統合 PR 自体は branch 名（`base:main` / `head:release/*`）で判別できるため、**対象 PR の識別に label は使わない**（label-mailbox.md §3.2）
 - 判断を仰ぐときは **`state:needs-po`**（不可逆 4 操作以外）/ **`state:needs-owner`**（4 操作）を付ける。**`state:*` を外すときは必ず次の state を付ける**
 - **`main..develop` が 50 commits を超えたら PO に release cut を提案する。** #3995 は develop が動き続けて凍結できず、4 日間実査不能のまま棄却された

--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -20,6 +20,8 @@ CronCreate(cron: "13 * * * *", recurring: true, prompt: <label-mailbox.md §4「
 
 Dev が拾うのは **`state:needs-dev`**（PO / QM が着手を渡したもの。**Issue と PR の両方**）、**`state:qm-blocked`**（QM からの差し戻し）、**自分に来た reviewer request**（`review-requested:@me`）、そして **ORPHAN**（`state:*` が 1 つも付いていない open）。実装完了・CI 全緑・Ready 化したら自分で `state:dev-done` を付けて QM へ渡す。**古い state label を外してから付ける。**
 
+**完成していなくても QM に送れる。** 実装の途中で観点を相談したい / `state:qm-blocked` の BLOCK 事由の意図を確認したい ときは **`state:needs-qm`**（#4180）。`dev-done` は「実装完了・CI 全緑・Ready 化済」を含意するので、**完成していないのに付けてはいけない**。監査に用があるときは **`state:needs-audit`**（cut 依頼に限らない）。
+
 - **BLOCK 事由は 3 類型のいずれか**（顧客に実害 / 証跡の真正性を弱める / 不可逆）。**症状ではなく事由に対処する** — 「テストが落ちている」は症状であって事由ではない（`#4134` は「commit の主張が HEAD に存在しない」= 証跡の真正性が事由で、落ちた 4 テストはその症状だった）
 - **テストの削除 / skip / assertion 弱体化で赤を消さない**（ADR-0006）。落ちたテストが実装不在を教えてくれている場合、テストを消すと次は誰も気づけない
 - **reviewer request は QM の Fix Agent が作った gate 修理 PR の可能性が高い**（gate 欠陥で Dev が PR を出せない場合の例外運用）。作成者 ≠ 承認者の分離を保つため Dev が approve する。**実 diff を読んでから approve する**

--- a/docs/sessions/label-mailbox.md
+++ b/docs/sessions/label-mailbox.md
@@ -34,18 +34,34 @@
 
 ## §3 仕様
 
-### §3.1 label 語彙（8 種）
+### §3.1 label 語彙（9 種 = 宛先 6 + 工程 3）
+
+label は 2 種類ある。**混ぜると経路が塞がる**（#4180 の原因）。
+
+#### 宛先 label（6 ロール分。「次に誰に用があるか」だけを表す）
 
 | label | 意味 | 付ける人 | 次に動く |
 |---|---|---|---|
-| `state:needs-dev` | PO / QM が Dev に**着手を渡した** | PO / QM | **Dev** |
-| `state:dev-done` | 実装完了・CI 全緑・Ready 化済 | Dev | **QM** |
-| `state:qm-blocked` | BLOCK 3 類型に該当（顧客に実害 / 証跡の真正性 / 不可逆） | QM | **Dev** |
-| `state:ready-to-merge` | QM approve 済 | QM | **QM**（merge を実行） |
-| `state:needs-audit` | 統合監査 / release cut を監査チームに渡した | PO | **監査** |
-| `state:needs-platform` | **装置の削減 / 統合 / 自動生成**をプラットフォームに渡した（[README.md §3.4](README.md#34-プラットフォーム開発基盤--新設ロール)） | PO / Dev / QM | **Platform** |
-| `state:needs-po` | **不可逆 4 操作ではない PO 判断**が要る（方針 / 優先度 / repo 設定 / 受容判断 / 語彙・ルールの改訂） | 誰でも | **PO** |
-| `state:needs-owner` | **不可逆 4 操作**（削除 / 本番 deploy / 課金書込 / スキーマ変更）を含む | 誰でも | **オーナー** |
+| `state:needs-dev` | **Dev に用がある** | 誰でも | **Dev** |
+| `state:needs-qm` | **QM に用がある**（レビュー依頼に限らない。問い合わせ / 見解確認を含む） | 誰でも | **QM** |
+| `state:needs-po` | **PO に用がある**（不可逆 4 操作ではない判断 — 方針 / 優先度 / repo 設定 / 受容判断 / 語彙・ルールの改訂） | 誰でも | **PO** |
+| `state:needs-audit` | **監査チームに用がある**（release cut 依頼 / 仕様の問い合わせ / 見解確認） | 誰でも | **監査** |
+| `state:needs-platform` | **Platform に用がある**（装置の削減 / 統合 / 自動生成、[README.md §3.4](README.md#34-プラットフォーム開発基盤--新設ロール)） | 誰でも | **Platform** |
+| `state:needs-owner` | **オーナーに用がある**（**不可逆 4 操作** = 削除 / 本番 deploy / 課金書込 / スキーマ変更を含む） | 誰でも | **オーナー** |
+
+> **宛先 label は用件を含意しない（#4180 で追加した原則）。** 「誰に用があるか」だけを表し、**何の用かは Issue / PR のコメントに書く**（§2 原則 2「label は状態であって指示ではない」）。
+>
+> この原則が守られていなかったために、**QM 宛が `dev-done`（実装完了・CI 全緑・Ready 化済）でしか表現できず「完成していないと送れない」**、**監査宛が「cut を渡した」に限定されて問い合わせに使えない**、という 2 つの欠落が同時に成立していた。**用件で label を分けようとすると語彙が際限なく増える** — 区別のために語彙を足さない。
+
+#### 工程 label（3 種。送り手の**状態**であり、前提条件を含意する）
+
+| label | 意味 | 付ける人 | 次に動く | `needs-qm` との違い |
+|---|---|---|---|---|
+| `state:dev-done` | 実装完了・CI 全緑・Ready 化済 | Dev / Platform | **QM** | **「レビューを開始できる」前提**を含意する |
+| `state:qm-blocked` | BLOCK 3 類型に該当（顧客に実害 / 証跡の真正性 / 不可逆） | QM | **Dev** | **判定結果**を含意する |
+| `state:ready-to-merge` | QM approve 済 | QM | **QM**（merge を実行） | **判定結果**を含意する |
+
+**`needs-qm` はこれらの前提を持たない汎用の宛先。完成していなくても送れる。**
 
 - `state:needs-po` / `state:needs-owner` は**誰が気づいても付けてよい**。Dev が実装中に気づいた場合も付ける
 - **判断を仰ぐときは必ずどちらかを付ける。** 「不可逆 4 操作に当たらないから `needs-owner` は付けない」で終わらせない — それは判断が要らないという意味ではない。**`needs-po` がその受け皿**
@@ -72,8 +88,13 @@
 | `state:needs-platform` | Platform | 装置の削減 / 生成が完了し CI 全緑 | **`state:dev-done`**（QM レビューへ。**自分の PR を自分で approve しない** — ADR-0022） |
 | `state:needs-platform` | Platform | **削除**（gate / guard / test）が必要と分かった | **`state:needs-owner`**（不可逆 4 操作） |
 | `state:needs-platform` | Platform | gate を**残すか消すか**の方針判断が要る | **`state:needs-po`**（[README.md §4.5](README.md#45-装置開発基盤に関する決定)） |
+| **`state:needs-qm`** | **QM** | **回答をコメントに残した** | **問い合わせ元の state に戻す**（`needs-dev` / `needs-po` / `needs-audit` / `needs-platform`） |
+| **`state:needs-qm`** | **QM** | **レビュー依頼だと判明した**（実装が完了している） | **`state:dev-done`** に読み替える |
+| **`state:needs-qm`** | **QM** | **不可逆 4 操作が絡むと分かった** | **`state:needs-owner`** |
 
 **原則**: `state:*` は「**次に動く人**」を指す。自分が動き終わったら、その label は自分を指したままにしない。
+
+> **問い合わせは往復である。** 工程 label（`dev-done` → `qm-blocked` / `ready-to-merge`）は一方向だが、**問い合わせは答えが返らないと終わらない**。`needs-qm` の 1 本目（回答したら問い合わせ元の state に戻す）を書かないと、#4149 の「対応済みなのに誰にも伝わらない」が問い合わせ側で再発する — 送り手は「戻ってこない」だけを観測し、QM は「答えたのに」と思う。
 
 > **判断待ちが 2 件以上ある場合**: 1 件目を解決して label を移すと、**2 件目が受信箱から消える**（#4145 の QM approve コメントで報告された orphan と同 class）。**未解決の判断が残っているなら label を移さない。** 移すのは「その受信箱に残る用件がゼロになったとき」だけ。
 
@@ -86,6 +107,25 @@
 > **§2 原則 3「付けた側が意味に責任を持つ」の適用**: 自分のレーンから次のレーンへ渡すとき、**渡す側が label を付ける**。書いたかどうかではなく、**相手の polling クエリに出るかどうか**が伝達の成否を決める。
 
 ### §3.2 label で表さないもの（GitHub 標準を使う）
+
+> **先に軸の話**: 本ファイルは長らく `state:*`（次に動く人）の遷移だけを定めており、**`status:*`（着手順・凍結）を誰が持つかが未定義だった**。Dev が着手前に「`status:on-hold` を外す権限は誰にあるのか」と質問して初めて分かった欠落（#4180 追記）。
+
+#### `status:*` 軸の権限（#4180 AC10）
+
+`status:*` は **PO 軸**。チーム憲章（[README.md](README.md) §4.1）で「backlog の順序」が PO の Approver 事項であり、`status:on-hold` はその表現だから。
+
+| 操作 | 誰が |
+|---|---|
+| `status:on-hold` を**付ける / 外す** | **PO** |
+| **外してほしいと申告する** | **誰でも**（`state:needs-po` を付けて渡す） |
+| **hold が付いていないものの着手順を決める** | **Dev**（PO の許可は要らない。README.md §4.2） |
+
+**`status:on-hold` は「上位に入っていない」ことを示すだけ**であり、着手を禁じる意味ではない。
+
+> **陳腐化が実際に起きた（2026-08-01）**: `status:on-hold` の 7 件が `priority:high` 以上で、**2 件は Dev が既に draft PR を出していた**（#4156 → PR #4185 / #4127 → PR #4182）。「着手順に入っていない」label が、着手済みのものに付いたまま残っていた。§3.1.1 で塞いだ「対応済みなのに誰にも伝わらない」と同じ形。検出は §4 PO cron に入れた（AC11）。
+
+> **1 つの軸に 2 つの値は不正**（#3990 / #3898 で `priority:medium` と `priority:low` が二重付与）。`--add-label` は既存を外さないため、**軸を変えるときは `--remove-label` を伴う**。検出は §4 PO cron に入れた（AC12）。Dev 側でも `state:dev-done` と `state:needs-dev` の同時付与を 2 回起こしている（PR #4168 / #4178）。
+
 
 | 用途 | 使うもの | 理由 |
 |---|---|---|
@@ -103,7 +143,7 @@
 | ロール | 拾うもの | コマンド |
 |---|---|---|
 | **Dev** | `state:needs-dev` / `state:qm-blocked` / 自分に来た reviewer request | `gh issue list --label "state:needs-dev" --state open` / `gh pr list --label "state:qm-blocked" --state open` / `gh pr list --search "review-requested:@me is:open"` |
-| **QM** | `state:dev-done` / `state:ready-to-merge`（自分が merge） | `gh pr list --label "state:dev-done" --state open` |
+| **QM** | `state:needs-qm` / `state:dev-done` / `state:ready-to-merge`（自分が merge） | `gh issue list --label "state:needs-qm" --state open` / `gh pr list --label "state:needs-qm" --state open` / `gh pr list --label "state:dev-done" --state open` |
 | **PO** | `state:needs-po` / `state:needs-owner` | `gh issue list --label "state:needs-po" --state open` + `state:needs-owner` + PR 側も |
 | **オーナー** | `state:needs-owner` | 同上 |
 | **監査** | `state:needs-audit` / `release/* → main` の open PR | `gh issue list --label "state:needs-audit" --state open` / `gh pr list --base main --state open` |
@@ -111,7 +151,24 @@
 
 **Issue と PR の両方を見る。** `gh pr list --label` は Issue を返さず、`gh issue list --label` は PR を返さない。片方だけ叩くと取りこぼす。
 
-### §3.3.1 orphan 検出（どの mailbox にも入っていないものを見つける）
+### §3.3.1 経路マトリクス（**空欄 = 経路の欠落**）
+
+**どのロールからどのロールへ渡せるか**を全数で並べる。**空欄が残っていたら、そこは mention に退化している**（§3.1.2 = 誰の受信箱にも入らない）。語彙が足りなくなったときに一目で気づくために置く。
+
+| from ＼ to | PO | Dev | QM | 監査 | Platform | オーナー |
+|---|---|---|---|---|---|---|
+| **PO** | — | `needs-dev` | `needs-qm` | `needs-audit` | `needs-platform` | `needs-owner` |
+| **Dev** | `needs-po` | — | `needs-qm` / `dev-done` | `needs-audit` | `needs-platform` | `needs-owner` |
+| **QM** | `needs-po` | `needs-dev` / `qm-blocked` | — | `needs-audit` | `needs-platform` | `needs-owner` |
+| **監査** | `needs-po` | `needs-dev` | `needs-qm` | — | `needs-platform` | `needs-owner` |
+| **Platform** | `needs-po` | `needs-dev` | `needs-qm` / `dev-done` | `needs-audit` | — | `needs-owner` |
+| **オーナー** | `needs-po` | `needs-dev` | `needs-qm` | `needs-audit` | `needs-platform` | — |
+
+**現在、空欄はない。** #4180 以前は **QM 宛の列が丸ごと空**で、監査宛・監査発の横方向も空いていた。
+
+> **表の読み方**: セルに複数あるものは、**汎用の宛先（`needs-*`）と、前提条件を含意する工程 label（`dev-done` / `qm-blocked`）の使い分け**を示す。完成しているなら工程 label、そうでない問い合わせなら宛先 label（§3.1）。
+
+### §3.3.2 orphan 検出（どの mailbox にも入っていないものを見つける）
 
 > **orphan の定義（2026-07-31 初回運用で精緻化）**: `state:*` が 1 つも付いていない open のうち、
 > **`status:on-hold` も `epic` label も付いていないもの**。Draft PR は対象外（まだ誰にも渡していない状態）。
@@ -199,9 +256,15 @@ gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|sele
 ```
 QM mailbox チェック。以下を実行して結果を簡潔に報告する（何も無ければ「mailbox 空」の 1 行でよい）:
 
+gh issue list --label "state:needs-qm" --state open --json number,title --jq '.[]|"QM宛 #\(.number) \(.title)"'
+gh pr list --label "state:needs-qm" --state open --json number,title --jq '.[]|"QM宛PR #\(.number) \(.title)"'
 gh pr list --label "state:dev-done" --state open --json number,title --jq '.[]|"レビュー待ち #\(.number) \(.title)"'
 gh pr list --label "state:ready-to-merge" --state open --json number,title,mergeStateStatus --jq '.[]|"MERGE可 #\(.number) [\(.mergeStateStatus)] \(.title)"'
 
+- state:needs-qm は **レビュー依頼とは限らない**（問い合わせ / 見解確認を含む）。用件は本文を読む
+- **回答したら label を問い合わせ元の state に戻す**（needs-dev / needs-po / needs-audit / needs-platform）。
+  戻さないと送り手は「返ってこない」だけを観測する（#4149 と同じ形が問い合わせ側で再発する）。
+  実装が完了しているレビュー依頼だと分かったら state:dev-done に読み替える
 - 報告は必ず「CI 個別行の実測（非 pass 行の有無）」を先に書き、結論はその後に置く。
   「BLOCK 3 類型に非該当」は CI 緑を含意しない
 - state:ready-to-merge でも、gh pr checks で緑を確認してから merge する。赤を跨いだ merge は
@@ -224,6 +287,19 @@ gh pr list --label "state:ready-to-merge" --state open --json number,title,merge
 gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN #\(.number) \(.title)"'
 gh pr list --state open --limit 50 --json number,title,labels --jq '.[]|select([.labels[].name]|map(select(startswith("state:") or .=="status:on-hold" or .=="epic"))|length==0)|"ORPHAN PR #\(.number) \(.title)"'
 
+# on-hold の陳腐化（着手順に入っていない扱いのまま、実は着手済 / Dev に渡っている）— #4180 AC11
+gh issue list --label "status:on-hold" --label "state:needs-dev" --state open --json number,title --jq '.[]|"STALE-HOLD #\(.number) \(.title)"'
+for n in $(gh issue list --label "status:on-hold" --state open --json number --jq '.[].number'); do
+  if [ -n "$(gh pr list --state open --search "$n in:body" --json number --jq '.[].number')" ]; then echo "STALE-HOLD(PR) #$n"; fi
+done
+
+# 1 つの軸に 2 つの値（--add-label の外し忘れ）— #4180 AC12
+gh issue list --state open --limit 100 --json number,title,labels --jq '.[]|. as $i|["priority:","state:","status:"]|map(. as $p|[$i.labels[].name]|map(select(startswith($p)))|length)|select(any(.>1))|"DUP-AXIS #\($i.number) \($i.title)"'
+gh pr list --state open --limit 50 --json number,title,labels --jq '.[]|. as $i|["priority:","state:","status:"]|map(. as $p|[$i.labels[].name]|map(select(startswith($p)))|length)|select(any(.>1))|"DUP-AXIS PR #\($i.number) \($i.title)"'
+
+- STALE-HOLD が出たら status:on-hold を外す。**hold は「上位に入っていない」ことを示すだけ**で、
+  着手済のものに付いたまま残すと §3.1.1 で塞いだ「対応済みなのに伝わらない」と同じ形になる（§3.2）
+- DUP-AXIS が出たら **--remove-label で片方を外す**。1 つの軸に 2 値だと次に見た人が優先度も宛先も読めない
 - state:needs-owner は、不可逆 4 操作（削除 / 本番 deploy / 課金書込 / スキーマ変更）のどれに
   該当するかを 1 行で示し、判断材料（実 diff / 影響範囲）を添えてオーナーに提示する
 - state:ready-to-merge は CI が実際に緑かを gh pr view で確認してから報告する。ラベルは実測を代替しない
@@ -324,11 +400,14 @@ gh issue list --state open --label "priority:critical" --json number,title --jq 
 | PO / QM → Dev に**着手を渡す**経路が無い | Dev が拾えるのは QM の差し戻しと reviewer request だけだった。PO が着手順を決めても Dev の受信箱に入らず、**5 件が滞留**したまま Dev は「対応事項なし」と報告した | `state:needs-dev` |
 | **不可逆 4 操作ではない PO 判断**を渡す経路が無い | Dev が「ruleset 変更」「node EBADENGINE」を判断待ちとして書いたが、4 操作に当たらず label を付けられなかった。**PO の mailbox に入らないまま PR が merge されて流れた** | `state:needs-po` |
 | PO → 監査に**release cut を渡す**経路が無い | 「明示依頼で足りる」としていたが、mention / コメントは通知経路ではない。Dev で起きたのと同じ取りこぼしが監査レーンでも成立する | `state:needs-audit` |
+| **QM 宛の経路が無い / 監査宛が cut 依頼に限定**（#4180、2026-08-01。2 ロールから同日に申告） | **宛先 label が用件に縛られていた**。QM 宛は工程 label `dev-done`（実装完了・CI 全緑・Ready 化済）でしか表現できず、**完成していないと送れない**。監査宛は定義が「cut を渡した」で付与者も PO 限定。結果、「実装の途中で観点を相談したい」「BLOCK 事由の意図を確認したい」が **mention に退化**した | `state:needs-qm`（+ `needs-audit` の定義を「監査チームに用がある」へ緩和） |
 
 **共通の教訓**: 語彙を増やさない原則（§2-5）は、**渡す経路が既にあるとき**にのみ有効。経路が無いまま「増やさない」を守ると、伝達が mention に退化し、mention は誰の受信箱にも入らない。
 
-## §7 現状（2026-07-31 時点）
+**4 例目（#4180）で分かった追加の教訓**: 経路が「無い」だけでなく「**用件に縛られていて使えない**」形でも同じことが起きる。**宛先 label に用件を含意させない**（§3.1）ことと、**経路マトリクスの空欄を可視化しておく**（§3.3.1）ことの 2 つで、次に足りなくなったときに気づけるようにした。
 
-- label **7 種**（`needs-dev` / `dev-done` / `qm-blocked` / `ready-to-merge` / `needs-audit` / `needs-po` / `needs-owner`）
+## §7 現状
+
+- label **9 種** = 宛先 6（`needs-dev` / `needs-qm` / `needs-po` / `needs-audit` / `needs-platform` / `needs-owner`）+ 工程 3（`dev-done` / `qm-blocked` / `ready-to-merge`）
 - PO セッションの cron は稼働中（`37 * * * *`）
 - **恒久化（GitHub workflow → Discord）は未実施。** 実際に見落としが発生してから作る

--- a/docs/sessions/platform-session.md
+++ b/docs/sessions/platform-session.md
@@ -22,6 +22,8 @@ CronCreate(cron: "43 * * * *", recurring: true, prompt: <下記テンプレー�
 
 **分は 43。** 他ロールと重ならない値にする（Dev=13 / QM=23 / PO=37 / 監査=47、[label-mailbox.md §3.4](label-mailbox.md)）。
 
+**Platform から他ロールへ渡す経路**: 装置変更の影響を QM に確認したいときは **`state:needs-qm`**（#4180）。完成して QM レビューに出すときは従来どおり **`state:dev-done`**（自分の PR を自分で approve しない、ADR-0022）。監査に用があれば **`state:needs-audit`**。
+
 ### cron プロンプト テンプレート
 
 ```

--- a/docs/sessions/po-session.md
+++ b/docs/sessions/po-session.md
@@ -309,7 +309,9 @@ Anthropic 公式記事推奨「モデル進化対応: 3-6 ヶ月ごとに設定�
 CronCreate(cron: "37 * * * *", recurring: true, prompt: <label-mailbox.md §4「PO セッション用」テンプレート>)
 ```
 
-PO が拾うのは **`state:needs-po`**（不可逆 4 操作**以外**の PO 判断 = 方針 / 優先度 / repo 設定・ruleset / 受容判断 / 語彙・ルールの改訂）、**`state:needs-owner`**（不可逆 4 操作 = 削除 / 本番 deploy / 課金書込 / スキーマ変更）、`state:ready-to-merge` の CI 実測確認、そして **ORPHAN**（`state:*` が 1 つも付いていない open Issue / PR）。**Issue と PR の両方**を見る。
+PO が拾うのは **`state:needs-po`**（不可逆 4 操作**以外**の PO 判断 = 方針 / 優先度 / repo 設定・ruleset / 受容判断 / 語彙・ルールの改訂）、**`state:needs-owner`**（不可逆 4 操作 = 削除 / 本番 deploy / 課金書込 / スキーマ変更）、`state:ready-to-merge` の CI 実測確認、**ORPHAN**（`state:*` が 1 つも付いていない open Issue / PR）、そして **STALE-HOLD / DUP-AXIS**（#4180 AC11 / AC12）。**Issue と PR の両方**を見る。
+
+**`status:*` は PO 軸**（label-mailbox.md §3.2）。`status:on-hold` の付け外しは PO が行い、外してほしい申告は誰でも `state:needs-po` で渡せる。**hold が付いていないものの着手順は Dev が決めてよい**（PO の許可は要らない）。**QM に用があるときは `state:needs-qm`**（#4180。gate 方針を決める前に QM の見解を聞く等）。
 
 PO が仕事を渡すときは **`state:needs-dev`**（Dev へ着手）/ **`state:needs-audit`**（監査へ release cut 依頼）を付ける。
 

--- a/docs/sessions/qa-session.md
+++ b/docs/sessions/qa-session.md
@@ -16,11 +16,13 @@
 CronCreate(cron: "23 * * * *", recurring: true, prompt: <label-mailbox.md §4「QM セッション用」テンプレート>)
 ```
 
-QM が拾うのは **`state:dev-done`**（レビュー待ち）と **`state:ready-to-merge`**（自分が merge を実行）。レビュー完了時は自分で label を付け替える（`state:qm-blocked` → Dev / `state:ready-to-merge` → 自分）。**古い state label を外してから付ける**（2 つ付いていると次に誰が動くか読めない）。**外すときは必ず次の state を付ける** — どの state も付かないと全受信箱から消え、「mailbox 空」と滞留が報告上まったく同じに見える（2026-07-31 に `#4144` で実際に発生）。
+QM が拾うのは **`state:needs-qm`**（**QM に用がある**。レビュー依頼に限らず問い合わせ / 見解確認を含む、#4180）、**`state:dev-done`**（レビュー待ち）、**`state:ready-to-merge`**（自分が merge を実行）。レビュー完了時は自分で label を付け替える（`state:qm-blocked` → Dev / `state:ready-to-merge` → 自分）。**古い state label を外してから付ける**（2 つ付いていると次に誰が動くか読めない）。**外すときは必ず次の state を付ける** — どの state も付かないと全受信箱から消え、「mailbox 空」と滞留が報告上まったく同じに見える（2026-07-31 に `#4144` で実際に発生）。
 
 **差し戻した PR は `state:qm-blocked` のまま Dev の受信箱に入る。** Dev が対応を終えると `state:dev-done` に戻る（label-mailbox.md §3.1.1 復路）。**この復路が定義されるまで、対応済みの差し戻しが QM に届かず停止していた**（PR #4149）。自衛として `state:qm-blocked` の PR も polling し、**自分が block した時点の HEAD から動いていれば再レビュー**する。
 
-**判断を仰ぐときも label を付ける。** 不可逆 4 操作 → `state:needs-owner` / それ以外の PO 判断（方針・優先度・repo 設定・受容判断）→ **`state:needs-po`**。QM が Dev に着手を渡すときは **`state:needs-dev`**。`@mention` や PR コメントは通知経路ではない（label-mailbox.md §3.1.1）。
+**`state:needs-qm` に答えたら、label を問い合わせ元の state に戻す**（`needs-dev` / `needs-po` / `needs-audit` / `needs-platform`、label-mailbox.md §3.1.1）。**問い合わせは往復**であり、戻さないと送り手は「返ってこない」だけを観測する（#4149 と同じ形が問い合わせ側で再発する）。実装が完了しているレビュー依頼だと分かったら `state:dev-done` に読み替える。
+
+**判断を仰ぐときも label を付ける。** 不可逆 4 操作 → `state:needs-owner` / それ以外の PO 判断（方針・優先度・repo 設定・受容判断）→ **`state:needs-po`**。QM が Dev に着手を渡すときは **`state:needs-dev`**。監査に用があるときは **`state:needs-audit`**（cut 依頼に限らない、#4180）。`@mention` や PR コメントは通知経路ではない（label-mailbox.md §3.1.1）。
 
 - **報告は「CI 個別行の実測（非 pass 行の有無）」を先に書き、結論はその後に置く。** 「BLOCK 3 類型に非該当」は CI 緑を含意しない（結論を先に置いたため PO が merge 可と誤読した実例あり、2026-07-31）
 - **`state:ready-to-merge` でも `gh pr checks` で緑を確認してから merge する。** 赤を跨いだ merge は理由が正当でも外形が admin bypass と区別できない

--- a/tests/unit/architecture/label-mailbox-routes.test.ts
+++ b/tests/unit/architecture/label-mailbox-routes.test.ts
@@ -1,0 +1,113 @@
+// tests/unit/architecture/label-mailbox-routes.test.ts
+// #4180 — 宛先 label が用件に縛られて経路が塞がるのを、docs 側で検出する。
+//
+// ## なぜ test で守るのか
+//
+// label mailbox は「経路が無いこと」に気づけないのが最大の弱点だった。実際 #4180 では
+// **QM 宛の列が丸ごと空**なのに、2 ロールが同日に困るまで誰も気づかなかった。
+// 経路マトリクス (§3.3.1) を書いただけでは、次に誰かが表を更新し忘れれば同じことが起きる。
+//
+// ## 何を守るか (守らないか)
+//
+// 守る: **マトリクスに空欄が無い** / **語彙表と本文が同じ 9 種を指している** /
+//       **各ロールファイルが新語彙を反映している** (docs 間の drift)。
+// 守らない: GitHub 上の label の実在。docs は SSOT だが GitHub API を CI で叩かない
+//           (ネットワーク依存の test にしない)。label 作成漏れは運用で気づく。
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const MAILBOX = 'docs/sessions/label-mailbox.md';
+
+/** 宛先 label 6 種 (§3.1)。ここを増減させたら本 test も一緒に直す。 */
+const ADDRESS_LABELS = [
+	'state:needs-dev',
+	'state:needs-qm',
+	'state:needs-po',
+	'state:needs-audit',
+	'state:needs-platform',
+	'state:needs-owner',
+];
+
+/** 工程 label 3 種 (§3.1)。前提条件を含意する特殊形。 */
+const STAGE_LABELS = ['state:dev-done', 'state:qm-blocked', 'state:ready-to-merge'];
+
+describe('#4180 label mailbox の経路', () => {
+	const doc = readFileSync(MAILBOX, 'utf8');
+
+	it('語彙は宛先 6 + 工程 3 の 9 種で、すべて §3.1 に載っている', () => {
+		const vocabSection = doc.slice(doc.indexOf('### §3.1 label 語彙'), doc.indexOf('### §3.1.1'));
+		for (const label of [...ADDRESS_LABELS, ...STAGE_LABELS]) {
+			expect(vocabSection, `${label} が §3.1 の語彙表にありません`).toContain(label);
+		}
+		// 見出しに件数を書いている以上、件数と中身がズレたら落とす
+		expect(vocabSection).toContain('9 種');
+	});
+
+	it('経路マトリクスに空欄がない (空欄 = 経路の欠落)', () => {
+		const start = doc.indexOf('### §3.3.1 経路マトリクス');
+		expect(start, '経路マトリクスの節が見つかりません').toBeGreaterThan(-1);
+		const section = doc.slice(start, doc.indexOf('### §3.3.2'));
+
+		// | **PO** | — | `needs-dev` | ... の行だけを取る (ヘッダ / 区切り行は除く)
+		const rows = section
+			.split('\n')
+			.filter((l) => l.trim().startsWith('| **') && l.includes('|'))
+			.map((l) =>
+				l
+					.trim()
+					.replace(/^\|/, '')
+					.replace(/\|$/, '')
+					.split('|')
+					.map((c) => c.trim()),
+			);
+
+		expect(rows.length, '経路マトリクスの行が 6 ロール分ありません').toBe(6);
+
+		const empty: string[] = [];
+		for (const row of rows) {
+			const from = row[0];
+			// 先頭列は from ロール名。以降 6 列が to。自分宛は「—」
+			for (let i = 1; i < row.length; i++) {
+				const cell = row[i];
+				if (cell === '' || cell === '無し' || cell === '**無し**') {
+					empty.push(`${from} 列${i}`);
+				}
+			}
+		}
+		expect(
+			empty,
+			`経路マトリクスに空欄があります (そこは mention に退化しています): ${empty.join(', ')}`,
+		).toEqual([]);
+	});
+
+	it('needs-qm の復路が遷移表にある (答えたら元に戻す)', () => {
+		const transition = doc.slice(doc.indexOf('### §3.1.1'), doc.indexOf('### §3.1.2'));
+		expect(transition).toContain('state:needs-qm');
+		// 「答えたら問い合わせ元に戻す」が無いと #4149 が問い合わせ側で再発する
+		expect(transition).toContain('問い合わせ元の state に戻す');
+	});
+
+	it('status:* 軸の権限が定義されている', () => {
+		expect(doc).toContain('`status:*` 軸の権限');
+		expect(doc).toContain('status:on-hold');
+	});
+
+	it('PO cron が on-hold 陳腐化と 1 軸 2 値を検出する', () => {
+		const cron = doc.slice(doc.indexOf('### PO セッション用'), doc.indexOf('### 監査セッション用'));
+		expect(cron, 'on-hold 陳腐化の検出が PO cron にありません').toContain('STALE-HOLD');
+		expect(cron, '1 軸 2 値の検出が PO cron にありません').toContain('DUP-AXIS');
+	});
+
+	// docs 間の drift guard。SSOT を直しても各ロールが知らなければ経路は開かない。
+	it.each([
+		'docs/sessions/dev-session.md',
+		'docs/sessions/qa-session.md',
+		'docs/sessions/po-session.md',
+		'docs/sessions/audit-team.md',
+		'docs/sessions/platform-session.md',
+		'docs/sessions/README.md',
+	])('%s が needs-qm を反映している', (path) => {
+		expect(readFileSync(path, 'utf8')).toContain('needs-qm');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（ロール間の伝達経路の修復）。**

**QM に「完成したのでレビューして」以外を送る手段がありませんでした。** QM 宛は工程 label `state:dev-done`（= 実装完了・CI 全緑・Ready 化済）で代用されており、**完成していないと送れない**。監査宛は `state:needs-audit` の定義が「cut を渡した」で付与者も PO 限定でした。

結果、次のような用件が **mention に退化**します。mention は誰の受信箱にも入りません（§3.1.2）。

- Dev が実装の**途中で** QM に観点を相談したい
- Dev が `qm-blocked` の **BLOCK 事由の意図**を確認したい
- PO が gate 方針を決める前に QM の**見解を聞きたい**
- 監査が統合で見つけた件を **QM に直接**戻したい（現状は `needs-po` 経由で PO がボトルネック）

これは #4144 / #4149 で既に 2 度起きた失敗形と同じです。

### 根本原因 — **宛先 label が用件に縛られていた**

label 8 種には **2 つの異なるものが混ざっていました**。

| 種類 | 意味 |
|---|---|
| **宛先**（次に動く人） | `needs-po` / `needs-dev` / `needs-audit` / `needs-platform` / `needs-owner` |
| **工程**（送り手の状態） | `dev-done` / `qm-blocked` / `ready-to-merge` |

**宛先 label は「誰に用があるか」だけを表すべきで、用件を含意してはいけません。** この原則が 2 箇所で守られていなかった、というのが本件の正体です。

## 関連 Issue

Closes #4180

- #4179（Dev / QM → 監査の経路。本 Issue に吸収）
- #4175（チーム憲章。`needs-platform` を追加したばかりで、そのとき QM の欠落に気づけなかった）
- #4149（復路未定義で「対応済みが伝わらない」が起きた実例）/ #4144（mention が受信箱に入らなかった実例）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC1** | label `state:needs-qm` を作成 | `gh label list` | ✅ **既に存在**（PO 作成済）。`QM に用がある (レビュー依頼に限らない。問い合わせ・見解確認を含む)` |
| **AC1b** | `needs-audit` の定義を広げ、付与者を「誰でも」に | `gh label edit` 実行 | ✅ `監査チームに用がある (cut 依頼 / 問い合わせ / 見解確認) — 次に動く: 監査` に更新済 |
| **AC2** | §3.1 を 9 種にし、**宛先 6 / 工程 3** の 2 分類を明示 + 「宛先 label は用件を含意しない」を原則化 | doc 差分 + fitness | ✅ 表を 2 つに分割。工程 label には「`needs-qm` との違い」列を足し、**何を含意するか**を明示 |
| **AC3** | §3.1.1 遷移表に `needs-qm` の復路 3 本 | doc 差分 + fitness | ✅ **答えたら問い合わせ元の state に戻す** / レビュー依頼だと判明 → `dev-done` / 不可逆 4 操作 → `needs-owner` |
| **AC4** | §3.3 polling の QM 行に追加 | doc 差分 | ✅ Issue と PR の両方を叩くコマンドを併記 |
| **AC5** | §4 QM cron に取得 + **回答後に元の state へ戻す**手順 | doc 差分 + fitness | ✅ |
| **AC6** | §3.3.1 に経路マトリクス（**空欄が経路の欠落と分かる形**） | doc 差分 + **fitness で空欄 0 を機械検証** | ✅ orphan 検出は §3.3.2 へ繰り下げ（外部参照ゼロを確認済） |
| **AC7** | §6「語彙が足りなかった実例」に追記 | doc 差分 | ✅ 4 例目 + 追加の教訓（「無い」だけでなく「**用件に縛られていて使えない**」形でも同じことが起きる） |
| **AC8** | 各ロールファイルに反映 | doc 差分 + fitness | ✅ `dev-session` / `qa-session` / `po-session` / `audit-team` / `platform-session` の 5 本 |
| **AC9** | root の記述と整合 | doc 差分 | ✅ `docs/sessions/README.md` §5.1 の図に 3 経路追加 + `.claude/agents/platform-session.md` |
| **AC10** | §3.2 に `status:*` 軸の権限を定義 | doc 差分 + fitness | ✅ 付け外しは **PO** / 申告は誰でも / **hold が無いものの着手順は Dev** |
| **AC11** | on-hold の陳腐化を PO cron の `gh` クエリで検出（**新規 script は作らない**） | **実 repo で実行して実測** | ✅ **2 種のクエリとも実発火を確認**（下記） |
| **AC12** | 1 つの軸に 2 値を PO cron の `gh` クエリで検出 | **実 repo で実行して実測** | ✅ **一時的に二重付与して発火を確認**（下記） |

### cron クエリは「書いた」ではなく「発火した」を確認しています

**クエリを書いただけでは、それが何も検出しない壊れたクエリでも分かりません。** 今日 #4189 で `PendingConfirmation` を見逃す smoke を作りかけた反省から、**実 repo で実行して実測**しました。

```
# STALE-HOLD（on-hold なのに state:needs-dev）→ 2 件検出
STALE-HOLD #3990 docs(billing): Stripe Webhook 購読 event のセットアップ手順書が 2 つあり…
STALE-HOLD #3898 ops: DSQL 費用モニタリング第 2 回…

# STALE-HOLD(PR)（on-hold なのに open PR がある）→ 2 件検出
STALE-HOLD(PR) #4199
STALE-HOLD(PR) #3412

# DUP-AXIS（1 軸 2 値）→ 現状 0 件。**0 件が正しいのか壊れているのか区別できない**ため、
# 自分が起票した #4224 に priority:low を一時付与して発火を確認 → その後 remove して原状復帰
DUP-AXIS #4224 fix(ci): staging deploy の手動実行が…
```

**AC11 の 2 本目は当初、PR body から Issue 番号を抜く複雑な jq を書いていましたが、実行したら動きませんでした。** 検証していなければ「書いたので OK」として壊れたまま入っていました。`gh pr list --search "$n in:body"` のループに置き換えて実測しています。

## 変更タイプ

- [x] ドキュメント更新（プロセス SSOT）
- [x] テスト追加（fitness function）
- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] インフラ変更

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **既存 label の意味変更** | `needs-audit` のみ（cut 依頼限定 → 監査チームに用がある）。**cut は label で自動起動しない設計**（実行判断と不可逆 action は audit-manager 専権）なので、定義を広げても cut が誤って走ることはない |
| **§3.3.1 の繰り下げ** | orphan 検出を §3.3.2 へ。`grep -rn "3.3.1"` で **label-mailbox.md への外部参照ゼロ**を確認済（ヒットしたのは WCAG 3.3.1 と別 doc の見出しのみ） |
| **語彙を増やす判断** | §2-5「語彙を増やさない」は §6 で「**渡す経路が既にあるとき**にのみ有効」と明記済。経路が無いので増やすのが正しい。**追加は 1 語彙のみ**（`needs-qm`） |
| **用件で label を分けない** | 「着手依頼か問い合わせか」を label で区別**しない**。区別のために語彙を足すと際限なく増える。用件は本文（§2 原則 2） |
| **cron の実行コスト** | AC11 の 2 本目は on-hold 件数ぶんループする（現状 11 件）。1 時間に 1 回の PO cron で 11 回の `gh pr list`。許容範囲 |

## テスト・品質セルフチェック

```
npx vitest run tests/unit/architecture/label-mailbox-routes.test.ts
 Tests  11 passed (11)

npx biome check --error-on-warnings .   → Found 3 infos（error 0）
npm run cspell                          → Issues found: 0
node scripts/check-repo-scan-test-declaration.mjs → OK（40 件）
```

### fitness function が守るもの / 守らないもの

**docs を直しただけでは、次に誰かが表を更新し忘れたときに同じことが起きます。**

| 守る | 守らない |
|---|---|
| **経路マトリクスに空欄が無い**（空欄 = mention に退化） | **GitHub 上の label の実在**（CI でネットワークを叩かない。作成漏れは運用で気づく） |
| 語彙表と見出しの件数が一致 | |
| `needs-qm` の復路が遷移表にある | |
| `status:*` 軸の権限が定義されている | |
| PO cron に STALE-HOLD / DUP-AXIS がある | |
| **6 つのロールファイルすべてが `needs-qm` を反映**（docs 間の drift） | |

- [x] cron クエリを**実 repo で実行**し、検出されることを確認した（書いただけにしない）
- [x] DUP-AXIS は**現状 0 件**なので、一時的に二重付与して発火を確認 → 原状復帰
- [x] `npm run pre-ready -- --pr <PR番号>` 全 6 step PASS

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: プロセス SSOT の docs 更新とテスト追加のみで src/ を 1 行も触っていない。顧客に見える画面が存在しない。 -->

**UI 変更はありません。** 変更は `docs/sessions/`（6 本）/ `.claude/agents/platform-session.md` / `tests/unit/architecture/`（1 本新規）です。

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **AC6 の配置**。Issue は「§3.3.1 に追加」でしたが、§3.3.1 は orphan 検出でした。**経路マトリクスを §3.3.1 として新設し、orphan を §3.3.2 に繰り下げ**ました（外部参照ゼロを確認済）。「§3.3 polling の直下に経路の全体像がある」ほうが読み手の順序に合うと判断しましたが、番号を動かしています。

2. **`needs-audit` の付与者を「誰でも」に緩めた影響**。cut は label で自動起動しない設計なので誤起動はしませんが、**監査の受信箱に cut 依頼と問い合わせが混ざります**。用件は本文を読む運用です（label で区別しない、という本 Issue の原則そのもの）。

3. **AC11 の 2 本目のコスト**。on-hold 件数ぶん `gh pr list` をループします（現状 11 回 / 時）。件数が増えたら見直しが要ります。

### 破壊的変更

**ありません。** 既存の label / 遷移は変えていません（`needs-audit` の**定義を広げた**だけで、従来の使い方はそのまま有効）。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] 全 12 AC を実装し、AC ごとに検証手段とエビデンスを書いた
- [x] **cron クエリを実 repo で実行し、実際に検出されることを確認した**（書いただけにしない）
- [x] **検出 0 件のクエリは、一時的に条件を作って発火を確認した**
- [x] 壊れていた jq を検証で発見し、動く形に置き換えた
- [x] docs を直すだけで終わらせず、**drift を検出する fitness function** を置いた
- [x] AC の指示と配置を変えた箇所（AC6）を明示した
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
