### PR TITLE
fix(billing): #4269 曖昧判定で継続月数の加算を skip したことをログに残す

### DIFF
--- a/src/lib/server/services/loyalty-service.ts
+++ b/src/lib/server/services/loyalty-service.ts
@@ -61,11 +61,37 @@ export function toJstMonthKeyValue(monthKey: string): string {
  * JST/UTC の 9 時間差では説明できないため曖昧でなく、加算してよい。
  */
 export function isSameJstMonth(stored: string | null | undefined, currentJstKey: string): boolean {
-	if (!stored) return false;
-	if (stored.startsWith(JST_MONTH_KEY_PREFIX)) return stored === currentJstKey;
+	return classifyMonthKeyMatch(stored, currentJstKey) !== 'no-match';
+}
+
+/**
+ * `isSameJstMonth` の判定を **理由付きで**返す (#4269 ②)。
+ *
+ * skip したこと自体は正しくても、**なぜ skip したかで意味がまったく違う**:
+ *
+ *   - `exact` — prefix 付きの厳密一致。設計どおりの二重加算防止で、何も起きていない
+ *   - `ambiguous-legacy` — prefix 無しの旧値が当月 / 前月リテラルと一致したので、
+ *     **安全側に倒して skip した**。正当な加算を取りこぼしている可能性がある
+ *
+ * 後者は継続月数が静かに 1 少なく計算されるだけで画面にも通知にも出ないため、
+ * 呼び出し側でログに残す。回復可能性を根拠に skip を選んだ以上、
+ * **回復が必要だと気づく経路**が要る。
+ *
+ * 判定ロジックの SSOT は本関数 1 つ (`isSameJstMonth` は本関数の薄い wrapper)。
+ * 2 箇所に分けると片方だけ直って乖離する。
+ */
+export function classifyMonthKeyMatch(
+	stored: string | null | undefined,
+	currentJstKey: string,
+): 'no-match' | 'exact' | 'ambiguous-legacy' {
+	if (!stored) return 'no-match';
+	if (stored.startsWith(JST_MONTH_KEY_PREFIX)) {
+		return stored === currentJstKey ? 'exact' : 'no-match';
+	}
 	// 旧値 (基準不明)。当月・前月のいずれかを指しているなら加算済みの可能性があるので skip する。
 	const currentMonthKey = currentJstKey.slice(JST_MONTH_KEY_PREFIX.length);
-	return stored === currentMonthKey || stored === shiftMonthKey(currentMonthKey, -1);
+	const ambiguous = stored === currentMonthKey || stored === shiftMonthKey(currentMonthKey, -1);
+	return ambiguous ? 'ambiguous-legacy' : 'no-match';
 }
 
 // ============================================================
@@ -231,7 +257,32 @@ export async function incrementSubscriptionMonth(tenantId: string): Promise<{
 	// prefix 無しの旧値は「基準不明」として扱う (下記 `isSameJstMonth`)。
 	const currentMonth = toJstMonthKeyValue(monthKeyJST());
 	const lastIncrement = await getSetting(KEYS.lastIncrementMonth, tenantId);
-	if (isSameJstMonth(lastIncrement, currentMonth)) {
+	const match = classifyMonthKeyMatch(lastIncrement, currentMonth);
+	if (match !== 'no-match') {
+		// #4269 ②: **なぜ skip したか**を残す。`exact` は設計どおりの二重加算防止で無害だが、
+		// `ambiguous-legacy` は「prefix 無しの旧値だったので安全側に倒して skip した」であり、
+		// 正当な加算を取りこぼしている可能性がある。取りこぼしは継続月数が静かに 1 少なくなる
+		// だけで画面にも通知にも出ないため、ログが唯一の気づく経路になる。
+		//
+		// この分岐は `loyalty_last_increment_month` を**再 write しない**ので、以後 webhook が
+		// 来ないテナントでは基準不明値が滞留し続ける。滞留の検知機構を持つかは PO 判断 (#4269 ①)。
+		//
+		// tenantId は認証された場所 (CloudWatch Logs) にだけ載せる。外部 SaaS (Discord) への
+		// 通知は行わない (#4174 Q3 / #4192 — 「どの家族か」は通知の役割ではない)。
+		if (match === 'ambiguous-legacy') {
+			logger.warn(
+				'[loyalty] 継続月数の加算を skip した (prefix 無しの旧値で基準が不明のため、安全側に倒した)',
+				{
+					tenantId,
+					service: 'loyalty',
+					context: {
+						kind: 'loyalty-increment-skipped-ambiguous',
+						storedMonthKey: lastIncrement,
+						currentMonthKey: currentMonth,
+					},
+				},
+			);
+		}
 		const months = await getSubscriptionMonths(tenantId);
 		return { newMonths: months, tierUp: false, newTier: null, ticketsAwarded: 0 };
 	}

--- a/tests/unit/services/loyalty-service.test.ts
+++ b/tests/unit/services/loyalty-service.test.ts
@@ -8,11 +8,19 @@ vi.mock('$lib/server/db/settings-repo', () => ({
 	setSetting: (...args: unknown[]) => mockSetSetting(...args),
 }));
 
+const mockLoggerWarn = vi.fn();
 vi.mock('$lib/server/logger', () => ({
-	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+	logger: {
+		info: vi.fn(),
+		warn: (...args: unknown[]) => mockLoggerWarn(...args),
+		error: vi.fn(),
+		debug: vi.fn(),
+	},
 }));
 
+import { monthKeyJST, shiftMonthKey } from '$lib/domain/date-utils';
 import {
+	classifyMonthKeyMatch,
 	consumeMemoryTicket,
 	getChurnPreventionData,
 	getCurrentTier,
@@ -273,5 +281,75 @@ describe('#4127 二重加算防止キーの基準 (JST prefix)', () => {
 			String(monthCall?.[1]).startsWith(JST_MONTH_KEY_PREFIX),
 			`基準 prefix の無い値を保存しています: ${String(monthCall?.[1])}`,
 		).toBe(true);
+	});
+});
+
+// #4269 ②: skip したこと自体は正しくても、**なぜ skip したか**で意味が違う。
+// 曖昧判定で skip した取りこぼしは継続月数が静かに 1 少なくなるだけで画面にも通知にも出ないため、
+// ログが「回復が必要だと気づく」唯一の経路になる。
+describe('#4269 曖昧判定 skip の観測', () => {
+	it('skip の理由を分類する (exact / ambiguous-legacy / no-match)', () => {
+		// prefix 付きの厳密一致 = 設計どおりの二重加算防止 (無害)
+		expect(classifyMonthKeyMatch('jst:2026-08', 'jst:2026-08')).toBe('exact');
+		// prefix 無しの旧値が当月 / 前月リテラルと一致 = 安全側に倒した skip (取りこぼしかもしれない)
+		expect(classifyMonthKeyMatch('2026-08', 'jst:2026-08')).toBe('ambiguous-legacy');
+		expect(classifyMonthKeyMatch('2026-07', 'jst:2026-08')).toBe('ambiguous-legacy');
+		// 加算してよいケース
+		expect(classifyMonthKeyMatch('2026-06', 'jst:2026-08')).toBe('no-match');
+		expect(classifyMonthKeyMatch('jst:2026-07', 'jst:2026-08')).toBe('no-match');
+		expect(classifyMonthKeyMatch(null, 'jst:2026-08')).toBe('no-match');
+	});
+
+	it('曖昧判定で skip したら warn ログが残る (prefix 無しの旧値)', async () => {
+		// 現在の JST 月の 1 つ前を prefix 無しで保存済 = 危険ウィンドウで保存された可能性がある値
+		const legacyPrevMonth = shiftMonthKey(monthKeyJST(), -1);
+		mockGetSetting.mockImplementation(async (key: string) =>
+			key === 'loyalty_last_increment_month' ? legacyPrevMonth : null,
+		);
+		mockSetSetting.mockResolvedValue(undefined);
+
+		const result = await incrementSubscriptionMonth(TENANT);
+
+		// skip されている (加算していない)
+		expect(mockSetSetting).not.toHaveBeenCalledWith(
+			'loyalty_subscription_months',
+			expect.anything(),
+			TENANT,
+		);
+		expect(result.ticketsAwarded).toBe(0);
+
+		// なぜ skip したかがログに残る
+		const skipLogs = mockLoggerWarn.mock.calls.filter(
+			(call) =>
+				(call[1] as { context?: { kind?: string } })?.context?.kind ===
+				'loyalty-increment-skipped-ambiguous',
+		);
+		expect(skipLogs, '曖昧判定 skip が無言で行われています').toHaveLength(1);
+
+		const [, entry] = skipLogs[0] as [
+			string,
+			{ tenantId?: string; context?: { storedMonthKey?: string; currentMonthKey?: string } },
+		];
+		// 「どのテナントか」は認証された場所 (CloudWatch Logs) でだけ引ける (#4174 Q3 / #4192)
+		expect(entry.tenantId).toBe(TENANT);
+		// 切り分けに要る値: 何が保存されていて、今どの月と比較したか
+		expect(entry.context?.storedMonthKey).toBe(legacyPrevMonth);
+		expect(entry.context?.currentMonthKey).toBe(`${JST_MONTH_KEY_PREFIX}${monthKeyJST()}`);
+	});
+
+	it('prefix 付きの厳密一致 (通常の二重加算防止) では warn ログを出さない — ノイズにしない', async () => {
+		mockGetSetting.mockImplementation(async (key: string) =>
+			key === 'loyalty_last_increment_month' ? `${JST_MONTH_KEY_PREFIX}${monthKeyJST()}` : null,
+		);
+		mockSetSetting.mockResolvedValue(undefined);
+
+		await incrementSubscriptionMonth(TENANT);
+
+		const skipLogs = mockLoggerWarn.mock.calls.filter(
+			(call) =>
+				(call[1] as { context?: { kind?: string } })?.context?.kind ===
+				'loyalty-increment-skipped-ambiguous',
+		);
+		expect(skipLogs, '正常な二重加算防止まで warn していると信号が埋もれます').toHaveLength(0);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者・課金者）— 運営（問い合わせ対応時の切り分け）

**解決する課題**: `isSameJstMonth` は prefix 無しの旧値について当月・前月リテラルの両方を skip する。「過剰加算（回収不能）より取りこぼし（次月で追いつく）の方が安い」という非対称性に基づく妥当な判断だが、**skip したことがどこにも残らない**。取りこぼしが起きると継続月数（＝ティア到達 = 思い出チケット付与のトリガ）が静かに 1 少なく計算されるだけで、画面にも通知にも出ない。

**期待される効果**: 「継続 6 ヶ月のはずなのにチケットが来ない」と問い合わせを受けたとき、**曖昧判定で skip した月があったのか**をログで切り分けられる。回復可能性を根拠に skip を選んだ以上、回復が必要だと気づく経路が要る。

## 関連 Issue

Refs #4269

<!-- no-issue-close: 論点 1 (滞留の検知機構) が PO 判断、論点 3 (本番データでの二重加算調査) がオーナー判断で未決のため、本 PR では Issue を閉じない -->

**本 PR は Issue の論点 2 のみを扱う**（顧客問い合わせ時の切り分けに直結し、実装が小さく Dev 判断で進められるもの）。残り 2 点は本 PR では実装しない:

- **論点 1（滞留の検知機構を入れるか）= PO 判断**。skip 分岐は `loyalty_last_increment_month` を再 write しないため、以後 `invoice.paid` が来ないテナントでは基準不明値が滞留し続ける。本 PR の warn ログは「skip が起きた瞬間」を残すが、「滞留し続けている」ことを能動的に検知する機構ではない
- **論点 3（危険ウィンドウで二重加算された行が実在するかを本番データで確認）= オーナー判断**（本番データの参照）

したがって `Closes` ではなく `Refs`（Issue は 1 / 3 の決着まで open のまま）。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1（論点 2） | `isSameJstMonth` の skip 分岐で「prefix 無しの旧値のため skip した」ことをログに残す | `npx vitest run tests/unit/services/loyalty-service.test.ts` | **PASS**（Test Files 1 passed / Tests 37 passed、3.31s）。`logger.warn` に `context.kind = 'loyalty-increment-skipped-ambiguous'` + `storedMonthKey` / `currentMonthKey` を出す |
| AC1-a | 正常な二重加算防止（prefix 付きの厳密一致）では出さない（信号をノイズに埋もれさせない） | 同上（テスト「prefix 付きの厳密一致（通常の二重加算防止）では warn ログを出さない」） | **PASS** — 判定を `classifyMonthKeyMatch`（`'no-match' \| 'exact' \| 'ambiguous-legacy'`）に集約し、`ambiguous-legacy` のときだけ warn する |
| AC1-b | 顧客識別子を載せない（#4174 Q3 / #4192 の privacy 方針に整合） | `src/lib/server/notify-privacy.ts` の方針表 / 本 PR の差分 | **PASS** — 方針は「**外部 SaaS（Discord）に tenantId / childId を載せない。どの家族かは認証された場所（CloudWatch Logs / DB）で引く**」。本 PR は **Discord 通知を一切足さず**、サーバーログにのみ `tenantId` を載せる（#4192 R16 が「`logger.warn`（`tenant=` 付き）」を明示要求）。`storedMonthKey` / `currentMonthKey` は月キー（`2026-07` 等）で識別子ではない |
| AC1-c | unit test で固定する | 下記 §mutation 検証 | **PASS** — ログ分岐を無効化すると該当 test が落ちることを実行して確認済 |

### mutation 検証（guard が実際に効くことの証跡）

実装をコミットしたうえで `if (match === 'ambiguous-legacy')` を `if ((false as boolean))` に差し替えて再実行した:

```
 ❯ tests/unit/services/loyalty-service.test.ts (37 tests | 1 failed) 29ms
AssertionError: 曖昧判定 skip が無言で行われています: expected [] to have a length of 1 but got +0
 Tests  1 failed | 36 passed (37)
```

差し替えを戻して `git diff` が空であることを確認済（実装ごと消していない）。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（観測のみ）。**加算する / skip する の判定結果は 1 ケースも変わらない** — `isSameJstMonth` は `classifyMonthKeyMatch(...) !== 'no-match'` の薄い wrapper になっただけで、既存の #4127 AC7 テスト 8 件がそのまま通ることで同値性を担保している。

- [x] **並行実装ペア**を同期した — ロイヤリティ月キーの判定は `loyalty-service.ts` 1 箇所のみ（`grep -rn "isSameJstMonth" src/` で確認）。backend 別実装（sqlite / dsql）を持たない（`settings-repo` 経由のため）
- [ ] **設計書同期** (ADR-0001) — N/A（機能仕様・API・スキーマの変更なし）
- [ ] **LP ↔ アプリ整合** (ADR-0013)
- [ ] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — N/A（値域 / schema / 陳列に触れていない）
- [ ] N/A — 上記いずれも影響範囲外

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4303` | PASS（全 step） |
| 追加・変更テスト | `npx vitest run tests/unit/services/loyalty-service.test.ts` | PASS（37 tests、うち新規 3 件） |

- [x] **SOLID / DRY / YAGNI**: 判定ロジックの SSOT を `classifyMonthKeyMatch` 1 箇所に保った。「skip するか」と「なぜ skip したか」を別々に評価すると片方だけ直って乖離する
- [x] **Security（OSS 公開前提）**: 秘密情報なし。外部送信を追加していない（ログのみ）
- [x] **A11y・パフォーマンス**: N/A（UI 変更なし）。ログは曖昧 skip 時のみで、通常経路のコストは不変
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:medium`）

## スクリーンショット / ビジュアルデモ

該当なし（サーバー側の観測性のみ。描画される UI に一切触れていない）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **ログレベルを `warn` にした判断**。曖昧 skip は「壊れている」わけではないが「取りこぼしているかもしれない」状態で、本番の `MIN_LOG_LEVEL=info` でも必ず残る必要がある。`error` にすると誤検知的に見えるため `warn` にした。
2. **`isSameJstMonth` を残した判断**。service 内の唯一の呼び出しは `classifyMonthKeyMatch` に置き換わったが、#4127 AC7 の危険ケース 8 件を固定している既存テストが本関数を叩いているため、public predicate として残した（消すとその 8 件を書き換えることになり、同値性の証拠が弱くなる）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（本 PR scope = 論点 2。論点 1 は PO 判断、論点 3 はオーナー判断として Issue に残す）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
