### PR TITLE
docs(security): #4280 CloudFront 層の防御が Function URL 直叩きに効かないことを SSOT に明記する

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -1030,16 +1030,23 @@ subscribe API の保存前検証だけでは、過去レコード混入 / repo �
 
 `/admin`（保護者 = 顧客の画面）と `/ops`（運営専用）に、どの層が何をかけているか。**IP allowlist は本番・staging とも持たない**（§5.2.9 の理由による）。
 
-| 層 | 本番 | AWS staging | 備考 |
-|---|---|---|---|
-| CloudFront 地域制限 | JP allowlist | **なし** | staging の post-deploy smoke を回す GitHub Actions runner が日本国外にあるため（#4204）。**staging に本番データを入れる運用が生まれたら JP allowlist を戻す**（PO 条件） |
-| CloudFront IP allowlist | なし | なし | 顧客画面 `/admin` まで遮断する設計だったため機構ごと撤去（#4266） |
-| CloudFront Function | query slash encode のみ | 同左 | SvelteKit の名前付き form action（`?/action`）を通すために必須 |
-| Cognito 認証（`/admin`） | 必須 | 必須 | `AUTH_MODE=cognito` |
-| 親 PIN gate（`/admin`） | 必須 | 必須 | §4.3 |
-| ops group + MFA（`/ops`） | 必須 | 必須 | §5.2.9。**アプリ層のため両環境に同じく効く** |
-| Function URL 直叩き | 遮断しない | 遮断しない | `authType: NONE`。CloudFront を迂回しても認証・認可は同じく効く（form action は通らない） |
-| Stripe / SES / Discord / Gemini | 注入する | **注入しない** | staging は外部サービス副作用ゼロ（`deploy-aws-staging.yml`） |
+| 層 | どこで効くか | 本番 | AWS staging | 備考 |
+|---|---|---|---|---|
+| CloudFront 地域制限 | **CloudFront のみ** | JP allowlist | **なし** | staging の post-deploy smoke を回す GitHub Actions runner が日本国外にあるため（#4204）。**staging に本番データを入れる運用が生まれたら JP allowlist を戻す**（PO 条件） |
+| CloudFront IP allowlist | — | なし | なし | 顧客画面 `/admin` まで遮断する設計だったため機構ごと撤去（#4266） |
+| CloudFront Function | **CloudFront のみ** | query slash encode のみ | 同左 | SvelteKit の名前付き form action（`?/action`）を通すために必須 |
+| Cognito 認証（`/admin`） | アプリ層（全経路） | 必須 | 必須 | `AUTH_MODE=cognito` |
+| 親 PIN gate（`/admin`） | アプリ層（全経路） | 必須 | 必須 | §4.3 |
+| ops group + MFA（`/ops`） | アプリ層（全経路） | 必須 | 必須 | §5.2.9。**アプリ層のため両環境に同じく効く** |
+| Function URL 直叩き | — | 遮断しない | 遮断しない | `authType: NONE`。CloudFront を迂回しても認証・認可は同じく効く（form action は通らない） |
+| Stripe / SES / Discord / Gemini | — | 注入する | **注入しない** | staging は外部サービス副作用ゼロ（`deploy-aws-staging.yml`） |
+
+**CloudFront 層の防御は、CloudFront を経由しない到達経路には効かない（#4280）**: Lambda Function URL は `authType: FunctionUrlAuthType.NONE`（`infra/lib/compute-stack.ts`、本番 Fn / demo Fn の 2 箇所）で公開されており、CloudFront → origin 間に共有シークレット header の検証も origin 制限（OAC 相当）も無い。したがって **上表「どこで効くか = CloudFront のみ」の層（地域制限 / CloudFront Function / 将来もし IP allowlist を戻す場合）は、Function URL のホスト名を知る者には掛からない**。
+
+- **Function URL の推測困難さを防御層として数えない。** ログ / エラー画面 / ブラウザ履歴 / 過去の設定ファイル / 外部サービスへの登録値（Stripe webhook endpoint 等）から漏れた時点で無効になる。「ネットワーク層で守られている」を前提にした判断をしないこと
+- **現状 `/admin` `/ops` を守っているのはアプリ層のみ**（Cognito 認証 + 親 PIN gate / ops group + MFA）。CloudFront 層は可用性・地域・form action の都合であって、認可の一部ではない
+- **塞ぐ場合の方式**: CloudFront → origin の custom header を Lambda 側（`hooks.server.ts`）で等値検査する（#4280 案 b、採用決定済 / 実装は別 PR）。`authType: AWS_IAM` + OAC は失敗時に全面 502 となるコストが Pre-PMF で重く不採用（ADR-0010）、**再評価トリガーは有料家庭 20 世帯到達時**
+- **custom header 方式を入れる際は、CloudFront を経由しない正規の受信経路を先に洗い出す**。Stripe webhook を含む外部サービスからの POST は custom header を持たないため、endpoint URL を CloudFront 経由に揃えるか、path 単位で検査対象から外すかを**明示的に決めてから**有効化する（外した場合、その path は Function URL 直叩きで到達可能なまま残り、署名検証が唯一の防御になる）
 
 **staging のデータ**: 合成 seed（#3412）の AWS staging 側配線は未了で、staging に載るのは**検証者が sign-up して作ったデータ**である。staging は全世界公開のため、sign-up には `deploy-aws-staging.yml` の `STAGING_ALLOWED_EMAIL_DOMAINS`（使い捨てドメインの SSOT）に載るアドレスだけを使う。allowlist 外のアドレスが登録されると deploy の `Staging PII guard` が Discord incident に通知する（手順は [runbooks/staging-live-verification.md](../runbooks/staging-live-verification.md)）。
 

