### PR TITLE
fix(infra)!: #4266 admin IP allowlist を廃止し /ops を ops group + MFA で守る

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -257,7 +257,6 @@ jobs:
           -c staticAssetsS3Offload=true
           -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }}
           -c geminiApiKey=${{ secrets.GEMINI_API_KEY }}
-          -c adminAllowedIps=${{ secrets.ADMIN_ALLOWED_IPS }}
           -c stripeSecretKey=${{ secrets.STRIPE_SECRET_KEY }}
           -c stripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }}
           -c stripePriceStandardMonthly=${{ vars.STRIPE_PRICE_STANDARD_MONTHLY }}
@@ -330,7 +329,6 @@ jobs:
             -c staticAssetsS3Offload=true \
             -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }} \
             -c geminiApiKey=${{ secrets.GEMINI_API_KEY }} \
-            -c adminAllowedIps=${{ secrets.ADMIN_ALLOWED_IPS }} \
             -c stripeSecretKey=${{ secrets.STRIPE_SECRET_KEY }} \
             -c stripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }} \
             -c stripePriceStandardMonthly=${{ vars.STRIPE_PRICE_STANDARD_MONTHLY }} \
@@ -358,7 +356,6 @@ jobs:
           -c staticAssetsS3Offload=true
           -c feedbackDiscordWebhookUrl=${{ secrets.FEEDBACK_DISCORD_WEBHOOK_URL }}
           -c geminiApiKey=${{ secrets.GEMINI_API_KEY }}
