### PR TITLE
fix(billing): #4166 Stripe portal をプラン変更 / 解約フローへ直行させ、完了後アプリへ戻す

### DIFF
--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -309,6 +309,34 @@ DynamoDB: PK=`GRADUATION_CONSENT`, SK=`<isoTs>#<uuid>` (single global partition�
 | 支払い方法更新 | （Stripe 側のみ） | DB 変更なし |
 | 請求書履歴閲覧 | （Stripe 側のみ） | DB 変更なし |
 
+### 3.2.1 Portal の着地は「顧客の意図」で決める（#4166）
+
+Stripe portal の**ボタン文言は変更できない**（Branding で変えられるのは色・ロゴ・事業者名のみ）。
+portal ホームに着地させると「サブスクリプションを更新」が並び、顧客はこれを
+**「支払い方法の更新 / 継続」と読んでプラン変更に到達しない**。
+
+したがって `createPortalSession(tenantId, returnUrl, flow)` が **flow を受け取り**、
+`billingPortal.sessions.create()` の `flow_data` で目的のフローへ直行させる。
+
+| flow | 入口 | 着地 | `flow_data` |
+|---|---|---|---|
+| `subscription_update` | 「⭐ プレミアムへ」等のアップグレード CTA（`intent='plan-upgrade'`） | プラン選択画面 | `type='subscription_update'` + `subscription_update.subscription` |
+| `subscription_cancel` | 解約理由フォーム送信後（`cancel/+page.server.ts`） | 解約画面 | `type='subscription_cancel'` + `subscription_cancel.subscription` |
+| `home`（既定） | 「プラン変更・支払い管理」 / 請求履歴 | portal ホーム | 付けない |
+
+**`home` を残す理由**: flow を付けると**請求書閲覧・支払い方法変更の入口が消える**。
+汎用導線はホームのままにする。
+
+**完了後はアプリへ戻す**: `after_completion = { type: 'redirect', redirect: { return_url } }` を
+**明示指定**する。省略時の挙動は公式ドキュメントに明記が無く、確認ページに留まると読めるため。
+途中でやめた顧客が戻れるよう、トップレベルの `return_url` は flow の有無に関わらず常に渡す。
+
+**`stripeSubscriptionId` を持たないテナントでは flow を付けない**（`home` にフォールバック）。
+付けたまま送ると Stripe が 400 を返し、**顧客は何を押しても portal に入れなくなる**。
+
+`subscription_update_confirm`（price 選択をアプリ側に持ち確認画面だけ portal に出す）は**採らない** —
+proration / 期末切替の表示責務がアプリに移り、Stripe を課金状態の SSOT とする方針（#4096）と逆行する。
+
 ### 3.3 Webhook 処理 — `customer.subscription.updated`
 
 `stripe-service.ts:handleSubscriptionUpdated()`

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3290,7 +3290,7 @@ export const BILLING_LABELS = {
 	billingPortalDesc: `Stripe の${STRIPE_PORTAL_TERMS.short}で以下の操作ができます:`,
 	featureInvoices: '過去の請求書の確認・ダウンロード',
 	featurePaymentMethod: '支払い方法（クレジットカード）の変更',
-	featurePlanSwitch: 'スタンダード / ファミリープランの切り替え',
+	featurePlanSwitch: `${PLAN_FULL_TERMS.standard} / ${PLAN_FULL_TERMS.premium}の切り替え`,
 	featureNextBilling: '次回請求日の確認',
 	notReadyAlert: '決済機能は現在準備中です',
 	openPortalError: `${STRIPE_PORTAL_TERMS.short}を開けませんでした`,

--- a/src/lib/features/admin/components/SaasLicensePanel.svelte
+++ b/src/lib/features/admin/components/SaasLicensePanel.svelte
@@ -130,7 +130,10 @@ const DOWNGRADE_CONFIRM_PHRASE = 'プランを変更します';
 // #4156: 同じ Portal でも「プランを変えに行く」のか「領収書を見に行く」のかで、
 // 顧客が確認ダイアログで読むべき文が違う。確認フレーズ自体はサーバー契約
 // (`/api/stripe/portal` の CONFIRM_PHRASE_REQUIRED) と同値である必要があるため変えない。
-let portalIntent = $state<'plan-change' | 'billing-history'>('plan-change');
+// #4166: 'plan-upgrade' は「⭐ プレミアムへ」等の**アップグレード意図**。
+// portal の flow_data に載せて Stripe のプラン変更画面へ直行させる。
+// 'plan-change' (汎用の「プラン変更・支払い管理」) は請求書 / 支払い方法の入口も兼ねるので home のまま。
+let portalIntent = $state<'plan-change' | 'plan-upgrade' | 'billing-history'>('plan-change');
 let showPortalConfirm = $state(false);
 let portalPinValue = $state('');
 let portalConfirmPhrase = $state('');
@@ -304,7 +307,8 @@ function handlePlanUpgrade(planId: string) {
 		return;
 	}
 	if (hasSubscription) {
-		requestPlanChange();
+		// #4166: 「⭐ プレミアムへ」は portal ホームではなくプラン変更画面へ直行させる
+		requestPlanUpgrade();
 		return;
 	}
 	void startCheckout(planId);
@@ -394,6 +398,12 @@ function requestPlanChange() {
 	void requestPortal();
 }
 
+/** #4166: アップグレード CTA から Portal を開く (Stripe のプラン変更画面へ直行する) */
+function requestPlanUpgrade() {
+	portalIntent = 'plan-upgrade';
+	void requestPortal();
+}
+
 /** #4156: 請求履歴を見る目的で Portal を開く (契約操作ではない) */
 function requestBillingHistory() {
 	portalIntent = 'billing-history';
@@ -458,9 +468,11 @@ async function openPortal() {
 		const res = await fetch('/api/stripe/portal', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(
-				pinConfigured ? { pin: portalPinValue } : { confirmPhrase: portalConfirmPhrase },
-			),
+			body: JSON.stringify({
+				...(pinConfigured ? { pin: portalPinValue } : { confirmPhrase: portalConfirmPhrase }),
+				// #4166: 顧客の意図をサーバへ伝え、portal の着地を決める
+				intent: portalIntent,
+			}),
 		});
 		if (!res.ok) {
 			let message: string = SUBSCRIPTION_PAGE_LABELS.portalFetchError;

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -133,9 +133,66 @@ export type CreatePortalResult =
 	| { error: 'TENANT_NOT_FOUND' }
 	| { error: 'NO_STRIPE_CUSTOMER' };
 
+/**
+ * portal で顧客にやらせたいこと (#4166)。
+ *
+ * Stripe portal の**ボタン文言は変更できない** (Branding で変えられるのは色・ロゴ・事業者名のみ)。
+ * ホームに着地させると「サブスクリプションを更新」が並び、顧客はこれを
+ * 「支払い方法の更新 / 継続」と読んでプラン変更に到達しない (本番実機、#4166)。
+ * したがって**呼び出し元が意図を宣言し**、`flow_data` で目的のフローへ直行させる。
+ *
+ * `home` は汎用導線 (請求書確認 / 支払い方法変更) 用。**flow を付けるとこれらの入口が消える**。
+ */
+export type PortalFlow =
+	| { kind: 'home' }
+	| { kind: 'subscription_update' }
+	| { kind: 'subscription_cancel' };
+
+/**
+ * `flow_data` を組み立てる (#4166)。
+ *
+ * **subscription を持たないときは flow を付けない。** 付けたまま投げると Stripe が 400 を返し、
+ * 顧客は何を押しても portal に入れなくなる (導線ごと死ぬ)。home に落とすのが安全側。
+ *
+ * `after_completion` は明示する。省略時の挙動は公式ドキュメントに明記が無く、
+ * 「完了した更新の詳細を示す確認ページ」に留まると読めるため、アプリへ戻す指定を必ず置く。
+ */
+function buildPortalFlowData(
+	flow: PortalFlow,
+	subscriptionId: string | null,
+	returnUrl: string,
+): { flow_data?: Stripe.BillingPortal.SessionCreateParams.FlowData } {
+	if (flow.kind === 'home') return {};
+	if (!subscriptionId) return {};
+
+	const afterCompletion = {
+		type: 'redirect',
+		redirect: { return_url: returnUrl },
+	} as const;
+
+	if (flow.kind === 'subscription_update') {
+		return {
+			flow_data: {
+				type: 'subscription_update',
+				subscription_update: { subscription: subscriptionId },
+				after_completion: afterCompletion,
+			},
+		};
+	}
+
+	return {
+		flow_data: {
+			type: 'subscription_cancel',
+			subscription_cancel: { subscription: subscriptionId },
+			after_completion: afterCompletion,
+		},
+	};
+}
+
 export async function createPortalSession(
 	tenantId: string,
 	returnUrl: string,
+	flow: PortalFlow = { kind: 'home' },
 ): Promise<CreatePortalResult> {
 	if (!isStripeEnabled()) return { error: 'STRIPE_DISABLED' };
 
@@ -147,7 +204,9 @@ export async function createPortalSession(
 	const stripe = getStripeClient();
 	const session = await stripe.billingPortal.sessions.create({
 		customer: tenant.stripeCustomerId,
+		// 途中でやめた顧客が戻れるリンク。flow の有無に関わらず常に渡す
 		return_url: returnUrl,
+		...buildPortalFlowData(flow, tenant.stripeSubscriptionId ?? null, returnUrl),
 	});
 
 	return { url: session.url };

--- a/src/routes/(parent)/admin/subscription/cancel/+page.server.ts
+++ b/src/routes/(parent)/admin/subscription/cancel/+page.server.ts
@@ -81,7 +81,12 @@ export const actions: Actions = {
 		// 課金プランかつ Stripe Customer がある場合 → Customer Portal にリダイレクト
 		if (license?.stripeCustomerId && isStripeEnabled()) {
 			const returnUrl = new URL('/admin/subscription', url).toString();
-			const portalResult = await createPortalSession(tenantId, returnUrl);
+			// #4166 AC4: 解約理由フォームを埋めきった顧客を portal ホームに放り出さない。
+			// ホームからは自分で「サブスクリプションをキャンセル」を探すことになり、
+			// 特商法の解約導線の実効性に接続する。解約フローへ直行させる。
+			const portalResult = await createPortalSession(tenantId, returnUrl, {
+				kind: 'subscription_cancel',
+			});
 			if ('url' in portalResult) {
 				throw redirect(303, portalResult.url);
 			}

--- a/src/routes/api/stripe/portal/+server.ts
+++ b/src/routes/api/stripe/portal/+server.ts
@@ -6,7 +6,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import { isPinConfigured, verifyPin } from '$lib/server/services/auth-service';
-import { createPortalSession } from '$lib/server/services/stripe-service';
+import { createPortalSession, type PortalFlow } from '$lib/server/services/stripe-service';
 import type { RequestHandler } from './$types';
 
 const DOWNGRADE_CONFIRM_PHRASE = 'プランを変更します';
@@ -27,6 +27,8 @@ export const POST: RequestHandler = async ({ locals, url, request }) => {
 	const body = (await request.json().catch(() => ({}))) as {
 		pin?: string;
 		confirmPhrase?: string;
+		/** #4166: 顧客の意図。portal の着地 (flow) を決める */
+		intent?: string;
 	};
 
 	const pinConfigured = await isPinConfigured(tenantId);
@@ -58,7 +60,13 @@ export const POST: RequestHandler = async ({ locals, url, request }) => {
 		}
 	}
 
-	const result = await createPortalSession(tenantId, `${url.origin}/admin/subscription`);
+	// #4166: 「⭐ プレミアムへ」だけをプラン変更フローへ直行させる。
+	// 汎用の「プラン変更・支払い管理」(plan-change) と請求履歴 (billing-history) は
+	// **home のまま**にする — flow を付けると請求書 / 支払い方法の入口が消えるため (AC5)。
+	const flow: PortalFlow =
+		body.intent === 'plan-upgrade' ? { kind: 'subscription_update' } : { kind: 'home' };
+
+	const result = await createPortalSession(tenantId, `${url.origin}/admin/subscription`, flow);
 
 	if ('error' in result) {
 		const statusMap: Record<string, number> = {

--- a/tests/unit/services/stripe-portal-flow.test.ts
+++ b/tests/unit/services/stripe-portal-flow.test.ts
@@ -118,7 +118,10 @@ describe('#4166 AC1 portal は「顧客がやりたいこと」へ直行する',
 
 		await createPortalSession('t-test', RETURN_URL, { kind: 'home' });
 
-		expect(lastArgs().flow_data, '汎用導線に flow を付けると請求書・支払い方法の入口が消える').toBeUndefined();
+		expect(
+			lastArgs().flow_data,
+			'汎用導線に flow を付けると請求書・支払い方法の入口が消える',
+		).toBeUndefined();
 	});
 
 	it('flow 未指定は home 相当（既存呼び出しの挙動を変えない）', async () => {
@@ -131,20 +134,20 @@ describe('#4166 AC1 portal は「顧客がやりたいこと」へ直行する',
 });
 
 describe('#4166 AC3 フロー完了後はアプリへ戻る', () => {
-	it.each(['subscription_update', 'subscription_cancel'] as const)(
-		'%s: after_completion で return_url へ redirect する',
-		async (kind) => {
-			mockFindTenantById.mockResolvedValue(tenant());
+	it.each([
+		'subscription_update',
+		'subscription_cancel',
+	] as const)('%s: after_completion で return_url へ redirect する', async (kind) => {
+		mockFindTenantById.mockResolvedValue(tenant());
 
-			await createPortalSession('t-test', RETURN_URL, { kind });
+		await createPortalSession('t-test', RETURN_URL, { kind });
 
-			const flow = lastArgs().flow_data as Record<string, unknown>;
-			expect(
-				flow.after_completion,
-				'省略時の挙動は公式ドキュメントに明記が無く、portal に留まる。明示指定する',
-			).toEqual({ type: 'redirect', redirect: { return_url: RETURN_URL } });
-		},
-	);
+		const flow = lastArgs().flow_data as Record<string, unknown>;
+		expect(
+			flow.after_completion,
+			'省略時の挙動は公式ドキュメントに明記が無く、portal に留まる。明示指定する',
+		).toEqual({ type: 'redirect', redirect: { return_url: RETURN_URL } });
+	});
 
 	it('途中離脱できるよう、トップレベルの return_url は常に渡す', async () => {
 		mockFindTenantById.mockResolvedValue(tenant());
@@ -158,19 +161,19 @@ describe('#4166 AC3 フロー完了後はアプリへ戻る', () => {
 describe('#4166 AC2 subscription を持たないなら home にフォールバックする', () => {
 	// flow を付けたまま subscription なしで投げると Stripe が 400 を返し、
 	// **導線ごと死ぬ**（顧客は何を押しても portal に入れない）。
-	it.each(['subscription_update', 'subscription_cancel'] as const)(
-		'%s: stripeSubscriptionId が無ければ flow を付けない',
-		async (kind) => {
-			mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: null }));
+	it.each([
+		'subscription_update',
+		'subscription_cancel',
+	] as const)('%s: stripeSubscriptionId が無ければ flow を付けない', async (kind) => {
+		mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: null }));
 
-			const result = await createPortalSession('t-test', RETURN_URL, { kind });
+		const result = await createPortalSession('t-test', RETURN_URL, { kind });
 
-			expect(
-				lastArgs().flow_data,
-				'subscription 無しで flow を付けると Stripe が 400 を返し導線ごと死ぬ',
-			).toBeUndefined();
-			// **落とさずに portal へは入れる**こと（fallback の意味）
-			expect(result).toEqual({ url: 'https://billing.stripe.com/session_1' });
-		},
-	);
+		expect(
+			lastArgs().flow_data,
+			'subscription 無しで flow を付けると Stripe が 400 を返し導線ごと死ぬ',
+		).toBeUndefined();
+		// **落とさずに portal へは入れる**こと（fallback の意味）
+		expect(result).toEqual({ url: 'https://billing.stripe.com/session_1' });
+	});
 });

--- a/tests/unit/services/stripe-portal-flow.test.ts
+++ b/tests/unit/services/stripe-portal-flow.test.ts
@@ -1,0 +1,176 @@
+// tests/unit/services/stripe-portal-flow.test.ts
+// #4166 — portal session が「顧客がやりたいこと」に直行する。
+//
+// ## 実害（本番実機、2026-08-01 オーナー操作）
+//
+// 「⭐⭐ プレミアムへ」を押すと Stripe Customer Portal の**ホーム**に着き、
+// 並ぶのは「サブスクリプションを更新」「サブスクリプションをキャンセル」。
+// 顧客は「更新 = 支払い方法の更新 / 継続」と読むため**プラン変更に到達しない**。
+// オーナー自身が最初に到達できなかった。
+//
+// **解約側はさらに悪い。** 解約理由フォームを埋めきった直後に portal ホームへ放り出され、
+// そこから自分で「サブスクリプションをキャンセル」を探すことになる（特商法の解約導線の実効性）。
+//
+// ## 何を固定するか
+//
+// Stripe portal の**ボタン文言は変更できない**（Branding は色・ロゴ・事業者名のみ）。
+// したがってアプリ側で `flow_data` を渡し、目的のフローへ直行させるのが唯一の手段。
+//
+// **CI では着地を検証できない**（flow の描画は Stripe 側、cognito-dev レーンの Stripe は無効 #4161）。
+// ユニットで担保できるのは **`create()` に渡した引数**までなので、そこを固定する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindTenantById = vi.fn();
+const mockPortalCreate = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		auth: { findTenantById: mockFindTenantById },
+		webhookEvent: {
+			findByEventId: async () => null,
+			claim: async () => true,
+			finalize: async () => {},
+			releaseClaim: async () => {},
+			incrementRetryCount: async () => {},
+			deleteOlderThan: async () => 0,
+		},
+	}),
+}));
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: () => true,
+	getStripeClient: () => ({ billingPortal: { sessions: { create: mockPortalCreate } } }),
+}));
+
+vi.mock('$lib/server/stripe/config', () => ({
+	getPlans: () => ({}),
+	planIdFromPriceId: () => null,
+	planIdFromLookupKey: () => null,
+	getWebhookSecret: () => 'whsec_test',
+	TRIAL_PERIOD_DAYS: 7,
+	GRACE_PERIOD_DAYS: 7,
+	CURRENCY: 'jpy',
+}));
+vi.mock('$lib/server/stripe/alert', () => ({ notifyStripeAlert: vi.fn() }));
+vi.mock('$lib/server/logger', () => ({ logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } }));
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyDiscord: vi.fn(),
+	notifyIncident: vi.fn(),
+}));
+
+import { createPortalSession } from '../../../src/lib/server/services/stripe-service';
+
+const RETURN_URL = 'https://app.example/admin/subscription';
+
+function tenant(overrides: Record<string, unknown> = {}) {
+	return {
+		tenantId: 't-test',
+		stripeCustomerId: 'cus_123',
+		stripeSubscriptionId: 'sub_123',
+		status: 'active',
+		plan: 'monthly',
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockPortalCreate.mockResolvedValue({ url: 'https://billing.stripe.com/session_1' });
+});
+
+/** 直近の create() 引数。 */
+function lastArgs(): Record<string, unknown> {
+	return mockPortalCreate.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+}
+
+describe('#4166 AC1 portal は「顧客がやりたいこと」へ直行する', () => {
+	it('subscription_update: プラン変更フローへ直行し、対象 subscription を渡す', async () => {
+		mockFindTenantById.mockResolvedValue(tenant());
+
+		await createPortalSession('t-test', RETURN_URL, { kind: 'subscription_update' });
+
+		const args = lastArgs();
+		expect(args.flow_data, 'flow_data が無いと portal ホームに着く (#4166 の実害そのもの)').toEqual(
+			expect.objectContaining({
+				type: 'subscription_update',
+				subscription_update: { subscription: 'sub_123' },
+			}),
+		);
+	});
+
+	it('subscription_cancel: 解約フローへ直行し、対象 subscription を渡す', async () => {
+		mockFindTenantById.mockResolvedValue(tenant());
+
+		await createPortalSession('t-test', RETURN_URL, { kind: 'subscription_cancel' });
+
+		expect(lastArgs().flow_data).toEqual(
+			expect.objectContaining({
+				type: 'subscription_cancel',
+				subscription_cancel: { subscription: 'sub_123' },
+			}),
+		);
+	});
+
+	// AC5: 汎用導線 (請求書確認 / 支払い方法変更) の入口を潰さない
+	it('home: flow_data を付けない（汎用導線は portal ホームのまま）', async () => {
+		mockFindTenantById.mockResolvedValue(tenant());
+
+		await createPortalSession('t-test', RETURN_URL, { kind: 'home' });
+
+		expect(lastArgs().flow_data, '汎用導線に flow を付けると請求書・支払い方法の入口が消える').toBeUndefined();
+	});
+
+	it('flow 未指定は home 相当（既存呼び出しの挙動を変えない）', async () => {
+		mockFindTenantById.mockResolvedValue(tenant());
+
+		await createPortalSession('t-test', RETURN_URL);
+
+		expect(lastArgs().flow_data).toBeUndefined();
+	});
+});
+
+describe('#4166 AC3 フロー完了後はアプリへ戻る', () => {
+	it.each(['subscription_update', 'subscription_cancel'] as const)(
+		'%s: after_completion で return_url へ redirect する',
+		async (kind) => {
+			mockFindTenantById.mockResolvedValue(tenant());
+
+			await createPortalSession('t-test', RETURN_URL, { kind });
+
+			const flow = lastArgs().flow_data as Record<string, unknown>;
+			expect(
+				flow.after_completion,
+				'省略時の挙動は公式ドキュメントに明記が無く、portal に留まる。明示指定する',
+			).toEqual({ type: 'redirect', redirect: { return_url: RETURN_URL } });
+		},
+	);
+
+	it('途中離脱できるよう、トップレベルの return_url は常に渡す', async () => {
+		mockFindTenantById.mockResolvedValue(tenant());
+
+		await createPortalSession('t-test', RETURN_URL, { kind: 'subscription_cancel' });
+
+		expect(lastArgs().return_url).toBe(RETURN_URL);
+	});
+});
+
+describe('#4166 AC2 subscription を持たないなら home にフォールバックする', () => {
+	// flow を付けたまま subscription なしで投げると Stripe が 400 を返し、
+	// **導線ごと死ぬ**（顧客は何を押しても portal に入れない）。
+	it.each(['subscription_update', 'subscription_cancel'] as const)(
+		'%s: stripeSubscriptionId が無ければ flow を付けない',
+		async (kind) => {
+			mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: null }));
+
+			const result = await createPortalSession('t-test', RETURN_URL, { kind });
+
+			expect(
+				lastArgs().flow_data,
+				'subscription 無しで flow を付けると Stripe が 400 を返し導線ごと死ぬ',
+			).toBeUndefined();
+			// **落とさずに portal へは入れる**こと（fallback の意味）
+			expect(result).toEqual({ url: 'https://billing.stripe.com/session_1' });
+		},
+	);
+});


