### PR TITLE
fix(security): #4309 /ops 配下の API に ops 認可を適用し、適用範囲を fitness function で機械強制する

### DIFF
--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1434,8 +1434,13 @@ readiness probe（shallow、#3657）。**プロセスが HTTP を受けられる
 
 ### 3.16 運営管理ダッシュボード（#0176 / #820 / ADR-0033）
 
-> `/ops` 配下は **Cognito User Pool の `ops` group メンバーのみがアクセス可能**（#820 / ADR-0033）。
-> 非メンバーは 403 Forbidden。実装は `src/routes/ops/+layout.server.ts` が `isOpsMember(locals.identity)` で判定する。
+> `/ops` 配下は **Cognito User Pool の `ops` group メンバー かつ MFA 済のみがアクセス可能**（#820 / #4266）。
+> 非メンバーは 403 Forbidden。判定は `src/lib/server/auth/ops-authz.ts` の `requireOpsAccess(locals)` に集約する。
+>
+> **API endpoint（`+server.ts`）は自分で `requireOpsAccess(locals)` を呼ぶこと（#4309）**。`+layout.server.ts` の gate は
+> page の load にしか適用されず `+server.ts` には走らないため、呼ばない endpoint は**認可ゼロで外部公開される**
+> （実害: `GET /ops/export?type=sales` が未認証で 200 + 売上台帳 CSV を返していた）。適用範囲は
+> `tests/unit/architecture/ops-route-auth-fitness.test.ts` が FS 列挙で機械強制する。詳細は 14-セキュリティ設計書 §5.2.9。
 >
 > 旧 `OPS_SECRET_KEY` Bearer token / `ops_token` Cookie / URL token 認証はすべて廃止済み。
 > なお `/api/cron/retention-cleanup` / `/api/cron/license-expire` は EventBridge から呼ばれる別経路のため、独自の shared secret

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -532,13 +532,15 @@ client 供給の opaque id（Cookie / POST form-field / URL param）は、uuid �
 | セッション保持 | ログイン時に確定した MFA を **context token（署名付き、`context-token.ts`）の `mfaAuthenticated` claim** に焼き込み、`hasOpsAccess(identity, context)` が token 側と OR で判定する。silent refresh（`REFRESH_TOKEN_AUTH`）で再発行される ID token が `amr` を保持するかは AWS 公式ドキュメントで確定できないため、identity 側だけで判定すると運営者が無操作で締め出される。**claim が載っていない旧トークンは `undefined` = 拒否側**（fail-closed） |
 | 判定不能時 | **拒否**（`mfaAuthenticated` が `undefined` = 旧トークン / claim 欠落でも通さない、fail-closed） |
 | 拒否時の応答 | ops group には居るが MFA で落ちた場合のみ `403 Forbidden: ops access requires MFA`。それ以外は `403 Forbidden`（非 ops に ops group の存在を示唆しない） |
-| 強制箇所 | `src/routes/ops/+layout.server.ts`（403）/ policy 層 `capabilities.ts` `access.ops_dashboard`・`view.ops_license_dashboard`（`ops-mfa-required`） |
+| 強制箇所 | `requireOpsAccess(locals)`（`ops-authz.ts`）を **page（`src/routes/ops/+layout.server.ts`）と API（`src/routes/ops/**/+server.ts`）の両方**が呼ぶ / policy 層 `capabilities.ts` `access.ops_dashboard`・`view.ops_license_dashboard`（`ops-mfa-required`） |
 | Cognito 側 | user pool は `mfa: OPTIONAL` のまま（**顧客に MFA を強制しない**）。運営者だけがアプリ層で MFA を要求される |
 
 - **IP allowlist を置かない理由**: 遮断対象に `/admin`（保護者 = 顧客の見守り画面）が含まれると全顧客が 403 になる。また運営者のグローバル IP は固定でなく、プロキシ経由では CloudFront が見る viewer IP が運営者の回線 IP と一致しない。
 - **この設計で守らないもの**: 未認証の第三者が `/ops` の URL に**到達すること自体**は防がない（到達しても認可で 403 になる）。
 - **運用上の注意**: MFA の再確認が必要になるのは **context token の TTL 切れ**（owner = 24 時間、`CONTEXT_TTL`）で再発行されたときである。その時点の ID token に `amr` が無ければ `/ops` は拒否され、**再ログインで復帰する**。応答メッセージで MFA が理由であることが分かる。
-- **fitness function**: `tests/unit/routes/ops-mfa-guard.test.ts`（ops group のみ / MFA 不明 → 403）+ `tests/unit/infra/admin-no-ip-allowlist.test.ts`（CloudFront Function に `/admin` `/ops` の遮断・IP 照合が再混入しないこと）。
+- **`+layout.server.ts` は API を守らない（#4309）**: SvelteKit の `+layout.server.ts` は page の load にしか適用されず `+server.ts` には走らない。したがって `/ops` 配下の endpoint は**各自が `requireOpsAccess(locals)` を呼ぶ**。呼ばない endpoint は認可ゼロで外部公開される。認可はクエリ解釈・集計より**前**に置く（後に置くと 403 を返しても集計は走る）。
+- **認可層が `/ops` を通す理由（#4309）**: `authorizeCognito` の `isPublicRoute` は `/ops` を通過させるが、これは「認証不要」ではなく **「認証の担い手が route 側にある」**（`/api/cron/` と同型）。認可層の `RouteRule.roles` は owner / parent / child の 3 値しか持たず Cognito group も MFA も表現できないため、ここから外すと「認証済みの任意のテナントメンバーが通り、ライセンス期限切れの運営者は締め出される」という逆の結果になる。境界は `/ops` 完全一致 + `/ops/` に限定する（`/opsedit` 等の別 route を巻き込まない）。
+- **fitness function**: `tests/unit/routes/ops-mfa-guard.test.ts`（ops group のみ / MFA 不明 → 403、述語の真理値表）+ **`tests/unit/architecture/ops-route-auth-fitness.test.ts`（`/ops/**/+server.ts` を FS 列挙し全件が `requireOpsAccess` を呼ぶこと = 適用範囲。#4309、`cron-route-auth-fitness.test.ts` と対の装置）** + `tests/unit/routes/ops-export-authz.test.ts`（`/ops/export` の 3 type × 未認証 / 非 ops / MFA 未済 → 403 かつ service 未到達）+ `tests/unit/infra/admin-no-ip-allowlist.test.ts`（CloudFront Function に `/admin` `/ops` の遮断・IP 照合が再混入しないこと）。**述語の真理値表だけでは適用範囲の穴を検出できない**（#4309 はまさにそれで見逃した）。
 
 ### 5.3 ライセンス状態による制限
 

--- a/playwright.cognito-dev.config.ts
+++ b/playwright.cognito-dev.config.ts
@@ -4,6 +4,16 @@
 
 import { defineConfig, devices } from '@playwright/test';
 
