### PR TITLE
fix(ci): #4243 統合 PR の evidence 表検査を当該セクション内に閉じる（誤検知と見逃しの両方を塞ぐ）

### DIFF
--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -40,15 +40,45 @@ function stripInlineCode(cell) {
 const NG_ZERO_PATTERN = /残\s*NG\s*(?:合計\s*)?0\s*件|残\s*NG[^\n|]*[:：]?\s*0\b|NG\s*0\s*件/;
 
 /**
+ * 次の `## ` 見出し（H2）の直前までを切り出す。見出しが無ければ全体を返す。
+ *
+ * `###` 以降の下位見出しでは止めない（同一セクション内の小見出しは表の所属を変えないため）。
+ *
+ * @param {string} text 見出し行を除いたセクション以降のテキスト
+ * @returns {string} 当該セクション本体
+ */
+function sliceUntilNextH2(text) {
+	const lines = text.split('\n');
+	const end = lines.findIndex((l) => l.startsWith('## '));
+	return end === -1 ? text : lines.slice(0, end).join('\n');
+}
+
+/**
  * AC 検証マップの 4 列行を本文から抽出する（共通 util）。
  * ヘッダー行（`| AC 番号 | AC 内容 ...` 等）とセパレーター（`|---|---|`）を除外する。
+ *
+ * **走査は当該セクション内で閉じる**（次の `## ` 見出しで停止、#4243）。
+ * 本文末尾まで見ていた旧実装は、統合 PR template が「マージ判定エビデンス」の**後ろ**に
+ * 4 列の表（Accepted residual 等）を持つため、**別表の行を evidence の行として数えていた**。
+ * 壊れ方は 2 方向あった:
+ *
+ *   - false positive: 後続表のプレースホルダ行を空欄と誤判定し、evidence 表が正しくても fail
+ *     （bot 生成の統合 PR が生まれた瞬間に落ちる。#4241 で実測）
+ *   - false negative: evidence 表が**空でも**後続表の 4 列行で `rows.length === 0` を通過し、
+ *     「main 反映前に evidence を必ず埋めさせる」という gate の目的が満たされない（より危険）
  *
  * @param {string} body PR 本文
  * @param {number} fromIdx 抽出開始 index（section 見出し以降に限定する用途）
  * @returns {string[]} 4 列のデータ行（生のマークダウン行）
  */
 function extractFourColumnRows(body, fromIdx) {
-	const section = body.slice(fromIdx);
+	const rest = body.slice(fromIdx);
+	// 見出し行自身を飛ばしてから、次の `## ` 見出しまでを section 本体とする。
+	const afterHeading = rest.indexOf('\n');
+	const section =
+		afterHeading === -1
+			? rest
+			: rest.slice(0, afterHeading + 1) + sliceUntilNextH2(rest.slice(afterHeading + 1));
 	return section
 		.split('\n')
 		.filter((l) => /^\|[^|]+\|[^|]+\|[^|]+\|[^|]+\|/.test(l))

--- a/tests/unit/scripts/check-ac-verification-map.test.ts
+++ b/tests/unit/scripts/check-ac-verification-map.test.ts
@@ -147,6 +147,47 @@ develop → main 統合 PR
 残 NG 合計 0 件。adversarial evidence の反対理由は解消済。
 `;
 
+// #4243: evidence 表の **後ろ** に別の 4 列表がある body。
+// 統合 PR template は「Accepted residual (Pre-PMF)」表を後続に持ち、その例示行が
+// プレースホルダ (`<!-- ... -->`) のため、走査がセクションで閉じていないと誤検知する。
+const INTEGRATION_EVIDENCE_WITH_TRAILING_TABLE = `
+## 概要
+develop -> main 統合 PR
+
+## マージ判定エビデンス表
+
+| 含有 PR | 対象領域 | 対応テストケース | 結果 |
+|---|---|---|---|
+| 機能 A（#3001） | admin/activities | unit×3 / e2e×1 | pass |
+
+残 NG 合計 0 件。adversarial evidence の反対理由は解消済。
+
+## Accepted residual (Pre-PMF)
+
+| finding (要約) | severity (1-2 のみ) | 受容理由 (Pre-PMF) | 関連 root class |
+|---|---|---|---|
+| <!-- 例: 命名精度 --> | <!-- 2 --> | <!-- dev-only 診断値 --> | <!-- 完全性 --> |
+`;
+
+// #4243: evidence 表が **空** なのに、後続表には埋まった 4 列行がある body。
+// 走査が閉じていないと `rows.length === 0` を後続表の行が満たしてしまい **見逃す**。
+const INTEGRATION_EVIDENCE_EMPTY_BUT_TRAILING_FILLED = `
+## 概要
+develop -> main 統合 PR
+
+## マージ判定エビデンス表
+
+（まだ埋めていない）
+
+残 NG 合計 0 件。
+
+## Accepted residual (Pre-PMF)
+
+| finding (要約) | severity (1-2 のみ) | 受容理由 (Pre-PMF) | 関連 root class |
+|---|---|---|---|
+| 命名精度 | 2 | dev-only 診断値 | 完全性 |
+`;
+
 const INTEGRATION_EVIDENCE_MISSING_SECTION = `
 ## 概要
 統合 PR だがエビデンス表 section が無い
@@ -272,6 +313,22 @@ describe('checkIntegrationEvidenceTable (integration lane、AC3)', () => {
 		const r = checkIntegrationEvidenceTable(INTEGRATION_EVIDENCE_PASS);
 		expect(r.ok).toBe(true);
 		expect(r.lane).toBe('integration');
+	});
+
+	it('#4243 後続表のプレースホルダ行を evidence の空欄と誤判定しない (false positive)', () => {
+		const r = checkIntegrationEvidenceTable(INTEGRATION_EVIDENCE_WITH_TRAILING_TABLE);
+		expect(
+			r.ok,
+			'Accepted residual 表の例示行を evidence 表の空欄として拾っています (走査がセクションで閉じていない)',
+		).toBe(true);
+	});
+
+	it('#4243 evidence 表が空なら、後続表に行があっても fail する (false negative)', () => {
+		const r = checkIntegrationEvidenceTable(INTEGRATION_EVIDENCE_EMPTY_BUT_TRAILING_FILLED);
+		expect(
+			r.ok,
+			'evidence 表が空なのに後続表の行で通過しています。main 反映前の証跡が空洞化します',
+		).toBe(false);
 	});
 
 	it('FAIL: エビデンス表 section が欠落', () => {


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（CI gate の修正）。**

`develop → main` の統合 PR は**本番反映の唯一の経路**で、その gate が「マージ判定エビデンス表を必ず埋めさせる」ことを担保しています。その検査が**別の表の行まで拾っていました**。

`extractFourColumnRows(body, fromIdx)` が

```js
const section = body.slice(fromIdx);   // ← 本文の末尾まで
```

とセクションで区切らず走査するため、統合 PR template が evidence 表の**後ろ**に持つ 4 列表（`Accepted residual (Pre-PMF)`）の行が混入します。

## 関連 Issue

Closes #4243

- #2945 / #4130（本 gate の起票元）/ #4241（現に fail している統合 PR）
- #4030（同 class = 「guard の母数が閉じていない」の横展開調査）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 走査を当該セクション内に限定する | 実装 | ✅ `sliceUntilNextH2` を追加し次の `## ` 見出しで停止（`check-ac-verification-map.mjs`） |
| AC2 | **false positive** を test で固定 | failing-test-first | ✅ `#4243 後続表のプレースホルダ行を evidence の空欄と誤判定しない` |
| AC3 | **false negative** を test で固定 | failing-test-first | ✅ `#4243 evidence 表が空なら、後続表に行があっても fail する` |
| AC4 | 既存 test が全件 green のまま | 実行 | ✅ 33 → **35 passed**（既存 33 件は無変更で green） |
| AC5 | PR #4241 の当該 fail 解消を実測 | **実 body で before/after** | ✅ 下記「実測」 |
| AC6 | `npm run pre-ready` 全 Step PASS | — | ✅ |

## 変更タイプ

- [x] バグ修正
- [x] テスト追加
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

### 壊れ方は 2 方向あります

| 方向 | 何が起きるか | 状態 |
|---|---|---|
| **false positive** | 後続表のプレースホルダ行を空欄と誤判定 → **bot 生成の統合 PR が生まれた瞬間に fail** | #4241 で発生中 |
| **false negative** | evidence 表が**空でも**後続表の 4 列行が `rows.length === 0` を満たし **fail しない** | 構造上いつでも起こりうる |

**危険なのは後者**です。「main 反映は不可逆だから証跡を必ず埋めさせる」という gate の目的が、**別表の行で満たされてしまいます**。今回は false positive で発覚しましたが、直すべきは走査範囲そのものです。

### 他の呼び出し元への影響

`extractFourColumnRows` は **feature lane の AC 検証マップ**（`checkPerPrAcMap`）でも使われます。feature lane の PR template は `## AC 検証マップ` の後ろにも 4 列表を持ちうるため、**同じ混入が起きていました**。本修正は両 lane に効きます（既存 33 test が無変更で green = feature lane の挙動は壊れていません）。

### 停止条件を H2 に限定した理由

`###` 以降の下位見出しでは止めません。**同一セクション内の小見出しは表の所属を変えない**ためです（セクションを跨ぐのは `## ` のみ）。

## テスト・品質セルフチェック

```
npx vitest run tests/unit/scripts/check-ac-verification-map.test.ts
 Test Files  1 passed (1)
      Tests  35 passed (35)   ← 既存 33 + 新規 2
```

### 実測: PR #4241 の**実 body**で before / after

`gh pr view 4241 --json body` で取得した実際の本文（12,712 bytes）を両 branch の実装に通しました。

| 実装 | 結果 |
|---|---|
| **develop（修正前）** | ❌ `「マージ判定エビデンス表」に 1 件の空欄/プレースホルダ行があります` |
| **本 branch（修正後）** | ✅ `ok = true` |

**#4241 の当該 CI fail はこの PR の merge で解消します。**

### mutation（commit 後に `git stash` で退避）

走査を `body.slice(fromIdx)`（末尾まで）に戻す → ✅ **新規 2 test が両方 red**

- `#4243 後続表のプレースホルダ行を evidence の空欄と誤判定しない` → FAIL
- `#4243 evidence 表が空なら、後続表に行があっても fail する` → FAIL

**1 つの mutation で 2 方向が同時に落ちる**のは、両者が同じ根（走査範囲）から出ているためです。

- [x] **mutation の前に commit した**
- [x] **両方向を test で固定した**

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: CI gate script (scripts/) と unit test のみの変更で、UI コンポーネントも routes も 1 行も触っていない。顧客に見える画面が存在しない。 -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **gate を緩めたのではなく、見る範囲を正した変更**です。false negative（evidence 表が空でも通る）を塞いでいるので、**検査は厳しくなっています**
2. **`Accepted residual` 表の例示行はそのまま残しました。** 監査が「受容 residual なし」と書くか実際の finding で埋めるかは監査の判断であり、Dev が template から消すべきではないと考えました

### 破壊的変更

**ありません。** 既存 33 test が無変更で green です。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **実 PR body で before / after を実測した**（推測で「直るはず」と書いていません）
- [x] **両方向（誤検知 / 見逃し）を test で固定した**
- [x] **既存 test を 1 件も書き換えずに green を維持した**
- [x] **feature lane への波及も確認した**
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