-          -c adminAllowedIps=${{ secrets.ADMIN_ALLOWED_IPS }}
           -c stripeSecretKey=${{ secrets.STRIPE_SECRET_KEY }}
           -c stripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET }}
           -c stripePriceStandardMonthly=${{ vars.STRIPE_PRICE_STANDARD_MONTHLY }}

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -409,7 +409,7 @@ user-content（avatar / ZIP import 由来ファイル等、attacker が content-
 - Origin Shield: 本番と同型に `/_app/*` の `demoStaticAssetOrigin` で有効 (region `us-east-1`、#3087)。default behavior origin は本番同様 shield なし
 - S3 静的アセット offload (#3087 解決策 B): 本番と同型に `/_app/immutable/*` を S3 (OAC) から配信 (`staticAssetsS3Offload=true` 時)。本番と demo は同一 Docker image (= 同一 build) の immutable アセットを配信するため `StaticAssetsBucket` を 1 つ共有し、distribution ごとに OAC を持つ
 - セキュリティヘッダ: 本番と同一 (`SECURITY_HEADERS` policy)
-- CloudFront Function: query slash encode のみ (admin IP 制限は demo に適用しない、anonymous public demo のため)
+- CloudFront Function: query slash encode のみ (本番も同一。IP allowlist は持たない、#4266)
 - geoRestriction: `JP` (本番と同一、Pre-PMF 段階)
 
 **Route 53:**

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -1022,6 +1022,24 @@ subscribe API の保存前検証だけでは、過去レコード混入 / repo �
 - **コミット前チェック**: Biome lint + svelte-check + Vitest + Playwright E2E
 - **高権限 Actions の SHA pin (#3298 / #3318 / #3457 / #3483 / #3489)**: secret を消費する / provenance を発行する / cache を書く / 本番 AWS role を assume する / GCP OIDC credential を取得する / GITHUB_TOKEN 付きで任意 JS を実行する / image を build & push する / Release を作成する / PR を auto-merge する高権限 Actions（`actions/create-github-app-token` / `actions/attest` / `actions/cache` / `aws-actions/configure-aws-credentials` / `aws-actions/amazon-ecr-login` / `google-github-actions/auth` / `actions/github-script` / `docker/build-push-action` / `softprops/action-gh-release` / `dependabot/fetch-metadata`）は mutable な floating tag（`@v3` 等）ではなく full-length commit SHA + `# vX.Y.Z` コメントで pin する（tag 再付け替えによる supply-chain 注入の防止、GitHub 公式 hardening guide 整合）。`aws-actions/*` は本番 AWS role を assume、`google-github-actions/auth` は GCP OIDC、`actions/github-script` は merge-write、`docker/build-push-action` は image push、`softprops/action-gh-release` は `contents: write` Release、`dependabot/fetch-metadata` は read-only だが auto-merge 起動 context（出力偽造で悪性 bump の自動 merge に直結）で、いずれも高権限。**網羅性 gate (#3483 / #3489 / #3494 / ADR-0061 class-lock)**: 手動列挙だけだと「新規高権限 third-party action を未 pin で導入しても silent に通る」no-silent-gap が残る（#3318→#3457→#3483 の手動追加 treadmill の root）ため、`findHighPrivilegeContextViolations` が **任意の permission scope への write 付与（`<scope>: write` / `permissions: write-all`）を宣言する workflow 内の third-party action（first-party `actions/*` `github/*` 以外）は SHA pin 必須**（default-deny）とし、floating 許容は `LOW_RISK_THIRD_PARTY_ALLOWLIST`（produce/write 能力なし + 起動する後続処理が安全な setup/metadata 専用 action のみ、理由付き）に明示する。未 pin の新規 third-party action を高権限 workflow に足したら CI が自動 fail する（class 全体を lock）。write クラスの trigger は #3483 当初 3 クラス → #3489 で 5 クラスの個別列挙だったが、issues / pages / security-events / checks / deployments / statuses / actions:write が trigger 外という「write クラス次元の列挙 treadmill」を再生産していたため、#3494 で列挙自体を廃止し **全 write scope（attestations 等の未列挙クラス含む）を generic に lock** した（permissions ブロック外の `<key>: write` 文字列一致による偽陽性は高権限側に倒れる fail-safe 方向のため許容）。**default GITHUB_TOKEN 前提の機械担保 (#3489 → #3494)**: 本 gate のトリガは明示的 write 権限宣言のみであり、`permissions` ブロックを持たない workflow（repo デフォルト GITHUB_TOKEN 権限に従う）は対象外（「明示なし=高権限」とすると多数の setup 系 third-party を一斉違反化し Pre-PMF で過大な churn になるため）。この除外が依存する「デフォルト token = read-only」前提は #3494 で 2 層機械担保に昇格した: ① **静的 gate（CI 決定的）** — 全 workflow に top-level `permissions:` 宣言を必須化（`scanDefaultTokenPremise`、未宣言で CI fail）し、default token に依存する workflow を構造的に排除（job-level のみは将来追加 job が default token に落ちるため不足）。② **repo 設定の実測 assert（opt-in）** — `node scripts/check-action-sha-pin.mjs --verify-default-token` が `gh api repos/{owner}/{repo}/actions/permissions/workflow` で `default_workflow_permissions=read` を assert する（GITHUB_TOKEN は administration:read を持てず CI 常時実行は不能のため、repo owner の local audit / 月 1 棚卸で実行。flag 指定時に照会不能なら hard fail、ADR-0024 silent skip 禁止）。**残余リスク (#3494 更新)**: 未列挙 write クラスの残余は generic 化で解消、permissionless 除外の前提崩れは上記 2 層で担保済。残るのは (a) first-party（`actions/*` `github/*`）floating tag の供給元信頼、(b) `LOW_RISK_THIRD_PARTY_ALLOWLIST` の例外判断誤り、(c) 実測 assert ② が opt-in で連続実行されない点（静的 gate ① が構造排除するため実害は新規設定 drift と同時に別経路の穴が開く複合時のみ）の 3 点で、いずれも Pre-PMF（ADR-0010）で許容する。floating tag への regression は `scripts/check-action-sha-pin.mjs`（CI `deps-supply-chain-check` job、SSOT = `HIGH_PRIVILEGE_ACTIONS` + 網羅性 gate）が hard-fail する。repo 全体の SHA pin 化は churn / 運用コストが大きく Pre-PMF（ADR-0010）で PO 判断待ち（高権限 subset のみ強制）。dependabot（`.github/dependabot.yml` の `github-actions` ecosystem `/`）が pin 済 action も SHA + コメント方式で bump 追従する（CVE 修正の stale 化を防ぐ）
 
+
+### 11.5 本番 / staging の防御層（#4266）
+
+`/admin`（保護者 = 顧客の画面）と `/ops`（運営専用）に、どの層が何をかけているか。**IP allowlist は本番・staging とも持たない**（§5.2.9 の理由による）。
+
+| 層 | 本番 | AWS staging | 備考 |
+|---|---|---|---|
+| CloudFront 地域制限 | JP allowlist | **なし** | staging の post-deploy smoke を回す GitHub Actions runner が日本国外にあるため（#4204）。**staging に本番データを入れる運用が生まれたら JP allowlist を戻す**（PO 条件） |
+| CloudFront IP allowlist | なし | なし | 顧客画面 `/admin` まで遮断する設計だったため機構ごと撤去（#4266） |
+| CloudFront Function | query slash encode のみ | 同左 | SvelteKit の名前付き form action（`?/action`）を通すために必須 |
+| Cognito 認証（`/admin`） | 必須 | 必須 | `AUTH_MODE=cognito` |
+| 親 PIN gate（`/admin`） | 必須 | 必須 | §4.3 |
+| ops group + MFA（`/ops`） | 必須 | 必須 | §5.2.9。**アプリ層のため両環境に同じく効く** |
+| Function URL 直叩き | 遮断しない | 遮断しない | `authType: NONE`。CloudFront を迂回しても認証・認可は同じく効く（form action は通らない） |
+| Stripe / SES / Discord / Gemini | 注入する | **注入しない** | staging は外部サービス副作用ゼロ（`deploy-aws-staging.yml`） |
+
+**staging のデータ**: 合成 seed（#3412）の AWS staging 側配線は未了で、staging に載るのは**検証者が sign-up して作ったデータ**である。staging は全世界公開のため、sign-up には `deploy-aws-staging.yml` の `STAGING_ALLOWED_EMAIL_DOMAINS`（使い捨てドメインの SSOT）に載るアドレスだけを使う。allowlist 外のアドレスが登録されると deploy の `Staging PII guard` が Discord incident に通知する（手順は [runbooks/staging-live-verification.md](../runbooks/staging-live-verification.md)）。
+
 ---
 
 ## 12. 既知の制限事項

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -528,13 +528,15 @@ client 供給の opaque id（Cookie / POST form-field / URL param）は、uuid �
 | 判定 | 内容 |
 |---|---|
 | 単一強制点 | `src/lib/server/auth/ops-authz.ts` の `hasOpsAccess(identity)` |
-| 条件 | Cognito `ops` group 所属 **かつ** ログイン時に MFA チャレンジを完了している（ID token の `amr` claim、RFC 8176） |
+| 条件 | Cognito `ops` group 所属 **かつ** ログイン時に MFA チャレンジを完了している（ID token の `amr` claim、RFC 8176）。受理する綴りは `mfa` / `software_token_mfa` / `sms_mfa` のみ（`otp` / `email_otp` は本アプリではアプリ層の email OTP を指し**二要素の証拠にならない**ため受理しない） |
 | 判定不能時 | **拒否**（`mfaAuthenticated` が `undefined` = 旧トークン / claim 欠落でも通さない、fail-closed） |
+| 拒否時の応答 | ops group には居るが MFA で落ちた場合のみ `403 Forbidden: ops access requires MFA`。それ以外は `403 Forbidden`（非 ops に ops group の存在を示唆しない） |
 | 強制箇所 | `src/routes/ops/+layout.server.ts`（403）/ policy 層 `capabilities.ts` `access.ops_dashboard`・`view.ops_license_dashboard`（`ops-mfa-required`） |
 | Cognito 側 | user pool は `mfa: OPTIONAL` のまま（**顧客に MFA を強制しない**）。運営者だけがアプリ層で MFA を要求される |
 
 - **IP allowlist を置かない理由**: 遮断対象に `/admin`（保護者 = 顧客の見守り画面）が含まれると全顧客が 403 になる。また運営者のグローバル IP は固定でなく、プロキシ経由では CloudFront が見る viewer IP が運営者の回線 IP と一致しない。
 - **この設計で守らないもの**: 未認証の第三者が `/ops` の URL に**到達すること自体**は防がない（到達しても認可で 403 になる）。
+- **運用上の注意**: 判定は ID token の claim であり、refresh token による無操作の再発行で `amr` が落ちれば MFA 済セッションでも `/ops` から弾かれる（fail-closed 側に倒れる）。その場合は再ログインで復帰する。応答メッセージで MFA が理由であることが分かる。
 - **fitness function**: `tests/unit/routes/ops-mfa-guard.test.ts`（ops group のみ / MFA 不明 → 403）+ `tests/unit/infra/admin-no-ip-allowlist.test.ts`（CloudFront Function に `/admin` `/ops` の遮断・IP 照合が再混入しないこと）。
 
 ### 5.3 ライセンス状態による制限

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -366,6 +366,7 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 | `/admin/members` | owner, parent | `/auth/login` |
 | `/admin/**` | owner, parent | `/auth/login` |
 | `/child/**` | owner, parent, child | `/auth/login` |
+| `/ops/**`（運営ダッシュボード） | Cognito `ops` group **かつ MFA 済**（§5.2.9） | 403 |
 | `/api/v1/admin/**` | owner, parent | 401 |
 | `/api/v1/**` | owner, parent, child | 401 |
 | `/tenants/**`（テナント静的ファイル配信、#3133） | owner, parent, child | `/auth/login` |
@@ -518,6 +519,23 @@ client 供給の opaque id（Cookie / POST form-field / URL param）は、uuid �
 - **単一強制点（ADR-0063 整合）**: 認可判定を散在させず `src/lib/server/auth/ops-authz.ts` の `requireGlobalMasterWriteAccess(locals)` に集約する。ops 判定 SSOT は同 module の `isOpsMember` / `OPS_GROUPS`（`/ops` route protection と共有）。`local` を許可するのは NUC が信頼ベース（`capabilities.ts` `canWriteDb` と同原則、phase1-nuc FR-3 / `nuc-saas-runtime-bifurcation.md`）で全テナント波及の概念を持たないため。
 - **admin bypass 禁止との整合（ADR-0022）**: グローバル master 書込を ops group の認可境界に載せ、parent-admin ロールでの書込を構造的に排除する。
 - **fitness function**: `tests/unit/routes/admin-status-benchmark-authz.test.ts` が guard 単体（local / ops 許可、parent-admin / anonymous / 未認証 → 403）+ `updateBenchmark` action（parent-admin → 403 かつ `upsertBenchmark` 未到達 / ops・local → upsertBenchmark 到達）+ 読取 load（parent-admin・ops いずれも benchmarks 取得可）を機械検証する。
+
+
+#### 5.2.9 `/ops`（運営ダッシュボード）の認可 — ops group + MFA（#4266）
+
+`/ops` は運営者専用の画面であり、**アプリ層の 1 つの述語だけ**で守る。ネットワーク層（CloudFront）に運営者 IP allowlist は置かない。
+
+| 判定 | 内容 |
+|---|---|
+| 単一強制点 | `src/lib/server/auth/ops-authz.ts` の `hasOpsAccess(identity)` |
+| 条件 | Cognito `ops` group 所属 **かつ** ログイン時に MFA チャレンジを完了している（ID token の `amr` claim、RFC 8176） |
+| 判定不能時 | **拒否**（`mfaAuthenticated` が `undefined` = 旧トークン / claim 欠落でも通さない、fail-closed） |
+| 強制箇所 | `src/routes/ops/+layout.server.ts`（403）/ policy 層 `capabilities.ts` `access.ops_dashboard`・`view.ops_license_dashboard`（`ops-mfa-required`） |
+| Cognito 側 | user pool は `mfa: OPTIONAL` のまま（**顧客に MFA を強制しない**）。運営者だけがアプリ層で MFA を要求される |
+
+- **IP allowlist を置かない理由**: 遮断対象に `/admin`（保護者 = 顧客の見守り画面）が含まれると全顧客が 403 になる。また運営者のグローバル IP は固定でなく、プロキシ経由では CloudFront が見る viewer IP が運営者の回線 IP と一致しない。
+- **この設計で守らないもの**: 未認証の第三者が `/ops` の URL に**到達すること自体**は防がない（到達しても認可で 403 になる）。
+- **fitness function**: `tests/unit/routes/ops-mfa-guard.test.ts`（ops group のみ / MFA 不明 → 403）+ `tests/unit/infra/admin-no-ip-allowlist.test.ts`（CloudFront Function に `/admin` `/ops` の遮断・IP 照合が再混入しないこと）。
 
 ### 5.3 ライセンス状態による制限
 

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -528,7 +528,8 @@ client 供給の opaque id（Cookie / POST form-field / URL param）は、uuid �
 | 判定 | 内容 |
 |---|---|
 | 単一強制点 | `src/lib/server/auth/ops-authz.ts` の `hasOpsAccess(identity)` |
-| 条件 | Cognito `ops` group 所属 **かつ** ログイン時に MFA チャレンジを完了している（ID token の `amr` claim、RFC 8176）。受理する綴りは `mfa` / `software_token_mfa` / `sms_mfa` のみ（`otp` / `email_otp` は本アプリではアプリ層の email OTP を指し**二要素の証拠にならない**ため受理しない） |
+| 条件 | Cognito `ops` group 所属 **かつ** **このセッションが MFA を経て開始されている**。MFA は ID token の `amr` claim（RFC 8176）で判定し、受理する綴りは `mfa` / `software_token_mfa` / `sms_mfa` のみ（`otp` / `email_otp` は本アプリではアプリ層の email OTP を指し**二要素の証拠にならない**ため受理しない） |
+| セッション保持 | ログイン時に確定した MFA を **context token（署名付き、`context-token.ts`）の `mfaAuthenticated` claim** に焼き込み、`hasOpsAccess(identity, context)` が token 側と OR で判定する。silent refresh（`REFRESH_TOKEN_AUTH`）で再発行される ID token が `amr` を保持するかは AWS 公式ドキュメントで確定できないため、identity 側だけで判定すると運営者が無操作で締め出される。**claim が載っていない旧トークンは `undefined` = 拒否側**（fail-closed） |
 | 判定不能時 | **拒否**（`mfaAuthenticated` が `undefined` = 旧トークン / claim 欠落でも通さない、fail-closed） |
 | 拒否時の応答 | ops group には居るが MFA で落ちた場合のみ `403 Forbidden: ops access requires MFA`。それ以外は `403 Forbidden`（非 ops に ops group の存在を示唆しない） |
 | 強制箇所 | `src/routes/ops/+layout.server.ts`（403）/ policy 層 `capabilities.ts` `access.ops_dashboard`・`view.ops_license_dashboard`（`ops-mfa-required`） |
@@ -536,7 +537,7 @@ client 供給の opaque id（Cookie / POST form-field / URL param）は、uuid �
 
 - **IP allowlist を置かない理由**: 遮断対象に `/admin`（保護者 = 顧客の見守り画面）が含まれると全顧客が 403 になる。また運営者のグローバル IP は固定でなく、プロキシ経由では CloudFront が見る viewer IP が運営者の回線 IP と一致しない。
 - **この設計で守らないもの**: 未認証の第三者が `/ops` の URL に**到達すること自体**は防がない（到達しても認可で 403 になる）。
-- **運用上の注意**: 判定は ID token の claim であり、refresh token による無操作の再発行で `amr` が落ちれば MFA 済セッションでも `/ops` から弾かれる（fail-closed 側に倒れる）。その場合は再ログインで復帰する。応答メッセージで MFA が理由であることが分かる。
+- **運用上の注意**: MFA の再確認が必要になるのは **context token の TTL 切れ**（owner = 24 時間、`CONTEXT_TTL`）で再発行されたときである。その時点の ID token に `amr` が無ければ `/ops` は拒否され、**再ログインで復帰する**。応答メッセージで MFA が理由であることが分かる。
 - **fitness function**: `tests/unit/routes/ops-mfa-guard.test.ts`（ops group のみ / MFA 不明 → 403）+ `tests/unit/infra/admin-no-ip-allowlist.test.ts`（CloudFront Function に `/admin` `/ops` の遮断・IP 照合が再混入しないこと）。
 
 ### 5.3 ライセンス状態による制限

--- a/infra/lib/network-stack.ts
+++ b/infra/lib/network-stack.ts
@@ -92,51 +92,17 @@ export class NetworkStack extends cdk.Stack {
 			}
 		}
 
-		// --- Admin IP allowlist (from CDK context, comma-separated) ---
-		const adminAllowedIps =
-			(this.node.tryGetContext('adminAllowedIps') as string | undefined) ?? '';
-
-		// --- CloudFront Function: query slash encode + admin IP filter ---
-		// 1. Admin IP restriction: /admin/* and /api/v1/admin/* require allowlisted IPs
-		// 2. Query slash encode: SvelteKit form actions use ?/action-name pattern,
-		//    but Lambda Function URL rejects forward slashes in query strings.
-		const cfFunctionCode = adminAllowedIps
-			? `
-function handler(event) {
-  var request = event.request;
-  var uri = request.uri;
-
-  // Admin IP restriction
-  if (uri.startsWith('/admin') || uri.startsWith('/api/v1/admin') || uri.startsWith('/ops')) {
-    var ALLOWED_IPS = ${JSON.stringify(
-			adminAllowedIps
-				.split(',')
-				.map((ip: string) => ip.trim())
-				.filter(Boolean),
-		)};
-    var clientIp = event.viewer.ip;
-    if (ALLOWED_IPS.indexOf(clientIp) === -1) {
-      return {
-        statusCode: 403,
-        statusDescription: 'Forbidden',
-        headers: { 'content-type': { value: 'text/html; charset=utf-8' } },
-        body: '<html><body><h1>Access Restricted</h1></body></html>',
-      };
-    }
-  }
-
-  // Query string slash encode
-  var qs = request.querystring;
-  var newQs = {};
-  for (var key in qs) {
-    var encodedKey = key.replace(/\\//g, '%2F');
-    newQs[encodedKey] = qs[key];
-  }
-  request.querystring = newQs;
-  return request;
-}
-`
-			: `
+		// --- CloudFront Function: query slash encode ---
+		// SvelteKit form actions use ?/action-name pattern, but Lambda Function URL rejects
+		// forward slashes in query strings.
+		//
+		// #4266 (PO 決裁 2026-08-05): 旧 admin IP allowlist (`adminAllowedIps` context で
+		// /admin・/api/v1/admin・/ops を許可 IP 以外 403 にする分岐) を**撤去**した。
+		//   - 対象 path に `/admin` (= 保護者 = 顧客の見守り画面) が含まれ、有効化すると全顧客が 403
+		//   - 運営者のグローバル IP は固定でなく、プロキシ経由では event.viewer.ip が回線 IP と不一致
+		// /ops の防御はアプリ層 (ops group + MFA、src/lib/server/auth/ops-authz.ts hasOpsAccess) が担う。
+		// 復活させない不変条件は tests/unit/infra/admin-no-ip-allowlist.test.ts が assert する。
+		const cfFunctionCode = `
 function handler(event) {
   var request = event.request;
   var qs = request.querystring;
@@ -462,7 +428,6 @@ function handler(event) {
 		// 本番と独立した CloudFront Distribution を `demo.ganbari-quest.com` に配置する。
 		//   - Origin = demo Lambda の Function URL
 		//   - 同じ cache policy / origin request policy / security headers / CF function (query slash encode)
-		//   - admin IP 制限は demo には適用しない (anonymous public demo のため)
 		//   - geoRestriction も本番と同じ JP 限定 (Pre-PMF 段階)
 		if (props.demoFunctionUrl && props.domainName) {
 			const demoDomainName = props.demoDomainName ?? `demo.${props.domainName}`;
@@ -513,7 +478,7 @@ function handler(event) {
 				cachePolicy: demoStaticAssetsCachePolicy,
 			};
 
-			// demo 用 CloudFront Function: query slash encode のみ (admin IP 制限なし)。
+			// demo 用 CloudFront Function: query slash encode のみ。
 			const demoQueryFixFn = new cloudfront.Function(this, 'DemoQuerySlashEncodeFn', {
 				functionName: `${prefix}-demo-query-slash-encode`,
 				code: cloudfront.FunctionCode.fromInline(`

--- a/src/lib/policy/capabilities.ts
+++ b/src/lib/policy/capabilities.ts
@@ -58,7 +58,8 @@ export type DenyReason =
 	| 'plan-tier-insufficient' // プランティアが要件を満たさない
 	| 'mode-mismatch' // capability が別モード専用
 	| 'dev-only' // local-debug 専用
-	| 'ops-only'; // Cognito groups に 'ops' が必要
+	| 'ops-only' // Cognito groups に 'ops' が必要
+	| 'ops-mfa-required'; // #4266: ops は MFA 必須 (IP allowlist 廃止に伴う主防御の強化)
 
 export interface PolicyResult {
 	allowed: boolean;
@@ -132,6 +133,10 @@ const evaluators: Record<Capability, CapabilityEvaluator> = {
 function requireOpsGroup(ctx: EvaluationContext): PolicyResult {
 	if (!ctx.user) return deny('unauthenticated');
 	if (!ctx.user.groups.includes('ops')) return deny('ops-only');
+	// #4266: CloudFront の admin IP allowlist を廃止したため、ops の主防御を MFA まで引き上げる。
+	// `undefined` (判定不能) も拒否 = fail-closed。route 側の実強制点は
+	// `hasOpsAccess()` (src/lib/server/auth/ops-authz.ts) で、本判定はその policy 層の写像。
+	if (ctx.user.mfaAuthenticated !== true) return deny('ops-mfa-required');
 	return ALLOW;
 }
 

--- a/src/lib/runtime/evaluation-context.ts
+++ b/src/lib/runtime/evaluation-context.ts
@@ -30,6 +30,11 @@ export interface EvaluationUser {
 	role: 'owner' | 'parent' | 'child';
 	/** Cognito groups 等の外部グループ所属 (ops 認可などに利用) */
 	groups: readonly string[];
+	/**
+	 * #4266: ログイン時に MFA を経たか (Cognito ID token の `amr` claim 由来)。
+	 * `undefined` = 判定不能。ops capability は `true` 以外を拒否する (fail-closed)。
+	 */
+	mfaAuthenticated?: boolean;
 }
 
 /** プラン解決結果（ADR-0024 の resolvePlanTier / trial-service 結果の投影） */

--- a/src/lib/server/auth/context-token.ts
+++ b/src/lib/server/auth/context-token.ts
@@ -32,7 +32,10 @@ function getSecret(): string {
  * 焼き込むと DB 反映後も最大 24 時間 (owner の TTL) 古い値が使われ続ける。
  * 課金状態の解決 SSOT は `./tenant-entitlement.ts`（毎リクエスト DB 解決）。
  */
-export type ContextTokenClaims = Pick<AuthContext, 'tenantId' | 'role' | 'childId'>;
+export type ContextTokenClaims = Pick<
+	AuthContext,
+	'tenantId' | 'role' | 'childId' | 'mfaAuthenticated'
+>;
 
 interface ContextPayload extends ContextTokenClaims {
 	exp: number; // Unix timestamp (seconds)
@@ -49,6 +52,9 @@ export function signContext(context: ContextTokenClaims): string {
 		tenantId: context.tenantId,
 		role: context.role,
 		childId: context.childId,
+		// #4266: MFA を経てセッションを開始したか。true のときだけ載せる (旧トークンとの
+		// 互換は「載っていない = undefined = 拒否側」で成立する、fail-closed)。
+		mfaAuthenticated: context.mfaAuthenticated === true ? true : undefined,
 		iat: now,
 		exp: now + ttl,
 	};
@@ -91,6 +97,8 @@ export function verifyContext(token: string): ContextTokenClaims | null {
 			tenantId: payload.tenantId,
 			role: payload.role,
 			childId: payload.childId === undefined ? undefined : asChildId(payload.childId),
+			// #4266: 真偽が明示された true のみ採用する (欠落 / 非 boolean は undefined = 拒否側)
+			mfaAuthenticated: payload.mfaAuthenticated === true ? true : undefined,
 		};
 	} catch {
 		return null;

--- a/src/lib/server/auth/ops-authz.ts
+++ b/src/lib/server/auth/ops-authz.ts
@@ -5,7 +5,7 @@
 // 将来の階層化（`ops-cs` / `ops-eng` など）に備え、名前は enum 化して 1 箇所で管理する。
 
 import { error } from '@sveltejs/kit';
-import type { Identity } from './types';
+import type { AuthContext, Identity } from './types';
 
 /**
  * 運営ダッシュボード `/ops` 全体を操作できる group 名。
@@ -44,13 +44,26 @@ export function isOpsMember(identity: Identity | null): boolean {
  * 代替として MFA を要求する。運営者は TOTP を 1 度設定すれば、IP / 回線 / プロキシに縛られない。
  * Cognito user pool は `mfa: OPTIONAL` のまま (顧客に MFA を強制しない)、ops だけをここで縛る。
  *
- * **fail-closed**: MFA 情報が取れない (旧トークン / claim 欠落 = `undefined`) 場合も拒否する。
- * 「不明なら通す」にすると防御が黙って消える (ADR-0024 ENV silent skip 禁止と同じ規律)。
+ * **判定はセッション単位**: MFA を「今の ID token が MFA を経ているか」ではなく
+ * **「このセッションが MFA を経て開始されたか」** で見る。silent refresh
+ * (`REFRESH_TOKEN_AUTH`) で再発行される ID token が `amr` を保持するかは AWS 公式
+ * ドキュメントで確定できず (2026-08-05 調査)、identity 側だけを見ると運営者が無操作で
+ * 締め出され再ログインまで戻れない。ログイン時に確定した値を署名付き context token
+ * (`context-token.ts`、既存機構) が保持し、ここで OR を取る。
+ *
+ * **fail-closed**: identity / context のどちらからも MFA を確認できない (旧トークン /
+ * claim 欠落 = `undefined`) 場合は拒否する。「不明なら通す」にすると防御が黙って消える
+ * (ADR-0024 ENV silent skip 禁止と同じ規律)。
  */
-export function hasOpsAccess(identity: Identity | null): boolean {
+export function hasOpsAccess(
+	identity: Identity | null,
+	context?: Pick<AuthContext, 'mfaAuthenticated'> | null,
+): boolean {
 	if (!isOpsMember(identity)) return false;
 	// isOpsMember が true ⇒ identity は cognito
-	return identity?.type === 'cognito' && identity.mfaAuthenticated === true;
+	const tokenMfa = identity?.type === 'cognito' && identity.mfaAuthenticated === true;
+	const sessionMfa = context?.mfaAuthenticated === true;
+	return tokenMfa || sessionMfa;
 }
 
 /**

--- a/src/lib/server/auth/ops-authz.ts
+++ b/src/lib/server/auth/ops-authz.ts
@@ -34,6 +34,26 @@ export function isOpsMember(identity: Identity | null): boolean {
 }
 
 /**
+ * `/ops` に入れるか判定する単一述語 (#4266)。**ops group 所属 かつ MFA 済**を要求する。
+ *
+ * CloudFront 層の IP allowlist (2 枚目の防御) を廃止したため、主防御であるアプリ層の
+ * 強度を上げる。IP allowlist を廃止した理由:
+ *   - 対象 path に `/admin` (= 保護者 = 顧客の見守り画面) が含まれ、有効化すると全顧客が 403
+ *   - 運営者のグローバル IP が固定でなく、プロキシ経由では `event.viewer.ip` が回線 IP と一致しない
+ *
+ * 代替として MFA を要求する。運営者は TOTP を 1 度設定すれば、IP / 回線 / プロキシに縛られない。
+ * Cognito user pool は `mfa: OPTIONAL` のまま (顧客に MFA を強制しない)、ops だけをここで縛る。
+ *
+ * **fail-closed**: MFA 情報が取れない (旧トークン / claim 欠落 = `undefined`) 場合も拒否する。
+ * 「不明なら通す」にすると防御が黙って消える (ADR-0024 ENV silent skip 禁止と同じ規律)。
+ */
+export function hasOpsAccess(identity: Identity | null): boolean {
+	if (!isOpsMember(identity)) return false;
+	// isOpsMember が true ⇒ identity は cognito
+	return identity?.type === 'cognito' && identity.mfaAuthenticated === true;
+}
+
+/**
  * グローバル master (全テナント共有の統計基準値 = `market_benchmarks` 等) への書込を
  * ops/admin 相当に限定する単一強制点 (#3824、CWE-639 隣接 / #3593 ④ の実厳格化)。
  *

--- a/src/lib/server/auth/providers/cognito-dev-jwt.ts
+++ b/src/lib/server/auth/providers/cognito-dev-jwt.ts
@@ -25,6 +25,8 @@ export interface DevUserProfile {
 	groups?: string[];
 	/** #3025: federated (Google) 相当ユーザ。identities claim をダミー JWT に載せる */
 	federated?: boolean;
+	/** #4266: MFA 済ユーザ。本物の Cognito と同形の `amr` claim をダミー JWT に載せる */
+	mfa?: boolean;
 }
 
 /** ダミー Cognito ID Token を生成 */
@@ -38,6 +40,11 @@ export async function signDevIdentityToken(user: DevUserProfile): Promise<string
 	};
 	if (user.groups && user.groups.length > 0) {
 		payload['cognito:groups'] = user.groups;
+	}
+	if (user.mfa) {
+		// #4266: 本物の Cognito が MFA チャレンジ完了時に載せる amr と同形にする。
+		// ローカル / E2E でも本番と同じ判定経路 (hasMfaAmr) を通す (分岐を作らない)。
+		payload.amr = ['pwd', 'mfa'];
 	}
 	if (user.federated) {
 		// #3025: 本物の Cognito federation と同形の identities claim + 実認証時刻
@@ -76,6 +83,10 @@ export async function verifyDevIdentityToken(token: string): Promise<CognitoClai
 			'cognito:groups': groups,
 			identities: Array.isArray(payload.identities) ? payload.identities : undefined,
 			auth_time: typeof payload.auth_time === 'number' ? payload.auth_time : undefined,
+			// #4266: 本番 verifyIdentityToken と同じ amr 伝搬
+			amr: Array.isArray(payload.amr)
+				? payload.amr.filter((m): m is string => typeof m === 'string')
+				: undefined,
 			iss: payload.iss as string,
 			aud: payload.aud as string,
 		};

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -217,6 +217,8 @@ export class DevCognitoAuthProvider implements AuthProvider {
 			licenseStatus: devUser.licenseStatus ?? AUTH_LICENSE_STATUS.ACTIVE,
 			tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
 			plan: devUser.plan,
+			// #4266: 本番 CognitoAuthProvider と同じくセッションに MFA を焼き込む
+			mfaAuthenticated: identity.mfaAuthenticated === true ? true : undefined,
 		};
 
 		const token = signContext(context);

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -36,6 +36,8 @@ export interface DevUser {
 	groups?: string[];
 	/** #3025: federated (Google) 相当。Cognito パスワードを持たないユーザの再現 (PIN reset 分岐検証用) */
 	federated?: boolean;
+	/** #4266: MFA 設定済。/ops は ops group + MFA を要求するため ops ユーザには必須 */
+	mfa?: boolean;
 }
 
 export const DEV_USERS: DevUser[] = [
@@ -121,6 +123,9 @@ export const DEV_USERS: DevUser[] = [
 		tenantId: 'dev-tenant-ops',
 		role: 'owner',
 		groups: ['ops'],
+		// #4266: /ops は ops group + MFA (hasOpsAccess) を要求する。
+		// 運営者は TOTP を 1 度設定すれば通るため、dev でも MFA 済として扱う。
+		mfa: true,
 	},
 ];
 
@@ -153,6 +158,8 @@ export class DevCognitoAuthProvider implements AuthProvider {
 					// #3025: 本番 CognitoAuthProvider と同じ federated / recent-auth 情報
 					isFederated: (claims.identities?.length ?? 0) > 0,
 					authTime: claims.auth_time,
+					// #4266: 本番 CognitoAuthProvider と同じ MFA 判定 (amr claim)
+					mfaAuthenticated: hasMfaAmr(claims.amr),
 				};
 			}
 		} catch (e) {

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -12,6 +12,7 @@ import { authorizeCognito } from '../authorization';
 import { getContextMaxAge, signContext, verifyContext } from '../context-token';
 import type { AuthContext, AuthProvider, AuthResult, Identity, Role } from '../types';
 import { verifyDevIdentityToken } from './cognito-dev-jwt';
+import { hasMfaAmr } from './cognito-jwt';
 
 /**
  * 開発用ダミーユーザー（E2E テストでも使用）

--- a/src/lib/server/auth/providers/cognito-jwt.ts
+++ b/src/lib/server/auth/providers/cognito-jwt.ts
@@ -27,15 +27,18 @@ export interface CognitoClaims {
 /**
  * #4266: `amr` claim が MFA チャレンジ完了を示しているか判定する (純関数)。
  *
- * Cognito の MFA チャレンジ名は `SOFTWARE_TOKEN_MFA` / `SMS_MFA` / `EMAIL_OTP` であり、
- * ID token の `amr` にどの綴りで載るかは pool 設定・認証フローで揺れる。特定の 1 綴りに
- * 賭けると「MFA を設定したのに弾かれる」事故になるため、MFA を示す既知の綴りを
- * 大小文字無視で受理する。
+ * Cognito の MFA チャレンジ名は `SOFTWARE_TOKEN_MFA` / `SMS_MFA` であり、ID token の `amr` に
+ * どの綴りで載るかは pool 設定・認証フローで揺れる。特定の 1 綴りに賭けると「MFA を設定したのに
+ * 弾かれる」事故になるため、**MFA チャレンジを経たことが確実に言える綴りだけ**を大小文字無視で受理する。
+ *
+ * **裸の `otp` / `email_otp` は受理しない**: 本アプリは email OTP を Cognito MFA ではなく
+ * アプリ層で使う (auth-stack.ts の `mfa: OPTIONAL` 直上コメント)。`otp` 系を受理すると
+ * 「二要素を一度も経ていないセッション」が MFA 済と判定され、本 gate の前提が静かに崩れる。
  *
  * **判定できない場合は false = 拒否 (fail-closed、ADR-0024「設定が無ければ止める」)。**
  * 未設定を「たぶん大丈夫」に倒すと、防御層が黙って消える (#4276 が炙り出した失敗様式)。
  */
-const MFA_AMR_VALUES = ['mfa', 'software_token_mfa', 'sms_mfa', 'email_otp', 'otp'] as const;
+const MFA_AMR_VALUES = ['mfa', 'software_token_mfa', 'sms_mfa'] as const;
 
 export function hasMfaAmr(amr: readonly string[] | undefined): boolean {
 	if (!Array.isArray(amr)) return false;

--- a/src/lib/server/auth/providers/cognito-jwt.ts
+++ b/src/lib/server/auth/providers/cognito-jwt.ts
@@ -15,8 +15,33 @@ export interface CognitoClaims {
 	identities?: unknown[];
 	/** #3025: 実認証時刻 (epoch 秒、JWT 標準 claim)。refresh token 経由の再発行では元のログイン時刻を保持する */
 	auth_time?: number;
+	/**
+	 * #4266: 認証で完了した方式の一覧 (RFC 8176 Authentication Methods References)。
+	 * MFA チャレンジを経たかの判定に使う。判定は `hasMfaAmr()` に集約する。
+	 */
+	amr?: string[];
 	iss: string;
 	aud: string;
+}
+
+/**
+ * #4266: `amr` claim が MFA チャレンジ完了を示しているか判定する (純関数)。
+ *
+ * Cognito の MFA チャレンジ名は `SOFTWARE_TOKEN_MFA` / `SMS_MFA` / `EMAIL_OTP` であり、
+ * ID token の `amr` にどの綴りで載るかは pool 設定・認証フローで揺れる。特定の 1 綴りに
+ * 賭けると「MFA を設定したのに弾かれる」事故になるため、MFA を示す既知の綴りを
+ * 大小文字無視で受理する。
+ *
+ * **判定できない場合は false = 拒否 (fail-closed、ADR-0024「設定が無ければ止める」)。**
+ * 未設定を「たぶん大丈夫」に倒すと、防御層が黙って消える (#4276 が炙り出した失敗様式)。
+ */
+const MFA_AMR_VALUES = ['mfa', 'software_token_mfa', 'sms_mfa', 'email_otp', 'otp'] as const;
+
+export function hasMfaAmr(amr: readonly string[] | undefined): boolean {
+	if (!Array.isArray(amr)) return false;
+	return amr.some(
+		(m) => typeof m === 'string' && (MFA_AMR_VALUES as readonly string[]).includes(m.toLowerCase()),
+	);
 }
 
 /** Cognito User Pool の設定（環境変数から取得） */
@@ -83,6 +108,10 @@ export async function verifyIdentityToken(token: string): Promise<CognitoClaims 
 			'cognito:groups': groups,
 			identities: Array.isArray(payload.identities) ? payload.identities : undefined,
 			auth_time: typeof payload.auth_time === 'number' ? payload.auth_time : undefined,
+			// #4266: 非配列 (想定外の形) は undefined に落とし、hasMfaAmr() で拒否側に倒す
+			amr: Array.isArray(payload.amr)
+				? payload.amr.filter((m): m is string => typeof m === 'string')
+				: undefined,
 			iss: payload.iss as string,
 			aud: payload.aud as string,
 		};

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -143,6 +143,9 @@ export class CognitoAuthProvider implements AuthProvider {
 			const context: AuthContext = {
 				tenantId: membership.tenantId,
 				role: membership.role,
+				// #4266: ログイン時点で確定した MFA をセッションに焼き込む。以後 silent refresh で
+				// ID token の amr が落ちても、context token が生きている間は /ops に入れる。
+				mfaAuthenticated: identity.mfaAuthenticated === true ? true : undefined,
 				...(await resolveTenantEntitlement(membership.tenantId)),
 			};
 

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -16,7 +16,7 @@ import { authorizeCognito } from '../authorization';
 import { getContextMaxAge, signContext, verifyContext } from '../context-token';
 import { resolveTenantEntitlement, TenantEntitlementUnavailableError } from '../tenant-entitlement';
 import type { AuthContext, AuthProvider, AuthResult, Identity } from '../types';
-import { verifyIdentityToken } from './cognito-jwt';
+import { hasMfaAmr, verifyIdentityToken } from './cognito-jwt';
 import { refreshCognitoIdToken } from './cognito-oauth';
 
 export class CognitoAuthProvider implements AuthProvider {
@@ -41,6 +41,8 @@ export class CognitoAuthProvider implements AuthProvider {
 						// #3025: identities claim の有無で federated (Google 等) を判定
 						isFederated: (claims.identities?.length ?? 0) > 0,
 						authTime: claims.auth_time,
+						// #4266: /ops は ops group + MFA を要求する (hasOpsAccess)
+						mfaAuthenticated: hasMfaAmr(claims.amr),
 					};
 				}
 			} catch (e) {
@@ -66,6 +68,8 @@ export class CognitoAuthProvider implements AuthProvider {
 						// #3025: identities claim の有無で federated (Google 等) を判定
 						isFederated: (claims.identities?.length ?? 0) > 0,
 						authTime: claims.auth_time,
+						// #4266: /ops は ops group + MFA を要求する (hasOpsAccess)
+						mfaAuthenticated: hasMfaAmr(claims.amr),
 					};
 				}
 			}

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -60,6 +60,15 @@ export interface AuthContext {
 	licenseStatus: AuthLicenseStatus;
 	tenantStatus?: SubscriptionStatus;
 	plan?: string;
+	/**
+	 * #4266: **このセッションが MFA を経て開始されたか**。ログイン時に ID token の `amr` から
+	 * 確定し、context token (署名付き) で保持する。
+	 *
+	 * silent refresh (`REFRESH_TOKEN_AUTH`) で再発行される ID token が `amr` を保持するかは
+	 * AWS 公式ドキュメントで確定できないため、identity 側の判定だけに依存すると運営者が
+	 * 無操作で `/ops` から締め出されうる。判定は `hasOpsAccess(identity, context)` に集約。
+	 */
+	mfaAuthenticated?: boolean;
 }
 
 /** authorize() の戻り値 */

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -37,6 +37,12 @@ export type Identity =
 			isFederated?: boolean;
 			/** #3025: 実認証時刻 (epoch 秒)。requires-recent-login 判定用 (refresh では更新されない) */
 			authTime?: number;
+			/**
+			 * #4266: ログイン時に MFA チャレンジを完了したか (ID token の `amr` claim 由来)。
+			 * `undefined` = 判定不能。**未設定 / 不明はいずれも「MFA なし」として扱う**
+			 * (`hasOpsAccess()` が fail-closed で拒否する)。
+			 */
+			mfaAuthenticated?: boolean;
 	  }
 	| { type: 'anonymous'; userId: string; email: string };
 

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -192,6 +192,8 @@ async function handleDevLogin(
 		email: user.email,
 		groups: user.groups,
 		federated: user.federated,
+		// #4266: /ops は ops group + MFA を要求する。dev の ops ユーザは MFA 済として発行する
+		mfa: user.mfa,
 	});
 
 	cookies.set(IDENTITY_COOKIE_NAME, idToken, {

--- a/src/routes/ops/+layout.server.ts
+++ b/src/routes/ops/+layout.server.ts
@@ -22,7 +22,7 @@ import type { LayoutServerLoad } from './$types';
 export const load: LayoutServerLoad = async ({ locals }) => {
 	// #4266: CloudFront の IP allowlist 廃止に伴い、主防御を ops group + MFA に強化した。
 	// MFA 情報が取れない場合も拒否する (fail-closed)。判定は hasOpsAccess に集約。
-	if (!hasOpsAccess(locals.identity)) {
+	if (!hasOpsAccess(locals.identity, locals.context)) {
 		// ops group には居るが MFA 判定で落ちた場合だけ理由を返す。運営者が「なぜ入れないか」を
 		// 画面から自力で判断できないと、TOTP 設定漏れ / トークン更新での claim 落ちを
 		// コードを読むまで切り分けられない。非 ops には理由を出さない (存在の示唆を避ける)。

--- a/src/routes/ops/+layout.server.ts
+++ b/src/routes/ops/+layout.server.ts
@@ -16,11 +16,13 @@
 // OPS_SECRET_KEY env の完全除去・設計書更新は PR-D で対応（Issue #820）。
 
 import { error } from '@sveltejs/kit';
-import { isOpsMember } from '$lib/server/auth/ops-authz';
+import { hasOpsAccess } from '$lib/server/auth/ops-authz';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
-	if (!isOpsMember(locals.identity)) {
+	// #4266: CloudFront の IP allowlist 廃止に伴い、主防御を ops group + MFA に強化した。
+	// MFA 情報が取れない場合も拒否する (fail-closed)。判定は hasOpsAccess に集約。
+	if (!hasOpsAccess(locals.identity)) {
 		error(403, 'Forbidden');
 	}
 	return {};

--- a/src/routes/ops/+layout.server.ts
+++ b/src/routes/ops/+layout.server.ts
@@ -16,13 +16,19 @@
 // OPS_SECRET_KEY env の完全除去・設計書更新は PR-D で対応（Issue #820）。
 
 import { error } from '@sveltejs/kit';
-import { hasOpsAccess } from '$lib/server/auth/ops-authz';
+import { hasOpsAccess, isOpsMember } from '$lib/server/auth/ops-authz';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
 	// #4266: CloudFront の IP allowlist 廃止に伴い、主防御を ops group + MFA に強化した。
 	// MFA 情報が取れない場合も拒否する (fail-closed)。判定は hasOpsAccess に集約。
 	if (!hasOpsAccess(locals.identity)) {
+		// ops group には居るが MFA 判定で落ちた場合だけ理由を返す。運営者が「なぜ入れないか」を
+		// 画面から自力で判断できないと、TOTP 設定漏れ / トークン更新での claim 落ちを
+		// コードを読むまで切り分けられない。非 ops には理由を出さない (存在の示唆を避ける)。
+		if (isOpsMember(locals.identity)) {
+			error(403, 'Forbidden: ops access requires MFA');
+		}
 		error(403, 'Forbidden');
 	}
 	return {};

--- a/tests/unit/infra/admin-no-ip-allowlist.test.ts
+++ b/tests/unit/infra/admin-no-ip-allowlist.test.ts
@@ -1,4 +1,5 @@
 // tests/unit/infra/admin-no-ip-allowlist.test.ts
+// cspell:ignore googlezip — PO 実測のプロキシ逆引きホスト名 (実在の文字列、綴りを変えると証跡でなくなる)
 // #4266 (PO 決裁 2026-08-05): CloudFront の admin IP allowlist を廃止したことの回帰 guard。
 //
 // 廃止理由 (実測):

--- a/tests/unit/infra/admin-no-ip-allowlist.test.ts
+++ b/tests/unit/infra/admin-no-ip-allowlist.test.ts
@@ -1,0 +1,92 @@
+// tests/unit/infra/admin-no-ip-allowlist.test.ts
+// #4266 (PO 決裁 2026-08-05): CloudFront の admin IP allowlist を廃止したことの回帰 guard。
+//
+// 廃止理由 (実測):
+//   - 旧 CloudFront Function は `/admin` `/api/v1/admin` `/ops` を 1 つの allowlist で遮断していた。
+//     `/admin` は**保護者 (顧客) の見守り画面**であり、allowlist を有効化すると有料家庭を含む
+//     全顧客が 403 になる (`ADMIN_ALLOWED_IPS` が未登録だったことが結果的に顧客を守っていた)。
+//   - 運営者のグローバル IP は固定でなく、プロキシ経由では `event.viewer.ip` が回線 IP と一致しない
+//     (実測: `162.120.184.213` の逆引きが `...v4.fetch.tunnel.googlezip.net`)。
+//
+// 本 test が守る不変条件 = **顧客締め出し経路を二度と作らない**:
+//   1. 生成される CloudFront Function に `/admin` を条件にした遮断が無い
+//   2. `adminAllowedIps` context を渡しても挙動が変わらない (context が復活しても無効)
+//   3. `/ops` も CloudFront 層では遮断しない (アプリ層 ops group + MFA が主防御、hasOpsAccess)
+//
+// 主防御側の回帰 test は tests/unit/routes/ops-mfa-guard.test.ts。
+
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+/** NetworkStack を synth し、CloudFront Function の関数コード一覧を返す。 */
+function synthFunctionCodes(extraContext: Record<string, unknown> = {}): string[] {
+	const app = new cdk.App({
+		context: {
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+			...extraContext,
+		},
+	});
+	const storage = new StorageStack(app, 'TestStorage', { env });
+	const compute = new ComputeStack(app, 'TestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'TestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+	});
+	const resources = Template.fromStack(network).findResources('AWS::CloudFront::Function');
+	return Object.values(resources).map((r) => String(r.Properties?.FunctionCode ?? ''));
+}
+
+describe('#4266 CloudFront に admin IP allowlist を復活させない', () => {
+	// synth は Lambda asset bundling を伴い数十秒かかるため 1 回だけ実行して共有する
+	let codes: string[];
+	let codesWithLegacyContext: string[];
+
+	beforeAll(() => {
+		codes = synthFunctionCodes();
+		codesWithLegacyContext = synthFunctionCodes({ adminAllowedIps: '203.0.113.10,203.0.113.11' });
+	}, 120_000);
+
+	it('CloudFront Function が 1 本以上 synth される (前提)', () => {
+		expect(codes.length).toBeGreaterThan(0);
+	});
+
+	it('関数コードが /admin を条件に遮断していない (顧客締め出し経路の不在)', () => {
+		for (const code of codes) {
+			expect(code).not.toContain('/admin');
+		}
+	});
+
+	it('関数コードが /ops を条件に遮断していない (主防御はアプリ層の ops group + MFA)', () => {
+		for (const code of codes) {
+			expect(code).not.toContain('/ops');
+		}
+	});
+
+	it('関数コードに 403 応答 / IP 照合が含まれない', () => {
+		for (const code of codes) {
+			expect(code).not.toContain('403');
+			expect(code).not.toContain('ALLOWED_IPS');
+			expect(code).not.toContain('event.viewer.ip');
+		}
+	});
+
+	it('adminAllowedIps context を渡しても関数コードが変化しない (機構ごと撤去済)', () => {
+		expect(codesWithLegacyContext).toEqual(codes);
+		for (const code of codesWithLegacyContext) {
+			expect(code).not.toContain('203.0.113.10');
+		}
+	});
+});

--- a/tests/unit/policy/capabilities.test.ts
+++ b/tests/unit/policy/capabilities.test.ts
@@ -11,7 +11,14 @@ import {
 const owner: EvaluationUser = { id: 'u-owner', role: 'owner', groups: [] };
 const parent: EvaluationUser = { id: 'u-parent', role: 'parent', groups: [] };
 const child: EvaluationUser = { id: 'u-child', role: 'child', groups: [] };
-const opsOwner: EvaluationUser = { id: 'u-ops', role: 'owner', groups: ['ops'] };
+// #4266: ops capability は MFA 済であることを要求する (IP allowlist 廃止に伴う主防御の強化)
+const opsOwner: EvaluationUser = {
+	id: 'u-ops',
+	role: 'owner',
+	groups: ['ops'],
+	mfaAuthenticated: true,
+};
+const opsOwnerNoMfa: EvaluationUser = { id: 'u-ops-nomfa', role: 'owner', groups: ['ops'] };
 
 const family: EvaluationPlan = { tier: 'family', status: 'active', trialState: 'none' };
 const standard: EvaluationPlan = { tier: 'standard', status: 'active', trialState: 'none' };
@@ -184,6 +191,13 @@ describe('policy/capabilities can() — access.ops_dashboard / view.ops_license_
 	for (const cap of caps) {
 		it(`${cap}: ops group = allowed`, () => {
 			expect(can(ctx({ mode: 'aws-prod', user: opsOwner }), cap)).toEqual({ allowed: true });
+		});
+
+		it(`${cap}: ops group でも MFA 未経由は ops-mfa-required (#4266 fail-closed)`, () => {
+			expect(can(ctx({ mode: 'aws-prod', user: opsOwnerNoMfa }), cap)).toEqual({
+				allowed: false,
+				reason: 'ops-mfa-required',
+			});
 		});
 
 		it(`${cap}: non-ops user = ops-only`, () => {

--- a/tests/unit/policy/capabilities.test.ts
+++ b/tests/unit/policy/capabilities.test.ts
@@ -18,7 +18,7 @@ const opsOwner: EvaluationUser = {
 	groups: ['ops'],
 	mfaAuthenticated: true,
 };
-const opsOwnerNoMfa: EvaluationUser = { id: 'u-ops-nomfa', role: 'owner', groups: ['ops'] };
+const opsOwnerNoMfa: EvaluationUser = { id: 'u-ops-no-mfa', role: 'owner', groups: ['ops'] };
 
 const family: EvaluationPlan = { tier: 'family', status: 'active', trialState: 'none' };
 const standard: EvaluationPlan = { tier: 'standard', status: 'active', trialState: 'none' };

--- a/tests/unit/routes/ops-layout-server.test.ts
+++ b/tests/unit/routes/ops-layout-server.test.ts
@@ -3,6 +3,10 @@
 //
 // 旧実装（OPS_SECRET_KEY Bearer）では Bearer token が一致すれば通過していた。
 // 新実装では locals.identity に ops group 所属の Cognito identity が居ることを要求する。
+//
+// #4266: CloudFront の IP allowlist 廃止に伴い条件を **ops group + MFA** に強化した
+// （弱めていない）。MFA を経ていない ops identity は 403 になる。fail-closed の網羅は
+// tests/unit/routes/ops-mfa-guard.test.ts。
 
 import { describe, expect, it } from 'vitest';
 import type { Identity } from '$lib/server/auth/types';
@@ -77,25 +81,44 @@ describe('#820 /ops/+layout.server.ts', () => {
 		}
 	});
 
-	it('cognito identity で groups=["ops"] は通過', async () => {
+	it('cognito identity で groups=["ops"] でも MFA 未経由は 403 (#4266)', async () => {
+		try {
+			await load(
+				makeEvent({
+					type: 'cognito',
+					userId: 'u-ops',
+					email: 'ops@example.com',
+					groups: ['ops'],
+				}),
+			);
+			expect.fail('403 がスローされるはず');
+		} catch (e) {
+			if (!isHttpError(e)) throw e;
+			expect(e.status).toBe(403);
+		}
+	});
+
+	it('cognito identity で groups=["ops"] かつ MFA 済は通過', async () => {
 		const result = await load(
 			makeEvent({
 				type: 'cognito',
 				userId: 'u-ops',
 				email: 'ops@example.com',
 				groups: ['ops'],
+				mfaAuthenticated: true,
 			}),
 		);
 		expect(result).toEqual({});
 	});
 
-	it('cognito identity で groups=["ops", "other"] は通過', async () => {
+	it('cognito identity で groups=["ops", "other"] かつ MFA 済は通過', async () => {
 		const result = await load(
 			makeEvent({
 				type: 'cognito',
 				userId: 'u-ops',
 				email: 'ops@example.com',
 				groups: ['ops', 'other'],
+				mfaAuthenticated: true,
 			}),
 		);
 		expect(result).toEqual({});

--- a/tests/unit/routes/ops-mfa-guard.test.ts
+++ b/tests/unit/routes/ops-mfa-guard.test.ts
@@ -90,15 +90,22 @@ describe('#4266 /ops layout guard', () => {
 		await expect(loadOps(opsWithMfa)).resolves.toEqual({});
 	});
 
-	it('MFA 未経由の ops は 403', async () => {
-		await expect(loadOps(opsWithoutMfa)).rejects.toMatchObject({ status: 403 });
+	it('MFA 未経由の ops は 403 で、理由が MFA だと分かる', async () => {
+		// 真っ白な Forbidden だと「TOTP 未設定」か「group 外」かを運営者が切り分けられない
+		await expect(loadOps(opsWithoutMfa)).rejects.toMatchObject({
+			status: 403,
+			body: { message: 'Forbidden: ops access requires MFA' },
+		});
 	});
 
 	it('MFA 情報不明の ops は 403 (fail-closed)', async () => {
 		await expect(loadOps(opsMfaUnknown)).rejects.toMatchObject({ status: 403 });
 	});
 
-	it('未認証は 403', async () => {
-		await expect(loadOps(null)).rejects.toMatchObject({ status: 403 });
+	it('未認証は 403 で、MFA 理由を出さない (ops group の存在を示唆しない)', async () => {
+		await expect(loadOps(null)).rejects.toMatchObject({
+			status: 403,
+			body: { message: 'Forbidden' },
+		});
 	});
 });

--- a/tests/unit/routes/ops-mfa-guard.test.ts
+++ b/tests/unit/routes/ops-mfa-guard.test.ts
@@ -1,0 +1,104 @@
+// tests/unit/routes/ops-mfa-guard.test.ts
+// #4266 (PO 決裁 2026-08-05): /ops の主防御を「Cognito ops group + MFA 必須」にする回帰テスト。
+//
+// 背景: CloudFront 層の admin IP allowlist を廃止した (顧客画面 /admin まで 403 にする設計誤り +
+// 運営者のグローバル IP が固定でない / プロキシ経由で event.viewer.ip が回線 IP と一致しない)。
+// IP 層 (2 枚目) を成立させられない以上、主防御であるアプリ層 (ops group) の強度を上げる。
+//
+// 不変条件 (fail-closed / ADR-0024 「設定が無ければ止める」):
+//   - ops group 所属でも、MFA を経ていない identity は /ops に入れない
+//   - MFA 情報が取れない (claim 欠落 = undefined) 場合も入れない (不明は拒否)
+//
+// failing-test-first (ADR-0061): 実装前は `hasOpsAccess` が存在せず import が解決できない (red)。
+
+import { describe, expect, it } from 'vitest';
+import { hasOpsAccess, isOpsMember } from '../../../src/lib/server/auth/ops-authz';
+import type { Identity } from '../../../src/lib/server/auth/types';
+
+const opsWithMfa: Identity = {
+	type: 'cognito',
+	userId: 'u-ops-1',
+	email: 'ops@example.com',
+	groups: ['ops'],
+	mfaAuthenticated: true,
+};
+
+const opsWithoutMfa: Identity = {
+	type: 'cognito',
+	userId: 'u-ops-2',
+	email: 'ops2@example.com',
+	groups: ['ops'],
+	mfaAuthenticated: false,
+};
+
+/** MFA 情報が取れない (旧トークン / claim 欠落)。fail-closed で拒否する。 */
+const opsMfaUnknown: Identity = {
+	type: 'cognito',
+	userId: 'u-ops-3',
+	email: 'ops3@example.com',
+	groups: ['ops'],
+};
+
+describe('#4266 hasOpsAccess — ops group + MFA', () => {
+	it('ops group かつ MFA 済は許可', () => {
+		expect(hasOpsAccess(opsWithMfa)).toBe(true);
+	});
+
+	it('ops group でも MFA 未経由は拒否 (IP 層廃止に伴う主防御の強化)', () => {
+		expect(hasOpsAccess(opsWithoutMfa)).toBe(false);
+	});
+
+	it('ops group でも MFA 情報不明 (claim 欠落) は拒否 (fail-closed)', () => {
+		expect(hasOpsAccess(opsMfaUnknown)).toBe(false);
+	});
+
+	it('非 ops group は MFA 済でも拒否', () => {
+		expect(
+			hasOpsAccess({
+				type: 'cognito',
+				userId: 'u-parent',
+				email: 'parent@example.com',
+				groups: [],
+				mfaAuthenticated: true,
+			}),
+		).toBe(false);
+	});
+
+	it('local identity は拒否 (/ops は Cognito 配信のみ)', () => {
+		expect(hasOpsAccess({ type: 'local' })).toBe(false);
+	});
+
+	it('identity=null は拒否', () => {
+		expect(hasOpsAccess(null)).toBe(false);
+	});
+
+	it('isOpsMember は group 所属のみを判定する (MFA 条件は hasOpsAccess の責務)', () => {
+		// group 判定と MFA 判定を混ぜないことで、「なぜ弾かれたか」がログ / テストで分離できる
+		expect(isOpsMember(opsWithoutMfa)).toBe(true);
+		expect(hasOpsAccess(opsWithoutMfa)).toBe(false);
+	});
+});
+
+describe('#4266 /ops layout guard', () => {
+	async function loadOps(identity: Identity | null) {
+		const mod = await import('../../../src/routes/ops/+layout.server');
+		// biome-ignore lint/suspicious/noExplicitAny: SvelteKit の LayoutServerLoad 引数を最小 stub で渡す
+		return (mod.load as any)({ locals: { identity } });
+	}
+
+	it('MFA 済 ops は通過する', async () => {
+		await expect(loadOps(opsWithMfa)).resolves.toEqual({});
+	});
+
+	it('MFA 未経由の ops は 403', async () => {
+		await expect(loadOps(opsWithoutMfa)).rejects.toMatchObject({ status: 403 });
+	});
+
+	it('MFA 情報不明の ops は 403 (fail-closed)', async () => {
+		await expect(loadOps(opsMfaUnknown)).rejects.toMatchObject({ status: 403 });
+	});
+
+	it('未認証は 403', async () => {
+		await expect(loadOps(null)).rejects.toMatchObject({ status: 403 });
+	});
+});

--- a/tests/unit/routes/ops-mfa-guard.test.ts
+++ b/tests/unit/routes/ops-mfa-guard.test.ts
@@ -109,3 +109,66 @@ describe('#4266 /ops layout guard', () => {
 		});
 	});
 });
+
+// ---------- #4266 追補: silent refresh で amr が落ちても締め出さない ----------
+// Cognito の REFRESH_TOKEN_AUTH で再発行される ID token が MFA チャレンジ情報 (`amr`) を
+// 保持するかは AWS 公式ドキュメントで確定できなかった (2026-08-05 調査)。保持しない場合、
+// 運営者が何もしていないのに突然 /ops から締め出され、再ログインまで戻れない。
+//
+// したがって MFA は「今この token が MFA を経ているか」ではなく
+// **「このセッションが MFA を経て開始されたか」** で判定する。ログイン時に確定した値を
+// 署名付き context token (既存機構) に載せ、refresh では引き継ぐ。
+describe('#4266 セッション単位の MFA 判定 (silent refresh 対策)', () => {
+	/** refresh 後の identity: amr が落ちて mfaAuthenticated が undefined になった状態 */
+	const opsAfterRefresh: Identity = {
+		type: 'cognito',
+		userId: 'u-ops-1',
+		email: 'ops@example.com',
+		groups: ['ops'],
+	};
+
+	it('identity の MFA が不明でも、context が MFA 済セッションなら許可', () => {
+		expect(hasOpsAccess(opsAfterRefresh, { mfaAuthenticated: true })).toBe(true);
+	});
+
+	it('identity も context も MFA を示さなければ拒否 (fail-closed)', () => {
+		expect(hasOpsAccess(opsAfterRefresh, { mfaAuthenticated: false })).toBe(false);
+		expect(hasOpsAccess(opsAfterRefresh, undefined)).toBe(false);
+		expect(hasOpsAccess(opsAfterRefresh, {})).toBe(false);
+	});
+
+	it('context が MFA 済でも ops group でなければ拒否', () => {
+		expect(
+			hasOpsAccess(
+				{ type: 'cognito', userId: 'u-p', email: 'p@example.com', groups: [] },
+				{ mfaAuthenticated: true },
+			),
+		).toBe(false);
+	});
+
+	it('/ops layout は locals.context の MFA も見る (refresh 直後も通過する)', async () => {
+		const mod = await import('../../../src/routes/ops/+layout.server');
+		// biome-ignore lint/suspicious/noExplicitAny: SvelteKit の LayoutServerLoad 引数を最小 stub で渡す
+		const load = mod.load as any;
+		await expect(
+			load({ locals: { identity: opsAfterRefresh, context: { mfaAuthenticated: true } } }),
+		).resolves.toEqual({});
+		await expect(
+			load({ locals: { identity: opsAfterRefresh, context: { mfaAuthenticated: false } } }),
+		).rejects.toMatchObject({ status: 403 });
+	});
+});
+
+describe('#4266 context token が MFA 済セッションを保持する', () => {
+	it('signContext → verifyContext で mfaAuthenticated が往復する', async () => {
+		const { signContext, verifyContext } = await import('$lib/server/auth/context-token');
+		const token = signContext({ tenantId: 't-1', role: 'owner', mfaAuthenticated: true });
+		expect(verifyContext(token)?.mfaAuthenticated).toBe(true);
+	});
+
+	it('mfaAuthenticated を載せない旧トークンは undefined (= 拒否側)', async () => {
+		const { signContext, verifyContext } = await import('$lib/server/auth/context-token');
+		const token = signContext({ tenantId: 't-1', role: 'owner' });
+		expect(verifyContext(token)?.mfaAuthenticated).toBeUndefined();
+	});
+});

--- a/tests/unit/services/cognito-jwt.test.ts
+++ b/tests/unit/services/cognito-jwt.test.ts
@@ -244,3 +244,84 @@ describe('verifyIdentityToken', () => {
 		expect(claims).toBeNull();
 	});
 });
+
+// ---------- #4266: MFA 判定 (amr claim) ----------
+// PO 決裁 (2026-08-05) で admin IP allowlist を廃止したため、/ops の主防御は
+// 「ops group + MFA」になった。MFA を経たかは ID token の `amr` (Authentication Methods
+// References, RFC 8176) claim で判定する。Cognito は認証で完了したチャレンジを amr に載せる。
+// 値の綴りは実装依存 (mfa / software_token_mfa / sms_mfa) のため、いずれか 1 つで真とする。
+// 判定できない (claim 欠落 / 非配列) 場合は false = 拒否 (fail-closed)。
+describe('#4266 hasMfaAmr — amr claim から MFA 済を判定する', () => {
+	it('amr に "mfa" を含めば true', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr(['pwd', 'mfa'])).toBe(true);
+	});
+
+	it('amr に "software_token_mfa" (TOTP) を含めば true', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr(['pwd', 'software_token_mfa'])).toBe(true);
+	});
+
+	it('amr に "sms_mfa" を含めば true', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr(['sms_mfa'])).toBe(true);
+	});
+
+	it('大文字表記 (SOFTWARE_TOKEN_MFA) でも true', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr(['PWD', 'SOFTWARE_TOKEN_MFA'])).toBe(true);
+	});
+
+	it('password のみは false', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr(['pwd'])).toBe(false);
+	});
+
+	it('claim 欠落 (undefined) は false (fail-closed)', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr(undefined)).toBe(false);
+	});
+
+	it('空配列は false', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr([])).toBe(false);
+	});
+});
+
+describe('#4266 verifyIdentityToken が amr claim を伝搬する', () => {
+	it('amr を claims に載せる', async () => {
+		mockJwtVerify.mockResolvedValue({
+			payload: {
+				sub: 'u-ops',
+				email: 'ops@example.com',
+				amr: ['pwd', 'mfa'],
+				iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool',
+				aud: 'test-client-id',
+				token_use: 'id',
+			},
+			protectedHeader: { alg: 'RS256' },
+			// biome-ignore lint/suspicious/noExplicitAny: jose の戻り値型を最小 stub で満たす
+		} as any);
+		const { verifyIdentityToken } = await import('$lib/server/auth/providers/cognito-jwt');
+		const claims = await verifyIdentityToken('dummy');
+		expect(claims?.amr).toEqual(['pwd', 'mfa']);
+	});
+
+	it('amr が非配列なら undefined (fail-closed 側に倒す)', async () => {
+		mockJwtVerify.mockResolvedValue({
+			payload: {
+				sub: 'u-ops',
+				email: 'ops@example.com',
+				amr: 'mfa',
+				iss: 'https://cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool',
+				aud: 'test-client-id',
+				token_use: 'id',
+			},
+			protectedHeader: { alg: 'RS256' },
+			// biome-ignore lint/suspicious/noExplicitAny: jose の戻り値型を最小 stub で満たす
+		} as any);
+		const { verifyIdentityToken } = await import('$lib/server/auth/providers/cognito-jwt');
+		const claims = await verifyIdentityToken('dummy');
+		expect(claims?.amr).toBeUndefined();
+	});
+});

