### PR TITLE
fix(billing): #4316 physical_deletion_date 欠落を「期限切れ」に倒すのをやめ、宙吊りから抜けられるようにする

### DIFF
--- a/docs/design/account-deletion-flow.md
+++ b/docs/design/account-deletion-flow.md
@@ -150,17 +150,35 @@ POST /api/v1/admin/account/delete  (pattern=owner-only / owner-full-delete)
 
 soft delete されたテナントは以下の状態になる:
 
-- `settings` テーブルに `soft_deleted_at` / `deletion_grace_plan_tier` / `physical_deletion_date` が記録される
+- `settings` テーブルに `physical_deletion_date` → `deletion_grace_plan_tier` → `soft_deleted_at` の順で記録される（**sentinel-last**）
 - Stripe Subscription は **即時にキャンセル**（grace 期間中に再課金されない / #741、§3 参照）
 - DB のテナント本体・children・activities 等は **保持**（復元のため）
 - ユーザはサインアウトされる（`window.location.href = '/auth/signout'`）が、再ログインすれば admin 画面で復元 UI を見られる
+
+#### 3 キーの書き込み順序と不完全メタデータの扱い
+
+`settings` の 3 キーは 1 キー 1 文の upsert で書かれ、まとめる txn は無い。よって**書き込み順序が不変条件を担保する**:
+
+| 操作 | 順序 | 途中失敗時に残る状態 |
+|---|---|---|
+| soft delete（記録） | `physical_deletion_date` → `deletion_grace_plan_tier` → **`soft_deleted_at`**（sentinel-last） | sentinel が立たない = soft-delete が始まっていない |
+| restore（クリア） | **`soft_deleted_at`** → `deletion_grace_plan_tier` → `physical_deletion_date`（sentinel-first） | sentinel が消えている = 復元済み |
+
+`soft_deleted_at` は soft-delete 状態を起動する sentinel（`getGracePeriodStatus` の早期 return と `hooks.server.ts` の読み取り専用ロック判定がこれだけを見る）。**sentinel を最後に立て、最初に降ろす**ことで、途中失敗はつねに「データを消さない側」に倒れる。
+
+**メタデータが不完全な行**（`physical_deletion_date` または `deletion_grace_plan_tier` が欠落・不正）は、`getGracePeriodStatus` が `metadataIncomplete: true` / `isExpired: false` を返す:
+
+- 「いつ消してよいか不明」を「もう消してよい」に写像しない（安全側 = データを消さない側）
+- **復元できる**（宙吊りからの脱出経路。復元 → 退会し直しで正常な状態に戻せる）
+- **物理削除の母集団に入らない**（`findExpiredSoftDeletedTenants`）
+- 発生は `logger.warn` で検出する（専用の通知機構は持たない）
 
 ### 4.4 復元フロー
 
 `POST /api/v1/admin/account/restore` (owner のみ):
 
-1. `getGracePeriodStatus` で grace 期限内であることを確認
-2. settings の 3 キー (`soft_deleted_at` / `deletion_grace_plan_tier` / `physical_deletion_date`) を空文字でクリア
+1. `getGracePeriodStatus` で grace 期限内であることを確認（メタデータ不完全な行は期限切れ扱いにせず復元を許す、§4.3）
+2. settings の 3 キーを `soft_deleted_at` → `deletion_grace_plan_tier` → `physical_deletion_date` の順（**sentinel-first**）で空文字にクリア
 3. テナント通常状態に戻る（次の admin/+layout.server.ts load で `gracePeriodStatus.isSoftDeleted=false`）
 
 > **Stripe 再購読について**: Stripe Subscription は grace 期間中にキャンセル済みのため、復元しても自動再購読されない。ユーザは `/pricing` から再度購読する必要がある（admin 画面で誘導する）。
@@ -169,7 +187,7 @@ soft delete されたテナントは以下の状態になる:
 
 `/api/cron/grace-period-deletion` が定期実行で `purgeExpiredSoftDeletedTenants` を呼ぶ:
 
