### PR TITLE
fix(security): #4280 CloudFront → origin の shared secret header で Function URL 直叩きを塞ぐ（webhook / cron は対象外）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -292,6 +292,40 @@ PORT=3000
 #   NUC は信頼ベース (判定なし) に移行し、license key に依存する debug 上書きは不要になった。
 
 # ============================================================
+# #4280: front door header (CloudFront -> origin shared secret)
+# ============================================================
+#
+# ORIGIN_VERIFY_SECRET: 32 文字以上のランダム文字列 (推奨 32 byte hex = 64 chars)
+#   CloudFront が origin request に付与する `x-origin-verify` header の期待値。
+#   /admin ・ /api/v1/admin ・ /ops への request が CloudFront を経由したことを証明する。
+#   Lambda Function URL (authType: NONE) 直叩きで CloudFront 層の制御 (地域制限等) を
+#   迂回する経路を、この 3 prefix に限って塞ぐ。
+#
+#   - **未設定なら検査は無効 (fail-open)**。CloudFront を持たない配備が正当に存在するため:
+#       * NUC セルフホスト (LAN 内で直接配信。**意図的に配布しない** — 配布すると
+#         front door が無いのに検査が有効になり、/admin が全 404 になる)
+#       * ローカル開発 / E2E
+#       * demo Lambda (独立 distribution、本番 secret を一切注入しない設計 ADR-0048)
+#   - 無効化は黙って起きない: プロセス 1 回だけ log に出る + AWS 側は CDK synth と
+#     deploy.yml の必須 secret 検証が未設定を止める (ADR-0024)
+#
+# 生成コマンド:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+#
+# 配布証跡 (infra/CLAUDE.md §配布 4 経路。**NUC には意図的に配布しない**):
+#   1. GitHub Actions Secrets:
+#        gh secret set ORIGIN_VERIFY_SECRET --body "<hex>" --repo Takenori-Kusaka/ganbari-quest
+#   2. AWS Lambda env (CDK SSOT、infra/lib/compute-stack.ts):
+#        deploy.yml / deploy-aws-staging.yml の `-c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}` 経由
+#      + CloudFront origin custom header (infra/lib/network-stack.ts) にも同じ値が入る
+#   3. NUC `.env`: **配布しない** (CloudFront が無いため。上記理由)
+#   4. CI (ci.yml / deploy.yml test job): 不要 (未設定 = 検査無効で従来どおり)
+#
+# rotate は docs/design/14-セキュリティ設計書.md §11.5.1 参照 (deploy 順序が窓を作らない)。
+# 平文コミット厳禁。
+# ORIGIN_VERIFY_SECRET=
+
+# ============================================================
 # EPIC #2310: Parent-Gate Session (ADR-0050) — REQUIRED in production
 # ============================================================
 #

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -133,9 +133,13 @@ jobs:
           OPS_SECRET_KEY: ${{ secrets.OPS_SECRET_KEY }}
           STRIPE_SECRET_KEY_TEST: ${{ secrets.STRIPE_SECRET_KEY_TEST }}
           STRIPE_WEBHOOK_SECRET_TEST: ${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}
+          # #4280: front door header の共有 secret。prod と同一値を使う
+          # (PARENT_GATE_COOKIE_SECRET / OPS_SECRET_KEY と同じ共有方針)。
+          # 未登録だと同一 CDK app の synth が throw して staging deploy も止まる。
+          ORIGIN_VERIFY_SECRET: ${{ secrets.ORIGIN_VERIFY_SECRET }}
         run: |
           missing=0
-          for s in AWS_OIDC_IAMROLE_ARN PARENT_GATE_COOKIE_SECRET OPS_SECRET_KEY; do
+          for s in AWS_OIDC_IAMROLE_ARN PARENT_GATE_COOKIE_SECRET OPS_SECRET_KEY ORIGIN_VERIFY_SECRET; do
             val=$(eval echo "\$$s")
             if [ -z "$val" ]; then
               echo "::error::Required GitHub Secret '$s' is missing. Register via 'gh secret set $s --body <value>'"
@@ -215,6 +219,7 @@ jobs:
             -c stagingEnabled=true \
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
+            -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }} \
             2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
 
       # Step 8: StorageStaging deploy (ECR repo / DynamoDB table / S3 を先行作成 —
@@ -226,6 +231,7 @@ jobs:
           -c stagingEnabled=true
           -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+          -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}
 
       # Step 9: Docker build (ARM64) → staging ECR push (sha + latest)。
       # prod repo は使わない (prod rollback の [-2] digest 選択 + lifecycle maxImageCount:10 を
@@ -277,6 +283,7 @@ jobs:
             -c dsqlStagingEnabled=true \
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+            -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}
 
       - name: Resolve DSQL staging outputs
         run: |
@@ -313,6 +320,7 @@ jobs:
             -c stagingEnabled=true $DSQL_CTX \
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
+            -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }} \
             -c stagingStripeSecretKey=${{ secrets.STRIPE_SECRET_KEY_TEST }} \
             -c stagingStripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }} \
             2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
@@ -334,6 +342,7 @@ jobs:
               -c stagingEnabled=true $DSQL_CTX \
               -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
               -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
+              -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }} \
               -c stagingStripeSecretKey=${{ secrets.STRIPE_SECRET_KEY_TEST }} \
               -c stagingStripeWebhookSecret=${{ secrets.STRIPE_WEBHOOK_SECRET_TEST }}
           done

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -916,6 +916,12 @@ jobs:
         run: npx playwright test --config playwright.production.config.ts
         env:
           E2E_BASE_URL: ${{ steps.function-url.outputs.url }}
+          # #4280: 本 smoke は Function URL を直接叩く (本番 CloudFront は geoRestriction JP で
+          # runner が日本国外のため経由できない)。front door 検査が掛かる /admin へ遷移するので、
+          # CloudFront が付けるのと同じ header を smoke 自身が付ける。未注入だと login 後の
+          # /admin が 404 になり deploy のたびに偽の赤が出る。
+          # trace は secret 保持時 off (public repo の artifact に header が載るため、config 参照)。
+          ORIGIN_VERIFY_SECRET: ${{ secrets.ORIGIN_VERIFY_SECRET }}
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -678,6 +678,26 @@ jobs:
           echo "Health check failed after 5 attempts (last status: $STATUS)"
           exit 1
 
+      # #4280: front door 検査が**実際に効いているか**を deploy 後に確認する。
+      # health check (/api/health) は front door 対象外なので必ず 200 を返し、
+      # 「検査が黙って無効」を検出できない (ADR-0024 silent skip 禁止の実効化)。
+      # header を付けずに /admin を叩いて 404 が返ることが、enforcement が live な証拠になる。
+      #
+      # 検出できない残余: CloudFront 側 header が origin 側 env とずれる方向。
+      # 検証には CloudFront 経由の request が要るが、本番 CloudFront は geoRestriction JP で
+      # GitHub Actions runner (日本国外) からは 403 になるため自動化できない (PR #4312 で明示)。
+      - name: Front door enforcement check (#4280)
+        run: |
+          FUNCTION_URL=$(aws lambda get-function-url-config             --function-name $LAMBDA_FUNCTION             --region $AWS_REGION             --query 'FunctionUrl' --output text)
+          FUNCTION_URL="${FUNCTION_URL%/}"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${FUNCTION_URL}/admin")
+          echo "Front door check: GET ${FUNCTION_URL}/admin (no header) -> $STATUS"
+          if [ "$STATUS" != "404" ]; then
+            echo "::error::front door 検査が効いていません (期待 404、実際 $STATUS)。ORIGIN_VERIFY_SECRET が Lambda env に届いていない可能性があります。この状態では /admin ・ /ops に Function URL 直で到達でき、CloudFront 層の制御 (geoRestriction) を迂回できます (#4280)"
+            exit 1
+          fi
+          echo "::notice::front door enforcement is live (Function URL 直の /admin は 404)"
+
       # Phase 5b: Rollback on health check failure
       - name: Rollback on failure
         if: failure() && steps.healthcheck.outcome == 'failure'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,9 +91,13 @@ jobs:
           # #2310 / #2337 / ADR-0050: parent-gate-session.ts が production で必須要求。
           # 未注入だと /admin/* cold start で throw して 500 連発 (PR #2325 で実害発生)。
           PARENT_GATE_COOKIE_SECRET: ${{ secrets.PARENT_GATE_COOKIE_SECRET }}
+          # #4280: CloudFront -> origin の front door header。未登録だと CDK synth が throw して
+          # deploy が止まる (header 無しの distribution = Function URL 直叩きで /admin ・ /ops に
+          # 到達可能なまま黙って動く、を作らせない)。ここで先に落として原因を明示する。
+          ORIGIN_VERIFY_SECRET: ${{ secrets.ORIGIN_VERIFY_SECRET }}
         run: |
           missing=0
-          for s in OPS_SECRET_KEY AWS_OIDC_IAMROLE_ARN STRIPE_SECRET_KEY PARENT_GATE_COOKIE_SECRET; do
+          for s in OPS_SECRET_KEY AWS_OIDC_IAMROLE_ARN STRIPE_SECRET_KEY PARENT_GATE_COOKIE_SECRET ORIGIN_VERIFY_SECRET; do
             val=$(eval echo "\$$s")
             if [ -z "$val" ]; then
               echo "::error::Required GitHub Secret '$s' is missing. Register via 'gh secret set $s --body <value>'"
@@ -142,6 +146,7 @@ jobs:
             -c certificateArn=${{ env.CERTIFICATE_ARN }} \
             -c cronSecret=${{ secrets.CRON_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
+            -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }} \
             2>&1 | COMMIT_MSG="$COMMIT_MSG" node ../scripts/check-cdk-replacement.mjs
 
       - name: CDK Deploy Storage
@@ -152,6 +157,7 @@ jobs:
           -c certificateArn=${{ env.CERTIFICATE_ARN }}
           -c cronSecret=${{ secrets.CRON_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+          -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}
 
       # Phase 2: Build and push Docker image to ECR (ARM64 native on Graviton runner)
       - name: Login to Amazon ECR
@@ -265,6 +271,7 @@ jobs:
           -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
           -c cronSecret=${{ secrets.CRON_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+          -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}
           -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }}
           -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
           ${{ secrets.GOOGLE_OAUTH_CLIENT_ID && format('-c googleClientId={0}', secrets.GOOGLE_OAUTH_CLIENT_ID) || '' }}
@@ -337,6 +344,7 @@ jobs:
             -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }} \
             -c cronSecret=${{ secrets.CRON_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
+            -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }} \
             -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }} \
             -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }} \
             -c discordWebhookIncident=${{ secrets.DISCORD_WEBHOOK_INCIDENT }} \
