### PR TITLE
fix(ci): #4273 main-pr-base-guard の fail メッセージに retarget コマンドを出す（止めるだけで直し方を書かない guard にしない）

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -550,3 +550,6 @@ mebibytes
 crond
 # ===== #3982 demo auth-repo の型導出コメント (TS の method shorthand はパラメータが双変) =====
 bivariant
+
+# ===== #4273 main-pr-base-guard の fail メッセージ test (bash の case 終端キーワード) =====
+esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1270,7 +1270,9 @@ jobs:
           case "$PR_ACTOR" in
             dependabot\[bot\]|renovate\[bot\])
               # #3922: security 更新の main 直行を検知して fail-close (exempt 廃止)。
-              echo "::error::dependabot/renovate の main 向け PR を検知しました (security 更新は target-branch=develop を無視して main に直行する仕様)。auto-merge は本 check の fail で阻止されます。対処: 本 PR は merge せず close し、同 version への更新を develop 向けに反映してください (次回 grouped bump を待つ / 手動で develop 向け bump PR を作成)。緊急の security fix は develop 反映後に統合 release で main へ。背景: #3922 / #3158→#3190 (develop 監査すり抜け → SIGSEGV) / branch-strategy.md §7。"
+              echo "::error::dependabot/renovate の main 向け PR を検知しました (security 更新は target-branch=develop を無視して main に直行する仕様)。auto-merge は本 check の fail で阻止されます。"
+              echo "::error::対処 (これ 1 つで済みます): gh pr edit ${{ github.event.pull_request.number }} --base develop"
+              echo "::error::close して bump PR を作り直す必要はありません。retarget すれば通常レーン (develop → 統合 release → main) に載り、必須 CI も再発火します。緊急の security fix も同じ経路で入れてください。背景: #3922 / #4273 / #3158→#3190 (develop 監査すり抜け → SIGSEGV) / branch-strategy.md §7。"
               exit 1 ;;
           esac
           # ISO 8601 UTC (YYYY-MM-DDTHH:MM:SSZ) 同士の辞書順比較
@@ -1282,7 +1284,8 @@ jobs:
             echo "head=$HEAD_REF → OK（develop/release 統合 PR または hotfix）"
             exit 0
           fi
-          echo "::error::main 向け PR の head は develop / release/*（統合 PR）または fix/*（hotfix、ADR-0002 重量 gate 必須）のみ許可されています。head=$HEAD_REF は develop 向けに PR を出し直してください（docs/sessions/branch-strategy.md §3 / §5）。"
+          echo "::error::main 向け PR の head は develop / release/*（統合 PR）または fix/*（hotfix、ADR-0002 重量 gate 必須）のみ許可されています。head=$HEAD_REF は develop 向けに出し直してください（docs/sessions/branch-strategy.md §3 / §5）。"
+          echo "::error::対処 (これ 1 つで済みます): gh pr edit ${{ github.event.pull_request.number }} --base develop"
           exit 1
 
   # Gate job: always runs and reports overall CI status.

--- a/tests/unit/architecture/main-pr-base-guard-message.test.ts
+++ b/tests/unit/architecture/main-pr-base-guard-message.test.ts
@@ -51,12 +51,20 @@ describe('#4273 main-pr-base-guard は「直し方」を出す', () => {
 		);
 	});
 