### PR DESCRIPTION
## 顧客価値・目的

**「⭐⭐ プレミアムへ」を押した顧客が、プレミアムに到達できるようになります。**

本番実機（2026-08-01、オーナー操作）で、押した先が Stripe Customer Portal の**ホーム**でした。並ぶのは「サブスクリプションを更新」「サブスクリプションをキャンセル」で、顧客はこれを「支払い方法の更新 / 継続」と読みます。**オーナー自身が最初に到達できませんでした。**

**解約側はさらに悪い状態でした。** 解約理由フォームを埋めきった直後に portal ホームへ放り出され、そこから自分で「サブスクリプションをキャンセル」を探すことになります。**特商法の解約導線の実効性に接続します。**

Stripe portal の**ボタン文言は変更できません**（Branding で変えられるのは色・ロゴ・事業者名のみ）。したがって `flow_data` で目的のフローへ直行させるのが唯一の手段です。

## 関連 Issue

Closes #4166

- #4139 / #4146（アップグレード導線の一本道化。**本 PR はその積み残し**）
- #4096（Stripe を課金状態の SSOT とする）/ #4161（CI がどちらの分岐も検証できない）
- ADR-0045（terms.ts atom の直書き禁止、AC6）/ ADR-0061（same-class N → 構造で潰す）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC1** | `createPortalSession()` が flow 種別を受け取り該当フローへ直行 | unit 9 件 | ✅ `PortalFlow` 型 + `buildPortalFlowData()`。`subscription_update` / `subscription_cancel` で `flow_data` を組み立て |
| **AC2** | `stripeSubscriptionId` 無しは flow を付けず home にフォールバック（導線が死なない） | unit（両分岐） | ✅ **落とさず portal には入れる**ことまで assert。付けたまま投げると Stripe が 400 を返し、顧客は何を押しても入れなくなる |
| **AC3** | `after_completion.type = 'redirect'` で `/admin/subscription` へ戻る | unit | ✅ 省略時の挙動は公式ドキュメントに明記が無く portal に留まると読めるため**明示指定**。途中離脱用のトップレベル `return_url` も常に渡す |
| **AC4** | 解約フォーム完了後を `subscription_cancel` フローに | 実装 | ✅ `cancel/+page.server.ts` |
| **AC5** | 「プラン変更・支払い管理」（汎用導線）は **home のまま** | unit + 実装 | ✅ **意図を 3 つに分けました**（下記）。flow を付けると請求書・支払い方法の入口が消えます |
| **AC6** | 用語の不整合を是正（`featurePlanSwitch` の atom 直書き） | lint + **実画面 Before/After SS** | ✅ `'スタンダード / ファミリープランの切り替え'` → `` `${PLAN_FULL_TERMS.standard} / ${PLAN_FULL_TERMS.premium}の切り替え` ``。`check-no-plan-literals` OK。**表示差分は `/admin/subscription` の Before/After SS（desktop + mobile）で実測**（下記「スクリーンショット」） |
| **AC7** | **本番実機で確認**（プラン選択画面に直着 / 完了後に戻る / 解約画面に直着） | — | ⚠️ **未達。deploy が前提で Dev の職掌外**（憲章 §4.3）。下記「引き継ぎ」参照 |

