### PR TITLE
fix(billing): #4286 残余 3 点 — 設計書同期 / TRIAL_PERIOD_DAYS 撤去 / Price 解決 fitness function

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1243,6 +1243,7 @@ Stripe Checkout セッションを作成し、リダイレクト URL を返す�
 - **`cancel_url`**: `returnPath` 指定時は `${origin}${returnPath}`、未指定時は `${origin}/pricing`
 - **完了時の処理**: webhook `checkout.session.completed` → `handleCheckoutCompleted` でテナント plan を更新する
 - **Price の解決 (#4286)**: `planId` → Price ID は **`getPriceId()`（`src/lib/server/stripe/config.ts`）単一経路**で解決する。`USE_LOOKUP_KEY=true` なら lookup_key（`standard_monthly` / `premium_monthly`）で解決し、解決に失敗したときだけ env var（`STRIPE_PRICE_STANDARD_MONTHLY` / `STRIPE_PRICE_FAMILY_MONTHLY`）へ fallback して alert を上げる。`false`（既定）なら env var 直読。**flag と env は両方効く** — flag が true でも env が設定されていれば lookup_key 失敗時の kill switch として機能し、env が無い配備でも lookup_key だけで購入が成立する。双方から解決できない場合のみ `PRICE_UNRESOLVED`
+- **`USE_LOOKUP_KEY=true` でも price env を外さない**: env は lookup_key 解決が失敗したときの kill switch であり、外すと Stripe API 障害 / Price archive の瞬間に購入が 503 になる。env を落としてよいのは lookup_key 移行 Step 4（旧 Price archive、[phase6-context-decisions-6.md §4.1](billing-redesign/phase6-context-decisions-6.md)）に到達した時点
 - **`getPlans().priceId`（env var 直読）を line_item に使わない**: 直読すると `USE_LOOKUP_KEY` がどの経路にも効かず、price env を注入しない配備で購入が必ず失敗する。`tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts` が呼び出し構造を固定する
 - **エラーコード**: `STRIPE_DISABLED` / `TENANT_NOT_FOUND` (404) / `ALREADY_SUBSCRIBED` (409) / `INVALID_PLAN` (400) / **`PRICE_UNRESOLVED` (503)**
   - `PRICE_UNRESOLVED` が **503** なのは、**配備の設定不備であって顧客の入力誤りではない**ため。4xx で返すと顧客側の操作ミスに見え、原因が運用側にあることが隠れる

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1237,12 +1237,13 @@ PINコードを使って他テナントのクラウドエクスポートデー�
 Stripe Checkout セッションを作成し、リダイレクト URL を返す。
 
 - **認可**: `requireRole(locals, ['owner', 'parent'])`（child → 403）
-- **リクエスト**: FormData `planId: 'monthly' | 'yearly' | 'family-monthly' | 'family-yearly'`
-- **成功レスポンス**: Stripe Checkout URL へリダイレクト
-- **`success_url`**: `${origin}/admin/subscription?session_id={CHECKOUT_SESSION_ID}`
-- **`cancel_url`**: `${origin}/pricing`
+- **リクエスト**: JSON `{ planId: 'monthly' | 'family-monthly', returnPath?: string }`（月額 2 種のみ。年額は新規購入の対象外。`returnPath` は相対パス（`/` 始まり）のみ許可し、それ以外は `/admin` に丸める）
+- **成功レスポンス**: `{ url }`（Stripe Checkout URL。呼び出し側が遷移する）
+- **`success_url`**: `returnPath` 指定時は `${origin}${returnPath}` + `session_id={CHECKOUT_SESSION_ID}`、未指定時は `${origin}/admin/subscription?session_id={CHECKOUT_SESSION_ID}`
+- **`cancel_url`**: `returnPath` 指定時は `${origin}${returnPath}`、未指定時は `${origin}/pricing`
 - **完了時の処理**: webhook `checkout.session.completed` → `handleCheckoutCompleted` でテナント plan を更新する
-- **Price の解決 (#4286)**: `planId` → Price ID は **`getPriceId()` 単一経路**で解決する。env に Price ID が無く `lookup_key` からも引けない場合は `PRICE_UNRESOLVED` を返す
+- **Price の解決 (#4286)**: `planId` → Price ID は **`getPriceId()`（`src/lib/server/stripe/config.ts`）単一経路**で解決する。`USE_LOOKUP_KEY=true` なら lookup_key（`standard_monthly` / `premium_monthly`）で解決し、解決に失敗したときだけ env var（`STRIPE_PRICE_STANDARD_MONTHLY` / `STRIPE_PRICE_FAMILY_MONTHLY`）へ fallback して alert を上げる。`false`（既定）なら env var 直読。**flag と env は両方効く** — flag が true でも env が設定されていれば lookup_key 失敗時の kill switch として機能し、env が無い配備でも lookup_key だけで購入が成立する。双方から解決できない場合のみ `PRICE_UNRESOLVED`
+- **`getPlans().priceId`（env var 直読）を line_item に使わない**: 直読すると `USE_LOOKUP_KEY` がどの経路にも効かず、price env を注入しない配備で購入が必ず失敗する。`tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts` が呼び出し構造を固定する
 - **エラーコード**: `STRIPE_DISABLED` / `TENANT_NOT_FOUND` (404) / `ALREADY_SUBSCRIBED` (409) / `INVALID_PLAN` (400) / **`PRICE_UNRESOLVED` (503)**
   - `PRICE_UNRESOLVED` が **503** なのは、**配備の設定不備であって顧客の入力誤りではない**ため。4xx で返すと顧客側の操作ミスに見え、原因が運用側にあることが隠れる
 

--- a/docs/design/billing-redesign/phase1-dunning-requirements.md
+++ b/docs/design/billing-redesign/phase1-dunning-requirements.md
@@ -59,7 +59,7 @@ active ──invoice.payment_failed──► past_due (grace: 有料維持) ─�
 |---|---|---|---|
 | **支払い失敗 grace (本要件)** | `GRACE_PERIOD_DAYS` (config.ts:95) | 7日 (app ハードコード) | **2週 (Stripe Smart Retries SSOT へ移行)** |
 | 解約/退会 読み取り専用猶予 | `grace-period-service.ts` | free 0/std 7/family 30日 | 変更なし (別概念) |
-| トライアル | `TRIAL_PERIOD_DAYS` (config.ts:92) | 7日 | 変更なし |
+| トライアル | `TRIAL_TERMS.durationDays` (`src/lib/domain/terms.ts`) | 7日 | 変更なし |
 | データ保持 | ADR-0049 | free 90/std 365/family ∞ | 変更なし |
 
 ### 既存実装からの変更点

--- a/docs/design/billing-redesign/phase6-context-decisions-6.md
+++ b/docs/design/billing-redesign/phase6-context-decisions-6.md
@@ -178,7 +178,7 @@ Phase 5 子 1 §3.4 で確定した lookup_key 経由参照を、Stripe 公式 [
 |---|---|---|---|
 | **1. caching layer 設計** | `stripeCache.getPriceByLookupKey(key)` 関数を新設、Stripe API 呼び出し結果を in-memory cache (TTL: 5 min) | — | 1 PR (~1 day、Phase 7 Step 3 内部) |
 | **2. 並行運用** (旧 env var + 新 lookup_key 両解決) | `USE_LOOKUP_KEY=false` で env var fallback、`true` で lookup_key 優先解決 (失敗時 env var fallback) | `USE_LOOKUP_KEY=false` (デフォルト) | 1-2 weeks |
-| **3. cutover** (新 lookup_key 直読) | `USE_LOOKUP_KEY=true` に切替、env var fallback は kill switch として残存 | `USE_LOOKUP_KEY=true` | cutover 1 日 + 1 週間 smoke test |
+| **3. cutover** (新 lookup_key 直読) | `USE_LOOKUP_KEY=true` に切替、env var fallback は kill switch として残存。**Price ID を必要とする経路 (checkout の line_item) は必ず `getPriceId()` を通す** — flag を立てても経路が `getPlans().priceId` (env var 直読) のままでは flag がどこにも効かず、price env を持たない配備で購入が失敗する (#4286) | `USE_LOOKUP_KEY=true` | cutover 1 日 + 1 週間 smoke test |
 | **4. 旧 Price archive** (active=false) | Stripe Dashboard #2627 領域 G で旧 4 Price archive、env var (`STRIPE_PRICE_*` 4 件) を CDK / Lambda env / GitHub Secrets から削除 | — | Phase 7 統合 PR Step 5 (子 1 SSOT) |
 
 ### 4.2 caching layer 設計 (Step 1)

--- a/src/lib/server/stripe/config.ts
+++ b/src/lib/server/stripe/config.ts
@@ -111,9 +111,6 @@ export function planIdFromLookupKey(lookupKey: string | null | undefined): PlanI
 	return null;
 }
 
-/** 無料トライアル日数 */
-export const TRIAL_PERIOD_DAYS = 7;
-
 /** 支払い失敗後の猶予期間（日数） */
 export const GRACE_PERIOD_DAYS = 7;
 

--- a/tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts
+++ b/tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts
@@ -1,0 +1,103 @@
+// tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts
+// #4286 — checkout の Price ID 解決は `getPriceId()` を通る (ADR-0061 fitness function)
+//
+// `USE_LOOKUP_KEY` flag と lookup_key 解決 (`getPriceId()`) は実装されていたが、製品コードから
+// 1 度も呼ばれていなかった (dead wiring)。checkout は `getPlans().priceId` (env var 直読) を
+// 見ていたため、price env を注入しない配備 (staging の正規構成) では購入が必ず 400 で失敗した。
+// 「flag は宣言されているが経路に繋がっていない」は振る舞い test でも E2E でも緑のまま通るため、
+// **呼び出しの存在そのもの**を構造で固定する (stripe-contract-write-single-enforcement と同型)。
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const STRIPE_SERVICE = resolve(REPO_ROOT, 'src/lib/server/services/stripe-service.ts');
+
+/** Price ID 解決の唯一の入口を呼ぶべき関数 */
+const CHECKOUT_ENTRYPOINT = 'createCheckoutSession';
+
+/** 最も内側の「名前のある関数」を辿る (関数外なら `<module-scope>`)。 */
+function enclosingFunctionName(node: ts.Node): string {
+	for (let cur: ts.Node | undefined = node.parent; cur; cur = cur.parent) {
+		if (ts.isFunctionDeclaration(cur) || ts.isMethodDeclaration(cur)) {
+			return cur.name?.getText() ?? '<anonymous>';
+		}
+		if (
+			(ts.isArrowFunction(cur) || ts.isFunctionExpression(cur)) &&
+			cur.parent &&
+			ts.isVariableDeclaration(cur.parent)
+		) {
+			return cur.parent.name.getText();
+		}
+	}
+	return '<module-scope>';
+}
+
+function parse(source: string, fileName: string): ts.SourceFile {
+	return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true);
+}
+
+/** 指定した関数名の呼び出しを含む「最も内側の関数」の名前を全件返す。 */
+function findCallers(source: string, fileName: string, callee: string): string[] {
+	const callers: string[] = [];
+	const visit = (node: ts.Node): void => {
+		if (ts.isCallExpression(node)) {
+			const expr = node.expression;
+			const name = ts.isIdentifier(expr)
+				? expr.text
+				: ts.isPropertyAccessExpression(expr)
+					? expr.name.text
+					: null;
+			if (name === callee) callers.push(enclosingFunctionName(node));
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(parse(source, fileName));
+	return callers;
+}
+
+/** `x.priceId` 形式のプロパティ参照を含む「最も内側の関数」の名前を全件返す。 */
+function findPriceIdPropertyReaders(source: string, fileName: string): string[] {
+	const readers: string[] = [];
+	const visit = (node: ts.Node): void => {
+		if (ts.isPropertyAccessExpression(node) && node.name.text === 'priceId') {
+			readers.push(enclosingFunctionName(node));
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(parse(source, fileName));
+	return readers;
+}
+
+describe('#4286 checkout の Price ID 解決経路 (fitness function)', () => {
+	const source = readFileSync(STRIPE_SERVICE, 'utf-8');
+
+	it('createCheckoutSession は getPriceId() で Price ID を解決する', () => {
+		// 呼び出しが 0 件 = lookup_key 経路が再び dead wiring に戻った状態。
+		// この 1 行が守れないと、price env を持たない配備で購入が必ず失敗する。
+		expect(findCallers(source, STRIPE_SERVICE, 'getPriceId')).toContain(CHECKOUT_ENTRYPOINT);
+	});
+
+	it('stripe-service.ts は PlanConfig.priceId (env var 直読) を参照しない', () => {
+		// `getPlans().priceId` は env var 由来なので、price env を持たない配備では空文字になる。
+		// webhook 側の plan 逆引きは `planIdFromPriceId(price.id)` (Stripe payload の id) を使う。
+		expect(findPriceIdPropertyReaders(source, STRIPE_SERVICE)).toEqual([]);
+	});
+
+	it('検出器は env 直読へ戻した実装を検出する (非トートロジー証明)', () => {
+		// 修正前の実装そのもの。これが検出されないなら上 2 つは常に緑になる。
+		const regressed = `
+			async function ${CHECKOUT_ENTRYPOINT}(input: { planId: string }): Promise<unknown> {
+				const plan = getPlans()[input.planId];
+				if (!plan?.priceId) return { error: 'INVALID_PLAN' };
+				return { line_items: [{ price: plan.priceId, quantity: 1 }] };
+			}
+		`;
+
+		expect(findCallers(regressed, 'fixture.ts', 'getPriceId')).not.toContain(CHECKOUT_ENTRYPOINT);
+		expect(findPriceIdPropertyReaders(regressed, 'fixture.ts')).toContain(CHECKOUT_ENTRYPOINT);
+	});
+});

--- a/tests/unit/routes/api-stripe-webhook.test.ts
+++ b/tests/unit/routes/api-stripe-webhook.test.ts
@@ -36,7 +36,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 		if (priceId === 'price_family_monthly_789') return 'family-monthly';
 		return null;
 	},
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));

--- a/tests/unit/services/period-end-cancellation-chain.test.ts
+++ b/tests/unit/services/period-end-cancellation-chain.test.ts
@@ -56,7 +56,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 	planIdFromPriceId: (priceId: string) => (priceId === 'price_monthly_123' ? 'monthly' : null),
 	planIdFromLookupKey: () => null,
 	getWebhookSecret: () => 'whsec_test',
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));

--- a/tests/unit/services/stripe-checkout-reconciliation.test.ts
+++ b/tests/unit/services/stripe-checkout-reconciliation.test.ts
@@ -72,7 +72,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 				? 'family-monthly'
 				: null,
 	getWebhookSecret: () => 'whsec_test',
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));

