### PR TITLE
test(admin): #4166 portal-fallback-notice の見た目を Storybook story で固定する

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -8643,6 +8643,12 @@ export const STORYBOOK_LABELS = {
 		overflowExport: 'エクスポート',
 		badge: '有料限定',
 	},
+	// #4302 follow-up: SaasLicensePanel story の mock 契約者名。
+	// portal-fallback-notice (Stripe が flow を拒否したときのみ描画) は demo 環境で撮影できないため
+	// (ss-render-impossible)、story の play で見た目を固定する (#4166)。
+	saasLicensePanel: {
+		tenantName: 'たろう家',
+	},
 } as const;
 
 // ============================================================

--- a/src/lib/features/admin/components/SaasLicensePanel.stories.svelte
+++ b/src/lib/features/admin/components/SaasLicensePanel.stories.svelte
@@ -1,0 +1,95 @@
+<script module lang="ts">
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import { expect, within } from 'storybook/test';
+import { PORTAL_FALLBACK_CONTEXT } from '$lib/domain/constants/stripe-portal';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { STORYBOOK_LABELS, SUBSCRIPTION_PAGE_LABELS } from '$lib/domain/labels';
+import SaasLicensePanel from './SaasLicensePanel.svelte';
+
+// #4302 follow-up (QM 指摘): `portal-fallback-notice` は Stripe が実際に flow を拒否したときだけ
+// 描画される (SaasLicensePanel.svelte の `openPortal()` / `$effect` 分岐)。demo 環境
+// (`DATA_SOURCE=demo`) では Stripe を叩けないため撮影できず (ss-render-impossible)、
+// 見た目を確認する手段が story しか無かった (#4166 / #4270)。
+//
+// `data.portalFallback` に `PORTAL_FALLBACK_CONTEXT.CANCEL` を渡すと、マウント時の `$effect` が
+// 決定的に `portalFallbackMessage` を立てる (fetch モック不要)。解約フォーム送信後に
+// server redirect (`?portalFallback=cancel`) で戻ってきた状態を再現する。
+
+const BASE_LICENSE = {
+	plan: 'standard' as const,
+	status: SUBSCRIPTION_STATUS.ACTIVE,
+	tenantName: STORYBOOK_LABELS.saasLicensePanel.tenantName,
+	stripeSubscriptionId: 'sub_mock_4302',
+	stripeCustomerId: 'cus_mock_4302',
+	createdAt: '2026-01-15T00:00:00.000Z',
+	updatedAt: '2026-01-15T00:00:00.000Z',
+};
+
+const BASE_PLAN_STATS = {
+	activityCount: 4,
+	activityMax: 20,
+	childCount: 1,
+	childMax: 3,
+	retentionDays: 365,
+};
+
+const BASE_TRIAL_STATUS = {
+	isTrialActive: false,
+	trialUsed: true,
+	daysRemaining: 0,
+	trialEndDate: null,
+	trialTier: null,
+};
+
+/** SaasLicensePanel `data` prop の mock (`+page.server.ts` の load 戻り値と同型)。 */
+function mockData(overrides: Partial<Record<string, unknown>> = {}) {
+	return {
+		license: BASE_LICENSE,
+		stripeEnabled: true,
+		loyaltyInfo: null,
+		planTier: 'standard' as const,
+		planStats: BASE_PLAN_STATS,
+		downgradeRetentionDays: 90,
+		pinConfigured: true,
+		checkoutReconciliation: null,
+		portalFallback: null,
+		trialStatus: BASE_TRIAL_STATUS,
+		cancellation: null,
+		...overrides,
+	};
+}
+
+const { Story } = defineMeta({
+	title: 'Admin/SaasLicensePanel',
+	component: SaasLicensePanel,
+	tags: ['autodocs'],
+});
+</script>
+
+<!-- 通常表示 (フォールバック無し)。プラン管理カード等は出るが portal-fallback-notice は無い。 -->
+<Story
+	name="Default"
+	args={{ data: mockData() }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getByTestId('saas-license-panel')).toBeVisible();
+		await expect(canvas.queryByTestId('portal-fallback-notice')).toBeNull();
+	}}
+/>
+
+<!-- #4270: 解約フローが Stripe に拒否されて portal home に倒れ、
+     `/admin/subscription?portalFallback=cancel` へ戻ってきた状態。
+     このケースでは作成済み session URL が無いため「続ける」ボタンは出ず、
+     「請求管理ページを開く」ボタンから続けるよう案内するだけになる (実装どおり)。 -->
+<Story
+	name="PortalFallbackCancel"
+	args={{ data: mockData({ portalFallback: PORTAL_FALLBACK_CONTEXT.CANCEL }) }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		const notice = canvas.getByTestId('portal-fallback-notice');
+		await expect(notice).toBeVisible();
+		await expect(notice).toHaveTextContent(SUBSCRIPTION_PAGE_LABELS.portalFallbackCancel);
+		// 解約経路のフォールバックには session URL が無いため continue ボタンは出ない
+		await expect(canvas.queryByTestId('portal-fallback-continue')).toBeNull();
+	}}
+/>


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: `portal-fallback-notice`（Stripe が portal の flow を拒否したときに出るフォールバック通知、#4166 / #4270）は、Stripe を実際に叩いたときにしか描画されないため demo 環境（`DATA_SOURCE=demo`）では撮影できず、誰も見た目を確認していなかった。