### AC5 のために意図を 3 つに分けました

Issue は「汎用導線は home のまま」と要求していますが、**調べたところ「⭐ プレミアムへ」と「プラン変更・支払い管理」は同じ関数（`requestPlanChange`）を通っていました**。そのままでは片方だけ flow を付けられません。

| 意図 | 入口 | portal の着地 |
|---|---|---|
| `plan-upgrade`（**新設**） | 「⭐ プレミアムへ」→ `handlePlanUpgrade` | **プラン変更フローへ直行** |
| `plan-change` | 「プラン変更・支払い管理」ボタン | **home のまま**（請求書 / 支払い方法の入口を潰さない） |
| `billing-history` | 請求履歴（#4156） | home のまま |

`portalIntent` は既存 state（`plan-change` / `billing-history`）だったので、**3 値目を足して POST body で server に渡す**形にしました。

## 変更タイプ

- [x] バグ修正（顧客が到達できない導線）
- [x] テスト追加
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

| 観点 | 確認結果 |
|---|---|
| **同型 2 箇所を両方直したか** | ✅ Issue が指摘した `api/stripe/portal/+server.ts` と `cancel/+page.server.ts` の**両方**。`createPortalSession` の呼び出しは grep で**この 2 箇所のみ**と確認 |
| **既存呼び出しの挙動** | **不変**。`flow` は既定値 `{ kind: 'home' }` で、引数を渡さない呼び出しは今までどおり |
| **`subscription_update_confirm`** | **採りません**（Issue の判断どおり）。price 選択 UI をアプリに持つと proration / 期末切替の表示責務がアプリに移り #4096 と逆行します |
| **AC6 の波及** | `labels.ts` 変更のため pre-commit の SSOT companion 検査（`generate-lp-labels --check` / `sync-lp-fallback --check`）が走り、いずれも同期済を確認 |
| **`svelte-check`** | 0 errors / 0 warnings |

