### PR TITLE
fix(reward): #4268 子供の画面に残っていた量ベースの称賛 (5 かい / 10 かい きろく) を撤去し、褒める軸を日数に一本化する

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -2866,22 +2866,26 @@ ADR-0023 §5 I9 / C-Q13 「ちゃんと使う前にやめる、価値実感が 1
 | `MonthlyValuePreview.svelte` | `src/lib/features/value-preview/` | 親 dashboard 用 — KPI 4 種 (totalActivities / currentStreak / longestStreak / totalPoints) + マイルストーン達成リスト + カテゴリ別 bar chart |
 | `MilestoneBanner.svelte` | `src/lib/features/value-preview/` | 子供 UI 用 — 未閲覧マイルストーン 1 件のみ表示。閲覧済みは `localStorage` (`gq:milestone-seen:<childId>:<id>`) で永続的に抑制 |
 
-### 18.3 マイルストーン定義（6 種）
+### 18.3 マイルストーン定義（4 種）
 
-`MILESTONES` 配列で管理（`value-preview-service.ts`）。
+`MILESTONES` 配列で管理（`value-preview-service.ts`）。ID 集合の SSOT は
+`src/lib/domain/constants/habit-milestones.ts` の `PRAISE_MILESTONE_IDS`。
 
 | id | kind | threshold | UI ラベル（`MILESTONE_LABELS`） |
 |----|----|----|----|
 | `first_record` | count | 1 | 「はじめての記録」 |
-| `records_5` | count | 5 | 「5 かい きろく」 |
-| `records_10` | count | 10 | 「10 かい きろく」 |
 | `streak_7` | streak | 7 | 「1 しゅうかん つづいた」 |
 | `streak_14` | streak | 14 | 「2 しゅうかん つづいた」 |
 | `streak_30` | streak | 30 | 「1 かげつ つづいた」 |
 
+褒める軸は**日数（続いたこと）**のみ。累計回数（量）で褒める軸は置かない。`first_record` は
+「量」ではなく「開始」を褒める唯一の例外で、`PRAISE_START_MILESTONE_ID` として明示する。
+称賛表示側（本定義 + `labels.ts`）と報酬発行側（`certificate-service` の月間習慣化 / ストリーク証明書）が
+同じ軸に従っていることは `tests/unit/architecture/praise-axis-ssot.test.ts` が検査する。
+
 判定ロジック:
 
-- **count 系**: 該当 child の有効な `activity_logs` 件数 ≥ threshold で達成
+- **count 系（`first_record` のみ）**: 該当 child の有効な `activity_logs` 件数 ≥ 1 で達成
 - **streak 系**: ユニークな `recordedAt` 日付列の最長連続セグメント ≥ threshold で達成
 
 ### 18.4 表示条件（親 dashboard）

--- a/docs/design/26-ゲーミフィケーション設計書.md
+++ b/docs/design/26-ゲーミフィケーション設計書.md
@@ -1307,14 +1307,15 @@ ADR-0023 §5 I9 / C-Q13 を解決するための「最初の 30 日体験」。
 
 | id | kind | threshold | 意味 |
 |----|----|----|----|
-| `first_record` | count | 1 | 最初の活動記録 |
-| `records_5` | count | 5 | 5 件記録 |
-| `records_10` | count | 10 | 10 件記録 |
+| `first_record` | count | 1 | 最初の活動記録（「量」ではなく「開始」の称賛） |
 | `streak_7` | streak | 7 | 1 週間連続 |
 | `streak_14` | streak | 14 | 2 週間連続 |
 | `streak_30` | streak | 30 | 1 ヶ月連続 |
 
-マスタ: `src/lib/server/services/value-preview-service.ts` の `MILESTONES` 定数。
+褒める軸は日数のみ。累計回数（5 件 / 10 件など「量」）で褒める軸は置かない（§2.4 / §4e.6）。
+
+マスタ: ID 集合は `src/lib/domain/constants/habit-milestones.ts` の `PRAISE_MILESTONE_IDS`、
+閾値と判定は `src/lib/server/services/value-preview-service.ts` の `MILESTONES` 定数。
 
 ### 4e.4 Anti-engagement (ADR-0012) 境界
 
@@ -1336,3 +1337,18 @@ ADR-0023 §5 I9 / C-Q13 を解決するための「最初の 30 日体験」。
 | `src/lib/domain/labels.ts` | `MILESTONE_LABELS` / `VALUE_PREVIEW_LABELS` |
 | `src/routes/(parent)/admin/+page.server.ts` | `getTenantValuePreview` 呼び出し |
 | `src/routes/(child)/+layout.server.ts` | child 別 milestones 配布 |
+| `src/lib/domain/constants/habit-milestones.ts` | 褒める軸（ID 集合・日数閾値）の SSOT |
+| `tests/unit/architecture/praise-axis-ssot.test.ts` | 褒める軸が両側に適用されていることの fitness function |
+
+### 4e.6 褒める軸の契約（称賛表示側と報酬発行側の両立）
+
+褒める対象は「**続いたこと**」であり「たくさん記録したこと」ではない（§2.4）。この軸は 2 系統に分かれて実装されている。
+
+| 系統 | 実装 | 軸 |
+|----|----|----|
+| 称賛表示側（子供に見える） | `value-preview-service` の `MILESTONES` → 子供ヘッダーの通知ベル / 履歴「記念」タブ / 親 dashboard | 連続日数（`streak_7/14/30`）+ 開始（`first_record`） |
+| 報酬発行側（通貨・証明書） | `certificate-service`（月間習慣化 = その月に記録した日数 / ストリーク証明書） | 日数（`MONTHLY_HABIT_DAYS_THRESHOLD` / `STREAK_MILESTONE_DAYS`） |
+
+**軸を追加・変更するときは `PRAISE_MILESTONE_IDS`（`src/lib/domain/constants/habit-milestones.ts`）を起点にする。**
+片側だけ変えても機能は壊れないため、両側の一致は `tests/unit/architecture/praise-axis-ssot.test.ts` が
+fitness function として検査する（量ベース軸の混入 / 表示側と判定側の ID ずれ / 報酬発行側の独自閾値を落とす）。

--- a/docs/design/lp-deploy-pipeline.md
+++ b/docs/design/lp-deploy-pipeline.md
@@ -102,8 +102,8 @@ demo (`/demo/**`) 配下に 3 段階の `?screenshot` mode を導入。SSOT は 
 
 ### `?screenshot=all` の責務
 