--- a/tests/unit/services/stripe-contract-state-classification.test.ts
+++ b/tests/unit/services/stripe-contract-state-classification.test.ts
@@ -69,7 +69,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 				: null,
 	planIdFromLookupKey: () => null,
 	getWebhookSecret: () => 'whsec_test',
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));

--- a/tests/unit/services/stripe-plan-drift-service.test.ts
+++ b/tests/unit/services/stripe-plan-drift-service.test.ts
@@ -45,7 +45,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 	planIdFromLookupKey: (key: string | null | undefined) =>
 		key === 'standard_monthly' ? 'monthly' : null,
 	getWebhookSecret: () => 'whsec_test',
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));

--- a/tests/unit/services/stripe-portal-flow.test.ts
+++ b/tests/unit/services/stripe-portal-flow.test.ts
@@ -48,7 +48,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 	planIdFromPriceId: () => null,
 	planIdFromLookupKey: () => null,
 	getWebhookSecret: () => 'whsec_test',
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -88,7 +88,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 		return null;
 	},
 	getWebhookSecret: () => 'whsec_test',
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));

--- a/tests/unit/services/stripe-webhook-contract-state.test.ts
+++ b/tests/unit/services/stripe-webhook-contract-state.test.ts
@@ -82,7 +82,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 	},
 	planIdFromLookupKey: () => null,
 	getWebhookSecret: () => 'whsec_test',
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));