-	it('retarget コマンドをそのまま出す（close + 再作成を第一手にしない）', () => {
+	it('dependabot 分岐が retarget コマンドを出す（close + 再作成を第一手にしない）', () => {
+		// **分岐の中を見る。** body 全体で `gh pr edit` を探すと、後段 (head 不一致) の
+		// メッセージに引っかかって dependabot 側が空でも通ってしまう
+		// （実際 mutation で素通りし、この assert の絞り込みで初めて red になった）。
+		const start = body.indexOf('dependabot');
+		const branch = body.slice(start, body.indexOf('esac', start));
 		expect(
-			body,
-			'`gh pr edit <N> --base develop` が出ていない = 止めるだけで直し方を書かない guard',
+			branch,
+			'dependabot 分岐に `gh pr edit <N> --base develop` が無い = 止めるだけで直し方を書かない guard',
 		).toContain('gh pr edit');
-		expect(body, 'retarget 先が develop と書かれていない').toMatch(/--base\s+develop/);
+		expect(branch, 'retarget 先が develop と書かれていない').toMatch(/--base\s+develop/);
+		expect(branch, 'close して作り直す案内が第一手のまま残っている').not.toMatch(
+			/close し、同 version/,
+		);
 	});
 
 	it('head が develop / release/* / fix/* 以外のときも retarget を案内する', () => {

--- a/tests/unit/architecture/main-pr-base-guard-message.test.ts
+++ b/tests/unit/architecture/main-pr-base-guard-message.test.ts
@@ -1,0 +1,67 @@
+// tests/unit/architecture/main-pr-base-guard-message.test.ts
+// #4273 — main 向け PR を止める guard が「直し方」を出しているか。
+//
+// ## 何を守る test か
+//
+// `main-pr-base-guard` は dependabot / renovate の main 向け PR を #3922 で既に fail-close
+// している（**gate は存在し、実際に #4251 は fail していた**）。残っていたのは *止め方* ではなく
+// *直し方* で、旧メッセージは「本 PR は merge せず **close し**、同 version への更新を develop
+// 向けに反映してください（次回 grouped bump を待つ / 手動で develop 向け bump PR を作成）」だった。
+//
+// 実際の解決は `gh pr edit <N> --base develop` の **retarget 1 コマンド**で足りる（#4251 /
+// #4271 / #4272 の 3 件をこれで通常レーンに載せた）。close + 再作成を案内すると、
+// **最も安い直し方に到達できないまま手戻りが発生する**。
+//
+// PO 決裁 (#4273 案 c): 「fail メッセージに retarget コマンドをそのまま出す。
+// **止めるだけで直し方を書かない guard にしない**」。
+//
+// ## なぜ workflow の文字列を test で見るのか
+//
+// このメッセージは **main 向け PR が作られたときにしか出ない**。通常の PR では 1 度も実行されず、
+// 文言が壊れても誰も気づかない（#4275 で「self-hosted でしか走らない step が main に到達して
+// 初めて落ちた」のと同じ構造）。静的に固定しておく。
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const CI_WORKFLOW = '.github/workflows/ci.yml';
+
+/** `main-pr-base-guard` job の本文（次の job 定義までを job の範囲とする）。 */
+function guardJobBody(): string {
+	const workflow = readFileSync(CI_WORKFLOW, 'utf-8');
+	const start = workflow.indexOf('  main-pr-base-guard:');
+	expect(start, `${CI_WORKFLOW} に main-pr-base-guard job が無い`).toBeGreaterThan(-1);
+	// job キーはインデント 2。次の「インデント 2 のキー」または comment 行までを本文とする。
+	const rest = workflow.slice(start + 1);
+	const nextJob = rest.search(/\n {2}(?:#|[a-z][a-z0-9-]*:)/);
+	return nextJob < 0 ? rest : rest.slice(0, nextJob);
+}
+
+describe('#4273 main-pr-base-guard は「直し方」を出す', () => {
+	const body = guardJobBody();
+
+	it('dependabot / renovate の main 向け PR を fail-close する（#3922 の維持）', () => {
+		// **本 test は既存挙動の維持確認**。ここが緩むと security 更新が main へ直行する。
+		expect(body, 'dependabot / renovate の分岐が無い').toMatch(
+			/dependabot\\\[bot\\\]\|renovate\\\[bot\\\]/,
+		);
+		const branch = body.slice(body.indexOf('dependabot'));
+		expect(branch.slice(0, branch.indexOf('esac')), '分岐内で exit 1 していない').toContain(
+			'exit 1',
+		);
+	});
+
+	it('retarget コマンドをそのまま出す（close + 再作成を第一手にしない）', () => {
+		expect(
+			body,
+			'`gh pr edit <N> --base develop` が出ていない = 止めるだけで直し方を書かない guard',
+		).toContain('gh pr edit');
+		expect(body, 'retarget 先が develop と書かれていない').toMatch(/--base\s+develop/);
+	});
+
+	it('head が develop / release/* / fix/* 以外のときも retarget を案内する', () => {
+		// dependabot 以外の経路（人が誤って main 宛に出した PR）でも同じ直し方が要る。
+		const tail = body.slice(body.lastIndexOf('main 向け PR の head'));
+		expect(tail, 'head 不一致の fail メッセージに retarget コマンドが無い').toContain('gh pr edit');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発者（顧客に見える変化はありません）

**解決する課題**: `main-pr-base-guard` は main 向け PR を**止めはするが、直し方を書いていません**でした。dependabot の security 更新は `target-branch=develop` を無視して base=main で PR を作るため必ずこの gate に当たりますが、メッセージは「**close して develop 向けに bump PR を作り直せ**」と案内しており、実際に必要な `gh pr edit <N> --base develop` の **1 コマンド**に到達できません。

**期待される効果**: 止められた人が、そのメッセージだけで直せる。

## 関連 Issue

Refs #4273（PO 決裁: 案 c）

<!-- no-issue-close: #4273 は「gate を dependabot にも効かせる」を含むが、それは #3922 で実装済だった（下記「起票時の事実誤認」参照）。本 PR は残スコープ（メッセージの是正）のみで、Issue の close 判断は PO に委ねる -->

- #3922（dependabot / renovate の main 向け PR を fail-close した Issue。**本 PR はこれを維持する**）
- #4251 / #4271 / #4272（実際に base=main で作られた security 更新 PR。retarget で解決済）

## 起票時の事実誤認と、実際に残っていたもの

**私（Dev）の起票は誤っていました。** 実装前に実測して判明したので、Issue にも訂正コメントを入れています。

| 起票時の記述 | 実測 |
|---|---|
| 「develop 二層 gate を**迂回している**」 | ❌ **迂回できていません**。`main-pr-base-guard` が #3922 で既に fail-close 済で、`gh pr checks 4251` で該当 job は **`fail`**、run log にも `::error::` が出ていました。**auto-merge はこの fail で阻止されていました** |
| 「security update が `target-branch` を無視して main に PR を作る」 | ✅ 事実（#4251 / #4271 / #4272 の 3 件とも base=main） |

**見落としの構造**: 必須 CI 5 job（`lint-and-test` / `unit-test` 等）を名前指定で確認して「非 pass 行 0」と判断し、**挙げなかった job（`main-pr-base-guard`）を見ていません**でした。#4264 で「必須 job を 1 本ずつ確認する」と学んだ直後に、**別の job を見落とす**同じ形です。

したがって本 PR のスコープは PO 決裁文の後半に絞りました。

> **fail メッセージに retarget コマンドをそのまま出す**（`gh pr edit <N> --base develop`）。止めるだけで直し方を書かない guard にしない

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | dependabot / renovate の main 向け PR を fail-close する（#3922 の**維持**） | unit test | ✅ 既存挙動。判定ロジックは 1 行も変えていない。test で分岐の存在と `exit 1` を固定 |
| AC2 | fail メッセージが retarget コマンドを出す | unit test + mutation | ✅ `対処 (これ 1 つで済みます): gh pr edit ${{ github.event.pull_request.number }} --base develop` を **PR 番号込み**で出力（コピペで実行できる） |
| AC3 | 「close して作り直す」を第一手にしない | unit test | ✅ 旧文言を撤回し「close して bump PR を作り直す必要はありません」と明示。緊急 security fix も同じ経路と書いた |
| AC4 | dependabot 以外（人が誤って main 宛に出した PR）にも同じ直し方を出す | unit test | ✅ head 不一致経路にも同じ retarget コマンドを追加 |

## 変更タイプ

- [x] fix: バグ修正
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（CI の fail メッセージのみ。判定は不変）

- [x] N/A — 並行実装ペア / 設計書同期 / LP 整合 / 重量 e2e 敏感領域はいずれも影響範囲外

**このメッセージが出る条件**: `github.base_ref == 'main'` の PR のときだけです。**通常の PR では 1 度も実行されません**。文言が壊れても誰も気づかないため、静的 test で固定しました（#4275 で「self-hosted でしか走らない step が main に到達して初めて落ちた」のと同じ構造です）。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4287` | **ALL PASS**（6 step） |
| 追加テスト | `npx vitest run tests/unit/architecture/main-pr-base-guard-message.test.ts` | **3 passed** |
| 周辺回帰 | `npx vitest run tests/unit/architecture/` | **329 passed (41 files)** |
| workflow parse | `js-yaml` で `ci.yml` を load → `main-pr-base-guard` の step 数 / `gh pr edit` 出現 2 箇所を確認 | **OK** |

### failing-test-first（commit 順序が証跡）

```
c833cb16e test(ci): retarget コマンドを failing-test で固定する        ← test のみ。2 red
<impl>    fix(ci):  fail メッセージに retarget コマンドを出す          ← 実装。3 passed
<fix>     test(ci): assert を dependabot 分岐に絞る                    ← 下記 mutation の結果
```

### mutation で red を実測（commit してから壊した）

| 壊した内容 | 結果 |
|---|---|
| dependabot 分岐の retarget 案内を削除 | ✅ **red 1 件** |

**この mutation は 1 回目に素通りしました。** 最初の assert は `body` 全体で `gh pr edit` を探していたため、後段（head 不一致）のメッセージに引っかかり、**dependabot 側が空でも通って**いました。assert を分岐内に絞って初めて red になっています（`git log` に是正 commit として残しています）。

- [x] **mutation の前に commit した**
- [x] **SOLID / DRY / YAGNI**: workflow の echo 行 3 本 + test 1 file。新規 script なし
- [x] **Security（OSS 公開前提）**: 秘密情報なし。`${{ github.event.pull_request.number }}` は PR 番号のみ
- [x] **A11y・パフォーマンス**: N/A
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

**該当なし（CI の fail メッセージと unit test のみの変更で、顧客に見える画面が存在しない）**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない（判定ロジック不変。**通っていた PR が落ちるようにはならない / 落ちていた PR が通るようにもならない**）

**レビュー依頼事項**:

1. **「close して作り直す」を完全に撤回してよいか。** 旧文言には「次回 grouped bump を待つ」という選択肢もありましたが、retarget が常に成立するなら不要と判断しました。grouped bump を待つべきケースが実在するなら残します
2. **Issue #4273 を close するかは PO 判断に委ねています**（`Refs` 止まり）。起票内容の主要部分（「gate が無い」）が誤りだったため、私が勝手に「対応完了」として閉じるのは不適切と考えました

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1〜AC4 すべて完了）
- [x] UI 変更なし
- [x] 認証画面変更なし

## QM レビュー結果

<!-- QM が記入。5 手順の approve body フォーマットは docs/sessions/qm-session.md 参照 -->

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
