### PR TITLE
feat(infra): #4189 CloudWatch アラームの宛先を Discord に寄せる（既定は鳴らさない opt-in、案 B）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -464,6 +464,43 @@ jobs:
             exit 1
           fi
 
+      # #4189 (オーナー決裁 2026-08-03、案 B): CloudWatch アラームの宛先を Discord に寄せた。
+      # **メール subscription を張らなくなった**ため、転送 Lambda が繋がっていなければ
+      # 全 alarm が宛先ゼロに戻る (#4189 の再演)。deploy 後に**実物**を 2 点見る。
+      #
+      #   1. SNS topic に subscription が 1 件以上ある (protocol=lambda)
+      #   2. 転送 Lambda の実 env に DISCORD_WEBHOOK_INCIDENT がある
+      #
+      # 「synth では繋がっているが実環境では届かない」を検出するのが目的なので、
+      # template ではなく **deploy 済みリソース**を問い合わせる。
+      - name: Ops alarm destination verification (production, #4189)
+        run: |
+          TOPIC_ARN=$(aws sns list-topics --region "$AWS_REGION" \
+            --query "Topics[?ends_with(TopicArn, ':ganbari-quest-ops-alerts')].TopicArn | [0]" \
+            --output text)
+          if [ -z "$TOPIC_ARN" ] || [ "$TOPIC_ARN" = "None" ]; then
+            echo "::error::SNS topic 'ganbari-quest-ops-alerts' が見つかりません (#4189)"
+            exit 1
+          fi
+          SUB_COUNT=$(aws sns list-subscriptions-by-topic --topic-arn "$TOPIC_ARN" \
+            --region "$AWS_REGION" \
+            --query "length(Subscriptions[?Protocol=='lambda'])" --output text)
+          if [ "$SUB_COUNT" = "0" ] || [ -z "$SUB_COUNT" ]; then
+            echo "::error::ops-alerts topic に lambda subscription が 0 件です。CloudWatch アラームが鳴っても誰にも届きません (#4189)"
+            exit 1
+          fi
+          echo "::notice::ops-alerts topic に lambda subscription が ${SUB_COUNT} 件あります (#4189)"
+
+          FWD_KEYS=$(aws lambda get-function-configuration \
+            --function-name ganbari-quest-ops-alert-forwarder --region "$AWS_REGION" \
+            --query 'keys(Environment.Variables)' --output text | tr '\t' '\n')
+          if echo "$FWD_KEYS" | grep -qx "DISCORD_WEBHOOK_INCIDENT"; then
+            echo "::notice::転送 Lambda の実 env に DISCORD_WEBHOOK_INCIDENT があります (#4189)"
+          else
+            echo "::error::転送 Lambda に DISCORD_WEBHOOK_INCIDENT がありません。alarm は SNS までは届きますが Discord には出ません (#4189)"
+            exit 1
+          fi
+
       # ADR-0048 hotfix #6 (2026-05-16): demo Lambda は `latest` タグで CDK 管理されるため
       # CloudFormation が新しい image push を検知できない (production と同じ問題)。
       # production と同じく aws lambda update-function-code で SHA タグ image に明示更新する。

--- a/docs/runbooks/ops-alert-notification.md
+++ b/docs/runbooks/ops-alert-notification.md
@@ -1,0 +1,112 @@
+# CloudWatch アラートの通知運用（Discord）
+
+| 項目 | 内容 |
+|---|---|
+| SSOT 対象 | どの alarm を Discord に出すか / 昇格・降格の手順 |
+| 方針表 | `infra/lib/ops-alert-policy.ts` |
+| 転送実装 | `infra/lambda/ops-alert-forwarder/index.ts` |
+| 関連 Issue | #4189（オーナー決裁 2026-08-03、案 B）/ #4174 / #4119 |
+
+---
+
+## 1. 設計背景
+
+### 課題
+
+本番の CloudWatch アラームは **宛先が 0 件**だった（SNS topic に subscription が無く、鳴っても誰にも届かない）。同型の欠陥が #4119（NUC バックアップが 18 晩失敗しても通知 0 通）/ #4174（Lambda incident 通知 0 通）でも起きている。
+
+### この運用がないと何が困るか
+
+宛先を繋ぐだけだと、今度は**逆の失敗**が起きる。閾値の妥当性を検証していない alarm を一斉に鳴らすと、平常時から通知が流れ続け、**本物の障害が同じ見た目で埋もれる**。「アラートが常態化していると見逃しかねない」（オーナー、2026-08-03）。
+
+---
+
+## 2. 設計原則
+
+**通知は opt-in。既定は鳴らさない。**
+
+| 状態 | CloudWatch | Discord |
+|---|---|---|
+| `notify: false`（既定） | alarm として存在し、コンソール / メトリクスで見える | **出さない**（転送 Lambda の log に「抑止した」と残る） |
+| `notify: true` | 同上 | 出す |
+
+**`notify: true` に上げてよいのは、その alarm が「実際に鳴って有効だった」実績が付いたときだけ。** 実績は `reason` に書く（いつ・何を検知したか）。
+
+**staging には alarm を作らない。** stg のノイズが本番と同じ経路で流れると、本番の異常が埋もれる。staging に監視を入れる場合は **別 topic / 別 webhook** にする。
+
+---
+
+## 3. 昇格の手順（`notify: false` → `true`）
+
+1. **平常時の発火回数を見る**
+   ```bash
+   aws cloudwatch describe-alarm-history \
+     --alarm-name <alarm 名> --history-item-type StateUpdate \
+     --start-date "$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ)" \
+     --region us-east-1 --query 'AlarmHistoryItems[].Timestamp'
+   ```
+   **平常時に鳴っているなら昇格しない。** 先に閾値を直す（それが「効果的」ということ）。
+
+2. **`infra/lib/ops-alert-policy.ts` を書き換える**
+   ```ts
+   'ganbari-quest-lambda-url-5xx': {
+     notify: true,
+     reason: '2026-09-12 の Lambda 障害で 1 回だけ発火し、平常 30 日間の発火 0 件を確認済み',
+   },
+   ```
+   **`reason` に「いつ・何を検知したか」を書く。** 空 / 定型 stub / 極端な短文は CI が弾く。
+
+3. **`tests/unit/infra/ops-alert-policy.test.ts` の「既定は鳴らさない」assertion を更新する**
+
+   現在は `notify: true` が 0 件であることを固定している。昇格したら期待値に alarm 名を足す。**assertion を消さない**（消すと次の昇格が無検証で通る）。
+
+4. **PR を出して deploy する。** 転送 Lambda に方針表が bundle されるため、**deploy しないと反映されない**。
+
+## 4. 降格の手順（`notify: true` → `false`）
+
+鳴りすぎて見なくなったら**降格させる**。放置して「見ない通知」を増やすより良い。手順は昇格と同じで、`reason` に「いつ・何回鳴って実用にならなかったか」を書く。
+
+---
+
+## 5. 宛先が壊れていないかの確認
+
+deploy のたびに `.github/workflows/deploy.yml` の **"Ops alarm destination verification"** が実物を 2 点見る。
+
+1. SNS topic `ganbari-quest-ops-alerts` に **lambda subscription が 1 件以上**
+2. **転送 Lambda の実 env** に `DISCORD_WEBHOOK_INCIDENT`
+
+どちらも欠けていれば deploy を止める。手で確認する場合:
+
+```bash
+TOPIC_ARN=$(aws sns list-topics --region us-east-1 \
+  --query "Topics[?ends_with(TopicArn, ':ganbari-quest-ops-alerts')].TopicArn | [0]" --output text)
+aws sns list-subscriptions-by-topic --topic-arn "$TOPIC_ARN" --region us-east-1 \
+  --query 'Subscriptions[].{Protocol:Protocol,Endpoint:Endpoint}'
+
+aws lambda get-function-configuration \
+  --function-name ganbari-quest-ops-alert-forwarder --region us-east-1 \
+  --query 'keys(Environment.Variables)'
+```
+
+## 6. 通知が来ないときの切り分け
+
+| 症状 | 見る場所 |
+|---|---|
+| alarm は ALARM だが Discord に出ない | 転送 Lambda の log。`suppressed alarm=...` があれば **仕様どおり抑止**（方針表が `notify: false`） |
+| log に `DISCORD_WEBHOOK_INCIDENT が未設定` | secret が未登録。deploy gate をすり抜けている（gate 自体を疑う） |
+| log が 1 行も無い | SNS subscription が無い。上記 §5 を確認 |
+
+**「通知が来ない」と「抑止した」は log で区別できる。** 転送 Lambda は抑止したことも必ず残す。
+
+---
+
+## 7. 環境変数
+
+| env | 用途 |
+|---|---|
+| `DISCORD_WEBHOOK_INCIDENT` | **本 runbook の対象**。CloudWatch アラーム + アプリ Lambda の incident |
+| `DISCORD_WEBHOOK_HEALTH` | ヘルスチェック Lambda（1 時間毎の外形監視） |
+| `DISCORD_WEBHOOK_SUPPORT` | 問い合わせ受信 |
+| `DISCORD_ALERT_WEBHOOK_URL` | NUC セルフホスト側（バックアップ失敗等）。`.env` に置く |
+
+`opsEmail` は **本 topic では使わない**。AWS Budgets が EMAIL 固定の仕様のため、DsqlStack のコスト通知にのみ残る。

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -110,6 +110,10 @@ new OpsStack(app, `${appName}Ops`, {
 	appLogGroup: compute.appLogGroup,
 	opsEmail,
 	discordWebhookHealth,
+	// #4189: CloudWatch アラームの転送先 (オーナー決裁 2026-08-03、案 B)。
+	// **メール subscription はもう張らない**ため、これが空だと alarm が鳴っても誰にも届かない。
+	// deploy.yml 側で空を検出して deploy を止める。
+	discordWebhookIncident: app.node.tryGetContext('discordWebhookIncident') as string | undefined,
 });
 
 // --- DSQL stack (EPIC #3424 M4-E item 12 / #3429 #3431 #3432) ---

--- a/infra/lambda/ops-alert-forwarder/index.ts
+++ b/infra/lambda/ops-alert-forwarder/index.ts
@@ -1,0 +1,169 @@
+/**
+ * infra/lambda/ops-alert-forwarder/index.ts
+ *
+ * #4189 — SNS topic `ganbari-quest-ops-alerts` に届いた CloudWatch アラームを Discord へ転送する。
+ *
+ * ## なぜ Lambda を挟むのか（オーナー決裁 2026-08-03、案 B）
+ *
+ * メール subscription をやめ Discord に寄せる。ただし
+ *
+ * > 本番のアラートが常態化していると見逃しかねないので、通知予測として十分効果的で
+ * > あることが認められてから届くように
+ *
+ * という制約があるため、**alarm 単位で「出す / 出さない」を判定する層**が要る。
+ * SNS の subscription filter でも近いことはできるが、判定根拠（なぜ鳴らさないのか）を
+ * コードに残せないため、方針表 (`ops-alert-policy.ts`) を読む Lambda を挟む。
+ *
+ * ## 落とした通知は「消える」のではなく log に残る
+ *
+ * `notify: false` の alarm も **CloudWatch 上には alarm として存在し**、本 Lambda の
+ * log にも「抑止した」ことが残る。誰にも見えない場所に消えるわけではない。
+ */
+
+import * as http from 'node:http';
+import * as https from 'node:https';
+import { shouldNotifyToDiscord } from '../../lib/ops-alert-policy';
+
+const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_INCIDENT ?? '';
+
+/** SNS が CloudWatch alarm を配送するときの payload（必要な項目のみ）。 */
+interface CloudWatchAlarmMessage {
+	AlarmName?: string;
+	AlarmDescription?: string | null;
+	NewStateValue?: string;
+	NewStateReason?: string;
+	StateChangeTime?: string;
+	Region?: string;
+}
+
+interface SnsEventRecord {
+	Sns?: { Message?: string; Subject?: string | null };
+}
+
+interface SnsEvent {
+	Records?: SnsEventRecord[];
+}
+
+/** ALARM = 赤 / OK = 緑 / それ以外 = 灰。 */
+function colorFor(state: string | undefined): number {
+	if (state === 'ALARM') return 0xdc2626;
+	if (state === 'OK') return 0x16a34a;
+	return 0x9ca3af;
+}
+
+export async function handler(event: SnsEvent): Promise<void> {
+	const records = event.Records ?? [];
+
+	for (const record of records) {
+		const raw = record.Sns?.Message;
+		if (!raw) {
+			console.warn('[ops-alert] SNS message が空です (skip)');
+			continue;
+		}
+
+		let message: CloudWatchAlarmMessage;
+		try {
+			message = JSON.parse(raw) as CloudWatchAlarmMessage;
+		} catch {
+			// CloudWatch alarm 以外 (AWS Health event 等) も同 topic に来る。
+			// 判定できないものは **落とさず** 転送する (未知を握り潰さない)。
+			await postDiscordEmbed({
+				title: '運用通知',
+				description: raw.slice(0, 1800),
+				color: colorFor(undefined),
+			});
+			continue;
+		}
+
+		const alarmName = message.AlarmName;
+		if (!alarmName) {
+			console.warn('[ops-alert] AlarmName が無い message (skip せず転送)');
+			await postDiscordEmbed({
+				title: '運用通知',
+				description: raw.slice(0, 1800),
+				color: colorFor(undefined),
+			});
+			continue;
+		}
+
+		if (!shouldNotifyToDiscord(alarmName)) {
+			// **抑止したことを log に残す** — 「通知が来ない」と「抑止した」を区別できるようにする。
+			console.log(
+				`[ops-alert] suppressed alarm=${alarmName} state=${message.NewStateValue ?? '?'} ` +
+					'(ops-alert-policy.ts で notify: false。実績が付いたら昇格させる)',
+			);
+			continue;
+		}
+
+		await postDiscordEmbed({
+			title: `${message.NewStateValue === 'OK' ? '復旧' : '異常'}: ${alarmName}`,
+			description: message.NewStateReason?.slice(0, 1800) ?? '(理由なし)',
+			color: colorFor(message.NewStateValue),
+			fields: [
+				{ name: 'リージョン', value: message.Region ?? '-', inline: true },
+				{ name: '発生時刻', value: message.StateChangeTime ?? '-', inline: true },
+			],
+		});
+	}
+}
+
+async function postDiscordEmbed(embed: object): Promise<void> {
+	if (!DISCORD_WEBHOOK_URL) {
+		// ここに来るのは deploy gate をすり抜けた場合のみ。**握り潰さず error で残す**
+		// (#4119 / #4174 の「通知経路はあるのに 0 通」を再演しない)。
+		console.error('[ops-alert] DISCORD_WEBHOOK_INCIDENT が未設定のため通知できません');
+		return;
+	}
+
+	try {
+		const payload = JSON.stringify({ embeds: [embed] });
+
+		await new Promise<void>((resolve) => {
+			const url = new URL(DISCORD_WEBHOOK_URL);
+			const isHttps = url.protocol === 'https:';
+			const client = isHttps ? https : http;
+			const options: https.RequestOptions = {
+				hostname: url.hostname,
+				port: url.port ? Number(url.port) : isHttps ? 443 : 80,
+				path: url.pathname + url.search,
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Content-Length': Buffer.byteLength(payload),
+				},
+				timeout: 5_000,
+			};
+
+			const req = client.request(options, (res) => {
+				let body = '';
+				res.on('data', (chunk: Buffer) => {
+					body += chunk.toString();
+				});
+				res.on('end', () => {
+					if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+						resolve();
+					} else {
+						console.error('[ops-alert] Discord webhook failed:', res.statusCode, body);
+						resolve(); // 通知失敗で Lambda を落とさない
+					}
+				});
+			});
+
+			req.on('timeout', () => {
+				req.destroy();
+				console.error('[ops-alert] Discord webhook timed out');
+				resolve();
+			});
+
+			req.on('error', (err) => {
+				console.error('[ops-alert] Discord webhook error:', err);
+				resolve();
+			});
+
+			req.write(payload);
+			req.end();
+		});
+	} catch (e) {
+		console.error('[ops-alert] Discord notification error:', e);
+	}
+}