--- a/tests/unit/services/stripe-webhook-dedup.test.ts
+++ b/tests/unit/services/stripe-webhook-dedup.test.ts
@@ -55,7 +55,6 @@ vi.mock('$lib/server/stripe/config', () => ({
 	planIdFromPriceId: (priceId: string) => (priceId === 'price_monthly_123' ? 'monthly' : null),
 	planIdFromLookupKey: () => null,
 	getWebhookSecret: () => 'whsec_test',
-	TRIAL_PERIOD_DAYS: 7,
 	GRACE_PERIOD_DAYS: 7,
 	CURRENCY: 'jpy',
 }));


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者・購入者） / 開発運用

**解決する課題**: #4286 の中核修正（checkout の Price ID 解決を `getPriceId()` 経由にする）は PR #4299 で develop に入ったが、**残余 3 点が未着地**だった。①設計書が実装と乖離したまま（07-API 設計書の checkout が廃止済 yearly 4 種 + FormData + リダイレクト前提）、②AC6 の sweep で見つかった未使用 export `TRIAL_PERIOD_DAYS` が二重定義のまま残存、③本欠陥の class（実装済みだが 1 度も呼ばれない dead wiring）を止める構造的な歯止めが無い。

**期待される効果**: 「お金の経路」の正しい構成（`USE_LOOKUP_KEY` と price env がそれぞれどう効くか）が設計書から読み取れるようになり、同じ dead wiring が入り直せば CI が落ちる。顧客の購入体験そのものは #4299 で既に是正済で、本 PR は再発可能性を閉じる。

