### PR TITLE
docs(process): §0 ルール 2 に QM の subagent ループ（レビュー→修正→再レビュー→merge）を明記する

### DIFF
--- a/docs/sessions/README.md
+++ b/docs/sessions/README.md
@@ -36,7 +36,24 @@
 
 **凍結の例外**（= 増やしてよい唯一のケース）: 顧客の金かデータに**現に**届いている装置不具合のみ。判定は QM が行う（PO 決裁は要らない）。
 
-**ルール 2 の実行方法**: QM は `gh auth switch` で **`ganbariquestsupport-lab`** に切り替えてから Dev の PR ブランチに push し、同じアカウントで approve / merge する。**Dev アカウント名義で push しない**（誰が書いたかが証跡から消える）。PR の作成者は Dev のまま。ADR-0022 Amendment 6 で明文化済み。
+### ルール 2 の実行方法 — QM は **自分のクローン内の subagent ループ**で 1 PR を閉じる
+
+**「QM が自分で直す」は、QM 本体が手作業で直すという意味ではありません。** QM は自分のクローン内で subagent を回して 1 PR を閉じ切ります。
+
+```
+① レビュー subagent      指摘を出す
+② 修正 subagent          指摘を直す（Dev に投げない）
+③ 再レビュー subagent    直ったか確認する
+④ QM 本体               CI 緑を実測して merge
+```
+
+- **①〜③ を回すのは QM 本体（lead）。** Dev の受信箱に戻さない
+- **収束条件**: 再レビューで BLOCK 3 類型が 0、かつ `gh pr checks` で非 pass 行が 0
+- **打ち切り条件**: **同じ指摘で 2 周したら、それは実装方針の問題**。ルール 6 ①として Dev に返す。3 周目を回さない
+- **subagent の報告を成果の根拠にしない。** lead が `git diff` と `gh pr checks` で実測してから merge する（[agent-teams.md](agent-teams.md) §4.3）
+- **ロールを跨いだ team は組まない。** teammate は lead の作業ディレクトリ・gh 認証で動くため、Dev クローンから QM を spawn すると分離が空洞化する
+
+**アカウント**: QM は `gh auth switch` で **`ganbariquestsupport-lab`** に切り替えてから Dev の PR ブランチに push し、同じアカウントで approve / merge する。**Dev アカウント名義で push しない**（誰が書いたかが証跡から消える）。PR の作成者は Dev のまま。ADR-0022 Amendment 6。
 
 **ルール 1 の見直しトリガー**: **E1（#4117）が staging で checkout → webhook → plan 反映 → 実画面 を 1 周した時点**（そのとき「増やさない」を続けるか再判断する。A / B の削減・移管はそれを待たずに進める）。
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（QM 補佐セッション運用）

**解決する課題**: QM が「subagent ループで 1 PR を閉じ切る」方針を理解できていなかった。§0 ルール 2 は「QM が自分で直して merge する」という方針だけを書いており、誰がどの順で何を回すかという実行方法を書いていなかった。

**期待される効果**: §0 ルール 2 に 4 ステップ（レビュー subagent → 修正 subagent → 再レビュー subagent → QM 本体が CI 実測して merge）+ 収束条件 + 打ち切り条件を明記することで、QM が同じ理解齟齬を再発させずに subagent ループを運用できる。

## 関連 Issue

Closes #4306

## AC 検証マップ (ADR-0004)

<!-- Issue #4306 の AC は目安（QM が実際にループを回して merge できたことで判定する、と明記されている）。
     本 PR は AC1（憲章 §0 ルール 2 への明記）のみを対象とする。AC2/AC3（実際にループを回して収束させる・打ち切りの記録）は
     本 PR の変更そのものではなく運用時の実績であり、本 PR merge 後の QM 運用で満たされる。 -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `docs/sessions/qm-session.md` に 4 ステップと収束 / 打ち切り条件を書く（既存手順と入れ替えて短くする） | `gh pr diff 4307 --patch` で diff 全行を目視 | HEAD `b1a56c1` / `docs/sessions/README.md` §0 ルール 2 を「アカウント注記 1 行」から「4 ステップ figure + 収束条件 + 打ち切り条件」に置換（+18/-1 行）。Issue 記載の対象は `qm-session.md`（**develop に実在**。#4236 の rename 済み）だが、**§0 が SSOT で §1 以降と食い違えば §0 が勝つ**ため、ルール 2 の本体は `docs/sessions/README.md` §0 に置くのが正しい。`qm-session.md` 側は §0 を参照する構成のため本 PR では変更不要（QM 訂正） |
| AC2 | 1 PR を実際にこのループで閉じ、何周で収束したかを PR コメントに残す | 本 PR merge 後、次の QM レビュー対象 PR で実運用として検証（本 PR 自体の diff では検証不可） | 未検証（運用開始後に別 PR コメントで記録する。Issue 本文も「AC は目安。QM が実際にループを回して merge できたことで判定する」と明記） |
| AC3 | 打ち切り（2 周で Dev に返す）が発生したらその判断も記録する | 同上（実運用での発生有無に依存） | 未検証（発生時に記録） |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・横展開チェック

**影響を受ける画面・機能**:
なし（`docs/sessions/README.md` のみの改訂。ユーザー向け画面・機能への影響はない）

- [x] N/A — 上記いずれも影響範囲外（QM 運用ドキュメントのみの変更。並行実装 / 設計書同期 / LP 整合 / 重量 e2e のいずれも対象外）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4307` | N/A — docs 1 ファイルのみの変更で実装差分なし |
| 追加・変更テスト | なし | N/A |

- [x] **SOLID / DRY / YAGNI**: N/A（ドキュメント改訂のみ、コード変更なし）
- [x] **Security（OSS 公開前提）**: N/A（秘密情報・内部 URL の追加なし）
- [x] **A11y・パフォーマンス**: N/A（UI 変更なし）
- [x] **Critical バグ修正**(ADR-0002): N/A（プロセスドキュメントの改訂であり critical バグ修正ではない）

## スクリーンショット / ビジュアルデモ

該当なし（`docs/sessions/README.md` のみの Markdown 改訂で UI 変更を含まない）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:
なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1 は実装済み。AC2/AC3 は Issue 側で「運用実績で判定」と明記された性質の AC であり、本 PR の diff 完了範囲は AC1）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

本 PR は 2026-08-05 チーム憲章改訂（§0 ルール 2、運用モード）の初回適用対象。QM (Fix Agent) が body の必須セクション欠落 / AC 検証マップ欠落を Dev に差し戻さず自分で埋めた。

- **確認**: `docs/sessions/README.md` の diff（+18/-1 行）を全行目視。追加内容は Issue #4306 本文の決定事項（4 ステップ figure + 収束条件 + 打ち切り条件 + アカウント注記の維持）と完全一致することを確認
- **判断（QM 訂正）**: 当初 body は「`qm-session.md` は存在せず実ファイルは `qa-session.md`」と書いていたが**事実誤認**。実測すると `docs/sessions/qm-session.md` が実在し `qa-session.md` は存在しない（#4236 で rename 済み、本日 merge）。実装先を `README.md` §0 にした判断自体は正しい — **§0 が SSOT で §1 以降と食い違えば §0 が勝つ**ため、ルール 2 の本体は §0 に置くべきであり、`qm-session.md` 側の変更は不要
- **未実装**: AC2（実運用でループを回し収束周数を記録）/ AC3（打ち切り発生時の記録）は本 PR merge 後の運用実績で満たすべき AC であり、本 PR の diff だけでは検証不可能。Issue 側 close は本 PR merge 後の運用実績を待って判断する