--- a/infra/lib/network-stack.ts
+++ b/infra/lib/network-stack.ts
@@ -51,6 +51,11 @@ export interface NetworkStackProps extends cdk.StackProps {
 	// PO 実測 (2026-08-02): 本番 cluster 1,801,692 bytes に対し staging 1,031,956 bytes (57%)。
 	// 本番 snapshot をコピーしていれば同等以上になるため、コピーされていないと判断した。
 	// **staging に本番データを入れる運用が将来生まれた場合は JP allowlist を戻すこと** (PO 条件)。
+	//
+	// #4280: geoRestriction は **CloudFront 層の制御であり、Lambda Function URL 直叩きには効かない**
+	// (authType=NONE、CloudFront → origin の shared secret / origin 制限なし)。
+	// JP allowlist を戻しても「日本国外から到達できない」ことにはならない。詳細は本 file の
+	// CloudFront Function 定義箇所のコメント / docs/design/14-セキュリティ設計書.md §11.5。
 	geoRestrictionCountries?: string[];
 }
 
@@ -102,6 +107,17 @@ export class NetworkStack extends cdk.Stack {
 		//   - 運営者のグローバル IP は固定でなく、プロキシ経由では event.viewer.ip が回線 IP と不一致
 		// /ops の防御はアプリ層 (ops group + MFA、src/lib/server/auth/ops-authz.ts hasOpsAccess) が担う。
 		// 復活させない不変条件は tests/unit/infra/admin-no-ip-allowlist.test.ts が assert する。
+		//
+		// #4280: **CloudFront Function は viewer request にしか介在しない**。本 stack が掛ける
+		// CloudFront 層の制御 (本 Function / 下記 geoRestriction / 将来もし IP allowlist を戻す場合) は、
+		// **Lambda Function URL を直接叩く経路には一切効かない**。Function URL は
+		// compute-stack.ts で authType=NONE で公開されており、CloudFront → origin 間に
+		// 共有シークレット header の検証も origin 制限 (OAC 相当) も無いため、URL を知る者は
+		// CloudFront を迂回できる。**URL の推測困難さは防御層として数えない**
+		// (ログ / エラー画面 / 外部サービスへの登録値から漏れた時点で無効になる)。
+		// /admin・/ops を実際に守っているのはアプリ層 (Cognito 認証 + 親 PIN gate / ops group + MFA) だけである。
+		// 迂回を塞ぐ方式 (CloudFront → origin の custom header 等値検査) は #4280 で別途扱う。
+		// 防御層マトリクスの SSOT: docs/design/14-セキュリティ設計書.md §11.5。
 		const cfFunctionCode = `
 function handler(event) {
   var request = event.request;


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営 / システム全体（間接的に親（管理者）— `/admin` の防御前提を誤らないこと）

**解決する課題**: `/admin`（保護者の見守り画面）と `/ops`（売上・コホート・コスト）を「ネットワーク層で守られている」と読める記述が SSOT に残っていた。CloudFront Function も geoRestriction も viewer request にしか介在せず、`authType: NONE` の Lambda Function URL を直接叩く経路には掛からない。誤った前提が SSOT にあると、後続の判断者が「そこは守られているから」と別の防御を省く。

**期待される効果**: 「CloudFront 層で効く制御」と「全経路で効くアプリ層の制御」が表で読み分けられるようになり、Function URL の推測困難さを防御層として数える判断が起きなくなる。実装コメントにも同じ限界を置いたので、`network-stack.ts` を触る人が最初に見る場所で分かる。

## 関連 Issue

Closes #4280

本 PR は Issue §「スコープ（a を採る場合・最小）」= PO 決裁の **a（記述の是正）** のみを扱う。**b（shared secret header）は PO 決裁で実施が決まっているが、`hooks.server.ts` = 全リクエスト経路を触るため別 PR**（Issue コメントの PO 指示どおり）。**c（`authType: AWS_IAM` + OAC）は不採用**、再評価トリガー = 有料家庭 20 世帯到達時（本 PR で設計書に記録）。

**AC の文言と現状の差分**: Issue 起票時点の AC は「IP allowlist が効かない」と書かれているが、その後の PO 決裁（Issue コメント 2026-08-05）で **IP allowlist 機構自体が #4266 / PR #4284 で撤去済**。したがって是正対象を「IP allowlist」に限定せず、**同じ性質を持つ CloudFront 層の制御全般（geoRestriction / CloudFront Function / 将来 IP allowlist を戻す場合）** に一般化して記述した。AC の意図（CloudFront を経由しない到達経路には CloudFront 層の防御が効かないと明記する）は満たしている。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `docs/design/14-セキュリティ設計書.md` の防御層マトリクスに **「CloudFront を経由しない到達経路（Function URL 直叩き）には IP allowlist が効かない」** を明記する | `grep -n "CloudFront を経由しない到達経路" docs/design/14-セキュリティ設計書.md` | PASS — §11.5 に見出し付き段落を追加。表に「どこで効くか」列（`CloudFront のみ` / `アプリ層（全経路）`）を追加し、行ごとに読み分けられるようにした |
| AC2 | `infra/lib/network-stack.ts` の IP フィルタ実装コメントにも同じ限界を書く（実装を読む人が最初に見る場所） | `grep -n "#4280" infra/lib/network-stack.ts` | PASS — 2 箇所。① 旧 IP フィルタがあった CloudFront Function 定義の直前（撤去理由コメントの直下）② `geoRestrictionCountries` props 定義（現存する唯一の CloudFront 層制御） |
| AC3（PO 追加指示） | PR #4276 で入った「CloudFront 層の IP allowlist が防御」という誤った前提の記述を是正する | `git show origin/develop:docs/design/14-セキュリティ設計書.md \| sed -n '1029,1045p'` | PASS（先行是正済 + 本 PR で補強）— #4276 の当初記述は PR #4284（#4266 再実装）で既に「**IP allowlist は本番・staging とも持たない**」に置換済。本 PR は残っていた「CloudFront 層の他の制御は効いている」という読み違いの余地を塞いだ |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（設計書 + CDK のコメントのみ。CloudFormation template の出力は不変 — TypeScript の行コメントは synth 対象外）

- [ ] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [x] **設計書同期** (ADR-0001): 影響する `docs/design/` を同 PR で更新（`14-セキュリティ設計書.md` §11.5 が本 PR の主対象）
- [ ] **LP ↔ アプリ整合** (ADR-0013): LP 記載が実装と一致。Aspirational を LP に新規追加していない
- [ ] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った
- [x] N/A — 上記いずれも影響範囲外（動作変更ゼロ）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4295` | PASS（全 step、ログは下記 §レビュー依頼事項） |
| 追加・変更テスト | N/A — 動作変更を伴わないため（既存 `tests/unit/infra/admin-no-ip-allowlist.test.ts` が IP allowlist 非復活の不変条件を引き続き assert） | N/A |
| infra 回帰 | `npx vitest run tests/unit/infra/` | 未実行（後述） |

**`tests/unit/infra/` をローカルで実行していません**。実行しようとした時点で heavy lock（マシン全体 1 本）を他セッションが保持しており、並走した結果は根拠にならないため見送りました（`docs/sessions/agent-concurrency.md`）。**本 PR の差分は TypeScript の行コメントのみで CloudFormation template の出力に影響しない**（synth 対象外）ため、CI の `unit-test` を正とします。Ready 化前に `gh pr checks` で `unit-test` が pass（skip でない）ことを確認します。

- [x] **SOLID / DRY / YAGNI**: 限界の記述を設計書 §11.5 に集約し、実装コメントからは「詳細は §11.5」と参照させた（同じ説明を 3 箇所に複製しない）
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。**Function URL の実ホスト名は本 PR の差分に一切書いていない**（Issue コメントには staging の実 URL があるが、公開 repo の設計書には持ち込まない）
- [x] **A11y・パフォーマンス**: N/A（UI 変更なし）
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:high` だが本 PR は記述の是正のみ）

## スクリーンショット / ビジュアルデモ

該当なし（docs / CDK コメントのみ。描画される UI に一切触れていない）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **b（shared secret header）を実装する前に、オーナー確認が必要な事項を Issue に残した**。監査コメント（Issue #4280、2026-08-05）が staging の Stripe webhook endpoint が Function URL 直で登録されていることを実測しており、header 検査を有効化すると staging の課金イベントが全滅する。**本番 endpoint が同じ状態かは live mode のため未確認**。本 PR ではこの「有効化前に正規の受信経路を洗い出す」規律を §11.5 に書き込むところまでを行い、実際の確認・変更は `state:needs-owner` として Issue に投げた。
2. **AC の一般化（IP allowlist → CloudFront 層の制御全般）の妥当性**。IP allowlist は既に撤去済のため、文言どおりに書くと「存在しない機構の限界」を記述することになる。同じ性質を持つ現存の制御（geoRestriction）に読み替えて書いたが、この読み替えが AC の意図から外れていないかを見てほしい。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)

## PO 決裁ブリーフ (po-decision:required)

<!-- `infra/**` を含むため labeler が自動付与。本 PR の infra 差分は TypeScript の行コメントのみで
     CloudFormation template の出力は不変だが、label を外さず正規の様式で判断材料を出す。 -->

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — revert 1 回で完全に戻る"]
    R2["顧客面: 変化なし — 設計書とコメントのみ"]
    R3["ロールバック: template 出力が不変でデータ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 防御層の誤読を断つ"]
    T2["捨てる: 穴は塞がらない。塞ぐのは b (別 PR)"]
  end
  subgraph OBJ["③ 反対理由"]
    O1["business: 記述だけでは到達可能性は変わらない"]
    O2["UX: 顧客が今回得るものはゼロ"]
    O3["security: 限界を書くと攻撃者にも読める"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["変化なし — UI も API も挙動も触っていない"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: AC の一般化 (IP allowlist→CF 層全般) で可か"]
    Q2["Q2: 本番 webhook 経路の確認を b の前提にしてよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R2,R3,T1,C1 ok
  class T2,O1,O2,O3 warn
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- **③ security の反対理由への回答**: 「限界を書くと攻撃者にも読める」は成立するが、本 repo は OSS 公開前提であり `authType: NONE` は `infra/lib/compute-stack.ts` を読めば既に分かる。**秘匿で守れていない事実**を内部の判断者に隠す方が害が大きい。実 Function URL のホスト名は差分に一切書いていない。
- **Q2 の背景**: 監査実測で staging の Stripe webhook が Function URL 直で登録されている。b（shared secret header）を先に入れると webhook が 403 で全滅する。本番も同じ状態なら本番の課金イベント断になるため、Issue #4280 に `state:needs-owner` で確認を投げた。
- **adversarial-reviewer の JSON 未生成**: ③ は本 PR の差分（docs + コメント）に対して Dev 自身が挙げた反対理由であり、`tmp/adversarial-evidence/4295.json` からの転記ではない。QM レビュー時に正規手順で生成される想定。

</details>