## 関連 Issue

Refs #4286（中核修正は PR #4299 で merge 済。本 PR は残余 3 点）

<!-- no-issue-close: AC5 (staging 実機 1 周) が deploy 後のオーナー操作を要し本 PR で完了できないため #4286 は open のまま残す -->

**Issue は close しない**: AC5（staging での checkout → webhook → plan 反映 → 実画面の実機 1 周）は deploy 後のオーナー操作が必要で、コード変更で完了できないため。AC5 完了をもって #4286 を close する。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `createCheckoutSession` を `getPriceId()` 経由にする。`getPlans().priceId` 直読をやめる | **PR #4299 で実装済**（本 PR は構造固定を追加）。`git grep -n "getPriceId(lookupPlan)" src/lib/server/services/stripe-service.ts` | PASS — `stripe-service.ts:78 priceId = await getPriceId(lookupPlan);`。本 PR で `tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts` が呼び出し構造を AST で固定 |
| AC2 | env 無し × `USE_LOOKUP_KEY=true` で checkout session が作れることを test で固定 | **PR #4299 で実装済**（`tests/unit/services/stripe-checkout-price-resolution.test.ts`）。`npx vitest run tests/unit/services/stripe-checkout-price-resolution.test.ts` | PASS（本 PR の全体 run に含まれる。下記「テスト・品質セルフチェック」参照） |
| AC3 | `USE_LOOKUP_KEY=false` × env あり（現本番の実効構成）で従来どおり動く | **PR #4299 で実装済**（同 spec）+ `tests/unit/server/stripe/lookup-key-config.test.ts` | PASS（同上） |
| AC4 | lookup_key 解決失敗時に silent に別 plan へ倒れない。env fallback 時は alert | **PR #4299 で実装済**（`PRICE_UNRESOLVED` = 503 で返し、alert は `getPriceId()` 内で発火）+ `tests/unit/server/stripe/alert-integration.test.ts` | PASS（同上）。本 PR で 07-API 設計書に `PRICE_UNRESOLVED`(503) / `INVALID_PLAN`(400) の区別と 503 の理由を明記 |
| AC5 | staging で E1 の S-0（checkout → webhook → plan 反映 → 実画面）を実機 1 周 | **本 PR scope 外** — deploy 後のオーナー操作（staging での実カード操作 / Stripe Dashboard 確認）が必要でコード変更では完了しない | 未実施。`docs/runbooks/staging-live-verification.md` に従い deploy 後に実施し、その時点で #4286 を close する |
| AC6 | 同型の dead wiring が他に無いか確認。`src/lib/server/stripe/` の未使用 export を洗う | 本 PR で実施。`git grep -n "TRIAL_PERIOD_DAYS"`（撤去前の全 tracked file sweep） | PASS — 製品コード参照 **0 件**（定義行 `config.ts:115` 以外は docs 1 行 + test 9 本の `vi.mock` factory 内 stale key のみ）。撤去 + 参照先を実 SSOT `TRIAL_TERMS.durationDays` へ是正。`getPriceId` は #4299 で配線済のため未使用 export は残り 0 |

