### PR TITLE
fix(docs): #4119 復元 runbook のバックアップ path に入った 0x08 を除去 + 制御文字混入 guard

### DIFF
--- a/docs/runbooks/pglite-restore-drill.md
+++ b/docs/runbooks/pglite-restore-drill.md
@@ -275,8 +275,8 @@ LAN 内の誰でも読める共有フォルダを退避先にしても、この�
 
 ```powershell
 # 1. NUC 側で最新世代のファイル名とサイズを確認する
-#    (HOST_BACKUP_DIR 未設定なら C:\Docker\ganbari-quest\dataackups)
-Get-ChildItem 'C:\Docker\ganbari-quest\dataackups' -Filter 'pglite-*.tgz' |
+#    (HOST_BACKUP_DIR 未設定なら C:\Docker\ganbari-quest\data\backups)
+Get-ChildItem 'C:\Docker\ganbari-quest\data\backups' -Filter 'pglite-*.tgz' |
   Sort-Object LastWriteTime -Descending | Select-Object -First 1 Name, Length
 ```
 

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -73,6 +73,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'src 配下の import 境界を走査する',
 	},
+	'tests/unit/architecture/no-stray-control-chars.test.ts': {
+		scope: 'repo',
+		note: '#4119 docs / src / scripts / tests のテキスト資産を byte 単位で走査し C0 制御文字の紛れ込みを検出する',
+	},
 	'tests/unit/architecture/dsql-txn-work-allowlist.test.ts': {
 		scope: 'repo',
 		note: 'src 配下の txn 内 work を走査する (ADR-0065)',

--- a/tests/unit/architecture/no-stray-control-chars.test.ts
+++ b/tests/unit/architecture/no-stray-control-chars.test.ts
@@ -1,0 +1,164 @@
+// cspell:ignore ackups
+//   `ackups` = 0x08 に食われた `backups` の残骸。**実際に file に入っていた壊れた綴り**を
+//   そのまま引用しないと「何が起きたか」が伝わらないため、綴りを直さず file scope で ignore する
+//   (global words に足すと他 file の typo が素通りする、tests/CLAUDE.md §負例 fixture と cspell)。
+// tests/unit/architecture/no-stray-control-chars.test.ts
+// #4119 — テキスト資産に紛れ込んだ C0 制御文字を止める。
+//
+// ## 何が起きたか
+//
+// `docs/runbooks/pglite-restore-drill.md` の復元 drill 手順に **0x08 (backspace)** が
+// 2 箇所紛れ込み、既定バックアップ先が
+//
+//     C:\Docker\ganbari-quest\data\backups   (正)
+//     C:\Docker\ganbari-quest\data<BS>ackups (実際に file に入っていたもの)
+//
+// になっていた。**片方は operator がそのまま貼り付けて実行する PowerShell コマンド**
+// (`Get-ChildItem '...'`) で、貼り付けても控えが見つからない。
+//
+// `\b` を含む path を shell 経由で書いたときに escape が解釈されると起きる。
+//
+// ## なぜ人のレビューで止まらないか
+//
+// **画面に出ない。** diff でも通常の表示でも `data\backups` と区別が付かず、
+// `cat -A` 等でバイトを見ない限り気付けない。人の注意力では原理的に落ちる class なので
+// 機械で止める (ADR-0061)。
+//
+// ## 何を許すか
+//
+// 制御文字を **意図して** 置いている箇所が 2 つある。どちらも「制御文字であること」自体が
+// 仕様なので、綴りを直すと意味が壊れる (`tests/CLAUDE.md` §負例 fixture と同じ形)。
+// 許可は file 単位で、**理由を機械検証する** (空 / 定型 stub / 極端な短文は弾く、#4237 と同型)。
+
+import { globSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+// repo 走査 test (#4085): 実行時間が repo の file 数に比例するため明示 timeout を置く。
+vi.setConfig({ testTimeout: 60_000 });
+
+const REPO_ROOT = join(__dirname, '../../..');
+
+/** 走査対象。人が読む / operator が貼り付けるテキスト資産。 */
+const GLOBS = [
+	'docs/**/*.md',
+	'*.md',
+	'src/**/*.{ts,svelte}',
+	'scripts/**/*.{mjs,cjs,js}',
+	'tests/**/*.ts',
+	'.env.example',
+	'docker-compose.yml',
+	'.github/workflows/*.yml',
+];
+
+/**
+ * C0 制御文字のうち、テキストとして正当なもの。
+ * tab (0x09) / LF (0x0a) / CR (0x0d) 以外は「紛れ込み」として扱う (deny by default)。
+ */
+const ALLOWED_CODES = new Set([0x09, 0x0a, 0x0d]);
+
+/** 制御文字を意図して置いている file。**理由は機械検証される**。 */
+const INTENTIONAL_CONTROL_CHARS: Record<string, string> = {
+	'src/lib/domain/export-migrations.ts':
+		'NUL (0x00) を childRef と loginDate の複合キー区切りに使う。両者に現れ得ない文字であることが分離の根拠',
+	'tests/unit/ui/error-notify.test.ts':
+		'sanitizeServerMessage が制御文字を空白化することの負例 fixture。実バイトで書かないと検査にならない',
+};
+
+const STUB_REASONS = ['todo', 'tbd', 'n/a', 'na', '-', '—', '未定', 'なし', '?', '??'];
+
+/** 理由として成立しているか。成立しない場合は理由文字列を返す。 */
+function findReasonDefect(reason: unknown): string | null {
+	if (typeof reason !== 'string') return `文字列ではありません (${typeof reason})`;
+	const trimmed = reason.trim();
+	if (trimmed.length === 0) return '空です';
+	if (STUB_REASONS.includes(trimmed.toLowerCase())) return `定型 stub です (「${trimmed}」)`;
+	if (trimmed.length < 8) return `短すぎます (${trimmed.length} 字)`;
+	return null;
+}
+
+function collectFiles(): string[] {
+	const seen = new Set<string>();
+	for (const g of GLOBS) {
+		for (const f of globSync(g, {
+			cwd: REPO_ROOT,
+			exclude: (p) => p.includes('node_modules') || p.includes('.svelte-kit'),
+		})) {
+			seen.add(f.replace(/\\/g, '/'));
+		}
+	}
+	return [...seen];
+}
+
+/** file 内の制御文字を `path:line (0xNN)` 形式で返す。 */
+function findControlChars(relPath: string): string[] {
+	let buf: Buffer;
+	try {
+		buf = readFileSync(join(REPO_ROOT, relPath));
+	} catch {
+		return [];
+	}
+	const out: string[] = [];
+	let line = 1;
+	for (const byte of buf) {
+		if (byte === 0x0a) {
+			line++;
+			continue;
+		}
+		if (byte < 0x20 && !ALLOWED_CODES.has(byte)) {
+			out.push(`${relPath}:${line} (0x${byte.toString(16).padStart(2, '0')})`);
+		}
+	}
+	return out;
+}
+
+describe('#4119 テキスト資産に C0 制御文字が紛れ込んでいないこと', () => {
+	const files = collectFiles();
+
+	// 母数が空なら「違反 0」ではなく「検査していない」(#4084 と同じ形)。
+	it('[母数] 走査対象が十分に集まっている', () => {
+		expect(files.length, 'glob が壊れて走査対象が集まっていません').toBeGreaterThan(100);
+	});
+
+	it('許可していない file に制御文字が無い', () => {
+		const violations: string[] = [];
+		for (const f of files) {
+			if (f in INTENTIONAL_CONTROL_CHARS) continue;
+			violations.push(...findControlChars(f));
+		}
+
+		expect(
+			violations,
+			'制御文字が紛れ込んでいます。**画面では通常の文字と区別が付きません**。\n' +
+				'`cat -A <file>` でバイトを確認してください。\n' +
+				'意図して置いているなら INTENTIONAL_CONTROL_CHARS に理由付きで登録してください',
+		).toEqual([]);
+	});
+
+	it('許可 entry の理由が空でも stub でもない', () => {
+		const entries = Object.entries(INTENTIONAL_CONTROL_CHARS);
+		expect(entries.length, '母数が空です').toBeGreaterThan(0);
+
+		const defects = entries
+			.map(([file, reason]) => {
+				const defect = findReasonDefect(reason);
+				return defect ? `${file}: ${defect}` : null;
+			})
+			.filter((v): v is string => v !== null);
+
+		expect(defects, '許可理由が実質空です。**なぜ制御文字が必要なのか**を書いてください').toEqual(
+			[],
+		);
+	});
+
+	it('許可 entry が stale でない (実際に制御文字を含んでいる)', () => {
+		// 制御文字が消えた file が許可に残り続けると、次に紛れ込んだとき素通りする。
+		const stale = Object.keys(INTENTIONAL_CONTROL_CHARS).filter(
+			(f) => findControlChars(f).length === 0,
+		);
+		expect(
+			stale,
+			'許可 entry の file に制御文字がありません。撤去済なら INTENTIONAL_CONTROL_CHARS から外してください',
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**復元 runbook に載っている PowerShell コマンドが、貼り付けても控えを見つけられない状態でした。**

`docs/runbooks/pglite-restore-drill.md` の 2 行に **0x08 (backspace)** が紛れ込み、既定バックアップ先が

```
C:\Docker\ganbari-quest\data\backups     ← 正しい
C:\Docker\ganbari-quest\data<BS>ackups   ← 実際に file に入っていたバイト列
```

になっていました。**片方は operator がそのまま貼り付けて実行する `Get-ChildItem '...'`** です。

これは EPIC #4119（データを失わない）の完了定義「本番実機で取得 → 退避 → **復元**が 1 サイクル通る」の直下にある手順書で、**復元しようとした瞬間に詰まる**箇所です。

## 関連 Issue

<!-- no-issue-close: EPIC #4119 は着手順 0 (本番 NUC の backup 機構是正) / 3 (#4087 失敗通知) / 4 (#3964 実機 1 サイクル) が未了。本 PR は runbook の 1 defect 修正 + guard のみで EPIC の完了定義を満たさない -->

EPIC #4119（**本 PR は runbook の defect 1 件 + guard のみ**。上記のとおり close しません）

- #4129（着手順 1、CLOSED）/ #4087（着手順 3、`state:dev-done`）/ #3964（着手順 4、CLOSED）
- #4237（除外理由の非空強制。本 PR の許可理由検証は同型）
- ADR-0061（same-class → guard）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 復元 runbook の path が operator の貼り付けで通る形になっている | byte 実測 | ✅ `0x08` = **2 → 0**。`git diff` で該当 2 行のみ変更 |
| AC2 | 同じ紛れ込みが再発したら CI で止まる | fitness function | ✅ `tests/unit/architecture/no-stray-control-chars.test.ts`（byte 単位走査） |
| AC3 | 意図的な制御文字を壊さない | 許可 + 理由の機械検証 | ✅ 2 件を理由付きで許可。理由の空 / stub / 短文は弾く（#4237 と同型） |
| AC4 | 許可が stale になったら検出する | assertion | ✅ 「許可 file に制御文字が無い」なら fail |
| AC5 | failing-test-first で示す | 実測 | ✅ **guard を先に書き、修正前に red を確認してから修正**（下記） |
| AC6 | mutation で壊して red を実測する | 実測 | ✅ **3 方向**（紛れ込み / 理由空 / stale） |
| AC7 | `npm run pre-ready` 全 Step PASS | — | ✅ |

## 変更タイプ

- [x] バグ修正（operator 向け手順書の実害）
- [x] テスト追加（guard）
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

### repo 全体を byte 走査した結果、制御文字は 3 file

| file | 制御文字 | 判定 |
|---|---|---|
| `docs/runbooks/pglite-restore-drill.md` | `0x08` × 2 | **defect**（本 PR で修正） |
| `src/lib/domain/export-migrations.ts` | `0x00` × 2 | **意図的** — `childRef` と `loginDate` の複合キー区切り |
| `tests/unit/ui/error-notify.test.ts` | `0x00` / `0x07` / `0x1f` | **意図的** — sanitize の負例 fixture（実バイトで書かないと検査にならない） |

**意図的な 2 件は綴りを直しません。** 直すと negative case が成立しなくなります（`tests/CLAUDE.md` §負例 fixture と同じ形）。許可は file 単位 + 理由の機械検証付きにしました。

### なぜ人のレビューで止まらないか

**画面に出ません。** diff でも通常表示でも `data\backups` と区別が付かず、`cat -A` 等でバイトを見ない限り気付けません。**人の注意力では原理的に落ちる class** なので機械で止めます（ADR-0061）。

### その他

- **cspell**: 壊れた綴り `ackups` を引用する必要があるため file scope `// cspell:ignore` + 理由コメント（global words には足さない、`tests/CLAUDE.md` 準拠）
- **repo 走査宣言**: `scripts/lib/ci/repo-scan-test-registry.mjs` に `scope: 'repo'` + 明示 timeout 60s で登録済（gate OK、41 件）
- **他の runbook**: 走査対象に `docs/**/*.md` 全件を含めており、他 file に制御文字はありませんでした

## テスト・品質セルフチェック

```
npx vitest run tests/unit/architecture/
 Test Files  35 passed (35)
      Tests  278 passed (278)

npm run cspell
 CSpell: Files checked: 1817, Issues found: 0 in 0 files.

node scripts/check-repo-scan-test-declaration.mjs
 OK — repo 走査 test 41 件すべて区分宣言済
```

### failing-test-first（guard を先に書いて red を実測）

修正**前**に guard だけを走らせ、実 defect で落ちることを確認しました。

```
docs/runbooks/pglite-restore-drill.md:278 (0x08)
docs/runbooks/pglite-restore-drill.md:279 (0x08)
      Tests  1 failed | 3 passed (4)
```

修正後 **4 passed**。

### mutation を 3 方向で実測（commit 後に `git stash` で退避）

1. **紛れ込み方向** — 修正した path に `0x08` を戻す → ✅ **red**: `docs/runbooks/pglite-restore-drill.md:14 (0x08)`
2. **理由が空** — 許可 entry の理由を `''` に → ✅ **red**: `tests/unit/ui/error-notify.test.ts: 空です`
3. **stale 方向** — 制御文字を持たない `docs/CLAUDE.md` を許可に追加 → ✅ **red**: `許可 entry の file に制御文字がありません`

**3 つ目が重要です。** 許可 entry が stale のまま残ると、次に同じ file へ紛れ込んだとき素通りします。

- [x] **mutation の前に commit した**
- [x] **guard を先に書き、修正前 red → 修正後 green を実測した**

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: 変更は runbook の markdown 2 行と tests/ の guard 追加のみ。UI コンポーネントも routes も 1 行も触っていないため、顧客に見える画面が存在しない。 -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **走査対象 glob の範囲**（`docs` / `src` / `scripts` / `tests` / `.env.example` / `docker-compose.yml` / workflows）。`site/` の LP HTML と `infra/` は入れていません。**必要なら足せます**が、まずは「人が読む / operator が貼り付ける」資産に絞りました
2. **許可を file 単位にしました。** 行単位の方が精密ですが、行番号は編集で動くため stale 化しやすいと判断しています

### 破壊的変更

**ありません。** 修正したのは壊れていた path 2 箇所のみで、意図的な制御文字は 1 バイトも触っていません。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **operator が貼り付けるコマンドが直っていることを byte で確認した**
- [x] **failing-test-first（guard 先行 → 修正前 red）**
- [x] **mutation 3 方向を実測した**
- [x] **意図的な制御文字を壊していないことを確認した**
- [x] **cspell を global words で回避せず file scope に閉じた**
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
