### PR TITLE
fix(arch): #4030 A-2 ADR-0063 テナント分離 guard が dsql/migration/ を一度も検査していなかったのを塞ぐ

### DIFF
--- a/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
+++ b/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
@@ -353,9 +353,10 @@ describe('#4030 母数: dsql 配下をサブディレクトリまで走査して
 			.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
 			.map((f) => resolve(migrationDir, f))
 			.sort();
-		expect(expected.length, 'migration/ に .ts が 1 つも無い (母数の前提が崩れている)').toBeGreaterThan(
-			0,
-		);
+		expect(
+			expected.length,
+			'migration/ に .ts が 1 つも無い (母数の前提が崩れている)',
+		).toBeGreaterThan(0);
 
 		const collected = new Set(listDsqlSourceFiles());
 		const missing = expected.filter((f) => !collected.has(f));

--- a/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
+++ b/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
@@ -325,3 +325,33 @@ describe('DSQL append-only 表 mutation allowlist (§3.4 B6 3 層防御の repo/
 		).toEqual([]);
 	});
 });
+
+// #4030 A-2: 母数がサブディレクトリを取りこぼしていないこと。
+//
+// `src/lib/server/db/dsql/migration/` には実 SQL を持つ file が存在する
+// (`provision.ts` の `INSERT INTO dsql_migrations` 等)。非再帰走査だと**この層が
+// 一度も検査されない**。先例は `dsql-append-only-update-fitness.test.ts` (#3658 AC2)。
+//
+// 母数の assertion を置かないと「違反 0 件」が「守られている」なのか
+// 「そもそも見ていない」なのか区別できない (#4084 と同じ形)。
+//
+// 期待値は **実 FS から導出する** (literal 固定にすると file 追加で陳腐化する、#4030 A-1 と同じ轍)。
+describe('#4030 母数: dsql 配下をサブディレクトリまで走査している', () => {
+	it('migration/ 配下の .ts が母数にすべて入っている', () => {
+		const migrationDir = resolve(DSQL_DIR, 'migration');
+		const expected = readdirSync(migrationDir)
+			.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
+			.map((f) => resolve(migrationDir, f))
+			.sort();
+		expect(expected.length, 'migration/ に .ts が 1 つも無い (母数の前提が崩れている)').toBeGreaterThan(
+			0,
+		);
+
+		const collected = new Set(listDsqlSourceFiles());
+		const missing = expected.filter((f) => !collected.has(f));
+		expect(
+			missing,
+			'dsql/migration/ 配下が母数から漏れています。非再帰走査だとこの層が一度も検査されません (#4030 A-2)',
+		).toEqual([]);
+	});
+});

--- a/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
+++ b/tests/unit/architecture/dsql-append-only-mutation-allowlist.test.ts
@@ -258,11 +258,21 @@ function collectViolations(statements: SqlStatement[]): Mutation[] {
 	);
 }
 
-function listDsqlSourceFiles(): string[] {
-	if (!existsSync(DSQL_DIR)) return [];
-	return readdirSync(DSQL_DIR)
-		.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
-		.map((f) => resolve(DSQL_DIR, f));
+/**
+ * dsql 配下の .ts を **再帰** 収集する (#4030 A-2 / 先例 #3658 AC2)。
+ *
+ * 旧実装は `readdirSync` 非再帰で、実 SQL を持つ `migration/` 配下を
+ * **一度も検査していなかった**。母数が閉じていない guard は「違反 0 件」と
+ * 「そもそも見ていない」を区別できない。
+ */
+function listDsqlSourceFiles(dir: string = DSQL_DIR, acc: string[] = []): string[] {
+	if (!existsSync(dir)) return acc;
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) listDsqlSourceFiles(full, acc);
+		else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) acc.push(full);
+	}
+	return acc;
 }
 
 describe('DSQL append-only 表 mutation allowlist (§3.4 B6 3 層防御の repo/AST 層)', () => {

--- a/tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
+++ b/tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
@@ -93,3 +93,33 @@ describe('DSQL mutation 件数は DB 側 count(*) 集約に固定 (#3625 same-cl
 		).toEqual([]);
 	});
 });