### 本 PR で入れた 3 点

1. **設計書同期 (ADR-0001)** — `docs/design/07-API設計書.md` の `POST /api/stripe/checkout`: リクエストを JSON `{ planId: 'monthly' | 'family-monthly', returnPath? }`、成功レスポンスを `{ url }`、`success_url` / `cancel_url` を `returnPath` 分岐に是正（実装 `src/routes/api/stripe/checkout/+server.ts` と突き合わせ）。Price 解決を「**flag と env は両方効く**」形で明記（`USE_LOOKUP_KEY=true` でも env があれば lookup_key 失敗時の kill switch として機能し、env が無い配備でも lookup_key だけで購入が成立する = 本番 Lambda `ganbari-quest-app` の実効構成 `USE_LOOKUP_KEY=true` + price env 両方設定済に一致）。`phase6-context-decisions-6.md` §4.1 Step 3 に「Price ID を要する経路は必ず `getPriceId()` を通す」を追記。`phase1-dunning-requirements.md` のトライアル行を実 SSOT へ差し替え
2. **`TRIAL_PERIOD_DAYS` 撤去** — 上表 AC6 の実測どおり参照 0 件を確認してから撤去。config module を mock する test 9 本に残っていた stale key（存在しない export を宣言し続ける状態）も同時に除去
3. **fitness function** — `tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts`。`createCheckoutSession` が `getPriceId()` を呼ぶこと / `stripe-service.ts` が `PlanConfig.priceId` を直読しないこと を TypeScript AST で構造固定（`stripe-contract-write-single-enforcement.test.ts` と同型）

