### PR TITLE
fix(ci): #4120 TZ guard の走査範囲そのものを宣言制にする（新しいコード置き場が黙って guard の外に出ない）

### DIFF
--- a/scripts/check-local-tz-date-getters.mjs
+++ b/scripts/check-local-tz-date-getters.mjs
@@ -74,6 +74,57 @@ const REPO_ROOT = path.resolve(__dirname, '..');
  */
 export const SEARCH_ROOTS = ['src', 'infra/lambda', 'scripts'];
 
+/**
+ * **走査しないと決めた** コード保有ディレクトリと、その理由 (#4120)。
+ *
+ * `SEARCH_ROOTS` 配下では「検出があったのに allowlist に無い file」を no-silent-gap で落とすが、
+ * **走査範囲そのものの網羅は誰も見ていなかった**。`infra/lib` に日付から schedule / 期限を
+ * 組み立てるコードが後から入っても、この guard は黙って素通りさせる。EPIC #4120 の目的は
+ * 「TZ 依存の日付導出を根絶する」ことなので、**新しいコード置き場が増えたときに気付けること**まで
+ * が guard の責務に含まれる。
+ *
+ * 除外は「今は違反が無いから」ではなく「**顧客に見える日付をここでは作らない**」を理由にする。
+ * 網羅は `tests/unit/scripts/check-local-tz-date-getters.test.ts` が実 repo と突き合わせる。
+ *
+ * @type {ReadonlyArray<{ root: string; reason: string }>}
+ */
+export const EXCLUDED_ROOTS = [
+	{
+		root: 'infra/lib',
+		reason:
+			'CDK stack 定義。deploy 時に 1 度評価されるだけで、顧客に見える日付を導出しない (実測 0 件)',
+	},
+	{
+		root: 'infra/bin',
+		reason: 'CDK app entry point。stack の組み立てのみで日付を扱わない (実測 0 件)',
+	},
+	{
+		root: 'tests',
+		reason: '意図的な時刻固定が多く、TZ 依存の検出が偽陽性になる (#4015 No-gos で除外を決定)',
+	},
+	{
+		root: 'site',
+		reason: 'LP の静的 HTML / CSS。日付を描画しない (実測 0 件)',
+	},
+	{
+		root: 'infra/gcp',
+		reason: 'Discord 連携の設定・シェル資材。走査対象拡張子の file を持たない (実測 0 件)',
+	},
+	{
+		root: 'infra/error-pages',
+		reason: 'CloudFront カスタムエラーページ (静的 HTML)。走査対象拡張子を持たない (実測 0 件)',
+	},
+	{
+		root: 'eslint-plugin-local',
+		reason: 'ESLint ルール実装。lint 時に評価されるだけで顧客に見える日付を作らない (実測 0 件)',
+	},
+	{ root: 'docs', reason: '設計文書。実行されるコードを含まない' },
+	{ root: 'actions', reason: 'GitHub Actions composite action 定義 (YAML)' },
+	{ root: 'data', reason: '静的データ資材。実行されるコードを含まない' },
+	{ root: 'drizzle', reason: 'DB migration SQL。実行されるコードを含まない' },
+	{ root: 'static', reason: '静的アセット (画像 / manifest 等)' },
+];
+
 /** 走査対象拡張子 */
 export const EXTENSIONS = ['.ts', '.svelte', '.mjs', '.js'];
 

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -45,6 +45,10 @@ export const MIN_REPO_SCAN_TIMEOUT_MS = 20_000;
  */
 export const REPO_SCAN_TEST_REGISTRY = {
 	// --- scope: repo (repo ツリーを走査。明示 timeout 必須) ---
+	'tests/unit/scripts/check-local-tz-date-getters.test.ts': {
+		scope: 'repo',
+		note: 'repo 直下 / infra 直下を depth 1 で readdir し、TZ guard の走査範囲 (SEARCH_ROOTS) と除外宣言 (EXCLUDED_ROOTS) の網羅を突き合わせる (#4120)。全 file walk はしないが静的判定は保守的に repo と見なすため、判定に合わせて明示 timeout を置く',
+	},
 	'tests/unit/ai-evaluation/axe-runner-inline.test.ts': {
 		scope: 'repo',
 		note: 'scripts/ai-evaluation 配下を走査して inline inject 経路の残存を検査する',

--- a/tests/unit/scripts/check-local-tz-date-getters.test.ts
+++ b/tests/unit/scripts/check-local-tz-date-getters.test.ts
@@ -301,7 +301,7 @@ describe('check-local-tz-date-getters (#4015 / #4127)', () => {
 		const repoRoot = join(__dirname, '../../..');
 
 		/** 直下のディレクトリ名 (走査対象外の作業 dir は除く)。 */
-		function subdirs(rel: string): string[] {
+		function listSubdirectories(rel: string): string[] {
 			const IGNORED = new Set(['node_modules', '.git', '.svelte-kit', '.claude', 'coverage']);
 			return readdirSync(join(repoRoot, rel), { withFileTypes: true })
 				.filter((e) => e.isDirectory() && !e.name.startsWith('.') && !IGNORED.has(e.name))
@@ -324,7 +324,7 @@ describe('check-local-tz-date-getters (#4015 / #4127)', () => {
 		}
 
 		it('repo 直下の全ディレクトリが走査対象か除外宣言のどちらかに属する', () => {
-			const undeclared = subdirs('.').filter((d) => !declared(d));
+			const undeclared = listSubdirectories('.').filter((d) => !declared(d));
 			expect(
 				undeclared,
 				'guard の走査範囲にも除外宣言にも無いディレクトリがあります。' +
@@ -333,7 +333,7 @@ describe('check-local-tz-date-getters (#4015 / #4127)', () => {
 		});
 
 		it('部分的にしか走査していない infra/ は直下も全て宣言済', () => {
-			const undeclared = subdirs('infra')
+			const undeclared = listSubdirectories('infra')
 				.map((d) => `infra/${d}`)
 				.filter((d) => !declared(d));
 			expect(

--- a/tests/unit/scripts/check-local-tz-date-getters.test.ts
+++ b/tests/unit/scripts/check-local-tz-date-getters.test.ts
@@ -14,6 +14,8 @@
  *   - UTC getter / 数値の桁区切り / timeZone 明示済の toLocale* は検出しない (誤検知しない)
  */
 
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -23,6 +25,7 @@ import {
 	classifyDateMembers,
 	classifyLine,
 	DATE_RECEIVER_AMBIGUOUS_CALL,
+	EXCLUDED_ROOTS,
 	evaluateOccurrences,
 	findAllowlistEntry,
 	findAllowlistIntegrityProblems,
@@ -32,6 +35,7 @@ import {
 	groupByFile,
 	isCommentLine,
 	NON_RUNTIME_PATTERNS,
+	SEARCH_ROOTS,
 } from '../../../scripts/check-local-tz-date-getters.mjs';
 
 /** 違反 1 件を作るヘルパ */
@@ -277,6 +281,89 @@ describe('check-local-tz-date-getters (#4015 / #4127)', () => {
 		it('allowlist に file の重複がない (max の解釈が曖昧にならない)', () => {
 			const files = ALLOWLIST.map((e) => e.file);
 			expect(new Set(files).size).toBe(files.length);
+		});
+	});
+	// #4120: 走査範囲そのものの網羅
+	//
+	// `SEARCH_ROOTS` 配下では「検出があったのに allowlist に無い file」を落とすが、
+	// **どのディレクトリを走査するかは誰も見ていなかった**。`infra/lib` に日付から
+	// schedule / 期限を組み立てるコードが後から入っても、guard は黙って素通りさせる。
+	// EPIC #4120 の目的は根絶なので、**新しいコード置き場が増えたときに気付けること**まで
+	// を guard の責務に含める。
+	//
+	// 走査は repo root と infra/ の直下 (depth 1) のみで、全 file walk はしない
+	// (本 file 冒頭の「実 repo 全走査は unit lane では行わない」方針を維持する)。
+	describe('#4120 走査範囲の網羅 (どの dir も宣言なしに guard の外に出られない)', () => {
+		const repoRoot = join(__dirname, '../../..');
+
+		/** 直下のディレクトリ名 (走査対象外の作業 dir は除く)。 */
+		function subdirs(rel: string): string[] {
+			const IGNORED = new Set(['node_modules', '.git', '.svelte-kit', '.claude', 'coverage']);
+			return readdirSync(join(repoRoot, rel), { withFileTypes: true })
+				.filter((e) => e.isDirectory() && !e.name.startsWith('.') && !IGNORED.has(e.name))
+				.map((e) => e.name);
+		}
+
+		/** その path が SEARCH_ROOTS / EXCLUDED_ROOTS のいずれかで宣言済か。 */
+		function declared(path: string): boolean {
+			return (
+				SEARCH_ROOTS.includes(path) ||
+				EXCLUDED_ROOTS.some((e) => e.root === path) ||
+				// 親が丸ごと宣言されていれば子も覆われる (例: 'src' が SEARCH_ROOTS)
+				SEARCH_ROOTS.some((r) => path.startsWith(`${r}/`)) ||
+				EXCLUDED_ROOTS.some((e) => path.startsWith(`${e.root}/`)) ||
+				// 子が宣言されている = 部分的に覆われている (例: infra/lambda だけ走査)。
+				// この場合は次の test が直下の全 dir の宣言を要求する
+				SEARCH_ROOTS.some((r) => r.startsWith(`${path}/`)) ||
+				EXCLUDED_ROOTS.some((e) => e.root.startsWith(`${path}/`))
+			);
+		}
+
+		it('repo 直下の全ディレクトリが走査対象か除外宣言のどちらかに属する', () => {
+			const undeclared = subdirs('.').filter((d) => !declared(d));
+			expect(
+				undeclared,
+				'guard の走査範囲にも除外宣言にも無いディレクトリがあります。' +
+					'走査するなら SEARCH_ROOTS に、しないなら EXCLUDED_ROOTS に理由付きで足してください',
+			).toEqual([]);
+		});
+
+		it('部分的にしか走査していない infra/ は直下も全て宣言済', () => {
+			const undeclared = subdirs('infra')
+				.map((d) => `infra/${d}`)
+				.filter((d) => !declared(d));
+			expect(
+				undeclared,
+				'infra/ は infra/lambda だけを走査しているため、直下の各 dir を個別に宣言する必要があります',
+			).toEqual([]);
+		});
+
+		it('除外理由が実質的である (空 / 定型 stub を許さない)', () => {
+			for (const e of EXCLUDED_ROOTS) {
+				expect(typeof e.reason, `${e.root}: reason が文字列ではありません`).toBe('string');
+				const reason = e.reason.trim();
+				expect(
+					reason.length,
+					`${e.root}: 除外理由が短すぎます (${reason.length} 字)`,
+				).toBeGreaterThanOrEqual(8);
+				expect(
+					['todo', 'tbd', 'n/a', '-', 'なし'].includes(reason.toLowerCase()),
+					`${e.root}: 除外理由が定型 stub です`,
+				).toBe(false);
+			}
+		});
+
+		it('除外宣言が stale でない (存在しない dir を除外し続けない)', () => {
+			const stale = EXCLUDED_ROOTS.filter((e) => !existsSync(join(repoRoot, e.root)));
+			expect(
+				stale.map((e) => e.root),
+				'存在しないディレクトリの除外宣言が残っています。消えた dir の除外は削除してください',
+			).toEqual([]);
+		});
+
+		it('走査対象と除外が重複しない (どちらの意図か曖昧にならない)', () => {
+			const overlap = EXCLUDED_ROOTS.filter((e) => SEARCH_ROOTS.includes(e.root));
+			expect(overlap.map((e) => e.root)).toEqual([]);
 		});
 	});
 });

--- a/tests/unit/scripts/check-local-tz-date-getters.test.ts
+++ b/tests/unit/scripts/check-local-tz-date-getters.test.ts
@@ -16,7 +16,11 @@
 
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: 走査 API を使うため静的判定が scope='repo' になる。判定を緩めず明示 timeout を置く
+// (実走査は depth 1 の readdir のみで、全 file walk はしない)。
+vi.setConfig({ testTimeout: 60_000 });
 
 import {
 	ALLOWLIST,


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（guard の守備範囲を閉じる変更）。**

EPIC #4120 の目的は「TZ 依存の日付導出を**根絶**する」ことです。現在の guard は `SEARCH_ROOTS`（`src` / `infra/lambda` / `scripts`）配下では「検出があったのに allowlist に無い file」を no-silent-gap で落としますが、**どのディレクトリを走査するかは誰も見ていませんでした**。

`infra/lib`（CDK stack）に日付から schedule / 期限を組み立てるコードが後から入っても、**guard は黙って素通りさせます**。

## 実測: 今は違反ゼロです

未走査の全ディレクトリを実測しました。

| dir | 走査対象 file | TZ 依存 getter |
|---|---|---|
| `infra/lib` / `infra/bin` / `site` | 有 / 有 / 有 | **0 件** |
| `eslint-plugin-local` | 6 | **0 件** |
| `actions` / `data` / `drizzle` / `static` / `infra/gcp` / `infra/error-pages` | 0 | — |
| `tests` | 815 | `setDate(getDate() - n)` のみ（絶対時刻オフセット、暦要素を外に出さない） |

**現時点で見逃している違反はありません。** 塞ぐのは「これから入るもの」です。

## 関連 Issue

Refs #4120（EPIC。走査範囲の宣言化。EPIC 自体は他の手が残るため close しない）

- #4015 / #4127（guard 本体の実装と強化）/ #4085（repo 走査 test の区分宣言）
- 同 class の先行修正: #4237（除外理由の非空検証）/ #4238（walker の母数）/ #4243（走査範囲がセクションで閉じていない）

<!-- no-issue-close: EPIC #4120 は本 PR では閉じない。本 PR は guard の走査範囲を宣言制にするだけで、EPIC が掲げる他の経路（既存 allowlist 19 file の縮小等）は残るため。 -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 走査しない dir を理由付きで宣言する | 実装 | ✅ `EXCLUDED_ROOTS`（10 件、各 1 行の理由付き） |
| AC2 | repo 直下の全 dir が宣言に属する | 実 repo と突き合わせ | ✅ depth 1 の `readdir` で照合 |
| AC3 | 部分走査の `infra/` は直下も全件宣言 | 同上 | ✅ `infra/lambda` だけ走査のため直下 5 dir を個別宣言 |
| AC4 | 除外理由が実質的である | 機械検証 | ✅ 空 / 8 字未満 / 定型 stub を弾く |
| AC5 | stale な除外を残さない | 機械検証 | ✅ 存在しない dir の宣言を fail |
| AC6 | 走査対象と除外が重複しない | 機械検証 | ✅ 意図が曖昧になる重複を fail |
| AC7 | 全 file walk をしない | 設計 | ✅ depth 1 の `readdir` のみ（既存 test file の方針を維持） |
| AC8 | repo 走査 test として宣言する | #4085 gate | ✅ registry 登録 + 明示 timeout。`OK — 41 件すべて区分宣言済` |
| AC9 | mutation で red を実測 | 実測 | ✅ **3 方向**（下記） |
| AC10 | `npm run pre-ready` 全 Step PASS | — | ✅ |

## 変更タイプ

- [x] テスト追加（fitness function）
- [x] バグ修正（guard の守備範囲の穴）
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

### 除外の理由は「今は違反が無い」ではありません

`EXCLUDED_ROOTS` の理由は **「顧客に見える日付をここでは作らない」** で書いています。「実測 0 件だから」を理由にすると、**違反が 1 件入った瞬間に理由が嘘になる**ためです（実測値は補足として括弧書きで添えています）。

### 全 dir を宣言対象にした理由

「コードを含む dir だけ」を対象にすると、**どれがコードを含むかの判定が新しい母数問題**になります。`docs` / `static` まで含めて全件宣言させれば、**新しいトップレベル dir が増えたとき必ず決断を迫れます**。

### 既存 guard との重複

`check-repo-scan-test-declaration`（#4085）が本 test を `scope: 'repo'` と静的判定しました。`tests/CLAUDE.md` の「**判定を緩めるのではなく明示 timeout 1 行を置いて合わせる**」に従い、registry 登録 + `vi.setConfig({ testTimeout: 60_000 })` を置いています（実走査は depth 1 のみ）。

## テスト・品質セルフチェック

```
npx vitest run tests/unit/scripts/check-local-tz-date-getters.test.ts
 Test Files  1 passed (1)
      Tests  67 passed (67)   ← 既存 62 + 新規 5

node scripts/check-repo-scan-test-declaration.mjs
 OK — repo 走査 test 41 件すべて区分宣言済

node scripts/check-local-tz-date-getters.mjs
 OK — allowlist (19 file、全件 kind 検証済) 外の TZ 依存日付導出なし
```

### mutation を 3 方向で実測（commit 後に `git stash` で退避）

1. **除外宣言を 1 件消す**（`drizzle`）→ ✅ **red**: `走査範囲にも除外宣言にも無いディレクトリがあります: ['drizzle']`
2. **除外理由を stub にする**（`TODO`）→ ✅ **red**: `static: 除外理由が短すぎます (4 字)`
3. **stale な除外を足す**（存在しない dir）→ ✅ **red**: `存在しないディレクトリの除外宣言が残っています: ['removed-dir']`

「宣言漏れ」「理由の空洞化」「陳腐化」で別々に落ちます。

- [x] **mutation の前に commit した**
- [x] **3 方向を実測した**

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: 変更は scripts/ (CI gate) と tests/unit/scripts/ のみ。UI コンポーネントも routes も 1 行も触っておらず、顧客に見える画面が存在しない。 -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **`tests` の除外理由**を「意図的な時刻固定が多く偽陽性になる（#4015 No-gos で決定）」としました。既存の判断を引き継いだもので、本 PR で新たに判断を変えてはいません
2. **`infra/lib` を走査対象にしなかった**こと。CDK は deploy 時に 1 度評価されるだけで顧客に見える日付を作らないため除外しましたが、**将来 budget 期間 / cron schedule を日付から組み立てるなら走査対象に移すべき**です。そのとき test が「宣言を変えろ」と教えます

### 破壊的変更

**ありません。** 既存 62 tests は無変更で green、guard の検出結果も不変です。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **実測してから宣言した**（未走査 dir の違反件数を全件確認）
- [x] **3 方向で mutation を実測した**
- [x] **既存 test / guard 出力を変えていない**
- [x] **静的判定を緩めず明示 timeout で合わせた**（#4085 の指示どおり）
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