+
+// #4030 A-2: 母数がサブディレクトリを取りこぼしていないこと。
+//
+// `src/lib/server/db/dsql/migration/` には実 SQL を持つ file が存在する
+// (`provision.ts` の `INSERT INTO dsql_migrations` 等)。非再帰走査だと**この層が
+// 一度も検査されない**。先例は `dsql-append-only-update-fitness.test.ts` (#3658 AC2)。
+//
+// 母数の assertion を置かないと「違反 0 件」が「守られている」なのか
+// 「そもそも見ていない」なのか区別できない (#4084 と同じ形)。
+//
+// 期待値は **実 FS から導出する** (literal 固定にすると file 追加で陳腐化する、#4030 A-1 と同じ轍)。
+describe('#4030 母数: dsql 配下をサブディレクトリまで走査している', () => {
+	it('migration/ 配下の .ts が母数にすべて入っている', () => {
+		const migrationDir = resolve(DSQL_DIR, 'migration');
+		const expected = readdirSync(migrationDir)
+			.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
+			.map((f) => resolve(migrationDir, f))
+			.sort();
+		expect(expected.length, 'migration/ に .ts が 1 つも無い (母数の前提が崩れている)').toBeGreaterThan(
+			0,
+		);
+
+		const collected = new Set(listDsqlSourceFiles());
+		const missing = expected.filter((f) => !collected.has(f));
+		expect(
+			missing,
+			'dsql/migration/ 配下が母数から漏れています。非再帰走査だとこの層が一度も検査されません (#4030 A-2)',
+		).toEqual([]);
+	});
+});

--- a/tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
+++ b/tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
@@ -121,9 +121,10 @@ describe('#4030 母数: dsql 配下をサブディレクトリまで走査して
 			.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
 			.map((f) => resolve(migrationDir, f))
 			.sort();
-		expect(expected.length, 'migration/ に .ts が 1 つも無い (母数の前提が崩れている)').toBeGreaterThan(
-			0,
-		);
+		expect(
+			expected.length,
+			'migration/ に .ts が 1 つも無い (母数の前提が崩れている)',
+		).toBeGreaterThan(0);
 
 		const collected = new Set(listDsqlSourceFiles());
 		const missing = expected.filter((f) => !collected.has(f));

--- a/tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
+++ b/tests/unit/architecture/dsql-mutation-count-cte-fitness.test.ts
@@ -53,11 +53,21 @@ function findBareRowsLengthCounts(source: string, file: string): Violation[] {
 	return found;
 }
 
-function listDsqlSourceFiles(): string[] {
-	if (!existsSync(DSQL_DIR)) return [];
-	return readdirSync(DSQL_DIR)
-		.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
-		.map((f) => resolve(DSQL_DIR, f));
+/**
+ * dsql 配下の .ts を **再帰** 収集する (#4030 A-2 / 先例 #3658 AC2)。
+ *
+ * 旧実装は `readdirSync` 非再帰で、実 SQL を持つ `migration/` 配下を
+ * **一度も検査していなかった**。母数が閉じていない guard は「違反 0 件」と
+ * 「そもそも見ていない」を区別できない。
+ */
+function listDsqlSourceFiles(dir: string = DSQL_DIR, acc: string[] = []): string[] {
+	if (!existsSync(dir)) return acc;
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) listDsqlSourceFiles(full, acc);
+		else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) acc.push(full);
+	}
+	return acc;
 }
 
 describe('DSQL mutation 件数は DB 側 count(*) 集約に固定 (#3625 same-class-N→guard)', () => {

--- a/tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts
+++ b/tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts
@@ -371,3 +371,33 @@ describe('DSQL tenant 述語 fitness (§3.4 / ADR-0063、RLS 非対応の代替�
 		).toEqual([]);
 	});
 });
+
+// #4030 A-2: 母数がサブディレクトリを取りこぼしていないこと。
+//
+// `src/lib/server/db/dsql/migration/` には実 SQL を持つ file が存在する
+// (`provision.ts` の `INSERT INTO dsql_migrations` 等)。非再帰走査だと**この層が
+// 一度も検査されない**。先例は `dsql-append-only-update-fitness.test.ts` (#3658 AC2)。
+//
+// 母数の assertion を置かないと「違反 0 件」が「守られている」なのか
+// 「そもそも見ていない」なのか区別できない (#4084 と同じ形)。
+//
+// 期待値は **実 FS から導出する** (literal 固定にすると file 追加で陳腐化する、#4030 A-1 と同じ轍)。
+describe('#4030 母数: dsql 配下をサブディレクトリまで走査している', () => {
+	it('migration/ 配下の .ts が母数にすべて入っている', () => {
+		const migrationDir = resolve(DSQL_DIR, 'migration');
+		const expected = readdirSync(migrationDir)
+			.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
+			.map((f) => resolve(migrationDir, f))
+			.sort();
+		expect(expected.length, 'migration/ に .ts が 1 つも無い (母数の前提が崩れている)').toBeGreaterThan(
+			0,
+		);
+
+		const collected = new Set(listDsqlSourceFiles());
+		const missing = expected.filter((f) => !collected.has(f));
+		expect(
+			missing,
+			'dsql/migration/ 配下が母数から漏れています。非再帰走査だとこの層が一度も検査されません (#4030 A-2)',
+		).toEqual([]);
+	});
+});