### fitness function の非トートロジー実測（ADR-0061）

commit 済みの状態で実装だけを env 直読に戻し、gate が落ちることを実測した（未コミットの実装ごと revert する事故を避けるため commit 後に実施）。

```
# 1. 変更を commit（tree clean を確認）
$ git status --porcelain | wc -l
0

# 2. 実装のみ mutation: priceId = await getPriceId(lookupPlan);  →  priceId = plan.priceId;
$ npx vitest run tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts
 FAIL ... > createCheckoutSession は getPriceId() で Price ID を解決する
 AssertionError: expected [] to include 'createCheckoutSession'
 FAIL ... > stripe-service.ts は PlanConfig.priceId (env var 直読) を参照しない
 AssertionError: expected [ 'createCheckoutSession' ] to deeply equal []
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)

# 3. mutation を戻す（git stash push -- <path> → drop、破壊的 restore は使わない）
$ git status --porcelain | wc -l
0
$ npx vitest run tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

加えて test 内に fixture ベースの非トートロジー証明（修正前の実装形を検出器に食わせて検出されることを assert）を同梱しており、検出器を空実装に弱体化させると 3 本目が落ちる。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `POST /api/stripe/checkout`（挙動不変 — 本 PR はコード上 `TRIAL_PERIOD_DAYS` の未使用 export 撤去のみで、checkout の実行経路は #4299 のまま）。設計書 3 file / architecture test 1 本 / stripe 系 unit test の mock 定義 9 本。

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）— いずれも本 PR の変更対象外（UI・DB スキーマ・ラベルに触れない）。config module を mock する test 9 本は同一ペアとして一括同期済
- [x] **設計書同期** (ADR-0001): `docs/design/07-API設計書.md` / `docs/design/billing-redesign/phase6-context-decisions-6.md` / `docs/design/billing-redesign/phase1-dunning-requirements.md` を同 PR で更新
- [x] **LP ↔ アプリ整合** (ADR-0013): LP / pricing の記載には触れない。トライアル日数の表示 SSOT は `TRIAL_TERMS.durationDays` のままで値も 7 日で不変
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — 該当なし（export/import schema / marketplace / reward 陳列 / domain 値域 / child shop / parent-gate / DB スキーマ のいずれにも触れない）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4310` | PASS（下記ログ参照） |
| 追加・変更テスト | `npx vitest run tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts` | PASS (3 passed) |
| 影響範囲テスト | `npx vitest run` に stripe 系 9 本 + `tests/unit/server/stripe/` + 新規 fitness を指定（変更した mock 定義 9 本と Price 解決経路の全 spec） | **PASS — Test Files 17 passed / Tests 276 passed (72.7s)**。`TRIAL_PERIOD_DAYS` 撤去後も静的 import 切れなし |

- [x] **SOLID / DRY / YAGNI**: 撤去は二重定義の解消（トライアル日数の SSOT は `TRIAL_TERMS.durationDays` 一本）。fitness function は既存 `stripe-contract-write-single-enforcement.test.ts` の AST walk パターンを踏襲し新規抽象を作っていない
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。設計書に書いたのは env 変数**名**と解決順序のみで値は含めない
- [x] **A11y・パフォーマンス**: N/A（backend / docs / test のみ、UI 変更なし）
- [x] **Critical バグ修正**(ADR-0002): 本 PR は #4299（critical 本体）の残余で、顧客に見える挙動は変えない。ADR-0002 の 5 要件は #4299 側で充足済（回帰テストは `stripe-checkout-price-resolution.test.ts`、本 PR はそこに構造 gate を足す）