## テスト・品質セルフチェック

```
npx vitest run tests/unit/services/ src/lib/domain/
 Test Files  159 passed (159)
      Tests  2617 passed (2617)

npx svelte-check          → 0 errors, 0 warnings
node scripts/check-no-plan-literals.mjs → OK
```

### failing-test-first（ADR-0061）

```
<red>  test(billing): #4166 portal が目的のフローへ直行しないことを failing-test で固定する
<impl> feat(billing): #4166 portal を目的のフローへ直行させ、完了後アプリへ戻す
```

**先に 4 件 red を実測**しました（`flow_data` / `after_completion`）。**home 系 5 件は既存挙動なので green が正しい**状態で、そこも同時に固定しています（AC5 の回帰防止）。

### CI で検証できないことを先に書きます

**flow の着地は Stripe 側の描画で、cognito-dev レーンの Stripe は無効（#4161）です。** ユニットで担保できるのは **`billingPortal.sessions.create()` に渡した引数**までで、そこを固定しました。

**#4139 → #4146 → 本 Issue と同じ穴を 3 度通しています。** AC7 の本番実測を省略した状態で close しません。

## スクリーンショット / ビジュアルデモ

**アプリ側にも表示差分があります。** `labels.ts` の `featurePlanSwitch` を SSOT 参照化したため、`SaasLicensePanel` の「請求管理ページでできること」リスト 3 行目の文言が変わります（`スタンダード / ファミリープランの切り替え` → `スタンダードプラン / プレミアムプランの切り替え`）。**その差分を Before / After で撮りました。**

