### PR TITLE
fix(backend): #4261 証明書発行の失敗を握りつぶさず観測できるようにする

### DIFF
--- a/src/lib/server/services/activity-log-service.ts
+++ b/src/lib/server/services/activity-log-service.ts
@@ -36,6 +36,7 @@ import { recordActivityDsql } from '$lib/server/services/activity-record-dsql';
 import { prepareActivityRecord } from '$lib/server/services/activity-record-preparation';
 import { type ComboResult, checkAndGrantCombo } from '$lib/server/services/combo-service';
 import { checkMissionCompletion } from '$lib/server/services/daily-mission-service';
+import { createOptionalWriteFailureHandler } from '$lib/server/services/optional-write-alert';
 import { type LevelUpInfo, updateStatus } from '$lib/server/services/status-service';
 
 // Re-export for backward compatibility with existing callers.
@@ -328,8 +329,19 @@ export async function recordActivity(
 		if (isFirstToday) {
 			await issueMonthlyHabitCertificateIfEligible(childId, monthKeyJST(), tenantId);
 		}
-	} catch {
-		// 証明書発行失敗は記録フローを止めない
+	} catch (err) {
+		// 証明書発行失敗は記録フローを止めない。
+		//
+		// #4261: ただし**握りつぶさない**。このブロックは月間の習慣化証明書 (#4172) の発行を
+		// 含み、その中で `insertPointEntry` が**通貨 (ポイント / 思い出チケット) を発行する**。
+		// 無ログだと「チケットがもらえていない」という問い合わせに対し、付与を試みたのか
+		// 失敗したのかを後から判別できない。
+		//
+		// DSQL 経路 (activity-record-dsql.ts) は `runOptionalWrite` + 本 handler で既に
+		// 観測できていたため、sqlite 経路も**同じ handler を通す**(観測の形を 2 つ持たない)。
+		// tenantId / childId は CloudWatch Logs 側にだけ載る (Discord payload からは
+		// handler 内で落とされる、#4174 Q3 / #4192)。
+		createOptionalWriteFailureHandler({ childId, tenantId })('certificate', err);
 	}
 
 	// #1782: カスタム実績機能廃止（ADR-0012 §6 整合 / #404 廃止合意の revert 復活への対応）。

