### PR TITLE
fix(billing): #4118 invoice.paid が猶予終了日を残して X3 を作るのを止める（手 2 の guard で発覚）

### DIFF
--- a/docs/design/billing-redesign/contract-state-matrix.md
+++ b/docs/design/billing-redesign/contract-state-matrix.md
@@ -115,7 +115,7 @@ KPI service（`cohort-analysis` / `ops-analytics` / `pricing-trigger` / `stripe-
 | # | トリガ | 実装 | 書く内容 | 遷移 |
 |---|---|---|---|---|
 | W1 | `checkout.session.completed` | `stripe-service.ts` `handleCheckoutCompleted` | `sub` / `plan` / `status=active` / `trialUsedAt` | S1 → S2 |
-| W2 | `invoice.paid` | `stripe-service.ts` `handleInvoicePaid` | `status=active` + `plan`（未解決なら**保持**） | S3 → S2 / S2 → S2 |
+| W2 | `invoice.paid` | `stripe-service.ts` `handleInvoicePaid` | `status=active` + `plan`（未解決なら**保持**） + **`plan_expires_at=null`** | S3 → S2 / S2 → S2 |
 | W3 | `invoice.payment_failed` | `stripe-service.ts` `handlePaymentFailed` | `status=grace_period` / `exp = now + 7d` | S2 → S3 |
 | W4 | `customer.subscription.updated` | `stripe-service.ts` `handleSubscriptionUpdated` | 非終端: `plan`（未解決なら保持）+ `status`（Stripe status を正規化） / 終端: W5 と同じ 4 列 | S2 ⇄ S3 / → S4 / → S5 |
 | W5 | `customer.subscription.deleted` | `stripe-service.ts` `handleSubscriptionDeleted` | `sub=NULL` / `plan=NULL` / `exp=NULL` / `status=suspended`（`TERMINAL_CONTRACT_STATE` の 4 列を網羅、#4026） | S2/S3/S4 → S5 |

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -853,6 +853,12 @@ async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
 		'invoice.paid',
 		() => ({
 			status: SUBSCRIPTION_STATUS.ACTIVE,
+			// #4118: 猶予終了日を消す。支払い失敗で `grace_period` + `planExpiresAt` が書かれた
+			// テナントが支払い成功で復帰するとき、期限だけ残すと **契約は生きているのに期限がある**
+			// (contract-state-matrix X3 =「dunning の残骸」) になる。この列を読む導出値は
+			// 支払い済みの顧客に「あと N 日で使えなくなります」と表示しうる。
+			// status を戻すなら、その status が持ってはいけない列も同時に落とす。
+			planExpiresAt: null,
 			// #3960: plan 未解決時は silent fallback せず **既存 plan を保持** する
 			// (`plan: undefined` は repo 実装で「更新しない」として扱われる)。
 			...planUpdateOrKeep(plan, tenant, 'invoice.paid', subscription.id),

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -553,7 +553,13 @@ describe('handleWebhookEvent', () => {
 		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
 
 		// plan キー自体が渡らない = repo 実装 (`if (data.plan !== undefined)`) で既存値保持
-		expect(mockUpdateTenantStripe).toHaveBeenCalledWith('t-test', { status: 'active' });
+		// #4118: 猶予終了日は同時に落とす (active + 期限残り = matrix X3)。
+		// plan を書かないことは `not.toHaveProperty` で明示し、列追加で緩まないようにする。
+		expect(mockUpdateTenantStripe).toHaveBeenCalledWith('t-test', {
+			status: 'active',
+			planExpiresAt: null,
+		});
+		expect(mockUpdateTenantStripe.mock.calls.at(-1)?.[1]).not.toHaveProperty('plan');
 		expect(mockNotifyStripeAlert).toHaveBeenCalledWith(
 			expect.objectContaining({ kind: 'stripe-plan-unresolved' }),
 		);

--- a/tests/unit/services/stripe-webhook-contract-state.test.ts
+++ b/tests/unit/services/stripe-webhook-contract-state.test.ts
@@ -1,0 +1,306 @@
+// tests/unit/services/stripe-webhook-contract-state.test.ts
+// EPIC #4118 手 2 — webhook handler 適用後の 4 列が「表に在る状態」に収まることを固定する。
+//
+// ## なぜ必要か
+//
+// `docs/design/billing-redesign/contract-state-matrix.md` §7 が実装方針を 3 手に分けている。
+//
+//   1. ドメイン層に S1-S6 / X1-X4 と `classifyContractState()` を置く（#4181 / PR #4233）
+//   2. **各 webhook handler の unit test で「適用後の行が S1-S6 に分類される」ことを assert する**  ← 本 file
+//   3. 定期監査で本番行を分類し X1-X4 を報告する
+//
+// 手 2 が「**意図と効果の乖離**」を落とす本体である（matrix §7 の記述）。
+// `updateTenantStripe` は **部分更新**（`undefined` = その列を更新しない）であり、
+// handler の意図としては正しく見えても「書き忘れた列が前の値のまま残る」ことで
+// 不正状態 (X1-X4) が生まれる。実際 #4026 では、cancel が `planExpiresAt` を書いた直後の
+// `deleted` が同列を書かず「契約が無いのに期限だけ残る」(X3) を作っていた。
+//
+// **静的解析では捕まえられない**（部分更新の効果は「適用前の行」と合成しないと決まらない）ため、
+// handler を実際に走らせ、捕獲した patch を適用前の行にマージして分類する。
+//
+// ## no-silent-gap
+//
+// 新しい webhook handler が dispatcher に増えたのに本 file の網羅から漏れると、
+// 「表に無い状態を作る handler」が検査されないまま入る。dispatcher の `case` を
+// **source から抽出**して、本 file が覆う event 型と突き合わせる。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	type ContractStateColumns,
+	classifyContractState,
+	VALID_CONTRACT_STATES,
+} from '../../../src/lib/domain/contract-state';
+
+// ---------- Mocks（stripe-service.test.ts と同型） ----------
+
+const mockFindTenantById = vi.fn();
+const mockUpdateTenantStripe = vi.fn();
+const mockFindTenantByStripeCustomerId = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		auth: {
+			findTenantById: mockFindTenantById,
+			updateTenantStripe: mockUpdateTenantStripe,
+			findTenantByStripeCustomerId: mockFindTenantByStripeCustomerId,
+		},
+		webhookEvent: {
+			findByEventId: async () => null,
+			claim: async () => true,
+			finalize: async () => {},
+			releaseClaim: async () => {},
+			incrementRetryCount: async () => {},
+			deleteOlderThan: async () => 0,
+		},
+	}),
+}));
+
+const mockIsStripeEnabled = vi.fn();
+const mockGetStripeClient = vi.fn();
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: (...args: unknown[]) => mockIsStripeEnabled(...args),
+	getStripeClient: (...args: unknown[]) => mockGetStripeClient(...args),
+}));
+
+vi.mock('$lib/server/stripe/config', () => ({
+	getPlans: () => ({
+		monthly: { priceId: 'price_monthly_123', amount: 500, interval: 'month', label: '月額' },
+		'family-monthly': {
+			priceId: 'price_family_monthly_789',
+			amount: 780,
+			interval: 'month',
+			label: 'プレミアム月額',
+		},
+	}),
+	planIdFromPriceId: (priceId: string) => {
+		if (priceId === 'price_monthly_123') return 'monthly';
+		if (priceId === 'price_family_monthly_789') return 'family-monthly';
+		return null;
+	},
+	planIdFromLookupKey: () => null,
+	getWebhookSecret: () => 'whsec_test',
+	TRIAL_PERIOD_DAYS: 7,
+	GRACE_PERIOD_DAYS: 7,
+	CURRENCY: 'jpy',
+}));
+
+vi.mock('$lib/server/stripe/alert', () => ({ notifyStripeAlert: vi.fn() }));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyBillingEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { handleWebhookEvent } from '../../../src/lib/server/services/stripe-service';
+
+// ---------- Helpers ----------
+
+const SUB_ID = 'sub_contract_state';
+
+/** 適用前の行（S2 = 課金中）。各 case で必要な列だけ上書きする。 */
+function rowBefore(overrides: Partial<ContractStateColumns> = {}): ContractStateColumns {
+	return {
+		status: 'active',
+		plan: 'monthly',
+		stripeSubscriptionId: SUB_ID,
+		planExpiresAt: null,
+		...overrides,
+	};
+}
+
+function tenantFrom(row: ContractStateColumns) {
+	return {
+		tenantId: 't-cs',
+		name: 'テスト家族',
+		ownerId: 'u-owner',
+		status: row.status,
+		plan: row.plan,
+		stripeCustomerId: 'cus_cs',
+		stripeSubscriptionId: row.stripeSubscriptionId,
+		planExpiresAt: row.planExpiresAt,
+		trialUsedAt: null,
+		createdAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-01T00:00:00Z',
+	};
+}
+
+/**
+ * `updateTenantStripe` の**部分更新セマンティクス**を再現して適用後の行を作る。
+ *
+ * `undefined` は「更新しない」。`null` は「NULL を書く」。この区別を潰すと、
+ * 「書き忘れた列が前の値のまま残る」という検出したい欠陥がそのまま消える。
+ */
+function applyPatch(
+	before: ContractStateColumns,
+	patch: Record<string, unknown>,
+): ContractStateColumns {
+	const pick = <K extends keyof ContractStateColumns>(key: K): ContractStateColumns[K] =>
+		patch[key as string] === undefined
+			? before[key]
+			: (patch[key as string] as ContractStateColumns[K]);
+	return {
+		status: pick('status'),
+		plan: pick('plan'),
+		stripeSubscriptionId: pick('stripeSubscriptionId'),
+		planExpiresAt: pick('planExpiresAt'),
+	};
+}
+
+/** handler を 1 回走らせ、書き込まれた patch を返す（書かなければ null）。 */
+async function runAndCapturePatch(
+	before: ContractStateColumns,
+	// biome-ignore lint/suspicious/noExplicitAny: Stripe.Event の fixture は部分形で足りる
+	event: any,
+): Promise<Record<string, unknown> | null> {
+	const tenant = tenantFrom(before);
+	mockFindTenantById.mockResolvedValue(tenant);
+	mockFindTenantByStripeCustomerId.mockResolvedValue(tenant);
+	mockUpdateTenantStripe.mockResolvedValue(undefined);
+
+	await handleWebhookEvent(event);
+
+	if (mockUpdateTenantStripe.mock.calls.length === 0) return null;
+	const last = mockUpdateTenantStripe.mock.calls.at(-1);
+	return (last?.[1] ?? {}) as Record<string, unknown>;
+}
+
+/** 適用後の行が「表に在る状態」であることを assert する。 */
+function expectValidAfter(
+	before: ContractStateColumns,
+	patch: Record<string, unknown> | null,
+	label: string,
+): void {
+	expect(
+		patch,
+		`${label}: 契約状態が書き込まれませんでした（fixture が handler に届いていません）`,
+	).not.toBeNull();
+	const after = applyPatch(before, patch ?? {});
+	const classification = classifyContractState(after);
+	expect(
+		VALID_CONTRACT_STATES.includes(classification as (typeof VALID_CONTRACT_STATES)[number]),
+		`${label}: 適用後の 4 列が表に無い状態 (${classification}) になりました。\n` +
+			`  before = ${JSON.stringify(before)}\n` +
+			`  patch  = ${JSON.stringify(patch)}\n` +
+			`  after  = ${JSON.stringify(after)}\n` +
+			'部分更新 (undefined = 更新しない) で書き忘れた列が残っていないか確認してください',
+	).toBe(true);
+}
+
+// ---------- Fixtures ----------
+
+function subscriptionEvent(type: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id: `evt_${type}`,
+		type,
+		data: {
+			object: {
+				id: SUB_ID,
+				customer: 'cus_cs',
+				status: 'active',
+				items: { data: [{ price: { id: 'price_monthly_123' } }] },
+				current_period_end: Math.floor(Date.UTC(2026, 8, 1) / 1000),
+				cancel_at_period_end: false,
+				...overrides,
+			},
+		},
+	};
+}
+
+function invoiceEvent(type: string) {
+	return {
+		id: `evt_${type}`,
+		type,
+		data: {
+			object: {
+				id: 'in_cs',
+				customer: 'cus_cs',
+				// extractSubscriptionId は parent.subscription_details 経由でしか解決しない
+				parent: { subscription_details: { subscription: SUB_ID } },
+				lines: { data: [{ price: { id: 'price_monthly_123' } }] },
+			},
+		},
+	};
+}
+
+/** 本 file が覆う event 型（dispatcher の case と突き合わせる）。 */
+const COVERED_EVENT_TYPES = [
+	'checkout.session.completed',
+	'invoice.paid',
+	'invoice.payment_failed',
+	'customer.subscription.updated',
+	'customer.subscription.deleted',
+] as const;
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockIsStripeEnabled.mockReturnValue(true);
+	mockGetStripeClient.mockReturnValue({
+		subscriptions: {
+			retrieve: vi.fn().mockResolvedValue({
+				id: SUB_ID,
+				customer: 'cus_cs',
+				status: 'active',
+				items: { data: [{ price: { id: 'price_monthly_123' } }] },
+				current_period_end: Math.floor(Date.UTC(2026, 8, 1) / 1000),
+				cancel_at_period_end: false,
+			}),
+		},
+	});
+});
+
+describe('#4118 手 2: webhook 適用後の契約状態が表に在ること', () => {
+	it('no-silent-gap: dispatcher が扱う event 型を全件覆っている', () => {
+		const source = readFileSync(
+			join(__dirname, '../../../src/lib/server/services/stripe-service.ts'),
+			'utf-8',
+		);
+		const dispatchIdx = source.indexOf('async function dispatchWebhookEvent');
+		expect(dispatchIdx, 'dispatchWebhookEvent が見つかりません').toBeGreaterThan(0);
+		const body = source.slice(dispatchIdx, source.indexOf('\n}', dispatchIdx));
+		const handled = [...body.matchAll(/case '([^']+)':/g)].map((m) => m[1]).sort();
+
+		expect(handled.length, 'dispatcher の case が 0 件です').toBeGreaterThan(0);
+		expect(
+			handled,
+			'dispatcher が扱う event 型と本 file の網羅がずれています。' +
+				'新しい handler を足したら、適用後の行が S1-S6 に収まることを本 file でも固定してください',
+		).toEqual([...COVERED_EVENT_TYPES].sort());
+	});
+
+	it('invoice.paid: 課金中 (S2) に収まる', async () => {
+		const before = rowBefore({ status: 'grace_period', planExpiresAt: '2026-09-01T00:00:00Z' });
+		const patch = await runAndCapturePatch(before, invoiceEvent('invoice.paid'));
+		expectValidAfter(before, patch, 'invoice.paid');
+	});
+
+	it('invoice.payment_failed: 支払い失敗猶予 (S3) に収まる', async () => {
+		const before = rowBefore();
+		const patch = await runAndCapturePatch(before, invoiceEvent('invoice.payment_failed'));
+		expectValidAfter(before, patch, 'invoice.payment_failed');
+	});
+
+	it('customer.subscription.updated: 表に在る状態に収まる', async () => {
+		const before = rowBefore({ status: 'grace_period', planExpiresAt: '2026-09-01T00:00:00Z' });
+		const patch = await runAndCapturePatch(
+			before,
+			subscriptionEvent('customer.subscription.updated'),
+		);
+		expectValidAfter(before, patch, 'customer.subscription.updated');
+	});
+
+	it('customer.subscription.deleted: 契約終了 (S5) に収まる — 期限だけ残る X3 を作らない', async () => {
+		// #4026 の実害を再現する初期状態: cancel が planExpiresAt を書いた直後
+		const before = rowBefore({ status: 'grace_period', planExpiresAt: '2026-09-01T00:00:00Z' });
+		const patch = await runAndCapturePatch(
+			before,
+			subscriptionEvent('customer.subscription.deleted', { status: 'canceled' }),
+		);
+		expectValidAfter(before, patch, 'customer.subscription.deleted');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**支払いに失敗して猶予に入った顧客が、支払い直しに成功しても猶予終了日が消えません。**

`handleInvoicePaid` は `status` を `active` に戻しますが `planExpiresAt` を落としません。`contract-state-matrix.md` が **X3「active に期限は無い。dunning / 解約の残骸」**と名前を付けている不正状態そのもので、**この列を読む導出値は支払い済みの顧客に「あと N 日で使えなくなります」と表示しうる**状態でした。

**#4026 が `subscription.deleted` に対して直したのと同じ class** が `invoice.paid` に残っていました。

## この欠陥は「探して見つけた」ものではありません

EPIC #4118 の**手 2**（matrix §7 =「各 webhook handler の unit test で適用後の行が S1-S6 に分類されることを assert する」）を実装したら **red になって発覚**しました。matrix §7 が手 2 を「**意図と効果の乖離**を落とす本体」と位置づけていた通りの結果です。

## 関連 Issue

Refs #4118（EPIC、手 2 の実装。EPIC 自体は手 3 = 定期監査が残るため close しない）

- **Depends on #4233**（`classifyContractState` を使うため stack。**merge 順は #4233 → 本 PR**）
- #4026 / #4077（同 class を `deleted` に対して修正した先行 PR）/ #3988（matrix SSOT）/ #3960（本 PR で assertion を格上げした既存 test）

<!-- no-issue-close: EPIC #4118 は手 2 (本 PR) の完了では閉じない。手 3 (本番行を定期監査して X1-X4 を報告する) が残るため、close は手 3 完了時に行う。 -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 手 2 の guard を置く | 新規 test | ✅ `stripe-webhook-contract-state.test.ts`（適用前の行 + patch を合成 → 分類） |
| AC2 | 部分更新の効果を正しく再現する | 実装 | ✅ `undefined` = 更新しない / `null` = NULL を書く を `applyPatch` で区別 |
| AC3 | dispatcher の網羅漏れを作らない | no-silent-gap | ✅ source から `case` を抽出し覆う event 型と突き合わせ（5 件一致） |
| AC4 | **発覚した X3 を修正する** | 実装 + red→green | ✅ `handleInvoicePaid` に `planExpiresAt: null` |
| AC5 | 既存 assertion を弱めない | ADR-0006 | ✅ `#3960` の完全一致 assertion を `not.toHaveProperty('plan')` で**明示に格上げ**してから期待値更新 |
| AC6 | 全 service test が green | 実行 | ✅ **160 files / 2618 tests passed** |
| AC7 | mutation で red を実測 | 実測 | ✅ **2 方向**（下記） |
| AC8 | `npm run pre-ready` 全 Step PASS | — | ✅ |

