### PR TITLE
fix(billing): #4181 契約状態 guard を 5 handler に完遂し、猶予入りで期限なしを書く経路を塞ぐ

### DIFF
--- a/docs/design/billing-redesign/contract-state-matrix.md
+++ b/docs/design/billing-redesign/contract-state-matrix.md
@@ -117,7 +117,7 @@ KPI service（`cohort-analysis` / `ops-analytics` / `pricing-trigger` / `stripe-
 | W1 | `checkout.session.completed` | `stripe-service.ts` `handleCheckoutCompleted` | `sub` / `plan` / `status=active` / `trialUsedAt` | S1 → S2 |
 | W2 | `invoice.paid` | `stripe-service.ts` `handleInvoicePaid` | `status=active` + `plan`（未解決なら**保持**） + **`plan_expires_at=null`** | S3 → S2 / S2 → S2 |
 | W3 | `invoice.payment_failed` | `stripe-service.ts` `handlePaymentFailed` | `status=grace_period` / `exp = now + 7d` | S2 → S3 |
-| W4 | `customer.subscription.updated` | `stripe-service.ts` `handleSubscriptionUpdated` | 非終端: `plan`（未解決なら保持）+ `status`（Stripe status を正規化） / 終端: W5 と同じ 4 列 | S2 ⇄ S3 / → S4 / → S5 |
+| W4 | `customer.subscription.updated` | `stripe-service.ts` `handleSubscriptionUpdated` | 非終端: `plan`（未解決なら保持）+ `status`（Stripe status を正規化）+ **`plan_expires_at`**（`active` 復帰 → `null` / `grace_period` 入りで未設定なら `now+7d` / それ以外は無変更。`planExpiresAtPatchFor()`） / 終端: W5 と同じ 4 列 | S2 ⇄ S3 / → S4 / → S5 |
 | W5 | `customer.subscription.deleted` | `stripe-service.ts` `handleSubscriptionDeleted` | `sub=NULL` / `plan=NULL` / `exp=NULL` / `status=suspended`（`TERMINAL_CONTRACT_STATE` の 4 列を網羅、#4026） | S2/S3/S4 → S5 |
 | W6 | アプリ内解約 | `tenant/cancel/+server.ts` | **書かない**（Stripe に `cancel_at_period_end=true` を予約するのみ、#3991） | S2 → S2（期末に W5 で S5 へ） |
 | W7 | 解約取り消し | `tenant/reactivate/+server.ts` | **書かない**（Stripe の `cancel_at_period_end=false`、#3991） | S2 → S2 |

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -984,16 +984,7 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription): Pro
 			// #3960: silent fallback (`?? MONTHLY`) 廃止。未解決時は既存 plan を保持 + alert。
 			...planUpdateOrKeep(plan, tenant, 'customer.subscription.updated', subscription.id),
 			status,
-			// #4181: `active` に戻ったら猶予終了日を消す。
-			//
-			// 消さないと `status=active` + `planExpiresAt` あり = **X3 (契約が無いのに期限だけ残る)**
-			// を書く (contract-state-matrix.md §4 不正状態)。`planExpiresAt` は W3
-			// (`invoice.payment_failed`) が猶予終了日として書く列で、**猶予が明けたら意味を失う**。
-			// 残すと dunning の残骸として後続の判定に効き続ける。
-			//
-			// `grace_period` は W3 が書いた期限を保持し、`suspended` は matrix で「任意」なので触らない
-			// (`undefined` = 更新しない)。
-			...(status === SUBSCRIPTION_STATUS.ACTIVE ? { planExpiresAt: null } : {}),
+			...planExpiresAtPatchFor(status, tenant),
 		}),
 	);
 	if (!applied) return;
@@ -1048,6 +1039,33 @@ const TERMINAL_SUBSCRIPTION_STATUSES = [
 
 function isSubscriptionTerminal(subscription: Stripe.Subscription): boolean {
 	return (TERMINAL_SUBSCRIPTION_STATUSES as readonly string[]).includes(subscription.status);
+}
+
+/**
+ * `customer.subscription.updated` (W4) が status を書き換えるとき、**その status が持つべき
+ * `plan_expires_at` を同時に決める** (#4181、`contract-state-matrix.md` §4)。
+ *
+ * status だけを書き換えると、表に無い / 不正な組み合わせが残る:
+ *
+ * - `active` に戻したのに猶予終了日が残る → **X3**「`active` に期限は無い」。
+ *   この列を読む導出値は、支払い済みの顧客に「あと N 日で使えなくなります」と表示しうる
+ * - `grace_period` に入れたのに猶予終了日が無い → **S3 は `exp` あり必須**なので表に無い組み合わせ。
+ *   Stripe は `invoice.payment_failed` (W3) と `past_due` の updated を両方送り到着順を保証しないため、
+ *   W4 が先着するとこの形になる。いつまで猶予なのかを画面にも出せず、W3 が届かなければ猶予が明けない
+ *
+ * 既に猶予終了日があるときは**触らない**。dunning 中 Stripe は retry のたび `past_due` を送るので、
+ * 毎回書き直すと猶予が延び続け、未払いのまま使い続けられる (W3 と同じ 7 日を初回だけ与える)。
+ * `suspended` の `exp` は matrix で「任意」なので `undefined` = 更新しない。
+ */
+function planExpiresAtPatchFor(
+	status: Tenant['status'],
+	tenant: Pick<Tenant, 'planExpiresAt'>,
+): { planExpiresAt?: string | null } {
+	if (status === SUBSCRIPTION_STATUS.ACTIVE) return { planExpiresAt: null };
+	if (status === SUBSCRIPTION_STATUS.GRACE_PERIOD && !tenant.planExpiresAt) {
+		return { planExpiresAt: new Date(Date.now() + GRACE_PERIOD_DAYS * MS_PER_DAY).toISOString() };
+	}
+	return {};
 }
 
 // ============================================================

--- a/tests/unit/services/stripe-contract-state-classification.test.ts
+++ b/tests/unit/services/stripe-contract-state-classification.test.ts
@@ -86,7 +86,9 @@ vi.mock('$lib/server/services/discord-notify-service', () => ({
 // ---------- Import after mocks ----------
 
 import {
+	type ContractStateClassification,
 	type ContractStateColumns,
+	VALID_CONTRACT_STATES,
 	classifyContractState,
 	isInvalidContractState,
 } from '$lib/domain/contract-state';
@@ -142,6 +144,22 @@ function resultingColumns(before: Record<string, unknown>): ContractStateColumns
 		columns = { ...columns, ...merged };
 	}
 	return mergePatch(columns, {});
+}
+
+/**
+ * 「書いた後の行が **S1〜S6 のいずれか** である」ことを assert する (AC3)。
+ *
+ * `isInvalidContractState()` だけでは足りない。同関数は `UNCLASSIFIED`
+ * (= 表がまだ何も言っていない組み合わせ) に対して **false** を返すため、
+ * 「X* ではない」だけを見ると **表に無い状態を書いた handler が緑で通る**。
+ * 本 Issue が塞ぐのは「表に無い遷移」そのものなので、正常集合への所属を直接見る。
+ */
+function expectWritesValidState(writer: string, after: ContractStateClassification): void {
+	expect(
+		(VALID_CONTRACT_STATES as readonly string[]).includes(after),
+		`${writer} が表に無い / 不正な状態 ${after} を書いた (S1〜S6 のいずれかである必要がある)`,
+	).toBe(true);
+	expect(isInvalidContractState(after), `${writer} が不正状態 ${after} を書いた`).toBe(false);
 }
 
 beforeEach(() => {
@@ -236,6 +254,40 @@ describe('#4181 AC3 webhook handler の書き込み後は正常状態に分類�
 		).toBe(false);
 		expect(after).toBe('S5');
 	});
+	it('W2 invoice.paid: S3 (猶予) → S2 (課金中)', async () => {
+		// 支払い成功で猶予から復帰する経路。**猶予終了日を消さないと X3** になる
+		// (`active` に期限は無い、matrix §4)。顧客には「支払い済みなのに期限が迫っている」と映る。
+		const before = makeTenant({
+			status: 'grace_period',
+			planExpiresAt: '2026-09-01T00:00:00.000Z',
+		});
+		expect(classifyContractState(mergePatch(before, {})), '前提が S3 でない').toBe('S3');
+		mockFindTenantById.mockResolvedValue(before);
+		mockFindTenantByStripeCustomerId.mockResolvedValue(before);
+		mockSubscriptionsRetrieve.mockResolvedValue({
+			id: SUB,
+			customer: 'cus_123',
+			status: 'active',
+			items: { data: [{ price: { id: 'price_monthly_123' } }] },
+		});
+
+		await handleWebhookEvent({
+			type: 'invoice.paid',
+			data: {
+				object: {
+					id: 'in_paid',
+					customer: 'cus_123',
+					parent: { subscription_details: { subscription: SUB } },
+				},
+			},
+		} as never);
+
+		expect(mockUpdateTenantStripe, 'W2 が書き込んでいない').toHaveBeenCalled();
+		const after = classifyContractState(resultingColumns(before));
+		expectWritesValidState('W2', after);
+		expect(after).toBe('S2');
+	});
+
 	it('W4 customer.subscription.updated: S3 (猶予) → S2 (課金中) に復帰', async () => {
 		const before = makeTenant({
 			status: 'grace_period',
@@ -257,7 +309,59 @@ describe('#4181 AC3 webhook handler の書き込み後は正常状態に分類�
 
 		expect(mockUpdateTenantStripe, 'W4 が書き込んでいない').toHaveBeenCalled();
 		const after = classifyContractState(resultingColumns(before));
-		expect(isInvalidContractState(after), `W4 が不正状態 ${after} を書いた`).toBe(false);
+		expectWritesValidState('W4 (active 復帰)', after);
+		expect(after).toBe('S2');
+	});
+
+	it('W4 customer.subscription.updated: S2 (課金中) → S3 (past_due で猶予入り)', async () => {
+		// Stripe は `invoice.payment_failed` (W3) と `past_due` の `updated` (W4) を両方送り、
+		// **到着順を保証しない**。W4 が先着したとき猶予終了日を書かないと
+		// `grace_period` + 期限なし = **表に無い組み合わせ**になる (S3 は exp あり必須)。
+		// 顧客の画面には「いつまで猶予なのか」が出せず、W3 が届かなければ猶予が明けない。
+		const before = makeTenant();
+		expect(classifyContractState(mergePatch(before, {})), '前提が S2 でない').toBe('S2');
+		mockFindTenantById.mockResolvedValue(before);
+
+		await handleWebhookEvent({
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					id: SUB,
+					metadata: { tenantId: 't-test' },
+					status: 'past_due',
+					items: { data: [{ price: { id: 'price_monthly_123' } }] },
+				},
+			},
+		} as never);
+
+		expect(mockUpdateTenantStripe, 'W4 が書き込んでいない').toHaveBeenCalled();
+		const after = classifyContractState(resultingColumns(before));
+		expectWritesValidState('W4 (past_due)', after);
+		expect(after).toBe('S3');
+	});
+
+	it('W4 customer.subscription.updated: S3 の猶予終了日は past_due の再送で延長されない', async () => {
+		// dunning 中 Stripe は retry のたび `past_due` の updated を送る。毎回 now+7d を書くと
+		// **猶予が無限に伸びて未払いのまま使い続けられる**。既に期限があるなら触らない。
+		const existingExpiry = '2026-09-01T00:00:00.000Z';
+		const before = makeTenant({ status: 'grace_period', planExpiresAt: existingExpiry });
+		mockFindTenantById.mockResolvedValue(before);
+
+		await handleWebhookEvent({
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					id: SUB,
+					metadata: { tenantId: 't-test' },
+					status: 'past_due',
+					items: { data: [{ price: { id: 'price_monthly_123' } }] },
+				},
+			},
+		} as never);
+
+		const after = resultingColumns(before);
+		expect(after.planExpiresAt, '猶予終了日が再送で書き換わっている').toBe(existingExpiry);
+		expectWritesValidState('W4 (past_due 再送)', classifyContractState(after));
 	});
 });
 
@@ -271,13 +375,6 @@ describe('#4181 AC4 test で覆えていない書き手を silent gap にしな�
 	 * **理由付きで列挙する**。ここが空配列になったら全件覆えたということ。
 	 */
 	const UNCOVERED_WRITERS: { id: string; trigger: string; reason: string }[] = [
-		{
-			id: 'W2',
-			trigger: 'invoice.paid',
-			reason:
-				'plan 未解決時の「保持」分岐が proration fixture 前提で、本 test の最小 fixture では ' +
-				'書き込みまで到達しない。分岐網羅は stripe-service.test.ts が別途担う',
-		},
 		{
 			id: 'W6',
 			trigger: 'アプリ内解約 (tenant/cancel)',
@@ -311,7 +408,7 @@ describe('#4181 AC4 test で覆えていない書き手を silent gap にしな�
 		}
 		// 覆えたら配列から消す。**消し忘れると「覆っていないのに覆った」と誤読される**ため、
 		// 実際に駆動している W1 / W3 / W5 が混ざっていないことを固定する。
-		const covered = ['W1', 'W3', 'W4', 'W5'];
+		const covered = ['W1', 'W2', 'W3', 'W4', 'W5'];
 		for (const id of covered) {
 			expect(
 				UNCOVERED_WRITERS.map((w) => w.id),

--- a/tests/unit/services/stripe-contract-state-classification.test.ts
+++ b/tests/unit/services/stripe-contract-state-classification.test.ts
@@ -88,9 +88,9 @@ vi.mock('$lib/server/services/discord-notify-service', () => ({
 import {
 	type ContractStateClassification,
 	type ContractStateColumns,
-	VALID_CONTRACT_STATES,
 	classifyContractState,
 	isInvalidContractState,
+	VALID_CONTRACT_STATES,
 } from '$lib/domain/contract-state';
 import { handleWebhookEvent } from '../../../src/lib/server/services/stripe-service';
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / システム全体（課金）

**解決する課題**: `families` の契約 4 列は顧客の請求と機能解放そのもので、書き手は 9 箇所ある。#4181 の guard（merge 済 PR #4233）は「handler が表に無い状態を書いたら落ちる」ことを狙ったが、**5 種のうち 4 種しか駆動しておらず、判定も「X1〜X4 ではない」だけを見ていた**。`classifyContractState()` は表が定義していない組み合わせに `UNCLASSIFIED` を返すため、**表に無い状態を書いた handler はその assert を素通りする**。

実際に素通りしていた: `customer.subscription.updated` (W4) が `past_due` で `grace_period` に入れるとき**猶予終了日を書かず**、`grace_period` + 期限なし = 表に無い組み合わせ（S3 は `exp` あり必須）を書いていた。Stripe は `invoice.payment_failed` (W3) と `past_due` の `updated` を両方送り**到着順を保証しない**ため、W4 が先着するとこの形になる。

**期待される効果**: 支払いが失敗した家族に「いつまで猶予か」を必ず持たせる。W3 が届かない経路（#4128 の silent 落ち 3 経路）でも猶予が期限なしで宙づりにならない。あわせて guard 自身が「表に無い状態」を検出できるようになり、次の handler 追加でも同じ抜けが再発しない。

## 関連 Issue

Closes #4181

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `classifyContractState()` をドメイン層に実装する。`families` 4 列を受け取り、**matrix §3 の S1〜S6 / X1〜X4 に分類**する | `npx vitest run tests/unit/domain/contract-state.test.ts` | **PASS**（実体 = `src/lib/domain/contract-state.ts`、merge 済 PR #4233）。本 PR は変更なし |
| AC2 | **matrix と実装の対応が機械検証される**こと（fitness function、新規 script は作らない） | `npx vitest run tests/unit/architecture/contract-state-matrix-ssot.test.ts` | **PASS**（`tests/unit/architecture/contract-state-matrix-ssot.test.ts`、merge 済 PR #4233）。本 PR は変更なし。残る限界は下記「レビュー依頼事項」に明記 |
| AC3 | webhook handler **5 種**の unit test で、**書き込み後の状態が S1〜S6 に分類される**ことを assert する。**X1〜X4 なら fail** | `npx vitest run tests/unit/services/stripe-contract-state-classification.test.ts` | **PASS（本 PR で 4 種 → 5 種に完遂）**。8 tests passed。W2 (`invoice.paid`) を新規に駆動 / W4 の `past_due` 分岐を新規に駆動 / 判定を `expectWritesValidState()`（S1〜S6 への所属を直接見る）に強化 |
| AC4 | 書き手 9 箇所のうち **test で覆えていないものを列挙して残す**（silent gap を作らない） | 同上（`#4181 AC4 …` describe） | **PASS**。未カバーは **W6 / W7 / W8 / W9 の 4 件**（いずれも「契約状態を書かない」or「webhook 経路でない」= 理由付きで列挙）。W2 は本 PR で駆動したため一覧から除去し、`covered` 側に移した |
| AC5 | `contract-state-matrix.md` §7 の後続実装への参照記述を本 Issue への参照に更新する（ADR-0001） | `sed -n '174,186p' docs/design/billing-redesign/contract-state-matrix.md` | **PASS**（merge 済 PR #4233 commit `64ea28685`）。§7 が ①② の実体 file と ③ の受け皿を名指しする形に同期済。本 PR は変更なし |
| AC6 | ③ 定期監査は別スライスに送ってよい。送る場合は判断と受け皿を明記する | Issue #4181 のコメント（受け皿明記） | **PASS**（merge 済 PR #4233）。③ は別スライスへ送付済で、現在 PR #4249 が `/ops` 在庫表示として実装中 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: Stripe webhook の `customer.subscription.updated` 経路のみ（`families.plan_expires_at` の書き込み）。画面側では `SaasLicensePanel` の猶予終了日表示 / `lifecycle-email-service` の期限リマインドが同列を読む。

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）— いずれも影響なし（server 側 webhook handler のみ）
- [x] **設計書同期** (ADR-0001): `contract-state-matrix.md` §5 の W4 遷移（`S2 ⇄ S3`）は既に本 PR の挙動を規定しており、表の記述変更は不要。実装が表に追随した側の修正
- [x] **LP ↔ アプリ整合** (ADR-0013): LP 記載に影響なし
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — 該当なし（課金 webhook は e2e 対象外、unit で駆動）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4300` | **PASS**（全 step、下記ログ） |
| 追加・変更テスト | `npx vitest run tests/unit/services/stripe-contract-state-classification.test.ts tests/unit/architecture/contract-state-matrix-ssot.test.ts tests/unit/domain/contract-state.test.ts tests/unit/services/stripe-webhook-contract-state.test.ts tests/unit/services/stripe-service.test.ts` | **PASS**（5 files / 77 tests） |

**guard が本当に落ちることの証跡（ADR-0061 / dev-session §再発防止台帳 観点 3）**

修正（`planExpiresAtPatchFor` の `grace_period` 分岐）を外して同 test を実行:

```
× W4 customer.subscription.updated: S2 (課金中) → S3 (past_due で猶予入り)
AssertionError: W4 (past_due) が表に無い / 不正な状態 UNCLASSIFIED を書いた
                (S1〜S6 のいずれかである必要がある): expected false to be true
  Tests  1 failed | 7 passed (8)
