### PR TITLE
fix(stripe): #4286 PRICE_UNRESOLVED と STRIPE_DISABLED のエラー文言を分ける

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1247,6 +1247,7 @@ Stripe Checkout セッションを作成し、リダイレクト URL を返す�
 - **`getPlans().priceId`（env var 直読）を line_item に使わない**: 直読すると `USE_LOOKUP_KEY` がどの経路にも効かず、price env を注入しない配備で購入が必ず失敗する。`tests/unit/architecture/stripe-price-resolution-single-entrypoint.test.ts` が呼び出し構造を固定する
 - **エラーコード**: `STRIPE_DISABLED` / `TENANT_NOT_FOUND` (404) / `ALREADY_SUBSCRIBED` (409) / `INVALID_PLAN` (400) / **`PRICE_UNRESOLVED` (503)**
   - `PRICE_UNRESOLVED` が **503** なのは、**配備の設定不備であって顧客の入力誤りではない**ため。4xx で返すと顧客側の操作ミスに見え、原因が運用側にあることが隠れる
+  - `STRIPE_DISABLED`（決済機能自体が無効な配備）と `PRICE_UNRESOLVED`（lookup_key / env 双方から Price ID を解決できない設定不備）は **同一 503 だが文言を分ける**（#4286）。同一文言だと顧客が原因を区別できず離脱していたため。`PRICE_UNRESOLVED` の文言は `SUBSCRIPTION_PAGE_LABELS.checkoutErrorPriceUnresolved`（`src/lib/domain/labels.ts`、DESIGN.md §6 SSOT）を参照する。エラーレスポンス body は `{ message }` のみで機械可読なエラーコードは含まないため、両エラーは HTTP ステータス単体では判別できず、文言（または呼び出し元でのログ相関）でのみ判別できる
 
 #### POST /api/stripe/portal
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2773,6 +2773,12 @@ export const SUBSCRIPTION_PAGE_LABELS = {
 	// #3204: checkout 失敗時のユーザ向けフィードバック (silent no-op 撲滅)
 	checkoutFailed: '決済を開始できませんでした。時間をおいて再度お試しください',
 	checkoutFailedToastTitle: '決済を開始できませんでした',
+	// #4286: STRIPE_DISABLED (決済機能自体が無効な配備) と PRICE_UNRESOLVED (price ID 解決失敗という
+	// 別種の設定不備) が同一文言 ('決済機能は現在利用できません') だったため、顧客が「設定不備」と
+	// 「機能停止」を区別できず、再試行導線も無いまま離脱していた問題を是正。原因の内部詳細
+	// (price ID 未解決等) は出さず、次に取るべき行動だけを示す (ADR-0062、内部例外の非露出)。
+	checkoutErrorPriceUnresolved:
+		'ただいま決済の準備ができていません。時間をおいて再度お試しください',
 	// #4161: 決済が未設定の配備 (セルフホスト / 設定不備) でアップグレード操作を押したときの説明。
 	// 確認ダイアログを開いてから失敗させる dead-end を作らず、押した時点で理由を提示する。
 	billingUnavailable:

--- a/src/routes/api/stripe/checkout/+server.ts
+++ b/src/routes/api/stripe/checkout/+server.ts
@@ -3,6 +3,7 @@
 
 import { error, json } from '@sveltejs/kit';
 import { SUBSCRIPTION_PLAN } from '$lib/domain/constants/subscription-plan';
+import { SUBSCRIPTION_PAGE_LABELS } from '$lib/domain/labels';
 import { createCheckoutSession } from '$lib/server/services/stripe-service';
 import type { RequestHandler } from './$types';
 
@@ -69,7 +70,9 @@ export const POST: RequestHandler = async ({ request, locals, url }) => {
 			TENANT_NOT_FOUND: 'アカウントが見つかりません',
 			ALREADY_SUBSCRIBED: '既にサブスクリプションに加入済みです',
 			INVALID_PLAN: 'プランが正しくありません',
-			PRICE_UNRESOLVED: '決済機能は現在利用できません',
+			// #4286: STRIPE_DISABLED と同一文言だと「設定不備」か「機能停止」かを顧客が区別できず、
+			// 再試行導線も無いまま離脱していた。原因の内部詳細は出さず次の行動だけを示す (ADR-0062)。
+			PRICE_UNRESOLVED: SUBSCRIPTION_PAGE_LABELS.checkoutErrorPriceUnresolved,
 		};
 		error(statusMap[result.error] ?? 500, messageMap[result.error] ?? 'エラーが発生しました');
 	}