--- a/infra/lib/ops-alert-policy.ts
+++ b/infra/lib/ops-alert-policy.ts
@@ -1,0 +1,98 @@
+// infra/lib/ops-alert-policy.ts
+// #4189 — CloudWatch アラームを Discord に出すかどうかの SSOT。
+//
+// ## なぜ「既定で鳴らさない」のか（オーナー決裁 2026-08-03、案 B の制約 ②）
+//
+// > 本番のアラートが常態化していると見逃しかねないので、通知予測として十分効果的で
+// > あることが認められてから届くように設定しましょうね
+//
+// 鳴りっぱなしの通知は「見ない通知」になり、**本物の障害が同じ見た目で埋もれる**。
+// そこで通知は **opt-in** にする。
+//
+//   - `notify: false` … CloudWatch 上には alarm として存在し、コンソール / メトリクスでは見える。
+//                       **Discord には出さない**（既定）
+//   - `notify: true`  … Discord に出す。**「実際に鳴らして有効だった」根拠を reason に書く**
+//
+// 昇格の手順は `docs/runbooks/ops-alert-notification.md` を参照。
+//
+// ## no-silent-gap
+//
+// OpsStack が作る alarm は**全件がこの表に載っていなければならない**。
+// 載っていない alarm が増えたら `tests/unit/infra/ops-alert-policy.test.ts` が fail する
+// （宣言を忘れた alarm が「既定で鳴らない」まま誰にも気付かれずに埋もれるのを防ぐ）。
+
+/** alarm 1 件の通知方針。 */
+export interface AlarmNotifyPolicy {
+	/** Discord に出すか。**既定は false**（有効性が確認できたものだけ true に上げる）。 */
+	notify: boolean;
+	/**
+	 * なぜその判断なのか。
+	 *
+	 * - `notify: false` … まだ実績が無い / ノイズが想定される、など**現時点で鳴らさない理由**
+	 * - `notify: true`  … **鳴らして有効だった根拠**（いつ・何を検知したか）
+	 *
+	 * 空 / 定型 stub / 極端な短文は CI で弾く（#4237 と同型）。
+	 */
+	reason: string;
+}
+
+/**
+ * alarm 名 → 通知方針。**alarm を追加したらここにも 1 行足す**（忘れると CI が落ちる）。
+ *
+ * 初期値は **全件 `notify: false`**。本番で 1 サイクル観測し、
+ * 「鳴った / 鳴らなかった」の実績が付いたものから `true` に上げる。
+ */
+export const ALARM_NOTIFY_POLICY: Record<string, AlarmNotifyPolicy> = {
+	'ganbari-quest-lambda-errors': {
+		notify: false,
+		reason:
+			'本番稼働の実績が無く、平常時に何回鳴るかを観測していない。1 サイクル観測してから昇格する',
+	},
+	'ganbari-quest-lambda-throttles': {
+		notify: false,
+		reason: '同時実行 50 に対して throttle 1 回で発火する。平常時のバースト頻度が未計測',
+	},
+	'ganbari-quest-lambda-duration-p99': {
+		notify: false,
+		reason: 'cold start を含む p99 10 秒。SSR 初回アクセスで日常的に超える可能性があり未検証',
+	},
+	'ganbari-quest-lambda-concurrent': {
+		notify: false,
+		reason: '同時実行 50 は現在の利用規模では到達しない想定。到達時のみ意味を持つため実績待ち',
+	},
+	'ganbari-quest-lambda-url-5xx': {
+		notify: false,
+		reason:
+			'5xx は本来鳴らすべき筆頭だが、平常時の 0 件を先に確認しないと閾値 5 の妥当性が判断できない',
+	},
+	'ganbari-quest-lambda-url-4xx-spike': {
+		notify: false,
+		reason: '4xx は bot / 未認証アクセスで日常的に出る。閾値 50 が実トラフィックで妥当か未計測',
+	},
+	'ganbari-quest-cloudfront-5xx': {
+		notify: false,
+		reason: 'geoRestriction(JP) 外からのアクセスが 4xx/5xx に混ざる。平常値の観測が先',
+	},
+	'ganbari-quest-auth-entitlement-db-unavailable': {
+		notify: false,
+		reason:
+			'log MetricFilter 由来で平常時はデータ点が無い。fail-closed の実発火を 1 度も観測していない',
+	},
+	'ganbari-quest-cron-dispatcher-errors': {
+		notify: false,
+		reason: 'cron 失敗は顧客影響が出るまで時間差がある。まず失敗頻度の実績を取る',
+	},
+	'ganbari-quest-static-assets-s3-4xx': {
+		notify: false,
+		reason: 'S3 origin offload 有効時のみ生成される。offload 自体が本番未適用で実績ゼロ',
+	},
+	'ganbari-quest-static-assets-s3-5xx': {
+		notify: false,
+		reason: '同上。S3 origin offload が本番未適用のため観測データが無い',
+	},
+};
+
+/** Discord に出す alarm かどうかを判定する（未宣言は「出さない」に倒す = fail-safe）。 */
+export function shouldNotifyToDiscord(alarmName: string): boolean {
+	return ALARM_NOTIFY_POLICY[alarmName]?.notify === true;
+}

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -40,6 +40,11 @@ export interface OpsStackProps extends cdk.StackProps {
 	appLogGroup?: logs.ILogGroup;
 	opsEmail?: string;
 	discordWebhookHealth?: string;
+	/**
+	 * #4189: CloudWatch アラームの転送先 Discord webhook。
+	 * 空だと転送 Lambda が error log を残す（deploy 側の gate で空を落とす）。
+	 */
+	discordWebhookIncident?: string;
 }
 
 /**
@@ -68,9 +73,43 @@ export class OpsStack extends cdk.Stack {
 			displayName: 'がんばりクエスト 運用通知',
 		});
 
-		if (opsEmail) {
-			opsTopic.addSubscription(new subscriptions.EmailSubscription(opsEmail));
-		}
+		// #4189 (オーナー決裁 2026-08-03、案 B): 宛先は **Discord に寄せる**。メール
+		// subscription は張らない。転送は下記 OpsAlertForwarder が担い、alarm ごとに
+		// 出す / 出さないを `ops-alert-policy.ts` で判定する（既定は出さない）。
+		//
+		// `opsEmail` は DsqlStack の Budget 通知（EMAIL 固定の AWS 仕様）でまだ使うため
+		// props 自体は残すが、**本 topic には subscribe しない**。
+		void opsEmail;
+
+		const discordWebhookIncident =
+			props.discordWebhookIncident ??
+			(this.node.tryGetContext('discordWebhookIncident') as string | undefined) ??
+			'';
+
+		const opsAlertForwarderLogGroup = new logs.LogGroup(this, 'OpsAlertForwarderLogGroup', {
+			logGroupName: '/aws/lambda/ganbari-quest-ops-alert-forwarder',
+			retention: logs.RetentionDays.TWO_WEEKS,
+			removalPolicy: cdk.RemovalPolicy.DESTROY,
+		});
+
+		const opsAlertForwarder = new lambdaNode.NodejsFunction(this, 'OpsAlertForwarder', {
+			functionName: 'ganbari-quest-ops-alert-forwarder',
+			entry: path.join(__dirname, '..', 'lambda', 'ops-alert-forwarder', 'index.ts'),
+			handler: 'handler',
+			runtime: lambda.Runtime.NODEJS_22_X,
+			architecture: lambda.Architecture.ARM_64,
+			memorySize: 128,
+			timeout: cdk.Duration.seconds(15),
+			environment: {
+				// 未設定なら Lambda 側が error log を残す (silent skip しない、ADR-0024 ルール 1)。
+				// deploy 側は `.github/workflows/deploy.yml` が空を検出して落とす。
+				...(discordWebhookIncident ? { DISCORD_WEBHOOK_INCIDENT: discordWebhookIncident } : {}),
+			},
+			bundling: { minify: true, sourceMap: false },
+		});
+		opsAlertForwarder.node.addDependency(opsAlertForwarderLogGroup);
+
+		opsTopic.addSubscription(new subscriptions.LambdaSubscription(opsAlertForwarder));
 
 		const alarmAction = new cw_actions.SnsAction(opsTopic);
 

--- a/tests/unit/infra/ops-alert-destination.test.ts
+++ b/tests/unit/infra/ops-alert-destination.test.ts
@@ -1,0 +1,158 @@
+// tests/unit/infra/ops-alert-destination.test.ts
+// #4189 — CloudWatch アラームの宛先が「メール」から「Discord 転送 Lambda」に移ったことを固定する。
+//
+// ## なぜ test で押さえるか
+//
+// #4189 の実害は「**alarm は存在するのに宛先が 0 件**」だった。宛先の付け替えは
+// 目視では確認しづらく（synth 結果を人が読む必要がある）、退行しても alarm は
+// 作られ続けるため**画面上は何も壊れて見えない**。以下 3 点を機械で固定する。
+//
+//   1. topic に **email subscription を張らない**（案 B: メールはやめる）
+//   2. topic に **lambda subscription が 1 件ある**（宛先ゼロに戻らない）
+//   3. **staging に alarm を作らない**（オーナー決裁の制約 ①: stg のノイズで本番を見落とさない）
+//
+// deploy 済みの実環境検証は `.github/workflows/deploy.yml` の
+// "Ops alarm destination verification" が担う（synth と実物の両輪）。
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { OpsStack } from '../../../infra/lib/ops-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+// cspell:ignore TESTPOOL
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+function makeApp(): cdk.App {
+	return new cdk.App({
+		context: {
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+		},
+	});
+}
+
+/** opsEmail を **あえて渡して** も email subscription が作られないことを見る。 */
+function buildOpsTemplate(sourceDir: string): Template {
+	const app = makeApp();
+	const storage = new StorageStack(app, 'TestStorage', { env });
+	const compute = new ComputeStack(app, 'TestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'TestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+		staticAssetsS3Offload: true,
+		staticAssetsSourceDir: sourceDir,
+	});
+	const ops = new OpsStack(app, 'TestOps', {
+		env,
+		lambdaFn: compute.fn,
+		distribution: network.distribution,
+		functionUrl: compute.functionUrl,
+		cronDispatcherFn: compute.cronDispatcherFn,
+		staticAssetsBucket: network.staticAssetsBucket,
+		appLogGroup: compute.appLogGroup,
+		opsEmail: 'ops@example.com',
+		discordWebhookIncident: 'https://discord.com/api/webhooks/test',
+	});
+	return Template.fromStack(ops as unknown as cdk.Stack);
+}
+
+let fixtureDir: string;
+let template: Template;
+
+beforeAll(() => {
+	fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gq-ops-dest-'));
+	const immutable = path.join(fixtureDir, '_app', 'immutable', 'chunks');
+	fs.mkdirSync(immutable, { recursive: true });
+	fs.writeFileSync(path.join(immutable, 'app.abc123.js'), 'export const x = 1;\n');
+	template = buildOpsTemplate(fixtureDir);
+}, 120_000);
+
+afterAll(() => {
+	if (fixtureDir) fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+describe('#4189 ops alarm の宛先', () => {
+	it('email subscription を張らない (opsEmail を渡しても)', () => {
+		const subs = template.findResources('AWS::SNS::Subscription');
+		const emailSubs = Object.values(subs).filter(
+			(r) => (r as { Properties?: { Protocol?: string } }).Properties?.Protocol === 'email',
+		);
+		expect(
+			emailSubs,
+			'ops-alerts topic に email subscription があります。案 B (Discord に寄せる) では張りません',
+		).toEqual([]);
+	});
+
+	it('lambda subscription が 1 件以上ある (宛先ゼロに戻らない)', () => {
+		template.hasResourceProperties('AWS::SNS::Subscription', {
+			Protocol: 'lambda',
+		});
+	});
+
+	it('転送 Lambda に webhook が env として渡る', () => {
+		template.hasResourceProperties('AWS::Lambda::Function', {
+			FunctionName: 'ganbari-quest-ops-alert-forwarder',
+			Environment: {
+				Variables: Match.objectLike({
+					DISCORD_WEBHOOK_INCIDENT: 'https://discord.com/api/webhooks/test',
+				}),
+			},
+		});
+	});
+
+	it('alarm が 1 件以上あり、全て SNS topic を action に持つ', () => {
+		const alarms = template.findResources('AWS::CloudWatch::Alarm');
+		const names = Object.keys(alarms);
+		expect(names.length, 'alarm が 0 件です').toBeGreaterThan(0);
+
+		const withoutAction = names.filter((k) => {
+			const actions = (alarms[k] as { Properties?: { AlarmActions?: unknown[] } }).Properties
+				?.AlarmActions;
+			return !Array.isArray(actions) || actions.length === 0;
+		});
+		expect(
+			withoutAction,
+			'AlarmActions を持たない alarm があります (鳴っても SNS に流れません)',
+		).toEqual([]);
+	});
+
+	it('制約 ①: staging 側 stack に OpsStack を作らない (bin/app.ts)', () => {
+		// stg のアラートがリリース以外で届くと、本番の異常が埋もれる (オーナー決裁 2026-08-03)。
+		// 現状 staging は Storage / Auth / Compute の 3 stack のみで alarm を持たない。
+		// 将来 `stagingEnabled` ブロックに Ops を足したらここで落ちる。
+		const binSource = fs.readFileSync(path.join(__dirname, '../../../infra/bin/app.ts'), 'utf-8');
+		const stagingBlock = binSource.slice(binSource.indexOf('if (stagingEnabled)'));
+		expect(
+			stagingBlock.includes('OpsStack'),
+			'staging ブロックで OpsStack を生成しています。stg の alarm が本番と同じ経路で鳴ると、' +
+				'本番の異常が埋もれます (#4189 オーナー決裁の制約 ①)。' +
+				'staging に監視を入れる場合は別 topic / 別 webhook にしてから本 assertion を更新してください',
+		).toBe(false);
+	});
+});

--- a/tests/unit/infra/ops-alert-policy.test.ts
+++ b/tests/unit/infra/ops-alert-policy.test.ts
@@ -1,0 +1,177 @@
+// tests/unit/infra/ops-alert-policy.test.ts
+// #4189 — CloudWatch アラームの通知方針が「宣言漏れなく」「理由付きで」保たれることを固定する。
+//
+// ## 何を守るか（オーナー決裁 2026-08-03、案 B）
+//
+// 1. **既定で鳴らさない** — 有効性が確認できた alarm だけ Discord に出す（常態化して見飛ばされるのを防ぐ）
+// 2. **宣言漏れを作らない** — OpsStack が作る alarm は全件が方針表に載っている
+// 3. **理由が実質空でない** — 「なぜ今は鳴らさないのか / なぜ鳴らすのか」が書かれている（#4237 と同型）
+//
+// alarm 名は CDK synth した**実テンプレート**から取る（source の grep ではなく実際に作られるもの）。
+// stack 構築の context stub は `ops-static-assets-alarm.test.ts` を踏襲する。
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { ALARM_NOTIFY_POLICY, shouldNotifyToDiscord } from '../../../infra/lib/ops-alert-policy';
+import { OpsStack } from '../../../infra/lib/ops-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+// cspell:ignore TESTPOOL
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+function makeApp(): cdk.App {
+	return new cdk.App({
+		context: {
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+		},
+	});
+}
+
+/** S3 offload ON（= alarm が最大数作られる構成）で OpsStack を synth する。 */
+function buildOpsTemplate(sourceDir: string): Template {
+	const app = makeApp();
+	const storage = new StorageStack(app, 'TestStorage', { env });
+	const compute = new ComputeStack(app, 'TestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'TestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+		staticAssetsS3Offload: true,
+		staticAssetsSourceDir: sourceDir,
+	});
+	const ops = new OpsStack(app, 'TestOps', {
+		env,
+		lambdaFn: compute.fn,
+		distribution: network.distribution,
+		functionUrl: compute.functionUrl,
+		cronDispatcherFn: compute.cronDispatcherFn,
+		staticAssetsBucket: network.staticAssetsBucket,
+		appLogGroup: compute.appLogGroup,
+	});
+	return Template.fromStack(ops as unknown as cdk.Stack);
+}
+
+const STUB_REASONS = ['todo', 'tbd', 'n/a', 'na', '-', '—', '未定', 'なし', '?', '??'];
+
+/** 理由として成立しているか。成立しない場合は理由文字列を返す。 */
+function findReasonDefect(reason: unknown): string | null {
+	if (typeof reason !== 'string') return `文字列ではありません (${typeof reason})`;
+	const trimmed = reason.trim();
+	if (trimmed.length === 0) return '空です';
+	if (STUB_REASONS.includes(trimmed.toLowerCase())) return `定型 stub です (「${trimmed}」)`;
+	if (trimmed.length < 8) return `短すぎます (${trimmed.length} 字)`;
+	return null;
+}
+
+let fixtureDir: string;
+let template: Template;
+
+beforeAll(() => {
+	fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gq-ops-policy-'));
+	const immutable = path.join(fixtureDir, '_app', 'immutable', 'chunks');
+	fs.mkdirSync(immutable, { recursive: true });
+	fs.writeFileSync(path.join(immutable, 'app.abc123.js'), 'export const x = 1;\n');
+	template = buildOpsTemplate(fixtureDir);
+}, 120_000);
+
+afterAll(() => {
+	if (fixtureDir) fs.rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+function synthAlarmNames(): string[] {
+	const alarms = template.findResources('AWS::CloudWatch::Alarm');
+	return Object.values(alarms)
+		.map((r) => (r as { Properties?: { AlarmName?: string } }).Properties?.AlarmName)
+		.filter((n): n is string => typeof n === 'string')
+		.sort();
+}
+
+describe('#4189 CloudWatch アラームの通知方針', () => {
+	it('[母数] 方針表が空でない', () => {
+		expect(Object.keys(ALARM_NOTIFY_POLICY).length, '方針表が空です').toBeGreaterThan(0);
+	});
+
+	it('全 entry の理由が空でも stub でもない', () => {
+		const defects = Object.entries(ALARM_NOTIFY_POLICY)
+			.map(([name, policy]) => {
+				const defect = findReasonDefect(policy.reason);
+				return defect ? `${name}: ${defect}` : null;
+			})
+			.filter((v): v is string => v !== null);
+
+		expect(
+			defects,
+			'通知方針の理由が実質空です。**なぜ今は鳴らさないのか / なぜ鳴らすのか**を書いてください',
+		).toEqual([]);
+	});
+
+	it('既定は「鳴らさない」— notify: true は実績の根拠が要る (常態化防止)', () => {
+		const notifying = Object.entries(ALARM_NOTIFY_POLICY)
+			.filter(([, p]) => p.notify)
+			.map(([n]) => n);
+
+		// 本番稼働の観測実績がまだ無いため現時点は 0 件が正。
+		// 実績が付いて昇格させるときは reason に「いつ・何を検知して有効だったか」を書き、
+		// 本 assertion を更新する（増やすこと自体は正しい進行）。
+		expect(
+			notifying,
+			'notify: true にした alarm があります。docs/runbooks/ops-alert-notification.md の昇格手順に従い、' +
+				'reason に実績を書いたうえで本 assertion を更新してください',
+		).toEqual([]);
+	});
+
+	it('未宣言の alarm 名は「鳴らさない」に倒れる (fail-safe)', () => {
+		expect(shouldNotifyToDiscord('ganbari-quest-undeclared-alarm')).toBe(false);
+	});
+
+	it('no-silent-gap: OpsStack が作る alarm が全件 方針表に載っている', () => {
+		const alarmNames = synthAlarmNames();
+
+		expect(
+			alarmNames.length,
+			'synth した alarm が 0 件です (stack 構築が壊れています)',
+		).toBeGreaterThan(0);
+
+		const undeclared = alarmNames.filter((n) => !(n in ALARM_NOTIFY_POLICY)).sort();
+		expect(
+			undeclared,
+			'方針が未宣言の alarm があります。infra/lib/ops-alert-policy.ts に理由付きで追加してください。' +
+				'未宣言のままだと「既定で鳴らない」状態が誰にも気付かれずに埋もれます',
+		).toEqual([]);
+
+		// 逆方向: 撤去済 alarm が表に残ると、次に同名を足したとき古い判断が効いてしまう
+		const stale = Object.keys(ALARM_NOTIFY_POLICY)
+			.filter((n) => !alarmNames.includes(n))
+			.sort();
+		expect(
+			stale,
+			'撤去済の alarm が方針表に残っています。ops-alert-policy.ts から外してください',
+		).toEqual([]);
+	});
+});

--- a/tests/unit/infra/physical-name-ratchet.test.ts
+++ b/tests/unit/infra/physical-name-ratchet.test.ts
@@ -288,6 +288,7 @@ const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
 			'GanbariQuestCompute/AWS::Lambda::Function/ganbari-quest-cron-dispatcher',
 			'GanbariQuestComputeStaging/AWS::Lambda::Function/ganbari-quest-staging-app',
 			'GanbariQuestOps/AWS::Lambda::Function/ganbari-quest-health-check',
+			'GanbariQuestOps/AWS::Lambda::Function/ganbari-quest-ops-alert-forwarder',
 			'GanbariQuestSes/AWS::Lambda::Function/ganbari-quest-ses-receive',
 		],
 	),
@@ -299,6 +300,7 @@ const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
 			'GanbariQuestCompute/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-cron-dispatcher',
 			'GanbariQuestComputeStaging/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-staging-app',
 			'GanbariQuestOps/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-health-check',
+			'GanbariQuestOps/AWS::Logs::LogGroup//aws/lambda/ganbari-quest-ops-alert-forwarder',
 		],
 	),
 	...group(


### PR DESCRIPTION
## 顧客価値・目的

**本番の CloudWatch アラームは 11 本すべて宛先ゼロで、鳴っても誰にも届きません。** 障害が起きても気付けない状態です。

同型の欠陥が続いています — #4119（NUC バックアップが **18 晩**失敗しても通知 0 通）/ #4174（Lambda incident 通知 0 通）。

**オーナー決裁（2026-08-03）で「案 B = メールをやめ Discord に寄せる」が確定**しました。ただし 2 つの制約が付いています。

> 案Bでいいです。ただ、stg環境のアラート通知がリリース以外で届いたり、**本番のアラートが常態化していると見逃しかねない**ので、**通知予測として十分効果的であることが認められてから届くように**設定しましょうね

**宛先を繋ぐだけだと逆の失敗が起きます。** 閾値の妥当性を検証していない alarm を一斉に鳴らすと平常時から通知が流れ続け、**本物の障害が同じ見た目で埋もれます**。

## 関連 Issue

Closes #4189

- **#4225（案 A、opsEmail 配布）は merge しないでください。** 本 PR が置き換えます。ただし同 PR の「宛先が無いまま deploy が成功するのを止める」性質は引き継いでいます
- #4119 / #4174（同じ「通知経路はあるのに 0 通」class）/ #3881（physical-name ratchet）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 宛先をメールから Discord に付け替える | CDK synth assert | ✅ `opsEmail` を**渡しても** email subscription が 0 件 / lambda subscription が存在（`ops-alert-destination.test.ts`） |
| AC2 | **制約 ②**: 既定で鳴らさない | 方針表 + guard | ✅ `ALARM_NOTIFY_POLICY` の 11 件すべて `notify: false`、理由付き（`ops-alert-policy.ts`） |
| AC3 | 宣言漏れを作らない | no-silent-gap | ✅ **synth した実テンプレート**の alarm 名と方針表を双方向照合（未宣言 / stale 両方 fail） |
| AC4 | 理由が実質空でない | 機械検証 | ✅ 空 / 定型 stub / 8 字未満を弾く（#4237 と同型） |
| AC5 | **制約 ①**: staging に alarm を作らない | source pin | ✅ `bin/app.ts` の `stagingEnabled` ブロックに `OpsStack` が無いことを assert |
| AC6 | 宛先ゼロに戻ったら deploy を止める | post-deploy 実物検証 | ✅ SNS の lambda subscription 件数 + **転送 Lambda の実 env** を deploy 後に問い合わせ |
| AC7 | 昇格・降格の手順が残っている | runbook | ✅ `docs/runbooks/ops-alert-notification.md`（実コマンド付き） |
| AC8 | mutation で red を実測する | 実測 | ✅ **4 方向**（宣言漏れ / 理由空 / stale / 実績なしで昇格） |
| AC9 | `npm run pre-ready` 全 Step PASS | — | ✅ |

## 変更タイプ

- [x] バグ修正（宛先ゼロ）
- [x] インフラ変更
- [x] テスト追加（guard）
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新

## 影響範囲・横展開チェック

### 制約 ② をどう機械で守るか

| 状態 | CloudWatch | Discord |
|---|---|---|
| `notify: false`（**既定**） | alarm として存在しコンソールで見える | **出さない**（転送 Lambda の log に `suppressed alarm=...` が残る） |
| `notify: true` | 同上 | 出す。**reason に「いつ・何を検知して有効だったか」を書く** |

**「通知が来ない」と「抑止した」を log で区別できます。** 抑止は握り潰しではありません。

現在の本番アラーム **11 本すべて `notify: false`** です。1 件ずつ「なぜ今は鳴らさないか」を書きました（例: `lambda-url-4xx-spike` = 4xx は bot / 未認証アクセスで日常的に出る、閾値 50 が実トラフィックで妥当か未計測）。

### 制約 ① は実測の結果すでに満たされていました

`OpsStack` は `bin/app.ts` で **1 回だけ**生成され本番 Lambda に束ねられています。staging 側は Storage / Auth / Compute の 3 stack のみで **alarm を 1 つも持ちません**。将来 staging に Ops を足すと壊れるため test で固定しました。

### その他

- **判定できない message は落とさず転送**します（AWS Health event 等も同 topic に来るため、未知を握り潰さない）
- **`opsEmail` prop は残しました** — AWS Budgets が EMAIL 固定の仕様で、DsqlStack のコスト通知では今も使うためです。**ops topic には subscribe しません**
- **env は `DISCORD_WEBHOOK_INCIDENT` を再利用**しました。5 本目の secret を増やさず、develop に既にある配布経路（context 受け渡し + secret 有無宣言 + post-deploy 実 env 検証）に相乗りします
- **`physical-name-ratchet` (#3881) が新規明示物理名 2 件を検出して fail しました。** 意図どおりの動作なので緩めず allowlist に追加しています

## テスト・品質セルフチェック

```
npx vitest run tests/unit/infra/
 Test Files  18 passed (18)
      Tests  177 passed (177)

npm run cspell                    → Issues found: 0 in 0 files
node scripts/check-doc-code-references.mjs → 新規違反なし
```

### mutation を 4 方向で実測（commit 後に `git stash` で退避）

1. **宣言漏れ** — 方針表から 1 件消す → ✅ **red**: `未宣言の alarm: ganbari-quest-cloudfront-5xx`
2. **理由が空** — reason を `''` に → ✅ **red**: `cron-dispatcher-errors: 空です`
3. **stale** — 撤去済 alarm を表に残す → ✅ **red**: `ganbari-quest-removed-alarm`
4. **実績なしで昇格** — `notify: true` に上げる → ✅ **red**: `lambda-url-4xx-spike`

**4 つ目が制約 ② の本体**です。実績を書かずに通知を有効化すると CI が落ちます。

- [x] **mutation の前に commit した**
- [x] **4 方向を実測した**

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: 変更は infra/ (CDK + Lambda) と .github/workflows/ と tests/ と docs/runbooks/ のみ。UI コンポーネントも routes も 1 行も触っておらず、顧客に見える画面が存在しない。 -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **`notify: true` を 0 件に固定する assertion を置きました。** 昇格のたびに test を更新する手間が増えますが、**assertion を消すと次の昇格が無検証で通る**ため意図的にそうしています
2. **抑止の粒度を alarm 単位にしました。** 「深夜だけ黙らせる」等の時間軸は入れていません（Pre-PMF で複雑度に見合わないと判断）
3. **転送 Lambda は通知失敗で落ちません**（Discord 側の障害で SNS 再送ループを起こさないため）。ただし **error log は必ず残します**

### 破壊的変更

**あります（意図的）。** `opsEmail` を渡してもメール通知は届かなくなります。オーナー決裁「案 B」に沿った変更です。**#4225 を merge するとメール subscription が復活し本 PR と競合します。**

## 配布済み env / secret (ADR-0006)

**新規 secret はありません。** 既存の `DISCORD_WEBHOOK_INCIDENT` を再利用します。

| 経路 | 状態 |
|---|---|
| `.github/workflows/deploy.yml` | ✅ context 受け渡し済（develop 既存）+ 本 PR で **OpsStack 側の実 env 検証**を追加 |
| `infra/bin/app.ts` | ✅ 本 PR で OpsStack へ配線 |
| secret 有無の宣言 | ✅ develop 既存（`Incident webhook secret presence`） |
| **GitHub secret の登録** | ⚠️ **オーナー作業**（未登録なら deploy 後の検証で止まります） |

## Ready for Review チェックリスト

- [x] **オーナー決裁の 2 制約を機械で守る形に落とした**
- [x] **mutation 4 方向を実測した**
- [x] **抑止を握り潰しにせず log に残した**
- [x] **既存 guard (#3881) の検出を緩めず allowlist で受けた**
- [x] **#4225 と競合することを明記した**
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## PO 決裁ブリーフ

### 決裁は済んでいます（2026-08-03、オーナー直接指示）

> 案Bでいいです。ただ、stg環境のアラート通知がリリース以外で届いたり、本番のアラートが常態化していると見逃しかねないので、通知予測として十分効果的であることが認められてから届くように設定しましょうね

本 PR はこの決裁の**実装**です。新たに決めていただくことはありません。**確認いただきたいのは「決裁どおりか」の 1 点**です。

```mermaid
flowchart TD
    A["CloudWatch alarm 発火"] --> B["SNS topic ganbari-quest-ops-alerts"]
    B --> C["転送 Lambda"]
    C --> D{"ops-alert-policy.ts の notify は?"}
    D -->|"true = 実績あり"| E["Discord に出す"]
    D -->|"false = 既定 現在 11/11"| F["log に suppressed と残す / Discord には出さない"]
    B -.->|"案 B で撤去"| G["メール subscription は張らない"]
    style F fill:#fef3c7
    style E fill:#dcfce7
    style G fill:#fee2e2
```

### 決裁 → 実装の対応

| 決裁 | 実装 |
|---|---|
| **案 B**（メールをやめ Discord へ） | EmailSubscription を撤去し SNS → 転送 Lambda → Discord |
| **制約 ①**（stg がリリース以外で届かない） | 実測の結果**すでに満たされていた**（OpsStack は本番 1 つだけ）。将来壊れないよう test で pin |
| **制約 ②**（効果的と認められてから届く） | **既定は鳴らさない**。11 本すべて silent から開始し、実績が付いたものだけ昇格 |

### 判断に必要な事実

- **現在 Discord に出る alarm は 0 件**です（11 本すべて silent）。**この PR を merge しても通知は 1 通も増えません**
- 昇格は runbook の手順（平常時の発火回数を実測 → 理由に記録 → assertion 更新 → deploy）で 1 件ずつ行います
- **鳴らない間も CloudWatch には alarm が存在**し、コンソール / メトリクスでは見えます。抑止したことは転送 Lambda の log にも残ります

### オーナー作業が 1 つ残ります

**Discord webhook の GitHub secret 登録**です。未登録のままだと deploy 後の検証で止まります（宛先ゼロのまま deploy が成功する #4189 の再演を防ぐため、あえて止めています）。

### 不可逆性

**ありません。** メール通知に戻す場合は EmailSubscription を戻すだけです（#4225 の diff が参考になります）。

## QM レビュー結果

<!-- QM が記入 -->
