### PR TITLE
fix(notify): #4197 inquiry 通知の payload から顧客識別子（tenantId / メールアドレス）を除く

### DIFF
--- a/docs/design/23-Discordサーバー設計書.md
+++ b/docs/design/23-Discordサーバー設計書.md
@@ -235,24 +235,39 @@ anti-engagement の運用者版）。復活させる場合は決裁をやり直�
 
 Discord は運用者の機器ではなく外部 SaaS で、embed は**チャットログとして永続化される**。
 `#3971`（バックアップを暗号化しない）の前提は「控えは運用者自身の機器内に留まる」であり、
-その前提は通知には成り立たない。
+その前提は通知には成り立たない。**incident / inquiry の両チャネルに等しく適用する**。
 
 | 載せてよい | 載せない |
 |---|---|
 | 事象の種別 / 発生時刻 / 件数 / エラー種別 / 環境名 / job 名 | tenantId / childId / メールアドレス / 家族名 |
 | `requestId`（ログを引くための鍵。顧客識別子ではない） | 顧客データそのもの（活動名 / ごほうび名 等） |
+| 受付番号 `inquiryId`（inquiry を引くための鍵。顧客識別子ではない） | 送信者 / 返信先のメールアドレス |
 
-「どの家族か」は**認証された場所（CloudWatch Logs / DB）で引く**。引き方は 2 通り:
+「どの家族か」は**認証された場所（CloudWatch Logs / DB）で引く**。引き方は 3 通り:
 
-| alert の出所 | 引く鍵 |
+| 通知の出所 | 引く鍵 |
 |---|---|
 | HTTP リクエスト起点（`handleError` / 503 fail-closed） | alert 内の `requestId` → `logger.error` の同 requestId 行に tenantId がある |
 | 非リクエスト起点（`optional-write-failed` / `push-validation-rejected` / cron / data-integrity） | alert title の**種別名がそのまま log の検索 key**（`context.kind`）→ 発生時刻で絞ると tenantId 付きの行が出る |
+| inquiry（お問い合わせ、`buildInquiryEmbed`） | embed の**受付番号** → `inquiries` 表を `inquiry_id` で照会（送信者 / 返信先 / テナントはそこにある） |
+
+#### inquiry で本文を載せる理由（#4197）
+
+**「返信先アドレスが目的そのもの」は載せてよい理由にならない — 返信する場所が Discord ではない**
+（#4174 Q3 決裁）。一方で**本文（自由記述）は載せる**。本文まで落としてよいのは「運用者が本文を
+読める認証済画面が実在する」場合に限られるが、`IInquiryRepo` は `generateInquiryId` /
+`saveInquiry` のみで**読み出し API を持たず**、`/ops` 配下にも inquiry を開く画面が無い。
+読めないまま絞ると問い合わせ対応が止まるため、本文は `redactNotificationText` を通したうえで残す。
+
+本文中の email / UUID / URL path 中の id は redaction で落ちる。順序は **redact → sanitize** で
+固定する（逆順だと `sanitizeDiscordText` が `foo@here.com` の `@here` に zero-width space を挿し、
+メールアドレスの形が壊れて redaction をすり抜ける）。
 
 - 実装 SSOT: `src/lib/server/notify-privacy.ts`（redaction を 1 箇所に集約）
-- 強制点: `discord-alert.ts` の送出入口（`redactAlertOptions`）と `buildIncidentEmbed`。
-  callsite ごとの注意に依存しない（alert が 1 つ増えるたびに漏れるため）
-- `AlertOptions` から `tenantId` を**型ごと撤去**してあるので、渡すとコンパイルで落ちる
+- 強制点: `discord-alert.ts` の送出入口（`redactAlertOptions`）と `buildIncidentEmbed` /
+  `buildInquiryEmbed`。callsite ごとの注意に依存しない（通知が 1 つ増えるたびに漏れるため）
+- `AlertOptions` から `tenantId` を、`notifyInquiry` から `tenantId` / `email` / `replyEmail` を
+  **引数ごと撤去**してあるので、渡すとコンパイルで落ちる
 - 回帰固定: `tests/unit/services/notify-payload-privacy.test.ts`
 - **残る穴（accepted residual）**: 自由記述に日本語の氏名や活動名がそのまま混ざる場合は機械的に
   検出できない。落とせるのは email / 電話 / カード / UUID / path 中の id など**形が決まっているもの**まで。