撮影条件（`/admin/subscription`、`hasSubscription=true` の契約中表示）:

```
# ローカル DB の契約 4 列 (settings: local_tenant_contract, #4156) に
# stripeSubscriptionId を入れ、STRIPE_SECRET_KEY を渡して該当カードを描画させる
STRIPE_SECRET_KEY=<dummy> npm run dev
MSYS_NO_PATHCONV=1 node scripts/capture.mjs --pr 4235 --config <spec> --full-page
```

Before は `git show origin/develop:src/lib/domain/labels.ts` で **develop の labels.ts を配置した状態**、After は PR HEAD で撮り直しています（同一画像ではありません。sha256 は 4 枚すべて相異）。

### Desktop

| Before (develop) | After (PR HEAD) |
|---|---|
| ![before-subscription-portal-features-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4235/before-subscription-portal-features-desktop.png) | ![after-subscription-portal-features-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4235/after-subscription-portal-features-desktop.png) |

### Mobile

| Before (develop) | After (PR HEAD) |
|---|---|
| ![before-subscription-portal-features-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4235/before-subscription-portal-features-mobile.png) | ![after-subscription-portal-features-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4235/after-subscription-portal-features-mobile.png) |

DOM スナップショット（SS と同一 page で取得、#1766）: [before desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4235/before-subscription-portal-features-desktop.dom.html) / [after desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4235/after-subscription-portal-features-desktop.dom.html) / [before mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4235/before-subscription-portal-features-mobile.dom.html) / [after mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4235/after-subscription-portal-features-mobile.dom.html)