--- a/tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts
+++ b/tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts
@@ -250,11 +250,21 @@ const HAS_FAMILY_COLUMN = /family_id/i;
  */
 const HAS_TENANT_FRAGMENT = /\$\{[^}]*tenant[^}]*\}/i;
 
-function listDsqlSourceFiles(): string[] {
-	if (!existsSync(DSQL_DIR)) return [];
-	return readdirSync(DSQL_DIR)
-		.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
-		.map((f) => resolve(DSQL_DIR, f));
+/**
+ * dsql 配下の .ts を **再帰** 収集する (#4030 A-2 / 先例 #3658 AC2)。
+ *
+ * 旧実装は `readdirSync` 非再帰で、実 SQL を持つ `migration/` 配下を
+ * **一度も検査していなかった**。母数が閉じていない guard は「違反 0 件」と
+ * 「そもそも見ていない」を区別できない。
+ */
+function listDsqlSourceFiles(dir: string = DSQL_DIR, acc: string[] = []): string[] {
+	if (!existsSync(dir)) return acc;
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) listDsqlSourceFiles(full, acc);
+		else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) acc.push(full);
+	}
+	return acc;
 }
 
 interface Violation {

--- a/tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts
+++ b/tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts
@@ -399,9 +399,10 @@ describe('#4030 母数: dsql 配下をサブディレクトリまで走査して
 			.filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
 			.map((f) => resolve(migrationDir, f))
 			.sort();
-		expect(expected.length, 'migration/ に .ts が 1 つも無い (母数の前提が崩れている)').toBeGreaterThan(
-			0,
-		);
+		expect(
+			expected.length,
+			'migration/ に .ts が 1 つも無い (母数の前提が崩れている)',
+		).toBeGreaterThan(0);
 
 		const collected = new Set(listDsqlSourceFiles());
 		const missing = expected.filter((f) => !collected.has(f));


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（guard の母数修正）。**

**ADR-0063 のテナント分離を守る guard が、現行アーキの一部を一度も検査していませんでした。**

`src/lib/server/db/dsql/migration/` には実 SQL を持つ file が **5 本**あります（`provision.ts` の `INSERT INTO dsql_migrations` 等）。しかし 3 つの guard は `readdirSync` を**非再帰**で使っており、**この層が母数に入っていませんでした**。

| guard | 守っている不変条件 |
|---|---|
| `dsql-tenant-predicate-fitness.test.ts` | **ADR-0063 テナント分離**（RLS 非対応の代替防御線） |
| `dsql-append-only-mutation-allowlist.test.ts` | 台帳 append-only（改竄防御） |
| `dsql-mutation-count-cte-fitness.test.ts` | 件数取得の CTE 化 |

**母数が閉じていない guard は「違反 0 件」と「そもそも見ていない」を区別できません**（#4084 と同じ形）。

**先例があります。** 兄弟の `dsql-append-only-update-fitness.test.ts` は #3658 AC2 で同じ gap を塞ぎ、コメントに「旧実装は readdirSync 非再帰でサブディレクトリを取りこぼしていた」と明記されています。**その先例が兄弟 3 件に適用されていませんでした。**

## 関連 Issue

<!-- no-issue-close: Issue #4030 本文が「1 PR にしない」と 3 分割を明示しており、本 PR はその 2 番目 (A-2) のみ。AC5 / AC6 (class B) と A-3 が未着手のため close しない -->

#4030（**本 PR は分割 2 = A-2 のみ**。上記のとおり close しません）

- #4025（本調査の起点）/ #3658（A-2 の先例）/ #3438（`dynamodb` layer 撤去 = A-1 の literal 母数が陳腐化した原因）
- PR #4040（merged、**A-1 = `check-orphan-repos.mjs` の母数**を実施済）
- ADR-0063（テナント分離）/ ADR-0061（same-class-N→guard）

**Issue 本文が「1 PR にしない」と 3 分割を明示**しており、本 PR はその 2 番目です。**class B（AC5 / AC6）は 3 番目のスライスとして残します** — AC6 が「`--update-baseline` の自動投入理由を『理由なし』扱いにするか」の判断を含み、先に決める必要があるためです。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `check-orphan-repos.mjs` の母数を実 FS 由来に | — | **本 PR の scope 外**（PR #4040 で実施済） |
| AC2 | AC1 で新規検出された orphan の是正は切り出す | — | 同上 |
| **AC3** | DSQL 系 3 guard（A-2）を再帰化する | failing-test + mutation | ✅ 3 件とも再帰化。**先例と同じ形**に揃えた |
| **AC4** | `migration/` 配下が新規検出された場合、allowlist 追加の要否を判断 | 全 guard 実行 | ✅ **新規 violation 0 件 → allowlist 追加は不要**（下記） |
| **AC7** | 各修正に mutation 実出力を添える | 実測 | ✅ 下記（**「検査が広がった」ことまで実証**） |
| **AC8** | `npm run pre-ready` 全 Step PASS | — | ✅ |
| AC5 / AC6 | class B（reason 非空 assertion） | — | **本 PR の scope 外**（分割 3） |

### AC4: 新規 violation は 0 件でした

Issue の「未確認事項」は「**再帰化すると新規 violation が出て即 red になる可能性がある**」と書いていました。**実測の結果、3 guard とも 0 件**でした。

```
npx vitest run tests/unit/architecture/dsql-*.test.ts
 Tests  14 passed (14)
```

`migration/` 配下の SQL（`dsql_migrations` 台帳への INSERT 等）は、いずれも tenant 表を触っていないか、既存の除外条件に合致します。**したがって allowlist への追加は行いません**（追加すると、実際には違反していないものを「例外として許した」記録が残り、後から読む人を誤らせます）。

## 変更タイプ

- [x] バグ修正（guard の母数が閉じていない）
- [x] テスト追加
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **母数の期待値** | **実 FS から導出**しています（`readdirSync(migrationDir)`）。literal 固定にすると file 追加で陳腐化し、**A-1 と同じ轍**を踏みます |
| **A-3（`restore-idempotency-registry.test.ts`）** | Issue が「現時点で取りこぼし 0 件だが母数が閉じていない」と分類。**本 PR では触っていません** — 実害が無く、走査対象も `{sqlite,dsql,demo}` と別軸のため、同じ PR に混ぜると「実害の是正」と「予防」が 1 つになります |
| **他の guard への波及** | 3 件とも `listDsqlSourceFiles` という**同名・同実装**を各 file が持っていました（共有していない）。共通化は行わず、各 file で再帰化しています（test 間の暗黙依存を作らないため） |
| **repo 走査宣言** | `check-repo-scan-test-declaration.mjs` OK（3 件とも既存の区分宣言のまま） |

## テスト・品質セルフチェック

```
npx vitest run tests/unit/architecture/
 Test Files  34 passed (34)
      Tests  277 passed (277)

node scripts/check-repo-scan-test-declaration.mjs
 OK — repo 走査 test 40 件すべて区分宣言済
```

### failing-test-first（ADR-0061）

```
<red>  test(arch): #4030 DSQL 系 3 guard が migration/ を検査していないことを failing-test で固定する (A-2)
<impl> fix(arch): #4030 DSQL 系 3 guard の走査を再帰化する (AC3)
```

**3 件すべて red を先に実測**しました（`expected [ …(5) ] to deeply equal []` = migration/ の 5 file が母数から漏れている）。

### mutation: 「母数が増えた」ではなく「検査が広がった」ことを実証しました

母数の件数が増えるだけでは、**その層に対して guard が実際に効いているか**は分かりません。そこで `migration/transform.ts` に **テナント述語を欠いた SQL** を注入しました。

```ts
export const PROBE = sql`SELECT * FROM children WHERE child_id = ${id}`;
```

```
× [main] tenant 表への全 SQL 文が family_id 述語/列を持つ (allowlist 例外は閉集合)
  transform.ts:303 [children] SELECT/UPDATE/DELETE (family_id 述語欠如)
```

✅ **red**。**再帰化前はこの file が母数に無いため、同じ違反を入れても永久に検出されませんでした。**

（最初の probe は素の template literal で書いたため素通りしました。guard は `` sql`...` `` タグ付き template だけを抽出するので、**probe の形を実装に合わせてから**改めて実測しています。「mutation が赤くならない = 安全」と早合点しない、という意味でもここは重要です。）

- [x] **mutation の前に commit した**（`git stash push` で退避）
- [x] **「母数」ではなく「検査の到達」を mutation で確かめた**

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: fitness function (tests/unit/architecture/) の走査範囲修正のみで、src/ の実装も UI も 1 行も変えていない。顧客に見える画面が存在しない。 -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **`listDsqlSourceFiles` を 3 file で重複させたままにしました。** 共通 helper に括ると、fitness 同士が 1 つの実装に依存し、**1 箇所壊れると 3 つ同時に盲目になります**。fitness function は独立していることに価値があると判断しましたが、重複を嫌う判断もありえます。

2. **A-3（`restore-idempotency-registry.test.ts`）を含めていません。** 実害 0 件の予防的修正で、走査対象も別軸のためです。**同じ PR に混ぜるべきというご判断なら追加します。**

3. **AC4 で allowlist を増やしていません。** 違反が実際に無いためです。「将来のために先回りで足す」ことはしていません。

### 破壊的変更

**ありません。** guard の走査範囲が広がるだけで、現時点の違反は 0 件です。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **failing-test を先に commit した**（3 件とも red を実測）
- [x] **mutation で「検査が実際に到達するようになった」ことを実証した**
- [x] **AC4 の判断（allowlist 追加不要）を実測で裏付けた**
- [x] **Issue の分割方針に従い、class B と A-3 を持ち込んでいない**
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 (revert だけで戻る)"]
    R2["顧客面: 変化なし。src/ を1行も触らない"]
    R3["🟡 ADR-0063 の fitness 本体に触れた"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: migration/ 5file が検査対象に入る"]
    T2["捨てる: 同じ収集関数を3箇所に重複させた"]
  end
  subgraph OBJ["③ 反対理由 (adversarial 転記)"]
    O1["business: 検査を触って検査されなくなる形"]
    O2["UX: 過去分の安全性は主張できない"]
    O3["security: Dev 単独で fitness を狭められる"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["変化なし。違反も新規 0 件"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 収集関数の重複を許すか集約するか"]
    Q2["Q2: A-3 と class B を別 PR のままでよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3,T2,O1,O2,O3 warn
  class R1,R2,T1,C1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

**なぜこの label が付いたか**: `.github/labeler.yml` が `tests/unit/architecture/dsql-tenant-predicate-fitness.test.ts` を「**ADR-0063 テナント分離 fitness function 弱体化検知**」として明示登録しているためです。**誤付与ではないので外しません。** 私が触ったのはまさにその fitness です。

**③ の反対理由は `tmp/adversarial-evidence/4234.json` から転記**しています（3 軸 / 各 100 字以上 / schema 検証 PASS）。

**security 軸の指摘は、本 PR では解けません。** 「Dev が単独で fitness を狭められる」構造は #4193（`po-decision:required` の PR が決裁前に merge できる）が扱う範囲で、**本 PR で塞ぐと 2 箇所に同じ機構ができます**。#4193 は本日 `state:needs-po` で判断待ちです。

**business 軸（検査を触って検査されなくなる形）への対処**: 母数が増えたことだけでなく、**`migration/transform.ts` に実際の違反を注入して guard が red になること**を実測しました（本文「mutation」節）。最初の probe は guard の抽出条件に合わず素通りしたため、**probe の形を実装に合わせてから**改めて赤を確認しています。

**Q1 の背景**: `listDsqlSourceFiles` は 3 file が同名・同実装で持っています（元から共有していません）。共通化すると 1 箇所の破損で 3 guard が同時に盲目になるため、本 PR では**重複のまま**にしました。

**Q2 の背景**: Issue #4030 本文が「**1 PR にしない**」と 3 分割を明示しています。A-3 は実害 0 件の予防、class B は AC6 の判断（`--update-baseline` の自動投入理由を「理由なし」扱いにするか）が先に要ります。

</details>
