### PR TITLE
docs(process): #4212 AC1 subagent の model 指定の根拠を残す + @import 実測

### DIFF
--- a/docs/sessions/dev-session.md
+++ b/docs/sessions/dev-session.md
@@ -84,6 +84,24 @@ Plan agent が「重大」と判断した場合・判断に迷う場合は **直
 
 > **backlog 上位から何を今のレーンに取り込むかは Dev が決める。** PO は backlog の順序（何が次に価値が高いか）を示すが、着手順・WIP 配分・レーン割当への個別指示は出さない。決定権の境界は [チーム憲章 §4.2](README.md#42-実装に関する決定)。
 
+#### subagent の `model:` 指定 — なぜ Opus / Sonnet なのか（#4212 AC1）
+
+`.claude/agents/*.md` の frontmatter `model:` は **agent を spawn したときのモデル**を決める。**未指定は「設定漏れ」ではなく「親セッションのモデルを継承する」という意味**である（この区別が書かれていなかったため、PO が dev-session の未指定を漏れと誤読した、#4212）。
+
+| agent | `model:` | 根拠 |
+|---|---|---|
+| `po-session` / `qa-session` / `platform-session` | `sonnet` | 出力の主体が文章（Issue / レビュー所見 / 手順書）で、失敗しても PR が落ちるだけ。**やり直しが安い** |
+| `audit-manager` | 未指定（= Opus） | 統合 PR の approve / merge 判定と Issue 起票という**不可逆 side-effect** を専権で持つ（`docs/sessions/audit-team.md`）。判断を誤ったときの巻き戻しが高い |
+| `dev-session` | 未指定（= Opus） | 「CI / pre-hook を自己解決できる能力が Sonnet に無い」— **ただしこの結論は Sonnet 4.5 時点のもので、以後再検証していない**（下記） |
+
+**dev-session を sonnet に落としてよいかの判定基準**（#4212 AC1）:
+
+- **合格条件** = Sonnet subagent 1 本に実 Issue を 1 件通させ、**CI が落ちたところから自力で緑に戻せること**を 1 回確認する。落ちた検査の意味を読み違えず、テストの削除 / skip / assertion 弱体化（ADR-0006 違反）に逃げないことまで含めて見る
+- **不合格なら未指定（Opus）のまま据え置く**。据え置く場合も本表に「いつ・何で不合格だったか」を 1 行残す（同じ問いが再燃するため）
+- **判定できる材料が無い間は据え置きが既定**。「安いから」だけを根拠に落とさない
+
+**モデル割当は Dev の職掌**（実装レーンの資源配分、憲章 §4.2）。ただし `audit-manager` は監査の職掌のため Dev が単独で変更しない。
+
 #### 多観点セルフレビュー推奨フロー
 1. 主担当（Opus）が AC を満たす実装を完了
 2. カテゴリに応じた Agent / Gemini CLI でレビュー（**別 Issue でなく、本 Issue の別観点**）:


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（開発プロセスの記録）。**

`.claude/agents/*.md` の `model:` 未指定は「**設定漏れ**」ではなく「**親セッションのモデルを継承する**」という意味ですが、**その区別がどこにも書かれていませんでした**。結果として PO が `dev-session` の未指定を漏れと誤読しています（#4212 本文に記載）。

Issue が明示的に「**判定理由を `docs/sessions/dev-session.md` に残す**」と要求しているのは、この誤読を再発させないためです。

## 関連 Issue

<!-- no-issue-close: #4212 は AC1〜AC6 のうち AC2/AC3/AC4 が `/usage` `/context` という CLI slash command を要し、Dev セッション（私）から実行できない。AC1 の実験も substrate である #4197 が state:needs-po でブロック中。本 PR は AC1 の文書化部分のみ。 -->

#4212（**本 PR は AC1 の文書化部分のみ**。上記のとおり close しません）

- #4210（親）/ PR #4211（`model:` 指定、merged 2026-08-01）/ commit `302ef4b0`（`@import` 削減）
- #4197（AC1 の実験 substrate に指定されているが **`state:needs-po` でブロック中**）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| **AC1（前半）** | 判定理由を `dev-session.md` に残す | 実装 | ✅ `docs/sessions/dev-session.md` §「subagent の `model:` 指定」を追加 |
| **AC1（後半）** | Sonnet subagent で CI 自己解決を 1 回通し判定する | — | ❌ **実行できませんでした**（下記「なぜ実行できないか」） |
| AC2 | merge 前後で `/usage` の割合を記録 | — | ❌ **`/usage` は CLI slash command で私からは実行不可**。オーナー実施事項 |
| AC3 | 次セッション開始時に `/context` で system prompt サイズを記録 | 静的計測で代替 | ⚠️ **部分**（下記「実測できたこと」。`/context` の数値そのものは取得不可） |
| AC4 | subagent を 1 回 spawn し `/usage` で消費を確認 | — | ❌ **`/usage` 不可**。オーナー実施事項 |
| AC5 | `/compact` の代わりに `/rewind` を試す | — | ❌ **セッション運用のため私からは実行不可**。オーナー実施事項 |
| AC6 | セッションを Issue 単位で区切る | — | ❌ 同上 |

### AC1 後半が実行できない理由

Issue は「**#4197 を Sonnet subagent 1 本で実施**」と substrate を指定していますが、**#4197 は現在 `state:needs-po`** です（読み取り経路が存在せず、創業者経路には永続化が一切ない、という調査結果を前セッションで PO へ渡しました）。実装可能な状態にありません。

代替 substrate も見つかりませんでした。**「CI 自己解決」を測るには CI が赤い実 PR が要る**ため、レビュー待ち 16 PR 全てで `gh pr checks` を実測しましたが **fail=0**（全緑）です。

```
#4220 fail=0  #4222 fail=0  #4223 fail=0  #4225 fail=0  #4226 fail=0
#4228 fail=0  #4229 fail=0  #4230 fail=0  #4231 fail=0  #4232 fail=0
#4233 fail=0  #4234 fail=0  #4235 fail=0  #4236 fail=0
```

**CI 失敗を人為的に作って測るのは採りませんでした。** 人為的な失敗は「原因が既知」なので、測りたい能力（未知の失敗を読み解いて自力で緑に戻す）とは別物になります。加えて週間リミット 88% の状況で subagent を消費する根拠になりません。

## 実測できたこと（AC3 の代替、静的計測）

`/context` は使えませんが、**私自身の system prompt に実際に入っている @import の実体**は特定できます。これは Dev セッションからしか観測できない情報です。

### 常時ロードされている 5 ファイル（実測 154,741 bytes）

| ファイル | bytes |
|---|---|
| `docs/DESIGN.md` | 66,974 |
| `docs/decisions/README.md` | 42,373 |
| `docs/CLAUDE.md` | 18,542 |
| `docs/codebase-map.md` | 16,185 |
| `src/routes/CLAUDE.md` | 10,667 |
| **合計** | **154,741** |

### commit `302ef4b0` の削減は効いています（ただし残りの方が大きい）

外した 3 本は `CLAUDE.md` から `@import` が消えており（`grep -c` = 0）、私の context にも入っていません。

| 外したファイル | bytes | `@import` 残存 |
|---|---|---|
| `docs/design/asset-catalog.md` | 37,799 | 0 |
| `docs/reference/gemini_image_generation_guide.md` | 11,550 | 0 |
| `docs/sessions/agent-teams.md` | 14,764 | 0 |

**ただし外した 3 本（計 64,113 bytes）より、残っている `docs/DESIGN.md` 1 本（66,974 bytes）の方が大きいです。**

### 次に削れる候補（byte 実測付き）

**いずれも「repo が既に自分で決めているルール」に反している箇所**で、新しい方針を持ち込む必要がありません。

| 候補 | bytes | 既存ルールとの関係 |
|---|---|---|
| `docs/decisions/README.md` の §棚卸レポート 以降 | **16,254**（同ファイルの 38%） | `docs/CLAUDE.md` §docs SSOT 原則が「**変更履歴は git commit / PR description に置き docs 本文に書かない**」と明記。棚卸レポートは 2026-05-09 以降の履歴そのもの |
| `docs/DESIGN.md` の terms.ts 全 atom 列挙 | **6,894** | 同ファイル §12 が `labels.ts` について「**全列挙をミラーしない**（ADR-0045 補遺）」と決めているのに、`terms.ts` は全 atom がミラーされている |

**注**: Issue 本文の「19,610 tok」は PO 側の計測ツールによる値で、私は **bytes しか実測していません**。日本語 UTF-8 の byte→token 換算は文字種で大きくぶれるため、**両者を足し引きしないでください**。

## 変更タイプ

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント更新
- [ ] インフラ変更
- [ ] テスト追加

## 影響範囲・横展開チェック

- **`.claude/agents/*.md` は 1 文字も変更していません。** 本 PR は現状の根拠を記録するだけで、モデル割当を変えていません
- **`dev-session` は未指定（= Opus）のまま**です。判定材料（AC1 後半）が揃っていないため、据え置きが既定という方針も同時に明文化しました
- **`audit-manager`（Opus 維持）には触れていません** — 監査の職掌のため Dev が単独で変更しない旨を記載するに留めました
- cspell: **Issues found: 0**（1816 files）/ `check-doc-code-references`: **baseline 内、新規違反なし**

## テスト・品質セルフチェック

```
npm run cspell
 CSpell: Files checked: 1816, Issues found: 0 in 0 files.

node scripts/check-doc-code-references.mjs
 ✓ baseline 内 (128 件、53 ファイル)。新規違反なし。
```

**docs のみの変更のため、mutation 検証の対象がありません**（guard もコード経路も追加していない）。

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: docs/sessions/dev-session.md の 1 ファイルのみの変更で、UI コンポーネントも routes も 1 行も触っていない。顧客に見える画面が存在しない。 -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **`dev-session` を Opus 据え置きにしたことの是非。** 「安いから落とす」ではなく「判定材料が無いから据え置く」という判断です。**測らずに落とす方がリスクが高い**と考えました（CI 自己解決に失敗すると往復が増え、結果的に高くつく）
2. **判定基準に「ADR-0006 に逃げないこと」を含めました。** CI を緑にするだけなら test を消せば通るため、**通し方まで見ないと能力測定にならない**と判断しています

### 破壊的変更

**ありません。** 設定ファイルは無変更、記録の追加のみです。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **実行できない AC を「できない理由 + 誰の作業か」付きで明示した**（推測で埋めていません）
- [x] **AC1 の substrate 不在を実測で示した**（16 PR 全て CI fail=0）
- [x] **byte と token を混ぜないことを明記した**
- [x] `.claude/agents/*.md` を変更していないことを確認した
- [x] cspell / doc-code-references PASS

## QM レビュー結果

<!-- QM が記入 -->