--- a/tests/unit/services/activity-log-certificate-failure.test.ts
+++ b/tests/unit/services/activity-log-certificate-failure.test.ts
@@ -1,0 +1,125 @@
+// tests/unit/services/activity-log-certificate-failure.test.ts
+// #4261 ①: 証明書発行ブロックの失敗を握りつぶさないことの回帰テスト。
+//
+// このブロックは月間の習慣化証明書 (#4172) の発行を含み、その中で `insertPointEntry` が
+// **通貨 (ポイント / 思い出チケット) を発行する**。失敗が無ログだと「チケットがもらえていない」
+// という問い合わせに対し、付与を試みたのか失敗したのかを後から判別できない。
+//
+// 本 test は「失敗 → ログが出る」を固定する。ログが消えたら赤になる (ADR-0006: assertion を
+// 弱めて赤を消さない)。
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { asActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
+import * as schema from '../../../src/lib/server/db/schema';
+import { assertSuccess } from '../helpers/assert-result';
+import {
+	closeDb,
+	createTestDb,
+	resetDb,
+	seedChildActivities,
+	type TestDb,
+	type TestSqlite,
+} from '../helpers/test-db';
+
+let sqlite: TestSqlite;
+let testDb: TestDb;
+
+const mockToday = '2026-02-20';
+vi.mock('$lib/domain/date-utils', async (importOriginal) => ({
+	...(await importOriginal<typeof import('$lib/domain/date-utils')>()),
+	todayDateJST: () => mockToday,
+}));
+
+vi.mock('$lib/server/db', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+
+const loggerError = vi.fn();
+vi.mock('$lib/server/logger', () => ({
+	logger: {
+		info: vi.fn(),
+		error: (...args: unknown[]) => loggerError(...args),
+		warn: vi.fn(),
+		debug: vi.fn(),
+	},
+}));
+
+// Discord 通知は本 test の対象外 (payload の privacy は optional-write-alert.test.ts が担う)。
+// 実 webhook fetch を張らないよう no-op に固定する。
+vi.mock('$lib/server/discord-alert', () => ({
+	sendDiscordAlert: vi.fn(async () => {}),
+}));
+
+// 証明書発行を**必ず失敗させる**。通貨付与 (insertPointEntry) を含む経路の失敗を模す。
+const CERT_FAILURE_MESSAGE = 'certificate issue failed (test)';
+vi.mock('$lib/server/services/certificate-service', () => ({
+	checkAndIssueStreakCertificates: vi.fn(async () => {
+		throw new Error(CERT_FAILURE_MESSAGE);
+	}),
+	checkAndIssueLevelCertificates: vi.fn(async () => {
+		throw new Error(CERT_FAILURE_MESSAGE);
+	}),
+	issueCategoryMasterCertificate: vi.fn(async () => {
+		throw new Error(CERT_FAILURE_MESSAGE);
+	}),
+	issueMonthlyHabitCertificateIfEligible: vi.fn(async () => {
+		throw new Error(CERT_FAILURE_MESSAGE);
+	}),
+}));
+
+import { recordActivity } from '../../../src/lib/server/services/activity-log-service';
+
+const TENANT = 'test-tenant';
+
+beforeAll(() => {
+	({ sqlite, db: testDb } = createTestDb());
+});
+
+afterAll(() => {
+	closeDb(sqlite);
+});
+
+beforeEach(() => {
+	loggerError.mockClear();
+	resetDb(sqlite);
+	testDb.insert(schema.children).values({ nickname: 'テスト子', age: 8, theme: 'blue' }).run();
+	seedChildActivities(testDb, 1, [
+		{ name: 'たいそう', categoryId: asCategoryId(1), icon: '🤸', basePoints: 5 },
+	]);
+});
+
+describe('recordActivity: 証明書発行 (通貨発行を含む) の失敗観測 (#4261 ①)', () => {
+	it('証明書発行が失敗しても記録フロー自体は成功する（既存の隔離挙動を維持）', async () => {
+		const result = assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+		expect(result.totalPoints).toBe(5);
+	});
+
+	it('証明書発行が失敗したら logger.error に構造化ログが残る（握りつぶさない）', async () => {
+		assertSuccess(await recordActivity(asChildId(1), asActivityId(1), TENANT));
+
+		const failureLogs = loggerError.mock.calls.filter(
+			(call) =>
+				(call[1] as { context?: { kind?: string } })?.context?.kind === 'optional-write-failed',
+		);
+		expect(failureLogs).toHaveLength(1);
+
+		const [, entry] = failureLogs[0] as [
+			string,
+			{ tenantId?: string; context?: { name?: string; childId?: string; cause?: string } },
+		];
+		// どの optional 書込が落ちたかが名前で分かる
+		expect(entry.context?.name).toBe('certificate');
+		// 「どの家族・どの子か」は認証された場所 (CloudWatch Logs) でだけ引ける (#4174 Q3 / #4192)
+		expect(entry.tenantId).toBe(TENANT);
+		expect(entry.context?.childId).toBe('1');
+		// 原因が分かる (問い合わせ時の切り分けに直結する情報)
+		expect(entry.context?.cause).toContain(CERT_FAILURE_MESSAGE);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）— 間接的に子供（通貨が届いたかどうか）

**解決する課題**: 「思い出チケットがもらえていない」と問い合わせを受けたとき、**付与を試みたのか / 試みて失敗したのか**を後から判別できなかった。月間の習慣化証明書（#4172）の発行ブロックは `insertPointEntry` で通貨（ポイント / 思い出チケット）を発行するが、sqlite 経路ではこのブロックの例外が bare `catch {}` で握りつぶされ、ログが一切残らない。

**期待される効果**: 通貨付与に失敗した記録が CloudWatch Logs / ローカルログに構造化ログとして残り、問い合わせ時に「どの家族・どの子・どの原因で落ちたか」を追える。記録フロー自体を止めない隔離の挙動は従来どおり。

## 関連 Issue

Refs #4261

<!-- no-issue-close: 論点 2 (閾値 10 日の再評価) と論点 3 (Push 未達家庭の無音) が PO 判断待ちのため、本 PR では Issue を閉じない -->

**本 PR は Issue の論点 1 のみを扱う**（Issue 本文で「推奨」と明記され、実装が小さく Dev 判断で進められるもの）。**論点 2（閾値 10 日の根拠が n=1 → いつ・どのデータで再評価するか）と論点 3（Push 未達家庭で無音を受容するか / 別の伝達手段を用意するか。ADR-0012 anti-engagement との兼ね合い）は PO 判断**のため本 PR では実装せず、Issue に `state:needs-po` で残す。したがって `Closes` ではなく `Refs`（Issue は 2 / 3 の決着まで open のまま）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1（論点 1） | 証明書発行ブロックの catch で通貨付与の失敗が無ログにならないよう、ログ出力を追加する | `npx vitest run tests/unit/services/activity-log-certificate-failure.test.ts` | **PASS**（Test Files 1 passed / Tests 2 passed、9.59s）。`activity-log-service.ts` の bare `catch {}` を `catch (err)` にし、`createOptionalWriteFailureHandler({ childId, tenantId })('certificate', err)` を通す |
| AC1-a | 既存の logger（`src/lib/server/logger.ts`）に相乗りする（新規ログ機構を作らない） | `grep -n "createOptionalWriteFailureHandler" src/lib/server/services/*.ts` | **PASS** — DSQL 経路（`activity-record-dsql.ts`）が既に使っている `optional-write-alert.ts` の handler を sqlite 経路からも呼ぶ。この handler の中身が `logger.error`（`$lib/server/logger`）。観測の形を 2 つ持たない |
| AC1-b | 顧客識別子の扱いが #4174 Q3 / #4192 の privacy 方針に整合する | `src/lib/server/notify-privacy.ts` の方針表 / `optional-write-alert.ts` の実装 | **PASS** — 方針は「**Discord（外部 SaaS、embed が永続化される）には tenantId / childId を載せない。どの家族かは認証された場所（CloudWatch Logs / DB）で引く**」。本 PR はその設計どおり、ログ側に `tenantId` / `context.childId` を載せ、Discord payload 側は handler 内の redact で落ちる。**#4192 R16 も「`logger.warn`（`tenant=` 付き）」を明示的に要求している**ため、ログから識別子を落とすと本 AC の目的（問い合わせ時の切り分け）が達成できない |
| AC1-c | unit test で「付与失敗時にログが出る」ことを固定する | 下記 §mutation 検証 | **PASS** — 実装を外すと該当 test が `AssertionError: expected [] to have a length of 1 but got +0` で落ちることを実行して確認済 |

### mutation 検証（guard が実際に効くことの証跡）

実装をコミットしたうえで、ログ呼び出しだけを `void err;` に差し替えて再実行した:

```
 ❯ tests/unit/services/activity-log-certificate-failure.test.ts (2 tests | 1 failed) 295ms
AssertionError: expected [] to have a length of 1 but got +0
 Tests  1 failed | 1 passed (2)
```

差し替えを戻して `git diff` が空であることを確認済（実装ごと消していない）。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（観測のみ。記録フローの成否・付与額・UI 表示は不変）

- [x] **並行実装ペア**を同期した — sqlite 経路（`activity-log-service.ts`）と DSQL 経路（`activity-record-dsql.ts`）が本件の並行実装ペア。**DSQL 側は既に `runOptionalWrite` + 同 handler で観測済**のため変更不要（両者が同一の `optional-write-failed` ログ形状に揃った）
- [ ] **設計書同期** (ADR-0001): 影響する `docs/design/` を同 PR で更新 — N/A（機能仕様・API・スキーマの変更なし）
- [ ] **LP ↔ アプリ整合** (ADR-0013)
- [ ] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — N/A（`activity-log-service.ts` の catch 節のみ。schema / 値域 / 陳列に触れていない）
- [ ] N/A — 上記いずれも影響範囲外

**あえて広げなかった範囲**: 同ファイルには他にも bare `catch {}`（チャレンジ進捗 / フォーカスボーナス / 通知）がある。Issue は「**通貨発行を含む経路に適用されたのは今回が初**」を根拠に証明書ブロックを名指ししており、本 PR もそこに限定した。他ブロックへの横展開は通貨を伴わないため別途判断とする。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4298` | PASS（全 step） |
| 追加・変更テスト | `npx vitest run tests/unit/services/activity-log-certificate-failure.test.ts` | PASS（2 tests） |
| 既存回帰 | `npx vitest run tests/unit/services/activity-log-service.test.ts tests/unit/services/optional-write-alert.test.ts` | PASS（Test Files 2 passed / Tests 35 passed） |

- [x] **SOLID / DRY / YAGNI**: 新規のログ機構を作らず、同一 class（recordActivity の optional 書込失敗）の既存 SSOT（`optional-write-alert.ts`）を再利用した。ログ形状が 2 つに分岐しない
- [x] **Security（OSS 公開前提）**: 顧客識別子は認証された場所（サーバーログ）にのみ載り、外部 SaaS（Discord）へは handler 内 redact で出ない（#4174 Q3 / #4192）。例外 message はそのまま `cause` に入るが、これは既存 DSQL 経路と同じ扱い
- [x] **A11y・パフォーマンス**: N/A（UI 変更なし）。ログ出力は失敗時のみで通常経路のコストは増えない
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:medium`）

## スクリーンショット / ビジュアルデモ

該当なし（サーバー側の観測性のみ。描画される UI に一切触れていない）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **ログに `tenantId` / `childId` を載せた判断**を見てほしい。着手時の指示は「顧客識別子を載せない（#4174 Q3 / #4192 整合）」だったが、**#4174 Q3 / #4192 が禁じているのは Discord payload であって、サーバーログはむしろ識別子を持つ側**（`notify-privacy.ts` の方針表 + #4192 R16「`logger.warn`（`tenant=` 付き）」）。ログから識別子を落とすと本 Issue の目的（問い合わせ時の切り分け）が果たせないため、既存 DSQL 経路と同じ形にした。方針を変えるべきなら差し戻してほしい。
2. **Discord alert も同時に飛ぶこと**の是非。`createOptionalWriteFailureHandler` は logger + Discord の 2 つを行う。ログだけを出す薄い呼び出しに分けることもできたが、観測の形を 2 種類に分けるほうが害が大きいと判断した（webhook 未設定環境では `sendDiscordAlert` が即 return するため NUC セルフホストでは no-op、throttle も既存機構が持つ）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = 論点 1。論点 2 / 3 は PO 判断待ちとして Issue に残す）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