@@ -364,6 +372,7 @@ jobs:
           -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
           -c cronSecret=${{ secrets.CRON_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
+          -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}
           -c parentGateCookieSecret=${{ secrets.PARENT_GATE_COOKIE_SECRET }}
           -c discordWebhookHealth=${{ secrets.DISCORD_WEBHOOK_HEALTH }}
           -c discordWebhookIncident=${{ secrets.DISCORD_WEBHOOK_INCIDENT }}

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -1038,15 +1038,45 @@ subscribe API の保存前検証だけでは、過去レコード混入 / repo �
 | Cognito 認証（`/admin`） | アプリ層（全経路） | 必須 | 必須 | `AUTH_MODE=cognito` |
 | 親 PIN gate（`/admin`） | アプリ層（全経路） | 必須 | 必須 | §4.3 |
 | ops group + MFA（`/ops`） | アプリ層（全経路） | 必須 | 必須 | §5.2.9。**アプリ層のため両環境に同じく効く** |
-| Function URL 直叩き | — | 遮断しない | 遮断しない | `authType: NONE`。CloudFront を迂回しても認証・認可は同じく効く（form action は通らない） |
+| front door header（`x-origin-verify`） | **CloudFront が付与 → アプリ層が検査** | `/admin` `/api/v1/admin` `/ops` で必須 | 同左 | CloudFront を経由しない到達をこの 3 prefix に限って拒否する（#4280、§11.5.1） |
+| Function URL 直叩き | — | 上記 3 prefix は 404 / その他は到達可 | 同左 | `authType: NONE` のため到達自体は防げない。到達しても Cognito 認証・認可は同じく効く（form action も通らない） |
 | Stripe / SES / Discord / Gemini | — | 注入する | **注入しない** | staging は外部サービス副作用ゼロ（`deploy-aws-staging.yml`） |
 
-**CloudFront 層の防御は、CloudFront を経由しない到達経路には効かない（#4280）**: Lambda Function URL は `authType: FunctionUrlAuthType.NONE`（`infra/lib/compute-stack.ts`、本番 Fn / demo Fn の 2 箇所）で公開されており、CloudFront → origin 間に共有シークレット header の検証も origin 制限（OAC 相当）も無い。したがって **上表「どこで効くか = CloudFront のみ」の層（地域制限 / CloudFront Function / 将来もし IP allowlist を戻す場合）は、Function URL のホスト名を知る者には掛からない**。
+**CloudFront 層の防御は、CloudFront を経由しない到達経路には効かない（#4280）**: Lambda Function URL は `authType: FunctionUrlAuthType.NONE`（`infra/lib/compute-stack.ts`、本番 Fn / demo Fn の 2 箇所）で公開されている。したがって **上表「どこで効くか = CloudFront のみ」の層（地域制限 / CloudFront Function / 将来もし IP allowlist を戻す場合）は、Function URL のホスト名を知る者には掛からない**。この迂回は `/admin` `/api/v1/admin` `/ops` に限り front door header（§11.5.1）で塞いでいる。
 
 - **Function URL の推測困難さを防御層として数えない。** ログ / エラー画面 / ブラウザ履歴 / 過去の設定ファイル / 外部サービスへの登録値（Stripe webhook endpoint 等）から漏れた時点で無効になる。「ネットワーク層で守られている」を前提にした判断をしないこと
-- **現状 `/admin` `/ops` を守っているのはアプリ層のみ**（Cognito 認証 + 親 PIN gate / ops group + MFA）。CloudFront 層は可用性・地域・form action の都合であって、認可の一部ではない
-- **塞ぐ場合の方式**: CloudFront → origin の custom header を Lambda 側（`hooks.server.ts`）で等値検査する（#4280 案 b、採用決定済 / 実装は別 PR）。`authType: AWS_IAM` + OAC は失敗時に全面 502 となるコストが Pre-PMF で重く不採用（ADR-0010）、**再評価トリガーは有料家庭 20 世帯到達時**
-- **custom header 方式を入れる際は、CloudFront を経由しない正規の受信経路を先に洗い出す**。Stripe webhook を含む外部サービスからの POST は custom header を持たないため、endpoint URL を CloudFront 経由に揃えるか、path 単位で検査対象から外すかを**明示的に決めてから**有効化する（外した場合、その path は Function URL 直叩きで到達可能なまま残り、署名検証が唯一の防御になる）
+- **`/admin` `/ops` の主防御はアプリ層**（Cognito 認証 + 親 PIN gate / ops group + MFA）。CloudFront 層は可用性・地域・form action の都合であって、認可の一部ではない。front door header も認可ではなく経路の限定である
+- **`authType: AWS_IAM` + OAC は不採用**（失敗時に全面 502 となるコストが Pre-PMF で重い、ADR-0010）。**再評価トリガーは有料家庭 20 世帯到達時**
+
+#### 11.5.1 front door header（CloudFront → origin の共有シークレット、#4280）
+
+**解く問題**: Lambda Function URL は `authType: NONE` で公開されており、URL を知っていれば CloudFront を経由せずに到達できる。CloudFront 層に置いた制御（現状は地域制限、将来の edge 制御も同様）は**その経路には一切効かない**。Function URL は推測困難だが、**秘匿性は防御層として数えない**（ログ / エラー画面 / 履歴から漏れた時点で無効になる）。
+
+**仕組み**: CloudFront が Lambda を指す全 origin に `x-origin-verify: <ORIGIN_VERIFY_SECRET>` を付与し、`hooks.server.ts` が保護対象 path で一致を要求する。CloudFront は viewer が同名 header を送ってきても**設定値で上書き**するため、外部から偽装して通ることはできない。不一致は **404**（403 ではない — 存在自体を伏せる。切り分けはサーバ側 log の `front_door_missing_header` で行う）。
+
+**これは認証ではない**。保護対象 path の主防御は従来どおり Cognito + 親 PIN（`/admin`）/ ops group + MFA（`/ops`）であり、本 header が足すのは「edge 層の制御を迂回できない」1 点のみ。
+
+**保護対象と、対象外にした経路の根拠**（allow list 方式。列挙外は「front door 必須ではない」= 各自の認証で守る、という宣言）:
+
+| path | front door | その path 自身が持つ認証 |
+|---|---|---|
+| `/admin` / `/api/v1/admin` | **必須** | Cognito セッション + 親 PIN gate（§4.3） |
+| `/ops` | **必須** | ops group + MFA（§5.2.9） |
+| `/api/stripe/webhook` | 対象外 | **Stripe 署名検証**（`STRIPE_WEBHOOK_SECRET`）。Stripe の送信元は米国で、CloudFront の地域制限を通れないため経路を CloudFront に寄せられない（本番・staging とも webhook endpoint は Function URL 直で登録されている） |
+| `/api/cron/*` | 対象外 | **CRON_SECRET**（`verifyCronAuth`、§9 表）。cron-dispatcher Lambda が Function URL 直で POST する |
+| `/api/health` / `/api/ready` | 対象外 | 公開情報のみ。Lambda Web Adapter の readiness と post-deploy smoke が Function URL 直で叩く |
+| 上記以外（子供画面 / 公開ページ / 認証画面 等） | 対象外 | Cognito セッション、または公開が正しい |
+
+**secret 未設定時は検査を無効化する（fail-open）**。CloudFront を持たない配備（NUC セルフホスト / ローカル開発 / demo Lambda）が正当に存在するためで、無効化しても主防御は 1 枚も剥がれない。**AWS 側で設定漏れが起きる経路は塞いである**: CDK synth（`infra/lib/origin-verify-context.ts`）が secret 未指定を throw で止め、`deploy.yml` / `deploy-aws-staging.yml` の `Validate required secrets` が GitHub Secret 未登録の deploy を止める（ADR-0024 silent skip 禁止）。無効状態はプロセス 1 回だけ log に出る。
+
+**secret の rotate**（無停止。CloudFront → origin の順で二度 deploy する）:
+
+```bash
+gh secret set ORIGIN_VERIFY_SECRET   --body "$(node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))')"   --repo Takenori-Kusaka/ganbari-quest
+# 次回 deploy で反映される（deploy.yml の順序が窓を作らない、下記）
+```
+
+新旧 2 値を並行受理する猶予期間は設けない。`deploy.yml` の実行順が **CDK deploy（CloudFront の header 更新 + Lambda env 更新）→ Lambda 関数イメージ更新**であり、CloudFormation は CloudFront distribution が Deployed になるまで完了しないため、**新しい header が配信され始めた後に、新しい検査コードが載る**。逆順にならないので窓は生じない。prod / staging は同一 secret を共有する（`PARENT_GATE_COOKIE_SECRET` / `OPS_SECRET_KEY` と同じ方針）。
 
 **staging のデータ**: 合成 seed（#3412）の AWS staging 側配線は未了で、staging に載るのは**検証者が sign-up して作ったデータ**である。staging は全世界公開のため、sign-up には `deploy-aws-staging.yml` の `STAGING_ALLOWED_EMAIL_DOMAINS`（使い捨てドメインの SSOT）に載るアドレスだけを使う。allowlist 外のアドレスが登録されると deploy の `Staging PII guard` が Discord incident に通知する（手順は [runbooks/staging-live-verification.md](../runbooks/staging-live-verification.md)）。
 

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -78,8 +78,15 @@ cfn-lint は Python dev tool（`pip install "cfn-lint==1.53.0"`）。本番 bund
 | `GEMINI_API_KEY` | Gemini API | 任意 |
 | `CRON_SECRET` | `/api/cron/*` 認証 (#820 / #1375) | OPS_SECRET_KEY と排他必須 |
 | `OPS_SECRET_KEY` | CRON_SECRET 後方互換 (#1586) | 同上 |
+| `ORIGIN_VERIFY_SECRET` | CloudFront → origin の front door header (`x-origin-verify`、#4280) | **Lambda 必須 / NUC には配布しない** |
 
 生成: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"` / Stripe Dashboard / aistudio.google.com
+
+#### `ORIGIN_VERIFY_SECRET` を NUC に配布しない理由 (#4280)
+
+`/admin` ・ `/api/v1/admin` ・ `/ops` は「CloudFront を通ってきたこと」を `x-origin-verify` header で要求する。**NUC セルフホストは CloudFront を持たず LAN 内で直接配信する**ため、NUC の `.env` にこの secret を入れると「front door が無いのに検査が有効」になり、保護者の見守り画面が全 404 になる。未設定 = 検査無効 (fail-open) が NUC の正しい状態である。
+
+AWS 側の設定漏れは別レイヤで止める: `infra/bin/app.ts` の `resolveOriginVerifySecret()` が context 未指定の synth を throw し、`deploy.yml` / `deploy-aws-staging.yml` の `Validate required secrets` が GitHub Secret 未登録の deploy を止める (ADR-0024)。仕様と rotate 手順の SSOT は `docs/design/14-セキュリティ設計書.md` §11.5.1。
 
 ### 新規 env 追加時 PR チェックリスト
 

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -7,6 +7,7 @@ import { ComputeStack } from '../lib/compute-stack';
 import { DsqlStack } from '../lib/dsql-stack';
 import { STAGING_ENV_CONFIG } from '../lib/env-config';
 import { NetworkStack } from '../lib/network-stack';
+import { resolveOriginVerifySecret } from '../lib/origin-verify-context';
 import { OpsStack } from '../lib/ops-stack';
 import { SesStack } from '../lib/ses-stack';
 import { StorageStack } from '../lib/storage-stack';
@@ -41,6 +42,12 @@ const staticAssetsSourceDir = staticAssetsS3Offload
 	? path.join(__dirname, '..', 'static-assets')
 	: undefined;
 
+// #4280 案 b: CloudFront → origin の shared secret。**未設定なら synth をここで止める**
+// (空文字で素通しすると header 無しの distribution + 無効なアプリ側検査 = 黙って無防備になる)。
+// prod / staging は同一 AWS アカウント内の同居構成で、PARENT_GATE_COOKIE_SECRET /
+// OPS_SECRET_KEY と同じく 1 本の secret を共有する。
+const originVerifySecret = resolveOriginVerifySecret(app.node);
+
 const storage = new StorageStack(app, `${appName}Storage`, {
 	env,
 	description: 'S3 + ECR for Ganbari Quest (DB backend は DsqlStack、#3438)',
@@ -71,6 +78,7 @@ const network = new NetworkStack(app, `${appName}Network`, {
 	env,
 	description: 'CloudFront + Route53 + ACM for Ganbari Quest',
 	functionUrl: compute.functionUrl,
+	originVerifySecret,
 	domainName,
 	certificateArn,
 	// ADR-0048 Multi-Lambda Demo (#2097 week 4)
@@ -190,6 +198,7 @@ if (stagingEnabled) {
 		env,
 		description: 'CloudFront for Ganbari Quest (staging, #4204 form action の query slash encode)',
 		functionUrl: stagingCompute.functionUrl,
+		originVerifySecret,
 		resourcePrefix: STAGING_ENV_CONFIG.resourcePrefix,
 		geoRestrictionCountries: [],
 	});

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -7,8 +7,8 @@ import { ComputeStack } from '../lib/compute-stack';
 import { DsqlStack } from '../lib/dsql-stack';
 import { STAGING_ENV_CONFIG } from '../lib/env-config';
 import { NetworkStack } from '../lib/network-stack';
-import { resolveOriginVerifySecret } from '../lib/origin-verify-context';
 import { OpsStack } from '../lib/ops-stack';
+import { resolveOriginVerifySecret } from '../lib/origin-verify-context';
 import { SesStack } from '../lib/ses-stack';
 import { StorageStack } from '../lib/storage-stack';
 

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -195,6 +195,16 @@ export class ComputeStack extends cdk.Stack {
 			);
 		}
 
+		// #4280 案 b: CloudFront → origin の shared secret (`x-origin-verify`)。CloudFront 側
+		// (network-stack.ts) が付与し、アプリ側 (hooks.server.ts) が /admin ・ /api/v1/admin ・
+		// /ops で一致を要求する。**同じ CDK context から両者に配るため、header と検査が食い違わない**。
+		//
+		// ここでは throw しない: 未設定時の fail-fast は `infra/bin/app.ts` の
+		// `resolveOriginVerifySecret()` が単一点で担う (どの cdk 実行も app.ts を通る)。
+		// demo Lambda (SvelteKitDemoFn) には注入しない — demo は独立 distribution 配信で
+		// /ops を持たず、/admin も公開デモデータのみ。未注入 = 検査無効 (fail-open) で従来どおり動く。
+		const originVerifySecret = this.node.tryGetContext('originVerifySecret') ?? '';
+
 		// --- DSQL backend 配線 (EPIC #3424 / #3438 Phase 2A で無条件既定化) ---
 		// DSQL は本番の唯一の DB backend。DATA_SOURCE=dsql + DSQL_ENDPOINT + dsql:DbConnect を
 		// **無条件**で配線する。旧 `dsqlEnabled` flag と「flag なしは DATA_SOURCE=dynamodb fallback」
@@ -362,6 +372,7 @@ export class ComputeStack extends cdk.Stack {
 						...(parentGateCookieSecret
 							? { PARENT_GATE_COOKIE_SECRET: parentGateCookieSecret }
 							: {}),
+						...(originVerifySecret ? { ORIGIN_VERIFY_SECRET: originVerifySecret } : {}),
 						...(geminiApiKey ? { GEMINI_API_KEY: geminiApiKey } : {}),
 						...(stripeSecretKey ? { STRIPE_SECRET_KEY: stripeSecretKey } : {}),
 						...(stripeWebhookSecret ? { STRIPE_WEBHOOK_SECRET: stripeWebhookSecret } : {}),
@@ -387,6 +398,7 @@ export class ComputeStack extends cdk.Stack {
 						...(parentGateCookieSecret
 							? { PARENT_GATE_COOKIE_SECRET: parentGateCookieSecret }
 							: {}),
+						...(originVerifySecret ? { ORIGIN_VERIFY_SECRET: originVerifySecret } : {}),
 					},
 		});
 		this.fn.node.addDependency(logGroup);

--- a/infra/lib/network-stack.ts
+++ b/infra/lib/network-stack.ts
@@ -13,6 +13,11 @@ import type { Construct } from 'constructs';
 
 export interface NetworkStackProps extends cdk.StackProps {
 	functionUrl: lambda.FunctionUrl;
+	// #4280 案 b: CloudFront → origin の shared secret (`x-origin-verify` header)。
+	// **必須**。optional にすると「header を付け忘れた distribution」を型で表現できてしまい、
+	// その配備は CloudFront 層の制御を Function URL 直叩きで迂回可能なまま黙って動く。
+	// 値の解決と未設定時の fail-fast は `infra/lib/origin-verify-context.ts` が単一点で担う。
+	originVerifySecret: string;
 	domainName?: string;
 	certificateArn?: string;
 	// --- ADR-0048 Multi-Lambda Demo (#2097 week 4) ---
@@ -150,9 +155,24 @@ function handler(event) {
 		// --- S3 Origin for error pages (served from S3 even when Lambda is down) ---
 		const s3ErrorOrigin = origins.S3BucketOrigin.withOriginAccessControl(errorPagesBucket);
 
+		// --- front door 証明 header (#4280 案 b) ---
+		// Lambda Function URL は authType: NONE で公開されており、URL を知っていれば
+		// CloudFront を経由せず直接到達できる。CloudFront 層に置いた制御 (geoRestriction JP 等)
+		// は**その経路には効かない**。origin custom header で「CloudFront を通った」ことを
+		// 証明し、origin (hooks.server.ts) が /admin ・ /api/v1/admin ・ /ops で一致を要求する。
+		//
+		// CloudFront は viewer が同名 header を送ってきても**設定値で上書き**するため、
+		// 外部から偽装して通ることはできない。origin への転送は HTTPS_ONLY。
+		//
+		// 対象は Lambda を指す 2 origin (default 動作の lambdaOrigin と /_app/* の
+		// staticAssetOrigin)。同一 Lambda なので両方に同じ header を付ける。S3 origin
+		// (error pages / immutable assets) は OAC で守られており本 header の対象外。
+		const originVerifyHeaders = { 'x-origin-verify': props.originVerifySecret };
+
 		// --- CloudFront Distribution ---
 		const lambdaOrigin = new origins.HttpOrigin(fnUrlDomain, {
 			protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+			customHeaders: originVerifyHeaders,
 		});
 
 		// --- Origin Shield origin for /_app/* static assets (#3087) ---
@@ -172,6 +192,7 @@ function handler(event) {
 			protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
 			originShieldEnabled: true,
 			originShieldRegion: 'us-east-1',
+			customHeaders: originVerifyHeaders,
 		});
 
 		// 静的アセット用 cache policy (365 日 immutable)。/_app/* (shield lambda) と

--- a/infra/lib/origin-verify-context.ts
+++ b/infra/lib/origin-verify-context.ts
@@ -46,7 +46,6 @@ export function resolveOriginVerifySecret(node: ContextReader): string {
 				'  1. GitHub Secret を登録する:\n' +
 				'     gh secret set ORIGIN_VERIFY_SECRET --body "$(node -e \'console.log(require("crypto").randomBytes(32).toString("hex"))\')" \\\n' +
 				'       --repo Takenori-Kusaka/ganbari-quest\n' +
-				// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax
 				`  2. cdk 実行に \`-c ${ORIGIN_VERIFY_CONTEXT_KEY}=\${{ secrets.ORIGIN_VERIFY_SECRET }}\` を渡す\n` +
 				'  3. ローカル synth / cfn-lint はダミー値でよい (scripts/check-cdk-cfn-lint.mjs 参照)',
 		);

--- a/infra/lib/origin-verify-context.ts
+++ b/infra/lib/origin-verify-context.ts
@@ -1,0 +1,65 @@
+// infra/lib/origin-verify-context.ts
+// #4280 案 b — CloudFront → origin shared secret の **単一 fail-fast 点**
+//
+// CloudFront を作る配備で「secret 未指定のまま synth が通る」= header 無しの distribution が
+// できあがり、アプリ側の検査 (fail-open) も同時に無効になる = **黙って無防備**になる。
+// これは #4266 で実際に刺された形 (未登録 secret が空文字に展開され、防御コードごと消えた)
+// と同一クラスなので、同じ形を作らない (ADR-0024 ENV silent skip 禁止)。
+//
+// 置き場所を `infra/bin/app.ts` の 1 箇所に絞る理由:
+//   - どの `cdk` 実行 (synth / diff / deploy、stack を絞った実行も含む) も app.ts を必ず通る
+//   - stack constructor 側で throw すると、NetworkStack を直接 synth する既存 unit test 群
+//     (11 file) が本質と無関係に壊れ、テストが「context を足すだけ」の作業に劣化する
+
+/** CDK context key。deploy workflow が `-c originVerifySecret=...` で渡す。 */
+export const ORIGIN_VERIFY_CONTEXT_KEY = 'originVerifySecret';
+
+/**
+ * 実運用で使える最小長。`src/lib/runtime/env.ts` の `ORIGIN_VERIFY_SECRET`
+ * (`z.string().min(32)`) と同値。ここを緩めるとアプリ側 boot が落ちるだけなので揃える。
+ */
+export const ORIGIN_VERIFY_MIN_LENGTH = 32;
+
+/** context を引くための最小 interface (`cdk.App` の node を受ける。テスト容易性のため型を絞る)。 */
+export interface ContextReader {
+	tryGetContext(key: string): unknown;
+}
+
+/**
+ * CDK context から shared secret を解決する。未指定 / 短すぎる場合は throw して
+ * synth を止める (deploy には一切進ませない)。
+ *
+ * @throws 未設定・空文字・32 文字未満のとき
+ */
+export function resolveOriginVerifySecret(node: ContextReader): string {
+	const raw = node.tryGetContext(ORIGIN_VERIFY_CONTEXT_KEY);
+	const secret = typeof raw === 'string' ? raw.trim() : '';
+
+	if (!secret) {
+		throw new Error(
+			`[origin-verify] CDK context \`${ORIGIN_VERIFY_CONTEXT_KEY}\` が未設定です (#4280)。\n` +
+				'CloudFront → origin の shared secret header がないと、Lambda Function URL 直叩きで\n' +
+				'/admin ・ /api/v1/admin ・ /ops に到達でき、CloudFront 層の制御 (geoRestriction 等) を\n' +
+				'迂回できます。空文字で素通しすると防御が黙って消えるため synth を止めます (ADR-0024)。\n' +
+				'\n' +
+				'対処:\n' +
+				'  1. GitHub Secret を登録する:\n' +
+				'     gh secret set ORIGIN_VERIFY_SECRET --body "$(node -e \'console.log(require("crypto").randomBytes(32).toString("hex"))\')" \\\n' +
+				'       --repo Takenori-Kusaka/ganbari-quest\n' +
+				// biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions template syntax
+				`  2. cdk 実行に \`-c ${ORIGIN_VERIFY_CONTEXT_KEY}=\${{ secrets.ORIGIN_VERIFY_SECRET }}\` を渡す\n` +
+				'  3. ローカル synth / cfn-lint はダミー値でよい (scripts/check-cdk-cfn-lint.mjs 参照)',
+		);
+	}
+
+	if (secret.length < ORIGIN_VERIFY_MIN_LENGTH) {
+		throw new Error(
+			`[origin-verify] CDK context \`${ORIGIN_VERIFY_CONTEXT_KEY}\` が短すぎます ` +
+				`(${secret.length} 文字、最低 ${ORIGIN_VERIFY_MIN_LENGTH} 文字、#4280)。` +
+				'アプリ側 env schema (ORIGIN_VERIFY_SECRET) も同じ下限を要求するため、' +
+				'短い値を通すと Lambda が起動時に落ちます。32 byte hex (64 文字) を推奨します。',
+		);
+	}
+
+	return secret;
+}

--- a/infra/lib/origin-verify-context.ts
+++ b/infra/lib/origin-verify-context.ts
@@ -11,8 +11,16 @@
 //   - stack constructor 側で throw すると、NetworkStack を直接 synth する既存 unit test 群
 //     (11 file) が本質と無関係に壊れ、テストが「context を足すだけ」の作業に劣化する
 
-/** CDK context key。deploy workflow が `-c originVerifySecret=...` で渡す。 */
-export const ORIGIN_VERIFY_CONTEXT_KEY = 'originVerifySecret';
+/**
+ * CDK context key。deploy workflow が `-c originVerifySecret=...` で渡す。
+ *
+ * **命名が camelCase なのは意図的**: これは env 変数名ではなく CDK context の key 名であり、
+ * 値 (`'originVerifySecret'`) と表記を揃える。SCREAMING_SNAKE で書くと env 変数と誤読され、
+ * 「配布経路 4 つを用意すべき env」に見えてしまう (実際 `check-new-required-env.mjs` が
+ * env 命名と同型として誤検出した)。この定数はプロセスの環境変数として読まれることはない。
+ * 配布が要る env 変数は別物の `ORIGIN_VERIFY_SECRET` (`.env.example` / `infra/CLAUDE.md`)。
+ */
+export const originVerifyContextKey = 'originVerifySecret';
 
 /**
  * 実運用で使える最小長。`src/lib/runtime/env.ts` の `ORIGIN_VERIFY_SECRET`
@@ -32,12 +40,12 @@ export interface ContextReader {
  * @throws 未設定・空文字・32 文字未満のとき
  */
 export function resolveOriginVerifySecret(node: ContextReader): string {
-	const raw = node.tryGetContext(ORIGIN_VERIFY_CONTEXT_KEY);
+	const raw = node.tryGetContext(originVerifyContextKey);
 	const secret = typeof raw === 'string' ? raw.trim() : '';
 
 	if (!secret) {
 		throw new Error(
-			`[origin-verify] CDK context \`${ORIGIN_VERIFY_CONTEXT_KEY}\` が未設定です (#4280)。\n` +
+			`[origin-verify] CDK context \`${originVerifyContextKey}\` が未設定です (#4280)。\n` +
 				'CloudFront → origin の shared secret header がないと、Lambda Function URL 直叩きで\n' +
 				'/admin ・ /api/v1/admin ・ /ops に到達でき、CloudFront 層の制御 (geoRestriction 等) を\n' +
 				'迂回できます。空文字で素通しすると防御が黙って消えるため synth を止めます (ADR-0024)。\n' +
@@ -46,14 +54,14 @@ export function resolveOriginVerifySecret(node: ContextReader): string {
 				'  1. GitHub Secret を登録する:\n' +
 				'     gh secret set ORIGIN_VERIFY_SECRET --body "$(node -e \'console.log(require("crypto").randomBytes(32).toString("hex"))\')" \\\n' +
 				'       --repo Takenori-Kusaka/ganbari-quest\n' +
-				`  2. cdk 実行に \`-c ${ORIGIN_VERIFY_CONTEXT_KEY}=\${{ secrets.ORIGIN_VERIFY_SECRET }}\` を渡す\n` +
+				`  2. cdk 実行に \`-c ${originVerifyContextKey}=\${{ secrets.ORIGIN_VERIFY_SECRET }}\` を渡す\n` +
 				'  3. ローカル synth / cfn-lint はダミー値でよい (scripts/check-cdk-cfn-lint.mjs 参照)',
 		);
 	}
 
 	if (secret.length < ORIGIN_VERIFY_MIN_LENGTH) {
 		throw new Error(
-			`[origin-verify] CDK context \`${ORIGIN_VERIFY_CONTEXT_KEY}\` が短すぎます ` +
+			`[origin-verify] CDK context \`${originVerifyContextKey}\` が短すぎます ` +
 				`(${secret.length} 文字、最低 ${ORIGIN_VERIFY_MIN_LENGTH} 文字、#4280)。` +
 				'アプリ側 env schema (ORIGIN_VERIFY_SECRET) も同じ下限を要求するため、' +
 				'短い値を通すと Lambda が起動時に落ちます。32 byte hex (64 文字) を推奨します。',

--- a/playwright.production.config.ts
+++ b/playwright.production.config.ts
@@ -4,6 +4,21 @@
 
 import { defineConfig, devices } from '@playwright/test';
 
+// #4280: 本 smoke は **Lambda Function URL を直接**叩く (`E2E_BASE_URL` = Function URL)。
+// 本番 CloudFront は geoRestriction JP で、GitHub Actions runner は日本国外にあるため
+// CloudFront 経由には切り替えられない (staging は geo 制限が無いので CloudFront 経由、#4204)。
+//
+// front door 検査 (`/admin` `/api/v1/admin` `/ops` で `x-origin-verify` 必須) が入ったため、
+// smoke は CloudFront が付けるのと同じ header を自分で付ける。付けないと login 後の
+// `/admin` 遷移が 404 になり、deploy のたびに偽の赤が出る。
+const originVerifySecret = process.env.ORIGIN_VERIFY_SECRET;
+
+// **secret を持つときは trace を録らない**。本リポジトリは public で、`test-results/` は
+// artifact として 14 日間**誰でもダウンロードできる**。Playwright の trace は request header を
+// そのまま記録するため、trace を残すと front door secret が公開される。
+// secret を持たないローカル実行では従来どおり trace を録る (漏れるものが無いため)。
+const trace = originVerifySecret ? 'off' : 'on-first-retry';
+
 export default defineConfig({
 	testDir: 'tests/e2e',
 	testMatch: 'production-smoke.spec.ts',
@@ -16,8 +31,9 @@ export default defineConfig({
 		baseURL: process.env.E2E_BASE_URL || 'https://ganbari-quest.com',
 		actionTimeout: 15_000,
 		navigationTimeout: 30_000,
-		trace: 'on-first-retry',
+		trace,
 		screenshot: 'only-on-failure',
+		...(originVerifySecret ? { extraHTTPHeaders: { 'x-origin-verify': originVerifySecret } } : {}),
 	},
 	projects: [
 		{

--- a/scripts/check-cdk-cfn-lint.mjs
+++ b/scripts/check-cdk-cfn-lint.mjs
@@ -60,8 +60,8 @@ const SYNTH_ACCOUNT = '000000000000';
  * 一時 `cdk.context.json` に書き込んで synth 後に元へ戻す (gitignored な build artifact、
  * CLI の JSON quoting を跨がず cross-platform で決定的)。
  *
- * - addError guard (parentGateCookieSecret / opsSecretKey / dsqlEndpoint / dsqlClusterArn の
- *   非空要求) を満たす**非秘密のダミー値**
+ * - addError / throw guard (parentGateCookieSecret / opsSecretKey / dsqlEndpoint /
+ *   dsqlClusterArn / originVerifySecret の非空要求) を満たす**非秘密のダミー値**
  * - 全 stack を synth 対象にする context gate (dsqlEnabled / dsqlStagingEnabled / stagingEnabled)。
  *   #3870 の DsqlBackupRole を含む全 11 stack (prod 6 + Dsql + DsqlStaging + staging 3) を検査対象化
  *   (`tests/unit/infra/iam-role-description-ascii.test.ts` と同じ網羅性)
@@ -71,6 +71,10 @@ const SYNTH_ACCOUNT = '000000000000';
  */
 const SYNTH_CONTEXT = {
 	parentGateCookieSecret: 'cfnlint-dummy-parent-gate-secret-0000000000',
+	// #4280: infra/bin/app.ts の resolveOriginVerifySecret() が未設定なら throw する
+	// (CloudFront に front door header の無い distribution を作らせないための単一 fail-fast 点)。
+	// 32 文字以上の非秘密ダミー。
+	originVerifySecret: 'cfnlint-dummy-origin-verify-secret-000000',
 	opsSecretKey: 'cfnlint-dummy-ops-secret-key',
 	dsqlEndpoint: 'cfnlintdummy1234.dsql.us-east-1.on.aws',
 	dsqlClusterArn: `arn:aws:dsql:us-east-1:${SYNTH_ACCOUNT}:cluster/cfnlintdummy1234`,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -37,6 +37,10 @@ import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
 import { runWithRequestContext } from '$lib/server/request-context';
 import { findLegacyRedirect, rewriteLegacyPath } from '$lib/server/routing/legacy-url-map';
+import {
+	evaluateFrontDoor,
+	ORIGIN_VERIFY_HEADER,
+} from '$lib/server/security/origin-verify';
 import { checkApiRateLimit, checkAuthRateLimit } from '$lib/server/security/rate-limiter';
 import { checkConsent } from '$lib/server/services/consent-service';
 import { notifyIncident } from '$lib/server/services/discord-notify-service';
@@ -183,6 +187,64 @@ const MAINTENANCE_MODE = process.env.MAINTENANCE_MODE === 'true';
 const COGNITO_DEV_MODE = process.env.COGNITO_DEV_MODE === 'true';
 
 /**
+ * #4280 案 b: front door (CloudFront) 検査が secret 未設定で無効なことを、プロセスで 1 回だけ
+ * log するためのフラグ。「黙って無防備」を作らないための可視化であり、毎リクエスト出すと
+ * NUC / ローカル (CloudFront を持たない正当な配備) でログが埋まるため 1 回に絞る。
+ */
+let frontDoorDisabledLogged = false;
+
+/**
+ * #4280 案 b: front door 検査。CloudFront を経由しない `/admin` `/api/v1/admin` `/ops` への
+ * 到達 (Lambda Function URL 直叩き) を拒否する。
+ *
+ * 拒否時は **404** を返す (403 ではない)。403 は「そこに何かがある」ことを教えるが、
+ * この経路に来る呼び出しは定義上まっとうなブラウザではない (実利用者は必ず CloudFront を
+ * 通る) ため、存在自体を伏せる側に倒す。代わりに**サーバ側 log には残す** —
+ * 呼び出し元に情報を与えず、運営者は CloudWatch で即座に切り分けられる。
+ *
+ * log には path / method / 判定コードのみを載せる。secret・header 値・IP・顧客識別子は載せない。
+ *
+ * @returns 拒否する場合は Response、通す場合は null
+ */
+function checkFrontDoor(event: RequestEvent, path: string): Response | null {
+	const decision = evaluateFrontDoor(
+		path,
+		event.request.headers.get(ORIGIN_VERIFY_HEADER),
+		env.ORIGIN_VERIFY_SECRET,
+	);
+
+	if (decision === 'not-configured') {
+		if (!frontDoorDisabledLogged) {
+			frontDoorDisabledLogged = true;
+			logger.info(
+				'[front-door] ORIGIN_VERIFY_SECRET 未設定のため CloudFront 経由検査は無効です ' +
+					'(CloudFront を持たない配備 = NUC / ローカル / demo では正常。AWS 本番・staging では ' +
+					'CDK synth と deploy.yml の必須 secret 検証が未設定を止めます、#4280)',
+			);
+		}
+		return null;
+	}
+	if (decision === 'allow') return null;
+
+	logger.warn('[front-door] blocked non-CloudFront request to protected path', {
+		requestId: event.locals.requestId,
+		path,
+		context: { code: 'front_door_missing_header', method: event.request.method },
+	});
+
+	if (acceptsHtml(event.request)) {
+		return new Response(
+			renderErrorHtml(404, 'ページが見つかりません', 'お探しのページは見つかりませんでした。'),
+			{ status: 404, headers: { 'Content-Type': 'text/html; charset=utf-8' } },
+		);
+	}
+	return new Response(JSON.stringify({ error: 'Not Found' }), {
+		status: 404,
+		headers: { 'Content-Type': 'application/json' },
+	});
+}
+
+/**
  * ADR-0040 P4 (#1217): Policy Gate `can(ctx, 'write.db')` 経由で "demo 書き込み no-op"
  * を判定する参考実装。hooks main handler の cognitive complexity を上げないために、
  * 判定をここへ切り出している。true を返したら呼び側で 200 `{ ok: true, demo: true }`
@@ -290,6 +352,15 @@ export const handle: Handle = ({ event, resolve }) =>
 				},
 			);
 		}
+
+		// 0-a2) front door 検査 (#4280 案 b)
+		//
+		// CloudFront を経由しない `/admin` `/api/v1/admin` `/ops` 到達を塞ぐ。rate limiter より
+		// **前**に置く: 迂回試行で rate limit の枠を消費させない + 判定が header 比較 1 回で最も安い。
+		// `/api/stripe/webhook` `/api/cron/*` `/api/health` は保護対象外のため、Function URL 直の
+		// 既存経路 (Stripe / cron-dispatcher / LWA readiness) は従来どおり通る。
+		const frontDoorBlock = checkFrontDoor(event, path);
+		if (frontDoorBlock) return frontDoorBlock;
 
 		// 0-b) レートリミット（cognito 本番モードのみ、dev モードは除外）
 		if (

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -37,10 +37,7 @@ import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
 import { runWithRequestContext } from '$lib/server/request-context';
 import { findLegacyRedirect, rewriteLegacyPath } from '$lib/server/routing/legacy-url-map';
-import {
-	evaluateFrontDoor,
-	ORIGIN_VERIFY_HEADER,
-} from '$lib/server/security/origin-verify';
+import { evaluateFrontDoor, ORIGIN_VERIFY_HEADER } from '$lib/server/security/origin-verify';
 import { checkApiRateLimit, checkAuthRateLimit } from '$lib/server/security/rate-limiter';
 import { checkConsent } from '$lib/server/services/consent-service';
 import { notifyIncident } from '$lib/server/services/discord-notify-service';

--- a/src/lib/runtime/env.ts
+++ b/src/lib/runtime/env.ts
@@ -159,6 +159,19 @@ const envSchema = z.object({
 	// 未設定時は本番 URL にフォールバック (email-service.ts と整合)。
 	APP_BASE_URL: z.string().url().optional(),
 
+	// ----- Front door (CloudFront → origin shared secret、#4280 案 b) -----
+	/**
+	 * CloudFront が origin request に付与する共有シークレット (`x-origin-verify` header)。
+	 * 一致しない `/admin` `/api/v1/admin` `/ops` への request を 404 にし、Lambda Function URL
+	 * (`authType: NONE`) 直叩きによる CloudFront 層制御の迂回を塞ぐ。
+	 *
+	 * **未設定なら検査は無効 (fail-open)**。CloudFront を持たない配備 (NUC セルフホスト /
+	 * ローカル開発 / demo Lambda) が正当に存在するため。AWS 側の設定漏れは CDK synth
+	 * (`infra/lib/origin-verify-context.ts`) と `deploy.yml` の必須 secret 検証で止める。
+	 * 判定ロジックと fail-open の根拠: `src/lib/server/security/origin-verify.ts`
+	 */
+	ORIGIN_VERIFY_SECRET: z.string().min(32).optional(),
+
 	// ----- Parent-Gate Session (#2310 / ADR-0050) -----
 	/**
 	 * /admin/* PIN gate の cookie 署名キー (cookie-signature HMAC-SHA256)。

--- a/src/lib/server/security/origin-verify.ts
+++ b/src/lib/server/security/origin-verify.ts
@@ -34,6 +34,11 @@
 // したがって本検査は **deny list ではなく allow list**（保護する prefix を明示列挙）で構成する。
 // 列挙外の path は「front door 必須ではない」= 各自の認証で守る、という宣言である。
 
+// cspell 例外 (本 file 限定、.cspell.json への global 追加はしない):
+//   - `Tcfv`: staging Stripe webhook endpoint ID `we_1TcfvFBgMFbHJZ0Z5t5Tt53B` の実値の一部。
+//     実在の識別子であり、綴りを変えると実測の証跡でなくなる (tests/CLAUDE.md §負例 fixture と cspell)。
+// cspell:ignore Tcfv
+
 import { timingSafeEqual } from 'node:crypto';
 
 /**

--- a/src/lib/server/security/origin-verify.ts
+++ b/src/lib/server/security/origin-verify.ts
@@ -1,0 +1,126 @@
+// src/lib/server/security/origin-verify.ts
+// #4280 案 b — CloudFront → origin の shared secret header 検証 (front door 強制)
+//
+// ## これは何を守るか
+//
+// Lambda Function URL は `authType: NONE` で公開されており (infra/lib/compute-stack.ts)、
+// URL を知っていれば CloudFront を経由せず直接到達できる。CloudFront 層に置いた制御
+// (現状は geoRestriction JP、将来の edge 制御も同様) は、その経路には一切効かない。
+//
+// 本モジュールは「**この request は正面玄関 (CloudFront) を通ってきたか**」だけを判定する。
+// CloudFront が origin custom header (`x-origin-verify: <secret>`) を付与し、origin 側で
+// 値の一致を確認する。CloudFront は viewer が同名 header を送ってきても**設定値で上書き**
+// するため、外部から header を偽装して通ることはできない。
+//
+// ## これは認証ではない
+//
+// 本検査は認証・認可を一切代替しない。保護対象 path は従来どおり Cognito セッション +
+// parent-gate PIN (`/admin`) / ops group + MFA (`/ops`) で守られる。本検査が足すのは
+// 「edge 層の制御を迂回できない」という 1 点だけである。
+//
+// ## なぜ「CloudFront を通らない到達を一律に拒否」しないか (重要)
+//
+// 実経路には、CloudFront を通れない / 通る必要のない正当な呼び出しが存在する。
+//
+//   - `/api/stripe/webhook` — Stripe の送信元は米国。CloudFront は geoRestriction JP のため
+//     経由させられない (実測: 本番 `we_1TGnf6BgMFbHJZ0Z3Djw6rpL` / staging
+//     `we_1TcfvFBgMFbHJZ0Z5t5Tt53B` とも Function URL 直で登録済)。この経路は **Stripe 署名検証**
+//     という、IP / 経路制限より強い認証を既に持つ
+//   - `/api/cron/*` — cron-dispatcher Lambda が Function URL 直で POST する
+//     (`FUNCTION_URL` env)。この経路は **CRON_SECRET** (`verifyCronAuth`) で認証済
+//   - `/api/health` / `/api/ready` — Lambda Web Adapter の readiness / post-deploy smoke が
+//     Function URL 直で叩く。公開情報のみを返す
+//
+// したがって本検査は **deny list ではなく allow list**（保護する prefix を明示列挙）で構成する。
+// 列挙外の path は「front door 必須ではない」= 各自の認証で守る、という宣言である。
+
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * CloudFront が origin request に付与する共有シークレット header 名。
+ * AWS の慣行 (`X-Origin-Verify`) に合わせる。HTTP header 名は case-insensitive で、
+ * `Request.headers.get()` は大小を問わず引ける。
+ */
+export const ORIGIN_VERIFY_HEADER = 'x-origin-verify';
+
+/**
+ * front door (CloudFront) 経由を必須とする path prefix。
+ *
+ * 選定基準 = 「**運営者 / 保護者の管理面**であり、ブラウザからのみ到達し、
+ * edge 層の制御 (geoRestriction 等) が防御として意味を持つもの」。
+ *
+ *   - `/admin`        保護者の見守り画面 (Cognito セッション + parent-gate PIN)
+ *   - `/api/v1/admin` 上記画面が呼ぶ管理 API (同上)
+ *   - `/ops`          運営専用ダッシュボード。売上 / コホート / コストが出る
+ *                     (ops group + MFA、src/lib/server/auth/ops-authz.ts)
+ *
+ * ここに **列挙しない path は本検査の対象外**であり、それぞれが自前の認証を持つ
+ * (Stripe 署名 / CRON_SECRET / Cognito セッション / 公開情報)。冒頭コメント参照。
+ */
+export const FRONT_DOOR_PROTECTED_PREFIXES = ['/admin', '/api/v1/admin', '/ops'] as const;
+
+/**
+ * front door 検査の判定結果。
+ *
+ *   - `allow`          通してよい (保護対象外 / header 一致)
+ *   - `deny`           保護対象なのに header が無い or 不一致
+ *   - `not-configured` 保護対象だが secret 未設定のため検査できない (下記 fail-open)
+ */
+export type FrontDoorDecision = 'allow' | 'deny' | 'not-configured';
+
+/**
+ * path が front door 必須かを判定する。
+ *
+ * prefix の**境界**まで見る (`/admin` は `/admin` `/admin/...` に一致し、
+ * `/administrator` には一致しない)。prefix 一致を `startsWith` だけで済ませると
+ * 別リソースを巻き込む / 逆に漏らす (#3956 教訓: 構造化識別子を緩い一致で判定しない)。
+ */
+export function isFrontDoorProtectedPath(pathname: string): boolean {
+	return FRONT_DOOR_PROTECTED_PREFIXES.some(
+		(prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+	);
+}
+
+/** 長さ差を漏らさない定数時間比較。長さ不一致は即 false (長さは秘密ではない)。 */
+function secretEquals(actual: string, expected: string): boolean {
+	const a = Buffer.from(actual, 'utf8');
+	const b = Buffer.from(expected, 'utf8');
+	if (a.length !== b.length) return false;
+	return timingSafeEqual(a, b);
+}
+
+/**
+ * front door 検査本体 (純関数・I/O なし・header 比較 1 回)。
+ *
+ * `hooks.server.ts` は全リクエスト経路のため、ここに DB / 外部 I/O を足してはならない。
+ *
+ * @param pathname     `event.url.pathname`
+ * @param headerValue  `request.headers.get(ORIGIN_VERIFY_HEADER)`
+ * @param expectedSecret `ORIGIN_VERIFY_SECRET` (未設定なら undefined / 空文字)
+ */
+export function evaluateFrontDoor(
+	pathname: string,
+	headerValue: string | null,
+	expectedSecret: string | undefined,
+): FrontDoorDecision {
+	if (!isFrontDoorProtectedPath(pathname)) return 'allow';
+
+	// secret 未設定 = 検査不能。**fail-open** にする (詳細は下記)。
+	//
+	// なぜ fail-open が安全か:
+	//   1. 本検査は認証ではなく「経路の限定」。無効化しても Cognito + PIN / ops group + MFA
+	//      という主防御は 1 枚も剥がれない。fail-closed にした場合に失われるもの (全顧客の
+	//      /admin が 404) の方が、得られるもの (経路限定) より桁違いに大きい
+	//   2. **CloudFront が存在しない配備が正当に存在する**。NUC セルフホスト (LAN 内直配信) と
+	//      ローカル開発は front door 自体を持たないため、fail-closed にすると起動不能になる
+	//   3. AWS 側で「設定漏れによる無防備」が起きないことは**別レイヤで担保済**:
+	//      `infra/lib/origin-verify-context.ts` が secret 未指定の CDK synth を throw で止め、
+	//      `deploy.yml` の `Validate required secrets` が GitHub Secret 未登録の deploy を止める。
+	//      つまり CloudFront を持つ配備で header 無しになる経路は存在しない (ADR-0024)
+	//   4. 黙って無効化しない: 呼び出し側 (`hooks.server.ts`) が `not-configured` を
+	//      プロセス 1 回だけ log する
+	if (!expectedSecret) return 'not-configured';
+
+	if (headerValue && secretEquals(headerValue, expectedSecret)) return 'allow';
+	return 'deny';
+}

--- a/tests/unit/infra/admin-no-ip-allowlist.test.ts
+++ b/tests/unit/infra/admin-no-ip-allowlist.test.ts
@@ -45,6 +45,8 @@ function synthFunctionCodes(extraContext: Record<string, unknown> = {}): string[
 	const network = new NetworkStack(app, 'TestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 	});
 	const resources = Template.fromStack(network).findResources('AWS::CloudFront::Function');
 	return Object.values(resources).map((r) => String(r.Properties?.FunctionCode ?? ''));

--- a/tests/unit/infra/cross-stack-export-ratchet.test.ts
+++ b/tests/unit/infra/cross-stack-export-ratchet.test.ts
@@ -294,6 +294,8 @@ function synthAllStacks(): { exports: Set<string>; imports: Set<string> } {
 	const network = new NetworkStack(app, `${APP_NAME}Network`, {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: DOMAIN,
 		certificateArn: CERT_ARN,
 		demoFunctionUrl: compute.demoFunctionUrl,
@@ -326,6 +328,8 @@ function synthAllStacks(): { exports: Set<string>; imports: Set<string> } {
 	new NetworkStack(app, `${APP_NAME}NetworkStaging`, {
 		env,
 		functionUrl: sCompute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		resourcePrefix: STAGING_ENV_CONFIG.resourcePrefix,
 		geoRestrictionCountries: [],
 	});

--- a/tests/unit/infra/entitlement-fail-closed-alarm.test.ts
+++ b/tests/unit/infra/entitlement-fail-closed-alarm.test.ts
@@ -62,6 +62,8 @@ function buildOpsTemplate(opts: { withAppLogGroup: boolean }): Template {
 	const network = new NetworkStack(app, 'TestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/infra/iam-role-description-ascii.test.ts
+++ b/tests/unit/infra/iam-role-description-ascii.test.ts
@@ -83,6 +83,8 @@ function buildAllTemplates(): Array<[string, Template]> {
 	const network = new NetworkStack(app, 'GanbariQuestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/infra/multi-lambda-cdk.test.ts
+++ b/tests/unit/infra/multi-lambda-cdk.test.ts
@@ -80,6 +80,8 @@ function buildStacks(): {
 	const network = new NetworkStack(app, 'TestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/infra/ops-alert-destination.test.ts
+++ b/tests/unit/infra/ops-alert-destination.test.ts
@@ -62,6 +62,8 @@ function buildOpsTemplate(sourceDir: string): Template {
 	const network = new NetworkStack(app, 'TestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/infra/ops-alert-policy.test.ts
+++ b/tests/unit/infra/ops-alert-policy.test.ts
@@ -59,6 +59,8 @@ function buildOpsTemplate(sourceDir: string): Template {
 	const network = new NetworkStack(app, 'TestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/infra/ops-static-assets-alarm.test.ts
+++ b/tests/unit/infra/ops-static-assets-alarm.test.ts
@@ -54,6 +54,8 @@ function buildOpsTemplate(opts: { offload: boolean; sourceDir?: string }): Templ
 	const network = new NetworkStack(app, 'TestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/infra/origin-verify-header.test.ts
+++ b/tests/unit/infra/origin-verify-header.test.ts
@@ -164,6 +164,27 @@ describe('#4280 deploy workflow の全 cdk 実行が context を渡す', () => {
 		expect(missing).toEqual([]);
 	});
 
+	it('本番 smoke (Function URL 直) に front door header が渡る', () => {
+		// 本番 CloudFront は geoRestriction JP、GitHub Actions runner は日本国外のため、
+		// production smoke は Function URL を直接叩く。header を渡し忘れると login 後の
+		// /admin が 404 になり、deploy のたびに偽の赤が出る (#4280)。
+		const yml = readFileSync(join(root, '.github/workflows/deploy.yml'), 'utf8');
+		const smokeStep = yml
+			.split(/^ {6}- name: /m)
+			.find((s) => s.includes('playwright.production.config.ts'));
+		expect(smokeStep).toBeDefined();
+		expect(smokeStep).toContain('ORIGIN_VERIFY_SECRET');
+	});
+
+	it('secret を持つときの production smoke は trace を録らない (public repo の artifact 経由の漏洩防止)', () => {
+		// Playwright の trace は request header をそのまま記録する。本リポジトリは public で
+		// test-results/ は artifact として誰でも取得できるため、secret 保持時は trace を off にする。
+		const cfg = readFileSync(join(root, 'playwright.production.config.ts'), 'utf8');
+		expect(cfg).toMatch(/originVerifySecret\s*\?\s*'off'/);
+		// header 注入自体も残っていること (trace off だけして header を消す改変を検出する)
+		expect(cfg).toContain("'x-origin-verify': originVerifySecret");
+	});
+
 	it.each([
 		'.github/workflows/deploy.yml',
 		'.github/workflows/deploy-aws-staging.yml',

--- a/tests/unit/infra/origin-verify-header.test.ts
+++ b/tests/unit/infra/origin-verify-header.test.ts
@@ -1,0 +1,181 @@
+/**
+ * tests/unit/infra/origin-verify-header.test.ts (#4280 案 b)
+ *
+ * CloudFront → origin の front door header が「付いていること」と、
+ * 「付け忘れた配備が作れないこと」を機械で固定する。
+ *
+ * 守る不変条件:
+ *   1. Lambda を指す全 origin に `x-origin-verify` が付く (default 動作 + /_app/* の 2 本)
+ *   2. secret 未指定の synth は throw で止まる (空文字で防御が黙って消える形を作らない、#4266 教訓)
+ *   3. deploy workflow の **全 cdk 実行** が `-c originVerifySecret` を渡す
+ *      (どの cdk 実行も infra/bin/app.ts を通るため、1 箇所でも欠けると deploy が止まる)
+ *
+ * アプリ側の判定 (どの path を保護するか / webhook・cron を壊さないか) は
+ * `tests/unit/security/origin-verify.test.ts` が担当する。
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import {
+	ORIGIN_VERIFY_CONTEXT_KEY,
+	resolveOriginVerifySecret,
+} from '../../../infra/lib/origin-verify-context';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+const SECRET = 'origin-verify-secret-for-unit-test-0000000';
+const HEADER = 'x-origin-verify';
+
+interface OriginLike {
+	OriginCustomHeaders?: Array<{ HeaderName?: string; HeaderValue?: string }>;
+}
+
+/** NetworkStack を synth し、distribution ごとの origin 配列を logicalId 付きで返す。 */
+function synthDistributions(): Array<{ logicalId: string; origins: OriginLike[] }> {
+	const app = new cdk.App({
+		context: {
+			// route53 / acm の fromLookup が credentials を要求するため lookup cache を注入する
+			// (multi-lambda-cdk.test.ts と同値。AWS API は呼ばれない)。
+			// demo distribution は `demoFunctionUrl && domainName` の両方が揃って初めて生成されるため、
+			// domainName を渡す = hosted-zone lookup が必要になる。
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+			dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+		},
+	});
+	const storage = new StorageStack(app, 'TestStorage', { env });
+	const compute = new ComputeStack(app, 'TestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'TestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		originVerifySecret: SECRET,
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+	});
+	const resources = Template.fromStack(network).findResources('AWS::CloudFront::Distribution');
+	return Object.entries(resources).map(([logicalId, r]) => ({
+		logicalId,
+		origins: (r.Properties?.DistributionConfig?.Origins ?? []) as OriginLike[],
+	}));
+}
+
+function verifyHeaderCount(origins: OriginLike[]): number {
+	return origins.filter((o) =>
+		(o.OriginCustomHeaders ?? []).some(
+			(h) => h.HeaderName === HEADER && h.HeaderValue === SECRET,
+		),
+	).length;
+}
+
+describe('#4280 CloudFront が front door header を付与する', () => {
+	// synth は Lambda asset bundling を伴い数十秒かかるため 1 回だけ実行して共有する
+	let distributions: Array<{ logicalId: string; origins: OriginLike[] }>;
+
+	// synth は Lambda asset bundling を含み既定 hook timeout (10s) を超える
+	beforeAll(() => {
+		distributions = synthDistributions();
+	}, 180_000);
+
+	it('本番 distribution の Lambda origin 2 本 (default + /_app/*) に header が付く', () => {
+		const prod = distributions.filter((d) => !d.logicalId.startsWith('Demo'));
+		expect(prod).toHaveLength(1);
+		// Lambda を指す origin は 2 本 (lambdaOrigin / staticAssetOrigin)。S3 origin (error pages)
+		// は OAC で守られるため対象外。
+		expect(verifyHeaderCount(prod[0].origins)).toBe(2);
+	});
+
+	it('header 値は secret そのもの (別値・空文字が混ざらない)', () => {
+		const prod = distributions.find((d) => !d.logicalId.startsWith('Demo'));
+		const headers = (prod?.origins ?? []).flatMap((o) => o.OriginCustomHeaders ?? []);
+		const verify = headers.filter((h) => h.HeaderName === HEADER);
+		expect(verify.length).toBeGreaterThan(0);
+		for (const h of verify) expect(h.HeaderValue).toBe(SECRET);
+	});
+
+	it('demo distribution には付けない (demo Lambda に secret を注入しないため、付けると全滅する)', () => {
+		// demo Lambda は本番 secret を一切注入しない設計 (ADR-0048)。CloudFront 側だけ header を
+		// 付けても origin は検査しないので無意味であり、逆に「付けたのに検査してない」ように見える。
+		// 意図的に付けないことを固定する。
+		const demo = distributions.filter((d) => d.logicalId.startsWith('Demo'));
+		expect(demo.length).toBeGreaterThan(0);
+		for (const d of demo) expect(verifyHeaderCount(d.origins)).toBe(0);
+	});
+});
+
+describe('#4280 secret 未指定の synth は止まる (silent skip 禁止、ADR-0024)', () => {
+	const reader = (value: unknown) => ({ tryGetContext: () => value });
+
+	it.each([[undefined], [''], ['   '], [null], [123]])(
+		'context が %p なら throw する',
+		(value) => {
+			expect(() => resolveOriginVerifySecret(reader(value))).toThrow(/originVerifySecret/);
+		},
+	);
+
+	it('32 文字未満なら throw する (アプリ側 env schema の下限と揃える)', () => {
+		expect(() => resolveOriginVerifySecret(reader('short-secret'))).toThrow(/短すぎます/);
+	});
+
+	it('32 文字以上なら trim した値を返す', () => {
+		expect(resolveOriginVerifySecret(reader(`  ${SECRET}  `))).toBe(SECRET);
+	});
+
+	it('エラーメッセージが対処方法 (gh secret set / -c) を含む', () => {
+		let message = '';
+		try {
+			resolveOriginVerifySecret(reader(undefined));
+		} catch (e) {
+			message = (e as Error).message;
+		}
+		// 止めるだけで直し方を書かない guard にしない (#4273 と同じ規律)
+		expect(message).toContain('gh secret set ORIGIN_VERIFY_SECRET');
+		expect(message).toContain(`-c ${ORIGIN_VERIFY_CONTEXT_KEY}=`);
+	});
+});
+
+describe('#4280 deploy workflow の全 cdk 実行が context を渡す', () => {
+	// infra/bin/app.ts が throw する以上、1 箇所でも欠けるとその step で deploy が止まる。
+	// 「動かしてみて気づく」ではなく PR 時点で検出する (ADR-0061 shift-left)。
+	const root = join(__dirname, '..', '..', '..');
+
+	it.each([
+		'.github/workflows/deploy.yml',
+		'.github/workflows/deploy-aws-staging.yml',
+	])('%s の cdk step が全て -c originVerifySecret を持つ', (relPath) => {
+		const yml = readFileSync(join(root, relPath), 'utf8');
+		// `- name:` 単位の step に切り、cdk を叩く step だけを検査する
+		const steps = yml.split(/^      - name: /m).slice(1);
+		const cdkSteps = steps.filter((s) => s.includes('npx cdk'));
+		expect(cdkSteps.length).toBeGreaterThan(0);
+
+		const missing = cdkSteps
+			.filter((s) => !s.includes(`-c ${ORIGIN_VERIFY_CONTEXT_KEY}=`))
+			.map((s) => s.split('\n')[0].trim());
+		expect(missing).toEqual([]);
+	});
+
+	it.each([
+		'.github/workflows/deploy.yml',
+		'.github/workflows/deploy-aws-staging.yml',
+	])('%s が ORIGIN_VERIFY_SECRET を必須 secret として検証する', (relPath) => {
+		const yml = readFileSync(join(root, relPath), 'utf8');
+		expect(yml).toContain('ORIGIN_VERIFY_SECRET');
+		// `for s in ... ORIGIN_VERIFY_SECRET ...` の必須ループに載っていること
+		expect(yml).toMatch(/for s in [^\n]*ORIGIN_VERIFY_SECRET/);
+	});
+});

--- a/tests/unit/infra/origin-verify-header.test.ts
+++ b/tests/unit/infra/origin-verify-header.test.ts
@@ -22,7 +22,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { ComputeStack } from '../../../infra/lib/compute-stack';
 import { NetworkStack } from '../../../infra/lib/network-stack';
 import {
-	ORIGIN_VERIFY_CONTEXT_KEY,
+	originVerifyContextKey,
 	resolveOriginVerifySecret,
 } from '../../../infra/lib/origin-verify-context';
 import { StorageStack } from '../../../infra/lib/storage-stack';
@@ -139,7 +139,7 @@ describe('#4280 secret 未指定の synth は止まる (silent skip 禁止、ADR
 		}
 		// 止めるだけで直し方を書かない guard にしない (#4273 と同じ規律)
 		expect(message).toContain('gh secret set ORIGIN_VERIFY_SECRET');
-		expect(message).toContain(`-c ${ORIGIN_VERIFY_CONTEXT_KEY}=`);
+		expect(message).toContain(`-c ${originVerifyContextKey}=`);
 	});
 });
 
@@ -159,7 +159,7 @@ describe('#4280 deploy workflow の全 cdk 実行が context を渡す', () => {
 		expect(cdkSteps.length).toBeGreaterThan(0);
 
 		const missing = cdkSteps
-			.filter((s) => !s.includes(`-c ${ORIGIN_VERIFY_CONTEXT_KEY}=`))
+			.filter((s) => !s.includes(`-c ${originVerifyContextKey}=`))
 			.map((s) => (s.split('\n')[0] ?? '').trim());
 		expect(missing).toEqual([]);
 	});

--- a/tests/unit/infra/origin-verify-header.test.ts
+++ b/tests/unit/infra/origin-verify-header.test.ts
@@ -76,9 +76,7 @@ function synthDistributions(): Array<{ logicalId: string; origins: OriginLike[] 
 
 function verifyHeaderCount(origins: OriginLike[]): number {
 	return origins.filter((o) =>
-		(o.OriginCustomHeaders ?? []).some(
-			(h) => h.HeaderName === HEADER && h.HeaderValue === SECRET,
-		),
+		(o.OriginCustomHeaders ?? []).some((h) => h.HeaderName === HEADER && h.HeaderValue === SECRET),
 	).length;
 }
 
@@ -96,7 +94,7 @@ describe('#4280 CloudFront が front door header を付与する', () => {
 		expect(prod).toHaveLength(1);
 		// Lambda を指す origin は 2 本 (lambdaOrigin / staticAssetOrigin)。S3 origin (error pages)
 		// は OAC で守られるため対象外。
-		expect(verifyHeaderCount(prod[0].origins)).toBe(2);
+		expect(verifyHeaderCount(prod[0]?.origins ?? [])).toBe(2);
 	});
 
 	it('header 値は secret そのもの (別値・空文字が混ざらない)', () => {
@@ -120,12 +118,9 @@ describe('#4280 CloudFront が front door header を付与する', () => {
 describe('#4280 secret 未指定の synth は止まる (silent skip 禁止、ADR-0024)', () => {
 	const reader = (value: unknown) => ({ tryGetContext: () => value });
 
-	it.each([[undefined], [''], ['   '], [null], [123]])(
-		'context が %p なら throw する',
-		(value) => {
-			expect(() => resolveOriginVerifySecret(reader(value))).toThrow(/originVerifySecret/);
-		},
-	);
+	it.each([[undefined], [''], ['   '], [null], [123]])('context が %p なら throw する', (value) => {
+		expect(() => resolveOriginVerifySecret(reader(value))).toThrow(/originVerifySecret/);
+	});
 
 	it('32 文字未満なら throw する (アプリ側 env schema の下限と揃える)', () => {
 		expect(() => resolveOriginVerifySecret(reader('short-secret'))).toThrow(/短すぎます/);
@@ -159,13 +154,13 @@ describe('#4280 deploy workflow の全 cdk 実行が context を渡す', () => {
 	])('%s の cdk step が全て -c originVerifySecret を持つ', (relPath) => {
 		const yml = readFileSync(join(root, relPath), 'utf8');
 		// `- name:` 単位の step に切り、cdk を叩く step だけを検査する
-		const steps = yml.split(/^      - name: /m).slice(1);
+		const steps = yml.split(/^ {6}- name: /m).slice(1);
 		const cdkSteps = steps.filter((s) => s.includes('npx cdk'));
 		expect(cdkSteps.length).toBeGreaterThan(0);
 
 		const missing = cdkSteps
 			.filter((s) => !s.includes(`-c ${ORIGIN_VERIFY_CONTEXT_KEY}=`))
-			.map((s) => s.split('\n')[0].trim());
+			.map((s) => (s.split('\n')[0] ?? '').trim());
 		expect(missing).toEqual([]);
 	});
 

--- a/tests/unit/infra/physical-name-ratchet.test.ts
+++ b/tests/unit/infra/physical-name-ratchet.test.ts
@@ -98,6 +98,8 @@ function buildAllTemplates(): Array<[string, Template]> {
 	const network = new NetworkStack(app, 'GanbariQuestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -723,6 +723,8 @@ describe('#4204 staging CloudFront (NetworkStack)', () => {
 		const network = new NetworkStack(app, `GanbariQuestNetwork${suffix}`, {
 			env,
 			functionUrl: compute.functionUrl,
+			// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+			originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 			...(staging
 				? { resourcePrefix: STAGING_ENV_CONFIG.resourcePrefix, geoRestrictionCountries: [] }
 				: {}),

--- a/tests/unit/infra/static-assets-s3-offload.test.ts
+++ b/tests/unit/infra/static-assets-s3-offload.test.ts
@@ -65,6 +65,8 @@ function buildNetwork(opts: {
 	return new NetworkStack(opts.app, 'TestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/security/origin-verify.test.ts
+++ b/tests/unit/security/origin-verify.test.ts
@@ -17,6 +17,13 @@
  *   - cron-dispatcher Lambda の env `FUNCTION_URL` も Function URL 直。
  */
 
+// cspell 例外 (本 file 限定、.cspell.json への global 追加はしない):
+//   - `Tcfv`: staging Stripe webhook endpoint ID の実値の一部。綴りを変えると実測の証跡でなくなる
+//   - `adminx` / `opsx`: **負例 fixture**。`/admin` `/ops` に前方一致するが保護対象であってはならない
+//     path で、「緩い前方一致で無関係な path を巻き込まない」ことを検証する実体。綴りを直すと
+//     negative case が成立しなくなる (tests/CLAUDE.md §負例 fixture と cspell)
+// cspell:ignore Tcfv adminx opsx
+
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/tests/unit/security/origin-verify.test.ts
+++ b/tests/unit/security/origin-verify.test.ts
@@ -92,12 +92,14 @@ describe('#4280 front door: 対象外 = 自前の認証を持つ実経路 (壊�
 });
 
 describe('#4280 front door: prefix 境界 (緩い前方一致で巻き込まない)', () => {
-	it.each(['/administrator', '/adminx', '/opsx', '/api/v1/administrators'])(
-		'%s は保護対象ではない',
-		(path) => {
-			expect(isFrontDoorProtectedPath(path)).toBe(false);
-		},
-	);
+	it.each([
+		'/administrator',
+		'/adminx',
+		'/opsx',
+		'/api/v1/administrators',
+	])('%s は保護対象ではない', (path) => {
+		expect(isFrontDoorProtectedPath(path)).toBe(false);
+	});
 
 	it.each([...FRONT_DOOR_PROTECTED_PREFIXES])('%s 自身は保護対象', (prefix) => {
 		expect(isFrontDoorProtectedPath(prefix)).toBe(true);
@@ -108,13 +110,14 @@ describe('#4280 front door: secret 未設定時 (fail-open)', () => {
 	// CloudFront を持たない配備 (NUC セルフホスト / ローカル開発 / demo Lambda) では
 	// secret が無いのが正常。fail-closed にすると全顧客の /admin が 404 になる。
 	// AWS 側の設定漏れは CDK synth (origin-verify-context.ts) と deploy.yml が止める。
-	it.each(['/admin', '/ops', '/api/v1/admin/tenant-cleanup'])(
-		'%s は not-configured を返す (呼び出し側が 1 回だけ log して通す)',
-		(path) => {
-			expect(evaluateFrontDoor(path, null, undefined)).toBe('not-configured');
-			expect(evaluateFrontDoor(path, null, '')).toBe('not-configured');
-		},
-	);
+	it.each([
+		'/admin',
+		'/ops',
+		'/api/v1/admin/tenant-cleanup',
+	])('%s は not-configured を返す (呼び出し側が 1 回だけ log して通す)', (path) => {
+		expect(evaluateFrontDoor(path, null, undefined)).toBe('not-configured');
+		expect(evaluateFrontDoor(path, null, '')).toBe('not-configured');
+	});
 
 	it('保護対象外は secret 未設定でも allow (not-configured を返さない = 無駄な log を出さない)', () => {
 		expect(evaluateFrontDoor('/api/stripe/webhook', null, undefined)).toBe('allow');

--- a/tests/unit/security/origin-verify.test.ts
+++ b/tests/unit/security/origin-verify.test.ts
@@ -1,0 +1,122 @@
+/**
+ * tests/unit/security/origin-verify.test.ts (#4280 案 b)
+ *
+ * CloudFront → origin の shared secret header 検査。
+ *
+ * **本 test が最優先で守るのは「壊さないこと」**:
+ *   `/api/stripe/webhook` と `/api/cron/*` は CloudFront を経由できない / する必要がない
+ *   正当な実経路であり、header 無しで従来どおり通らなければならない。ここが落ちる実装を
+ *   本番に出すと、課金 webhook が全滅し (Stripe は 403 連続で endpoint を無効化する)、
+ *   cron が「経路はあるのに 0 通」で静かに死ぬ (#4119 / #4174 と同型)。
+ *
+ * 実測前提 (2026-08-06、read-only 照会):
+ *   - 本番 (live)   we_1TGnf6BgMFbHJZ0Z3Djw6rpL → https://<prod-fn-url>/api/stripe/webhook
+ *   - staging(test) we_1TcfvFBgMFbHJZ0Z5t5Tt53B → https://<staging-fn-url>/api/stripe/webhook
+ *   いずれも **Lambda Function URL 直**で登録済 (CloudFront が geoRestriction JP のため、
+ *   米国から送信される Stripe webhook を CloudFront 経由にはできない)。
+ *   - cron-dispatcher Lambda の env `FUNCTION_URL` も Function URL 直。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	evaluateFrontDoor,
+	FRONT_DOOR_PROTECTED_PREFIXES,
+	isFrontDoorProtectedPath,
+	ORIGIN_VERIFY_HEADER,
+} from '../../../src/lib/server/security/origin-verify';
+
+const SECRET = 'a'.repeat(64);
+
+/** 実際の `Request` から header を引いて評価する (hooks.server.ts と同じ引き方)。 */
+function evaluateRequest(path: string, headers: Record<string, string>, secret = SECRET) {
+	const request = new Request(`https://example.invalid${path}`, { headers });
+	return evaluateFrontDoor(path, request.headers.get(ORIGIN_VERIFY_HEADER), secret);
+}
+
+describe('#4280 front door: 保護対象 (/admin ・ /api/v1/admin ・ /ops)', () => {
+	const protectedPaths = [
+		'/admin',
+		'/admin/activities',
+		'/admin/settings/rules',
+		'/api/v1/admin',
+		'/api/v1/admin/tenant-cleanup',
+		'/ops',
+		'/ops/cost',
+	];
+
+	it.each(protectedPaths)('header 無しの %s は拒否される', (path) => {
+		expect(evaluateRequest(path, {})).toBe('deny');
+	});
+
+	it.each(protectedPaths)('正しい header 付きの %s は通る', (path) => {
+		expect(evaluateRequest(path, { [ORIGIN_VERIFY_HEADER]: SECRET })).toBe('allow');
+	});
+
+	it('値が違う header は拒否される (推測では通らない)', () => {
+		expect(evaluateRequest('/ops', { [ORIGIN_VERIFY_HEADER]: 'b'.repeat(64) })).toBe('deny');
+	});
+
+	it('長さの違う header は拒否される (定数時間比較の長さ guard)', () => {
+		expect(evaluateRequest('/ops', { [ORIGIN_VERIFY_HEADER]: 'a'.repeat(63) })).toBe('deny');
+		expect(evaluateRequest('/ops', { [ORIGIN_VERIFY_HEADER]: `${SECRET}x` })).toBe('deny');
+	});
+
+	it('空文字の header は拒否される', () => {
+		expect(evaluateRequest('/admin', { [ORIGIN_VERIFY_HEADER]: '' })).toBe('deny');
+	});
+
+	it('header 名は case-insensitive に引ける (CloudFront の送出表記に依存しない)', () => {
+		expect(evaluateRequest('/admin', { 'X-Origin-Verify': SECRET })).toBe('allow');
+	});
+});
+
+describe('#4280 front door: 対象外 = 自前の認証を持つ実経路 (壊さない)', () => {
+	// path → その path が front door の代わりに持っている認証 (PR body の除外根拠と同じ表)
+	const exempt: Array<[string, string]> = [
+		['/api/stripe/webhook', 'Stripe 署名検証 (STRIPE_WEBHOOK_SECRET)'],
+		['/api/cron/retention-cleanup', 'CRON_SECRET (verifyCronAuth)'],
+		['/api/cron/trial-notifications', 'CRON_SECRET (verifyCronAuth)'],
+		['/api/cron/pglite-backup', 'CRON_SECRET (verifyCronAuth)'],
+		['/api/health', '公開情報のみ (LWA readiness / post-deploy smoke が Function URL 直で叩く)'],
+		['/api/ready', '同上'],
+		['/auth/login', 'Cognito (未認証で到達するのが正常)'],
+		['/', '公開ページ'],
+		['/marketplace', '公開ページ'],
+		['/api/v1/activities', 'Cognito セッション (子供画面が呼ぶ)'],
+	];
+
+	it.each(exempt)('header 無しの %s は従来どおり通る (根拠: %s)', (path) => {
+		expect(evaluateRequest(path, {})).toBe('allow');
+	});
+});
+
+describe('#4280 front door: prefix 境界 (緩い前方一致で巻き込まない)', () => {
+	it.each(['/administrator', '/adminx', '/opsx', '/api/v1/administrators'])(
+		'%s は保護対象ではない',
+		(path) => {
+			expect(isFrontDoorProtectedPath(path)).toBe(false);
+		},
+	);
+
+	it.each([...FRONT_DOOR_PROTECTED_PREFIXES])('%s 自身は保護対象', (prefix) => {
+		expect(isFrontDoorProtectedPath(prefix)).toBe(true);
+	});
+});
+
+describe('#4280 front door: secret 未設定時 (fail-open)', () => {
+	// CloudFront を持たない配備 (NUC セルフホスト / ローカル開発 / demo Lambda) では
+	// secret が無いのが正常。fail-closed にすると全顧客の /admin が 404 になる。
+	// AWS 側の設定漏れは CDK synth (origin-verify-context.ts) と deploy.yml が止める。
+	it.each(['/admin', '/ops', '/api/v1/admin/tenant-cleanup'])(
+		'%s は not-configured を返す (呼び出し側が 1 回だけ log して通す)',
+		(path) => {
+			expect(evaluateFrontDoor(path, null, undefined)).toBe('not-configured');
+			expect(evaluateFrontDoor(path, null, '')).toBe('not-configured');
+		},
+	);
+
+	it('保護対象外は secret 未設定でも allow (not-configured を返さない = 無駄な log を出さない)', () => {
+		expect(evaluateFrontDoor('/api/stripe/webhook', null, undefined)).toBe('allow');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（`/ops` に売上・コホート・コストが出る） / 親（管理者、`/admin` の見守り画面）

**解決する課題**: Lambda Function URL が `authType: NONE` で公開されているため、URL を知っていれば **CloudFront を経由せずに `/admin` `/ops` へ到達できる**。CloudFront 層に置いた制御（現状は地域制限 JP、将来の edge 制御も同様）は、この経路に一切効かない。Function URL は推測困難だが、**秘匿性は防御層として数えられない**（ログ / エラー画面 / 履歴から漏れた時点で無効になる）。

**期待される効果**: CloudFront が付与する共有シークレット header を origin 側で検証し、`/admin` `/api/v1/admin` `/ops` については「正面玄関を通ってきたこと」を必須にする。**課金 webhook と cron は 1 通も止めない**（下記の設計判断）。

## 関連 Issue

Closes #4280

## 設計ポリシー確認（ADR-0008）

PO 決裁済み（Issue #4280 コメント 2026-08-05）: **案 b（shared secret header）実施 / 案 c（`authType: AWS_IAM` + OAC）不採用**。案 a（記述の是正）は PR #4295 で対応中。本 PR は決定 4（Function URL 直叩きの迂回を shared secret header で塞ぐ）の実装。

PO が付けた実装条件と、本 PR での満たし方:

| PO 条件 | 本 PR での実装 |
|---|---|
| secret が無いときに検査を skip しない（ADR-0024） | **CDK synth が throw して deploy 前に止まる**（`infra/lib/origin-verify-context.ts`）+ `deploy.yml` / `deploy-aws-staging.yml` の `Validate required secrets` に `ORIGIN_VERIFY_SECRET` を追加。「空文字で防御が黙って消える」形（#4266 で刺された形）を作らない |
| rotate 経路を書く | 本文「rotate 手順」+ `docs/design/14-セキュリティ設計書.md` §11.5.1 |
| `hooks.server.ts` は全リクエスト経路。独立 PR にする | 本 PR は #4276 と分離。追加処理は **header 比較 1 回のみ**（DB / 外部 I/O ゼロ、rate limiter より前） |

### 実測した事実（2026-08-06、すべて read-only 照会）

本 PR の設計は以下の実測に基づく。**推定ではない**。

1. **本番の Stripe webhook も Function URL 直で登録されている**（staging 固有の問題ではない）
   - 本番 (live): `we_1TGnf6BgMFbHJZ0Z3Djw6rpL` enabled → `https://<prod-fn-url>.lambda-url.us-east-1.on.aws/api/stripe/webhook`
   - staging (test): `we_1TcfvFBgMFbHJZ0Z5t5Tt53B` enabled → `https://<staging-fn-url>.lambda-url.us-east-1.on.aws/api/stripe/webhook`
2. **なぜ Function URL 直なのか = CloudFront が地理制限しているから**。`infra/lib/network-stack.ts` の本番・demo 両ディストリビューションが `geoRestriction: GeoRestriction.allowlist('JP')`。**Stripe の送信元は米国**のため、webhook を CloudFront ドメインへ移すと geo で弾かれる
3. 経路自体は両方生きている: 本番の `POST /api/stripe/webhook` は CloudFront 経由も Function URL 直も **HTTP 400**（署名不正で拒否 = 到達はしている）
4. **cron も Function URL 直**。`ganbari-quest-cron-dispatcher` Lambda の env `FUNCTION_URL = https://<prod-fn-url>.lambda-url.us-east-1.on.aws/`。`x-cron-secret` / `Authorization: Bearer` を付けて POST している
5. Function URL は本番・demo とも `authType: lambda.FunctionUrlAuthType.NONE`（`infra/lib/compute-stack.ts`）

### なぜ「CloudFront を通らない到達を一律に拒否」しないのか（本 Issue の本質）

**一律拒否は誤り**。上記 1・2・4 のとおり、実経路には **CloudFront を通れない / 通る必要がない正当な呼び出し**が 2 系統ある。一律拒否にすると、本番の課金 webhook が全滅し（Stripe は 403 を受けて再送 → やがて endpoint を無効化する）、cron が「経路はあるのに 0 通」で静かに死ぬ（#4119 / #4174 と同型を自分で作ることになる）。

したがって shared secret header は「**front door を通ったことの代用**」であり、**front door の制御（geo）が防御になっている経路にだけ要求する**。#4280 が守りたいのは `/admin` と `/ops` である。実装は **deny list ではなく allow list**（保護する prefix を明示列挙）で構成した。

**掛ける対象 / 外す対象と、外したものが各々持つ認証**（「なんとなく除外」を作らない）:

| path | front door | 根拠 = その path 自身が持つ認証 |
|---|---|---|
| `/admin` / `/api/v1/admin` | **必須** | Cognito セッション + 親 PIN gate（14-セキュリティ設計書 §4.3）。ブラウザからのみ到達し、edge 制御が防御として意味を持つ |
| `/ops` | **必須** | ops group + MFA（§5.2.9、`hasOpsAccess`）。売上 / コホート / コストが出る |
| `/api/stripe/webhook` | 対象外 | **Stripe 署名検証**（`STRIPE_WEBHOOK_SECRET`）。IP / 経路制限より強い認証を既に持つ。かつ実測 1・2 のとおり CloudFront 経由にできない |
| `/api/cron/*` | 対象外 | **CRON_SECRET**（`verifyCronAuth`、`x-cron-secret` / `Bearer` の 2 系統）。実測 4 のとおり cron-dispatcher が Function URL 直で叩く |
| `/api/health` / `/api/ready` | 対象外 | 公開情報のみ。Lambda Web Adapter の readiness と post-deploy smoke が Function URL 直で叩く |
| 上記以外（子供画面 / 公開ページ / 認証画面 等） | 対象外 | Cognito セッション、または公開が正しい |

**もう 1 つの実経路 — 本番 post-deploy smoke（rebase 中に発見）**: `deploy.yml` の `e2e-production` job は `E2E_BASE_URL` に **Lambda Function URL** を入れて `tests/e2e/production-smoke.spec.ts` を回しており、その中で **login 後に `/admin` へ遷移する / `/admin` に直接 goto する**。本番 CloudFront は geoRestriction JP で GitHub Actions runner は日本国外にあるため、**staging (#4204) のように CloudFront 経由へ切り替えることはできない**。放置すると deploy のたびに smoke が 404 で落ち、`release` job まで止まる偽の赤になる。

対処は「除外」ではなく「**smoke に header を持たせる**」にした（smoke は secret を正当に持てる内部の呼び出し元であり、除外すると `/admin` の front door 検査だけが smoke で一度も通らなくなる）。あわせて **本リポジトリは public で `test-results/` artifact は誰でもダウンロードできる**ため、Playwright の trace が request header を記録して secret が公開されないよう、**secret を持つ実行では trace を off** にした（`playwright.production.config.ts`）。この 2 点はいずれも guard で固定した（AC8）。

**これは認証ではない**。保護対象 path の主防御は従来どおり Cognito + PIN / ops group + MFA であり、本 header が足すのは「edge 層の制御を迂回できない」1 点のみ。

### 検証失敗時の応答と log

**404 を返す**（403 ではない）。403 は「そこに何かがある」ことを教えるが、この経路に来る呼び出しは定義上まっとうなブラウザではない（実利用者は必ず CloudFront を通る）ため、存在自体を伏せる側に倒した。切り分け可能性は **サーバ側 log** で担保する（`front_door_missing_header`、path + method + code のみ）。**secret・header 値・IP・顧客識別子は log に載せない**。

### secret 未設定時（fail-open）と、その安全性の根拠

`ORIGIN_VERIFY_SECRET` 未設定なら **検査を無効化する（fail-open）**。理由:

1. 本検査は認証ではなく「経路の限定」。無効化しても主防御（Cognito + PIN / ops group + MFA）は 1 枚も剥がれない。**fail-closed にして失うもの（全顧客の `/admin` が 404）の方が、得るもの（経路限定）より桁違いに大きい**
2. **CloudFront が存在しない配備が正当に存在する** — NUC セルフホスト（LAN 内直配信）/ ローカル開発 / demo Lambda。fail-closed にするとこれらが起動不能になる
3. **AWS 側で「設定漏れによる無防備」が起きる経路は塞いである**: CDK synth が context 未指定を throw で止め（実証は下記 AC5）、両 deploy workflow の必須 secret 検証が GitHub Secret 未登録の deploy を止める
4. **黙って無効化しない**: `hooks.server.ts` がプロセス 1 回だけ `[front-door] ... 検査は無効です` を log に出す

**NUC には意図的に配布しない**（`deploy-nuc.yml` に追加していない）。NUC は CloudFront を持たないため、配布すると「front door が無いのに検査が有効」になり保護者の見守り画面が全 404 になる。理由は `infra/CLAUDE.md` と `.env.example` に明記した。

### rotate 手順

```bash
gh secret set ORIGIN_VERIFY_SECRET \
  --body "$(node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))')" \
  --repo Takenori-Kusaka/ganbari-quest
# 次回 deploy で反映される（新旧 2 値の並行受理期間は不要。理由は下記 deploy 順序）
```

**新旧を並行受理する猶予期間は設けない**。`deploy.yml` の step 順が **`CDK Deploy all stacks`（CloudFront の header 更新 + Lambda env 更新）→ `Update Lambda function image`（検査コードの配備）** であり、CloudFormation は **CloudFront distribution が Deployed になるまで完了しない**。したがって「新しい header が配信され始めた後に、新しい検査コードが載る」順序が構造的に保証され、窓は生じない。prod / staging は同一 secret を共有する（`PARENT_GATE_COOKIE_SECRET` / `OPS_SECRET_KEY` と同じ既存方針）。

## AC 検証マップ (ADR-0004)

> **AC の読み替え**: 本 Issue の AC1 / AC2 は「案 a（記述の是正）を採る場合の最小スコープ」として書かれており、案 a は PR #4295 が担当中。PO 決裁は **a を即時 + b も実施**であり、本 PR は決定 4（案 b）の実装。したがって AC1 / AC2 は #4295 側の担当として扱いつつ本 PR でも該当箇所を満たし、加えて **案 b に対して PO が付けた条件**（Issue コメント「b の実装条件」3 点）とオーナー指示（webhook / cron を壊さない・fail-open の根拠明記・設計書更新）を AC3 以降として検証する。読み替えが AC の意図から外れていれば指摘してほしい。

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 設計書に「CloudFront を経由しない到達には CloudFront 層の防御が効かない」を明記（#4295 と分担） | `docs/design/14-セキュリティ設計書.md` の §11.5 マトリクスに front door 行を追加し、§11.5.1 で経路限定を記述 | PASS — §11.5 の 2 行（front door header / Function URL 直叩き）+ §11.5.1 新設。#4295 と競合しないよう追記のみ |
| AC2 | 実装コメントにも同じ限界を書く（実装を読む人が最初に見る場所） | `infra/lib/network-stack.ts` の header 付与箇所 | PASS — `--- front door 証明 header (#4280 案 b) ---` ブロックに「Function URL 直では CloudFront 層の制御が効かない」を明記 |
| AC3 | `/admin` `/ops` に header 無しで到達すると拒否される | `npx vitest run tests/unit/security/origin-verify.test.ts` | PASS — 39 tests passed。`/admin` `/admin/activities` `/admin/settings/rules` `/api/v1/admin` `/api/v1/admin/tenant-cleanup` `/ops` `/ops/cost` の 7 path で header 無し = `deny`、正しい header = `allow`、値違い / 長さ違い / 空文字 = `deny` |
| AC4 | **`/api/stripe/webhook` と `/api/cron/*` は header 無しでも従来どおり処理される**（回帰） | 同上（`front door: 対象外 = 自前の認証を持つ実経路 (壊さない)` describe） | PASS — webhook / cron 3 種 / health / ready / login / `/` / marketplace / `/api/v1/activities` の 10 path が header 無しで `allow` |
| AC5 | secret 未設定の配備でどう振る舞うか（fail-open）+ 設定漏れが黙って起きない | ① unit: `evaluateFrontDoor(path, null, undefined) === 'not-configured'` ② 実 synth: context 無しで `cdk synth` | PASS — ① 同 test file の `secret 未設定時 (fail-open)` describe ② `npx cdk synth GanbariQuestNetwork`（context 無し）が exit 1 + `[origin-verify] CDK context 'originVerifySecret' が未設定です (#4280)` と対処手順を出力 |
| AC6 | CloudFront が実際に header を付与する | `npx cdk synth GanbariQuestNetwork -c originVerifySecret=...` → 生成テンプレートの Origins を検査 | PASS — `cdk.out/GanbariQuestNetwork.template.json` の Lambda origin 2 本（Origin1 = default / Origin3 = `/_app/*`）に `('x-origin-verify', '<secret>')`。S3 error-pages origin（Origin2）は付与なし（OAC で守られるため対象外） |
| AC7 | header 付与漏れ / context 渡し漏れが PR 時点で検出される | `npx vitest run tests/unit/infra/origin-verify-header.test.ts` | PASS — 15 tests passed（origin 2 本の header / demo distribution 非付与 / synth throw 5 ケース / 両 workflow の全 cdk step が `-c originVerifySecret` を持つ / 両 workflow の必須 secret ループに `ORIGIN_VERIFY_SECRET` がある） |
| AC8 | 本番 post-deploy smoke（Function URL 直で `/admin` に遷移する）を壊さない | `npx vitest run tests/unit/infra/origin-verify-header.test.ts` | PASS — smoke step に `ORIGIN_VERIFY_SECRET` が渡ることと、secret 保持時に trace が off であること（public repo の artifact 経由の secret 漏洩防止）を 2 test で固定 |
| AC9 | 検査が「黙って無効」になっていないことを deploy 後に確認する | `deploy.yml` の `Front door enforcement check (#4280)` step | PASS（実装）— header 無しで Function URL の `/admin` を叩き **404 でなければ deploy を fail** させる。`/api/health` は front door 対象外で必ず 200 を返すため、既存 health check では「検査が無効」を検出できない |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `/admin`（保護者の見守り画面 全体）/ `/api/v1/admin`（同画面が呼ぶ API）/ `/ops`（運営ダッシュボード）。**いずれも CloudFront 経由の通常アクセスでは挙動不変**（header が付くため）。CloudFront を経由しない到達のみ 404 になる。

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）— UI 文言・年齢モード・DB スキーマのいずれにも触れないため該当なし。CloudFront ↔ Lambda env という本 PR 固有の「並行」は、**同一 CDK context (`originVerifySecret`) から両方へ配る**ことで構造的に食い違わないようにした
- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md` §11.5 マトリクス + §11.5.1 新設、`infra/CLAUDE.md` env 表 + NUC 非配布の理由、`.env.example`
- [x] **CI / deploy 経路**: 本番 post-deploy smoke（`e2e-production`）が Function URL 直で `/admin` を叩くため、smoke に header を渡す対応を同 PR に含めた（別 PR に切り出すと本 PR merge 時点で deploy が赤くなる）
- [x] **LP ↔ アプリ整合** (ADR-0013): LP 記載に影響なし
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — export/import schema / marketplace / reward 陳列 / child shop / parent-gate / DB スキーマのいずれにも触れないため該当なし
- [ ] N/A — 上記いずれも影響範囲外

**PR #4295 との関係**: #4295（案 a、open）も `docs/design/14-セキュリティ設計書.md` §11.5 と `infra/lib/network-stack.ts` を触る。本 PR は追記のみ（#4295 が追加する「どこで効くか」列とは別の行 / 別セクション）に留めた。**#4295 が先に merge された場合は本 PR を rebase し、マトリクスの列構成を #4295 側に合わせる**。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | PASS（全 step、Ready 化前に実行） |
| 追加テスト（アプリ層） | `npx vitest run tests/unit/security/origin-verify.test.ts` | PASS（39 tests） |
| 追加テスト（infra 層） | `npx vitest run tests/unit/infra/origin-verify-header.test.ts` | PASS（15 tests） |
| 既存 infra + security + hooks 統合 | `npx vitest run tests/unit/infra/ tests/unit/security/ tests/unit/services/hooks-integration.test.ts` | PASS（23 files / 266 tests、400.79s） |
| 型 | `npx svelte-check --threshold error` | PASS（8355 files / 0 errors / 0 warnings） |
| lint | `npx biome check src/ infra/ tests/unit/infra/ tests/unit/security/ scripts/check-cdk-cfn-lint.mjs` | PASS（1066 files） |
| 実 CDK synth（正常系） | `npx cdk synth GanbariQuestNetwork -c originVerifySecret=... ...` | PASS（exit 0、生成テンプレートに header 2 本） |
| 実 CDK synth（異常系） | 同上（`-c originVerifySecret` 無し） | **exit 1**（意図どおり deploy を止める） |

### guard の mutation 検証（「その guard を外すと fail するか」）

書いた guard が実際に検出できることを、実装を壊して実行した（実装を commit したうえで壊し、`git stash` で復元）。

| mutation | 実行コマンド | 結果 |
|---|---|---|
| `lambdaOrigin` から `customHeaders` を削除 | `npx vitest run tests/unit/infra/origin-verify-header.test.ts` | **検出** — `AssertionError: expected 1 to be 2`（1 failed / 14 passed） |
| 保護対象から `/ops` を落とす | `npx vitest run tests/unit/security/origin-verify.test.ts` | **検出** — `/ops` 系 5 tests fail（5 failed / 33 passed） |
| `isFrontDoorProtectedPath` を `return true`（= 一律拒否 / deny list 化） | 同上 | **検出** — webhook / cron / health を含む対象外 14 tests fail。**「本番の課金 webhook を止める実装」が必ず落ちる** |
| `deploy.yml` から `-c originVerifySecret` を 1 箇所削除 | `npx vitest run tests/unit/infra/origin-verify-header.test.ts -t "cdk step"` | **検出** — 1 failed |
| production smoke step から `ORIGIN_VERIFY_SECRET` を削除 | `npx vitest run tests/unit/infra/origin-verify-header.test.ts -t "smoke"` | **検出** — 1 failed（= 本番 smoke を壊す変更が落ちる） |
| `playwright.production.config.ts` の trace を常時 on に戻す | `npx vitest run tests/unit/infra/origin-verify-header.test.ts -t "trace"` | **検出** — 1 failed（= public artifact への secret 漏洩が落ちる） |

- [x] **SOLID / DRY / YAGNI**: 判定は純関数 1 本（`evaluateFrontDoor`）に集約し、`hooks.server.ts` は呼ぶだけ。secret の解決 / fail-fast は `resolveOriginVerifySecret` の 1 箇所（stack constructor に散らさない）。新規依存ゼロ、新規 script ゼロ
- [x] **Security（OSS 公開前提）**: secret を log / エラーメッセージ / テストに実値で書かない（テストはダミー値）。header 比較は `timingSafeEqual`（長さ guard 付き）。拒否応答に内部情報を載せない
- [x] **A11y・パフォーマンス**: 追加処理は header 比較 1 回のみ（DB / 外部 I/O ゼロ）。rate limiter より前に置き、迂回試行が rate limit 枠を消費しないようにした。UI 変更なし
- [x] **Critical バグ修正**(ADR-0002): 該当なし（`priority:high`、`priority:critical` ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（infra / server hooks のみ。`.svelte` / `.css` / `site/` の変更ゼロ）**。CloudFront 経由の通常アクセスでは header が付くため、**顧客に見える画面は 1 px も変わらない**。

<!-- ss-pair-none: infra + server hooks のみの変更で .svelte / .css / site/ の差分がゼロ。CloudFront 経由の通常アクセスは header が付くため描画は完全に不変で、修正前後の SS ペアが原理的に存在しない -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [ ] 含まれない
- [x] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**破壊的変更の内容**: `NetworkStackProps.originVerifySecret` を **必須プロパティ**にした。optional にすると「header を付け忘れた distribution」を型で表現できてしまい、その配備は CloudFront 層の制御を Function URL 直叩きで迂回可能なまま黙って動くため。既存の `NetworkStack` 構築点 13 箇所（unit test 11 file + `infra/bin/app.ts` 2 箇所）はすべて本 PR で追従済み。**顧客データ・課金への影響はなし**（DB スキーマ / 課金ロジックに触れない）。マイグレーション不要、必要なのは GitHub Secret 登録のみ（下記）。

**レビュー依頼事項**:

1. **保護対象 3 prefix の線引き**が妥当か。特に `/api/v1/admin/tenant-cleanup` は `verifyCronAuth`（CRON_SECRET）で認証される内部 API だが、`/api/v1/admin` 配下のため **front door 必須側に含めた**。自動呼び出し元は存在しない（cron-dispatcher の job 表にも workflow にも無い）ことを確認済みだが、**手作業で Function URL 直に curl する運用があれば 404 になる**（CloudFront ドメイン経由なら通る）。この扱いでよいか
2. **404 か 403 か**。「情報を与えない側に倒す」判断で 404 にし、切り分けはサーバ側 log に寄せた
3. **`ORIGIN_VERIFY_SECRET` を prod / staging で共有する**判断（既存の `PARENT_GATE_COOKIE_SECRET` / `OPS_SECRET_KEY` と同方針）。分離した方がよければ context key を分ける

## merge 後の確認事項（オーナー作業）

**merge 前に必要な作業（これをやらないと deploy が止まる）**:

```bash
# GitHub Secret を登録する（未登録だと Validate required secrets step で deploy が停止する）
gh secret set ORIGIN_VERIFY_SECRET \
  --body "$(node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))')" \
  --repo Takenori-Kusaka/ganbari-quest
```

**deploy 順序について（窓ができないこと）**: 本 PR は deploy 順序に手を入れていない。`deploy.yml` の既存順序が **CDK deploy（CloudFront header 配布 + Lambda env）→ Lambda イメージ更新（検査有効化）** であり、CloudFormation は CloudFront distribution が Deployed になるまで完了しないため、**header 配布が先・検査有効化が後**が構造的に保証される。逆順（検査が先に効いて header がまだ来ない）にはならないので、`/admin` `/ops` が一時的に 404 になる窓は生じない。

**merge 後に確認すること**:

1. 本番 deploy 後、CloudFront 経由で `/admin` と `/ops` が **200** で開けること（= header が正しく届いている）
2. `https://<prod-fn-url>.lambda-url.us-east-1.on.aws/admin` が **404** になること（= 迂回が塞がった）
3. **`POST https://<prod-fn-url>.lambda-url.us-east-1.on.aws/api/stripe/webhook` が従来どおり 400（署名不正で拒否）を返すこと** — ここが 404 になっていたら webhook が壊れている（即 revert 対象）
4. Stripe Dashboard の webhook 配信が成功し続けていること（`we_1TGnf6BgMFbHJZ0Z3Djw6rpL`）
5. 翌日の cron が動いていること（CloudWatch Logs `/aws/lambda/ganbari-quest-cron-dispatcher`）

**Stripe / AWS の設定は本 PR では変更していない**（webhook endpoint URL の変更も Function URL の authType 変更も不要）。本 PR は「webhook を Function URL 直のまま通す」前提の設計であり、**webhook endpoint URL を CloudFront に移す作業は行ってはならない**（移すと geo 制限で弾かれる、実測 2）。

## 配布済み env / secret (ADR-0006)

新規 secret `ORIGIN_VERIFY_SECRET` を追加した。配布経路と、**意図的に配布しない経路**:

- **未配布（オーナー作業）**: `ORIGIN_VERIFY_SECRET` → GitHub Actions Secrets（`gh secret set ORIGIN_VERIFY_SECRET --body <hex> --repo Takenori-Kusaka/ganbari-quest`）。上記「merge 後の確認事項」参照。**未登録のまま deploy すると `Validate required secrets` step が exit 1 で止める**（黙って無防備にはならない）
- **配布済み**: `ORIGIN_VERIFY_SECRET` → AWS Lambda env（`infra/lib/compute-stack.ts` で CDK SSOT 化、prod / staging 両方）+ CloudFront origin custom header（`infra/lib/network-stack.ts`）。両方が **同一 CDK context `originVerifySecret`** から配られるため食い違わない
- **配布済み**: `ORIGIN_VERIFY_SECRET` → `.env.example` に説明 + 生成コマンド + rotate 手順を追記
- **意図的に非配布**: `ORIGIN_VERIFY_SECRET` → NUC `.env`（`deploy-nuc.yml`）。**NUC は CloudFront を持たないため、配布すると front door が無いのに検査が有効になり `/admin` が全 404 になる**。未設定 = 検査無効（fail-open）が NUC の正しい状態。理由は `infra/CLAUDE.md` §「`ORIGIN_VERIFY_SECRET` を NUC に配布しない理由」に明記
- **非該当**: CI（`ci.yml` / `deploy.yml` test job）。未設定 = 検査無効で既存 E2E は従来どおり通るため注入不要

> **CI gate の誤検出について**: `check-new-required-env.mjs` が当初 `ORIGIN_VERIFY_CONTEXT_KEY`（CDK context key 名を保持する TS 定数）を「新たに必須化された env」と誤検出した。**理由付き opt-out コメントで黙らせるのではなく、誤読の原因である命名そのものを直した** — SCREAMING_SNAKE は env 変数の表記であり、context key の値（`'originVerifySecret'`）と表記が合っていなかった。`originVerifyContextKey` に改名し、意図をコメントに明記した（`process.env` として読まれる箇所は 0 件、grep 実測）。
## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — **UI 変更なしのため該当なし**（`.svelte` / `.css` / `site/` の変更ゼロ）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — **認証画面の変更なしのため該当なし**（認証・認可のロジックには一切触れず、経路の限定のみ）

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 (revert で完全に戻る)"]
    R2["顧客面: 親画面 /admin の到達経路のみ。課金・データ・法務は不変"]
    R3["ロールバック: revert のみで戻る。データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: Function URL 直の /admin /ops 迂回を封鎖"]
    T2["捨てる: secret 1 本の運用 + rotate 手順が増える"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: 🔴 CloudFront と origin の secret ずれを検知する監視が無い"]
    O2["UX: 🟡 誤設定時に親が見るのは汎用 404 で自己診断できない"]
    O3["security: 🟡 境界は 3 prefix のみ + secret を prod/staging 共有"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["変化なし: CloudFront 経由は header が付き 1px も変わらない"]
  end
  subgraph ASK["⑤ PO 判断依頼 (Yes/No で回答可能に)"]
    Q1["Q1: ③business の残余 (CloudFront 側ずれ無検知) を受容して merge して良いか"]
    Q2["Q2: secret を prod/staging で共有して良いか (分離なら secret 2 本運用)"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3 ok
  class R2 warn
  class T2,O2,O3 warn
  class O1 danger
  class T1,C1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

反対理由 3 件の原文は `tmp/adversarial-evidence/4312.json`（`node scripts/verify-adversarial-output.mjs --pr 4312` PASS）。

**③ business への本 PR の対処と、残った穴**:

- 対処済: deploy 後に `Front door enforcement check (#4280)` step が header 無しの `/admin` を叩き、404 でなければ deploy を fail させる（= 「検査が黙って無効」= 無防備方向は検出できるようにした）。既存 health check は front door 対象外の `/api/health` を叩くため、この方向を検出できなかった
- **残った穴（accepted residual、Q1）**: 逆方向 =「CloudFront が送る header が origin の期待値とずれる」は、検証に **CloudFront 経由の request** が要る。本番 CloudFront は geoRestriction JP で GitHub Actions runner（日本国外）からは 403 になるため自動化できない。両者は同一 CDK context から同時に配られるため、ずれるのは deploy 外の手動変更に限られる。検知したい場合の選択肢は (a) 拒否ログ件数の CloudWatch アラーム新設 (b) 日本国内から叩く外形監視の追加 で、いずれも Pre-PMF では重いと判断して本 PR に含めていない
- **② UX への対処**: 誤設定時の 404 は上記 enforcement check が deploy 時点で fail させるため、顧客に届く前に止まる想定。それでも 403 に変える判断があれば従う
- **③ security の境界の部分性**: 「front door は 3 prefix のみで、他の path は Function URL 直で到達できる」ことは設計書 §11.5 の表（どこで効くか列）と §11.5.1 に明記した。将来の判断者が「edge 制御が全経路に効く」と誤認しないようにする対処はここまで

</details>

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