## 変更タイプ

- [x] バグ修正（顧客に見える誤表示）
- [x] テスト追加（fitness function）
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

### なぜ静的解析で捕まえられないか

`updateTenantStripe` は**部分更新**（`undefined` = その列を更新しない）です。handler の patch だけを読むと `{status:'active', plan:'monthly'}` は正しく見えます。**不正状態は「適用前の行」と合成して初めて現れます**。

```
before = { status:'grace_period', plan:'monthly', sub:あり, exp:'2026-09-01' }   ← 支払い失敗直後
patch  = { status:'active',       plan:'monthly' }                              ← 一見正しい
after  = { status:'active',       plan:'monthly', sub:あり, exp:'2026-09-01' }   ← X3
```

だから handler を**実際に走らせて** patch を捕獲し、適用前の行にマージして分類しています。

### 同 class の横展開

| handler | 適用後 | 状態 |
|---|---|---|
| `invoice.paid` | **X3 だった** | **本 PR で修正** |
| `invoice.payment_failed` | S3 | OK |
| `customer.subscription.updated` | 表に在る | OK |
| `customer.subscription.deleted` | S5 | OK（#4026 で修正済） |
| `checkout.session.completed` | 表に在る | OK |

**5 handler 全てが本 PR の guard 下に入りました。** 新しい handler が dispatcher に増えると no-silent-gap が落ちます。