-- `MilestoneBanner` を `bypassSeenCheck` prop で localStorage 無視で強制表示（demo (child) layout で `records_10` 達成済 milestone を生成）
-- demo seed (`src/lib/server/demo/demo-data.ts`) の 902 番ペルソナは「ひなちゃん」（旧「ゆうきちゃん」、13 日分活動ログ ≥ 10 件で `records_10` マイルストーン達成済）に固定し、本番 NUC ユーザ視覚と一致させる
+- `MilestoneBanner` を `bypassSeenCheck` prop で localStorage 無視で強制表示（demo (child) layout で連続記録マイルストーン (`streak_7`) 達成済 milestone を生成）
+- demo seed (`src/lib/server/demo/demo-data.ts`) の 902 番ペルソナは「ひなちゃん」（旧「ゆうきちゃん」、13 日分活動ログ + 11 日連続で `streak_7` マイルストーン達成済）に固定し、本番 NUC ユーザ視覚と一致させる
 - `scripts/capture-hp-screenshots.mjs` の `withScreenshotParam(path)` のデフォルトは `screenshot=all` (#1893 で変更)。後方互換で `?screenshot=1` (noise-only) が必要な場合は `withScreenshotParam(path, { mode: 'noise-only' })` を使う
 
 ### 日付依存演出の抑止（決定的撮影、#3017）
@@ -184,7 +184,7 @@ pages.yml
 
 | AC | 対応 |
 |----|------|
-| AC1 demo seed が「ひなちゃん」「テーマ pink」「マイルストーン進行中 (records_10 達成済)」「活動数 ≥ 10 件」 | `src/lib/server/demo/demo-data.ts` 902 番ペルソナを `はなこ` → `ひなちゃん` (旧 `ゆうきちゃん`、2026-05-16 リネーム) に変更、13 日分活動ログ (DEMO_ACTIVITY_LOGS 902 行) で 36 件達成済 |
+| AC1 demo seed が「ひなちゃん」「テーマ pink」「マイルストーン進行中 (streak_7 達成済)」「活動数 ≥ 10 件」 | `src/lib/server/demo/demo-data.ts` 902 番ペルソナを `はなこ` → `ひなちゃん` (旧 `ゆうきちゃん`、2026-05-16 リネーム) に変更、13 日分活動ログ (DEMO_ACTIVITY_LOGS 902 行) で 36 件達成済 |
 | AC2 `?screenshot=all` 訪問時にマイルストーン演出が表示 | §6.5 参照。demo (child) layout で `getScreenshotModeKind() === 'all'` 時に `MilestoneBanner` を `bypassSeenCheck` prop で強制表示 |
 | AC3 / AC6 視覚 baseline diff < 10% | §6.6 参照。Phase 2 (別 Issue) で対応。本 PR で運用 README + ディレクトリ + pixelmatch dev 依存を tracked |
 | AC4 SS 鮮度 CI 新設、stale 時 exit 1 | §6.6 参照。`scripts/check-screenshot-freshness.mjs` 新規 + 18 unit tests |

--- a/docs/rationale/06-milestones-thresholds-rationale.md
+++ b/docs/rationale/06-milestones-thresholds-rationale.md
@@ -90,15 +90,33 @@ Duolingo blog (公式データ)         Pokémon Unite (achievement)
 - [Achievement (UNITE) - Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Achievement_(UNITE))
 - [Pokemon Unite: All Symbols and Their Meaning - GameRant](https://gamerant.com/pokemon-unite-medals-symbols-meaning/)
 
+## 再判断: records 軸の棄却 (#4172 → #4268)
+
+本 rationale の「案 A 現状維持」結論は **records 軸 (`records_5` / `records_10`) について棄却された**。棄却の判断は
+閾値の妥当性ではなく、**褒める対象そのものの変更**による。
+
+- **判断の起点**: #4172 は「褒める対象を『記録の量』から『月間の習慣化』へ変える」と決めた。実装は #4215（量ベース自動ごほうびの撤去）と
+  #4220（月間習慣化の証明書 + 50pt）で報酬発行側に適用されたが、称賛表示側 (`MILESTONES`) が旧軸のまま残っていた（#4268）
+- **本 rationale の前提が崩れた点**: 上の妥当性評価は「records 軸を持つこと」を所与として閾値だけを比較していた。
+  #4172 は所与そのものを否定した。**5 回 / 10 回という閾値が業界 prior art と整合していても、量で褒めない方針とは両立しない**
+- **`first_record` は残す**: 閾値 1 は量の達成ではなく「開始」の事実であり、#4172 が撤去したのは `totalRecords % 5` 型の累積量判定。
+  外すと最初のストリーク (7 日) まで子供に称賛が 1 つも無くなる
+- **案 C (Duolingo 7 日特化) の再評価**: 棄却理由の 1 つだった「records_5 が無いと親の dataset 到達感が出ない」は、
+  親側の到達感を #4220 の月間習慣化証明書（その月に記録した日数 ≥ 10）が担うため成立しなくなった。
+  結果として現行構造は案 C（日数軸中心）に近い
+
+現行の軸は `src/lib/domain/constants/habit-milestones.ts` の `PRAISE_MILESTONE_IDS` が SSOT。
+
 ## 残された懸念・フォローアップ
 
-- [ ] **PMF 後の閾値再評価** — MAU が安定し dataset が貯まったら、実データ (records_X / streak_X 到達率分布) に基づき再評価。例えば `streak_30` 到達率が極端に低ければ `streak_21` 等の中間段階追加判断
+- [ ] **PMF 後の閾値再評価** — MAU が安定し dataset が貯まったら、実データ (streak_X 到達率分布) に基づき再評価。例えば `streak_30` 到達率が極端に低ければ `streak_21` 等の中間段階追加判断
 - [ ] **段階追加候補** — Duolingo の `100 日 / 365 日` 等のロングテール streak は **本機構では現時点で不要**。理由: 初月価値プレビュー (#1600) の scope は「最初の 30 日」であり、長期 streak は別機構 (称号 / バッジ #1782 廃止済) で扱う
-- [ ] **閾値変更が必要になった場合の影響範囲** — 変更時は以下も同期更新:
+- [ ] **閾値・軸の変更が必要になった場合の影響範囲** — 変更時は以下も同期更新:
+  - `src/lib/domain/constants/habit-milestones.ts` の `PRAISE_MILESTONE_IDS` / `STREAK_MILESTONE_DAYS`（起点）
   - `src/lib/server/services/value-preview-service.ts` の `MILESTONES` 定数
-  - `docs/design/26-ゲーミフィケーション設計書.md §4e.3` の表
+  - `docs/design/26-ゲーミフィケーション設計書.md §4e.3` / `docs/design/06-UI設計書.md §18.3` の表
   - `src/lib/domain/labels.ts` の `MILESTONE_LABELS`
-  - `tests/unit/server/services/value-preview-service.test.ts` (集計テスト) — 該当 test の閾値依存箇所
+  - `tests/unit/services/value-preview-service.test.ts` (集計テスト) / `tests/unit/architecture/praise-axis-ssot.test.ts` (軸の両側適用)
 - [ ] **実装側 follow-up なし** — 本 rationale は「現状値妥当」結論のため、別 Issue 起票不要 (Issue #2174 AC3)
 
 ## 関連

--- a/src/lib/domain/constants/habit-milestones.ts
+++ b/src/lib/domain/constants/habit-milestones.ts
@@ -61,17 +61,52 @@ export const MONTHLY_HABIT_POINTS = 50;
  * 別ドメインで、同じ日数に別の意味の points 表を持つ。**値が同じだから統合する、は誤り** —
  * 混ぜると片方を変えたときに他方が壊れる (PO 決裁 Q5)。
  *
- * `labels.ts` の `MilestoneId` union (`'streak_7' | 'streak_14' | 'streak_30'`) も
- * **表示層なので SSOT に含めない**。参照側として扱う。
+ * 表示層 (`labels.ts` の文言) は本 SSOT の参照側として扱う。
  */
 export const STREAK_MILESTONE_DAYS = [7, 14, 30, 60, 100] as const;
 
 /**
  * `MILESTONES` (value-preview) が通知に使うストリーク閾値。
  *
- * 表示層 (`labels.ts` の `MilestoneId` union) が 7 / 14 / 30 しか持たないため、
- * `STREAK_MILESTONE_DAYS` からその範囲だけを取る。**別のリテラルを置かない。**
+ * 子供に見せる称賛は 30 日までを扱うため、`STREAK_MILESTONE_DAYS` からその範囲だけを取る
+ * (60 / 100 日は証明書側のみ)。**別のリテラルを置かない。**
+ * ここから導かれる ID 集合が `PRAISE_MILESTONE_IDS` と一致することは
+ * `tests/unit/architecture/praise-axis-ssot.test.ts` [P3] が検査する。
  */
 export const NOTIFIED_STREAK_MILESTONE_DAYS = STREAK_MILESTONE_DAYS.filter(
 	(d) => d <= 30,
 ) as readonly number[];
+
+/**
+ * 子供に見せる称賛 (マイルストーン) の ID 集合 = **褒める軸の SSOT** (#4268)。
+ *
+ * ## 軸の契約
+ *
+ * **褒めるのは「続いた」ことだけ。「たくさん記録した」ことでは褒めない** (#4172)。
+ * したがって本配列に入れてよいのは日数ベース (`streak_*`) の軸のみで、
+ * 累計回数ベース (旧「5 回記録」「10 回記録」型) の軸は置かない。
+ *
+ * 唯一の例外が `first_record` で、これは**量ではなく「開始」を褒める**
+ * (閾値 1 = 最初の 1 件。2 件目以降を数え上げない)。
+ * 例外はこの 1 件だけであることを `PRAISE_START_MILESTONE_ID` で明示する。
+ *
+ * ## 両側適用の機械検査
+ *
+ * 褒める軸は「称賛表示側」(本配列 → `value-preview-service` の `MILESTONES` /
+ * `labels.ts` の文言) と「報酬発行側」(`certificate-service` の月間習慣化 /
+ * ストリーク証明書) の 2 系統に分かれている。片側だけ変えても壊れないため、
+ * 両側が同じ軸に従っていることを `tests/unit/architecture/praise-axis-ssot.test.ts`
+ * が fitness function として検査する。**軸を足す / 変えるときは本配列を起点にする。**
+ */
+export const PRAISE_MILESTONE_IDS = ['first_record', 'streak_7', 'streak_14', 'streak_30'] as const;
+
+export type PraiseMilestoneId = (typeof PRAISE_MILESTONE_IDS)[number];
+
+/**
+ * 「開始」を褒める唯一の非日数軸 (#4268 AC2)。
+ *
+ * `first_record` を残したのは、閾値 1 が**量の達成ではなく開始の事実**だから。
+ * #4172 が撤去したのは `totalRecords % 5` 型の累積量判定であり、初回の祝福ではない。
+ * これを外すと、子供は最初のストリーク (7 日) まで称賛が 1 つも無い状態になる。
+ */
+export const PRAISE_START_MILESTONE_ID = 'first_record' satisfies PraiseMilestoneId;

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3,6 +3,8 @@
 // 全てのUIラベルはこのファイルからインポートすること。ハードコード禁止。
 // #1304: baby=準備モード に表記変更済み（AGE_TIER_LABELS / AGE_TIER_SHORT_LABELS）
 
+// #4268: マイルストーン (褒める軸) の ID 集合は domain 定数が SSOT
+import { PRAISE_MILESTONE_IDS, type PraiseMilestoneId } from './constants/habit-milestones';
 import { jstDayOfWeek } from './date-utils';
 // #1916: 用語集（atom）は terms.ts に集約。labels.ts は compound 専用とする SSOT 2 階層化基盤。
 // #1958 (Phase 7 H1): CTA_TERMS を ACTION_LABELS / TRIAL_LABELS から参照（freeTrial / freeTrialWord / freeTrialDesc）
@@ -8623,13 +8625,12 @@ export const STORYBOOK_LABELS = {
 // 年齢帯 variant (ADR-0015): preschool = ひらがな / elementary 以上 = 漢字
 // 同一カード内のひらがな + 漢字混在を解消 (#2169)
 // ============================================================
-type MilestoneTextKey =
-	| 'first_record'
-	| 'records_5'
-	| 'records_10'
-	| 'streak_7'
-	| 'streak_14'
-	| 'streak_30';
+// #4268: ID 集合の SSOT は `constants/habit-milestones.ts` の `PRAISE_MILESTONE_IDS`
+// (褒める軸 = 日数ベース + 開始の 1 件)。ここで独自 union を再定義しない。
+type MilestoneTextKey = PraiseMilestoneId;
+
+/** 表示文言を持つマイルストーン ID (fitness function が判定側との一致を検査する、#4268 AC4) */
+export const MILESTONE_LABEL_IDS: readonly MilestoneTextKey[] = PRAISE_MILESTONE_IDS;
 
 type MilestoneAgeContext = 'preschool' | 'elementary' | 'junior' | 'senior';
 
@@ -8638,14 +8639,6 @@ const MILESTONE_HIRAGANA: Record<MilestoneTextKey, { title: string; description:
 	first_record: {
 		title: 'はじめての きろく',
 		description: 'さいしょの がんばりを きろくできたよ',
-	},
-	records_5: {
-		title: '5 かい きろく',
-		description: '5 かい きろくが できたよ',
-	},
-	records_10: {
-		title: '10 かい きろく',
-		description: '10 かい きろくが できたよ',
 	},
 	streak_7: {
 		title: '1 しゅうかん つづいた',
@@ -8666,14 +8659,6 @@ const MILESTONE_KANJI: Record<MilestoneTextKey, { title: string; description: st
 	first_record: {
 		title: 'はじめての記録',
 		description: '最初のがんばりを記録できました',
-	},
-	records_5: {
-		title: '5 回 記録',
-		description: '5 回の活動を記録できました',
-	},
-	records_10: {
-		title: '10 回 記録',
-		description: '10 回の活動を記録できました',
 	},
 	streak_7: {
 		title: '1 週間 つづいた',
@@ -8698,8 +8683,6 @@ export const MILESTONE_LABELS = {
 	bellAriaLabel: (count: number) => `新着のおしらせ ${count}件 を見る`,
 	/** legacy: 漢字 variant (elementary 以上の callers が直接参照する場合用、後方互換) */
 	first_record: MILESTONE_KANJI.first_record,
-	records_5: MILESTONE_KANJI.records_5,
-	records_10: MILESTONE_KANJI.records_10,
 	streak_7: MILESTONE_KANJI.streak_7,
 	streak_14: MILESTONE_KANJI.streak_14,
 	streak_30: MILESTONE_KANJI.streak_30,

--- a/src/lib/server/demo/demo-data.ts
+++ b/src/lib/server/demo/demo-data.ts
@@ -18,7 +18,7 @@
  * - 902 はなこ → ひなちゃん (旧 PO 期待値「ゆうきちゃん」だったが user 家族実名のため 2026-05-16 リネーム)
  *   注: PO 期待値「テーマ sakura」は THEME_LABELS に sakura が未定義のため、
  *       現行 5 themes 中で本番 NUC 実態と最も近い pink を維持する
- * - 902 活動ログ ≥ 10 件 + records_10 マイルストーン達成済 (MilestoneBanner 表示用)
+ * - 902 活動ログ ≥ 10 件 + 連続記録マイルストーン (streak_7) 達成済 (MilestoneBanner 表示用)
  * - LP `feature-belongings-checklist` 等の SS 撮影元は #2097 PR-B1 で本番 routes
  *   `/checklist?childId=903` に切替、本 PR-B2 (#2187) で `/demo/checklist` 自体を撤去 →
  *   本番 path に 308 redirect。child 903 は既に活動ログ ≥ 14 件あり、`?screenshot=all`

--- a/src/lib/server/services/activity-log-service.ts
+++ b/src/lib/server/services/activity-log-service.ts
@@ -340,7 +340,8 @@ export async function recordActivity(
 	const customUnlocked: { type: string; name: string; icon: string; bonusPoints: number }[] = [];
 
 	// #4172: 固定間隔自動ごほうび (活動 5 回ごとに `${n}かいきろく達成！` を棚へ INSERT + 50pt 発行) は撤去。
-	// 達成の表現は `value-preview-service.ts` の MILESTONES (records_1/5/10 等、報酬を発行しない通知) が担う。
+	// 達成の表現は `value-preview-service.ts` の MILESTONES (初回記録 + 連続日数、報酬を発行しない通知) が担う。
+	// #4268: その MILESTONES 側にも残っていた量ベース (5 回 / 10 回) の称賛は撤去済。褒める軸は日数。
 	// 撤去理由: 26-ゲーミフィケーション設計書 §2.4「唯一の出口はごほうびショップのみ」/ §2.1-2「親が褒める仕組み」
 	// (自動生成行は grantedBy=null で親が一度も関与しない) / §13 実績システム廃止 (#1782 の同型が残っていた)。
 

--- a/src/lib/server/services/value-preview-service.ts
+++ b/src/lib/server/services/value-preview-service.ts
@@ -13,19 +13,22 @@ import type { CategoryId, ChildId } from '$lib/domain/ids';
  * - Anti-engagement (ADR-0012): 滞在時間延伸 UI ではなく、純粋に進捗の可視化
  */
 
-import { NOTIFIED_STREAK_MILESTONE_DAYS } from '$lib/domain/constants/habit-milestones';
+import {
+	NOTIFIED_STREAK_MILESTONE_DAYS,
+	PRAISE_START_MILESTONE_ID,
+	type PraiseMilestoneId,
+} from '$lib/domain/constants/habit-milestones';
 import { todayDateJST } from '$lib/domain/date-utils';
 import { findActivityLogs } from '$lib/server/db/activity-repo';
 import { findAllChildren } from '$lib/server/db/child-repo';
 
-/** 初月マイルストーン定義 (#1600 AC マイルストーン設計) */
-export type MilestoneId =
-	| 'first_record'
-	| 'records_5'
-	| 'records_10'
-	| 'streak_7'
-	| 'streak_14'
-	| 'streak_30';
+/**
+ * 初月マイルストーン定義 (#1600 AC マイルストーン設計)。
+ *
+ * ID 集合の SSOT は `$lib/domain/constants/habit-milestones` の `PRAISE_MILESTONE_IDS`
+ * (褒める軸 = 日数ベース + 開始の 1 件、#4268)。ここで独自 union を再定義しない。
+ */
+export type MilestoneId = PraiseMilestoneId;
 
 export interface MilestoneDefinition {
 	id: MilestoneId;
@@ -37,10 +40,13 @@ export interface MilestoneDefinition {
 // 3 箇所に別々のリテラルとして存在していた。**数値だけ**を domain 定数へ集約する。
 // 表示層 (`labels.ts` の MilestoneId union) は 7/14/30 しか持たないため、
 // `NOTIFIED_STREAK_MILESTONE_DAYS` (= 30 以下) を使う。ここに別のリテラルを置かない。
+//
+// #4268: 褒める軸は日数 (`kind: 'streak'`) のみ。累計回数で褒める軸は置かない。
+// `first_record` だけが「量」ではなく「開始」を褒める明示的な例外
+// (`PRAISE_START_MILESTONE_ID`)。両側適用は
+// `tests/unit/architecture/praise-axis-ssot.test.ts` が検査する。
 export const MILESTONES: readonly MilestoneDefinition[] = [
-	{ id: 'first_record', threshold: 1, kind: 'count' },
-	{ id: 'records_5', threshold: 5, kind: 'count' },
-	{ id: 'records_10', threshold: 10, kind: 'count' },
+	{ id: PRAISE_START_MILESTONE_ID, threshold: 1, kind: 'count' },
 	...NOTIFIED_STREAK_MILESTONE_DAYS.map(
 		(days): MilestoneDefinition => ({
 			id: `streak_${days}` as MilestoneId,

--- a/tests/unit/architecture/praise-axis-ssot.test.ts
+++ b/tests/unit/architecture/praise-axis-ssot.test.ts
@@ -1,0 +1,100 @@
+// tests/unit/architecture/praise-axis-ssot.test.ts
+//
+// #4268 AC4 — 「褒める軸」が称賛表示側と報酬発行側の両方に適用されたことを機械検査する
+// fitness function (ADR-0061 same-class-N→guard)。
+//
+// ## なぜ必要か
+//
+// #4172 は「褒める対象を『記録の量』から『月間の習慣化』へ変える」と宣言し、
+// #4215 (撤去) / #4220 (代替) で**報酬の発行経路**を是正した。しかし
+// **称賛の表示経路** (`value-preview-service` の `MILESTONES` と `labels.ts` の文言) に
+// `records_5` / `records_10` が残り、子供の画面では旧軸で褒め続けていた。
+// 両者が別ファイル・別機構にあり、片方だけ直しても機械検査が落ちなかったことが根本原因。
+//
+// ## 本 guard が落とすもの
+//
+// 1. 量ベース (累計回数) の称賛軸を足した     → [P1] / [P2]
+// 2. 称賛表示側と判定側の ID 集合がずれた      → [P3]
+// 3. 表示文言の無い / 余った ID を作った       → [P4]
+// 4. 報酬発行側が日数 SSOT を離れて独自閾値を持った → [P5] / [P6]
+//
+// **この guard を外すと落ちるか**: `PRAISE_MILESTONE_IDS` に `records_5` を足して
+// labels / MILESTONES を追従させると [P1] が落ちる (量ベース軸の混入を検出) 。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+	MONTHLY_HABIT_DAYS_THRESHOLD,
+	PRAISE_MILESTONE_IDS,
+	PRAISE_START_MILESTONE_ID,
+	STREAK_MILESTONE_DAYS,
+} from '../../../src/lib/domain/constants/habit-milestones';
+import { MILESTONE_LABEL_IDS } from '../../../src/lib/domain/labels';
+import { MILESTONES } from '../../../src/lib/server/services/value-preview-service';
+
+const REPO_ROOT = join(import.meta.dirname, '../../..');
+
+function readSource(relPath: string): string {
+	return readFileSync(join(REPO_ROOT, relPath), 'utf-8');
+}
+
+describe('褒める軸 SSOT (#4268 AC4 / #4172 方針の両側適用)', () => {
+	it('[P1] 称賛表示側に量ベース (累計回数) の軸が無い — 開始の 1 件だけが count 種', () => {
+		const countAxes = MILESTONES.filter((m) => m.kind === 'count');
+
+		expect(countAxes.map((m) => m.id)).toEqual([PRAISE_START_MILESTONE_ID]);
+		// 閾値 1 = 「開始」。2 以上は「量」なので置けない (#4172)
+		for (const axis of countAxes) {
+			expect(axis.threshold).toBe(1);
+		}
+	});
+
+	it('[P2] 日数ベース以外の軸を増やしていない — count 種は 1 件を上限とする', () => {
+		const streakAxes = MILESTONES.filter((m) => m.kind === 'streak');
+
+		expect(MILESTONES.length).toBe(streakAxes.length + 1);
+		expect(streakAxes.length).toBeGreaterThan(0);
+	});
+
+	it('[P3] 判定側 (MILESTONES) の ID 集合が SSOT (PRAISE_MILESTONE_IDS) と一致する', () => {
+		expect(MILESTONES.map((m) => m.id)).toEqual([...PRAISE_MILESTONE_IDS]);
+	});
+
+	it('[P4] 表示側 (labels.ts) の ID 集合が SSOT と一致する — 文言欠落も余剰も許さない', () => {
+		expect([...MILESTONE_LABEL_IDS].sort()).toEqual([...PRAISE_MILESTONE_IDS].sort());
+	});
+
+	it('[P5] 称賛表示側の streak 閾値が報酬発行側と同じ日数 SSOT の部分集合である', () => {
+		const streakDays = MILESTONES.filter((m) => m.kind === 'streak').map((m) => m.threshold);
+
+		for (const days of streakDays) {
+			expect(STREAK_MILESTONE_DAYS as readonly number[]).toContain(days);
+		}
+	});
+
+	it('[P6] 報酬発行側 (certificate-service) が日数 SSOT を import して独自閾値を持たない', () => {
+		const source = readSource('src/lib/server/services/certificate-service.ts');
+
+		expect(source).toContain('MONTHLY_HABIT_DAYS_THRESHOLD');
+		expect(source).toContain('STREAK_MILESTONE_DAYS');
+		expect(source).toContain("from '$lib/domain/constants/habit-milestones'");
+		// 月間習慣化は「日数」で判定する (量に戻していない)
+		expect(MONTHLY_HABIT_DAYS_THRESHOLD).toBeGreaterThan(0);
+	});
+
+	it('[P7] 撤去した量ベース軸の識別子が src 配下に残っていない', () => {
+		const sources = [
+			'src/lib/server/services/value-preview-service.ts',
+			'src/lib/domain/labels.ts',
+			'src/lib/domain/constants/habit-milestones.ts',
+			'src/lib/server/services/activity-log-service.ts',
+			'src/lib/server/demo/demo-data.ts',
+		];
+
+		for (const rel of sources) {
+			const source = readSource(rel);
+			expect(source, `${rel} に量ベース軸の残存`).not.toMatch(/\brecords_(5|10)\b/);
+		}
+	});
+});

--- a/tests/unit/domain/labels.test.ts
+++ b/tests/unit/domain/labels.test.ts
@@ -3,6 +3,7 @@
 // #573: 内部コード (kinder/lower/upper/teen) が UI に漏れる回帰防止
 
 import { describe, expect, it } from 'vitest';
+import { PRAISE_MILESTONE_IDS } from '../../../src/lib/domain/constants/habit-milestones';
 import {
 	AGE_TIER_LABELS,
 	AGE_TIER_SHORT_LABELS,
@@ -112,17 +113,17 @@ describe('NAV_ITEM_LABELS', () => {
 // #2169 / ADR-0015: MILESTONE_LABELS の年齢別 variant
 describe('getMilestoneLabel (#2169, ADR-0015)', () => {
 	it('preschool 向けはひらがな variant を返す', () => {
-		const r = getMilestoneLabel('records_5', { ageTier: 'preschool' });
-		expect(r.title).toBe('5 かい きろく');
-		expect(r.description).toContain('きろくが できたよ');
+		const r = getMilestoneLabel('streak_7', { ageTier: 'preschool' });
+		expect(r.title).toBe('1 しゅうかん つづいた');
+		expect(r.description).toContain('つづけて きろくできたよ');
 		// 漢字を含まない (ひらがな統一の AC3 検証)
 		expect(r.description).not.toMatch(/[一-龯]/);
 	});
 
 	it('elementary 向けは漢字 variant を返す', () => {
-		const r = getMilestoneLabel('records_5', { ageTier: 'elementary' });
-		expect(r.title).toBe('5 回 記録');
-		expect(r.description).toBe('5 回の活動を記録できました');
+		const r = getMilestoneLabel('streak_14', { ageTier: 'elementary' });
+		expect(r.title).toBe('2 週間 つづいた');
+		expect(r.description).toBe('14 日連続で記録できました');
 	});
 
 	it('junior / senior も漢字 variant を返す (elementary と同じ)', () => {
@@ -135,15 +136,8 @@ describe('getMilestoneLabel (#2169, ADR-0015)', () => {
 		expect(r.title).toBe('はじめての記録');
 	});
 
-	it('全 6 マイルストーン x 全 4 年齢で title が空でなく取得できる', () => {
-		const ids = [
-			'first_record',
-			'records_5',
-			'records_10',
-			'streak_7',
-			'streak_14',
-			'streak_30',
-		] as const;
+	it('全マイルストーン x 全 4 年齢で title が空でなく取得できる (#4268: ID 集合は SSOT 由来)', () => {
+		const ids = PRAISE_MILESTONE_IDS;
 		const ages = ['preschool', 'elementary', 'junior', 'senior'] as const;
 		for (const id of ids) {
 			for (const ageTier of ages) {

--- a/tests/unit/services/value-preview-service.test.ts
+++ b/tests/unit/services/value-preview-service.test.ts
@@ -182,25 +182,29 @@ describe('getTenantValuePreview - マイルストーン判定', () => {
 		expect(firstRecord?.achieved).toBe(true);
 		expect(firstRecord?.achievedAt).toBe(fiveDaysAgo);
 
-		// 5 件マイルストーンは未達成
-		const r5 = child?.milestones.find((m) => m.id === 'records_5');
-		expect(r5?.achieved).toBe(false);
+		// 連続記録マイルストーンは未達成
+		const s7 = child?.milestones.find((m) => m.id === 'streak_7');
+		expect(s7?.achieved).toBe(false);
 	});
 
-	it('活動 5 件で records_5 マイルストーン達成', async () => {
+	// #4268: 旧 `records_5` / `records_10` の達成テストは、軸そのものを撤去したため
+	// 「量では褒めない」ことの回帰テストに置き換えた (assertion の弱体化ではない)。
+	it('同じ日に 10 件記録しても量ベースの称賛は 1 件も発生しない (#4268)', async () => {
 		const tenDaysAgo = addDaysJST(todayDateJST(), -10);
 		const { childId } = seed({ childCreatedAt: `${tenDaysAgo}T10:00:00.000Z` });
-		// 5 日分 × 1 活動 = 5 件
-		for (let i = 0; i < 5; i++) {
-			const date = addDaysJST(todayDateJST(), -(10 - i));
-			logActivity(childId, 1, date);
+		// 同一日に 10 件 = 「量」は十分だが「続いた」わけではない
+		const sameDay = addDaysJST(todayDateJST(), -1);
+		for (let i = 0; i < 10; i++) {
+			logActivity(childId, 1, sameDay);
 		}
 
 		const preview = await getTenantValuePreview(TENANT);
 		const child = preview.children[0];
-		expect(child?.totalActivities).toBe(5);
-		const r5 = child?.milestones.find((m) => m.id === 'records_5');
-		expect(r5?.achieved).toBe(true);
+		expect(child?.totalActivities).toBe(10);
+
+		// 達成するのは「開始」(first_record) のみ。連続日数系は 1 日しか記録していないので未達成
+		const achieved = (child?.milestones ?? []).filter((m) => m.achieved).map((m) => m.id);
+		expect(achieved).toEqual(['first_record']);
 	});
 
 	it('7 日連続記録で streak_7 マイルストーン達成（longest streak で判定）', async () => {
@@ -246,14 +250,16 @@ describe('getTenantValuePreview - カテゴリ別集計', () => {
 });
 
 describe('MILESTONES 定義', () => {
-	it('6 件のマイルストーンが定義されている', () => {
-		expect(MILESTONES).toHaveLength(6);
+	it('4 件のマイルストーンが定義されている (#4268: 量ベース 2 件を撤去)', () => {
+		expect(MILESTONES).toHaveLength(4);
 	});
 
-	it('count 系と streak 系の両方を含む', () => {
+	it('count 系は「開始」の 1 件のみで、残りは全て streak 系 (#4268)', () => {
 		const counts = MILESTONES.filter((m) => m.kind === 'count');
 		const streaks = MILESTONES.filter((m) => m.kind === 'streak');
-		expect(counts.length).toBeGreaterThan(0);
+		expect(counts).toHaveLength(1);
+		expect(counts[0]?.id).toBe('first_record');
+		expect(counts[0]?.threshold).toBe(1);
 		expect(streaks.length).toBeGreaterThan(0);
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供（および子供の画面を一緒に見る親）

**解決する課題**: #4172 は「褒める対象を『記録の量』から『月間の習慣化』へ変える」と決め、#4215（撤去）/ #4220（代替）で**報酬の発行経路**を是正しました。しかし**子供に見える称賛**（通知ベル / 履歴「記念」タブ）には「5 かい きろく」「10 かい きろく」が残り、**もう褒めないと決めた軸で今も褒め続けていました**。

**期待される効果**: 子供が受け取る称賛が「続いたこと」に一本化されます。同じ日に 10 回記録しても称賛は増えず、7 日 / 14 日 / 30 日と**続いたときだけ**褒められます。方針と画面の自己矛盾（顧客に見える食い違い）が解消されます。

### AC1 / AC2 の判断と理由（#4172 / #4220 を読んだ上での決定）

| 対象 | 判断 | 理由 |
|---|---|---|
| `records_5` / `records_10` | **撤去** | #4172 が否定したのはまさにこの軸（累計回数）。5 回 / 10 回という閾値が業界 prior art と整合していても（`docs/rationale/06-milestones-thresholds-rationale.md`）、**量で褒めない方針とは両立しません**。日数へ読み替える案は、月間記録日数を #4220 が既に担っており、子供側に日数軸の称賛（`streak_7/14/30`）が同じ一覧に既に並んでいるため、**新しい軸を足すと二重になります**（ADR-0012: 称賛の重畳を増やさない） |
| `first_record` | **残す** | 閾値 1 は「量の達成」ではなく**「開始」の事実**です。#4172 が撤去したのは `totalRecords % 5` 型の累積量判定であり、初回の祝福ではありません。外すと子供は**最初のストリーク（7 日）まで称賛が 1 つも無い**状態になります。例外がこの 1 件だけであることを `PRAISE_START_MILESTONE_ID` としてコードに明示しました |

**「穴を #4220 が埋めているか」の実画面確認（AC1 但し書き）**: 埋めているのは**親側だけ**でした。#4220 の月間習慣化は証明書 + 50pt で、証明書一覧は `/admin/certificates`（親）にしかなく、通知先も親のみ（#4220 AC11'）です。**子供側の穴を埋めているのは同じ一覧に元からある `streak_7/14/30`** で、これは撤去後も残ります。実画面（後掲 SS）で、記念タブが撤去後も空にならず「1 しゅうかん つづいた」等が表示されることを確認しました。

## 関連 Issue

Closes #4268

- 方針元: #4172（褒める対象の転換）
- 実装: #4215（撤去）/ #4220（代替 = 月間習慣化の証明書 + 50pt）
- class 起点: #4265（instance 5 を単独化したもの。#4265 は duplicate として close 済のため、**AC4 の lock は本 PR 内に個別に置きました**）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `records_5` / `records_10` を撤去するか日数ベースへ読み替えるかを決めて実装。撤去なら #4220 が穴を埋めているかを実画面で確認 | **撤去を選択**。`src/lib/server/services/value-preview-service.ts` の `MILESTONES` から 2 件削除 + `labels.ts` の文言削除。`grep -rn "records_5\|records_10" src/` → **0 件**。実画面は後掲 SS（記念タブ 修正前 4 件 → 修正後 2 件、空にならない） | ✅ 上表「AC1 / AC2 の判断と理由」に判断と理由を記載。#4220 は親側のみを埋めており、子供側は `streak_7/14/30` が担うことを実画面で確認 |
| AC2 | `first_record` を残すか外すかも判断し、**どちらを選んだかと理由を記録** | **残すことを選択**。理由は上表 + `PRAISE_START_MILESTONE_ID` の docstring（`src/lib/domain/constants/habit-milestones.ts`）にコードとして記録 | ✅ 判断・理由とも PR body とコードの両方に記録 |
| AC3 | 5 年齢モードで表示崩れが無いことを確認。文言は `labels.ts` SSOT 経由を維持 | baby / preschool / elementary / junior / senior の履歴「記念」タブを mobile + desktop で撮影（後掲 SS）。文言は `getMilestoneLabel()` 経由のまま（`.svelte` の文言直書きは 0 件、`git diff` に `*.svelte` の変更なし） | ✅ 崩れなし。ひらがな variant（preschool）/ 漢字 variant（elementary 以上）も維持 |
| AC4 | 「褒める軸」の変更が報酬発行側と称賛表示側の両方に適用されたことを検査できるようにする | `tests/unit/architecture/praise-axis-ssot.test.ts` を新設（[P1]〜[P7]）。**guard 有効性を mutation で実測**: `MILESTONES` に `{ id: 'records_5', threshold: 5, kind: 'count' }` を足すと [P1] [P2] [P3] [P7] の 4 件が fail | ✅ `npx vitest run tests/unit/architecture/praise-axis-ssot.test.ts` → 7 passed（mutation 時 4 failed / 3 passed） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [x] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 子供ヘッダーの通知ベル（`MilestoneBellButton`）/ 子供 履歴「記念」タブ（全 5 年齢モード）/ 親 dashboard の「達成したマイルストーン」（`MonthlyValuePreview`）

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [x] **設計書同期** (ADR-0001): 影響する `docs/design/` を同 PR で更新
- [x] **LP ↔ アプリ整合** (ADR-0013): LP 記載が実装と一致。Aspirational を LP に新規追加していない
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った
- [ ] N/A — 上記いずれも影響範囲外

| 観点 | 確認結果 |
|---|---|
| **ID 集合の二重定義** | 表示側（`labels.ts`）と判定側（`value-preview-service`）が別々に union を持っていたのが根本原因の一部。**両方を `PRAISE_MILESTONE_IDS`（domain 定数）から導出**するようにし、片側だけ変えると型エラー + fitness function fail になるようにした |
| **報酬発行側** | `certificate-service`（月間習慣化 / ストリーク証明書）は**日数ベースのまま無変更**。称賛表示側と同じ `STREAK_MILESTONE_DAYS` を共有していることを [P5] [P6] で assert |
| **demo seed / LP SS** | demo 902（ひなちゃん）は 11 日連続記録があり `streak_7` を達成するため、`?screenshot=all` の `MilestoneBanner` 強制表示は**引き続き成立**（表示される milestone が `records_10` → `streak_7` に変わるだけ）。`demo-data.ts` / `lp-deploy-pipeline.md` の該当記述を実態に合わせて更新 |
| **DB スキーマ** | 変更なし（`MILESTONES` は算出のみで永続化していない）。マイグレーション不要 |
| **既存データへの影響** | milestone は都度算出。`localStorage` の既読キー（`gq:milestone-seen:<childId>:records_5` 等）は参照されなくなるだけで、エラーにはならない |
| **設計書同期** | `06-UI設計書.md §18.3` / `26-ゲーミフィケーション設計書.md §4e.3・§4e.5`（+ §4e.6 新設）/ `lp-deploy-pipeline.md` / `rationale/06-milestones-thresholds-rationale.md`（結論の再判断を追記） |

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4301` | PASS（全 6 step） |
| 追加・変更テスト | `npx vitest run tests/unit/architecture/praise-axis-ssot.test.ts tests/unit/domain/labels.test.ts tests/unit/services/value-preview-service.test.ts` | PASS（3 files / 40 tests） |
| 重量 e2e | `npx playwright test tests/e2e/value-preview-and-milestone.spec.ts --reporter=line` | **846 passed / 0 failed / 8 skipped / 21 did not run (14.6m)**。file 絞り込みが効かず 2 project (mobile / tablet) の全 spec が走ったため、milestone spec を含む E2E 全体の結果。`value-preview-and-milestone.spec.ts` は milestone id 非依存の smoke（bell 描画 / KPI testid）で、本変更で assert の意味は変わらない |
| 型 | `npx svelte-check --threshold error` | 0 errors / 0 warnings（8353 files） |

- [x] **SOLID / DRY / YAGNI**: ID 集合の SSOT を domain 定数 1 箇所に集約（表示側 / 判定側の二重定義を解消）。新規抽象は追加していない
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし
- [x] **A11y・パフォーマンス**: 表示要素の削除のみで DOM 構造・ARIA は不変。クエリ増加なし
- [x] **Critical バグ修正**(ADR-0002): `priority:high` のため N/A

### fitness function の有効性検証（mutation、ADR-0061）

guard を書いたら「外すと fail するか」を実行して証跡に残す運用に従い、実装 commit 後に mutation を入れて実測しました。

```
# mutation: MILESTONES に量ベース軸を戻す
{ id: 'records_5' as MilestoneId, threshold: 5, kind: 'count' },

npx vitest run tests/unit/architecture/praise-axis-ssot.test.ts
 × [P1] 称賛表示側に量ベース (累計回数) の軸が無い — 開始の 1 件だけが count 種
 × [P2] 日数ベース以外の軸を増やしていない — count 種は 1 件を上限とする
 × [P3] 判定側 (MILESTONES) の ID 集合が SSOT (PRAISE_MILESTONE_IDS) と一致する
 × [P7] 撤去した量ベース軸の識別子が src 配下に残っていない
 Tests  4 failed | 3 passed (7)
```

mutation は `git stash push` で退避してから drop し、実装が消えていないことを `grep -c records_5 src/lib/server/services/value-preview-service.ts` → 0 で確認しています。

### 既存テストの変更について（ADR-0006 非抵触）

- `tests/unit/services/value-preview-service.test.ts` の「活動 5 件で records_5 マイルストーン達成」は、**軸そのものを撤去したため削除ではなく置換**しました。新テストは「同じ日に 10 件記録しても量ベースの称賛は 1 件も発生しない」を assert しており、**検証項目はむしろ強くなっています**（旧テストは「5 件で達成する」ことしか見ていなかった）。
- `tests/unit/domain/labels.test.ts` の `records_5` を使っていた 2 件は `streak_7` / `streak_14` に置き換え、網羅ループは `PRAISE_MILESTONE_IDS`（SSOT）から回すようにしたため、**ID を足したら自動で検査対象に入ります**。

## スクリーンショット / ビジュアルデモ

撮影環境: `AUTH_MODE=anonymous DATA_SOURCE=demo`（ADR-0048、demo fixture）で本番ルートを起動し、
子供の **履歴 → 「記念」タブ**（マイルストーン一覧）を撮影。spec は `scripts/capture-specs/praise-milestones-4268.mjs`。

### 4 スロット（preschool = ひらがな variant、差分が最も分かりやすいモード）

| | モバイル (390px) | PC (1280px) |
|---|---|---|
| **修正前** | ![before-milestones-preschool-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/before-milestones-preschool-mobile.png) | ![before-milestones-preschool-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/before-milestones-preschool-desktop.png) |
| **修正後** | ![after-milestones-preschool-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-preschool-mobile.png) | ![after-milestones-preschool-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-preschool-desktop.png) |

DOM HTML: [before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/before-milestones-preschool-mobile.dom.html) / [before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/before-milestones-preschool-desktop.dom.html) / [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-preschool-mobile.dom.html) / [after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-preschool-desktop.dom.html)

**修正前**は「10 かい きろく」「5 かい きろく」が並び、**#4172 が「もう褒めない」と決めた軸で褒め続けていました**。
**修正後**は「はじめての きろく」「1 しゅうかん つづいた」だけが残り、**一覧は空になりません**（AC1 の但し書き = 穴が埋まっているかの実画面確認）。

### AC3: 5 年齢モード × mobile / desktop（修正後）

| モード | モバイル | PC | 表示内容 |
|---|---|---|---|
| preschool (3-5) | ![after-preschool-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-preschool-mobile.png) | ![after-preschool-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-preschool-desktop.png) | ひらがな variant「はじめての きろく」「1 しゅうかん つづいた」。崩れなし |
| elementary (6-12) | ![after-elementary-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-elementary-mobile.png) | ![after-elementary-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-elementary-desktop.png) | 漢字 variant「はじめての記録」「1 週間 つづいた」「2 週間 つづいた」。崩れなし |
| junior (13-15) | ![after-junior-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-junior-mobile.png) | ![after-junior-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-junior-desktop.png) | 漢字 variant。崩れなし |
| senior (16-18) | ![after-senior-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-senior-mobile.png) | ![after-senior-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-senior-desktop.png) | 漢字 variant。崩れなし |
| baby (0-2) | ![after-baby-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-baby-mobile.png) | ![after-baby-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4301/after-milestones-baby-desktop.png) | 準備モード（ADR-0011）でゲーミフィケーション非適用。`/baby/history` は `/baby/home` へリダイレクトされ、**マイルストーン面自体が存在しない**（修正前後で描画対象が無いため before との対比なし） |

対応する `.dom.html` は同 URL の `.png` を `.dom.html` に置き換えたパスに全 18 件添付済（SS と同一 page で取得、#1747 AC4 / #1766）。

### DESIGN.md §9 禁忌 6 点の自己判定

| 禁忌 | 判定 |
|---|---|
| hex 直書き | 該当なし（`.svelte` / `.css` の変更 0 件。表示要素が 2 件減っただけ） |
| プリミティブ再実装 | 該当なし |
| 内部コード UI 露出 | 該当なし（`getMilestoneLabel()` 経由のまま。`records_5` 等の内部 ID は画面に出ない） |
| 用語ハードコード | 該当なし（文言は `labels.ts` SSOT のまま。削除のみで直書き追加なし） |
| インラインスタイル | 該当なし |
| `<style>` 50 行超 | 該当なし |

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

- **子供側の称賛が 1 日目（`first_record`）から 7 日目（`streak_7`）まで空く点**を意図的に受け入れています。「続いたこと」は続くまで褒められないためで、ADR-0012（anti-engagement）とも同方向です。ここに中間の日数軸（例: `streak_3`）を置くべきかは PO 判断の余地があると考えます（本 PR では**足していません** — 軸を増やすのは #4172 の方針転換とは別の意思決定のため）。
- AC4 の lock 範囲: 本 guard は「褒める軸」の SSOT 一致と量ベース軸の混入を落とします。#4265 が扱う「宣言と実態の乖離」class 全体の lock ではありません（#4265 は duplicate close 済）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: N/A（認証画面の変更なし）
- [x] QM 承認・動作確認が完了している

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