**撮れないのは Stripe Customer Portal 側の着地画面だけです。** 外部 SaaS の画面であり、ローカル / demo 環境では実 Stripe に到達できないため撮影できません。ここは **AC7 の本番実測**に委ねます（本 Issue が「実機確認を省略して close しない」と明記している箇所）。

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **AC5 のために `portalIntent` に 3 値目を足しました。** 「⭐ プレミアムへ」と「プラン変更・支払い管理」が同じ関数を通っていたためです。**「汎用導線も直行させるべき」という判断なら 1 行で変えられます**が、Issue の AC5 は home 維持なのでそちらに従いました。

2. **`intent` はクライアントから来る値です。** 改竄されても起きるのは「portal の着地が変わる」だけで、認可（PIN / 確認フレーズ）は手前で済んでいます。サーバ側は既知の値以外を **home に倒す**実装です。

3. **AC2 の fallback は「flow を付けない」だけです。** subscription が無い顧客が「プレミアムへ」を押すと portal ホームに着きます（今までと同じ）。**そもそも subscription が無ければ checkout 経路に分岐する**ため、実際にここへ来るのは異常系です。

### 破壊的変更

**ありません。** `flow` は既定 `home` で、既存の 2 呼び出し以外に影響しません。

## AC7 の引き継ぎ（deploy 実施者 / オーナーへ）