### 直し方の原則

**status を戻すなら、その status が持ってはいけない列も同時に落とす。** 個別 handler ごとに「どの列を消し忘れたか」を追うのではなく、matrix を SSOT にして機械判定します。

## テスト・品質セルフチェック

```
npx vitest run tests/unit/services/
 Test Files  160 passed (160)
      Tests  2618 passed (2618)
```

### mutation を 2 方向で実測（commit 後に `git stash` で退避）

1. **実装を戻す**（`planExpiresAt: null` を削除）→ ✅ **red**: `invoice.paid: 適用後の 4 列が表に無い状態 (X3) になりました`
2. **網羅から 1 件外す**（`invoice.payment_failed` を covered から削除）→ ✅ **red**: `no-silent-gap: dispatcher が扱う event 型を全件覆っている`

1 つ目は「**欠陥を検出できること**」、2 つ目は「**検査していないことを検出できること**」で、別方向です。

- [x] **mutation の前に commit した**
- [x] **2 方向を実測した**

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: 変更は src/lib/server/services/ (webhook handler) と tests/unit/services/ のみ。サーバ側の DB 書き込み列の修正で、UI コンポーネントも routes も 1 行も触っていない。 -->

**UI 変更はありません。** 顧客に見える影響（誤った期限表示）は本修正で消えますが、描画コードは変えていません。

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **`planExpiresAt: null` を無条件に書いてよいか。** `invoice.paid` が到達する時点で subscription は終端でないことが確定済（handler 冒頭で早期 return）なので、`active` に戻す文脈で期限を残す正当な理由は無いと判断しました
2. **既存 test の assertion 変更**（#3960）。列が増えたことで完全一致が落ちたため更新していますが、**緩めた箇所はありません** — 元の意図（plan を書かない）を `not.toHaveProperty` で明示に格上げしています

### 破壊的変更

**ありません。** 既存 2617 tests は無変更で green（1 件のみ上記のとおり格上げ更新）。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **欠陥を red で固定してから直した**（後付けの test ではない）
- [x] **2 方向で mutation を実測した**
- [x] **既存 assertion を弱めずに更新した**
- [x] **5 handler 全てを guard 下に入れ、no-silent-gap を置いた**
- [x] **stack 元（#4233）と merge 順を明記した**
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