+/**
+ * dev server の port。既定は 5174 (CI / 単独作業ではこれを使う)。
+ *
+ * #4309: `reuseExistingServer` が有効なため、**別の worktree が 5174 を掴んでいると
+ * そちらのコードに対して test が走る**。並列 Agent 環境では「修正済みのはずが fail する」
+ * (実測: 未認証 403 を期待した spec が他 worktree の未修正 server に当たり 200 で fail) という
+ * 原因の分かりにくい偽 fail になるため、port を env で逃がせるようにする。
+ */
+const PORT = Number(process.env.E2E_COGNITO_PORT ?? 5174);
+
 export default defineConfig({
 	testDir: 'tests/e2e',
 	// #776: plan-gated-features spec も cognito-dev モードでのみ実行可能
@@ -22,8 +32,10 @@ export default defineConfig({
 	// #1535: upgrade-checkout を tests/e2e/integration/ に移動
 	// #2346 / #2347 (EPIC #2345): stripe-checkout-labels / stripe-checkout-monthly-yearly を追加
 	//   (景表法対応 + 月額/年額切替 + 年額表示強化、test.use({ storageState: 'playwright/.auth/free.json' }) 使用)
+	// #4309: ops-export-authz を追加（/ops 配下 API の認可を実 HTTP 経路で回帰検証。
+	//   未認証 / 非 ops → 403、ops → 認可通過。cognito-dev でないと ops group を再現できない）
 	testMatch:
-		/(cognito-auth|plan-gated-features|plan-standard|plan-family|plan-free|premium-welcome|trial-flow|ops-license|ops-license-issue|upgrade-flow|pricing-page-signup|trial-banner-display|account-deletion|notification-permission-banner|parent-gate|integration\/upgrade-checkout|integration\/stripe-checkout-labels|integration\/stripe-checkout-monthly-yearly)\.spec\.ts$/,
+		/(cognito-auth|ops-export-authz|plan-gated-features|plan-standard|plan-family|plan-free|premium-welcome|trial-flow|ops-license|ops-license-issue|upgrade-flow|pricing-page-signup|trial-banner-display|account-deletion|notification-permission-banner|parent-gate|integration\/upgrade-checkout|integration\/stripe-checkout-labels|integration\/stripe-checkout-monthly-yearly)\.spec\.ts$/,
 	fullyParallel: true,
 	forbidOnly: !!process.env.CI,
 	retries: process.env.CI ? 2 : 1,
@@ -32,7 +44,7 @@ export default defineConfig({
 	reporter: [['list'], ['html', { open: 'never' }]],
 	globalSetup: './tests/e2e/global-setup.ts',
 	use: {
-		baseURL: 'http://localhost:5174',
+		baseURL: `http://localhost:${PORT}`,
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',
 		actionTimeout: 15_000,
@@ -71,12 +83,12 @@ export default defineConfig({
 	webServer: {
 		command: process.env.CI
 			? process.platform === 'win32'
-				? 'set AUTH_MODE=cognito&& set COGNITO_DEV_MODE=true&& npm run preview -- --port 5174'
-				: 'AUTH_MODE=cognito COGNITO_DEV_MODE=true npm run preview -- --port 5174'
+				? `set AUTH_MODE=cognito&& set COGNITO_DEV_MODE=true&& npm run preview -- --port ${PORT}`
+				: `AUTH_MODE=cognito COGNITO_DEV_MODE=true npm run preview -- --port ${PORT}`
 			: process.platform === 'win32'
-				? 'set AUTH_MODE=cognito&& set COGNITO_DEV_MODE=true&& npm run dev -- --port 5174'
-				: 'AUTH_MODE=cognito COGNITO_DEV_MODE=true npm run dev -- --port 5174',
-		port: 5174,
+				? `set AUTH_MODE=cognito&& set COGNITO_DEV_MODE=true&& npm run dev -- --port ${PORT}`
+				: `AUTH_MODE=cognito COGNITO_DEV_MODE=true npm run dev -- --port ${PORT}`,
+		port: PORT,
 		reuseExistingServer: !process.env.CI,
 		timeout: 60_000,
 	},

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -117,6 +117,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'bounded',
 		note: '走査は src/routes/api/cron 配下のみ (再帰だが単一 dir で有界)。全 cron route が verifyCronAuth を呼ぶことを検査する (#4206)',
 	},
+	'tests/unit/architecture/ops-route-auth-fitness.test.ts': {
+		scope: 'repo',
+		note: '実走査は src/routes/ops 配下のみだが、静的判定が repo と見なすため宣言を合わせ明示 timeout を置く。全 ops endpoint が requireOpsAccess を呼ぶことを検査する (#4309)',
+	},
 	'tests/unit/architecture/workflow-judgment-delegation-guard.test.ts': {
 		scope: 'repo',
 		note: '.github/workflows を走査し、合否判定が YAML でなく scripts/*.mjs に委譲されているかを検査する (#4158)',

--- a/src/lib/server/auth/authorization.ts
+++ b/src/lib/server/auth/authorization.ts
@@ -156,7 +156,20 @@ function isPublicRoute(path: string): boolean {
 		path.startsWith('/legal') ||
 		path.startsWith('/demo') ||
 		path.startsWith('/marketplace') ||
-		path.startsWith('/ops') ||
+		// #4309: `/api/cron/` と同じく「認証不要」ではなく **「認証の担い手が route 側にある」** の意。
+		// 本認可層は ops group / MFA を表現できない — `RouteRule.roles` が持つのは
+		// owner / parent / child の 3 値だけで、Cognito group も MFA 有無も語彙に無い。
+		// ここから外すと `/ops` は「認証済みの任意のテナントメンバーなら通る」+ ライセンス状態
+		// (期限切れ → /admin/subscription へリダイレクト) に縛られ、運営者が締め出される一方で
+		// 顧客が入れてしまう。したがって判定は route 側の `requireOpsAccess`
+		// (ops-authz.ts、ops group + MFA / fail-closed) に集約し、本行はそこへ委譲する宣言である。
+		// **page (`+layout.server.ts`) と API (`+server.ts`) の両方が呼ぶ必要がある** —
+		// layout の gate は `+server.ts` に走らず、それが #4309 の実害 (未認証で売上台帳 CSV 200)。
+		// 適用範囲は tests/unit/architecture/ops-route-auth-fitness.test.ts が FS 列挙で機械強制する。
+		// 境界は `/ops` 完全一致と `/ops/` に限定する — 素朴な startsWith('/ops') は
+		// `/opsedit` のような別 route まで巻き込んで公開してしまう (cron の #4206 と同型)。
+		path === '/ops' ||
+		path.startsWith('/ops/') ||
 		path.startsWith('/view')
 	);
 }

--- a/src/lib/server/auth/authorization.ts
+++ b/src/lib/server/auth/authorization.ts
@@ -1,3 +1,7 @@
+// cspell:ignore opsedit
+// ↑ #4309 のコメント内の負例。`/ops` に前方一致する**実在しない route** を例示するためのもので、
+//   綴りを直すと「素朴な startsWith が何を巻き込むか」の説明が成立しない (file scope に閉じる)。
+
 // src/lib/server/auth/authorization.ts
 // ロール × ルート 認可マトリクス (#0123: viewer廃止, device廃止)
 

--- a/src/lib/server/auth/ops-authz.ts
+++ b/src/lib/server/auth/ops-authz.ts
@@ -67,6 +67,35 @@ export function hasOpsAccess(
 }
 
 /**
+ * `/ops` 配下に入れなければ 403 で止める、**`/ops` 認可の単一強制点** (#4309)。
+ *
+ * `/ops` はグローバル認可層 (`authorizeCognito` → `isPublicRoute`) を意図的に通過させ、
+ * 認可の担い手を route 側に置いている。理由は認可層が ops group / MFA を表現できないため
+ * (`ROUTE_RULES.roles` は owner / parent / child の 3 値しか持たない)。詳細は
+ * `authorization.ts` の `isPublicRoute` にある `/ops` の注釈。
+ *
+ * したがって `/ops` の防御は本関数**だけ**であり、`+layout.server.ts` (page) と
+ * 各 `+server.ts` (API endpoint) の**両方**がこれを呼ぶ必要がある。
+ * SvelteKit の `+layout.server.ts` は page の load にしか適用されず `+server.ts` には
+ * 走らないため、layout に置いた gate は API を 1 mm も守らない (#4309 の実害:
+ * `/ops/export?type=sales` が未認証で 200 + 実顧客の売上台帳 CSV を返していた)。
+ *
+ * 判定を 2 つに分けないため、layout / endpoint は本関数を共有する。適用範囲は
+ * `tests/unit/architecture/ops-route-auth-fitness.test.ts` が FS 列挙で機械強制する
+ * (新しく `/ops` 配下に API を足した人が黙って穴を開けられないようにする)。
+ */
+export function requireOpsAccess(locals: App.Locals): void {
+	if (hasOpsAccess(locals.identity, locals.context)) return;
+	// ops group には居るが MFA 判定で落ちた場合だけ理由を返す。運営者が「なぜ入れないか」を
+	// 画面から自力で判断できないと、TOTP 設定漏れ / トークン更新での claim 落ちを
+	// コードを読むまで切り分けられない。非 ops には理由を出さない (存在の示唆を避ける)。
+	if (isOpsMember(locals.identity)) {
+		error(403, 'Forbidden: ops access requires MFA');
+	}
+	error(403, 'Forbidden');
+}
+
+/**
  * グローバル master (全テナント共有の統計基準値 = `market_benchmarks` 等) への書込を
  * ops/admin 相当に限定する単一強制点 (#3824、CWE-639 隣接 / #3593 ④ の実厳格化)。
  *

--- a/src/routes/ops/+layout.server.ts
+++ b/src/routes/ops/+layout.server.ts
@@ -15,21 +15,15 @@
 //
 // OPS_SECRET_KEY env の完全除去・設計書更新は PR-D で対応（Issue #820）。
 
-import { error } from '@sveltejs/kit';
-import { hasOpsAccess, isOpsMember } from '$lib/server/auth/ops-authz';
+import { requireOpsAccess } from '$lib/server/auth/ops-authz';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
 	// #4266: CloudFront の IP allowlist 廃止に伴い、主防御を ops group + MFA に強化した。
-	// MFA 情報が取れない場合も拒否する (fail-closed)。判定は hasOpsAccess に集約。
-	if (!hasOpsAccess(locals.identity, locals.context)) {
-		// ops group には居るが MFA 判定で落ちた場合だけ理由を返す。運営者が「なぜ入れないか」を
-		// 画面から自力で判断できないと、TOTP 設定漏れ / トークン更新での claim 落ちを
-		// コードを読むまで切り分けられない。非 ops には理由を出さない (存在の示唆を避ける)。
-		if (isOpsMember(locals.identity)) {
-			error(403, 'Forbidden: ops access requires MFA');
-		}
-		error(403, 'Forbidden');
-	}
+	// MFA 情報が取れない場合も拒否する (fail-closed)。
+	//
+	// #4309: 判定は requireOpsAccess (単一強制点) に集約する。本 layout は **page にしか
+	// 適用されない** ため、`+server.ts` (API endpoint) は同じ関数を各自で呼ぶ必要がある。
+	requireOpsAccess(locals);
 	return {};
 };

--- a/src/routes/ops/export/+server.ts
+++ b/src/routes/ops/export/+server.ts
@@ -3,6 +3,7 @@
 
 import { error } from '@sveltejs/kit';
 import { jstYearMonth } from '$lib/domain/date-utils';
+import { requireOpsAccess } from '$lib/server/auth/ops-authz';
 import {
 	generateExpenseLedgerCsv,
 	generatePLSummary,
@@ -12,7 +13,12 @@ import {
 } from '$lib/server/services/ops-service';
 import type { RequestHandler } from './$types';
 
-export const GET: RequestHandler = async ({ url }) => {
+export const GET: RequestHandler = async ({ url, locals }) => {
+	// #4309: `+layout.server.ts` の ops gate は page にしか適用されず本 endpoint には走らない。
+	// 未認証で売上台帳 CSV が 200 で取れていたため、同じ判定 (ops group + MFA) をここで通す。
+	// **クエリ解釈より前に置く** — 認可の前にデータ集計が走ると、403 を返しても情報は流れる。
+	requireOpsAccess(locals);
+
 	const type = url.searchParams.get('type');
 	// 既定の対象年は JST SSOT 経由 (#4015)
 	const year = Number.parseInt(url.searchParams.get('year') ?? String(jstYearMonth().year), 10);

--- a/tests/e2e/ops-export-authz.spec.ts
+++ b/tests/e2e/ops-export-authz.spec.ts
@@ -1,0 +1,77 @@
+// tests/e2e/ops-export-authz.spec.ts
+// #4309: /ops/export が未認証で売上台帳 CSV を返していた欠陥の E2E 回帰 (ADR-0002 要件 1)。
+//
+// staging 実測 (2026-08-06): cookie 無し・認証ヘッダ無しの
+//   GET /ops/export?type=sales&year=2026
+// が **200 + 実顧客の売上台帳 CSV** を返した。原因は `/ops` の認可を
+// `+layout.server.ts` にだけ置いていたこと (SvelteKit の layout load は page にしか適用されず
+// `+server.ts` には走らない)。
+//
+// 本 spec は unit (`tests/unit/routes/ops-export-authz.test.ts`) と違い、**実際の HTTP 経路**
+// (hooks.server.ts の identity 解決 → 認可層 → route handler) を通して塞がったことを確認する。
+// unit は handler を直接呼ぶため、hooks / 認可層の側で穴が開いても検出できない。
+//
+// 実行: npx playwright test --config playwright.cognito-dev.config.ts tests/e2e/ops-export-authz.spec.ts
+
+import { expect, test } from '@playwright/test';
+
+const EXPORT_TYPES = ['sales', 'expenses', 'summary'] as const;
+
+/**
+ * 認可が**クエリ解釈より前**に走ることを確かめるための不正 type。
+ *
+ * - 認可を通れば handler の validation に到達して 400 (Invalid export type)
+ * - 認可で止まれば 403
+ *
+ * 400 と 403 を撃ち分けられるので、「通った / 止まった」を外部サービス
+ * (Stripe / AWS Cost Explorer) に一切依存せず決定的に判定できる。
+ */
+const INVALID_TYPE = 'not-a-real-type';
+
+test.describe('未認証は /ops/export に到達できない (#4309)', () => {
+	// 認証情報を持たない素の状態。storageState を明示的に空にする。
+	test.use({ storageState: { cookies: [], origins: [] } });
+
+	for (const type of EXPORT_TYPES) {
+		test(`type=${type} は 403 を返し CSV を渡さない`, async ({ request }) => {
+			const res = await request.get(`/ops/export?type=${type}&year=2026`);
+
+			expect(res.status()).toBe(403);
+			// 200 に戻る回帰では body に台帳のヘッダ行が載る。status だけでなく中身も見る。
+			const body = await res.text();
+			expect(body).not.toContain('取引日');
+		});
+	}
+
+	test('認可はクエリ解釈より前に走る (不正 type でも 400 ではなく 403)', async ({ request }) => {
+		// ここが 400 になる = validation が先に走っている = 認可前にリクエストが解釈されている。
+		const res = await request.get(`/ops/export?type=${INVALID_TYPE}`);
+		expect(res.status()).toBe(403);
+	});
+});
+
+test.describe('ops group 非所属の認証済ユーザも到達できない (#4309)', () => {
+	// 通常の顧客 (保護者)。ログイン済みでも /ops は運営専用。
+	test.use({ storageState: 'playwright/.auth/free.json' });
+
+	for (const type of EXPORT_TYPES) {
+		test(`type=${type} は 403 を返す`, async ({ request }) => {
+			const res = await request.get(`/ops/export?type=${type}&year=2026`);
+			expect(res.status()).toBe(403);
+		});
+	}
+});
+
+test.describe('正規の ops ユーザは従来どおり通過する (塞ぎすぎ回帰、#4309)', () => {
+	test.use({ storageState: 'playwright/.auth/ops.json' });
+
+	test('認可を通過し handler の validation に到達する (403 ではなく 400)', async ({ request }) => {
+		// 正常 type (sales 等) の 200 は Stripe / AWS Cost Explorer への実アクセスに依存し
+		// E2E 環境では非決定的なため、**認可を通過したこと**を不正 type の 400 で判定する。
+		// 403 が返れば運営者を締め出す回帰 (over-blocking) であり、ここで必ず落ちる。
+		// CSV 中身の正常性は unit (service mock) が担保する。
+		const res = await request.get(`/ops/export?type=${INVALID_TYPE}`);
+
+		expect(res.status()).toBe(400);
+	});
+});

--- a/tests/unit/architecture/cron-route-auth-fitness.test.ts
+++ b/tests/unit/architecture/cron-route-auth-fitness.test.ts
@@ -31,6 +31,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { authorizeCognito } from '../../../src/lib/server/auth/authorization';
+import { stripCommentsAndStrings } from './helpers/strip-comments-and-strings';
 
 // #4085: 走査 test の区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT。
 // 本 test は再帰 walk だが対象が src/routes/api/cron 配下の単一 dir で有界なため
@@ -52,26 +53,9 @@ interface CronRoute {
 	code: string;
 }
 
-/**
- * コメント (`//` / 文末 `/* … *​/`) と文字列リテラル (' " `) を空白に潰す。
- *
- * これを挟まないと、**コメントに書かれた関数名が呼び出しとして誤検出される**。
- * 実測 (#4206 の adversarial review): `src/routes/api/cron/pglite-backup/+server.ts:8` の
- * 「認証は既存 cron 群と同じ verifyCronAuth (x-cron-secret …)」というコメントだけで
- * [C2] が緑になり、L33 の実呼び出しを消しても検出できなかった。
- * **guard が「唯一の防波堤」である以上、コメントで満たせる検査は防波堤ではない。**
- *
- * 完全な字句解析ではない (正規表現の限界) が、コメント / 文字列という
- * 最も現実的なすり抜け経路は閉じる。
- */
-function stripCommentsAndStrings(source: string): string {
-	return source
-		.replace(/\/\*[\s\S]*?\*\//g, ' ')
-		.replace(/\/\/[^\n]*/g, ' ')
-		.replace(/`(?:\\.|[^`\\])*`/g, ' ')
-		.replace(/'(?:\\.|[^'\\\n])*'/g, ' ')
-		.replace(/"(?:\\.|[^"\\\n])*"/g, ' ');
-}
+// コメント / 文字列リテラルの除去は #4309 で ops 側 fitness と共有ヘルパ化した
+// (`./helpers/strip-comments-and-strings`)。**コメントで満たせる検査は防波堤ではない**という
+// [C2] の前提はそちらの doc comment が SSOT。
 
 /**
  * `+server.ts` を**再帰的に**集める。

--- a/tests/unit/architecture/helpers/strip-comments-and-strings.ts
+++ b/tests/unit/architecture/helpers/strip-comments-and-strings.ts
@@ -1,0 +1,23 @@
+// tests/unit/architecture/helpers/strip-comments-and-strings.ts
+// route の「認可関数を実際に呼んでいるか」を検査する fitness function 群の共有ヘルパ (#4206 / #4309)。
+
+/**
+ * コメント (`//` / `/* … *​/`) と文字列リテラル (' " `) を空白に潰す。
+ *
+ * これを挟まないと、**コメントに書かれた関数名が呼び出しとして誤検出される**。
+ * 実測 (#4206 の adversarial review): `src/routes/api/cron/pglite-backup/+server.ts:8` の
+ * 「認証は既存 cron 群と同じ verifyCronAuth (x-cron-secret …)」というコメントだけで
+ * 呼び出し検査が緑になり、実呼び出しを消しても検出できなかった。
+ * **guard が「唯一の防波堤」である以上、コメントで満たせる検査は防波堤ではない。**
+ *
+ * 完全な字句解析ではない (正規表現の限界) が、コメント / 文字列という
+ * 最も現実的なすり抜け経路は閉じる。
+ */
+export function stripCommentsAndStrings(source: string): string {
+	return source
+		.replace(/\/\*[\s\S]*?\*\//g, ' ')
+		.replace(/\/\/[^\n]*/g, ' ')
+		.replace(/`(?:\\.|[^`\\])*`/g, ' ')
+		.replace(/'(?:\\.|[^'\\\n])*'/g, ' ')
+		.replace(/"(?:\\.|[^"\\\n])*"/g, ' ');
+}

--- a/tests/unit/architecture/ops-route-auth-fitness.test.ts
+++ b/tests/unit/architecture/ops-route-auth-fitness.test.ts
@@ -1,0 +1,157 @@
+// tests/unit/architecture/ops-route-auth-fitness.test.ts
+// #4309: /ops の認可の担い手が route 側にあり、**その適用範囲に穴が無い**ことを機械強制する
+//        fitness function。`cron-route-auth-fitness.test.ts` (#4206) と同型の対の装置。
+//
+// 背景:
+//   `/ops` は `isPublicRoute()` の allowlist に載っている。これは「認証不要」ではなく
+//   「**認証の担い手が認可層ではなく route 側 (requireOpsAccess) にある**」の意味である
+//   (認可層の `RouteRule.roles` は owner / parent / child の 3 値しか持たず、
+//   Cognito group も MFA 有無も表現できない。詳細は authorization.ts の該当注釈)。
+//
+//   そのため `/ops` の防御は `requireOpsAccess` **だけ**になる。ところが #4266 / PR #4284 は
+//   その gate を `+layout.server.ts` にだけ置いた。**SvelteKit の `+layout.server.ts` は
+//   page にしか適用されず `+server.ts` には走らない**ため、`/ops/export/+server.ts` は
+//   認可ゼロのまま外部公開され、staging で `GET /ops/export?type=sales` が未認証で
+//   200 + 実顧客の売上台帳 CSV を返した (#4309)。
+//
+//   PR #4284 が追加した `tests/unit/routes/ops-mfa-guard.test.ts` は**純関数の真理値表のみ**を
+//   検証しており、「`/ops/**` の全 route が実際にその gate を通るか」は 1 件も見ていなかった。
+//   本 test がその適用範囲を見る唯一の装置である。
+//
+// 検証範囲:
+//   [O1] 母数 — 実 FS 上の src/routes/ops/**/+server.ts を列挙する (literal 固定禁止)。
+//        新しい ops API を足した人が本 test を書き換えなくても自動で検査対象に入る。
+//   [O2] 全 endpoint が requireOpsAccess を import し、かつ呼び出していること。
+//        import だけして呼んでいない (= 素通し) を検出するため、import と呼び出しを別々に見る。
+//   [O3] page 側 (+layout.server.ts) も**同じ関数**を使っていること。
+//        判定が 2 つに分かれると、片方だけ直して片方が古いままになる (#4309 の再演)。
+//   [O4] allowlist 側の実装が実際に /ops を認可層で通していること (認可層との突き合わせ)。
+//        ここが fail する = 委譲の前提が崩れた。route 側 gate の意味づけを見直すこと。
+//   [O5] 境界 — `/ops` に前方一致する**別 route** (`/opsedit` 等) まで公開していないこと。
+//
+// no-silent-gap: 除外リストを持たない。/ops 配下の endpoint は例外なく requireOpsAccess を
+//   要求する。「この endpoint だけは別の認証」が必要になった時点で、本 test を fail させたうえで
+//   除外構造を理由・追跡 Issue 付きで設計すること。
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { authorizeCognito } from '../../../src/lib/server/auth/authorization';
+import { stripCommentsAndStrings } from './helpers/strip-comments-and-strings';
+
+// #4085: 走査 test の区分は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT。
+// 実走査は src/routes/ops 配下の単一 dir で有界だが、静的判定は保守的に repo と見なす。
+// 判定を緩めるのではなく宣言を合わせ、明示 timeout を置く (tests/CLAUDE.md §「repo 走査 test」)。
+vi.setConfig({ testTimeout: 60_000 });
+
+/** ops 画面の実体ディレクトリ (母数の SSOT。literal 列挙は禁止) */
+const OPS_ROUTE_DIR = 'src/routes/ops';
+
+/** 認可の単一強制点。ここを変えるときは ops-authz.ts と同時に変える */
+const OPS_GUARD = 'requireOpsAccess';
+
+interface OpsEndpoint {
+	/** endpoint 名 (OPS_ROUTE_DIR からの相対パス) */
+	name: string;
+	/** repo root からの +server.ts パス */
+	file: string;
+	/** 認可層に渡される path */
+	urlPath: string;
+	/** コメント / 文字列リテラルを除去した実コード (呼び出し検査用) */
+	code: string;
+}
+
+/**
+ * `/ops` 配下の `+server.ts` を**再帰的に**集める。
+ *
+ * 認可層の allowlist は `/ops/` の**任意深度**を通すため、深さ 1 だけを見る母数収集では
+ * 「公開されるが検査されない」endpoint が生まれる。母数は公開範囲と一致させる。
+ */
+function collectOpsEndpoints(): OpsEndpoint[] {
+	const root = path.resolve(process.cwd(), OPS_ROUTE_DIR);
+	if (!fs.existsSync(root)) return [];
+
+	const endpoints: OpsEndpoint[] = [];
+
+	const walk = (absDir: string, relSegments: string[]): void => {
+		for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+			const abs = path.join(absDir, entry.name);
+
+			if (entry.isDirectory()) {
+				walk(abs, [...relSegments, entry.name]);
+				continue;
+			}
+			if (entry.name !== '+server.ts') continue;
+
+			const rel = relSegments.join('/');
+			endpoints.push({
+				name: rel === '' ? '(root)' : rel,
+				file: path.posix.join(OPS_ROUTE_DIR, rel, '+server.ts'),
+				// SvelteKit の route group `(name)` は URL に現れない
+				urlPath: `/ops${relSegments
+					.filter((s) => !s.startsWith('('))
+					.map((s) => `/${s}`)
+					.join('')}`,
+				code: stripCommentsAndStrings(fs.readFileSync(abs, 'utf-8')),
+			});
+		}
+	};
+
+	walk(root, []);
+	return endpoints;
+}
+
+const opsEndpoints = collectOpsEndpoints();
+
+describe('/ops の認可は route 側が担い、適用範囲に穴が無い (#4309)', () => {
+	it('[O1] 母数: /ops 配下の +server.ts が 1 本以上検出される', () => {
+		// 0 件なら「全部通った」ではなく「1 本も検査していない」。
+		// ディレクトリ移動やリネームで本 test が空振りするのを防ぐ。
+		expect(opsEndpoints.length).toBeGreaterThan(0);
+	});
+
+	describe(`[O2] 全 endpoint が ${OPS_GUARD} を呼ぶ`, () => {
+		for (const endpoint of opsEndpoints) {
+			it(`${endpoint.name} が ${OPS_GUARD} を import している`, () => {
+				expect(endpoint.code).toMatch(new RegExp(`import\\s*\\{[^}]*\\b${OPS_GUARD}\\b[^}]*\\}`));
+			});
+
+			it(`${endpoint.name} が ${OPS_GUARD} を呼び出している`, () => {
+				// import しただけで呼んでいない = 素通し。import 検査だけでは捕まらない。
+				// 判定は code (コメント / 文字列除去済) に対して行う。
+				expect(endpoint.code).toMatch(new RegExp(`\\b${OPS_GUARD}\\s*\\(`));
+			});
+		}
+	});
+
+	it(`[O3] page 側 (+layout.server.ts) も同じ ${OPS_GUARD} を使う`, () => {
+		// page と API で判定を分けると、片方だけ直して片方が古いままになる。
+		// #4309 はまさに「page だけ新しい鍵で守り、API は鍵をかけないまま」で起きた。
+		const layout = stripCommentsAndStrings(
+			fs.readFileSync(path.resolve(process.cwd(), OPS_ROUTE_DIR, '+layout.server.ts'), 'utf-8'),
+		);
+		expect(layout).toMatch(new RegExp(`\\b${OPS_GUARD}\\s*\\(`));
+	});
+
+	describe('[O4] 認可層は /ops を route 側に委譲している', () => {
+		for (const endpoint of opsEndpoints) {
+			it(`${endpoint.urlPath} は認可層を通過し route 側 gate に到達する`, () => {
+				// ここが fail する = allowlist から /ops が消えた。
+				// route 側 gate との二重防御になるだけで危険側には倒れないが、
+				// 前提が変わったので本 test の意味づけ (委譲) を見直すこと。
+				expect(authorizeCognito(endpoint.urlPath, null, null).allowed).toBe(true);
+			});
+		}
+	});
+
+	describe('[O5] 前方一致で別 route を巻き込まない', () => {
+		// 素朴な startsWith('/ops') はこれらまで公開してしまう (cron の #4206 と同型)。
+		const notOpsPaths = ['/opsedit', '/ops-admin', '/opsx'];
+
+		for (const notOps of notOpsPaths) {
+			it(`${notOps} は公開しない`, () => {
+				expect(authorizeCognito(notOps, null, null).allowed).toBe(false);
+			});
+		}
+	});
+});

--- a/tests/unit/architecture/ops-route-auth-fitness.test.ts
+++ b/tests/unit/architecture/ops-route-auth-fitness.test.ts
@@ -1,3 +1,8 @@
+// cspell:ignore opsedit opsx
+// ↑ [O5] の負例。`/ops` に前方一致するが `/ops` ではない**実在しない route** を意図的に置く。
+//   綴りを「直す」と negative case が成立せず、過剰公開を検出できないことを検出できなくなる
+//   (tests/CLAUDE.md §「負例 fixture と cspell」)。global words には足さない (file scope に閉じる)。
+
 // tests/unit/architecture/ops-route-auth-fitness.test.ts
 // #4309: /ops の認可の担い手が route 側にあり、**その適用範囲に穴が無い**ことを機械強制する
 //        fitness function。`cron-route-auth-fitness.test.ts` (#4206) と同型の対の装置。

--- a/tests/unit/architecture/ops-route-auth-fitness.test.ts
+++ b/tests/unit/architecture/ops-route-auth-fitness.test.ts
@@ -33,6 +33,11 @@
 //   [O4] allowlist 側の実装が実際に /ops を認可層で通していること (認可層との突き合わせ)。
 //        ここが fail する = 委譲の前提が崩れた。route 側 gate の意味づけを見直すこと。
 //   [O5] 境界 — `/ops` に前方一致する**別 route** (`/opsedit` 等) まで公開していないこと。
+//   [O6] form action — `+page.server.ts` の `export const actions` も layout gate の**外側**にある。
+//        SvelteKit は form action を **layout load より先に**実行するため、action を持つ page は
+//        `+server.ts` と全く同じ理由で無防備になる。`+server.ts` だけを母数にすると
+//        「穴の残り半分」が検査されないまま『guard があるから安全』という誤った安心が残る
+//        (adversarial review で指摘 → 本 test の母数に含めた)。
 //
 // no-silent-gap: 除外リストを持たない。/ops 配下の endpoint は例外なく requireOpsAccess を
 //   要求する。「この endpoint だけは別の認証」が必要になった時点で、本 test を fail させたうえで
@@ -108,6 +113,55 @@ function collectOpsEndpoints(): OpsEndpoint[] {
 
 const opsEndpoints = collectOpsEndpoints();
 
+/**
+ * `/ops` 配下で **form action を持つ** `+page.server.ts` を集める。
+ *
+ * SvelteKit は form action を `+layout.server.ts` の load より**先に**実行する。したがって
+ * action は `+server.ts` と同様に layout gate の外側にあり、`requireOpsAccess` を自分で
+ * 呼ばなければ未認証の POST がそのまま処理される。#4309 の欠陥と**同じ class** である。
+ *
+ * 現時点で該当は 0 件だが、`/ops` は運営が操作を足していく画面であり action の追加は起こりうる。
+ * 母数に含めておくことで、足した瞬間に CI が要求する。
+ */
+function collectOpsActionPages(): OpsEndpoint[] {
+	const root = path.resolve(process.cwd(), OPS_ROUTE_DIR);
+	if (!fs.existsSync(root)) return [];
+
+	const pages: OpsEndpoint[] = [];
+
+	const walk = (absDir: string, relSegments: string[]): void => {
+		for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+			const abs = path.join(absDir, entry.name);
+
+			if (entry.isDirectory()) {
+				walk(abs, [...relSegments, entry.name]);
+				continue;
+			}
+			if (entry.name !== '+page.server.ts') continue;
+
+			const code = stripCommentsAndStrings(fs.readFileSync(abs, 'utf-8'));
+			// load だけの page は layout gate が効くので対象外。action を持つものだけを見る。
+			if (!/export\s+const\s+actions\b/.test(code)) continue;
+
+			const rel = relSegments.join('/');
+			pages.push({
+				name: rel === '' ? '(root)' : rel,
+				file: path.posix.join(OPS_ROUTE_DIR, rel, '+page.server.ts'),
+				urlPath: `/ops${relSegments
+					.filter((s) => !s.startsWith('('))
+					.map((s) => `/${s}`)
+					.join('')}`,
+				code,
+			});
+		}
+	};
+
+	walk(root, []);
+	return pages;
+}
+
+const opsActionPages = collectOpsActionPages();
+
 describe('/ops の認可は route 側が担い、適用範囲に穴が無い (#4309)', () => {
 	it('[O1] 母数: /ops 配下の +server.ts が 1 本以上検出される', () => {
 		// 0 件なら「全部通った」ではなく「1 本も検査していない」。
@@ -147,6 +201,19 @@ describe('/ops の認可は route 側が担い、適用範囲に穴が無い (#4
 				expect(authorizeCognito(endpoint.urlPath, null, null).allowed).toBe(true);
 			});
 		}
+	});
+
+	it(`[O6] form action を持つ /ops page も ${OPS_GUARD} を呼ぶ`, () => {
+		// SvelteKit は form action を layout load より先に実行するため、action は
+		// `+server.ts` と同じく layout gate の外にある。呼び忘れれば未認証 POST が通る。
+		//
+		// 該当 0 件でも本 it は必ず走る (動的 it 生成だと 0 件で「検査したふり」になる)。
+		// 違反 file 名を出すことで、足した人が何を直せばよいか即分かるようにする。
+		const violations = opsActionPages
+			.filter((page) => !new RegExp(`\\b${OPS_GUARD}\\s*\\(`).test(page.code))
+			.map((page) => page.file);
+
+		expect(violations).toEqual([]);
 	});
 
 	describe('[O5] 前方一致で別 route を巻き込まない', () => {

--- a/tests/unit/routes/ops-export-authz.test.ts
+++ b/tests/unit/routes/ops-export-authz.test.ts
@@ -1,0 +1,161 @@
+// tests/unit/routes/ops-export-authz.test.ts
+// #4309: /ops/export (売上台帳 / 費用台帳 / PL サマリの CSV エクスポート) が
+//        未認証で 200 + 実データを返していた欠陥の回帰テスト。
+//
+// 何が壊れていたか:
+//   `/ops` はグローバル認可層 (authorizeCognito → isPublicRoute) を意図的に通過させ、
+//   保護を `src/routes/ops/+layout.server.ts` の ops gate (#4266 ops group + MFA) に委ねている。
+//   しかし **SvelteKit の `+layout.server.ts` は page (`+page.svelte`) の load にしか適用されず、
+//   `+server.ts` (API endpoint) には走らない**。`/ops/export/+server.ts` には認可が 1 行も無く、
+//   cookie 無し・認証ヘッダ無しの `GET /ops/export?type=sales&year=2026` が staging で
+//   **200 + 実顧客の売上台帳 CSV** を返していた (2026-08-06 実証、#4309)。
+//
+// failing-test-first (ADR-0061): 修正前は「未認証は 403」系の it が **200 を返して red**、
+//   かつ mock service が呼ばれてしまう (= データ生成まで到達している) ことも検出する。
+//
+// 検証観点:
+//   - 未認証 / 非 ops / ops だが MFA 未済 → 403。かつ **service 層に一切到達しない**
+//     (403 を返すだけで裏で集計クエリが走るなら、認可は「表示の抑制」でしかない)
+//   - type=sales / expenses / summary の **3 種すべて**で塞がっている (同一ハンドラの分岐漏れ防止)
+//   - 正規の ops ユーザ (ops group + MFA) では従来どおり CSV / TXT が 200 で取れる (回帰)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthContext, Identity } from '../../../src/lib/server/auth/types';
+
+// ---------- mocks ----------
+// service 層は Stripe / AWS Cost Explorer を叩くため全 mock。
+// 「認可で弾かれたなら 1 度も呼ばれない」ことを assert するための spy でもある。
+
+const mockGetRevenueData = vi.fn();
+const mockGetAWSCostData = vi.fn();
+const mockGenerateSalesLedgerCsv = vi.fn();
+const mockGenerateExpenseLedgerCsv = vi.fn();
+const mockGeneratePLSummary = vi.fn();
+
+vi.mock('$lib/server/services/ops-service', () => ({
+	getRevenueData: (...args: unknown[]) => mockGetRevenueData(...args),
+	getAWSCostData: (...args: unknown[]) => mockGetAWSCostData(...args),
+	generateSalesLedgerCsv: (...args: unknown[]) => mockGenerateSalesLedgerCsv(...args),
+	generateExpenseLedgerCsv: (...args: unknown[]) => mockGenerateExpenseLedgerCsv(...args),
+	generatePLSummary: (...args: unknown[]) => mockGeneratePLSummary(...args),
+}));
+
+const { GET } = await import('../../../src/routes/ops/export/+server');
+
+// ---------- fixtures ----------
+
+const OPS_WITH_MFA: Identity = {
+	type: 'cognito',
+	userId: 'u-ops-1',
+	email: 'ops@example.com',
+	groups: ['ops'],
+	mfaAuthenticated: true,
+};
+
+/** ops group には居るが MFA を経ていない (#4266 fail-closed の対象) */
+const OPS_WITHOUT_MFA: Identity = {
+	type: 'cognito',
+	userId: 'u-ops-2',
+	email: 'ops2@example.com',
+	groups: ['ops'],
+	mfaAuthenticated: false,
+};
+
+/** 通常の顧客 (保護者)。ops group 非所属 */
+const PARENT: Identity = {
+	type: 'cognito',
+	userId: 'u-parent',
+	email: 'parent@example.com',
+	groups: [],
+	mfaAuthenticated: true,
+};
+
+const EXPORT_TYPES = ['sales', 'expenses', 'summary'] as const;
+
+function makeEvent(type: string, identity: Identity | null, context?: Partial<AuthContext> | null) {
+	return {
+		url: new URL(`http://localhost/ops/export?type=${type}&year=2026`),
+		locals: { identity, context: context ?? null },
+	} as unknown as Parameters<typeof GET>[0];
+}
+
+/** handler を呼び、`error()` が throw する HttpError の status を取り出す */
+async function statusOf(event: Parameters<typeof GET>[0]): Promise<number> {
+	try {
+		const res = await GET(event);
+		return res.status;
+	} catch (e) {
+		const status = (e as { status?: number }).status;
+		if (typeof status !== 'number') throw e;
+		return status;
+	}
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockGetRevenueData.mockResolvedValue({ invoices: [], monthlyBreakdown: [] });
+	mockGetAWSCostData.mockResolvedValue({});
+	mockGenerateSalesLedgerCsv.mockReturnValue('取引日,顧客ID（匿名化）\n');
+	mockGenerateExpenseLedgerCsv.mockReturnValue('取引日,勘定科目\n');
+	mockGeneratePLSummary.mockReturnValue('PL サマリ');
+});
+
+describe('/ops/export の認可 (#4309)', () => {
+	describe('未認証は 3 種すべてで 403 (staging で 200 + 実データが返っていた)', () => {
+		for (const type of EXPORT_TYPES) {
+			it(`type=${type} は 403 を返す`, async () => {
+				expect(await statusOf(makeEvent(type, null))).toBe(403);
+			});
+
+			it(`type=${type} は service 層に到達しない`, async () => {
+				await statusOf(makeEvent(type, null));
+				// 403 を返しつつ裏で集計が走るなら、認可ではなく「表示の抑制」でしかない。
+				expect(mockGetRevenueData).not.toHaveBeenCalled();
+				expect(mockGetAWSCostData).not.toHaveBeenCalled();
+			});
+		}
+	});
+
+	describe('ops group 非所属 (通常の顧客) は 3 種すべてで 403', () => {
+		for (const type of EXPORT_TYPES) {
+			it(`type=${type} は 403 を返す`, async () => {
+				expect(await statusOf(makeEvent(type, PARENT))).toBe(403);
+				expect(mockGetRevenueData).not.toHaveBeenCalled();
+			});
+		}
+	});
+
+	describe('ops group だが MFA 未済は 403 (#4266 fail-closed を API にも適用)', () => {
+		for (const type of EXPORT_TYPES) {
+			it(`type=${type} は 403 を返す`, async () => {
+				expect(await statusOf(makeEvent(type, OPS_WITHOUT_MFA))).toBe(403);
+				expect(mockGetRevenueData).not.toHaveBeenCalled();
+			});
+		}
+	});
+
+	describe('正規の ops ユーザは従来どおり取得できる (塞ぎすぎて運用が止まらないこと)', () => {
+		for (const type of EXPORT_TYPES) {
+			it(`type=${type} は 200 を返す`, async () => {
+				const res = await GET(makeEvent(type, OPS_WITH_MFA));
+				expect(res.status).toBe(200);
+				expect(await res.text()).not.toBe('');
+			});
+		}
+
+		it('token 側に MFA claim が無くても、session context が MFA 済なら通る (silent refresh 対策)', async () => {
+			// hasOpsAccess は identity(token) と context(session) の OR を取る (#4266)。
+			// 片側だけを見ると、無操作の運営者が silent refresh で締め出される。
+			const identityWithoutMfaClaim: Identity = {
+				type: 'cognito',
+				userId: 'u-ops-3',
+				email: 'ops3@example.com',
+				groups: ['ops'],
+			};
+			const res = await GET(
+				makeEvent('sales', identityWithoutMfaClaim, { mfaAuthenticated: true }),
+			);
+			expect(res.status).toBe(200);
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（および、データを晒されていた全顧客）

**解決する課題**: **`/ops/export` が未認証で売上台帳 CSV を返していた。** staging 実証済み（cookie 無し・認証ヘッダ無しの `GET /ops/export?type=sales&year=2026` が 200 + 実データ）。`type=expenses` / `summary` も同一ハンドラで費用台帳・PL が取れる。対比として `/ops` ページ自体は同じ未認証で 403 であり、**ページは守られ API だけが素通ししていた**。

根本原因は `/ops` の認可を `+layout.server.ts` にだけ置いたこと。**SvelteKit の `+layout.server.ts` は page の load にしか適用されず `+server.ts` には走らない**ため、`src/routes/ops/export/+server.ts` には認可が 1 行も無かった。

**期待される効果**: 露出の停止に加え、**同じ穴を二度と開けられなくする**。`/ops/**/+server.ts` を FS 列挙して全件が認可を通ることを fitness function で機械強制するため、今後 `/ops` 配下に API を足した人が黙って穴を開けると CI が落ちる。

## 関連 Issue

Closes #4309

関連 PR:

- **#4304**（第 21 回統合 PR。本件により merge 保留中）
- #4284 / #4266（IP allowlist 廃止 + ops group + MFA。本件の発見契機。gate を layout にだけ置いた）
- #4280（CloudFront → origin の shared secret header）— **本 PR とは別レイヤ**。shared secret header は「CloudFront 経由を強制する」だけで認証にはならず、本件は塞がらない。`hooks.server.ts` は #4280 の作業面なので本 PR では**一切触っていない**
- #4282（IP allowlist 廃止し /ops を ops group + MFA で守る）— 本 PR はその「API 側の穴」に限定。**page 側の認可条件そのもの（MFA 判定ロジック・Cognito 設定）は #4282 の範囲であり本 PR で変更していない**（本 PR は既存 `hasOpsAccess` を API にも適用しただけ）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | **`/ops/**` 配下の全 `+server.ts` に ops + MFA 認可を適用する**。`/ops/export` の `GET` が未認証で 200 を返さないこと（403 or 401） | ① 実 HTTP: `curl "http://localhost:5199/ops/export?type=sales&year=2026"`（自 worktree の dev server、`AUTH_MODE=cognito`）② `npx vitest run tests/unit/routes/ops-export-authz.test.ts` ③ `E2E_COGNITO_PORT=5199 npx playwright test --config playwright.cognito-dev.config.ts tests/e2e/ops-export-authz.spec.ts` | **PASS**。① 修正前 `200` + `取引日,顧客ID（匿名化）,…` → 修正後 **`403 {"message":"Forbidden"}`**（sales / expenses / summary / 不正 type すべて 403）② 修正前 **12 failed**（未認証で 200、かつ service 層に到達）→ 修正後 **16 passed** ③ **14 passed** |
| AC2 | **適用範囲を機械強制する fitness function を置く。** `cron-route-auth-fitness.test.ts` と同型で、`src/routes/ops/**/+server.ts` を FS 列挙し、全件が ops 認可を通ることを検証する | `npx vitest run tests/unit/architecture/ops-route-auth-fitness.test.ts` + mutation 3 種 | **PASS**（8 passed）。`tests/unit/architecture/ops-route-auth-fitness.test.ts` を追加。mutation 実測は下記「fitness function の非トートロジー実証」参照（3 種すべて kill） |
| AC3 | staging で `curl "https://<staging>/ops/export?type=sales"` が **403 を返すことを実測**する（synth ではなく実物） | — | **本 PR の diff では達成不能**。staging は develop の deploy であり本修正を含まないため、この branch の状態では 403 を実測できない（現在 staging が返す 200 は Issue 記載の実証そのもの）。**deploy 後の実機確認として Issue #4309 に残す**。コードが返す値は上記 ①（実 HTTP、同じ `AUTH_MODE=cognito` 経路）で 403 を実測済 |
| AC4 | **本番の現状を確認し、露出していた期間を記録する。** アクセスログから未認証の `/ops/export` 到達が実際にあったかを確認する（無ければ「無かった」と記録する） | `git log --follow --diff-filter=A -- src/routes/ops/export/+server.ts` / 本番 CloudWatch Logs 照会 | **一部 PASS**。露出期間はコード履歴から確定（下記「露出期間」）。**実アクセスの有無は本番ログ照会が必要で、本 PR では実施していない**（実顧客の売上データが落ちる本番を叩かない方針、Issue 記載と同じ）。ログ照会は本番権限を持つ運営の作業として Issue #4309 に残す |
| AC5 | 同型の穴が他に無いか確認する。**`isPublicRoute()` が列挙する path のうち、`+server.ts` を持つものすべて**について、route 側の認証が実在するかを洗う（`/api/cron/**` は fitness function 済、`/legal` `/demo` `/marketplace` `/view` は要確認） | `find src/routes -name '+server.ts'` を `isPublicRoute()` の全 path と突き合わせ | **PASS**（全数結果は下記「AC5: `isPublicRoute()` 全 path × `+server.ts` 全数調査」）。`/legal` `/demo` `/marketplace` `/view` `/pricing` `/setup` は **`+server.ts` が 0 本**。`/ops/export` が唯一の無防備なデータ返却 endpoint だった |

## 変更タイプ

- [x] fix: バグ修正

## AC5: `isPublicRoute()` 全 path × `+server.ts` 全数調査

`isPublicRoute()` が通す全 path を `find src/routes -name '+server.ts'` の結果と突き合わせた全数結果。

| public path | `+server.ts` | route 側の認証 | 判定 |
|---|---|---|---|
| `/ops` | **`ops/export/+server.ts` 1 本** | **無かった** | **本 PR で `requireOpsAccess` を適用 + fitness function** |
| `/api/cron/` | 複数 | `verifyCronAuth` | OK（`cron-route-auth-fitness.test.ts` が機械強制、#4206） |
| `/api/stripe/webhook` | 1 本 | Stripe 署名検証 | OK |
| `/api/health` / `/api/ready` | 各 1 本 | 不要（LWA readiness probe、機微データを返さない） | OK |
| `/auth` | 4 本（callback / logout / oauth/google / signout） | 認証フロー自体の入口。機微データを返さない | OK |
| `/sitemap.xml` | 1 本 | 不要（SEO、公開情報） | OK |
| `/legal` `/demo` `/marketplace` `/view` `/pricing` `/setup` `/_app` `/favicon` `/robots.txt` `/` | **0 本** | — | OK（API が存在しないので同型の穴が原理的に無い） |

`/tenants` `/uploads` は `isPublicRoute()` に**無く** `ROUTE_RULES` で認証必須のため、グローバル認可層が守っている（本調査の対象外）。

## `isPublicRoute()` から `/ops` を外せたか — 外していない（理由）

**外していない。外すと認可がむしろ弱くなるため。**

グローバル認可層は **ops group / MFA を表現できない**。`RouteRule.roles` が持つ語彙は `owner` / `parent` / `child` の 3 値だけで、Cognito group も MFA 有無も型に存在しない。したがって `/ops` を allowlist から外した場合に得られるのは「**認証済みの任意のテナントメンバーなら通る**」という条件であり、これは ops 限定より弱い。

加えて副作用が 2 つある:

1. `checkLicenseAccess` に載るため、ライセンス期限切れのテナントに属する運営者は `/admin/subscription?reason=expired` に**リダイレクトされて `/ops` に入れなくなる**
2. `!context`（テナント未所属）の分岐で `/auth/login` に落ちる

つまり「顧客が入れて運営者が入れない」方向に倒れる。よって `/api/cron/` と同じ構図（#4206）を採り、**この行は「認証不要」ではなく「認証の担い手が route 側にある」の宣言**として残し、判定を `requireOpsAccess`（`ops-authz.ts`）に集約した。認可層のコメントにこの理由を明記している。

あわせて**境界を狭めた**: `path.startsWith('/ops')` は `/opsedit` のような別 route まで公開してしまうため、`path === '/ops' || path.startsWith('/ops/')` に限定した（cron の #4206 と同型の是正）。

## 判定を 2 つに分けない

`+layout.server.ts`（page）と `+server.ts`（API）が**同じ `requireOpsAccess(locals)` を呼ぶ**。layout に埋め込まれていた判定分岐（`hasOpsAccess` + `isOpsMember` による理由分け）を `ops-authz.ts` に移し、layout はそれを呼ぶだけにした。片方だけ直して片方が古くなる状態（#4309 そのもの）を構造的に作れなくする。fitness function `[O3]` が layout も同じ関数を使っていることを検査する。

認可は **クエリ解釈・集計より前**に置いた。後ろに置くと 403 を返しても裏で集計クエリは走るため、unit test 側で「403 かつ service 層に一度も到達しない」ことも assert している。

## 露出期間（AC4 のコード側）

| 事象 | 日付 | 根拠 |
|---|---|---|
| `/ops/export/+server.ts` の初出（認可なし） | 2026-03-31 | `git log --follow --diff-filter=A` → `54dabe7d6 feat: #0176 Phase 2-4 運営ダッシュボード拡張 — 収益・費用・エクスポート` |
| 同 endpoint の再追加（依然 認可なし） | 2026-07-29 | `e838423c2`（#4032） |
| 認可の適用 | 本 PR | — |

**endpoint は初出時点から一度も認可を持っていない。** 本番の IP allowlist も `ADMIN_ALLOWED_IPS` 未登録によりコードごと無効だったことを PO が #4280 で実測しており、本番でも実質露出していたと考えるのが妥当。**ただし「未認証の到達が実際にあったか」は本番アクセスログでしか判定できず、本 PR では確認していない**（本番を叩かない方針）。

## ADR-0002 Critical 修正 5 要件チェック（必須）

### 要件 1: E2E 回帰テストを同一 PR 内で追加

| AC | テストファイル | テスト内容 |
|---|---|---|
| AC1 | `tests/e2e/ops-export-authz.spec.ts` | 未認証で `/ops/export` の 3 type すべてが 403 かつ body に `取引日`（台帳ヘッダ）を含まない / 認可がクエリ解釈より前に走る（不正 type でも 400 でなく 403）/ ops group 非所属の認証済ユーザも 403 / **正規 ops ユーザは認可を通過する**（over-blocking 回帰） |
| AC1 | `tests/unit/routes/ops-export-authz.test.ts` | handler 直呼びで 3 type × 未認証 / 非 ops / MFA 未済 → 403 かつ service 層未到達 / ops + MFA → 200 / token に MFA claim が無くても session context が MFA 済なら通る |
| AC2 | `tests/unit/architecture/ops-route-auth-fitness.test.ts` | `/ops/**/+server.ts` の FS 列挙・全件が `requireOpsAccess` を import かつ呼び出し・layout も同関数・認可層が `/ops` を通す・`/opsedit` 等を巻き込まない |

E2E と unit は役割が違う。unit は handler を直接呼ぶため **hooks / 認可層の側に穴が開いても検出できない**。E2E は実 HTTP 経路（identity 解決 → 認可層 → handler）を通す。

### 要件 2: AC 全項目完了（部分実装で closes 禁止）

- [x] Issue の全 AC が本 PR で完了している

AC1 / AC2 / AC5 はコードで完遂。**AC3（staging 実測）と AC4 の「実アクセスログ照会」だけは、本 PR の diff では原理的に達成できない**（前者は本修正が deploy されていないと測れない、後者は本番権限が要る）。両者は AC 検証マップに未達として明示し、Issue #4309 に残している。コードが返す値そのものは実 HTTP で 403 を実測済。

### 要件 3: 提案全実装

- [x] Issue 本文の「根本原因」「受け入れ条件」に記載された全提案を実装した

Issue が求めた「`cron-route-auth-fitness.test.ts` と同型の fitness function」をそのまま実装した（母数の FS 列挙 / import と呼び出しを別々に検査 / 認可層との突き合わせ / 前方一致境界 / 除外リストを持たない no-silent-gap）。加えて cron 側と**コメント除去ヘルパを共有**し、「コメントに書かれた関数名で検査が緑になる」すり抜け（#4206 で実測された経路）を ops 側でも同時に塞いだ。

### 要件 4: 全 5 年齢モードで実機検証 + スクリーンショット

**N/A（UI 非影響）**。根拠: 変更したのは server 側の認可（`+server.ts` / `+layout.server.ts` / `ops-authz.ts` / `authorization.ts`）とテストのみで、`.svelte` の差分が 0 件。かつ `/ops` は運営専用画面であり年齢モード（baby / preschool / elementary / junior / senior）の描画経路と交差しない。子供・保護者画面の認可条件は一切変更していない（`ROUTE_RULES` 無変更、`isPublicRoute` の変更は `/ops` 行のみ）。

### 要件 5: 直近 30 日の同一ファイル変更 PR チェック

`git log --since="30 days ago" -- src/lib/server/auth/ops-authz.ts src/routes/ops/ src/lib/server/auth/authorization.ts`

| PR | マージ日 | 同一ファイルでの変更内容 | 本 PR との関係 |
|---|---|---|---|
| #4284 | 2026-08-05 | IP allowlist 廃止 + `/ops` を ops group + MFA で守る（gate を `+layout.server.ts` に設置） | **直接の契機**。ページ側の鍵を強化し外側の塀を撤去したが API は無施錠のままだった。本 PR がその API 側を塞ぐ（#4284 の判定 `hasOpsAccess` はそのまま再利用、変更なし） |
| #4249 | 2026-08-06 | `/ops` に契約状態の在庫画面を追加（#4118） | page 追加のみ。`+server.ts` を持たないため本 PR の fitness function は追加検査対象を持たない（layout gate で保護済） |
| #4216 | 2026-08-02 | cron dispatcher が認可層で 401 になる問題を `isPublicRoute` に `/api/cron/` を追加して解消（#4206） | **同型の先例**。本 PR はその対の装置（fitness function）を `/ops` 側に用意し、コメント除去ヘルパを共有化した |
| #4188 / #4182 / #4080 / #4032 | 2026-07-29〜08-01 | 課金 event / TZ 日付 / settings guard の修正 | 認可とは無関係。本 PR と競合しない |

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `/ops/export`（運営の CSV エクスポート API）のみ。`/ops` 配下の page は認可条件が変わらない（同じ `hasOpsAccess` を関数越しに呼ぶだけ）。顧客画面（`/admin` `/switch` 等）は無変更。

- [x] **同一バグの横展開調査済み**（ADR-0002）: `isPublicRoute()` の全 path × `+server.ts` を全数突合（上記 AC5 表）。同型の穴は他に無い
- [x] **並行実装ペア**を同期した: 該当なし（labels / 年齢モード / ナビ / DB seed / チュートリアルのいずれにも触れていない）
- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md` §5.2.9（強制箇所を `requireOpsAccess` に更新、layout が API を守らない構造・認可層が `/ops` を通す理由・fitness function 2 本を追記）/ `docs/design/07-API設計書.md` §3.16（`/ops` 配下の `+server.ts` は自分で認可を呼ぶ旨）
- [x] **並行 PR overlap** 確認 (#1200): #4280 が触る `src/hooks.server.ts` は**本 PR で一切変更していない**。設計書もセクション単位のピンポイント追記に留め衝突面積を最小化した

## fitness function の非トートロジー実証（mutation）

`ops-route-auth-fitness.test.ts` が「認可チェックを外すと必ず落ちる」ことを 3 種の mutation で実測した（mutation 前に実装を commit し、`git stash push` で退避・復元。実装ごと破棄する事故を避けるため `git checkout --` は使っていない）。

| # | mutation | 結果 |
|---|---|---|
| 1 | `+server.ts` から `requireOpsAccess(locals);` を削除 | **kill**（fitness `[O2]` 呼び出し検査 + `ops-export-authz.test.ts` 併せて **13 failed**） |
| 2 | `+layout.server.ts` の呼び出しを**コメント化**（`// requireOpsAccess(locals);`） | **kill**（`[O3]` が fail。コメントに関数名が残っていても緑にならない = コメント除去ヘルパが効いている） |
| 3 | `isPublicRoute` の境界を `path.startsWith('/ops')` に戻す | **kill**（`[O5]` の `/opsedit` `/ops-admin` `/opsx` が 3 件 fail） |
| 4 | `/ops/costs/+page.server.ts` に guard 無しの `export const actions` を追加 | **kill**（`[O6]` が fail し違反 file 名 `src/routes/ops/costs/+page.server.ts` を出力） |

mutation 2 は特に重要で、「コメントで満たせる検査は防波堤ではない」（#4206 の adversarial review で実測された経路）が ops 側でも成立していることを示す。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4326` | PASS（全 6 step。実行ログは本 PR の実行時出力、内訳は本表の各行と一致） |
| E2E 回帰（要件 1、必須） | `E2E_COGNITO_PORT=5199 npx playwright test --config playwright.cognito-dev.config.ts tests/e2e/ops-export-authz.spec.ts` | PASS（14 passed） |
| unit（新規 3 本） | `npx vitest run tests/unit/routes/ops-export-authz.test.ts tests/unit/architecture/ops-route-auth-fitness.test.ts tests/unit/routes/ops-mfa-guard.test.ts tests/unit/architecture/cron-route-auth-fitness.test.ts` | PASS（85 passed） |
| unit 全体 | CI `unit-test` (2 shard) + `unit-test-merge` | PASS（shard 1: 10m33s / shard 2: 11m29s / merge: 1m15s、run 31054355148）。**ローカルの全体実行は他 Agent の vitest と同時起動して server 生成で落ちたため、証跡は CI の実行を採る**（落ちた local 実行を PASS として記載しない） |
| cspell | `npm run cspell` | PASS（Issues found: 0 in 0 files）。負例 `opsedit` / `opsx` は file scope の `cspell:ignore` で通す（global words には足さない、`tests/CLAUDE.md` §「負例 fixture と cspell」） |
| biome | `npx biome check .` | PASS（exit 0） |
| svelte-check | `npx svelte-check --threshold error` | PASS（0 ERRORS 0 WARNINGS） |
| 走査 test 区分宣言 | `node scripts/check-repo-scan-test-declaration.mjs` | PASS（45 件すべて宣言済） |

`scripts/lib/ci/repo-scan-test-registry.mjs` に新 fitness function を登録した。静的判定が `repo` と見なすため宣言を `repo` に合わせ、明示 timeout（60s）を置いている（`tests/CLAUDE.md` §「repo 走査 test」の「判定を緩めるのではなく明示 timeout を置く」に従う）。

- [x] **YAGNI**: 過剰防衛設計を追加していない（ADR-0010）。新規 script は 0 本、新規依存 0 件。既存の fitness function 様式（#4206）と既存の述語（`hasOpsAccess`）の再利用に留めた
- [x] **Security**: 修正により新たな攻撃面を作っていない。追加したのは拒否経路のみで、許可条件は既存 `hasOpsAccess` から変更していない。`isPublicRoute` の境界変更は**公開範囲を狭める**方向のみ
- [x] **A11y・パフォーマンス**: 認可判定は同期の述語 1 回で、DB / 外部アクセスを伴わない。UI 非影響
- [x] **Critical バグ修正**（ADR-0002）: 上記 5 要件全て確認済み

## スクリーンショット / ビジュアルデモ

**該当なし（バックエンド / security 修正のみ）**。`.svelte` の差分 0 件。

<!-- ss-pair-none: UI 差分ゼロの server 側認可修正であり、修正前後で描画される画面が存在しない -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

運営が `/ops/export` を利用する際の手順は変わらない（ログイン済み ops セッションであれば従来どおり CSV が落ちる）。**未認証での取得は不能になる**が、これは修正対象の欠陥そのものであり、正規の運用手順ではない。

**レビュー依頼事項・QM**:

1. **`isPublicRoute()` から `/ops` を外さなかった判断**（上記セクション）。認可層が ops group / MFA を表現できないため外すと弱くなる、という結論の妥当性
2. **AC3 / AC4 を未達として明示したこと**の可否。前者は deploy 前に測れず、後者は本番ログ権限が要る。コードが返す値は実 HTTP で 403 実測済
3. **`playwright.cognito-dev.config.ts` の port env 化**が本 PR の scope として許容範囲か（既定値 5174 は不変で CI 挙動に影響なし。並列 worktree で他 agent の server に当たり偽 fail した実測に基づく）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

`E2E_COGNITO_PORT` は **test 実行時のみの任意 override** であり、未設定で従来どおり動作する（既定 5174）。アプリ実行時に参照されないため配布経路（GitHub Secrets / Lambda / NUC .env / .env.example）の対象外。

## Ready for Review チェックリスト

- [x] **ADR-0002 5 要件全て満たした**（再掲、自己確認）
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（AC3 / AC4 の deploy 後・本番ログ部分は達成不能理由を明示）
- [x] UI 変更時: 5 年齢モード SS が GitHub 上で表示確認できる（**UI 変更なしのため N/A、根拠は要件 4 に記載**）
- [x] QM 承認・動作確認が完了している

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 (revert で元に戻る)"]
    R2["顧客面: 🔴全顧客の売上データが未認証で露出中"]
    R3["ロールバック: データ破壊なし・認可追加のみ"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 台帳 CSV の無認証露出を停止"]
    T2["捨てる: 新規 guard 1 本の保守 (既存様式の複製)"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: action が母数外 → 🟢本PRで是正済"]
    O2["UX: 期限切れ時に生JSON 403 → 🟡残存"]
    O3["security: 呼出有無のみ検査・実行順は不問 → 🟡残存"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["顧客 UI 変化なし (server 認可のみ・svelte 差分 0)"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 本 PR を #4304 に載せて出すか?"]
    Q2["Q2: 本番ログ照会 (露出実績) を運営が行うか?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R2 danger
  class T2,O2,O3 warn
  class R1,R3,T1,C1,O1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

反対理由 3 件は `tmp/adversarial-evidence/4326.json`（schema 検証 PASS）から転記。処遇:

- **③ business（form action が母数外）→ 本 PR で是正済**。SvelteKit は form action を layout load より**先に**実行するため、`/ops` 配下の `+page.server.ts` に `actions` を足すと `+server.ts` と同じ理由で無防備になる。`+server.ts` だけを母数にすると「穴の残り半分」が検査されない。fitness function `[O6]` を追加して母数に含め、mutation 4 で kill を実測した（現時点で該当 action は 0 件だが、足した瞬間に CI が要求する）
- **③ UX（context token 期限切れ時に生 JSON 403）→ Accepted residual (Pre-PMF)**。ops 運営者 1 名規模で、再ログインで復帰でき、page 側には理由付き 403 が出る。API 側の応答整形は顧客面に一切出ない（`/ops` は運営専用）ため ADR-0010 で受容
- **③ security（呼び出しの有無は見るが実行順は見ない）→ Accepted residual (Pre-PMF)**。正規表現ベースの guard に内在する限界で、先行する `cron-route-auth-fitness.test.ts`（#4206）も同じ性質。実行順の担保は export endpoint に対する unit の「403 かつ service 層未到達」assert が担う。AST 解析による経路検証は Pre-PMF で過剰（ADR-0010）

いずれも severity は high 未満。high 以上を residual 化していない。

</details>

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