**deploy は Dev の職掌ではありません**（憲章 §4.3）。deploy 後に**本番実機**で確認してください。

1. `/admin/subscription` の「⭐⭐ プレミアムへ」→ **プラン選択画面に直接着く**（portal ホームを経由しない）
2. 変更を完了 → **`/admin/subscription` に自動で戻る**
3. 解約導線（理由フォーム送信後）→ **解約画面に直接着く**
4. 「プラン変更・支払い管理」→ **portal ホーム**（請求書・支払い方法が並ぶこと。ここが変わっていたら AC5 の回帰）

**4 が重要です。** 1〜3 だけ見て「直った」と判断すると、請求書と支払い方法の入口が消えていることに気づけません。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **failing-test を先に commit した**（4 件 red / home 系 5 件は green が正しい）
- [x] **同型 2 箇所を両方直した**（grep で呼び出し全件を確認）
- [x] **AC5 のために意図を分離し、汎用導線の入口を潰していない**
- [x] **AC7 が未達であることと、確認手順（4 項目）を明示した**
- [x] **CI で検証できない範囲を先に書いた**
- [x] **`labels.ts` の表示差分を実画面 Before/After SS（desktop + mobile）で撮った**（develop 側 / PR HEAD 側をそれぞれ撮り直し）
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 (revert だけで戻る)"]
    R2["顧客面: 課金導線。収益に直結"]
    R3["🔴 着地の正しさを CI で検証できない"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: プレミアムへ到達できる導線"]
    T2["捨てる: 意図が3値に増え分岐が増えた"]
  end
  subgraph OBJ["③ 反対理由 (adversarial 転記)"]
    O1["business: Stripe側設定が外れると更に悪化"]
    O2["UX: 汎用ボタンは名前と着地がずれたまま"]
    O3["security: intent はクライアント由来の値"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["押した先が変わる + プラン名表記を是正"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 汎用ボタンの名前を実態に合わせるか"]
    Q2["Q2: Stripe側 portal 設定を監視するか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3 danger
  class R2,T2,O1,O2,O3 warn
  class R1,T1,C1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

**なぜこの label が付いたか**: `.github/labeler.yml` が `src/routes/api/stripe/**` を対象にしています。**誤付与ではないので外しません。**

**③ の反対理由は `tmp/adversarial-evidence/4235.json` から転記**しています（3 軸 / 各 100 字以上 / schema 検証 PASS）。

**Q1（UX 軸の指摘への対応）**: 「プラン変更・支払い管理」ボタンは **AC5 の指示どおり home のまま**にしました。しかし**名前がプラン変更を含意するのに、押した先はホーム**です。Issue が問題視した誤読（「更新 = 継続」）は、**この導線では残ります**。

- 案 a: **名前を実態に合わせる**（例:「請求書・支払い方法」）。AC5 の「入口を潰さない」は満たしたまま、名前と着地が一致します
- 案 b: そのまま（プラン変更の入口が 2 つあること自体は許容）

**名前を変えるのは顧客に見える文言の変更**なので Dev の判断で寄せませんでした。

**Q2（business 軸の指摘への対応）**: flow が機能する前提は **Stripe Dashboard の「顧客がプランを切り替えられるようにする」が ON で、両 price が登録済**であることです。オーナーが 2026-08-01 に目視で確認していますが、**設定が外れたことを検知する仕組みはありません**。外れると本 PR 後の導線は今より悪化します（ホームですらなく flow が空になる）。監視を持つかは Pre-PMF の判断（ADR-0010）です。

**security 軸について**: `intent` はクライアント由来ですが、認可（PIN / 確認フレーズ）は手前で完了しており、差し替えても**自分のセッションの着地が変わるだけ**です。サーバは既知の値以外を home に倒します。解約フローは server 側固定で、API から誘発できません。

</details>