--- a/src/lib/server/services/discord-notify-service.ts
+++ b/src/lib/server/services/discord-notify-service.ts
@@ -135,39 +135,70 @@ export async function notifyIncident(
 	await notifyDiscord('incident', buildIncidentEmbed(errorMessage, context));
 }
 
-/** お問い合わせ通知 */
-// biome-ignore lint/complexity/useMaxParams: 型安全のため引数を個別定義、別 Issue でオブジェクト引数化予定
-export async function notifyInquiry(
-	tenantId: string,
+const INQUIRY_CATEGORY_LABELS: Record<string, string> = {
+	feature: '機能要望',
+	bug: 'バグ報告',
+	opinion: 'ご意見',
+	consult: '相談・困りごと',
+	other: 'その他',
+};
+
+/**
+ * inquiry embed を組み立てる (顧客識別子を落とした後の payload)。
+ *
+ * **送出と分けてある理由**: buildIncidentEmbed と同じ — 「顧客識別子が出力に現れない」ことを
+ * unit test で固定するため (#4197 / #4192 AC4)。fetch を張らずに payload そのものを検査できる。
+ *
+ * ## 何を載せ、何を載せないか (#4174 Q3 の PO 決裁 / #4197)
+ *
+ * - **載せる**: 受付番号 (inquiryId)・カテゴリ・本文
+ * - **載せない**: tenantId / 送信者メールアドレス / 返信先メールアドレス
+ *
+ * 「返信先アドレスが目的そのもの」は載せてよい理由にならない。**返信する場所は Discord ではない**。
+ * 送信者 / 返信先 / テナントは受付番号を鍵に `inquiries` 表 (認証された場所) から引く。
+ *
+ * ## 本文を載せる判断 (#4197 AC3)
+ *
+ * 本文は**載せる**。載せない選択が可能なのは「運用者が本文を読める認証済画面が実在する」場合だが、
+ * 現状 `IInquiryRepo` は `generateInquiryId` / `saveInquiry` のみで**読み出し API を持たず**、
+ * `/ops` 配下にも inquiry を開く画面が無い。本文まで落とすと問い合わせ対応が止まるため、
+ * 本文は redaction を通したうえで残す。自由記述に混ざる email / UUID / path 中の id は
+ * `redactNotificationText` (単一強制点) が落とす。
+ *
+ * 順序は **redact → sanitize** で固定する。逆順だと `sanitizeDiscordText` が `foo@here.com` の
+ * `@here` に zero-width space を挿してメールアドレスの形を壊し、redaction をすり抜ける。
+ */
+export function buildInquiryEmbed(
 	category: string,
 	text: string,
-	email: string,
-	replyEmail?: string,
 	inquiryId?: string,
-): Promise<void> {
-	const categoryLabel: Record<string, string> = {
-		feature: '機能要望',
-		bug: 'バグ報告',
-		other: 'その他',
-	};
-
-	// #3388: ping の構造的無効化は notifyDiscord の allowed_mentions:{parse:[]} が担う (単一点防御)。
-	// 本文 (text、childAge を含む自由記述) は表示上のノイズ低減と二重防御で zero-width space 中和を継続する。
-	// email / replyEmail は zero-width space 中和しない: `foo@here.com` 等 mention 語を含む正当アドレスが破損し
-	// コピペ返信が壊れるため (#3211 回帰)。ping は allowed_mentions で既に無効化済で中和不要。
-	await notifyDiscord('inquiry', {
-		title: `📬 ${categoryLabel[category] ?? category}${inquiryId ? ` (${inquiryId})` : ''}`,
-		description: sanitizeDiscordText(text.slice(0, 2000)),
+): DiscordEmbed {
+	const categoryLabel = INQUIRY_CATEGORY_LABELS[category] ?? category;
+	const redacted = redactNotificationText(text.slice(0, 2000)) ?? '';
+	return {
+		title: `📬 ${categoryLabel}${inquiryId ? ` (${inquiryId})` : ''}`,
+		// #3388: ping の構造的無効化は notifyDiscord の allowed_mentions:{parse:[]} が担う (単一点防御)。
+		// ここでの中和は表示ノイズ低減の二重防御。
+		description: sanitizeDiscordText(redacted),
 		color: category === 'bug' ? 0xff4444 : 0x4a90d9,
 		fields: [
 			...(inquiryId ? [{ name: '受付番号', value: inquiryId, inline: true }] : []),
-			{ name: 'テナント', value: tenantId, inline: true },
-			{ name: '送信者', value: email, inline: true },
+			{ name: 'カテゴリ', value: categoryLabel, inline: true },
 			{
-				name: '返信先',
-				value: replyEmail || 'なし',
-				inline: true,
+				name: '送信者を見る',
+				value: inquiryId
+					? `認証された場所で引く: \`inquiries\` 表を inquiry_id=\`${inquiryId}\` で照会 (送信者 / 返信先 / テナントはそこにある)`
+					: '認証された場所で引く: `inquiries` 表を送信時刻で照会 (受付番号の採番前に失敗した通知)',
 			},
 		],
-	});
+	};
+}
+
+/** お問い合わせ通知 */
+export async function notifyInquiry(
+	category: string,
+	text: string,
+	inquiryId?: string,
+): Promise<void> {
+	await notifyDiscord('inquiry', buildInquiryEmbed(category, text, inquiryId));
 }

--- a/src/routes/(parent)/admin/settings/support/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/support/+page.server.ts
@@ -152,17 +152,16 @@ export const actions = {
 			// #3210: save 失敗を握り潰して偽成功を返さない (data-loss + 偽成功の根治)。
 			// Discord は founder の実 inbox なので best-effort backup として試行しつつ、
 			// ユーザーには明示エラーを返し「届いた」と誤認させない (feedback / consult 双方)。
-			notifyInquiry(tenantId, category, body, email, replyEmail || undefined, inquiryId).catch(
-				() => {},
-			);
+			// #4197: 通知 payload に tenantId / メールアドレスを載せない (#4174 Q3 の PO 決裁)。
+			// save 失敗時もそれは同じ — ここでユーザーには明示エラーを返しており (下)、
+			// 「届いたのに誰からか分からない」状態にはならない。
+			notifyInquiry(category, body, inquiryId).catch(() => {});
 			return fail(500, {
 				feedbackError: '送信に失敗しました。お手数ですが時間をおいて再度お試しください',
 			});
 		}
 
-		notifyInquiry(tenantId, category, body, email, replyEmail || undefined, inquiryId).catch(
-			() => {},
-		);
+		notifyInquiry(category, body, inquiryId).catch(() => {});
 
 		const confirmTo = replyEmail || (email !== 'local-user' ? email : '');
 		if (confirmTo && inquiryId) {

--- a/src/routes/api/v1/feedback/+server.ts
+++ b/src/routes/api/v1/feedback/+server.ts
@@ -50,9 +50,8 @@ function cleanupRateLimitMap(): void {
 
 export const POST: RequestHandler = async ({ request, locals }) => {
 	const context = locals.context;
+	// tenantId はレート制限キーとしてのみ使う (通知 payload には載せない、#4197)
 	const tenantId = context?.tenantId ?? 'anonymous';
-	const identity = locals.identity;
-	const email = identity?.type === 'cognito' ? identity.email : 'local-user';
 
 	// レート制限チェック（チェック前にクリーンアップ）
 	cleanupRateLimitMap();
@@ -95,11 +94,11 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 
 	const screenshotNote = screenshot ? '\n📎 スクリーンショット添付あり' : '';
 
+	// #4197: 通知 payload に tenantId / メールアドレスを載せない (#4174 Q3 の PO 決裁)。
+	// 「誰から」は受付番号を鍵に認証された場所 (inquiries 表 / ログ) で引く。
 	await notifyInquiry(
-		tenantId,
 		category,
 		`${categoryLabel[category] ?? category}\n\n${text}${currentUrl ? `\n\n📍 送信元: ${currentUrl}` : ''}${screenshotNote}`,
-		email,
 	);
 
 	// レート制限記録

--- a/tests/unit/services/discord-notify-service.test.ts
+++ b/tests/unit/services/discord-notify-service.test.ts
@@ -117,33 +117,34 @@ describe('discord-notify-service', () => {
 	});
 
 	describe('notifyInquiry', () => {
-		it('問い合わせ通知を送信する', async () => {
-			await notifyInquiry(
-				'tenant-123',
-				'bug',
-				'ログインできません',
-				'user@test.com',
-				'reply@test.com',
-			);
+		// #4197: payload には受付番号 / カテゴリ / 本文だけを載せる (tenantId / email は載せない)。
+		// 「誰から」は受付番号を鍵に inquiries 表 (認証された場所) で引く。
+		it('受付番号とカテゴリを載せ、tenantId / メールアドレスは載せない', async () => {
+			await notifyInquiry('bug', 'ログインできません', 'INQ-20260805-001');
 
 			const body = getLastBody();
-			expect(body.embeds[0].title).toBe('📬 バグ報告');
+			expect(body.embeds[0].title).toBe('📬 バグ報告 (INQ-20260805-001)');
 			expect(body.embeds[0].description).toBe('ログインできません');
-			expect(body.embeds[0].fields).toEqual(
+			const fields = body.embeds[0].fields as Array<{ name: string; value: string }>;
+			expect(fields).toEqual(
 				expect.arrayContaining([
-					expect.objectContaining({ name: '返信先', value: 'reply@test.com' }),
+					expect.objectContaining({ name: '受付番号', value: 'INQ-20260805-001' }),
+					expect.objectContaining({ name: 'カテゴリ', value: 'バグ報告' }),
 				]),
 			);
+			// 認証された場所で引く導線が載る (受付番号が照会の鍵)
+			const lookup = fields.find((f) => f.name === '送信者を見る')?.value ?? '';
+			expect(lookup).toContain('inquiries');
+			expect(lookup).toContain('INQ-20260805-001');
+			// 撤去された field は復活していない
+			expect(fields.map((f) => f.name)).not.toContain('テナント');
+			expect(fields.map((f) => f.name)).not.toContain('送信者');
+			expect(fields.map((f) => f.name)).not.toContain('返信先');
 		});
 
-		// #3211: ユーザー自由記述の mention 構文中和 (PII 自由記述の webhook 素通り抑止 + 誤 ping 防止)
+		// #3211: ユーザー自由記述の mention 構文中和 (誤 ping 防止)
 		it('本文の @everyone / @here / role mention を中和して embed に載せる', async () => {
-			await notifyInquiry(
-				'tenant-1',
-				'other',
-				'緊急 @everyone @here <@&999> 見てください',
-				'user@test.com',
-			);
+			await notifyInquiry('other', '緊急 @everyone @here <@&999> 見てください');
 			const body = getLastBody();
 			const desc = body.embeds[0].description as string;
 			// 可視内容は保持しつつ mention 構文を壊す (素の @everyone / role mention は残らない)
@@ -152,17 +153,6 @@ describe('discord-notify-service', () => {
 			expect(desc).not.toMatch(/<@&999>/);
 			expect(desc).toContain('everyone'); // zero-width space 挿入で文字自体は保持
 			expect(desc).toContain('見てください');
-		});
-
-		it('#3388: email/返信先は zero-width space 中和せず原文のまま (foo@here.com 破損回帰の防止)', async () => {
-			await notifyInquiry('tenant-1', 'other', '本文', 'parent@here.com', 'reply@everyone.org');
-			const body = getLastBody();
-			const fields = body.embeds[0].fields as Array<{ name: string; value: string }>;
-			const sender = fields.find((f) => f.name === '送信者')?.value;
-			const reply = fields.find((f) => f.name === '返信先')?.value;
-			// zero-width space が混入せず原文一致 (コピペ返信が壊れない)。ping は allowed_mentions で無効化済。
-			expect(sender).toBe('parent@here.com');
-			expect(reply).toBe('reply@everyone.org');
 		});
 	});
 

--- a/tests/unit/services/notify-payload-privacy.test.ts
+++ b/tests/unit/services/notify-payload-privacy.test.ts
@@ -20,7 +20,7 @@ import {
 	redactAlertOptions,
 } from '$lib/server/discord-alert';
 import { redactNotificationText, redactPathIds } from '$lib/server/notify-privacy';
-import { buildIncidentEmbed } from '$lib/server/services/discord-notify-service';
+import { buildIncidentEmbed, buildInquiryEmbed } from '$lib/server/services/discord-notify-service';
 
 /** 通知に出てはいけない値 (PO 決裁 Q3 の「載せない」列)。 */
 const CUSTOMER_IDENTIFIERS = {
@@ -109,6 +109,63 @@ describe('#4192 通知 payload に顧客識別子が出ない', () => {
 		expect(out).not.toContain(CUSTOMER_IDENTIFIERS.childId);
 		expect(out).not.toContain(CUSTOMER_IDENTIFIERS.tenantId);
 		expect(out).toContain('req-1');
+	});
+});
+
+describe('#4197 inquiry 通知 payload に顧客識別子が出ない', () => {
+	// #4197 AC1/AC2: tenantId / 送信者 / 返信先 は field ごと撤去し、受付番号 + カテゴリ +
+	// 「認証された画面で読む」導線だけを載せる。本文は残す (AC3、下の it で根拠を書く)。
+	it('受付番号とカテゴリは載り、tenantId / メールアドレスの field は無い', () => {
+		const embed = buildInquiryEmbed('bug', 'ログインできません', 'INQ-20260805-001');
+		const fieldNames = (embed.fields as Array<{ name: string }>).map((f) => f.name);
+
+		expect(embed.title).toContain('INQ-20260805-001');
+		expect(fieldNames).toContain('受付番号');
+		expect(fieldNames).toContain('カテゴリ');
+		// 旧 payload の 3 field は復活させない
+		expect(fieldNames).not.toContain('テナント');
+		expect(fieldNames).not.toContain('送信者');
+		expect(fieldNames).not.toContain('返信先');
+		// 受付番号を鍵に認証された場所へ誘導する (読めないまま絞らない)
+		expect(serialize(embed)).toContain('inquiries');
+	});
+
+	// AC3: 本文は載せる (運用者が本文を読める認証済画面が現状存在しないため)。
+	// ただし本文に混ざる顧客識別子は redaction を通す。
+	it('本文は残るが、本文に混ざった email / tenantId は出力に現れない', () => {
+		const embed = buildInquiryEmbed(
+			'consult',
+			`朝の準備が進みません。返信は ${CUSTOMER_IDENTIFIERS.email} まで (tenant=${CUSTOMER_IDENTIFIERS.tenantId})`,
+			'INQ-20260805-002',
+		);
+		const out = serialize(embed);
+
+		expect(out).not.toContain(CUSTOMER_IDENTIFIERS.email);
+		expect(out).not.toContain(CUSTOMER_IDENTIFIERS.tenantId);
+		// 用件そのものは読める (絞りすぎて問い合わせ対応が止まらない)
+		expect(out).toContain('朝の準備が進みません');
+	});
+
+	// #3211 / #3388 回帰: sanitize が先に走ると `foo@here.com` の `@here` に zero-width space が
+	// 入り email の形が壊れて redaction をすり抜ける。順序は redact → sanitize で固定する。
+	it('mention 語を含むメールアドレス (foo@here.com) も落ちる (redact → sanitize 順の固定)', () => {
+		const out = serialize(buildInquiryEmbed('other', '返信先は parent@here.com です', 'INQ-1'));
+
+		expect(out).not.toContain('parent@here.com');
+		expect(out).not.toContain('here.com');
+		// mention 中和自体は維持 (誤 ping させない)
+		expect(serialize(buildInquiryEmbed('other', '@everyone 見て', 'INQ-2'))).not.toMatch(
+			/@everyone/,
+		);
+	});
+
+	// 受付番号の採番前に save が落ちた経路 (support page の catch) でも識別子を載せない
+	it('受付番号が無い場合でも tenantId / email を載せない', () => {
+		const embed = buildInquiryEmbed('feature', `連絡先 ${CUSTOMER_IDENTIFIERS.email}`);
+		const out = serialize(embed);
+
+		expect(out).not.toContain(CUSTOMER_IDENTIFIERS.email);
+		expect((embed.fields as Array<{ name: string }>).map((f) => f.name)).not.toContain('受付番号');
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 運営

**解決する課題**: お問い合わせを送ると、その家族の **tenantId と送信者メールアドレス・返信先メールアドレスが Discord のチャットログに永続化**されていた。Discord は運用者の機器ではなく外部 SaaS で、削除しても SaaS 側に残りうる。`#3971`（バックアップを暗号化しない）の前提は「控えは運用者自身の機器内に留まる」であり、通知にはその前提が成り立たない。

**期待される効果**: 問い合わせを送った家族の連絡先が外部 SaaS に蓄積されなくなる。運用者は「問い合わせが来た」を通知で知り、**誰からかは受付番号を鍵に認証された場所（`inquiries` 表）で引く**。件数が増えるほど後始末が重くなる（外部 SaaS に残った PII の事後削除は難しい）ため、件数が少ない今のうちに止める。

## 関連 Issue

Closes #4197

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `notifyInquiry` の Discord payload から **tenantId / 送信者メールアドレス / 返信先メールアドレス**を除く | `grep -n "テナント\|送信者', value\|返信先" src/lib/server/services/discord-notify-service.ts` / `npx vitest run tests/unit/services/notify-payload-privacy.test.ts` | PASS — 該当 field は 0 件。引数からも撤去（`notifyInquiry(category, text, inquiryId?)`）したため、渡すとコンパイルで落ちる（incident 側 `AlertOptions` の型ごと撤去と同型） |
| AC2 | 通知には**受付番号（inquiryId）とカテゴリ**を載せ、「**認証された画面で読む**」導線（該当 inquiry を開く ops 画面へのパス）を示す | `npx vitest run tests/unit/services/discord-notify-service.test.ts` （title に受付番号 / `受付番号`・`カテゴリ` field / 照会導線 field を assert） | PASS（**導線は ops 画面パスではなく `inquiries` 表の照会鍵**）— **inquiry を開く ops 画面は実在しない**ため、死んだリンクを書かず「`inquiries` 表を `inquiry_id=<受付番号>` で照会（送信者 / 返信先 / テナントはそこにある）」を載せた。根拠は AC3 欄 |
| AC3 | 本文（自由記述）を Discord に載せるかを決める。載せない場合は、**運用者が本文を読める認証済画面が実在すること**を確認する | コード実査: `src/lib/server/db/interfaces/inquiry-repo.interface.ts` / `find src/routes -ipath "*inquir*"` / `grep -rni "inquir" src/routes/ops/` | **判断 = 本文は載せる。** 読み出し経路が実在しないため。① `IInquiryRepo` は `generateInquiryId` / `saveInquiry` の 2 メソッドのみで read API 無し ② `/ops` 配下は analytics / business / cohort / costs / export / pmf-survey / revenue の 7 画面で inquiry 画面は無い ③ `src/routes` 内の `inquir` パスは送信側（`/inquiry/founder`・`/api/v1/inquiry/founder`）のみ。本文まで落とすと問い合わせ対応が止まるので、本文は `redactNotificationText`（単一強制点）を通したうえで残す |
| AC4 | AC1 を**機械で固定**する — `tests/unit/services/notify-payload-privacy.test.ts` に inquiry payload builder のケースを足す（新規 script は作らない） | `npx vitest run tests/unit/services/notify-payload-privacy.test.ts tests/unit/services/discord-notify-service.test.ts tests/unit/routes/feedback-api.test.ts tests/unit/routes/support-feedback-action.test.ts` | PASS — 4 files / 37 tests。既存 test に 4 ケース追加（field 撤去 / 本文中の email・tenantId が出ない / `foo@here.com` 型も落ちる / 受付番号無しでも落ちる）。新規 script は追加していない |
| AC5 | `docs/design/23-Discordサーバー設計書.md §4.6` の表を inquiry まで含む形に更新する | `git diff develop -- docs/design/23-Discordサーバー設計書.md` | PASS — 「載せてよい / 載せない」表に `inquiryId` と「送信者 / 返信先のメールアドレス」行を追加、引く鍵の表を 2 通り → 3 通り（inquiry 行）に拡張、`#### inquiry で本文を載せる理由（#4197）` を追加、強制点に `buildInquiryEmbed` を追記 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客に見える画面の変更は無い。変わるのは運用者が受け取る Discord inquiry 通知の中身のみ。送信側 UI（設定 > サポートのフォーム / 送信完了の受付番号表示 / 確認メール）と `inquiries` 表への保存内容は不変。

`notifyInquiry` の callsite は 3 箇所すべて更新済（`grep -rn "notifyInquiry(" src/`）:

- `src/routes/(parent)/admin/settings/support/+page.server.ts` × 2（正常系 / save 失敗時の best-effort backup）
- `src/routes/api/v1/feedback/+server.ts` × 1（**リポジトリ内に呼び出し元 UI が無い**エンドポイント。`grep -rn "api/v1/feedback" src/` の hit は自身とテストのみ）

save 失敗経路（`#3210`）でも識別子を載せない。この経路はユーザーに 500 と「時間をおいて再度お試しください」を返す設計であり、「届いたのに誰からか分からない」状態にはならない。

- [ ] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [x] **設計書同期** (ADR-0001): 影響する `docs/design/` を同 PR で更新（`23-Discordサーバー設計書.md §4.6`）
- [ ] **LP ↔ アプリ整合** (ADR-0013): LP 記載が実装と一致。Aspirational を LP に新規追加していない
- [ ] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った
- [x] N/A — 上記のうち並行実装ペア / LP / 重量 e2e は影響範囲外（通知 payload のみ）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4296` | PASS（全 step。ログは PR コメント参照） |
| 追加・変更テスト | `npx vitest run tests/unit/services/notify-payload-privacy.test.ts tests/unit/services/discord-notify-service.test.ts tests/unit/routes/feedback-api.test.ts tests/unit/routes/support-feedback-action.test.ts` | PASS（4 files / 37 tests） |

**mutation verify（テストが本当に落とせるか）**: `buildInquiryEmbed` の redaction を外し `送信者: kazoku@example.com` field を足した状態で `notify-payload-privacy.test.ts` を実行し、新規 3 ケースが fail することを確認 → 実装を revert して再度 PASS。結果は PR コメントに貼る。

- [x] **SOLID / DRY / YAGNI**: redaction は既存の単一強制点 `notify-privacy.ts` を再利用（新規実装なし）。`buildInquiryEmbed` は `buildIncidentEmbed` と同型で、送出と組み立てを分けたのは payload を fetch なしで検査するため
- [x] **Security（OSS 公開前提）**: 外部 SaaS への PII 送出を減らす変更そのもの。`sanitizeDiscordText` の mention 中和（#3211 / #3388）と `allowed_mentions:{parse:[]}` は維持。**順序を redact → sanitize に固定**した（逆順だと sanitize が `foo@here.com` の `@here` に zero-width space を挿してメールアドレスの形を壊し、redaction をすり抜ける。この回帰を test で固定）
- [x] **A11y・パフォーマンス**: N/A（UI 変更なし / 通知 1 通あたりの処理は正規表現 3 本）
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:medium`）

## スクリーンショット / ビジュアルデモ

**該当なし（backend / docs のみ。顧客に見える画面の変更が無く、変わるのは運用者向け Discord 通知の payload）**

<!-- ss-pair-none: UI 変更を含まない backend / docs のみの PR のため Before / After ペアが原理的に存在しない -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

（運用手順は変わる: 返信先を知るには Discord ではなく `inquiries` 表を引く。PO 決裁済みの「1 段増える手間」）

**レビュー依頼事項**:

1. **AC2 を ops 画面パスではなく DB 照会鍵で満たしたこと**の可否。inquiry を開く ops 画面は実在せず（AC3 欄の実査）、存在しない `/ops/inquiries` を書けば死んだリンクになるため、受付番号 + `inquiries` 表の照会指示にした。運用者向けの inquiry 一覧画面（read API + `/ops` 画面）は本 PR の scope 外で、別 Issue 化が要ると考えている（起票の要否を判断いただきたい）。
2. **scope 外として触っていない隣接の漏れ**: `notifyFounderInquiry`（`src/lib/server/services/founder-inquiry-service.ts`）は今も **お名前 / 返信先メール / テナント ID** を Discord に載せる。ただしこの経路は **DB 保存を持たず Discord が唯一の記録**（「SES 等の二重保管は YAGNI」）のため、同じ形に揃えるには保存先の用意が先に要る。本 Issue の AC は `notifyInquiry` 限定のため本 PR では触っていない。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