--- a/tests/unit/routes/api-stripe-checkout-error-messages.test.ts
+++ b/tests/unit/routes/api-stripe-checkout-error-messages.test.ts
@@ -1,0 +1,85 @@
+// tests/unit/routes/api-stripe-checkout-error-messages.test.ts
+// #4286: POST /api/stripe/checkout の messageMap で STRIPE_DISABLED と PRICE_UNRESOLVED が
+// 同一文言（「決済機能は現在利用できません」）だったため、顧客が「設定不備」か「機能停止」かを
+// 区別できず、再試行導線も無いまま離脱していた問題の回帰防止。
+//
+// 固定する不変条件:
+//   1. PRICE_UNRESOLVED と STRIPE_DISABLED は異なる文言を返す
+//   2. PRICE_UNRESOLVED の文言は SUBSCRIPTION_PAGE_LABELS.checkoutErrorPriceUnresolved
+//      (labels.ts SSOT) と一致する（ハードコード禁止、DESIGN.md §6）
+//   3. PRICE_UNRESOLVED の文言に price ID 等の内部詳細を含まない（ADR-0062、内部例外非露出）
+//   4. 両者とも status は 503（配備の設定不備であって顧客の入力誤りではない）
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SUBSCRIPTION_PAGE_LABELS } from '../../../src/lib/domain/labels';
+
+const mockCreateCheckoutSession = vi.fn();
+
+vi.mock('$lib/server/services/stripe-service', () => ({
+	createCheckoutSession: (...args: unknown[]) => mockCreateCheckoutSession(...args),
+}));
+
+import { POST } from '../../../src/routes/api/stripe/checkout/+server';
+
+function makeRequestEvent(errorCode: string) {
+	mockCreateCheckoutSession.mockResolvedValue({ error: errorCode });
+
+	const request = new Request('http://localhost/api/stripe/checkout', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({ planId: 'monthly' }),
+	});
+
+	return {
+		request,
+		url: new URL('http://localhost/api/stripe/checkout'),
+		locals: {
+			context: { role: 'owner', tenantId: 't-test' },
+		},
+	} as Parameters<typeof POST>[0];
+}
+
+/** POST が `error()` (SvelteKit HttpError) を throw する前提で、その中身を取り出す */
+async function catchHttpError(
+	errorCode: string,
+): Promise<{ status: number; body: { message: string } }> {
+	try {
+		await POST(makeRequestEvent(errorCode));
+	} catch (e) {
+		return e as { status: number; body: { message: string } };
+	}
+	throw new Error(`POST が例外を throw しなかった (errorCode=${errorCode})`);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('POST /api/stripe/checkout エラー文言 (#4286)', () => {
+	it('PRICE_UNRESOLVED は STRIPE_DISABLED と異なる文言を返す', async () => {
+		const priceUnresolved = await catchHttpError('PRICE_UNRESOLVED');
+		const stripeDisabled = await catchHttpError('STRIPE_DISABLED');
+
+		expect(priceUnresolved.body.message).not.toBe(stripeDisabled.body.message);
+	});
+
+	it('PRICE_UNRESOLVED は labels.ts SSOT (SUBSCRIPTION_PAGE_LABELS.checkoutErrorPriceUnresolved) の文言を 503 で返す', async () => {
+		const thrown = await catchHttpError('PRICE_UNRESOLVED');
+
+		expect(thrown.status).toBe(503);
+		expect(thrown.body.message).toBe(SUBSCRIPTION_PAGE_LABELS.checkoutErrorPriceUnresolved);
+	});
+
+	it('PRICE_UNRESOLVED の文言は内部詳細 (price ID 等) を含まない (ADR-0062)', async () => {
+		const thrown = await catchHttpError('PRICE_UNRESOLVED');
+
+		expect(thrown.body.message).not.toMatch(/price[_ ]?id/i);
+	});
+
+	it('STRIPE_DISABLED の文言・status は既存のまま変化しない (回帰防止)', async () => {
+		const thrown = await catchHttpError('STRIPE_DISABLED');
+
+		expect(thrown.status).toBe(503);
+		expect(thrown.body.message).toBe('決済機能は現在利用できません');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: `PRICE_UNRESOLVED`（price ID 解決失敗という配備の設定不備）と `STRIPE_DISABLED`（決済機能自体が無効な配備）が同一文言「決済機能は現在利用できません」を返していたため、顧客が「入力ミス／自分側の問題」なのか「サービス側の一時的な機能停止」なのかを区別できず、次に何をすればよいか（再試行してよいのか、問い合わせるべきか）が分からないまま離脱していた。

**期待される効果**: `PRICE_UNRESOLVED` に専用の文言を用意し、原因の内部詳細（price ID 未解決等）は出さず「時間をおいて再度お試しください」という次の行動だけを示す。`STRIPE_DISABLED` とは異なる文言になるため、両者を混同せず、少なくとも「再試行すればよい」ことが伝わる。

## 関連 Issue

<!-- QM follow-up: PR #4299 / #4310 の approve コメントで指摘された残課題。#4286 の番号付き AC ではなく、
     #4286 の checkout エラーハンドリング周辺で見つかった別種の顧客体験欠陥のため close しない -->
Refs #4286
<!-- no-issue-close: #4286 は AC5（staging 実機確認、deploy 後のオーナー操作待ち）が未完了で残っており、本 PR はその一部ではなく QM が別途指摘した文言 follow-up のため -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| QM-1 | `PRICE_UNRESOLVED` と `STRIPE_DISABLED` で異なる文言を返す | `npx vitest run tests/unit/routes/api-stripe-checkout-error-messages.test.ts` | 4 passed / `tests/unit/routes/api-stripe-checkout-error-messages.test.ts:60-64`（`PRICE_UNRESOLVED は STRIPE_DISABLED と異なる文言を返す`） |
| QM-2 | 文言は labels.ts SSOT 経由（ハードコード禁止、DESIGN.md §6） | `node scripts/check-hardcoded-strings.mjs` / `node scripts/check-no-plan-literals.mjs` | 両方 OK。`src/lib/domain/labels.ts` の `SUBSCRIPTION_PAGE_LABELS.checkoutErrorPriceUnresolved` を `src/routes/api/stripe/checkout/+server.ts:69` から参照 |
| QM-3 | 原因の内部詳細（price ID 等）を露出しない（ADR-0062） | `npx vitest run tests/unit/routes/api-stripe-checkout-error-messages.test.ts` | 4 passed / 同ファイル `PRICE_UNRESOLVED の文言は内部詳細 (price ID 等) を含まない (ADR-0062)` |
| QM-4 | `STRIPE_DISABLED` の既存文言・status は変更しない（回帰防止） | 同上 | 同ファイル `STRIPE_DISABLED の文言・status は既存のまま変化しない (回帰防止)` で固定。既存 `tests/e2e/integration/stripe-checkout-monthly-yearly.spec.ts` の STRIPE_DISABLED 文言アサーションは無変更 |

## 変更タイプ

- [x] fix: バグ修正

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `/admin/subscription` の決済開始（`POST /api/stripe/checkout`）で `PRICE_UNRESOLVED` エラーになった場合のエラーメッセージのみ。UI コンポーネント（`.svelte`）は変更していない。

- [x] N/A — 上記いずれも影響範囲外（`.ts` のみの文言修正。並行実装ペア / 5 年齢モード / ナビ / 設計書更新を要する変更ではない）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4319` | Step 9 (pr-body) / plan-literals / local-tz-getters / svelte-check / ss-embed-gate は PASS。Step 1 biome のみ本 clone 固有の CLI 既知事象 (`biome check --error-on-warnings .` がルート `.` 指定時のみ 0 ファイルヒットになり `src` 等サブパス指定では正常動作) で local 実行不能のため、下表の対象ファイル個別実行 PASS で代替し、CI の biome ジョブで最終確認する |
| biome | `npx biome check src/routes/api/stripe/checkout/+server.ts src/lib/domain/labels.ts tests/unit/routes/api-stripe-checkout-error-messages.test.ts` | PASS |
| hardcode 検出 | `node scripts/check-hardcoded-strings.mjs` | PASS（`[Svelte] Hardcoded JP text violations: 0 (baseline: 0)`） |
| plan literal 検出 | `node scripts/check-no-plan-literals.mjs` | PASS（`リテラル直書きなし`） |
| 型検査 | `npx tsc --noEmit -p tsconfig.json` | PASS（変更ファイルに関するエラーなし） |
| 追加テスト | `npx vitest run tests/unit/routes/api-stripe-checkout-error-messages.test.ts` | PASS（4 passed） |
| 既存関連テスト | `npx vitest run tests/unit/services/stripe-service.test.ts tests/unit/services/stripe-checkout-price-resolution.test.ts tests/unit/domain` | PASS（58 files / 1075 tests、当該 3 グループを含む全体実行結果） |

- [x] **SOLID / DRY / YAGNI**: 単一責任・依存性逆転を満たす / `grep -n "PRICE_UNRESOLVED\|STRIPE_DISABLED"` で同一ロジックの重複調査済（`portal/+server.ts` は `PRICE_UNRESOLVED` を持たないため対象外）/ 不要な抽象化なし
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし / 本変更はエラーメッセージ文言のみで OWASP Top 10 の境界に影響なし
- [x] **A11y・パフォーマンス**: 表示経路は既存の `error()` → エラーバナー描画を変更していないため N/A
- [x] **Critical バグ修正**(ADR-0002): 該当なし（`priority:critical` ラベルなし）。N/A

## スクリーンショット / ビジュアルデモ

該当なし（`.svelte` / `.css` を含まない `.ts` のみの変更 — エラーメッセージ文言の差し替えとテスト追加。`PRICE_UNRESOLVED` は price ID 未解決という配備設定不備でのみ発生し、通常の開発・demo 環境では再現できないため実機 SS は取得していない）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:
`PRICE_UNRESOLVED` の新文言（「ただいま決済の準備ができていません。時間をおいて再度お試しください」）が既存の類似文言（`checkoutFailed` 等）と語調が揃っているか確認をお願いします。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし、上記参照）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付 — N/A（認証画面変更なし）

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert のみ"]
    R2["顧客面: 課金エラー文言のみ"]
    R3["ロールバック: revert で完全に戻る"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 設定不備を機能停止と誤認させない"]
    T2["捨てる/負債: なし。文言 1 件追加のみ"]
  end
  subgraph OBJ["③ 反対理由 (未実施)"]
    O1["business: 未実施 (低リスクのため省略)"]
    O2["UX: 未実施 (低リスクのため省略)"]
    O3["security: 未実施 (低リスクのため省略)"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["PRICE_UNRESOLVED 発生時のみ文言差替。他フローは無変化"]
  end
  subgraph ASK["⑤ PO 判断依頼 (Yes/No で回答可能に、1〜3 個)"]
    Q1["Q1: この文言で承認してよいか?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3 ok
  class T2 warn
  class T1,C1 ok
  class Q1 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- Stripe API / 決済ロジックは変更していない。`src/routes/api/stripe/checkout/+server.ts` のエラーメッセージ文字列 1 件と `src/lib/domain/labels.ts` への SSOT 追加のみ (`po-decision:required` は `src/routes/api/stripe/**` パス一致による機械判定)。
- adversarial-reviewer (③) は低リスク・低影響のため本 PR では実施していない。必要なら QM / PO の指示で追記する。

</details>