## スクリーンショット / ビジュアルデモ

**該当なし（backend / docs / test のみ、`.svelte` / `.css` / `site/` の変更 0 件）**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

`TRIAL_PERIOD_DAYS` は `src/lib/server/stripe/config.ts` の export だが、製品コードからの参照が 0 件であることを撤去前に全 tracked file の `git grep` で確認済（上表 AC6）。外部公開 API ではなくサーバー内部 module の export のため、撤去による顧客影響・後方互換の問題は発生しない。

**レビュー依頼事項**:
- 設計書の Price 解決記述が実配備と一致しているか（本番 Lambda `ganbari-quest-app` は `USE_LOOKUP_KEY=true` かつ `STRIPE_PRICE_STANDARD_MONTHLY` / `STRIPE_PRICE_FAMILY_MONTHLY` 両方が設定済 = 「flag が死んでいたが env があったので本番は動いていた」という #4286 の分析どおりの構成。この実効構成を設計書に書いています）
- fitness function の検出粒度（`stripe-service.ts` 単一 file の AST walk。他 file から `getPlans().priceId` を line_item に渡す経路が将来生えた場合は検出範囲外で、その時は走査対象 file を足す想定）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`USE_LOOKUP_KEY` / `STRIPE_PRICE_*_MONTHLY` はいずれも既存で、本 PR は設計書に解決順序を記述するだけ）

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC5 は上表のとおりコード変更では完了しない項目として明示。AC1-AC4 は #4299、AC6 は本 PR）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — revert 1 回で全戻る"]
    R2["顧客面: 🟢変化なし 購入経路は #4299 のまま"]
    R3["ロールバック: revert のみ。DB 書込ゼロ"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 設計書=実装 一致 + 再発を CI が阻止"]
    T2["捨てる: architecture test 1 本ぶんの保守"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: AC5 未消化のまま対応済の空気が先行"]
    O2["UX: env 整理を促し 503 を生む読み方の余地"]
    O3["security: 撤去根拠が grep 1 手法のみ"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["🟢 UI 変更 0。撤去は参照 0 件の内部定数のみ"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: AC5 未消化のまま本 PR を merge してよいか"]
    Q2["Q2: env 整理は Step 4 まで禁止で合意してよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3 ok
  class T2,O1,O2,O3 warn
  class T1,C1,R2 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

反対理由の生成元: `tmp/adversarial-evidence/4310.json`（`node scripts/verify-adversarial-output.mjs --pr 4310` PASS）。3 件それぞれの扱い:

| 軸 | 反対理由 | 本 PR での扱い |
|---|---|---|
| business | AC5（staging 実機 1 周）が未消化のまま「対応済」の空気だけ先行し、実際には 1 円も課金できない状態が放置されうる。fitness function は「呼び出しが存在する」ことしか保証せず、呼んだ先の Price が正しい商品を指すかは保証しない | **受容せず明示化**: Issue を close せず `<!-- no-issue-close -->` で理由を残し、AC 検証マップ AC5 行に「deploy 後にオーナー操作が必要」「AC5 完了をもって #4286 を close」と書いた。Q1 として PO 判断に上げる |
| UX | 「flag と env は両方効く」の記述が「env を整理してよい」と読まれ、env を落とした瞬間に kill switch を失い 503（買いたいのに買えない）を生む | **本 PR で対処済**（commit `6f78d8162`）: 07-API 設計書に「`USE_LOOKUP_KEY=true` でも price env を外さない。外してよいのは移行 Step 4 到達時」を追記 |
| security | `TRIAL_PERIOD_DAYS` 撤去根拠が `git grep` 1 手法のみ。動的アクセス / namespace 経由 / `infra/`（別 node_modules）からの参照が漏れると trial 判定が silent に壊れ金銭事故になりうる | **本 PR で追加検証済**: ① 大文字小文字無視の全 repo grep → 追加ヒットは全て Stripe API 側の param 名 `trial_period_days`（別物）で、定数参照は 0 件 ② `import * as` / `export * from` による `stripe/config` の namespace 参照 **0 件**（動的キーアクセス経路が存在しない） ③ 静的 import が残っていれば `svelte-check` / vitest が落ちるが両者 PASS |

</details>
