### PR TITLE
fix(ci): #4255 ss-render-impossible の story 参照判定を実在パスのみに絞る（誤マッチで SS 証跡ゼロの PR が通った）

### DIFF
--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -136,6 +136,7 @@ export function detectBeforeAfterLabels(body) {
 	};
 }
 
+import { existsSync, readdirSync } from 'node:fs';
 import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 
 /**
@@ -194,7 +195,8 @@ export function checkRenderImpossibleDeclaration(body) {
 				message:
 					'`ss-render-impossible` 宣言には **Storybook story の参照**が必須です。\n' +
 					'  「原理的に撮れない」は「見た目を確認しなくてよい」ではありません。\n' +
-					'  PR body に story のタイトル (例: `Features/Admin/BackupHealthCard`) を書いてください。',
+					'  PR body に **story ファイルのパス** を書いてください (例: `src/lib/features/admin/components/BackupHealthCard.stories.svelte`)。' +
+					' タイトルだけの言及は受理しません — 実在確認ができず、それっぽい文字列で素通りするためです (#4255)。',
 			},
 		};
 	}
@@ -205,19 +207,62 @@ export function checkRenderImpossibleDeclaration(body) {
 /**
  * PR body に Storybook story への参照があるか。
  *
- * story タイトル (`Foo/Bar/Baz` 形式) か `*.stories.svelte` のパス言及を受理する。
+ * **実在する `*.stories.svelte` のパス参照だけを受理する** (#4255)。
+ *
+ * 旧実装は「`story` の語 + どこかに `word/word`」で true にしていたため、GitHub の
+ * `owner/repo` に誤マッチした。PR #4235 は body に「Storybook story は本変更に対応する
+ * ものがありません」と**書いてある**のに pass し、課金導線の UI 変更が SS 証跡ゼロで
+ * merge 手前まで進んだ。#4084 (ペア 0 件を skip で通した) と同 class の 2 回目。
+ *
+ * story タイトル (`Features/Admin/Foo`) は**受理しない**。実在確認ができず、
+ * 「それっぽい文字列を書けば通る」に戻るため。判定できないときは false に倒す。
  *
  * @param {string} body
  * @returns {boolean}
  */
 export function hasStorybookStoryReference(body) {
 	const b = body ?? '';
-	// story ファイルへの言及、または story タイトル (Foo/Bar 形式) の言及を受理する。
-	if (b.includes('.stories.svelte')) return true;
-	return (
-		/(?:Storybook|story|ストーリー)/i.test(b) &&
-		/[A-Za-z][A-Za-z0-9]*\/[A-Za-z][A-Za-z0-9]*/.test(b)
-	);
+	const referenced = [...b.matchAll(/[\w./-]*[\w-]+\.stories\.svelte/g)].map((m) => m[0]);
+	return referenced.some((ref) => storyFileExists(ref));
+}
+
+/**
+ * PR body が参照した story のパスが repo に実在するか (#4255)。
+ *
+ * 完全パスでも basename だけでも受理するが、**実在しない名前は受理しない**。
+ * 走査に失敗した場合 (checkout が無い等) は **false に倒す** —
+ * 「確認できなかった」を「確認した」と同じ扱いにしない (#4084 の教訓)。
+ *
+ * @param {string} ref
+ * @returns {boolean}
+ */
+function storyFileExists(ref) {
+	const normalized = ref.replace(/^\.\//, '').replaceAll('\\', '/');
+	if (existsSync(normalized)) return true;
+	const base = normalized.split('/').pop();
+	if (!base) return false;
+	try {
+		return findStoryFiles('src').some((p) => p.endsWith(`/${base}`) || p === base);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * `src` 配下の `*.stories.svelte` を列挙する (#4255)。
+ *
+ * @param {string} dir
+ * @param {string[]} acc
+ * @returns {string[]}
+ */
+function findStoryFiles(dir, acc = []) {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+		const path = `${dir}/${entry.name}`;
+		if (entry.isDirectory()) findStoryFiles(path, acc);
+		else if (entry.name.endsWith('.stories.svelte')) acc.push(path);
+	}
+	return acc;
 }
 
 /**

--- a/tests/unit/scripts/check-pr-screenshot.test.ts
+++ b/tests/unit/scripts/check-pr-screenshot.test.ts
@@ -526,4 +526,57 @@ ${STORY_REF}`;
 	it('hasStorybookStoryReference: 無関係な本文では false', () => {
 		expect(hasStorybookStoryReference('ただの説明文です')).toBe(false);
 	});
+
+	// ---- #4255: 誤マッチで gate が素通りした実例を固定する ----
+	//
+	// PR #4235（課金導線の文言変更）は body に **「Storybook story は本変更に対応するものが
+	// ありません」と明記**していたのに、`screenshot-check` が pass した。旧判定が
+	// 「`story` の語 + どこかに `word/word` があれば true」だったため、GitHub の
+	// `Takenori-Kusaka/ganbari-quest` 等に誤マッチしていた。
+	//
+	// **SS 証跡ゼロの PR が「証跡あり」に見えた**ので、#4084（ペア 0 件を skip で通した）と
+	// 同 class の 2 回目にあたる。判定できないときは fail に倒す。
+	describe('#4255 誤マッチ防止（negative fixture）', () => {
+		it('「story は無い」と書いてある body を true にしない（PR #4235 の実 body 抜粋）', () => {
+			const body = [
+				'## スクリーンショット / ビジュアルデモ',
+				'',
+				'<!-- ss-render-impossible: Stripe Portal は外部 SaaS で demo 環境から到達できない -->',
+				'',
+				'Storybook story は本変更に対応するものがありません。',
+				'',
+				'関連: https://github.com/Takenori-Kusaka/ganbari-quest/pull/4166',
+			].join(String.fromCharCode(10));
+			expect(
+				hasStorybookStoryReference(body),
+				'「story が無い」と書いた body を story 参照ありと判定している（#4255 の誤マッチ）',
+			).toBe(false);
+			// gate としても落ちること（判定関数だけ直して gate が通ると意味がない）
+			const r = checkRenderImpossibleDeclaration(body);
+			expect(r.ok).toBe(false);
+			expect(r.violation?.id).toBe('ss-render-impossible-story-missing');
+		});
+
+		it('story タイトルだけの言及は受理しない（パスで書かせる）', () => {
+			// 旧実装はこれを true にしていた。タイトルは実在確認ができない。
+			expect(
+				hasStorybookStoryReference('Storybook の Features/Admin/BackupHealthCard を参照'),
+			).toBe(false);
+		});
+
+		it('実在しない *.stories.svelte のパスは受理しない', () => {
+			expect(
+				hasStorybookStoryReference('src/lib/features/admin/components/NoSuchThing.stories.svelte'),
+				'実在しない story を書けば通る = 検査が空洞化する',
+			).toBe(false);
+		});
+
+		it('実在する *.stories.svelte のパスは受理する', () => {
+			expect(
+				hasStorybookStoryReference(
+					'src/lib/features/admin/components/BackupHealthCard.stories.svelte を追加',
+				),
+			).toBe(true);
+		});
+	});
 });

--- a/tests/unit/scripts/check-pr-screenshot.test.ts
+++ b/tests/unit/scripts/check-pr-screenshot.test.ts
@@ -477,7 +477,11 @@ describe('ss-render-impossible 宣言 (#4087)', () => {
 	// 「UI は変わるが、その環境では原理的に描画できない」に対する語彙。
 	// 兄弟 gate (ss-blob-sha-uniqueness) には理由必須の宣言が 4 種あるのに本 gate だけ無く、
 	// 「UI 変更なし」と嘘を書くか label の意味を曲げるかしか道が無かった (#4084 / PO 決裁 2026-08-01)。
-	const STORY_REF = 'Storybook の Features/Admin/BackupHealthCard で 4 状態を確認できます';
+	// #4255: story 参照は **実在する `*.stories.svelte` のパス**で書く。
+	// タイトルだけ (`Features/Admin/BackupHealthCard`) は実在確認ができず、
+	// 「それっぽい文字列を書けば通る」に戻るため受理しない (判定の厳格化であって弱体化ではない)。
+	const STORY_REF =
+		'Storybook の src/lib/features/admin/components/BackupHealthCard.stories.svelte で 4 状態を確認できます';
 
 	it('宣言が無ければ何も起きない (既存 PR に影響しない)', () => {
 		expect(checkRenderImpossibleDeclaration('本文だけ').ok).toBe(false);


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（顧客に見える変化はありません）

**解決する課題**: SS 証跡の gate が**走ったのに検査していない**状態でした。`ss-render-impossible` 宣言に必須の「Storybook story 参照」判定が誤マッチし、**PR #4235（課金導線の文言変更）は body に「Storybook story は本変更に対応するものがありません」と明記していたのに `screenshot-check` が pass**。UI 変更が SS 証跡ゼロで merge 手前まで進みました。

**期待される効果**: 「story がある」と偽れなくなる。判定できないときは fail に倒れる。

## 関連 Issue

Closes #4255

- #4087（`ss-render-impossible` に story 参照必須を定めた Issue）
- #4084（`ss-blob-sha-uniqueness` がペア 0 件を skip で通した件。**同 class 1 回目**）
- ADR-0061（same-class-N → guard）/ ADR-0006（assertion 弱体化禁止）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 判定は **実在する `*.stories.svelte` へのパス参照**または明示マーカーのみ true | unit test + mutation | ✅ `hasStorybookStoryReference` を「body 中の `*.stories.svelte` 参照を抽出 → repo に実在するものだけ受理」に変更（HEAD `547bc8fb8`）。**story タイトルだけの言及は受理しない**（実在確認ができず「それっぽい文字列で通る」に戻るため） |
| AC2 | **PR #4235 の body を negative fixture として固定**する | unit test | ✅ `tests/unit/scripts/check-pr-screenshot.test.ts` の `#4255 誤マッチ防止（negative fixture）` に **実 body 抜粋**（`ss-render-impossible` 宣言 + 「Storybook story は本変更に対応するものがありません」+ GitHub URL）を置き、`hasStorybookStoryReference` = false かつ **gate も `ss-render-impossible-story-missing` で落ちる**ことを assert |
| AC3 | **判定できなければ fail に倒す**（skip / silent pass を作らない） | unit test | ✅ 実在しないパス → false / 走査失敗（checkout 無し等）→ `catch` で false。**「確認できなかった」を「確認した」と同じ扱いにしない**（#4084 の結論と同じ） |

### 誤マッチの機序（なぜ「story は無い」と書いた PR が通ったか）

旧判定はこうでした。

```js
if (b.includes('.stories.svelte')) return true;
return /(?:Storybook|story|ストーリー)/i.test(b) && /[A-Za-z][A-Za-z0-9]*\/[A-Za-z][A-Za-z0-9]*/.test(b);
```

**`story` の語がどこかにあり、かつ `word/word` の形がどこかにあれば true** になります。PR #4235 の body には「Storybook story は…ありません」という**否定文**と、GitHub URL の `Takenori-Kusaka/ganbari-quest` が両方あったため成立しました。

## 変更タイプ

- [x] fix: バグ修正
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（CI gate の判定のみ。顧客に見える画面は不変）

- [x] N/A — 並行実装ペア / 設計書同期 / LP 整合 / 重量 e2e 敏感領域はいずれも影響範囲外

**既存 PR への影響**: `ss-render-impossible` を使う PR は **story をパスで書く**必要があります。現行 repo で本宣言を使っているのは #4087 起因の 1 系統のみで、既存 test fixture（`STORY_REF`）も実在パスに更新済みです。

**この変更で厳しくなる点（意図的）**: タイトル参照（`Features/Admin/BackupHealthCard`）は通らなくなります。実在確認ができないため、gate として意味を持たないと判断しました。**判定の厳格化であって assertion の弱体化ではありません**（ADR-0006 整合）。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4285` | **ALL PASS**（6 step。Step 11b は UI 変更なしで適用対象外） |
| 追加・変更テスト | `npx vitest run tests/unit/scripts/check-pr-screenshot.test.ts` | **73 passed**（新規 4 件 + 既存 69 件） |
| lint | `npx biome check scripts/check-pr-screenshot.mjs tests/unit/scripts/check-pr-screenshot.test.ts` | **PASS** |

### failing-test-first（commit 順序が証跡）

```
748296fe0 test(ci): #4255 SS gate の誤マッチを failing-test で固定する   ← test のみ。3 red
547bc8fb8 fix(ci):  #4255 判定を実在パスのみに絞る                      ← 実装。73 passed
```

### mutation で red を実測（commit してから壊した）

| 壊した内容 | 結果 |
|---|---|
| 判定を**旧実装**（`story` の語 + `word/word`）に戻す | ✅ **red 3 件** — 「story は無い」body / タイトルのみ / 実在しないパス がすべて通ってしまう |

- [x] **mutation の前に commit した**
- [x] **SOLID / DRY / YAGNI**: 判定関数 1 つの絞り込み + 実在確認 helper 2 つ。新規 script なし
- [x] **Security（OSS 公開前提）**: 秘密情報なし
- [x] **A11y・パフォーマンス**: N/A（CI script）
- [x] **Critical バグ修正**(ADR-0002): N/A（priority:high）

## スクリーンショット / ビジュアルデモ

**該当なし（CI gate script と unit test のみの変更で、顧客に見える画面が存在しない）**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない（既存の正しい使い方＝パス参照は引き続き通る）

**レビュー依頼事項**:

1. **basename 一致を許すかどうか。** 完全パスだけに限定する案もありましたが、PR body に短縮形で書く運用を潰すと「gate を通すためだけに長いパスを貼る」動機を作るため、`src` 配下を走査して **basename 一致も実在確認つきで受理**しています
2. **走査範囲を `src` に限定**しています（`.storybook/` 等に story を置く運用が将来出たら広げる必要があります）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1 / AC2 / AC3 すべて完了）
- [x] UI 変更なし
- [x] 認証画面変更なし

## QM レビュー結果

<!-- QM が記入。5 手順の approve body フォーマットは docs/sessions/qm-session.md 参照 -->

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