**期待される効果**: 顧客が想定外の画面に落ちたときに出る通知の見た目を、Storybook story で決定的に再現・確認できるようにする。

## 関連 Issue

<!-- no-issue-close: PR #4302 の QM approve コメントで挙げられた follow-up。#4166 の AC を追加実装するものではなく story 追加のみのため close しない -->
Refs #4166

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `portal-fallback-notice` を含む component (`SaasLicensePanel.svelte`) の Storybook story を追加し、通知が出ている状態を最低 1 つ固定する | `SaasLicensePanel.stories.svelte` の `PortalFallbackCancel` Story（`data.portalFallback = PORTAL_FALLBACK_CONTEXT.CANCEL` で mount 時の `$effect` が決定的に notice を立てる） | PASS（`src/lib/features/admin/components/SaasLicensePanel.stories.svelte:87-98`。`npx svelte-check` PASS、詳細は下表） |
| AC2 | 通知なし（通常）の状態も対比として作る | `Default` Story（`portalFallback: null`） | PASS（`SaasLicensePanel.stories.svelte:76-84`、`portal-fallback-notice` が無いことを play で assert） |
| AC3 | 表示テキストは `STORYBOOK_LABELS` 経由（文字列リテラル直書き禁止、DESIGN.md §6） | `grep -n "saasLicensePanel" src/lib/domain/labels.ts` | PASS（`STORYBOOK_LABELS.saasLicensePanel.tenantName` を追加、story から参照。通知本文自体は実装と同じ `SUBSCRIPTION_PAGE_LABELS.portalFallbackCancel` を参照 — これは本番と同じ表示文言を確認する目的のため意図的） |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [x] test: テスト改善
- [ ] docs: ドキュメント

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: Storybook のみ（`Admin/SaasLicensePanel`）。本番 UI・ロジックの変更なし。

- [x] N/A — 並行実装ペア / 設計書同期 / LP↔アプリ整合 / 重量 e2e は影響範囲外（Storybook story + labels.ts 追加のみ、実装ロジック無変更）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4312`（ローカルでは `check-pr-body.mjs --body-file` のみ実行、他 step は PR 作成後に CI で検証） | 下記参照 |
| svelte-check | `npx svelte-check` | PASS（0 errors, 0 warnings） |
| biome | `npx biome check src/lib/features/admin/components/SaasLicensePanel.stories.svelte src/lib/domain/labels.ts` | PASS |
| storybook test | `npx cross-env STORYBOOK_TESTS=true vitest run --project storybook --dangerouslyIgnoreUnhandledErrors -t "SaasLicensePanel"` | **未実行** — ローカルの `heavy-run-lock` が別セッション（`grace-period-service.test.ts` 実行中）に握られており実行できなかった。CI (`test:storybook` job) での結果を正とする |

- [x] **SOLID / DRY / YAGNI**: mock data 生成は `mockData()` 1 関数に集約、既存 `+page.server.ts` load 戻り値と同型
- [x] **Security（OSS 公開前提）**: N/A（Storybook story のみ、秘密情報・実 API 呼び出しなし）
- [x] **A11y・パフォーマンス**: N/A（既存 `Alert` / `Button` primitive の表示確認のみ、新規 DOM 構造なし）
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

<!-- ss-render-impossible: portal-fallback-notice は Stripe が flow を拒否したときのみ描画され、撮影に使う demo 環境 (DATA_SOURCE=demo) では Stripe を叩けないため原理的に撮れない (#4161)。本 PR はその見た目を確認可能にするための story 追加そのものである -->

参照 story: `src/lib/features/admin/components/SaasLicensePanel.stories.svelte`（PortalFallbackCancel / Default の 2 状態）

**本番 UI の見た目・DOM は無変更**（追加したのは story のみ）のため before/after の差分は存在しない。

参照 story: （`PortalFallbackCancel` / `Default` の 2 状態）

**本番 UI の見た目・DOM は無変更**（追加したのは story のみ）のため before/after の差分は存在しない。

該当なし（本番 UI の変更を含まない。`portal-fallback-notice` の見た目は Storybook story `Admin/SaasLicensePanel` → `PortalFallbackCancel` で確認できる。story のスクリーンショットは撮影していない — Storybook 自体が本 PR の成果物であり、通知の見た目確認手段としては story を Storybook UI 上で開くことを想定している）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:

- `portalFallbackMessage` を確定的に再現する手段として `data.portalFallback = PORTAL_FALLBACK_CONTEXT.CANCEL`（解約フロー側、サーバー redirect 経由）を選んだ。プラン変更フロー側（`openPortal()` の fetch response 経由で `portalFallbackMessage` が立つ分岐）は fetch mock が要るため本 PR の story には含めていない。文言 (`SUBSCRIPTION_PAGE_LABELS.portalFallbackPlanChange`) は既に labels.ts に定義済みなので、fetch mock 付き story として同じ `mockData()` を土台に拡張できる
- storybook test をローカルで実行できていない（`heavy-run-lock` 競合）。CI 上の `test:storybook` job の結果を確認してほしい

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: N/A（Storybook story のみ、本番 UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)


