### PR TITLE
fix(ci): #4120 TZ allowlist の ratchet 余白 19 件を締め、余白そのものを検出する

### DIFF
--- a/scripts/check-local-tz-date-getters.mjs
+++ b/scripts/check-local-tz-date-getters.mjs
@@ -305,7 +305,7 @@ export const ALLOWLIST_KINDS = ['ssot', 'tz-proof', 'instant-offset', 'non-runti
 export const ALLOWLIST = [
 	{
 		file: 'src/lib/domain/date-utils.ts',
-		max: 20,
+		max: 5,
 		kind: 'ssot',
 		reason:
 			'JST SSOT の実装本体。UTC 算術 + toISOString で JST 暦日を組み立てる唯一の場所であり、ここが違反を持つのは定義上正しい',
@@ -336,25 +336,25 @@ export const ALLOWLIST = [
 	},
 	{
 		file: 'src/lib/features/child-home/BabyHomePage.stories.svelte',
-		max: 8,
+		max: 7,
 		kind: 'non-runtime',
 		reason: 'Storybook の fixture 生成 (「N ヶ月前生まれ」等の相対誕生日)。本番ビルドに含まれない',
 	},
 	{
 		file: 'src/lib/server/demo/demo-data.ts',
-		max: 6,
+		max: 5,
 		kind: 'non-runtime',
 		reason: 'デモ fixture の相対日付生成。顧客テナントのデータを作らない',
 	},
 	{
 		file: 'src/lib/server/demo/synthetic-staging-dataset.ts',
-		max: 2,
+		max: 1,
 		kind: 'non-runtime',
 		reason: 'staging 合成 seed の相対日付生成 (#3412)。顧客テナントのデータを作らない',
 	},
 	{
 		file: 'src/lib/server/debug-plan.ts',
-		max: 2,
+		max: 1,
 		kind: 'non-runtime',
 		reason: 'DEBUG_TRIAL の擬似終了日 (dev 専用、本番ビルド無効)',
 	},
@@ -591,11 +591,11 @@ export function groupByFile(occurrences) {
 /**
  * occurrence 群を allowlist と突き合わせ、違反 (no-silent-gap / ratchet 超過) を返す。
  * @param {Array<{file: string, line: number, snippet: string, kind: string}>} occurrences
- * @returns {Array<{kind: 'not-allowlisted'|'over-max', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string, kind: string}>}>}
+ * @returns {Array<{kind: 'not-allowlisted'|'over-max'|'slack', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string, kind: string}>}>}
  */
 export function evaluateOccurrences(occurrences) {
 	const byFile = groupByFile(occurrences);
-	/** @type {Array<{kind: 'not-allowlisted'|'over-max', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string, kind: string}>}>} */
+	/** @type {Array<{kind: 'not-allowlisted'|'over-max'|'slack', file: string, count: number, max: number, samples: Array<{file: string, line: number, snippet: string, kind: string}>}>} */
 	const violations = [];
 	for (const [file, list] of byFile) {
 		const entry = findAllowlistEntry(file);
@@ -616,6 +616,17 @@ export function evaluateOccurrences(occurrences) {
 				count: list.length,
 				max: entry.max,
 				samples: list.slice(0, 5),
+			});
+		} else if (list.length < entry.max) {
+			// #4120: ratchet は「減ったら下げる」まで含めて初めて締まる。
+			// max を実数より高いまま放置すると、**その差分だけ新規違反を黙って受け入れる**
+			// 予算になる (実測: date-utils.ts は max=20 / actual=5 で 15 件分の余白があった)。
+			violations.push({
+				kind: 'slack',
+				file,
+				count: list.length,
+				max: entry.max,
+				samples: [],
 			});
 		}
 	}
@@ -702,17 +713,23 @@ function main() {
 	}
 
 	console.error(
-		`[check-local-tz-date-getters] ✗ TZ 依存の日付導出を ${violations.length} file で検出しました (#4015 / #4127):\n`,
+		`[check-local-tz-date-getters] ✗ allowlist と実数が食い違う file が ${violations.length} 件あります (#4015 / #4127 / #4120):\n`,
 	);
 	for (const v of violations) {
 		const head =
 			v.kind === 'not-allowlisted'
 				? `${v.file}: ${v.count} 件 (allowlist 未登録)`
-				: `${v.file}: ${v.count} 件 (allowlist 上限 ${v.max} 件を超過)`;
+				: v.kind === 'slack'
+					? `${v.file}: ${v.count} 件 (allowlist 上限 ${v.max} 件を下回っています — max を ${v.count} に下げてください)`
+					: `${v.file}: ${v.count} 件 (allowlist 上限 ${v.max} 件を超過)`;
 		console.error(`  ${head}`);
 		for (const s of v.samples) console.error(`    L${s.line} [${s.kind}]: ${s.snippet}`);
 	}
 	console.error('\n修正方針:');
+	console.error(
+		'  - [slack] 違反が減ったのに max が下がっていません。ratchet は「減ったら下げる」まで含めて初めて\n' +
+			'    締まります (差分だけ新規違反を黙って受け入れる予算になる)。ALLOWLIST の max を実数に下げてください。',
+	);
 	console.error(
 		'  - [tz-dependent-member] 実時刻から暦要素をローカル TZ で取り出しています。$lib/domain/date-utils.ts の',
 	);

--- a/tests/unit/scripts/check-local-tz-date-getters.test.ts
+++ b/tests/unit/scripts/check-local-tz-date-getters.test.ts
@@ -370,4 +370,38 @@ describe('check-local-tz-date-getters (#4015 / #4127)', () => {
 			expect(overlap.map((e) => e.root)).toEqual([]);
 		});
 	});
+	// #4120: ratchet は「減ったら下げる」まで含めて初めて締まる。
+	// max を実数より高いまま放置すると、その差分だけ新規違反を黙って受け入れる予算になる
+	// (実測: date-utils.ts は max=20 / actual=5 で 15 件分の余白があった)。
+	describe('#4120 ratchet の余白 (slack) を検出する', () => {
+		it('max が実数を上回っていたら slack として報告する', () => {
+			const occurrences = [
+				{
+					file: 'src/lib/domain/date-utils.ts',
+					line: 1,
+					snippet: 'x',
+					kind: 'tz-dependent-member',
+				},
+			];
+			const violations = evaluateOccurrences(occurrences);
+			const slack = violations.find((v) => v.kind === 'slack');
+			expect(
+				slack,
+				'allowlist の max を実数が下回っているのに slack として報告されていません',
+			).toBeDefined();
+			expect(slack?.file).toBe('src/lib/domain/date-utils.ts');
+		});
+
+		it('max と実数が一致していれば違反にしない', () => {
+			const entry = ALLOWLIST.find((e) => e.file === 'src/lib/server/debug-plan.ts');
+			expect(entry, 'fixture 対象の allowlist entry が見つかりません').toBeDefined();
+			const occurrences = Array.from({ length: entry?.max ?? 0 }, (_, i) => ({
+				file: 'src/lib/server/debug-plan.ts',
+				line: i + 1,
+				snippet: 'x',
+				kind: 'tz-dependent-member',
+			}));
+			expect(evaluateOccurrences(occurrences)).toEqual([]);
+		});
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**顧客に見える変化はありません（ratchet を締める変更）。**

TZ guard の allowlist は各 file の許容件数 `max` を持ちますが、**実数が減っても `max` が下がっていませんでした**。

実測すると **19 件分の余白**があり、最大は **JST SSOT の実装本体** `date-utils.ts`（`max=20` / **実数 5**）です。**15 件分、新規の TZ 依存導出を黙って受け入れる予算**になっていました。SSOT 本体に「JST 以外で暦要素を取り出すコード」が入っても、guard は無反応です。

```
SLACK src/lib/domain/date-utils.ts               max=20 actual=5   (kind=ssot)
SLACK .../BabyHomePage.stories.svelte             max=8  actual=7
SLACK src/lib/server/demo/demo-data.ts            max=6  actual=5
SLACK .../synthetic-staging-dataset.ts            max=2  actual=1
SLACK src/lib/server/debug-plan.ts                max=2  actual=1
--- 合計 slack = 19 ---
```

**ratchet は「増えたら落とす」だけでは締まりません。「減ったら下げる」まで含めて初めて締まります。**

## 関連 Issue

Refs #4120（EPIC。ratchet の締め直し。EPIC 自体は他の手が残るため close しない）

- **Depends on #4246**（同 file を触るため stack。**merge 順は #4246 → 本 PR**）
- #4015 / #4127（guard 本体）
- 同原則の先行実装: `base-token-routes-ratchet`（`src/routes/CLAUDE.md`「**削減したら baseline を下げる**」）

<!-- no-issue-close: EPIC #4120 は本 PR では閉じない。ratchet の余白を締めるだけで、EPIC が掲げる他の経路は残るため。 -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 余白を実測する | 実行 | ✅ 5 entry / 合計 19 件（上記出力） |
| AC2 | max を実数まで切り下げる | 実装 | ✅ 20→5 / 8→7 / 6→5 / 2→1 / 2→1 |
| AC3 | **余白そのものを検出する** | 実装 | ✅ `evaluateOccurrences` に `slack` 種別を追加 |
| AC4 | 修正方針を出す | 実装 | ✅ `max を N に下げてください` を file 名付きで出力 |
| AC5 | slack 検出を test で固定 | unit test | ✅ 検出する / 一致時は違反にしない の 2 件 |
| AC6 | guard が緑のまま | 実行 | ✅ `OK — allowlist (19 file、全件 kind 検証済) 外の TZ 依存日付導出なし` |
| AC7 | 既存 test が全件 green | 実行 | ✅ 67 → **69 passed**（既存は無変更） |
| AC8 | mutation で red を実測 | 実測 | ✅ **2 方向**（下記） |
| AC9 | `npm run pre-ready` 全 Step PASS | — | ✅ |

## 変更タイプ

- [x] バグ修正（ratchet の空洞化）
- [x] テスト追加
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント更新
- [ ] インフラ変更

## 影響範囲・横展開チェック

### なぜ「余白があること」自体を fail にするのか

余白は**放置すると必ず溜まります**（違反を減らす PR は max を下げる動機を持たない）。溜まった余白は「guard が緑だから安全」という誤った安心を生みます。**減らしたら下げることを機械が要求する**なら、余白は構造的に発生しません。

### 運用への影響

違反を 1 件減らす PR は、**同じ PR で max も下げる**必要があります。手間は 1 行ですが、これが ratchet の本体です。修正方針を出力に含めたので、落ちたときに何をすべきかは画面で分かります。

### 横展開

`src/routes/CLAUDE.md` の base-token ratchet が既に「**削減したら baseline を下げる**」と明文化しています。本 PR はその原則を TZ guard に**機械で効かせた**もので、新しい方針ではありません。他の baseline 系 gate（`lp-removal-residue` / `lp-inline-style` / hardcoded-strings）への同様の適用は、本 PR の形が定着してから個別に判断すべきと考えます（一度に広げると運用負荷の見積もりができないため、本 PR では広げていません）。

## テスト・品質セルフチェック

```
npx vitest run tests/unit/scripts/check-local-tz-date-getters.test.ts
 Test Files  1 passed (1)
      Tests  69 passed (69)   ← 既存 67 + 新規 2

node scripts/check-local-tz-date-getters.mjs
 OK — allowlist (19 file、全件 kind 検証済) 外の TZ 依存日付導出なし
```

### mutation を 2 方向で実測（commit 後に `git stash` で退避）

1. **max を元に戻す**（`date-utils.ts` を 20 に）→ ✅ **red**:
   `src/lib/domain/date-utils.ts: 5 件 (allowlist 上限 20 件を下回っています — max を 5 に下げてください)`
2. **slack 検出を消す** → ✅ **red**: `allowlist の max を実数が下回っているのに slack として報告されていません`

1 つ目は「**余白を検出できること**」、2 つ目は「**検出機構が消えたことを検出できること**」です。

- [x] **mutation の前に commit した**
- [x] **2 方向を実測した**

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: 変更は scripts/ (CI gate) と tests/unit/scripts/ のみ。UI コンポーネントも routes も 1 行も触っておらず、顧客に見える画面が存在しない。 -->

**UI 変更はありません。**

## レビュー依頼事項・破壊的変更

### 見ていただきたい点

1. **slack を hard-fail にしてよいか。** 違反を減らす PR に「max も下げる」1 行の手間が増えます。warn に留める選択もありますが、**warn は溜まる**（今回 19 件溜まったのと同じ経路）ため hard-fail にしました
2. **`date-utils.ts` の max=5 は妥当か。** ここは JST SSOT の実装本体で、UTC 算術 + `toISOString` で JST 暦日を組み立てる唯一の場所です。**増やす必要が出たときは、その増加が本当に SSOT の責務かを 1 度立ち止まって考える**ことになります（それが狙いです）

### 破壊的変更

**ありません。** 既存 67 tests は無変更で green、guard の検出結果も現時点では不変です。

## 配布済み env / secret (ADR-0006)

**新規 env / secret はありません。**

## Ready for Review チェックリスト

- [x] **実測してから締めた**（余白 19 件を数えた）
- [x] **2 方向で mutation を実測した**
- [x] **既存 test を 1 件も書き換えずに green を維持した**
- [x] **横展開を一度に広げず、定着後の判断に残した**
- [x] `npm run pre-ready` 全 step PASS / `gh pr checks` 確認

## QM レビュー結果

<!-- QM が記入 -->