```

`UNCLASSIFIED` が出ている点が重要で、**旧 assert（`isInvalidContractState()` のみ）はこの値に false を返すため緑で通っていた**。強化前の guard では検出できなかったことが、失敗メッセージ自体で示されている。mutation は commit 済みの状態に対して行い、`git stash` で退避して戻した（実装ごと破棄していない）。

- [x] **SOLID / DRY / YAGNI**: status の書き換えと `plan_expires_at` の決定を 1 関数（`planExpiresAtPatchFor`）に閉じ、「status を戻すならその status が持てない列も同時に落とす」対を 1 箇所で表現。条件分岐の重複を作っていない
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の追加なし。alert / log に tenantId 以上の情報を新規に載せていない
- [x] **A11y・パフォーマンス**: N/A（server 側 webhook handler、UI 変更なし。追加クエリなし）
- [x] **Critical バグ修正**(ADR-0002): 該当なし（`priority:high`。5 要件は N/A）

## スクリーンショット / ビジュアルデモ

**該当なし（backend / test のみ。`.svelte` / `.css` / `site/` の変更ゼロ）**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **猶予終了日を「無いときだけ」書く判断**: dunning 中 Stripe は retry のたび `past_due` の `updated` を送るため、毎回 `now + 7d` を書くと猶予が延び続け未払いのまま使い続けられる。よって既存値があれば触らない実装にし、再送で延長されないことを test で固定した（`W4 … 再送で延長されない`）。W3 (`invoice.payment_failed`) は従来どおり毎回書き直す（そちらの挙動は変えていない）。
2. **AC2 の残る限界（silent にしないための明示）**: `contract-state-matrix-ssot.test.ts` は表と実装の **状態 ID 集合**（S*/X* の増減）を突き合わせるが、**表のセルの値**（例: S2 の `exp` を「なし」→「あり」に書き換える）までは突き合わせない。AC2 の文言（状態を足した / 消した の検出）は満たしているが、セル単位の drift は検出できない。列単位の突合に強めるには実装側を宣言的な spec 表に持ち替える必要があり、本 PR の scope（AC3 完遂 + 実バグ是正）を超えるため別スライス判断を仰ぎたい。
3. **設計書の dead pointer（本 PR では触っていない）**: `contract-state-matrix.md` §7 ③ / §8 が `#4252` を「未実装の受け皿」として指しているが、**#4252 は `duplicate` で close 済**（#4118 に集約）であり、③ 自体は PR #4249 が実装中。同 doc 行は #4249 側が「未実装 → 実装」に更新する必要があるため、競合を避けて本 PR では変更していない。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