-1. `findExpiredSoftDeletedTenants` で grace 期限切れのテナントを検出
+1. `findExpiredSoftDeletedTenants` で grace 期限切れのテナントを検出（メタデータ不完全な行は母集団に入らない、§4.3）
 2. 各テナントの owner を特定
 3. `deleteOwnerOnlyAccount` (他メンバーなし) または `deleteOwnerFullDelete` (他メンバーあり) で物理削除
 4. Pattern 2b の場合、他メンバーへ `sendMemberRemovedEmail` 通知

--- a/src/lib/server/services/grace-period-service.ts
+++ b/src/lib/server/services/grace-period-service.ts
@@ -177,10 +177,11 @@ export async function getGracePeriodStatus(tenantId: string): Promise<GracePerio
 		};
 	}
 
+	const storedPhysicalDeletionDate = values.physical_deletion_date ?? null;
 	const storedPlanTier = parseStoredPlanTier(values.deletion_grace_plan_tier);
 	const planTier = storedPlanTier ?? 'free';
 	const graceDays = DELETION_GRACE_PERIOD_DAYS[planTier];
-	const deleteDate = parseStoredDate(values.physical_deletion_date);
+	const deleteDate = parseStoredDate(storedPhysicalDeletionDate);
 
 	// #4316: メタデータが不完全なら「期限切れ」に倒さない (安全側 = データを消さない側)。
 	// 復元は許可し、物理削除の母集団には入れない (findExpiredSoftDeletedTenants)。
@@ -193,7 +194,7 @@ export async function getGracePeriodStatus(tenantId: string): Promise<GracePerio
 				context: {
 					tenantId,
 					softDeletedAt,
-					storedPhysicalDeletionDate: values.physical_deletion_date ?? null,
+					storedPhysicalDeletionDate,
 					storedPlanTier: values.deletion_grace_plan_tier ?? null,
 				},
 			},
@@ -221,7 +222,7 @@ export async function getGracePeriodStatus(tenantId: string): Promise<GracePerio
 		isSoftDeleted: true,
 		softDeletedAt,
 		gracePeriodDays: graceDays,
-		physicalDeletionDate: values.physical_deletion_date,
+		physicalDeletionDate: storedPhysicalDeletionDate,
 		daysRemaining,
 		isExpired,
 		planTier,

