### PR TITLE
fix(test): #4030 A-3 restore registry の走査を再帰化する（no-silent-gap guard 自身の silent gap）

### DIFF
--- a/tests/unit/db/restore-idempotency-registry.test.ts
+++ b/tests/unit/db/restore-idempotency-registry.test.ts
@@ -27,12 +27,33 @@ const DB_DIR = join(__dirname, '../../../src/lib/server/db');
 const BACKENDS = ['sqlite', 'dsql', 'demo'] as const;
 type Backend = (typeof BACKENDS)[number];
 
-/** backend dir 配下の *-repo.ts から `<basename>:<fn>` の ForRestore 関数集合を抽出する。 */
+/**
+ * backend dir 配下の *-repo.ts を **再帰的に**列挙する (#4030 A-3)。
+ *
+ * 旧実装は `readdirSync(dir)` の非再帰走査だった。`dsql/migration/` 等のサブディレクトリに
+ * `*-repo.ts` を置いた瞬間、**registry 未分類のまま緑で通る** (no-silent-gap を名乗る guard 自身が
+ * silent gap を持つ)。現時点で subdir に repo は 0 件なので取りこぼしは無いが、母数が閉じていない。
+ *
+ * 返す key は **backend dir からの相対パス (拡張子なし、区切りは `/`)**。top-level file では
+ * 従来の basename と一致するため registry の既存 key は不変。
+ */
+function listRepoFiles(dir: string, prefix = ''): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.isDirectory()) {
+			out.push(...listRepoFiles(join(dir, entry.name), `${prefix}${entry.name}/`));
+		} else if (entry.name.endsWith('-repo.ts')) {
+			out.push(`${prefix}${entry.name}`);
+		}
+	}
+	return out;
+}
+
+/** backend dir 配下の *-repo.ts から `<相対パス>:<fn>` の ForRestore 関数集合を抽出する。 */
 function scanRestoreFunctions(backend: Backend): Set<string> {
 	const dir = join(DB_DIR, backend);
 	const found = new Set<string>();
-	for (const file of readdirSync(dir)) {
-		if (!file.endsWith('-repo.ts')) continue;
+	for (const file of listRepoFiles(dir)) {
 		const source = readFileSync(join(dir, file), 'utf-8');
 		const basename = file.replace(/\.ts$/, '');
 		// sqlite/demo: `export async function xxxForRestore(` /
@@ -61,6 +82,19 @@ const GUARD_MARKERS: Record<Exclude<RestoreGuardImpl, 'none' | 'service-layer'>,
 };
 
 describe('#3394 restore-idempotency registry fitness (ADR-0061 same-class → guard)', () => {
+	// 母数が空だと「違反 0」ではなく「検査していない」(#4084 と同じ形)。walker が壊れて []
+	// を返したとき、no-silent-gap test は undeclared=[] / missing=全件 で落ちるが、**落ち方が
+	// 「registry の typo」に見えて原因を誤らせる**。母数を独立に固定して切り分けを速くする。
+	it('[母数] 全 backend で *-repo.ts が再帰走査で見つかっている', () => {
+		for (const backend of BACKENDS) {
+			const files = listRepoFiles(join(DB_DIR, backend));
+			expect(
+				files.length,
+				`${backend}/ の *-repo.ts が 0 件です。walker か dir 構成が壊れています`,
+			).toBeGreaterThan(0);
+		}
+	});
+
 	it('no-silent-gap: 全 backend の *ForRestore 関数が registry に分類されている (双方向一致)', () => {
 		const union = new Set<string>();
 		for (const backend of BACKENDS) {


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（guard の穴を塞ぐ）。**

`restore-idempotency-registry.test.ts` は「**no-silent-gap**」を名乗る fitness function です。3 backend の `*ForRestore` 関数が registry に全件分類されていることを検査し、分類漏れを CI で落とします。

**その guard 自身が silent gap を持っていました。** 走査が `readdirSync(dir)` の**非再帰**だったため、`src/lib/server/db/dsql/migration/` のようなサブディレクトリに `*-repo.ts` を置いた瞬間、**registry 未分類のまま緑で通ります**。

restore の冪等 guard は「**バックアップ復元でデータが二重に増えない**」ことを守る機構です。分類漏れが緑で通ると、guard 対称性検査 (`onConflictDoNothing` / `ON CONFLICT` の存在確認) も一緒にすり抜けます。

## 関連 Issue

<!-- no-issue-close: Issue #4030 本文が「1 PR にしない」と 3 分割を明示。本 PR は A-3 のみで、AC6 (orphan-utils の --update-baseline 自動投入理由の扱い) が未着手のため close しない -->

#4030（**本 PR は A-3 のみ**。上記のとおり close しません）

- PR #4040（merged、**A-1** = `check-orphan-repos.mjs` の母数）
- PR #4234（**A-2** = DSQL 系 3 guard の再帰化、QM レビュー待ち）
- PR #4237（**class B / AC5** = 除外理由の非空強制、QM レビュー待ち）
- #3394（本 guard の起票元）/ #3658（同じ gap を兄弟 guard で塞いだ先例）
- ADR-0061（same-class-N→guard）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 / AC2 | `check-orphan-repos.mjs` の母数 | — | **本 PR の scope 外**（PR #4040 で実施済） |
| **AC3** | class A の走査を再帰化する | `listRepoFiles` で再帰化 | ✅ `tests/unit/db/restore-idempotency-registry.test.ts` の `scanRestoreFunctions` |
| **AC4** | 再帰化で新規 violation が出ないことを確認する | 実行 | ✅ **5 passed**（`dsql/migration/` の既存 5 file はいずれも `*-repo.ts` ではないため検出増加なし） |
| AC5 | 除外理由の非空 assertion | — | **本 PR の scope 外**（PR #4237） |
| AC6 | `--update-baseline` の自動投入理由の扱い | — | ⚠️ **未着手**（判断が要る、#4237 の PO 決裁ブリーフで提起済） |
| **AC7** | 各修正に mutation 実出力を添える | 実測 | ✅ **3 方向**（取りこぼし / 母数崩壊 / **旧実装が緑になることの実証**） |
| **AC8** | `npm run pre-ready` 全 Step PASS | — | ✅ |

### 何を変えたか

- **`listRepoFiles(dir, prefix)` を追加**し、`readdirSync(..., { withFileTypes: true })` で subdir を再帰する
- key は **backend dir からの相対パス（拡張子なし、区切りは `/`）**。top-level file では従来の basename と一致するため **registry の既存 key は 1 件も変わりません**
- **母数 assertion を追加**（後述）

### 母数 assertion を足した理由

walker が壊れて `[]` を返したとき、no-silent-gap test は「undeclared=0 / missing=全件」で落ちます。**落ちますが、落ち方が「registry の typo」に見えて原因を誤らせます。** 母数を独立に固定して切り分けを速くしました（#4084 と同じ形）。

## 変更タイプ

- [x] テスト追加（guard の穴を塞ぐ）
- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

- **registry への影響**: **0 件**。`RESTORE_IDEMPOTENCY_REGISTRY` の key は 1 件も変えていません（top-level file の相対パス = 従来の basename）
- **検出件数の変化**: **0 件**。`dsql/migration/` には既に 5 file（`app-role.ts` / `async-index-poll.ts` / `provision.ts` / `runner.ts` / `transform.ts`）ありますが、いずれも `*-repo.ts` ではないため対象外です
- **`functionVicinity` の path 解決**: `join(DB_DIR, backend, `${repoFile}.ts`)` は相対パス（`migration/foo-repo`）でもそのまま解決できます
- **A-2（PR #4234）との重複**: なし。#4234 は `dsql-{append-only,mutation-count,tenant-predicate}` の 3 guard、本 PR は `restore-idempotency-registry` 1 本です
- **repo 走査宣言**: `check-repo-scan-test-declaration.mjs` OK（本 file は既に registry 登録済、区分変更なし）

## テスト・品質セルフチェック

```
npx vitest run tests/unit/db/restore-idempotency-registry.test.ts
      Tests  5 passed (5)

node scripts/check-repo-scan-test-declaration.mjs
 OK — repo 走査 test 40 件すべて区分宣言済
```

### mutation を 3 方向で実測しました（commit 後に実施）

1. **取りこぼし方向** — `dsql/migration/legacy-repo.ts` に未分類の `legacyThingForRestore` を置く
   → ✅ **red**: `+ "migration/legacy-repo:legacyThingForRestore"`（registry 未分類として検出）
2. **母数崩壊方向** — `listRepoFiles` を空返しにする
   → ✅ **red**: `sqlite/ の *-repo.ts が 0 件です。walker か dir 構成が壊れています`
3. **旧実装が緑になることの実証** — walker の再帰分岐だけを旧実装（非再帰）に戻し、同じ subdir file を置く
   → **5 passed（緑）**。**これが本 PR の存在理由です。** 未分類の restore 関数が subdir にあるだけで、guard が何も言わずに通っていました

### 作業中の事故と復旧（隠さず記載します）

mutation 3 の後片付けで `rm -rf src/lib/server/db/dsql/migration` を実行し、**実在する 5 file を消しました**（mutation 用に `mkdir -p` した dir が既存だったため）。`git stash push` → `drop` で即座に復元し、`git status` clean・全 test green を確認済みです。commit には含まれていません。

- [x] **mutation の前に commit した**
- [x] **3 方向を実測した**（取りこぼし / 母数崩壊 / 旧実装の緑）

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: fitness function (tests/unit/db/) の走査ロジック変更のみで、UI コンポーネントも routes も 1 行も触っていない。顧客に見える画面が存在しない。 -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **key を「相対パス」にしました。** top-level では従来と一致するため既存 registry は無変更ですが、**将来 subdir に repo を置いた場合、registry 側の key も `migration/foo-repo:fnName` になります**。これは意図した挙動です（同名 file が別 dir にあっても衝突しない）
2. **母数の下限を `> 0` にしています。** 「N 件以上」と固定値で縛る案もありますが、repo の増減で頻繁に更新が必要になるため採りませんでした

### 破壊的変更

**ありません。** 検出件数・registry key ともに現状不変です。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **旧実装が緑で通ることを実測して silent gap を証明した**
- [x] **母数 0 件で緑になる形を塞いだ**
- [x] **registry key が不変であることを確認した**
- [x] **作業中の誤削除と復旧を記載した**
- [x] Issue の分割方針に従い、A-1 / A-2 / class B を持ち込んでいない
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