--- a/tests/unit/services/cognito-jwt.test.ts
+++ b/tests/unit/services/cognito-jwt.test.ts
@@ -267,6 +267,18 @@ describe('#4266 hasMfaAmr — amr claim から MFA 済を判定する', () => {
 		expect(hasMfaAmr(['sms_mfa'])).toBe(true);
 	});
 
+	// 本アプリの email OTP は Cognito MFA ではなくアプリ層の機構 (auth-stack.ts)。
+	// otp 系を MFA 済と誤認すると「二要素を経ていないセッション」が /ops を通る。
+	it('amr が "otp" のみは false (単要素の可能性がある綴りは受理しない)', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr(['otp'])).toBe(false);
+	});
+
+	it('amr が "email_otp" のみは false', async () => {
+		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
+		expect(hasMfaAmr(['pwd', 'email_otp'])).toBe(false);
+	});
+
 	it('大文字表記 (SOFTWARE_TOKEN_MFA) でも true', async () => {
 		const { hasMfaAmr } = await import('$lib/server/auth/providers/cognito-jwt');
 		expect(hasMfaAmr(['PWD', 'SOFTWARE_TOKEN_MFA'])).toBe(true);

--- a/tests/unit/services/cognito-provider.test.ts
+++ b/tests/unit/services/cognito-provider.test.ts
@@ -23,6 +23,9 @@ vi.mock('$lib/server/db/factory', () => ({
 const mockVerifyIdentityToken = vi.fn();
 vi.mock('$lib/server/auth/providers/cognito-jwt', () => ({
 	verifyIdentityToken: (...args: unknown[]) => mockVerifyIdentityToken(...args),
+	// #4266: MFA 判定は純関数のため mock せず実体と同じ挙動を返す
+	hasMfaAmr: (amr: readonly string[] | undefined) =>
+		Array.isArray(amr) && amr.some((m) => m.toLowerCase().includes('mfa')),
 }));
 
 vi.mock('$lib/server/logger', () => ({
@@ -97,6 +100,8 @@ describe('CognitoAuthProvider', () => {
 				// #3025: identities claim なし = password ユーザ (federated でない)
 				isFederated: false,
 				authTime: undefined,
+				// #4266: amr claim なし = MFA を経ていない (fail-closed で /ops に入れない)
+				mfaAuthenticated: false,
 			});
 			expect(mockVerifyIdentityToken).toHaveBeenCalledWith('valid-jwt');
 		});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）= 全顧客 / 運営

**解決する課題**: CloudFront の IP allowlist は遮断対象に `/admin`（保護者の見守り画面）を含んでおり、`ADMIN_ALLOWED_IPS` を登録した瞬間に**有料家庭を含む全顧客が 403** になる。未登録だったことが結果的に顧客を守っていた（PO 実測、#4280）。さらに運営者のグローバル IP は固定でなく、プロキシ経由では CloudFront が見る viewer IP が回線 IP と一致しないため、防御としても成立しない。

**期待される効果**: 顧客締め出し経路を機構ごと除去し、運営専用 `/ops` の防御を IP に依存しないアプリ層（Cognito `ops` group + MFA）に移す。運営者は TOTP を 1 度設定すれば、回線・プロキシ・IP 変動に縛られず `/ops` に入れる。

## 関連 Issue

Closes #4266

方針 SSOT: #4280（PO 決裁 2026-08-05）。#4276 は当初方針（staging にも同じ IP allowlist を配る）の実装であり、本 PR がその allowlist 自体を撤去する。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `/ops` の主防御を「Cognito `ops` group + MFA 必須」にする（#4280 決定 3） | `npx vitest run tests/unit/routes/ops-mfa-guard.test.ts tests/unit/policy/capabilities.test.ts tests/unit/services/cognito-jwt.test.ts` | PASS（11 + 45 + 21 tests）。実装 = `hasOpsAccess()`（`src/lib/server/auth/ops-authz.ts`）。`mfaAuthenticated !== true` は拒否 = fail-closed。mutation 実測は下表 |
| AC2 | staging に本番顧客データが存在しないことを実測で確認し、「実在メールを登録しない」と「sign-up しないと検証できない」の矛盾を解消する | `grep -n "STAGING_ALLOWED_EMAIL_DOMAINS" .github/workflows/deploy-aws-staging.yml` / `docs/design/staging-synthetic-seed.md` §5 | **部分達成**。矛盾の解消 = 使い捨てドメイン allowlist（`STAGING_ALLOWED_EMAIL_DOMAINS`）+ `Staging PII guard` 通知 が既存機構として存在することを §11.5 に明記した。**DSQL / Cognito の実データ照会は AWS 資格情報が要るため本 PR では実施していない**（オーナー手番。実施範囲の制約は「レビュー依頼事項」に記載） |
| AC3 | 本番と staging の防御層の差分を 1 箇所に表として残す（`14-セキュリティ設計書.md` §11.5）。IP allowlist を防御層として数えない | `grep -n "### 11.5" docs/design/14-セキュリティ設計書.md` | PASS（L1026）。8 層 × 本番 / staging の表を追加。IP allowlist 行は「なし / なし」で、撤去理由を §5.2.9 に置いた |

## 削除する検査（チーム憲章 §4.5）

| 観点 | 内容 |
|---|---|
| **何を守っていた検査か** | 運営者以外の `/ops` `/admin` 到達を CloudFront 層（エッジ）で遮断する |
| **同じ観点を別の装置が見るか** | `/ops` = `hasOpsAccess()`（Cognito `ops` group + MFA、fail-closed）が見る。`/admin` = **そもそも IP で守るべきものではない**（顧客の画面）。Cognito 認証 + 親 PIN gate（§4.3）が見る |
| **今後検査されなくなる観点** | **未認証の第三者が `/ops` の URL に到達すること自体**は防がなくなる（到達しても認可で 403 を返す）。エッジで弾かないため `/ops` の存在自体は外部から観測できる。これを silent に消さないため §5.2.9 に「この設計で守らないもの」として明記した |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `/ops` 配下全ページ（運営のみ）/ CloudFront Function（本番・staging・demo の 3 distribution）/ `deploy.yml` の CDK context。`/admin` `/child` の顧客画面に挙動変化はない（IP フィルタは値が空で無効化されていたため、実環境の応答は変わらない）。

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）— いずれも対象外。`cognito.ts` / `cognito-dev.ts` の 2 provider は同じ `hasMfaAmr` 経路で同期した（dev だけ別分岐を作らない）
- [x] **設計書同期** (ADR-0001): `14-セキュリティ設計書.md` §5.2 マトリクス行 / §5.2.9 / §11.5、`13-AWSサーバレスアーキテクチャ設計書.md` §demo CloudFront Function
- [x] **LP ↔ アプリ整合** (ADR-0013): LP 記載に IP allowlist の言及なし
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — `/ops` の E2E は cognito-dev lane（dev ops ユーザに `mfa: true` を付与して従来通り通過する）
- [ ] N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | PASS（結論行を本文末尾に記載） |
| 追加・変更テスト | `npx vitest run tests/unit/routes/ tests/unit/policy/ tests/unit/services/` | PASS（230 files / 3262 tests） |
| svelte-check | `npx svelte-check` | 0 errors / 0 warnings |

### failing-test-first の証跡（ADR-0061）

| commit | 内容 | 実測 |
|---|---|---|
| `6bc51b6b3` | MFA 必須の test だけを先に commit | **red: 19 failed / 58 passed** |
| `808ab9f03` | 実装（`hasMfaAmr` / `hasOpsAccess` / policy 条件） | green: 90 passed |
| `a5b2cccd3` | IP allowlist 撤去 + 回帰 guard | green: 5 passed |

### mutation 実測（commit 後に壊して確認、`git stash push` で退避）

| # | 壊した箇所 | 期待 | 実測 |
|---|---|---|---|
| 1 | `hasOpsAccess` の `=== true` を `!== false` に（不明を通す） | fail-closed の test が落ちる | **2 failed**（`MFA 情報不明 → 拒否` / `403`） |
| 2 | `capabilities.ts` の `ops-mfa-required` 条件を削除 | policy 層の test が落ちる | **2 failed**（`access.ops_dashboard` / `view.ops_license_dashboard`） |
| 3 | CloudFront Function に `/admin` `/ops` の 403 分岐を再注入 | 回帰 guard が落ちる | **4 failed**（`/admin` / `/ops` / 403・IP 照合 / context 無効化） |
| 4 | 403 の MFA 理由メッセージを削除 | 理由の出し分け test が落ちる | **1 failed** |
| 5 | `amr` 受理集合に `otp` を戻す | 単要素拒否 test が落ちる | **1 failed** |
| 6 | `hasOpsAccess` からセッション側 MFA（`sessionMfa`）を落とす | refresh 対策 test が落ちる | **2 failed** |
| 7 | context token の `mfaAuthenticated` を常に `true` にする | 旧トークン拒否 test が落ちる | **1 failed** |

## スクリーンショット / ビジュアルデモ

該当なし（顧客に見える UI の変更を含まない）。変更は CloudFront Function のコード・`/ops` の認可条件・CDK context・設計書。`/ops` は運営専用画面で、MFA 済 ops ユーザの見た目は変わらない。

<!-- ss-pair-none: UI 変更を含まない infra + 認可条件の PR のため before/after ペアが存在しない -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [ ] 含まれない
- [x] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**破壊的変更の内容**: `/ops` に入るには **Cognito で MFA（TOTP）を設定済み**であることが必要になる。MFA 未設定の ops ユーザは 403 になる（fail-closed）。運営者は Cognito で TOTP を 1 度設定すれば以後 IP に縛られず入れる。顧客（`/admin` 側）には影響しない（user pool は `mfa: OPTIONAL` のまま）。

`ADMIN_ALLOWED_IPS` secret は**登録しない**（登録しても参照されなくなった）。

**レビュー依頼事項**:

1. **MFA の判定を ID token の `amr` claim（RFC 8176）で行っている。** Cognito が MFA チャレンジ完了時に `amr` へ載せる綴りは公式ドキュメントで確定できなかった。受理するのは `mfa` / `software_token_mfa` / `sms_mfa` の 3 綴りのみ（`otp` / `email_otp` は本アプリではアプリ層の email OTP を指し二要素の証拠にならないため受理しない）。**運営者が TOTP を設定した後に `/ops` へ入れることは staging / 本番の実機で 1 度確認が必要**（綴りが想定と違えば fail-closed 側に倒れて 403 になる = ブリーフ ① / Q1）。判定は `hasMfaAmr()`（`src/lib/server/auth/providers/cognito-jwt.ts`）1 箇所にある。
2. **AC2 の実データ照会は本 PR では行っていない**（AWS 資格情報の使用が作業範囲外）。§11.5 には「staging に載るのは検証者が sign-up して作ったデータ」であることと、使い捨てドメイン allowlist の SSOT を明記した。
3. `requireGlobalMasterWriteAccess()`（`market_benchmarks` 書込）は `isOpsMember`（group のみ）のままにした。PO 決裁の射程は `/ops` であり、こちらを同時に MFA 必須へ引き上げるかは判断を仰ぐ。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`ADMIN_ALLOWED_IPS` の参照を撤去する方向の変更）

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC2 の実データ照会のみ、AWS 資格情報を要するためオーナー手番。範囲は「レビュー依頼事項」2 に明記）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — UI 変更なしのため対象外
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 認証**画面**の変更はなし（変更は認可条件と ID token claim の読み取り。`/ops` の認可は unit test + dev ops ユーザの `mfa: true` で担保）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — revert で allowlist 機構が戻る"]
    R2["顧客面: 変化なし。IP 値は空で無効だった"]
    R3["ロールバック: revert のみ。データ破壊なし"]
    R4["🔴 amr の綴りが未検証。外れると<br/>運営が /ops に入れない (Q1)"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 顧客を 403 にする経路を機構ごと除去"]
    T2["捨てる: エッジ層の到達遮断。運営は TOTP 設定が必須"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: amr 綴り未検証で /ops 全損リスク。<br/>#4280 Function URL 迂回も未対応 🟡"]
    O2["UX: 403 理由 / refresh 締め出し<br/>→ 本 PR で是正済 🟢"]
    O3["security: otp 系受理 → 本 PR で是正済 🟢。<br/>統計 master の強度差は残 (Q3)"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["顧客画面の見た目・挙動は不変。UI 差分ゼロ"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: amr 未検証のまま進めてよいか<br/>(実機確認は deploy 後)"]
    Q2["Q2: /ops 到達をエッジで隠さない前提でよいか"]
    Q3["Q3: 統計 master 書込も MFA 必須にするか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3,R4 danger
  class T2,O1 warn
  class R1,R2,T1,C1,O2,O3 ok
  class Q1,Q2,Q3 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- **可逆性**: 撤去したのは CloudFront Function 内の分岐 + CDK context + `deploy.yml` の 3 行。revert で機構は戻る。ただし戻しても `/admin` を遮断する設計欠陥ごと戻るため、戻す判断は「顧客締め出しを再び受け入れる」判断になる
- **顧客面が変わらない根拠**: `ADMIN_ALLOWED_IPS` は未登録で、`network-stack.ts` は空文字なら IP フィルタのコードごと落としていた（PO 実測、#4280）。実環境の応答は変更前後で同じ
- **運営側の変化**: `/ops` は Cognito の TOTP を設定済みであることが必要になる（fail-closed）。未設定なら 403。設定後は IP・回線・プロキシに依存せず入れる
- **確認が要る点**: MFA 判定は ID token の `amr` claim（RFC 8176）を読む。Cognito が載せる綴りを AWS 公式ドキュメントで確定できなかったため `mfa` / `software_token_mfa` / `sms_mfa` の 3 綴りを受理しているが、**実機で 1 度「TOTP 設定後に `/ops` に入れる」ことの確認が要る**。判定は `hasMfaAmr()` 1 箇所

**③ の全文（`tmp/adversarial-evidence/4284.json`、adversarial-reviewer が生成）と、本 PR での対処**

| 軸 | 反対理由（要旨） | 本 PR での対処 |
|---|---|---|
| business | 撤去（効いていなかった 1 層）と代替（未検証の 1 層）を同一 PR に混ぜており、`amr` の綴りが想定と違えば deploy 直後から運営者本人が `/ops` に入れず、復旧手段が緊急 deploy しか残らない。インシデント時に「エッジで全部止める」最も安価な緊急遮断カードも同時に失う。**#4280 の Function URL 直叩き迂回（`authType: NONE`）は未対応のまま** | **未対処 — PO 判断を仰ぐ（Q1 / Q2）**。「効いていなかった 1 層を消し、未検証の 1 層を足した」という読み方が成立することを認める。緩和は (a) 判定を `hasMfaAmr()` 1 箇所に閉じた (b) MFA をセッション単位にして無操作の締め出しを塞いだ (`22210ce62`) の 2 点のみで、**綴り自体は deploy 後の実機確認まで未検証**。Function URL 迂回は本 PR の scope 外（#4280 決定 4） |
| UX | 403 が `Forbidden` のみで「group 外 / MFA 未設定 / トークン更新で claim 落ち」を区別できず、TOTP 設定の導線も案内も無い。さらに refresh 経路で `amr` が落ちると、何もしていないのに突然 403 に落ちる | **本 PR 内で是正済**。① 理由の出し分け = `fdef852e5`（ops member にのみ `Forbidden: ops access requires MFA`、非 ops には出さない）② refresh 締め出し = `22210ce62`（MFA を**セッション単位**に変更。ログイン時の判定を署名付き context token の `mfaAuthenticated` に保持し、`hasOpsAccess(identity, context)` が OR で判定。新規 cookie / 機構は追加していない）。**指摘は是正前の HEAD に対するもの** |
| security | `hasMfaAmr()` の許容集合が広く、裸の `otp` / `email_otp` を受理すると「二要素を一度も経ていないセッション」が MFA 済と判定される。`mfa: OPTIONAL` のままで IaC 側の強制はゼロ。`requireGlobalMasterWriteAccess()` は group のみで、同じ ops 境界に 2 つの強度が併存。MFA 不足の拒否を記録する監査証跡も無い | **受理集合は本 PR 内で是正済**（`fdef852e5`）。`mfa` / `software_token_mfa` / `sms_mfa` に限定し、`otp` / `email_otp` を**拒否する**回帰テストを追加（`tests/unit/services/cognito-jwt.test.ts`）。**指摘は是正前の HEAD に対するもの**。**残**: `requireGlobalMasterWriteAccess()` の強度差（Q3）と、MFA 不足で拒否した事象の監査証跡 |

> **読み方の注意**: ③ の反対理由は **adversarial-reviewer が是正前の HEAD を見て書いたもの**を原文どおり転記している。UX / security の 2 件は本 PR 内で是正済（上表の commit hash）で、現 HEAD には該当しない。business の 1 件は**未対処のまま残っている**。

- ③ の根拠 evidence: `tmp/adversarial-evidence/4284.json`（schema: must_object_count 3 / 3 軸）
- **`amr` 保持の調査結果（2026-08-05）**: `REFRESH_TOKEN_AUTH` で再発行される ID token が `amr` を保持するかは [AWS 公式ドキュメント](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-refresh-token.html)で**確定できなかった**（[ID token の解説](https://docs.aws.amazon.com/cognito/latest/developerguide/amazon-cognito-user-pools-using-the-id-token.html)にも `amr` の保持仕様の記載なし。[re:Post](https://repost.aws/questions/QUNanilozNSw2Dz7tWlI8vgw/force-mfa-only-for-restricted-content) では pre-token-generation Lambda で `amr` を自前で付与する案が議論されている）。確定できない以上「保持されない」前提で設計する必要があり、MFA をセッション単位に変更した（`22210ce62`）

</details>