--- a/src/lib/server/services/grace-period-service.ts
+++ b/src/lib/server/services/grace-period-service.ts
@@ -202,7 +202,8 @@ export async function getGracePeriodStatus(tenantId: string): Promise<GracePerio
 		return {
 			isSoftDeleted: true,
 			softDeletedAt,
-			gracePeriodDays: storedPlanTier === null ? 0 : graceDays,
+			// tier 欠落時は planTier が 'free' にフォールバックするため graceDays は 0 になる。
+			gracePeriodDays: graceDays,
 			physicalDeletionDate: null,
 			daysRemaining: 0,
 			isExpired: false,

--- a/src/lib/server/services/grace-period-service.ts
+++ b/src/lib/server/services/grace-period-service.ts
@@ -46,6 +46,14 @@ export interface GracePeriodStatus {
 	daysRemaining: number;
 	isExpired: boolean;
 	planTier: PlanTier | null;
+	/**
+	 * #4316: soft-delete メタデータが不完全 (`physical_deletion_date` /
+	 * `deletion_grace_plan_tier` が欠落・不正) であることを示す。
+	 *
+	 * true のとき `isExpired` は必ず false になり (= 復元できる)、物理削除の母集団にも
+	 * 入らない。「いつ消してよいか不明」を「もう消してよい」に写像しないための旗。
+	 */
+	metadataIncomplete: boolean;
 }
 
 export interface RestoreResult {
@@ -92,10 +100,22 @@ export async function softDeleteTenant(
 
 	// Soft delete state is stored in settings table (not Tenant entity)
 	// to avoid schema migration on DynamoDB.
+	//
+	// #4316: **sentinel-last** — 書き込み順序で「宙吊り」の成立を防ぐ。
+	// `setSetting` は 1 キー 1 文の upsert (dsql/settings-repo.ts) で、3 キーをまとめる
+	// txn は settings repo に無い。したがって途中失敗 (Lambda timeout / DSQL OCC 40001 /
+	// 接続断) は起こりうる前提で順序を決める。
+	//
+	// `soft_deleted_at` は soft-delete 状態を起動する sentinel である
+	// (getGracePeriodStatus の早期 return と hooks.server.ts の読み取り専用ロック判定が
+	// これだけを見る)。これを **最後に** 書けば、途中で失敗しても残るのは
+	// 「sentinel が立っていない = soft-delete が始まっていない」状態だけになり、
+	// 「ロックはかかるが物理削除の母集団に入らない」宙吊りが成立しない。
+	// 逆に先に書くと (旧実装)、1 本目成功 + 3 本目失敗がそのまま宙吊りになる。
 	const repos = getRepos();
-	await repos.settings.setSetting('soft_deleted_at', softDeletedAt, tenantId);
-	await repos.settings.setSetting('deletion_grace_plan_tier', planTier, tenantId);
 	await repos.settings.setSetting('physical_deletion_date', physicalDeletionDate, tenantId);
+	await repos.settings.setSetting('deletion_grace_plan_tier', planTier, tenantId);
+	await repos.settings.setSetting('soft_deleted_at', softDeletedAt, tenantId);
 
 	logger.info('[grace-period] Tenant soft deleted', {
 		context: { tenantId, planTier, graceDays, physicalDeletionDate },
@@ -114,8 +134,27 @@ export async function softDeleteTenant(
 // Grace period status
 // ============================================================
 
+/** 保存済み ISO 文字列を Date にする。未設定 / 空文字 / パース不能は null。 */
+function parseStoredDate(value: string | undefined | null): Date | null {
+	if (!value) return null;
+	const parsed = new Date(value);
+	return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/** 保存済みプランティアを検証する。未設定 / 未知の値は null。 */
+function parseStoredPlanTier(value: string | undefined | null): PlanTier | null {
+	if (!value) return null;
+	return value in DELETION_GRACE_PERIOD_DAYS ? (value as PlanTier) : null;
+}
+
 /**
  * テナントのグレースピリオド状態を取得する。
+ *
+ * #4316: `physical_deletion_date` / `deletion_grace_plan_tier` が欠落している行
+ * (softDeleteTenant の部分書き込みで成立しうる) は「期限切れ」ではなく
+ * 「メタデータ不完全」として扱い、復元を許す。旧実装は欠落時に `deleteDate = now`
+ * へフォールバックしていたため `now >= now` が恒真となり、復元が恒久拒否される一方で
+ * 物理削除の母集団にも入らない「宙吊り」を作っていた。
  */
 export async function getGracePeriodStatus(tenantId: string): Promise<GracePeriodStatus> {
 	const repos = getRepos();
@@ -134,15 +173,44 @@ export async function getGracePeriodStatus(tenantId: string): Promise<GracePerio
 			daysRemaining: 0,
 			isExpired: false,
 			planTier: null,
+			metadataIncomplete: false,
 		};
 	}
 
-	const planTier = (values.deletion_grace_plan_tier as PlanTier) ?? 'free';
+	const storedPlanTier = parseStoredPlanTier(values.deletion_grace_plan_tier);
+	const planTier = storedPlanTier ?? 'free';
 	const graceDays = DELETION_GRACE_PERIOD_DAYS[planTier];
-	const physicalDeletionDate = values.physical_deletion_date ?? null;
+	const deleteDate = parseStoredDate(values.physical_deletion_date);
+
+	// #4316: メタデータが不完全なら「期限切れ」に倒さない (安全側 = データを消さない側)。
+	// 復元は許可し、物理削除の母集団には入れない (findExpiredSoftDeletedTenants)。
+	// 顧客は復元 → 退会し直しで正常な状態に復帰でき、宙吊りから抜けられる。
+	if (deleteDate === null || storedPlanTier === null) {
+		// 既存のログ経路に載せて検出可能にする (新規の通知機構は作らない)。
+		logger.warn(
+			'[grace-period] soft-delete metadata incomplete (physical_deletion_date / deletion_grace_plan_tier); treating as NOT expired',
+			{
+				context: {
+					tenantId,
+					softDeletedAt,
+					storedPhysicalDeletionDate: values.physical_deletion_date ?? null,
+					storedPlanTier: values.deletion_grace_plan_tier ?? null,
+				},
+			},
+		);
+		return {
+			isSoftDeleted: true,
+			softDeletedAt,
+			gracePeriodDays: storedPlanTier === null ? 0 : graceDays,
+			physicalDeletionDate: null,
+			daysRemaining: 0,
+			isExpired: false,
+			planTier: storedPlanTier,
+			metadataIncomplete: true,
+		};
+	}
 
 	const now = new Date();
-	const deleteDate = physicalDeletionDate ? new Date(physicalDeletionDate) : now;
 	const daysRemaining = Math.max(
 		0,
 		Math.ceil((deleteDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)),
@@ -153,10 +221,11 @@ export async function getGracePeriodStatus(tenantId: string): Promise<GracePerio
 		isSoftDeleted: true,
 		softDeletedAt,
 		gracePeriodDays: graceDays,
-		physicalDeletionDate,
+		physicalDeletionDate: values.physical_deletion_date,
 		daysRemaining,
 		isExpired,
 		planTier,
+		metadataIncomplete: false,
 	};
 }
 
@@ -189,6 +258,10 @@ export async function restoreSoftDeletedTenant(tenantId: string): Promise<Restor
 
 	// ソフトデリート情報をクリア
 	// Empty string = unset (deleteSetting が存在しないため)
+	//
+	// #4316: **sentinel-first** — クリアは sentinel (`soft_deleted_at`) から消す。
+	// 途中で失敗しても残るのは「sentinel が消えている = 復元済み」状態であり、
+	// 安全側 (データを消さない側) に倒れる。set 側の sentinel-last と対になる。
 	const repos = getRepos();
 	await repos.settings.setSetting('soft_deleted_at', '', tenantId);
 	await repos.settings.setSetting('deletion_grace_plan_tier', '', tenantId);
@@ -225,7 +298,15 @@ export async function findExpiredSoftDeletedTenants(): Promise<
 
 	for (const tenant of allTenants) {
 		const status = await getGracePeriodStatus(tenant.tenantId);
-		if (status.isSoftDeleted && status.isExpired && status.physicalDeletionDate) {
+		// #4316: `metadataIncomplete` を明示的に除外する。`isExpired === false` /
+		// `physicalDeletionDate === null` でも既に除外されるが、「いつ消してよいか不明な行は
+		// 物理削除しない」という意図をこの条件で読めるようにしておく (多重防御)。
+		if (
+			status.isSoftDeleted &&
+			status.isExpired &&
+			status.physicalDeletionDate &&
+			!status.metadataIncomplete
+		) {
 			expired.push({
 				tenantId: tenant.tenantId,
 				planTier: status.planTier ?? 'free',

--- a/tests/unit/services/grace-period-service.test.ts
+++ b/tests/unit/services/grace-period-service.test.ts
@@ -71,6 +71,7 @@ vi.mock('$lib/server/logger', () => ({
 	},
 }));
 
+import { logger } from '$lib/server/logger';
 import {
 	DELETION_GRACE_PERIOD_DAYS,
 	findExpiredSoftDeletedTenants,
@@ -159,6 +160,22 @@ describe('grace-period-service', () => {
 			expect(result.gracePeriodDays).toBe(30);
 			expect(result.requiresImmediateDeletion).toBe(false);
 		});
+
+		// #4316: sentinel-last 書き込み順序
+		// 3 キーの setSetting は非原子 (settings repo に txn は無く、setSetting は 1 キー 1 文の
+		// upsert)。`soft_deleted_at` は soft-delete 状態を起動する sentinel なので **最後に**
+		// 書く。途中で失敗しても「soft-delete が始まっていない」状態にしかならず、
+		// 「ロックはかかるが物理削除の母集団に入らない」宙吊りが成立しない。
+		it('#4316: sentinel である soft_deleted_at を最後に書く (途中失敗で宙吊りを作らない)', async () => {
+			await softDeleteTenant('tenant-1', 'active', 'family-monthly');
+
+			const writtenKeys = mockSetSetting.mock.calls.map((call) => call[0]);
+			expect(writtenKeys).toEqual([
+				'physical_deletion_date',
+				'deletion_grace_plan_tier',
+				'soft_deleted_at',
+			]);
+		});
 	});
 
 	// ============================================================
@@ -242,6 +259,90 @@ describe('grace-period-service', () => {
 			const result = await restoreSoftDeletedTenant('tenant-1');
 
 			expect(result.success).toBe(false);
+		});
+	});
+
+	// ============================================================
+	// #4316: physical_deletion_date 欠落時の宙吊り
+	//
+	// 欠落を「期限切れ」に倒すと、復元は恒久拒否される一方 (isExpired 恒真) で
+	// 物理削除の母集団にも入らない (`&& status.physicalDeletionDate`) ため、
+	// 「復元できないが物理削除もされない」状態から抜ける経路が 1 本も無くなる。
+	// 安全側 = データを消さない側 = 復元を許す側に倒す。
+	// ============================================================
+
+	describe('#4316: physical_deletion_date 欠落 (soft_deleted_at のみ立った部分書き込み)', () => {
+		/** soft_deleted_at と plan tier だけが書かれた宙吊り行を作る */
+		function seedLimboTenant(physicalDeletionDate?: string) {
+			settingsStore.set('soft_deleted_at', new Date(Date.now() - 86400000).toISOString());
+			settingsStore.set('deletion_grace_plan_tier', 'family');
+			if (physicalDeletionDate !== undefined) {
+				settingsStore.set('physical_deletion_date', physicalDeletionDate);
+			}
+		}
+
+		it('欠落している行を期限切れ扱いにしない', async () => {
+			seedLimboTenant();
+
+			const result = await getGracePeriodStatus('tenant-limbo');
+
+			expect(result.isSoftDeleted).toBe(true);
+			expect(result.isExpired).toBe(false);
+			expect(result.metadataIncomplete).toBe(true);
+			expect(result.physicalDeletionDate).toBeNull();
+		});
+
+		it('空文字 / パース不能な値も欠落として扱う', async () => {
+			seedLimboTenant('not-a-date');
+
+			const result = await getGracePeriodStatus('tenant-limbo');
+
+			expect(result.isExpired).toBe(false);
+			expect(result.metadataIncomplete).toBe(true);
+			expect(result.physicalDeletionDate).toBeNull();
+		});
+
+		it('deletion_grace_plan_tier が欠落している場合も期限切れ扱いにしない', async () => {
+			const pastDate = new Date(Date.now() - 5 * 86400000).toISOString();
+			settingsStore.set('soft_deleted_at', new Date(Date.now() - 35 * 86400000).toISOString());
+			settingsStore.set('physical_deletion_date', pastDate);
+
+			const result = await getGracePeriodStatus('tenant-limbo');
+
+			expect(result.isExpired).toBe(false);
+			expect(result.metadataIncomplete).toBe(true);
+		});
+
+		it('欠落している行は復元できる (宙吊りからの脱出経路が存在する)', async () => {
+			seedLimboTenant();
+
+			const result = await restoreSoftDeletedTenant('tenant-limbo');
+
+			expect(result.success).toBe(true);
+			expect(mockSetSetting).toHaveBeenCalledWith('soft_deleted_at', '', 'tenant-limbo');
+			expect(mockSetSetting).toHaveBeenCalledWith('physical_deletion_date', '', 'tenant-limbo');
+		});
+
+		it('欠落している行は物理削除の母集団に入らない (安全側を維持)', async () => {
+			seedLimboTenant();
+			mockListAllTenants.mockResolvedValue([{ tenantId: 'tenant-limbo' }]);
+
+			const result = await findExpiredSoftDeletedTenants();
+
+			expect(result).toHaveLength(0);
+		});
+
+		it('欠落を検出できるよう warn ログを出す (新規通知機構は作らない)', async () => {
+			seedLimboTenant();
+
+			await getGracePeriodStatus('tenant-limbo');
+
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('physical_deletion_date'),
+				expect.objectContaining({
+					context: expect.objectContaining({ tenantId: 'tenant-limbo' }),
+				}),
+			);
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者）

**解決する課題**: 退会（soft-delete）した家庭の `settings.physical_deletion_date` が欠落すると、**退会を取り消すこともできず、退会が完了することもない**状態で固定される。読み取り専用ロックだけは効き続けるため、その家庭は子供の記録も残せない。抜ける経路が 1 本も無い。

**期待される効果**: メタデータが欠落した行でも**復元できる**ようになり、復元 → 退会し直しで正常な状態に戻せる。あわせて、そもそも欠落行が新しく作られない書き込み順序にする。

## 関連 Issue

Closes #4316

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `physical_deletion_date` 欠落（空文字 / パース不能を含む）の soft-delete 行に対し `getGracePeriodStatus` が `isExpired: false` を返す | `npx vitest run tests/unit/services/grace-period-service.test.ts` — 「欠落している行を期限切れ扱いにしない」「空文字 / パース不能な値も欠落として扱う」「deletion_grace_plan_tier が欠落している場合も期限切れ扱いにしない」 | PASS（修正前は 3 件とも FAIL、下記「failing-test-first 証跡」） |
| AC2 | 上記 1 の行に対し `restoreSoftDeletedTenant` が成功し soft-delete 情報がクリアされる | 同上 — 「欠落している行は復元できる (宙吊りからの脱出経路が存在する)」 | PASS（修正前 FAIL: `expected false to be true`） |
| AC3 | 上記 1 の行は `findExpiredSoftDeletedTenants` の母集団に入らない（物理削除されない） | 同上 — 「欠落している行は物理削除の母集団に入らない (安全側を維持)」 | PASS（修正前後とも PASS。既存の安全側挙動を壊さないための回帰ガード。実装側は `!status.metadataIncomplete` を明示条件に追加し多重防御） |
| AC4 | 欠落を既存のログ経路で検出できる（新規の通知機構は作らない） | 同上 — 「欠落を検出できるよう warn ログを出す (新規通知機構は作らない)」 | PASS（修正前 FAIL: `Number of calls: 0`）。既存 `logger.warn` に載せるのみで、通知機構・cron・alert 定義の新設なし |
| AC5 | `softDeleteTenant` の非原子的な 3 連 `setSetting` に対処する（できない場合は理由を明記） | 同上 — 「sentinel である soft_deleted_at を最後に書く (途中失敗で宙吊りを作らない)」 | PASS（修正前 FAIL）。**対処した**（sentinel-last、下記「非原子性への対処」） |
| AC6 | 正常系（`physical_deletion_date` あり）の期限判定 / 復元 / 物理削除母集団が変わらない | `npx vitest run tests/unit/services/grace-period-service.test.ts tests/unit/routes/withdrawal-readonly-lock.test.ts` | PASS（32 passed / 32）。既存 21 件は本 PR で 1 件も変更していない（`git diff` 上、既存 `it` ブロックへの変更なし）。`withdrawal-readonly-lock.test.ts` の L2/L3（期限内 / 期限切れ判定）も不変 |
| AC7 | failing-test-first: 欠落状態の再現テストを先に書き、修正前 fail・修正後 pass を証跡に残す | 下記「failing-test-first 証跡」 | PASS（test 先行コミット `f70dfa75a` → 修正コミット `e0a286f2f` の 2 コミット構成） |

### failing-test-first 証跡（ADR-0061）

テストのみのコミット `f70dfa75a` 時点で `npx vitest run tests/unit/services/grace-period-service.test.ts` を実行:

```
Tests  6 failed | 21 passed (27)

FAIL > softDeleteTenant > #4316: sentinel である soft_deleted_at を最後に書く (途中失敗で宙吊りを作らない)
FAIL > #4316: physical_deletion_date 欠落 ... > 欠落している行を期限切れ扱いにしない
FAIL > #4316: physical_deletion_date 欠落 ... > 空文字 / パース不能な値も欠落として扱う
FAIL > #4316: physical_deletion_date 欠落 ... > deletion_grace_plan_tier が欠落している場合も期限切れ扱いにしない
FAIL > #4316: physical_deletion_date 欠落 ... > 欠落している行は復元できる (宙吊りからの脱出経路が存在する)
FAIL > #4316: physical_deletion_date 欠落 ... > 欠落を検出できるよう warn ログを出す (新規通知機構は作らない)
```

修正コミット `e0a286f2f` 適用後、同コマンド + `withdrawal-readonly-lock.test.ts`:

```
Test Files  2 passed (2)
     Tests  32 passed (32)
```

新規 7 件のうち「物理削除の母集団に入らない」1 件のみ修正前から PASS（既存の安全側挙動の回帰ガード）、残り 6 件が fail → pass。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

### 何が壊れていたか（`src/lib/server/services/grace-period-service.ts`）

1. **欠落を「期限切れ」に倒していた**: `deleteDate = physicalDeletionDate ? new Date(...) : now` のフォールバックにより `now >= now` が成立し `isExpired` が恒真になる
2. **その結果、復元が恒久拒否される**: `restoreSoftDeletedTenant` は `isExpired` で早期 return する
3. **一方で物理削除の母集団にも入らない**: `findExpiredSoftDeletedTenants` が `&& status.physicalDeletionDate` で除外する

2 と 3 が同時に成立するため、抜ける経路が無い。`hooks.server.ts` の読み取り専用ロックは `soft_deleted_at` だけを見るため効き続ける。

**根本原因**: 「値が無い」を「期限が切れた」に写像している（不明 → 危険側）。安全側 = データを消さない側 = 復元を許す側に倒すべきところが逆に倒れていた。

### 非原子性（3 連 `setSetting`）への対処 — 対処した

`softDeleteTenant` の 3 キー書き込みは非原子である（`setSetting` は 1 キー 1 文の upsert、`src/lib/server/db/dsql/settings-repo.ts`。3 キーをまとめる txn は settings repo に存在しない）。Lambda timeout / DSQL の OCC 競合（`40001`）/ 接続断のいずれでも途中失敗しうる。

**書き込み順序を変えて対処した（sentinel-last）**。`soft_deleted_at` は soft-delete 状態を起動する sentinel であり、`getGracePeriodStatus` の早期 return と `hooks.server.ts` の読み取り専用ロック判定はこれだけを見る。

| 操作 | 順序 | 途中失敗時に残る状態 |
|---|---|---|
| soft delete（記録） | `physical_deletion_date` → `deletion_grace_plan_tier` → **`soft_deleted_at`** | sentinel が立たない = soft-delete が始まっていない（宙吊りが成立しない） |
| restore（クリア） | **`soft_deleted_at`** → `deletion_grace_plan_tier` → `physical_deletion_date` | sentinel が消えている = 復元済み |

旧実装は sentinel を**先に**書いていたため、1 本目成功 + 3 本目失敗がそのまま宙吊りになっていた。restore 側のクリア順序は既存で既に sentinel-first だったため、コードは変えず意図をコメントで明文化した。

これにより **DSQL の OCC に触れずに済む**（トランザクション境界を新設しないため、既存の retry 機構との整合を崩さない）。

### 採らなかった案

| 案 | 不採用の理由 |
|---|---|
| `settings` の 3 キーを単一 JSON カラムに統合 | **スキーマ変更（不可逆操作）**。Issue の scope 外として明示。順序変更で同じ不変条件が担保でき、必要性が無い |
| 3 キーを 1 txn で書く（`setSettings` bulk API 新設） | `ISettingsRepo` の変更が 4 backend 実装（dsql / sqlite / demo / 集約）に波及し blast radius が大きい。sentinel 順序で不変条件は担保済で、追加の複雑さに見合わない |
| 宙吊り行を補正する定期ジョブ新設（#4088 AC 案 1 の後段） | 読み取り側を安全側に倒せば宙吊りは解消するため不要。cron を 1 本増やすのは Pre-PMF で過剰（ADR-0010） |
| 欠落時に `soft_deleted_at + graceDays` から削除日を再構成する | 一見できるが、`deletion_grace_plan_tier` も欠落しうる（同じ部分書き込み）ため常に再構成できるわけではない。再構成日が既に過ぎていれば結局復元を拒否することになり、「復元を許す」という Issue の要求を満たさない |

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `/admin`（`+layout.server.ts` の `gracePeriodStatus`）、`GET /api/v1/admin/account/grace-status`、`POST /api/v1/admin/account/restore`、`POST /api/cron/grace-period-deletion`、`hooks.server.ts` の読み取り専用ロック。いずれも**正常系の挙動は不変**で、メタデータ欠落行の扱いのみが変わる。

`GracePeriodStatus` に `metadataIncomplete` を追加したが、この型を**構築する箇所は service 内のみ**（`grep -rn "GracePeriodStatus" src/ tests/` で確認、他は全て読み取り）。既存フィールドの意味・型は変えていないため呼び出し側の破壊的変更なし。

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル） — いずれも該当なし（server service 層のみ、UI 文言・年齢モード・seed に触れない）
- [x] **設計書同期** (ADR-0001): `docs/design/account-deletion-flow.md` §4.3 に書き込み順序表と不完全メタデータの扱いを追加、§4.4 / §4.5 の参照を同期
- [x] **LP ↔ アプリ整合** (ADR-0013): LP 記載に影響なし
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — `tests/e2e/grace-period-soft-delete.spec.ts` / `cron-grace-period-deletion.spec.ts` は正常系のみを検証しており本 PR で挙動が変わらない。CI の e2e レーンに委ねる
- [ ] N/A — 上記いずれも影響範囲外

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4321` | PASS（全 step） |
| 追加・変更テスト | `npx vitest run tests/unit/services/grace-period-service.test.ts tests/unit/routes/withdrawal-readonly-lock.test.ts` | PASS（32 passed / 32） |

- [x] **SOLID / DRY / YAGNI**: 判定を `getGracePeriodStatus` の 1 箇所に集約（`restore` / `findExpired` は同じ status を読む）。パース処理は `parseStoredDate` / `parseStoredPlanTier` の 2 ヘルパに集約。新規の抽象化・依存追加なし
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。`logger.warn` の context に出るのは `tenantId` と settings の値（日付文字列 / プランティア）のみで PII なし。**安全側の変更**（削除しない方向）であり、認可境界（`hooks.server.ts` のロックは `isSoftDeleted` を見る）は不変
- [x] **A11y・パフォーマンス**: UI 変更なし。クエリ本数は不変（`getSettings` 1 回）。欠落行では早期 return するため僅かに減る
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:high`、`priority:critical` ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（backend / test のみ）** — 変更は `src/lib/server/services/grace-period-service.ts`（server service 層）と unit test、設計書のみで、`.svelte` ファイルおよび UI 描画への変更を一切含まない。

<!-- ss-pair-none: backend service 層と unit test のみの変更で UI 描画差分が存在しないため -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **本番に該当行が実在するかは未確認**（本番 DB を参照しない方針のため）。「実在する」とは主張していない。あわせて、**#4311 の dryRun 0 件は宙吊り行の不在の証明にならない** — `findExpiredSoftDeletedTenants` の `&& status.physicalDeletionDate` により、宙吊り行は原理的に母集団から除外され dryRun には現れない。本 PR は「欠落経路が実在する（非原子な 3 連書き込み）」ことのみを根拠にしている
2. `deletion_grace_plan_tier` の欠落・不正値も `metadataIncomplete` に含め `isExpired: false` に倒した点。`physical_deletion_date` が有効ならそちらが権威なので `isExpired` を判定できる、という解釈も成り立つ。ただし tier 欠落は同じ部分書き込みの帰結であり「メタデータが不完全なら消さない」の一貫したルールにする方を採った
3. 宙吊り行は物理削除の母集団に入らないため、放置すれば残り続ける。復元 → 退会し直しという**脱出経路**と `logger.warn` による**検出可能性**でこれを扱い、自動補正 cron は新設していない（ADR-0010）

**脱出経路が実際に到達可能であることの確認**: 宙吊り行は `isSoftDeleted: true` のままなので `hooks.server.ts` の読み取り専用ロックは効き続ける（これは正しい — 実際に退会申請中である）。その状態で復元 API を叩けることが脱出の前提になるため確認したところ、`src/hooks.server.ts` L586-592 の書き込み許可リストに `/api/v1/admin/account/restore` が含まれており、ロック中でも復元要求は 403 にならない。よって本 PR の「復元できる」は API 層でも実際に到達可能。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)

