### PR TITLE
fix(infra): #4327 物理削除 cron が作る宙吊り行を封じ、部分失敗を観測可能にし、緊急停止手段を持たせる

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -383,3 +383,23 @@ PORT=3000
 # AI_EVAL_MODEL=claude-opus-4-7
 # AI_EVAL_RUNS=3
 # AI_EVAL_BASE_URL=http://localhost:5180
+
+# ===================================================
+# GRACE_PERIOD_DELETION_DISABLED (#4327、既定 false = 有効)
+# ===================================================
+# 顧客データの物理削除 cron (grace-period-deletion、毎日 02:00 JST) の kill-switch。
+# `true` / `1` で **対象の走査すら行わずに即 return** する (EventBridge 経由でも手動 POST でも止まる)。
+#
+# 消したら戻せない処理であり、止める手段が EventBridge Rule の手動 disable しか無かった。
+# Rule の disable が「cron を呼ばせない」防御なのに対し、本 env は「呼ばれても消させない」防御で
+# 層が違う (Rule は次回 deploy で ENABLED に戻るため、停止を維持するには本 env 側が要る)。
+#
+# 必須 env ではない (未設定 = 従来どおり有効)。配布:
+#   - AWS: GitHub Actions Variables `GRACE_PERIOD_DELETION_DISABLED`
+#          → deploy.yml `-c gracePeriodDeletionDisabled=...`
+#          → compute-stack.ts `tryGetContext` → Lambda env
+#   - NUC: 本 `.env` に直接記述 (scheduler コンテナが同 cron を叩くため)
+#
+# 停止 / 再開 / 観測 / 復旧の限界: docs/runbooks/grace-period-deletion-operations.md
+#
+# GRACE_PERIOD_DELETION_DISABLED=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,6 +144,7 @@ jobs:
           npx cdk diff GanbariQuestStorage \
             -c domainName=${{ env.DOMAIN_NAME }} \
             -c certificateArn=${{ env.CERTIFICATE_ARN }} \
+            -c gracePeriodDeletionDisabled=${{ vars.GRACE_PERIOD_DELETION_DISABLED || 'false' }} \
             -c cronSecret=${{ secrets.CRON_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
             -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }} \
@@ -155,6 +156,7 @@ jobs:
           npx cdk deploy GanbariQuestStorage --require-approval never
           -c domainName=${{ env.DOMAIN_NAME }}
           -c certificateArn=${{ env.CERTIFICATE_ARN }}
+          -c gracePeriodDeletionDisabled=${{ vars.GRACE_PERIOD_DELETION_DISABLED || 'false' }}
           -c cronSecret=${{ secrets.CRON_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
           -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}
@@ -269,6 +271,7 @@ jobs:
           -c stripePriceFamilyMonthly=${{ vars.STRIPE_PRICE_FAMILY_MONTHLY }}
           -c useLookupKey=${{ vars.USE_LOOKUP_KEY || 'true' }}
           -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
+          -c gracePeriodDeletionDisabled=${{ vars.GRACE_PERIOD_DELETION_DISABLED || 'false' }}
           -c cronSecret=${{ secrets.CRON_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
           -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}
@@ -342,6 +345,7 @@ jobs:
             -c stripePriceFamilyMonthly=${{ vars.STRIPE_PRICE_FAMILY_MONTHLY }} \
             -c useLookupKey=${{ vars.USE_LOOKUP_KEY || 'true' }} \
             -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }} \
+            -c gracePeriodDeletionDisabled=${{ vars.GRACE_PERIOD_DELETION_DISABLED || 'false' }} \
             -c cronSecret=${{ secrets.CRON_SECRET }} \
             -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }} \
             -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }} \
@@ -370,6 +374,7 @@ jobs:
           -c stripePriceFamilyMonthly=${{ vars.STRIPE_PRICE_FAMILY_MONTHLY }}
           -c useLookupKey=${{ vars.USE_LOOKUP_KEY || 'true' }}
           -c discordWebhookSupport=${{ secrets.DISCORD_WEBHOOK_SUPPORT }}
+          -c gracePeriodDeletionDisabled=${{ vars.GRACE_PERIOD_DELETION_DISABLED || 'false' }}
           -c cronSecret=${{ secrets.CRON_SECRET }}
           -c opsSecretKey=${{ secrets.OPS_SECRET_KEY }}
           -c originVerifySecret=${{ secrets.ORIGIN_VERIFY_SECRET }}

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -217,7 +217,7 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 - **他ジョブ**: retention-cleanup / analytics・challenge aggregate 系もテナント数比例だが、現規模 (Pre-PMF、~100 tenants) では 30 秒内に収まる。顕在化 (CronDispatcherErrors alarm での 504 / timeout 検出) 時に本規約を同パターンで適用する
 - **代替案と発動条件**: dispatcher からの専用長時間 Lambda 直接 invoke (案 B) は関数分離 + コード配布 2 系統の運用負荷、Step Functions (案 C) は Pre-PMF 過剰 (ADR-0010) のため不採用。**self-limiting でも 1 スケジュールスパン内に消化しきれないバックログが定常化した時点** (例: export-build の pending 滞留が 1 時間超 / grace-period の持ち越しが 3 日連続) **で案 B を再検討**する
 - **新規ジョブ追加時**: `schedule-registry.ts` 冒頭の checklist に従う (本規約 + KNOWN_ENDPOINTS / CRON_JOBS 並行登録)
-- **自動リトライは無効 (#4327)**: EventBridge target は `retryAttempts: 0`。Lambda 非同期呼び出しの既定リトライ (最大 2 回) は、self-limiting で「途中まで進んで打ち切られた」job を非冪等に再走させる (grace-period-deletion なら部分削除されたテナントに purge が再走する)。1 回の取りこぼしは翌日の実行が回収し、失敗自体は `CronDispatcherErrors` alarm で観測されるため、再送より再走回避を優先する
+- **自動リトライは「非冪等な job だけ」切る (#4327)**: 既定は Lambda 非同期呼び出しのリトライ (最大 2 回) を**維持**する。切るのは `grace-period-deletion` のみ (`compute-stack.ts` の `CRON_JOBS` に `disableRetry: true`)。理由は「途中まで削除されたテナントに purge が再走する」非冪等性で、そこだけ再送より再走回避が勝つ。**一律 0 にしてはならない** — 冪等な job ではリトライが「1 回の失敗で取りこぼす」ことへの防御として働いており、とくに `deletion-warning-emails` は送信済フラグで冪等かつ 1 度の失敗が「予告のないまま削除される」に直結し、`pmf-survey` は年 2 回起動のため 1 失敗が 6 ヶ月の欠測になる。不変条件は `tests/unit/infra/grace-period-deletion-safety.test.ts` [C1]-[C3] が固定する (切っている job が grace-period-deletion 1 本だけであることまで assert)
 
 ### 3.4 OpsStack（監視・コスト防衛）
 

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -192,7 +192,7 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 | trial-notifications | `cron(0 0 * * ? *)` | 毎日 09:00 | ✓ | ✓ | トライアル終了通知バッチ (#737) |
 | age-recalc | `cron(0 15 * * ? *)` | 毎日 00:00 | ✓ | ✓ | 子供の年齢自動インクリメント (#1381) |
 | lifecycle-emails | `cron(30 0 * * ? *)` | 毎日 09:30 | ✓ | ✓ | 期限切れ前リマインド + 休眠復帰メール (#1601, ADR-0023 §5 I11) |
-| grace-period-deletion | `cron(0 17 * * ? *)` | 毎日 02:00 | ✓ | ✓ | グレースピリオド期限切れテナントの物理削除バッチ (#1648 R43, `grace-period-service.ts`)。解約後の猶予期間 (プラン別保持期間) を過ぎたソフト削除済テナントを物理削除する |
+| grace-period-deletion | `cron(0 17 * * ? *)` | 毎日 02:00 | ✓ | ✓ | グレースピリオド期限切れテナントの物理削除バッチ (#1648 R43, `grace-period-service.ts`)。解約後の猶予期間 (プラン別保持期間) を過ぎたソフト削除済テナントを物理削除する。**不可逆**のため 2 層の停止手段 (EventBridge Rule disable / `GRACE_PERIOD_DELETION_DISABLED` env) を持ち、部分失敗は HTTP 500 + 専用 alarm + Discord incident に載る (#4327)。運用 SSOT: [`docs/runbooks/grace-period-deletion-operations.md`](../runbooks/grace-period-deletion-operations.md) |
 | deletion-warning-emails | `cron(0 1 * * ? *)` | 毎日 10:00 | ✓ | ✓ | アカウント削除予告メール (#2399, `deletion-warning-service.ts`)。猶予期間中のテナントの所有者へ、物理削除予定日と復元導線を 1 通だけ送る。しきい値は family = 残り 14 日 / standard = 残り 1 日 / free = 送信なし (猶予 0 日) |
 | pmf-survey | `cron(0 0 1 6,12 ? *)` | 6/1・12/1 09:00 | ✓ | ✓ | PMF 判定アンケート (Sean Ellis Test) 年 2 回配信 (#1598, ADR-0023 §5 I7) |
 | export-build | `cron(0/5 * * * ? *)` | 5 分毎 | ✓ | ✓ | クラウドエクスポート非同期 build バッチ (#3504, async-backup-export.md §3.2)。`status='pending'` の `cloud_exports` を拾い ZIP 生成 → S3/ローカル FS 保存 → `ready` に遷移。AWS (cron-dispatcher) / NUC (scheduler container) 双方が同一 endpoint を駆動 |
@@ -217,6 +217,7 @@ EventBridge / dispatcher 未登録のジョブも NUC では起動する。
 - **他ジョブ**: retention-cleanup / analytics・challenge aggregate 系もテナント数比例だが、現規模 (Pre-PMF、~100 tenants) では 30 秒内に収まる。顕在化 (CronDispatcherErrors alarm での 504 / timeout 検出) 時に本規約を同パターンで適用する
 - **代替案と発動条件**: dispatcher からの専用長時間 Lambda 直接 invoke (案 B) は関数分離 + コード配布 2 系統の運用負荷、Step Functions (案 C) は Pre-PMF 過剰 (ADR-0010) のため不採用。**self-limiting でも 1 スケジュールスパン内に消化しきれないバックログが定常化した時点** (例: export-build の pending 滞留が 1 時間超 / grace-period の持ち越しが 3 日連続) **で案 B を再検討**する
 - **新規ジョブ追加時**: `schedule-registry.ts` 冒頭の checklist に従う (本規約 + KNOWN_ENDPOINTS / CRON_JOBS 並行登録)
+- **自動リトライは無効 (#4327)**: EventBridge target は `retryAttempts: 0`。Lambda 非同期呼び出しの既定リトライ (最大 2 回) は、self-limiting で「途中まで進んで打ち切られた」job を非冪等に再走させる (grace-period-deletion なら部分削除されたテナントに purge が再走する)。1 回の取りこぼしは翌日の実行が回収し、失敗自体は `CronDispatcherErrors` alarm で観測されるため、再送より再走回避を優先する
 
 ### 3.4 OpsStack（監視・コスト防衛）
 

--- a/docs/design/account-deletion-flow.md
+++ b/docs/design/account-deletion-flow.md
@@ -187,12 +187,34 @@ soft delete されたテナントは以下の状態になる:
 
 `/api/cron/grace-period-deletion` が定期実行で `purgeExpiredSoftDeletedTenants` を呼ぶ:
 
+0. `GRACE_PERIOD_DELETION_DISABLED` が `true` / `1` なら**対象の走査を行わず即 return**（kill-switch）
 1. `findExpiredSoftDeletedTenants` で grace 期限切れのテナントを検出（メタデータ不完全な行は母集団に入らない、§4.3）
 2. 各テナントの owner を特定
 3. `deleteOwnerOnlyAccount` (他メンバーなし) または `deleteOwnerFullDelete` (他メンバーあり) で物理削除
 4. Pattern 2b の場合、他メンバーへ `sendMemberRemovedEmail` 通知
 
 > Stripe キャンセルは soft delete 時に既に完了しているため、cron 経由の `cancelSubscription` 再実行は idempotent な no-op になる。
+
+#### 削除の実行順（判定材料は最後に消す）
+
+soft-delete 判定の SSOT は `settings` の `soft_deleted_at` / `physical_deletion_date` であり、
+対象列挙は `families` を歩いて 1 件ずつ `settings` を読む。したがって **`settings` は `families` 行より後に削除する**。
+
+```
+1 Stripe cancel → 2 S3 → 3 tenant-scoped データ (settings を除く) → 4 children
+→ 5 memberships / users → 6 invites → 7 families → 8 settings（判定材料）
+```
+
+step 7 より前で失敗しても判定材料が残るため、翌日の実行が同じテナントを再び対象にして完遂する（自己回復）。
+逆順にすると「`families` は残るが判定材料が無い」= 再削除も復元もできない行が生まれる。
+step 8 の失敗は例外を投げ、`errors[]` → alarm に載る（`settings` 行のみ孤児として残るため手動掃除が要る）。
+
+#### 部分失敗の扱い
+
+`tenantsFailed > 0` のとき endpoint は **HTTP 500** を返し、Discord incident webhook にも件数を出す
+（テナント識別子は log にのみ残す）。停止 / 観測 / 復旧の限界は
+[`docs/runbooks/grace-period-deletion-operations.md`](../runbooks/grace-period-deletion-operations.md) が SSOT。
+**単一テナントだけを削除前の状態に戻す手段は存在しない。**
 
 ### 4.6 §2 マトリクスへの影響
 

--- a/docs/design/account-deletion-flow.md
+++ b/docs/design/account-deletion-flow.md
@@ -207,7 +207,9 @@ soft-delete 判定の SSOT は `settings` の `soft_deleted_at` / `physical_dele
 
 step 7 より前で失敗しても判定材料が残るため、翌日の実行が同じテナントを再び対象にして完遂する（自己回復）。
 逆順にすると「`families` は残るが判定材料が無い」= 再削除も復元もできない行が生まれる。
-step 8 の失敗は例外を投げ、`errors[]` → alarm に載る（`settings` 行のみ孤児として残るため手動掃除が要る）。
+step 8 の失敗は例外を投げ、`errors[]` → alarm に載る。このとき `settings` 行のみが孤児として残り、
+そこには `pin_hash` / `session_token` / `questionnaire_*` が含まれるため**手動掃除が必要**
+（判断根拠と手順は [`grace-period-deletion-operations.md`](../runbooks/grace-period-deletion-operations.md) §3）。
 
 #### 部分失敗の扱い
 

--- a/docs/runbooks/grace-period-deletion-operations.md
+++ b/docs/runbooks/grace-period-deletion-operations.md
@@ -107,12 +107,24 @@ aws logs filter-log-events --region us-east-1 \
 翌日の実行で同じテナントが再び対象になり、削除が完遂する（自己回復）。
 
 例外は最終ステップ（families 行を消した**後**の settings 削除）が失敗した場合で、
-このときは `settings` 行だけが孤児として残る。個人データ本体は既に消えており、
-log に tenantId が出るので手動で掃除する:
+このときは `settings` 行だけが孤児として残る。log に tenantId が出るので手動で掃除する:
 
 ```
 [tenant-cleanup] settings 削除失敗 (tenant 行は削除済 / 手動掃除が必要)
 ```
+
+**この孤児には `pin_hash`（おやカギコードのハッシュ）/ `session_token` / `questionnaire_*`（初期アンケートの回答）が含まれる。**
+子供の記録・活動・ポイント・画像・音声といったデータ本体は既に消えているが、
+「退会したのに認証情報とアンケート回答が残っている」状態であり、**放置してよいものではない**。
+上記 log が出たら speed 優先で手動削除する（対象は `settings` テーブルの当該 `tenant_id` 行すべて）。
+
+これを避けるために「機微なキーだけ先に消す」設計は**採らなかった**。判定材料（`soft_deleted_at` /
+`physical_deletion_date` / `deletion_grace_plan_tier`）と機微キーは同じ `settings` に同居しており、
+repo が持つのは「全キー取得」ではなく `getSettings(keys)` と `deleteByTenantId(tenantId)` だけなので、
+部分削除には「消すキーを列挙する」実装が要る。列挙を置くと**新しい設定キーが増えたとき黙って消し漏らす**
+（今回と同型の silent gap をもう 1 つ作る）。一方この孤児は alarm + log で必ず観測され、手で消せる。
+**「観測できて直せる残余」を選び、「観測できず直せない宙吊り行」を消した**という trade-off である。
+repo に「指定キー以外を消す」機能を足すかは #4338 で扱う。
 
 ---
 

--- a/docs/runbooks/grace-period-deletion-operations.md
+++ b/docs/runbooks/grace-period-deletion-operations.md
@@ -1,0 +1,151 @@
+# grace-period-deletion 運用 runbook（顧客データの物理削除）
+
+対象: `grace-period-deletion` cron（毎日 02:00 JST / `cron(0 17 * * ? *)`）。
+グレースピリオドが切れた退会済みテナントを**物理削除**する。**取り消せない処理**であり、
+本 runbook は「止める / 気付く / どこまで戻せるか」を SSOT として定める。
+
+関連: `src/lib/server/services/grace-period-service.ts` / `src/lib/server/cron/schedule-registry.ts` /
+`infra/lib/compute-stack.ts` / `infra/lib/ops-stack.ts` / ADR-0049（保持期間ポリシー）
+
+---
+
+## 1. 緊急停止（2 層）
+
+**どちらか一方ではなく、性質が違う 2 層**。急ぐときは層 1 を先に打つ（即時・deploy 不要）。
+
+### 層 1: EventBridge Rule を無効化する（cron を呼ばせない・即時）
+
+```bash
+aws events disable-rule --name ganbari-quest-cron-grace-period-deletion --region us-east-1
+
+# 効いたことの確認（State が DISABLED であること）
+aws events describe-rule --name ganbari-quest-cron-grace-period-deletion --region us-east-1 \
+  --query 'State' --output text
+```
+
+- **効く範囲**: EventBridge → cron-dispatcher の起動のみ。手動 POST や別経路の呼び出しは止まらない。
+- **注意**: CDK は Rule の `enabled` を指定していないため、**次回 deploy で ENABLED に戻る**。
+  停止を維持したいなら層 2 を併用する。
+- 再有効化: `aws events enable-rule --name ganbari-quest-cron-grace-period-deletion --region us-east-1`
+
+### 層 2: env kill-switch（呼ばれても消させない）
+
+`GRACE_PERIOD_DELETION_DISABLED=true` で、**対象の走査すら行わずに即 return** する
+（`purgeExpiredSoftDeletedTenants`）。手動 POST も止まる。
+
+即時に効かせる（次の Lambda 起動から反映。**次回 deploy で CDK 値に戻る**）:
+
+```bash
+# 既存 env を壊さないよう、必ず現行値を取得してから上書きする
+aws lambda get-function-configuration --function-name ganbari-quest-app --region us-east-1 \
+  --query 'Environment.Variables' > /tmp/env.json
+# /tmp/env.json の GRACE_PERIOD_DELETION_DISABLED を "true" にして
+aws lambda update-function-configuration --function-name ganbari-quest-app --region us-east-1 \
+  --environment "Variables=$(jq -c . /tmp/env.json)"
+```
+
+恒久的に停止したまま deploy する（推奨。deploy で戻らない）:
+
+1. GitHub の repository variable `GRACE_PERIOD_DELETION_DISABLED` を `true` にする
+   （`gh variable set GRACE_PERIOD_DELETION_DISABLED --body true --repo Takenori-Kusaka/ganbari-quest`）
+2. deploy すると CDK context 経由で Lambda env に `true` が入る
+
+停止中は実行のたびに以下の warn が残る（無音で止まらない）:
+
+```
+[grace-period] physical deletion is disabled by kill-switch env; skipping
+```
+
+---
+
+## 2. 気付く（観測）
+
+| 事象 | どこに出るか |
+|---|---|
+| 部分失敗（`tenantsFailed > 0`） | endpoint が **HTTP 500** を返す → dispatcher の Lambda invocation error → alarm `ganbari-quest-cron-dispatcher-errors` |
+| 同上（cron の切り分け用） | log `[grace-period-deletion] partial failure` → metric `GanbariQuest/Deletion / GracePeriodPartialFailure` → alarm `ganbari-quest-grace-period-partial-failure`（1 件で即発火） |
+| 同上（人に届く経路） | Discord incident webhook（`sendDiscordAlert`、level=critical）。件数のみで**テナント識別子は載せない** |
+| 削除メタデータの欠落 | log `[grace-period] soft-delete metadata incomplete`（#4321。該当テナントは削除対象から外れ復元可能） |
+| 持ち越し発生 | log `[grace-period] purge carried over remaining tenants to next run` |
+
+**alarm の Discord 通知は既定 off**（#4189 のオーナー決裁で通知は opt-in）。
+`ganbari-quest-grace-period-partial-failure` も現時点で `notify: false` のため、
+**CloudWatch 上には出るが alarm 自体は Discord に出ない**。ただし同じ部分失敗は
+上表の `sendDiscordAlert` 経路で人に届く。alarm 側の昇格手順は
+[ops-alert-notification.md](ops-alert-notification.md) §3。
+
+失敗したテナントの特定（識別子は log にのみ残す）:
+
+```bash
+aws logs filter-log-events --region us-east-1 \
+  --log-group-name /aws/lambda/ganbari-quest-app \
+  --filter-pattern '"[grace-period-deletion] partial failure"' \
+  --start-time $(( ($(date +%s) - 86400) * 1000 ))
+```
+
+---
+
+## 3. 復旧の限界（できないことを明記する）
+
+**単一テナントだけを削除前の状態に戻す手段は存在しない。** 期待しないこと。
+
+| 対象 | 手段 | 実際にできること |
+|---|---|---|
+| DSQL（テナント・子供・活動・ポイント等） | cluster 単位の日次 snapshot・7 日保持（`infra/lib/dsql-stack.ts`）。**PITR 非対応** | 新しい cluster を作って endpoint を切り替える = **全テナントを snapshot 時点へ巻き戻す**。1 テナントだけの復元は不可 |
+| S3 `tenants/<tenantId>/`（アバター / 音声 / 画像） | AssetsBucket は **versioning 未設定** | **復旧不能** |
+| 削除直前の退避 | 無し（`fullTenantDeletion` は export / backup を呼ばない） | — |
+| 顧客自身のバックアップ | 退会前にエクスポート（バックアップ ZIP）を取っていれば、そこからの取り込みは可能 | 顧客の手元にファイルがある場合のみ |
+
+したがって**運用上の第一原則は「消してから戻す」ではなく「怪しければ止める」**。
+部分失敗の alarm が鳴ったら、原因調査より先に §1 層 1 で cron を止めてよい
+（1〜2 日の遅延は許容範囲 — 個人情報保護法 22 条は努力義務）。
+
+### 途中失敗したテナントはどうなるか（#4327）
+
+削除は「判定材料（`settings` の `soft_deleted_at` / `physical_deletion_date`）を最後に消す」
+順序になっており、**families 行の削除より前で失敗した場合は判定材料が残る** →
+翌日の実行で同じテナントが再び対象になり、削除が完遂する（自己回復）。
+
+例外は最終ステップ（families 行を消した**後**の settings 削除）が失敗した場合で、
+このときは `settings` 行だけが孤児として残る。個人データ本体は既に消えており、
+log に tenantId が出るので手動で掃除する:
+
+```
+[tenant-cleanup] settings 削除失敗 (tenant 行は削除済 / 手動掃除が必要)
+```
+
+---
+
+## 4. 再有効化の手順（停止から戻すとき）
+
+1. §1 の層 2（env / repository variable）を `false` に戻し deploy する
+2. **dry-run で対象件数を実測する**（実削除しない）
+
+   ```bash
+   aws lambda invoke --function-name ganbari-quest-cron-dispatcher --region us-east-1 \
+     --payload '{"cronJob":"grace-period-deletion","dryRun":true}' \
+     --cli-binary-format raw-in-base64-out response.json && cat response.json
+   ```
+
+   **根拠に使うのは `tenantsProcessed` と `expired` の 2 つ**。
+   `tenantsRemaining` は dryRun 分岐でハードコード 0 を返すため、
+   対象が何件あっても 0 になる（#4327 product-5）。安全根拠として引用しないこと。
+3. `expired` が想定より多い場合は止めたまま原因を確認する（想定外の soft-delete が起きていないか）
+4. §1 層 1 で Rule を有効化する
+5. 初回実行後、実際の削除件数（`tenantsProcessed` / `tenantsDeleted`）を記録する
+
+---
+
+## 5. 動作確認（dry-run）
+
+```bash
+# dispatcher 経由
+aws lambda invoke --function-name ganbari-quest-cron-dispatcher --region us-east-1 \
+  --payload '{"cronJob":"grace-period-deletion","dryRun":true}' \
+  --cli-binary-format raw-in-base64-out response.json
+
+# endpoint 直（GET は常に dry-run）
+curl -s https://ganbari-quest.com/api/cron/grace-period-deletion -H "x-cron-secret: $CRON_SECRET"
+```
+
+cron 全体の検証手順は [cron-3-endpoints-verification.md](cron-3-endpoints-verification.md)。

--- a/docs/runbooks/grace-period-deletion-operations.md
+++ b/docs/runbooks/grace-period-deletion-operations.md
@@ -83,6 +83,8 @@ aws logs filter-log-events --region us-east-1 \
   --start-time $(( ($(date +%s) - 86400) * 1000 ))
 ```
 
+⚠ **調査には期限がある。** Discord alert と alarm は「起きた」ことしか伝えず、**どのテナントかは log にしかない**（`discord-alert.ts` の設計制約で payload に顧客識別子を載せられないため）。`AppLogGroup` の retention は **30 日**なので、それを過ぎると孤児行の tenantId を引く手段が無くなる。**alert を見たら 30 日以内に上記コマンドで tenantId を控える**こと。後回しにすると §3 の孤児掃除ができなくなる。
+
 ---
 
 ## 3. 復旧の限界（できないことを明記する）

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -228,6 +228,23 @@ cron-dispatcher は **CRON_SECRET** または **OPS_SECRET_KEY** 最低 1 本必
 
 `ganbari-quest-cron-dispatcher-errors` (`ops-stack.ts` L237-249) が dispatcher Lambda Errors metric 監視。5 分内 1 回以上で SNS topic `ganbari-quest-ops-alerts` 通知。
 
+### 自動リトライは全 cron で無効 (#4327)
+
+EventBridge target は `retryAttempts: 0`。cron は 30 秒 self-limiting + 翌日持ち越し前提で設計されているため、途中まで進んだ job の自動再送は非冪等な再走 (部分削除されたテナントに purge が再走する等) を生む。取りこぼしは翌日の実行が回収し、失敗は上記 alarm で観測される。**新規 job を足すときも target に retry を復活させない**。
+
+### 顧客データ物理削除 (grace-period-deletion) の緊急停止 (#4327)
+
+**不可逆な処理**であり、止める手段を 2 層持つ。手順・観測・復旧の限界の SSOT は
+[docs/runbooks/grace-period-deletion-operations.md](../docs/runbooks/grace-period-deletion-operations.md)。
+
+```bash
+# 層 1: cron を呼ばせない (即時。ただし次回 deploy で ENABLED に戻る)
+aws events disable-rule --name ganbari-quest-cron-grace-period-deletion --region us-east-1
+
+# 層 2: 呼ばれても消させない (手動 POST も止まる。deploy でも戻らない)
+gh variable set GRACE_PERIOD_DELETION_DISABLED --body true --repo Takenori-Kusaka/ganbari-quest
+```
+
 **注意**: `cdk deploy` は PO が実行する（GHA `deploy.yml` または手動 `cdk deploy --all`）。
 
 ## CDK Replacement gate の既知良性パターン (ADR-0019 運用)

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -228,9 +228,11 @@ cron-dispatcher は **CRON_SECRET** または **OPS_SECRET_KEY** 最低 1 本必
 
 `ganbari-quest-cron-dispatcher-errors` (`ops-stack.ts` L237-249) が dispatcher Lambda Errors metric 監視。5 分内 1 回以上で SNS topic `ganbari-quest-ops-alerts` 通知。
 
-### 自動リトライは全 cron で無効 (#4327)
+### 自動リトライを切るのは非冪等な cron だけ (#4327)
 
-EventBridge target は `retryAttempts: 0`。cron は 30 秒 self-limiting + 翌日持ち越し前提で設計されているため、途中まで進んだ job の自動再送は非冪等な再走 (部分削除されたテナントに purge が再走する等) を生む。取りこぼしは翌日の実行が回収し、失敗は上記 alarm で観測される。**新規 job を足すときも target に retry を復活させない**。
+既定は Lambda 非同期呼び出しのリトライ (最大 2 回) を**維持**する。切るのは `CRON_JOBS` に `disableRetry: true` を持つ job のみで、現状 `grace-period-deletion` 1 本だけ (途中まで削除されたテナントに purge が再走するため)。
+
+**一律 0 にしない**。冪等な job ではリトライが「1 回の失敗で取りこぼす」ことへの防御であり、`deletion-warning-emails` は 1 失敗が「予告のないまま削除される」に、`pmf-survey` は年 2 回起動のため 1 失敗が 6 ヶ月欠測になる。新規 job に `disableRetry` を付けるのは**再実行が壊す状態を持つ場合だけ**。不変条件は `tests/unit/infra/grace-period-deletion-safety.test.ts` [C1]-[C3] が固定する。
 
 ### 顧客データ物理削除 (grace-period-deletion) の緊急停止 (#4327)
 

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -27,7 +27,12 @@ const CRON_JOBS = [
 	// #1601 (ADR-0023 §5 I11): 期限切れ前リマインド + 休眠復帰メール
 	{ name: 'lifecycle-emails', utcCronExpression: 'cron(30 0 * * ? *)' },
 	// #1648 R43 (#4033 AC3): グレースピリオド期限切れテナントの物理削除バッチ
-	{ name: 'grace-period-deletion', utcCronExpression: 'cron(0 17 * * ? *)' },
+	// #4327: 唯一 disableRetry=true。理由は下の DISABLE_RETRY_REASON 参照。
+	{
+		name: 'grace-period-deletion',
+		utcCronExpression: 'cron(0 17 * * ? *)',
+		disableRetry: true,
+	},
 	// #2399: 猶予期間中のテナントへ削除予定日を予告する (grace-period-deletion の前段通知)
 	{ name: 'deletion-warning-emails', utcCronExpression: 'cron(0 1 * * ? *)' },
 	// #1598 (ADR-0023 §5 I7): PMF 判定アンケート (Sean Ellis Test) 年 2 回配信
@@ -533,13 +538,16 @@ export class ComputeStack extends cdk.Stack {
 				rule.addTarget(
 					new eventsTargets.LambdaFunction(this.cronDispatcherFn, {
 						event: events.RuleTargetInput.fromObject({ cronJob: job.name }),
-						// #4327: 非同期呼び出しの既定リトライ (最大 2 回) を切る。
-						// cron job は 30 秒 self-limiting + 翌日持ち越し前提で設計されており
-						// (grace-period-deletion の tenantsRemaining 等)、途中まで進んだ job の
-						// 自動再送は「部分削除されたテナントに対して purge が再走する」非冪等な
-						// 危険を生む。1 回の取りこぼしは翌日の実行が回収し、失敗自体は
-						// dispatcher Errors alarm + grace-period 失敗 alarm で観測される。
-						retryAttempts: 0,
+						// #4327: 非冪等な job だけリトライを切る (既定は Lambda 非同期の 2 回リトライを維持)。
+						//
+						// 一律 0 にしてはならない。ほとんどの cron は冪等で、リトライは
+						// 「1 回の失敗で取りこぼす」ことへの防御として働いている:
+						//   - deletion-warning-emails … 送信済フラグ (settings) で冪等。ここで retry を
+						//     切ると 1 度の失敗で **予告のないまま削除される** (#4327 が塞ごうとしている状態そのもの)
+						//   - pmf-survey … 年 2 回起動。1 回の失敗が 6 ヶ月の欠測になる
+						// 一方 grace-period-deletion は「途中まで削除されたテナントに purge が再走する」
+						// 非冪等性を持つため、再送より再走回避を優先する。
+						...('disableRetry' in job && job.disableRetry ? { retryAttempts: 0 } : {}),
 					}),
 				);
 			}

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -169,6 +169,10 @@ export class ComputeStack extends cdk.Stack {
 		// 後方互換: 既存 GitHub Secret `OPS_SECRET_KEY` を cronSecret context として渡す運用が続く間は、
 		// CDK でも OPS_SECRET_KEY / CRON_SECRET の両方の env を Lambda に注入し、
 		// アプリ側 (checkAuth) がどちらでも通るようにする。
+		// #4327: 顧客データ物理削除の kill-switch。deploy 時に `-c gracePeriodDeletionDisabled=true`
+		// を渡すと物理削除を停止したまま deploy できる (既定は従来どおり有効)。
+		const gracePeriodDeletionDisabled =
+			this.node.tryGetContext('gracePeriodDeletionDisabled') === 'true' ? 'true' : 'false';
 		const cronSecret = this.node.tryGetContext('cronSecret') ?? '';
 		const legacyOpsSecretKey = this.node.tryGetContext('opsSecretKey') ?? '';
 
@@ -356,6 +360,12 @@ export class ComputeStack extends cdk.Stack {
 						COGNITO_CALLBACK_URL: 'https://ganbari-quest.com/auth/callback',
 						CONTEXT_TOKEN_SECRET: contextTokenSecret,
 						MAINTENANCE_MODE: 'false',
+						// #4327: 顧客データ物理削除 (grace-period-deletion cron) の kill-switch。
+						// 'true' で削除を一切実行しない。既定 'false' = 従来動作。
+						// EventBridge Rule の disable (`aws events disable-rule`) が「cron を呼ばない」
+						// 防御なのに対し、本 env は「呼ばれても消さない」防御 (手動 POST も止まる)。
+						// 手順: docs/runbooks/grace-period-deletion-operations.md
+						GRACE_PERIOD_DELETION_DISABLED: gracePeriodDeletionDisabled,
 						...(feedbackDiscordWebhookUrl
 							? { FEEDBACK_DISCORD_WEBHOOK_URL: feedbackDiscordWebhookUrl }
 							: {}),
@@ -523,6 +533,13 @@ export class ComputeStack extends cdk.Stack {
 				rule.addTarget(
 					new eventsTargets.LambdaFunction(this.cronDispatcherFn, {
 						event: events.RuleTargetInput.fromObject({ cronJob: job.name }),
+						// #4327: 非同期呼び出しの既定リトライ (最大 2 回) を切る。
+						// cron job は 30 秒 self-limiting + 翌日持ち越し前提で設計されており
+						// (grace-period-deletion の tenantsRemaining 等)、途中まで進んだ job の
+						// 自動再送は「部分削除されたテナントに対して purge が再走する」非冪等な
+						// 危険を生む。1 回の取りこぼしは翌日の実行が回収し、失敗自体は
+						// dispatcher Errors alarm + grace-period 失敗 alarm で観測される。
+						retryAttempts: 0,
 					}),
 				);
 			}

--- a/infra/lib/ops-alert-policy.ts
+++ b/infra/lib/ops-alert-policy.ts
@@ -78,6 +78,11 @@ export const ALARM_NOTIFY_POLICY: Record<string, AlarmNotifyPolicy> = {
 		reason:
 			'log MetricFilter 由来で平常時はデータ点が無い。fail-closed の実発火を 1 度も観測していない',
 	},
+	'ganbari-quest-grace-period-partial-failure': {
+		notify: false,
+		reason:
+			'log MetricFilter 由来で平常時はデータ点が無く、cron 自体が #4327 の対応まで Rule 無効。実発火の観測がゼロのため、まず本番で 1 サイクル観測してから昇格する。なお同じ部分失敗は endpoint が Discord incident webhook (sendDiscordAlert) へ直接出すため、昇格前でも人には届く',
+	},
 	'ganbari-quest-cron-dispatcher-errors': {
 		notify: false,
 		reason: 'cron 失敗は顧客影響が出るまで時間差がある。まず失敗頻度の実績を取る',

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -59,6 +59,21 @@ export interface OpsStackProps extends cdk.StackProps {
  */
 export const ENTITLEMENT_FAIL_CLOSED_LOG_TERM = '[auth-alert] auth-entitlement-db-unavailable';
 
+/**
+ * #4327: 顧客データの物理削除 (grace-period-deletion cron) が**部分的に失敗**したことを表す
+ * log の検索語。
+ *
+ * SSOT は `GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM`
+ * (`src/lib/server/services/grace-period-service.ts`)。上記 entitlement 版と同じく rootDir
+ * 制約で import できないため literal で持ち、
+ * `tests/unit/infra/grace-period-partial-failure-alarm.test.ts` が drift を機械検証する。
+ *
+ * この失敗は「途中まで消えたテナント」を意味し、放置すると顧客データが中途半端な状態で
+ * 残り続ける。dispatcher の Errors metric (endpoint が 500 を返すため発火する) だけでは
+ * どの cron が失敗したのか分からないため、専用の metric で切り分け可能にする。
+ */
+export const GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM = '[grace-period-deletion] partial failure';
+
 export class OpsStack extends cdk.Stack {
 	constructor(scope: Construct, id: string, props: OpsStackProps) {
 		super(scope, id, props);
@@ -283,6 +298,54 @@ export class OpsStack extends cdk.Stack {
 			});
 			entitlementFailClosedAlarm.addAlarmAction(alarmAction);
 			entitlementFailClosedAlarm.addOkAction(alarmAction);
+
+			// P0: 顧客データ物理削除の部分失敗 (#4327)
+			//
+			// grace-period-deletion cron は「消したら戻せない」処理を 1 日 1 回走らせる。
+			// 部分失敗 (tenantsFailed > 0) は「途中まで消えたテナント」が生まれた合図であり、
+			// 気付くのが遅れるほど回復の選択肢が減る (単一テナントの復旧手段は無い —
+			// docs/runbooks/grace-period-deletion-operations.md §復旧の限界)。
+			//
+			// endpoint が 500 を返すため dispatcher の Errors metric にも乗るが、
+			// あちらは「どれかの cron が失敗した」までしか分からない。切り分けのために
+			// log 本文を情報源とする専用 metric を持つ。
+			//
+			// 閾値: 1 件で即発火。cron は 1 日 1 回のためデータ点が密には出ず、
+			// 「複数 window で継続」を待つと丸 1 日以上気付けない。log が無い間は
+			// データ点自体が無いため treatMissingData=NOT_BREACHING。
+			const gracePeriodPartialFailure = new logs.MetricFilter(
+				this,
+				'GracePeriodPartialFailureFilter',
+				{
+					logGroup: props.appLogGroup,
+					filterPattern: logs.FilterPattern.literal(`"${GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM}"`),
+					metricNamespace: 'GanbariQuest/Deletion',
+					metricName: 'GracePeriodPartialFailure',
+					metricValue: '1',
+					defaultValue: 0,
+				},
+			);
+
+			const gracePeriodPartialFailureAlarm = new cloudwatch.Alarm(
+				this,
+				'GracePeriodPartialFailure',
+				{
+					alarmName: 'ganbari-quest-grace-period-partial-failure',
+					alarmDescription:
+						'顧客データの物理削除が途中で失敗した (途中まで消えたテナントが存在する可能性) (#4327)',
+					metric: gracePeriodPartialFailure.metric({
+						period: cdk.Duration.hours(1),
+						statistic: 'Sum',
+					}),
+					threshold: 1,
+					evaluationPeriods: 1,
+					datapointsToAlarm: 1,
+					comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+					treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+				},
+			);
+			gracePeriodPartialFailureAlarm.addAlarmAction(alarmAction);
+			gracePeriodPartialFailureAlarm.addOkAction(alarmAction);
 		}
 
 		// P0: Cron Dispatcher Lambda Errors (#1376 AC6)

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -66,7 +66,7 @@ export const ENTITLEMENT_FAIL_CLOSED_LOG_TERM = '[auth-alert] auth-entitlement-d
  * SSOT は `GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM`
  * (`src/lib/server/services/grace-period-service.ts`)。上記 entitlement 版と同じく rootDir
  * 制約で import できないため literal で持ち、
- * `tests/unit/infra/grace-period-partial-failure-alarm.test.ts` が drift を機械検証する。
+ * `tests/unit/infra/grace-period-deletion-safety.test.ts` が drift を機械検証する。
  *
  * この失敗は「途中まで消えたテナント」を意味し、放置すると顧客データが中途半端な状態で
  * 残り続ける。dispatcher の Errors metric (endpoint が 500 を返すため発火する) だけでは

--- a/src/lib/runtime/env.ts
+++ b/src/lib/runtime/env.ts
@@ -123,6 +123,18 @@ const envSchema = z.object({
 	// ----- Ops (ADR-0033) -----
 	CRON_SECRET: z.string().min(32).optional(),
 	OPS_SECRET_KEY: z.string().optional(),
+
+	/**
+	 * #4327: 顧客データ物理削除 (grace-period-deletion cron) の kill-switch。
+	 * `'true'` / `'1'` で削除を一切実行しない。未設定 = 従来どおり有効。
+	 *
+	 * **`booleanStringSchema` を使わない**: 同 schema は `'true'|'false'` 以外を
+	 * validation error にし、`getEnv()` は module load 時に throw する
+	 * (= アプリ全体が起動しない)。本 env は**障害対応中に手で急いで設定する**もので、
+	 * `1` / `yes` 等の打ち間違いでアプリを落とすのは筋が悪い。文字列のまま受け、
+	 * 解釈と「解釈できない値だった」の警告は grace-period-service 側で行う。
+	 */
+	GRACE_PERIOD_DELETION_DISABLED: z.string().optional(),
 	OPS_DOMAIN_COST_JPY: z.coerce.number().int().default(117),
 	OPS_VIRTUAL_OFFICE_COST_JPY: z.coerce.number().int().default(0),
 

--- a/src/lib/server/services/account-deletion-service.ts
+++ b/src/lib/server/services/account-deletion-service.ts
@@ -16,7 +16,11 @@ import { logger } from '$lib/server/logger';
 import { deleteByPrefix } from '$lib/server/storage';
 import { sendMemberRemovedEmail } from './email-service';
 import { cancelSubscription } from './stripe-service';
-import { deleteAllChildrenData, deleteTenantScopedData } from './tenant-cleanup-service';
+import {
+	deleteAllChildrenData,
+	deleteTenantScopedData,
+	deleteTenantSettings,
+} from './tenant-cleanup-service';
 
 // ============================================================
 // Types
@@ -170,7 +174,12 @@ async function fullTenantDeletion(
 	const filesDeleted = await deleteByPrefix(`tenants/${tenantId}/`);
 
 	// 2. テナントスコープのデータ削除（activities, viewerTokens, cloudExports, pushSubscriptions, voice 等）
-	itemsDeleted += await deleteTenantScopedData(tenantId);
+	// #4327: `settings` だけは消さない (deferSettings)。`settings` は soft-delete 判定材料
+	// (`soft_deleted_at` / `physical_deletion_date`) の置き場であり、ここで消すと後続ステップの
+	// 途中失敗が「families / users / memberships は残るが判定材料は無い」宙吊り行を作る
+	// (findExpiredSoftDeletedTenants の母集団から外れて二度と消せず、soft_deleted_at も無いので
+	// 復元もできない)。判定材料は families 行を消した後に落とす (末尾)。
+	itemsDeleted += await deleteTenantScopedData(tenantId, { deferSettings: true });
 
 	// 3. 子供データ削除
 	itemsDeleted += await deleteAllChildrenData(tenantId);
@@ -197,6 +206,12 @@ async function fullTenantDeletion(
 	// 6. テナント削除
 	await repos().auth.deleteTenant(tenantId);
 	itemsDeleted++;
+
+	// 7. 判定材料 (settings) の削除 — #4327: 必ず families 行の削除より後に置く。
+	// ここまで来ていれば「families が残ったまま判定材料だけ消えた」状態は成立しない。
+	// 本 step が失敗した場合は settings 行だけが孤児として残るが、例外は握り潰さず
+	// 呼び出し元 (purge) の errors[] → alarm に載せる。
+	itemsDeleted += await deleteTenantSettings(tenantId);
 
 	// #4192: 削除完了の Discord 通知は**持たないと決めた** (#4174 Q2、churn チャネル)。
 	// 削除の事実・件数は呼び出し元の `[account-deletion] ... 削除完了` ログ (tenantId + 件数付き) が残す。
@@ -362,7 +377,8 @@ export async function deleteOwnerFullDelete(
 	const filesDeleted = await deleteByPrefix(`tenants/${tenantId}/`);
 
 	// 2. テナントスコープのデータ削除（activities, viewerTokens, cloudExports, pushSubscriptions, voice 等）
-	itemsDeleted += await deleteTenantScopedData(tenantId);
+	// #4327: `settings` (soft-delete 判定材料) は step 8 まで残す。理由は fullTenantDeletion 参照。
+	itemsDeleted += await deleteTenantScopedData(tenantId, { deferSettings: true });
 
 	// 3. Children data
 	itemsDeleted += await deleteAllChildrenData(tenantId);
@@ -381,6 +397,9 @@ export async function deleteOwnerFullDelete(
 	// 7. Delete tenant
 	await repos().auth.deleteTenant(tenantId);
 	itemsDeleted++;
+
+	// 8. 判定材料 (settings) の削除 — #4327: 必ず families 行の削除より後。
+	itemsDeleted += await deleteTenantSettings(tenantId);
 
 	// #4192: 削除完了の Discord 通知は**持たないと決めた** (#4174 Q2、churn チャネル)。
 	// 削除の事実・件数は呼び出し元の `[account-deletion] ... 削除完了` ログが残す。

--- a/src/lib/server/services/grace-period-service.ts
+++ b/src/lib/server/services/grace-period-service.ts
@@ -9,7 +9,7 @@
 //   standard: 7日間
 //   family:   30日間
 
-import { env } from '$env/dynamic/private';
+import { env } from '$lib/runtime/env';
 import { createTimeBudget, type TimeBudget } from '$lib/server/cron/time-budget';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -34,7 +34,7 @@ export const DELETION_WARNING_SENT_KEY = 'deletion_warning_sent_at';
  *
  * この語で CloudWatch Logs MetricFilter を張り、alarm 化する
  * (`infra/lib/ops-stack.ts` の `GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM` と同値であることを
- * `tests/unit/infra/grace-period-partial-failure-alarm.test.ts` が drift 検証する)。
+ * `tests/unit/infra/grace-period-deletion-safety.test.ts` が drift 検証する)。
  * infra は CDK の rootDir 制約で src から import できないため、値の二重定義 + test で守る
  * (`ENTITLEMENT_FAIL_CLOSED_LOG_TERM` と同じ形)。
  */
@@ -400,12 +400,27 @@ export const DEFAULT_PURGE_LIMIT = 5;
  */
 export const GRACE_PERIOD_DELETION_DISABLED_ENV = 'GRACE_PERIOD_DELETION_DISABLED';
 
+/** 「止める」と解釈する値。障害対応中に手で打つものなので表記ゆれを許容する。 */
+const DISABLED_VALUES = new Set(['true', '1', 'yes', 'on']);
+/** 「止めない」と解釈する値 (明示的に有効化した状態)。 */
+const ENABLED_VALUES = new Set(['false', '0', 'no', 'off', '']);
+
 function isPhysicalDeletionDisabled(): boolean {
-	// env 名は直接プロパティで読む (`env[定数]` にすると env 配布 closure gate
-	// `tests/unit/architecture/env-distribution-closure.test.ts` の抽出から外れ、
-	// 「読んでいるのに配られていない」を検出できなくなるため)。
 	const raw = env.GRACE_PERIOD_DELETION_DISABLED;
-	return raw === 'true' || raw === '1';
+	if (raw === undefined) return false;
+	const normalized = raw.trim().toLowerCase();
+	if (DISABLED_VALUES.has(normalized)) return true;
+	if (ENABLED_VALUES.has(normalized)) return false;
+
+	// 打ち間違いを **silent に「有効」へ倒さない**。停止したつもりの人が
+	// 「止まっていない」ことに気付けるよう、実行のたびに warn を残す。
+	// (throw しないのは、障害対応中の typo でアプリ全体を落とさないため。
+	//  env schema 側も同じ理由で booleanStringSchema を使っていない)
+	logger.warn(
+		`[grace-period] ${GRACE_PERIOD_DELETION_DISABLED_ENV} の値を解釈できません。物理削除は「有効」として続行します`,
+		{ context: { value: raw, expected: [...DISABLED_VALUES].join(' / ') } },
+	);
+	return false;
 }
 
 export async function purgeExpiredSoftDeletedTenants(opts?: {

--- a/src/lib/server/services/grace-period-service.ts
+++ b/src/lib/server/services/grace-period-service.ts
@@ -9,6 +9,7 @@
 //   standard: 7日間
 //   family:   30日間
 
+import { env } from '$env/dynamic/private';
 import { createTimeBudget, type TimeBudget } from '$lib/server/cron/time-budget';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -28,6 +29,17 @@ import { resolveFullPlanTier } from './plan-limit-service';
 export const DELETION_WARNING_SENT_KEY = 'deletion_warning_sent_at';
 
 /** プラン別グレースピリオド（日数）。0 = 即時物理削除 */
+/**
+ * #4327: 物理削除の**部分失敗**を表す log 行の検索語 (SSOT)。
+ *
+ * この語で CloudWatch Logs MetricFilter を張り、alarm 化する
+ * (`infra/lib/ops-stack.ts` の `GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM` と同値であることを
+ * `tests/unit/infra/grace-period-partial-failure-alarm.test.ts` が drift 検証する)。
+ * infra は CDK の rootDir 制約で src から import できないため、値の二重定義 + test で守る
+ * (`ENTITLEMENT_FAIL_CLOSED_LOG_TERM` と同じ形)。
+ */
+export const GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM = '[grace-period-deletion] partial failure';
+
 export const DELETION_GRACE_PERIOD_DAYS: Record<PlanTier, number> = {
 	free: 0,
 	standard: 7,
@@ -376,6 +388,26 @@ export function getGracePeriodDays(planTier: PlanTier): number {
  */
 export const DEFAULT_PURGE_LIMIT = 5;
 
+/**
+ * #4327: 物理削除の kill-switch (env)。`'true'` / `'1'` で**削除を一切実行しない**。
+ *
+ * 不可逆な削除を止める手段が EventBridge Rule の手動 disable しかない状態を解消する。
+ * Rule 側 (`aws events disable-rule`) は「cron を呼ばない」防御、本 env は
+ * 「呼ばれても消さない」防御で、層が違う (手動実行 / 別経路からの呼び出しも止まる)。
+ *
+ * 既定 (未設定) は有効 = 従来動作。新規 required env は増やさない (opt-out 方式)。
+ * 手順は `docs/runbooks/grace-period-deletion-operations.md`。
+ */
+export const GRACE_PERIOD_DELETION_DISABLED_ENV = 'GRACE_PERIOD_DELETION_DISABLED';
+
+function isPhysicalDeletionDisabled(): boolean {
+	// env 名は直接プロパティで読む (`env[定数]` にすると env 配布 closure gate
+	// `tests/unit/architecture/env-distribution-closure.test.ts` の抽出から外れ、
+	// 「読んでいるのに配られていない」を検出できなくなるため)。
+	const raw = env.GRACE_PERIOD_DELETION_DISABLED;
+	return raw === 'true' || raw === '1';
+}
+
 export async function purgeExpiredSoftDeletedTenants(opts?: {
 	dryRun?: boolean;
 	/** #3695: 1 回の実行で物理削除を試行する最大テナント数。 */
@@ -389,12 +421,32 @@ export async function purgeExpiredSoftDeletedTenants(opts?: {
 	/** #3695: limit / 時間予算により今回処理せず次回実行へ持ち越した件数。 */
 	tenantsRemaining: number;
 	dryRun: boolean;
+	/** #4327: kill-switch (env) により削除を実行しなかったことを示す。 */
+	disabled: boolean;
 	expired: Array<{ tenantId: string; planTier: PlanTier; physicalDeletionDate: string }>;
 	errors: Array<{ tenantId: string; error: string }>;
 }> {
 	const dryRun = opts?.dryRun ?? false;
 	const limit = opts?.limit ?? DEFAULT_PURGE_LIMIT;
 	const budget = opts?.budget ?? createTimeBudget();
+
+	// #4327: kill-switch — 対象の走査すら行わずに即返す (誤って消す経路を残さない)。
+	if (isPhysicalDeletionDisabled()) {
+		logger.warn('[grace-period] physical deletion is disabled by kill-switch env; skipping', {
+			context: { env: GRACE_PERIOD_DELETION_DISABLED_ENV },
+		});
+		return {
+			tenantsProcessed: 0,
+			tenantsDeleted: 0,
+			tenantsFailed: 0,
+			tenantsRemaining: 0,
+			dryRun,
+			disabled: true,
+			expired: [],
+			errors: [],
+		};
+	}
+
 	const expired = await findExpiredSoftDeletedTenants();
 
 	if (dryRun || expired.length === 0) {
@@ -407,6 +459,7 @@ export async function purgeExpiredSoftDeletedTenants(opts?: {
 			tenantsFailed: 0,
 			tenantsRemaining: 0,
 			dryRun,
+			disabled: false,
 			expired,
 			errors: [],
 		};
@@ -472,6 +525,7 @@ export async function purgeExpiredSoftDeletedTenants(opts?: {
 		tenantsFailed: errors.length,
 		tenantsRemaining: remaining,
 		dryRun: false,
+		disabled: false,
 		expired,
 		errors,
 	};

--- a/src/lib/server/services/tenant-cleanup-service.ts
+++ b/src/lib/server/services/tenant-cleanup-service.ts
@@ -93,10 +93,20 @@ export async function deleteAllChildrenData(tenantId: string): Promise<number> {
  * checklist templates 等）もここで削除されるため、クリア後のユーザーは
  * トライアルを再度使えないか、使えてしまうかが確定する。
  *
+ * @param opts.deferSettings
+ *   #4327: `settings` の削除だけを行わない。`settings` は soft-delete 判定材料
+ *   (`soft_deleted_at` / `physical_deletion_date`) を保持しており、これを消した後に
+ *   後続ステップが失敗すると「`families` は残るが判定材料が無い」宙吊り行ができる
+ *   (物理削除の母集団にも復元対象にも入らない)。full deletion 経路は本 flag を立て、
+ *   `families` 行を消した**後**に {@link deleteTenantSettings} を呼ぶ。
+ *
  * @returns 削除を試みた操作数（エラーを含む）
  */
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: 複雑なビジネスロジックのため、別 Issue でリファクタ予定
-export async function deleteTenantScopedData(tenantId: string): Promise<number> {
+export async function deleteTenantScopedData(
+	tenantId: string,
+	opts?: { deferSettings?: boolean },
+): Promise<number> {
 	let deleted = 0;
 	const r = repos();
 
@@ -195,11 +205,14 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 	}
 
 	// Settings
-	try {
-		await r.settings.deleteByTenantId(tenantId);
-		deleted++;
-	} catch (err) {
-		logger.warn(`[tenant-cleanup] settings 削除失敗: ${String(err)}`);
+	// #4327: full deletion 経路は判定材料を最後まで残すため deferSettings=true で飛ばす。
+	if (!opts?.deferSettings) {
+		try {
+			await r.settings.deleteByTenantId(tenantId);
+			deleted++;
+		} catch (err) {
+			logger.warn(`[tenant-cleanup] settings 削除失敗: ${String(err)}`);
+		}
 	}
 
 	// Checklists（templates, items, logs, overrides）
@@ -371,4 +384,29 @@ export async function deleteTenantScopedData(tenantId: string): Promise<number> 
 	}
 
 	return deleted;
+}
+
+/**
+ * #4327: テナントの `settings` を削除する（物理削除の**最終ステップ**専用）。
+ *
+ * `settings` は soft-delete 判定材料 (`soft_deleted_at` / `physical_deletion_date`) の
+ * 置き場であり、`findExpiredSoftDeletedTenants` / `getGracePeriodStatus` はこれだけを見る。
+ * したがって `families` 行より先に消すと、途中失敗時に
+ * 「`families` / `users` / `memberships` は残るが判定材料が無い」= 再削除も復元もできない
+ * 宙吊り行ができる。`families` を消した後に本関数を呼ぶことで、その状態を構造的に作れなくする。
+ *
+ * {@link deleteTenantScopedData} 内の settings 削除 (best-effort / warn 継続) と異なり、
+ * 本関数は**失敗を投げる**。この時点で `families` は既に無く自動リトライの母集団に戻せないため、
+ * silent に握り潰さず呼び出し元の errors[] → alarm に載せて人が気付けるようにする (ADR-0006)。
+ */
+export async function deleteTenantSettings(tenantId: string): Promise<number> {
+	try {
+		await repos().settings.deleteByTenantId(tenantId);
+		return 1;
+	} catch (err) {
+		logger.error('[tenant-cleanup] settings 削除失敗 (tenant 行は削除済 / 手動掃除が必要)', {
+			context: { tenantId, error: String(err) },
+		});
+		throw err;
+	}
 }

--- a/src/lib/server/services/tenant-cleanup-service.ts
+++ b/src/lib/server/services/tenant-cleanup-service.ts
@@ -398,6 +398,18 @@ export async function deleteTenantScopedData(
  * {@link deleteTenantScopedData} 内の settings 削除 (best-effort / warn 継続) と異なり、
  * 本関数は**失敗を投げる**。この時点で `families` は既に無く自動リトライの母集団に戻せないため、
  * silent に握り潰さず呼び出し元の errors[] → alarm に載せて人が気付けるようにする (ADR-0006)。
+ *
+ * ## 受容した残余リスク
+ *
+ * 本関数が失敗すると `settings` 行だけが孤児として残る。そこには `pin_hash` /
+ * `session_token` / `questionnaire_*` が含まれるため、無害ではなく**手動掃除が要る**
+ * (`docs/runbooks/grace-period-deletion-operations.md` §3 に手順と判断根拠)。
+ *
+ * 「機微キーだけ先に消す」設計は採らなかった: settings repo は `getSettings(keys)` と
+ * `deleteByTenantId(tenantId)` しか持たず、部分削除には消すキーの列挙が要る。列挙を置くと
+ * 新しい設定キーが増えたとき黙って消し漏らす (#4327 と同型の silent gap をもう 1 つ作る)。
+ * この孤児は alarm + log で必ず観測でき手で消せるのに対し、判定材料を先に消して生まれる
+ * 宙吊り行は観測も修復もできない。**観測できて直せる残余を選んでいる**。
  */
 export async function deleteTenantSettings(tenantId: string): Promise<number> {
 	try {

--- a/src/routes/api/cron/grace-period-deletion/+server.ts
+++ b/src/routes/api/cron/grace-period-deletion/+server.ts
@@ -67,11 +67,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			await sendDiscordAlert({
 				level: 'critical',
 				message: '顧客データの物理削除が途中で失敗しました (grace-period-deletion)',
-				details: {
-					tenantsProcessed: String(result.tenantsProcessed),
-					tenantsDeleted: String(result.tenantsDeleted),
-					tenantsFailed: String(result.tenantsFailed),
-				},
+				details: `処理 ${result.tenantsProcessed} 件 / 削除成功 ${result.tenantsDeleted} 件 / 失敗 ${result.tenantsFailed} 件`,
 			}).catch(() => {
 				// 通知の失敗で 500 応答自体を潰さない (500 は dispatcher の Errors alarm に載る)。
 			});

--- a/src/routes/api/cron/grace-period-deletion/+server.ts
+++ b/src/routes/api/cron/grace-period-deletion/+server.ts
@@ -23,8 +23,12 @@
 
 import { json } from '@sveltejs/kit';
 import { verifyCronAuth } from '$lib/server/auth/cron-auth';
+import { sendDiscordAlert } from '$lib/server/discord-alert';
 import { logger } from '$lib/server/logger';
-import { purgeExpiredSoftDeletedTenants } from '$lib/server/services/grace-period-service';
+import {
+	GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM,
+	purgeExpiredSoftDeletedTenants,
+} from '$lib/server/services/grace-period-service';
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ request }) => {
@@ -41,6 +45,39 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	try {
 		const result = await purgeExpiredSoftDeletedTenants({ dryRun });
+
+		// #4327: 部分失敗 (tenantsFailed > 0) を 200 に埋めない。
+		// dispatcher は 2xx を成功として扱うため、200 で返すとどの alarm にも乗らず
+		// 「途中まで消えたテナント」が誰にも観測されないまま残る。500 で返して
+		// dispatcher Lambda の Errors metric (既存 alarm) に載せる。
+		// 本文は同じ shape のまま返し、どのテナントが失敗したかを errors[] で残す。
+		if (result.tenantsFailed > 0) {
+			logger.error(GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM, {
+				service: 'grace-period-deletion',
+				context: {
+					tenantsProcessed: result.tenantsProcessed,
+					tenantsDeleted: result.tenantsDeleted,
+					tenantsFailed: result.tenantsFailed,
+					failedTenantIds: result.errors.map((e) => e.tenantId),
+				},
+			});
+			// 既存の incident 経路に載せる (新規通知機構は作らない)。
+			// payload に tenantId 等の顧客識別子は載せない (discord-alert.ts の設計制約)。
+			// 調査は CloudWatch Logs の同 log 行 (failedTenantIds 付き) から行う。
+			await sendDiscordAlert({
+				level: 'critical',
+				message: '顧客データの物理削除が途中で失敗しました (grace-period-deletion)',
+				details: {
+					tenantsProcessed: String(result.tenantsProcessed),
+					tenantsDeleted: String(result.tenantsDeleted),
+					tenantsFailed: String(result.tenantsFailed),
+				},
+			}).catch(() => {
+				// 通知の失敗で 500 応答自体を潰さない (500 は dispatcher の Errors alarm に載る)。
+			});
+			return json({ ok: false, ...result }, { status: 500 });
+		}
+
 		return json({
 			ok: true,
 			...result,

--- a/tests/unit/infra/grace-period-deletion-safety.test.ts
+++ b/tests/unit/infra/grace-period-deletion-safety.test.ts
@@ -4,7 +4,7 @@
 // 守る不変条件:
 //   [A] 部分失敗が CloudWatch の専用 metric / alarm に乗る (観測)
 //   [B] CDK の literal 検索語がアプリ側の SSOT と一致する (drift)
-//   [C] cron の EventBridge target が自動リトライしない (非冪等な再走の防止)
+//   [C] 非冪等な cron だけ自動リトライを切る (再走の防止と、取りこぼしの防止の両立)
 //   [D] kill-switch env がアプリ Lambda に配られている (呼ばれても消さない防御)
 //
 // [C] / [D] は「宣言したつもりで配線が無い」を防ぐため synth 済み template を見る。
@@ -140,8 +140,40 @@ describe('#4327 [B] 検索語 SSOT の drift', () => {
 	});
 });
 
-describe('#4327 [C] cron target は自動リトライしない', () => {
-	it('[C1] 全 EventBridge Rule の Lambda target が RetryPolicy MaximumRetryAttempts=0 を持つ', () => {
+describe('#4327 [C] 非冪等な cron だけ自動リトライを切る', () => {
+	/** cron Rule を物理名 (`...-cron-<job>`) で引く。 */
+	function cronRuleTargets(jobName: string): Array<Record<string, unknown>> {
+		const rules = computeTemplate.findResources('AWS::Events::Rule');
+		const hit = Object.values(rules).find(
+			(r) => (r.Properties as { Name?: string }).Name === `ganbari-quest-cron-${jobName}`,
+		);
+		expect(hit, `cron rule ${jobName} が見つからない`).toBeDefined();
+		const targets = (hit?.Properties as { Targets?: Array<Record<string, unknown>> }).Targets;
+		expect(targets, `${jobName} に target が無い`).toBeDefined();
+		return targets ?? [];
+	}
+
+	it('[C1] grace-period-deletion は RetryPolicy MaximumRetryAttempts=0 (非冪等な削除の再走を防ぐ)', () => {
+		for (const target of cronRuleTargets('grace-period-deletion')) {
+			expect(target.RetryPolicy).toEqual({ MaximumRetryAttempts: 0 });
+		}
+	});
+
+	// 一律 0 にすると「1 回の失敗で取りこぼす」方向に倒れる。とくに deletion-warning-emails は
+	// 送信済フラグで冪等であり、retry を切ると 1 度の失敗で **予告のないまま削除される**
+	// (#4327 が塞ごうとしている状態そのもの)。pmf-survey は年 2 回起動で 1 失敗 = 6 ヶ月欠測。
+	it.each([
+		'deletion-warning-emails',
+		'pmf-survey',
+		'export-build',
+		'retention-cleanup',
+	])('[C2] 冪等な cron (%s) は既定のリトライを維持する', (jobName) => {
+		for (const target of cronRuleTargets(jobName)) {
+			expect(target.RetryPolicy).toBeUndefined();
+		}
+	});
+
+	it('[C3] リトライを切っている cron は grace-period-deletion のみ (無自覚な横展開の検出)', () => {
 		const rules = computeTemplate.findResources('AWS::Events::Rule');
 		const cronRules = Object.entries(rules).filter(([, r]) =>
 			String((r.Properties as { Name?: string }).Name ?? '').includes('-cron-'),
@@ -149,15 +181,15 @@ describe('#4327 [C] cron target は自動リトライしない', () => {
 		// gate 自身の故障検出 (抽出が壊れて 0 件になると全部素通りする)
 		expect(cronRules.length).toBeGreaterThanOrEqual(5);
 
-		for (const [id, rule] of cronRules) {
-			const targets = (rule.Properties as { Targets?: Array<Record<string, unknown>> }).Targets;
-			expect(targets, `${id} に target が無い`).toBeDefined();
-			for (const target of targets ?? []) {
-				expect(target.RetryPolicy, `${id} の target に RetryPolicy が無い`).toEqual({
-					MaximumRetryAttempts: 0,
-				});
-			}
-		}
+		const disabled = cronRules
+			.filter(([, r]) =>
+				((r.Properties as { Targets?: Array<Record<string, unknown>> }).Targets ?? []).some(
+					(t) => t.RetryPolicy !== undefined,
+				),
+			)
+			.map(([, r]) => (r.Properties as { Name?: string }).Name);
+
+		expect(disabled).toEqual(['ganbari-quest-cron-grace-period-deletion']);
 	});
 });
 

--- a/tests/unit/infra/grace-period-deletion-safety.test.ts
+++ b/tests/unit/infra/grace-period-deletion-safety.test.ts
@@ -1,0 +1,188 @@
+// tests/unit/infra/grace-period-deletion-safety.test.ts
+// #4327: 顧客データ物理削除まわりの infra 側不変条件。
+//
+// 守る不変条件:
+//   [A] 部分失敗が CloudWatch の専用 metric / alarm に乗る (観測)
+//   [B] CDK の literal 検索語がアプリ側の SSOT と一致する (drift)
+//   [C] cron の EventBridge target が自動リトライしない (非冪等な再走の防止)
+//   [D] kill-switch env がアプリ Lambda に配られている (呼ばれても消さない防御)
+//
+// [C] / [D] は「宣言したつもりで配線が無い」を防ぐため synth 済み template を見る。
+// context stub パターンは tests/unit/infra/entitlement-fail-closed-alarm.test.ts を踏襲。
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import { ALARM_NOTIFY_POLICY } from '../../../infra/lib/ops-alert-policy';
+import { GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM, OpsStack } from '../../../infra/lib/ops-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+import { GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM as APP_LOG_TERM } from '../../../src/lib/server/services/grace-period-service';
+
+// cspell:ignore TESTPOOL
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+const ALARM_NAME = 'ganbari-quest-grace-period-partial-failure';
+
+function makeApp(extraContext: Record<string, unknown> = {}): cdk.App {
+	return new cdk.App({
+		context: {
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+			...extraContext,
+		},
+	});
+}
+
+function build(extraContext: Record<string, unknown> = {}): {
+	ops: Template;
+	compute: Template;
+} {
+	const app = makeApp(extraContext);
+	const storage = new StorageStack(app, 'TestStorage', { env });
+	const compute = new ComputeStack(app, 'TestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'TestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+	});
+	const ops = new OpsStack(app, 'TestOps', {
+		env,
+		lambdaFn: compute.fn,
+		distribution: network.distribution,
+		functionUrl: compute.functionUrl,
+		cronDispatcherFn: compute.cronDispatcherFn,
+		appLogGroup: compute.appLogGroup,
+		opsEmail: 'ops@example.com',
+	});
+	return { ops: Template.fromStack(ops), compute: Template.fromStack(compute) };
+}
+
+let opsTemplate: Template;
+let computeTemplate: Template;
+let computeDisabledTemplate: Template;
+
+beforeAll(() => {
+	const built = build();
+	opsTemplate = built.ops;
+	computeTemplate = built.compute;
+	computeDisabledTemplate = build({ gracePeriodDeletionDisabled: 'true' }).compute;
+}, 240_000);
+
+describe('#4327 [A] 部分失敗が専用の metric / alarm に乗る', () => {
+	it('[A1] MetricFilter が期待の pattern / metric で作られる', () => {
+		opsTemplate.hasResourceProperties('AWS::Logs::MetricFilter', {
+			FilterPattern: `"${GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM}"`,
+			MetricTransformations: Match.arrayWith([
+				Match.objectLike({
+					MetricNamespace: 'GanbariQuest/Deletion',
+					MetricName: 'GracePeriodPartialFailure',
+					MetricValue: '1',
+					DefaultValue: 0,
+				}),
+			]),
+		});
+	});
+
+	// cron は 1 日 1 回しか走らない。継続 window を待つ設計にすると気付くまで丸 1 日以上
+	// かかり、その間に翌日の実行がさらに削除を進める。1 件で即発火させること。
+	it('[A2] Alarm は 1 件で即発火し、SNS topic に接続されている', () => {
+		opsTemplate.hasResourceProperties('AWS::CloudWatch::Alarm', {
+			AlarmName: ALARM_NAME,
+			Namespace: 'GanbariQuest/Deletion',
+			MetricName: 'GracePeriodPartialFailure',
+			Threshold: 1,
+			EvaluationPeriods: 1,
+			DatapointsToAlarm: 1,
+			TreatMissingData: 'notBreaching',
+			AlarmActions: Match.anyValue(),
+		});
+	});
+
+	it('[A3] 通知方針 (ALARM_NOTIFY_POLICY) に宣言されている', () => {
+		expect(ALARM_NOTIFY_POLICY[ALARM_NAME]).toBeDefined();
+		expect(ALARM_NOTIFY_POLICY[ALARM_NAME]?.reason.length).toBeGreaterThan(20);
+	});
+});
+
+describe('#4327 [B] 検索語 SSOT の drift', () => {
+	it('[B1] CDK の literal がアプリ側の定数と一致する', () => {
+		expect(GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM).toBe(APP_LOG_TERM);
+	});
+
+	it('[B2] endpoint が実際にその定数で log を書いている', () => {
+		const source = fs.readFileSync(
+			path.resolve(__dirname, '../../..', 'src/routes/api/cron/grace-period-deletion/+server.ts'),
+			'utf-8',
+		);
+		expect(source).toContain('logger.error(GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM');
+	});
+});
+
+describe('#4327 [C] cron target は自動リトライしない', () => {
+	it('[C1] 全 EventBridge Rule の Lambda target が RetryPolicy MaximumRetryAttempts=0 を持つ', () => {
+		const rules = computeTemplate.findResources('AWS::Events::Rule');
+		const cronRules = Object.entries(rules).filter(([, r]) =>
+			String((r.Properties as { Name?: string }).Name ?? '').includes('-cron-'),
+		);
+		// gate 自身の故障検出 (抽出が壊れて 0 件になると全部素通りする)
+		expect(cronRules.length).toBeGreaterThanOrEqual(5);
+
+		for (const [id, rule] of cronRules) {
+			const targets = (rule.Properties as { Targets?: Array<Record<string, unknown>> }).Targets;
+			expect(targets, `${id} に target が無い`).toBeDefined();
+			for (const target of targets ?? []) {
+				expect(target.RetryPolicy, `${id} の target に RetryPolicy が無い`).toEqual({
+					MaximumRetryAttempts: 0,
+				});
+			}
+		}
+	});
+});
+
+describe('#4327 [D] kill-switch env がアプリ Lambda に配られている', () => {
+	it('[D1] 既定は "false" (従来動作)', () => {
+		computeTemplate.hasResourceProperties('AWS::Lambda::Function', {
+			Environment: Match.objectLike({
+				Variables: Match.objectLike({ GRACE_PERIOD_DELETION_DISABLED: 'false' }),
+			}),
+		});
+	});
+
+	it('[D2] context で "true" を渡すと停止状態で deploy できる', () => {
+		computeDisabledTemplate.hasResourceProperties('AWS::Lambda::Function', {
+			Environment: Match.objectLike({
+				Variables: Match.objectLike({ GRACE_PERIOD_DELETION_DISABLED: 'true' }),
+			}),
+		});
+	});
+
+	it('[D3] deploy workflow が context を渡している (配布経路が繋がっている)', () => {
+		const workflow = fs.readFileSync(
+			path.resolve(__dirname, '../../..', '.github/workflows/deploy.yml'),
+			'utf-8',
+		);
+		expect(workflow).toContain('-c gracePeriodDeletionDisabled=');
+	});
+});

--- a/tests/unit/infra/grace-period-deletion-safety.test.ts
+++ b/tests/unit/infra/grace-period-deletion-safety.test.ts
@@ -63,6 +63,8 @@ function build(extraContext: Record<string, unknown> = {}): {
 	const network = new NetworkStack(app, 'TestNetwork', {
 		env,
 		functionUrl: compute.functionUrl,
+		// #4280: front door shared secret (NetworkStackProps 必須)。テスト用ダミー値。
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
 		domainName: 'ganbari-quest.com',
 		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
 		demoFunctionUrl: compute.demoFunctionUrl,

--- a/tests/unit/infra/physical-name-ratchet.test.ts
+++ b/tests/unit/infra/physical-name-ratchet.test.ts
@@ -328,6 +328,9 @@ const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-auth-entitlement-db-unavailable',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-cloudfront-5xx',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-cron-dispatcher-errors',
+			// #4327: 顧客データ物理削除の部分失敗。runbook (grace-period-deletion-operations.md §2) が
+			// この名前で参照するため固定名が要る。
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-grace-period-partial-failure',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-concurrent',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-duration-p99',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-errors',

--- a/tests/unit/routes/cron-grace-period-deletion.test.ts
+++ b/tests/unit/routes/cron-grace-period-deletion.test.ts
@@ -1,0 +1,135 @@
+// tests/unit/routes/cron-grace-period-deletion.test.ts
+// #4327: 物理削除 cron endpoint の観測性テスト。
+//
+// 部分失敗 (tenantsFailed > 0) が HTTP 200 に埋もれると、cron-dispatcher は 2xx を成功として
+// 扱うためどの alarm にも乗らず、「途中まで消えたテナント」が誰にも観測されないまま残る
+// (#4327 product-2 / security-2)。endpoint が 500 を返すことで
+//   - dispatcher の httpPost が非 2xx を reject → Lambda invocation error
+//   - → 既存の `ganbari-quest-cron-dispatcher-errors` alarm が発火する
+// という既存経路に載る。あわせて Discord の incident webhook にも直接出す。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), critical: vi.fn() },
+}));
+
+const purgeMock = vi.fn();
+vi.mock('$lib/server/services/grace-period-service', () => ({
+	GRACE_PERIOD_PARTIAL_FAILURE_LOG_TERM: '[grace-period-deletion] partial failure',
+	purgeExpiredSoftDeletedTenants: (...args: unknown[]) => purgeMock(...args),
+}));
+
+const sendDiscordAlertMock = vi.fn(async () => {});
+vi.mock('$lib/server/discord-alert', () => ({
+	sendDiscordAlert: (...args: unknown[]) => sendDiscordAlertMock(...args),
+}));
+
+const ENDPOINT = 'http://localhost/api/cron/grace-period-deletion';
+const SECRET = 'test-cron-secret-4327';
+const originalEnv = { ...process.env };
+
+function authedRequest(): Request {
+	return new Request(ENDPOINT, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', 'x-cron-secret': SECRET },
+		body: JSON.stringify({}),
+	});
+}
+
+async function postEndpoint() {
+	const { POST } = await import('../../../src/routes/api/cron/grace-period-deletion/+server');
+	return POST({ request: authedRequest() } as unknown as Parameters<typeof POST>[0]);
+}
+
+function purgeResult(over: Partial<Record<string, unknown>> = {}) {
+	return {
+		tenantsProcessed: 0,
+		tenantsDeleted: 0,
+		tenantsFailed: 0,
+		tenantsRemaining: 0,
+		dryRun: false,
+		disabled: false,
+		expired: [],
+		errors: [],
+		...over,
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	process.env = { ...originalEnv };
+	process.env.CRON_SECRET = SECRET;
+});
+
+afterEach(() => {
+	process.env = originalEnv;
+});
+
+describe('#4327 grace-period-deletion endpoint の部分失敗の観測性', () => {
+	it('部分失敗 (tenantsFailed > 0) は 200 ではなく 500 を返す', async () => {
+		purgeMock.mockResolvedValue(
+			purgeResult({
+				tenantsProcessed: 2,
+				tenantsDeleted: 1,
+				tenantsFailed: 1,
+				errors: [{ tenantId: 't-fail', error: 'boom' }],
+			}),
+		);
+
+		const res = await postEndpoint();
+
+		expect(res.status).toBe(500);
+		const body = await res.json();
+		expect(body.ok).toBe(false);
+		// 何が起きたかは body に残す (500 にするだけで情報を落とさない)
+		expect(body.tenantsFailed).toBe(1);
+		expect(body.errors).toEqual([{ tenantId: 't-fail', error: 'boom' }]);
+	});
+
+	it('部分失敗は既存の Discord incident 経路にも出す (顧客識別子は載せない)', async () => {
+		purgeMock.mockResolvedValue(
+			purgeResult({
+				tenantsProcessed: 3,
+				tenantsDeleted: 2,
+				tenantsFailed: 1,
+				errors: [{ tenantId: 't-fail', error: 'boom' }],
+			}),
+		);
+
+		await postEndpoint();
+
+		expect(sendDiscordAlertMock).toHaveBeenCalledTimes(1);
+		const payload = sendDiscordAlertMock.mock.calls[0][0] as {
+			level: string;
+			message: string;
+			details?: Record<string, string>;
+		};
+		expect(payload.level).toBe('critical');
+		expect(payload.details).toMatchObject({ tenantsFailed: '1' });
+		// tenantId が payload に載っていないこと (discord-alert.ts の設計制約)
+		expect(JSON.stringify(payload)).not.toContain('t-fail');
+	});
+
+	it('全件成功なら従来どおり 200 を返し、alert も出さない (回帰)', async () => {
+		purgeMock.mockResolvedValue(
+			purgeResult({ tenantsProcessed: 2, tenantsDeleted: 2, tenantsFailed: 0 }),
+		);
+
+		const res = await postEndpoint();
+
+		expect(res.status).toBe(200);
+		await expect(res.json()).resolves.toMatchObject({ ok: true, tenantsDeleted: 2 });
+		expect(sendDiscordAlertMock).not.toHaveBeenCalled();
+	});
+
+	it('kill-switch で無効化されている場合も 200 (失敗ではない)', async () => {
+		purgeMock.mockResolvedValue(purgeResult({ disabled: true }));
+
+		const res = await postEndpoint();
+
+		expect(res.status).toBe(200);
+		await expect(res.json()).resolves.toMatchObject({ ok: true, disabled: true });
+		expect(sendDiscordAlertMock).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/routes/cron-grace-period-deletion.test.ts
+++ b/tests/unit/routes/cron-grace-period-deletion.test.ts
@@ -20,9 +20,10 @@ vi.mock('$lib/server/services/grace-period-service', () => ({
 	purgeExpiredSoftDeletedTenants: (...args: unknown[]) => purgeMock(...args),
 }));
 
-const sendDiscordAlertMock = vi.fn(async () => {});
+type AlertPayload = { level: string; message: string; details?: string };
+const sendDiscordAlertMock = vi.fn(async (_payload: AlertPayload) => {});
 vi.mock('$lib/server/discord-alert', () => ({
-	sendDiscordAlert: (...args: unknown[]) => sendDiscordAlertMock(...args),
+	sendDiscordAlert: (payload: AlertPayload) => sendDiscordAlertMock(payload),
 }));
 
 const ENDPOINT = 'http://localhost/api/cron/grace-period-deletion';
@@ -100,13 +101,10 @@ describe('#4327 grace-period-deletion endpoint の部分失敗の観測性', () 
 		await postEndpoint();
 
 		expect(sendDiscordAlertMock).toHaveBeenCalledTimes(1);
-		const payload = sendDiscordAlertMock.mock.calls[0][0] as {
-			level: string;
-			message: string;
-			details?: Record<string, string>;
-		};
-		expect(payload.level).toBe('critical');
-		expect(payload.details).toMatchObject({ tenantsFailed: '1' });
+		const payload = sendDiscordAlertMock.mock.calls[0]?.[0];
+		expect(payload?.level).toBe('critical');
+		// 件数は届く (triage に必要な「毎回変わる情報」)
+		expect(payload?.details).toContain('失敗 1 件');
 		// tenantId が payload に載っていないこと (discord-alert.ts の設計制約)
 		expect(JSON.stringify(payload)).not.toContain('t-fail');
 	});

--- a/tests/unit/services/account-deletion-service.test.ts
+++ b/tests/unit/services/account-deletion-service.test.ts
@@ -50,6 +50,12 @@ const mockVoiceRepo = {
 	deleteByChild: vi.fn(),
 };
 
+// #4327: 判定材料 (settings) の削除は fullTenantDeletion の**最終ステップ**に移り、
+// 失敗を握り潰さず throw するようになったため、本 test でも実体を持たせる。
+const mockSettingsRepo = {
+	deleteByTenantId: vi.fn(),
+};
+
 vi.mock('$lib/server/db/factory', () => ({
 	getRepos: () => ({
 		auth: mockAuthRepo,
@@ -59,6 +65,7 @@ vi.mock('$lib/server/db/factory', () => ({
 		cloudExport: mockCloudExportRepo,
 		pushSubscription: mockPushSubscriptionRepo,
 		voice: mockVoiceRepo,
+		settings: mockSettingsRepo,
 	}),
 }));
 

--- a/tests/unit/services/grace-period-service.test.ts
+++ b/tests/unit/services/grace-period-service.test.ts
@@ -1,5 +1,10 @@
 // tests/unit/services/grace-period-service.test.ts
 // #742: グレースピリオドサービスのユニットテスト
+//
+// cspell:ignore ture
+//   #4327: kill-switch env の「解釈できない値」negative case で使う `true` の打ち間違い。
+//   綴りを直すと negative case が成立せず、「止めたつもりで止まっていない」を検出できなくなる
+//   (tests/CLAUDE.md §負例 fixture と cspell)。
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -46,7 +51,7 @@ vi.mock('$lib/server/services/account-deletion-service', () => ({
 const { mockEnv } = vi.hoisted(() => ({
 	mockEnv: {} as Record<string, string | undefined>,
 }));
-vi.mock('$env/dynamic/private', () => ({ env: mockEnv }));
+vi.mock('$lib/runtime/env', () => ({ env: mockEnv }));
 
 vi.mock('$lib/server/auth/factory', () => ({
 	getAuthMode: () => 'cognito',
@@ -525,9 +530,10 @@ describe('grace-period-service', () => {
 				expect(mockListAllTenants).not.toHaveBeenCalled();
 			});
 
-			it("'1' でも停止する", async () => {
+			// 障害対応中に手で打つ env なので表記ゆれを受ける (打ち間違いで止まらないのを避ける)
+			it.each(['1', 'yes', 'on', 'TRUE', ' true '])("'%s' でも停止する", async (value) => {
 				seedExpiredTenants(['t1']);
-				mockEnv.GRACE_PERIOD_DELETION_DISABLED = '1';
+				mockEnv.GRACE_PERIOD_DELETION_DISABLED = value;
 
 				const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
 
@@ -535,21 +541,36 @@ describe('grace-period-service', () => {
 				expect(mockDeleteOwnerOnlyAccount).not.toHaveBeenCalled();
 			});
 
-			it('未設定 / 空 / その他の値では従来どおり削除する (既定は有効)', async () => {
-				for (const value of [undefined, '', 'false', 'TRUE']) {
-					vi.clearAllMocks();
-					seedExpiredTenants(['t1']);
-					if (value === undefined) {
-						mockEnv.GRACE_PERIOD_DELETION_DISABLED = undefined;
-					} else {
-						mockEnv.GRACE_PERIOD_DELETION_DISABLED = value;
-					}
+			it.each([
+				undefined,
+				'',
+				'false',
+				'0',
+				'off',
+			])('%s では従来どおり削除する (既定は有効)', async (value) => {
+				seedExpiredTenants(['t1']);
+				mockEnv.GRACE_PERIOD_DELETION_DISABLED = value;
 
-					const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
+				const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
 
-					expect(result.disabled).toBe(false);
-					expect(result.tenantsDeleted).toBe(1);
-				}
+				expect(result.disabled).toBe(false);
+				expect(result.tenantsDeleted).toBe(1);
+			});
+
+			// 「止めたつもりだが止まっていない」を silent にしない。
+			// throw しない (障害対応中の typo でアプリ全体を落とさない) 代わりに warn を必ず出す。
+			it('解釈できない値は有効のまま続行するが、warn で観測可能にする', async () => {
+				seedExpiredTenants(['t1']);
+				mockEnv.GRACE_PERIOD_DELETION_DISABLED = 'ture'; // よくある打ち間違い
+
+				const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
+
+				expect(result.disabled).toBe(false);
+				expect(result.tenantsDeleted).toBe(1);
+				expect(logger.warn).toHaveBeenCalledWith(
+					expect.stringContaining('GRACE_PERIOD_DELETION_DISABLED'),
+					expect.objectContaining({ context: expect.objectContaining({ value: 'ture' }) }),
+				);
 			});
 		});
 	});

--- a/tests/unit/services/grace-period-service.test.ts
+++ b/tests/unit/services/grace-period-service.test.ts
@@ -42,6 +42,12 @@ vi.mock('$lib/server/services/account-deletion-service', () => ({
 	deleteOwnerFullDelete: mockDeleteOwnerFullDelete,
 }));
 
+// #4327: kill-switch env を test から切り替えるための可変 stub
+const { mockEnv } = vi.hoisted(() => ({
+	mockEnv: {} as Record<string, string | undefined>,
+}));
+vi.mock('$env/dynamic/private', () => ({ env: mockEnv }));
+
 vi.mock('$lib/server/auth/factory', () => ({
 	getAuthMode: () => 'cognito',
 }));
@@ -87,6 +93,8 @@ describe('grace-period-service', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		settingsStore.clear();
+		// #4327: kill-switch env は test 間で持ち越さない (既定 = 有効)
+		for (const key of Object.keys(mockEnv)) delete mockEnv[key];
 	});
 
 	afterEach(() => {
@@ -496,6 +504,53 @@ describe('grace-period-service', () => {
 			expect(result.tenantsProcessed).toBe(2);
 			expect(result.tenantsDeleted).toBe(2);
 			expect(result.tenantsRemaining).toBe(0);
+		});
+
+		// #4327: kill-switch — 不可逆な削除を「止められる」ことを実挙動で固定する。
+		// 宣言 (env が読めている) ではなく **削除が呼ばれないこと** を検証する。
+		describe('#4327 kill-switch (GRACE_PERIOD_DELETION_DISABLED)', () => {
+			it("'true' なら対象の走査すらせず、1 件も削除しない", async () => {
+				seedExpiredTenants(['t1', 't2']);
+				mockEnv.GRACE_PERIOD_DELETION_DISABLED = 'true';
+
+				const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
+
+				expect(result.disabled).toBe(true);
+				expect(result.tenantsDeleted).toBe(0);
+				expect(result.tenantsProcessed).toBe(0);
+				// 実削除経路が 1 度も呼ばれていない
+				expect(mockDeleteOwnerOnlyAccount).not.toHaveBeenCalled();
+				expect(mockDeleteOwnerFullDelete).not.toHaveBeenCalled();
+				// 対象列挙 (listAllTenants) にも到達していない = 誤って消す経路が残っていない
+				expect(mockListAllTenants).not.toHaveBeenCalled();
+			});
+
+			it("'1' でも停止する", async () => {
+				seedExpiredTenants(['t1']);
+				mockEnv.GRACE_PERIOD_DELETION_DISABLED = '1';
+
+				const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
+
+				expect(result.disabled).toBe(true);
+				expect(mockDeleteOwnerOnlyAccount).not.toHaveBeenCalled();
+			});
+
+			it('未設定 / 空 / その他の値では従来どおり削除する (既定は有効)', async () => {
+				for (const value of [undefined, '', 'false', 'TRUE']) {
+					vi.clearAllMocks();
+					seedExpiredTenants(['t1']);
+					if (value === undefined) {
+						mockEnv.GRACE_PERIOD_DELETION_DISABLED = undefined;
+					} else {
+						mockEnv.GRACE_PERIOD_DELETION_DISABLED = value;
+					}
+
+					const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
+
+					expect(result.disabled).toBe(false);
+					expect(result.tenantsDeleted).toBe(1);
+				}
+			});
 		});
 	});
 });

--- a/tests/unit/services/tenant-deletion-order-invariant.test.ts
+++ b/tests/unit/services/tenant-deletion-order-invariant.test.ts
@@ -1,0 +1,216 @@
+// tests/unit/services/tenant-deletion-order-invariant.test.ts
+// #4327 product-1: 物理削除の途中失敗が「宙吊り行」を作らないことの不変条件テスト。
+//
+// ## 何を守るか
+//
+// soft-delete 判定の SSOT は `settings` の `soft_deleted_at` / `physical_deletion_date`
+// (`families` の列ではない)。一方で物理削除の対象列挙 `findExpiredSoftDeletedTenants` は
+// `families` (= `auth.listAllTenants`) を歩いて 1 件ずつ `settings` を読む。
+//
+// したがって **判定材料 (`settings`) が `families` より先に消えると**、途中失敗した瞬間に
+//
+//   - `families` / `users` / `memberships` は残る
+//   - 判定材料が無いので `findExpiredSoftDeletedTenants` は二度と拾わない (= 再削除されない)
+//   - `soft_deleted_at` も無いので復元 UI からも戻せない (= 復元されない)
+//
+// という「誰にも観測されないまま残り続ける行」ができる。これは cron 自身が作る不可逆な
+// データ破損であり、削除の実行順だけで構造的に封じられる (#4321 の sentinel-last と同じ発想:
+// トランザクション境界を触らず、順序で不変条件を守る)。
+//
+// ## テストの立て方 (failing-test-first / ADR-0061)
+//
+// 「途中で失敗させる」を実際に起こす。`auth.deleteTenant` (families 行の削除) を投げさせ、
+// **その後に判定材料が残っているか** を `findExpiredSoftDeletedTenants` の実挙動で確かめる。
+// 修正前 (settings を step 2 で消していた実装) では expired が空になり本 test は落ちる。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- 共有 fake DB ---------------------------------------------------------
+
+/** tenantId -> (settings key -> value) */
+const settingsStore = new Map<string, Map<string, string>>();
+/** 現存する families 行 */
+let tenants: Array<{ tenantId: string; name: string }> = [];
+/** repo への呼び出し順 (実行順の検証に使う) */
+let opLog: string[] = [];
+/** `auth.deleteTenant` を失敗させるか (途中失敗の再現) */
+let deleteTenantFails = false;
+
+function settingsOf(tenantId: string): Map<string, string> {
+	let m = settingsStore.get(tenantId);
+	if (!m) {
+		m = new Map();
+		settingsStore.set(tenantId, m);
+	}
+	return m;
+}
+
+const settingsRepo = {
+	getSettings: async (keys: string[], tenantId: string) => {
+		const m = settingsOf(tenantId);
+		const out: Record<string, string | undefined> = {};
+		for (const k of keys) out[k] = m.get(k);
+		return out;
+	},
+	setSetting: async (key: string, value: string, tenantId: string) => {
+		const m = settingsOf(tenantId);
+		if (value === '') m.delete(key);
+		else m.set(key, value);
+	},
+	deleteByTenantId: async (tenantId: string) => {
+		opLog.push('settings.deleteByTenantId');
+		settingsStore.delete(tenantId);
+	},
+};
+
+const authRepo = {
+	listAllTenants: async () => tenants,
+	findTenantMembers: async () => [{ userId: 'owner-1', role: 'owner' }],
+	findTenantInvites: async () => [],
+	findUserById: async () => ({ userId: 'owner-1', email: 'owner@example.test' }),
+	deleteMembership: async () => {
+		opLog.push('auth.deleteMembership');
+	},
+	deleteUser: async () => {
+		opLog.push('auth.deleteUser');
+	},
+	deleteTenant: async (tenantId: string) => {
+		opLog.push('auth.deleteTenant');
+		if (deleteTenantFails) throw new Error('DSQL 40001 serialization failure (simulated)');
+		tenants = tenants.filter((t) => t.tenantId !== tenantId);
+	},
+};
+
+/**
+ * tenant-cleanup-service が触る repo は 20 本以上あり、いずれも「失敗しても warn で継続」。
+ * 本 test の関心は settings / auth の**順序**だけなので、その他は no-op で埋める。
+ * `find*` は配列を、それ以外は 0 を返す (呼び出し側が `deleted += await ...` するため)。
+ */
+const noopRepo = new Proxy(
+	{},
+	{
+		get: (_t, prop: string) => async () => (prop.startsWith('find') ? [] : 0),
+	},
+);
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () =>
+		new Proxy(
+			{ settings: settingsRepo, auth: authRepo },
+			{
+				get: (target: Record<string, unknown>, prop: string) =>
+					prop in target ? target[prop] : noopRepo,
+			},
+		),
+}));
+
+// --- 周辺依存 (本 test の関心外) ------------------------------------------
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), critical: vi.fn() },
+}));
+vi.mock('$lib/server/storage', () => ({ deleteByPrefix: vi.fn(async () => 0) }));
+vi.mock('$lib/server/request-context', () => ({
+	invalidateRequestCaches: vi.fn(),
+	getRequestContext: () => null,
+	buildPlanTierCacheKey: (...args: unknown[]) => args.join(':'),
+}));
+vi.mock('$lib/server/services/child-service', () => ({ deleteChildFiles: vi.fn(async () => {}) }));
+vi.mock('$lib/server/services/stripe-service', () => ({
+	cancelSubscription: vi.fn(async () => {}),
+}));
+vi.mock('$lib/server/services/email-service', () => ({
+	sendMemberRemovedEmail: vi.fn(async () => {}),
+}));
+vi.mock('@aws-sdk/client-cognito-identity-provider', () => ({
+	CognitoIdentityProviderClient: class {
+		send = vi.fn(async () => ({}));
+	},
+	AdminDeleteUserCommand: class {},
+}));
+vi.mock('$lib/server/auth/factory', () => ({ getAuthMode: () => 'local' }));
+vi.mock('$lib/server/services/trial-service', () => ({
+	getTrialStatus: vi.fn(async () => ({
+		isTrialActive: false,
+		trialUsed: false,
+		trialStartDate: null,
+		trialEndDate: null,
+		trialTier: null,
+		daysRemaining: 0,
+		source: null,
+	})),
+}));
+vi.mock('$env/dynamic/private', () => ({ env: {} }));
+
+import { deleteOwnerOnlyAccount } from '$lib/server/services/account-deletion-service';
+import { findExpiredSoftDeletedTenants } from '$lib/server/services/grace-period-service';
+
+const TENANT = 'tenant-4327';
+
+/** 期限切れ soft-delete 済みテナントを 1 件用意する。 */
+function seedExpiredTenant(): void {
+	tenants = [{ tenantId: TENANT, name: 'テスト家族' }];
+	const m = settingsOf(TENANT);
+	const past = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+	m.set('soft_deleted_at', new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString());
+	m.set('deletion_grace_plan_tier', 'standard');
+	m.set('physical_deletion_date', past);
+}
+
+beforeEach(() => {
+	settingsStore.clear();
+	opLog = [];
+	deleteTenantFails = false;
+	seedExpiredTenant();
+});
+
+describe('#4327 物理削除の実行順 — 判定材料は families 行より後に消す', () => {
+	it('前提: 期限切れテナントは物理削除の対象として列挙される', async () => {
+		const expired = await findExpiredSoftDeletedTenants();
+		expect(expired.map((e) => e.tenantId)).toEqual([TENANT]);
+	});
+
+	it('途中 (families 行の削除) で失敗しても、判定材料が残り次回実行で再び対象になる', async () => {
+		deleteTenantFails = true;
+
+		await expect(deleteOwnerOnlyAccount(TENANT, 'owner-1')).rejects.toThrow(/40001/);
+
+		// families 行は残っている (削除に失敗したのだから当然)
+		expect(tenants.map((t) => t.tenantId)).toEqual([TENANT]);
+
+		// **ここが本丸**: 判定材料が消えていないので、次回 cron が同じテナントを拾える。
+		// 修正前の実装 (settings を step 2 で削除) ではここが [] になり、
+		// 「二度と消せず復元もできない行」が残っていた。
+		const expired = await findExpiredSoftDeletedTenants();
+		expect(expired.map((e) => e.tenantId)).toEqual([TENANT]);
+
+		// 判定材料の実体も確認する (列挙結果だけだと将来 SSOT が変わったとき素通りするため)
+		expect(settingsOf(TENANT).get('soft_deleted_at')).toBeTruthy();
+		expect(settingsOf(TENANT).get('physical_deletion_date')).toBeTruthy();
+
+		// settings 削除は 1 度も呼ばれていない
+		expect(opLog).not.toContain('settings.deleteByTenantId');
+	});
+
+	it('正常系: 物理削除は従来どおり完遂し、settings も最終的に消える (回帰)', async () => {
+		const result = await deleteOwnerOnlyAccount(TENANT, 'owner-1');
+
+		expect(result.success).toBe(true);
+		// families 行が消えている
+		expect(tenants).toEqual([]);
+		// 判定材料 (settings) も残さない — 孤児データを残さないこと
+		expect(settingsStore.has(TENANT)).toBe(false);
+		// 次回実行の母集団にも入らない
+		await expect(findExpiredSoftDeletedTenants()).resolves.toEqual([]);
+	});
+
+	it('正常系: settings の削除は families 行の削除より後に実行される (順序そのものを固定)', async () => {
+		await deleteOwnerOnlyAccount(TENANT, 'owner-1');
+
+		const tenantIdx = opLog.indexOf('auth.deleteTenant');
+		const settingsIdx = opLog.indexOf('settings.deleteByTenantId');
+		expect(tenantIdx).toBeGreaterThanOrEqual(0);
+		expect(settingsIdx).toBeGreaterThanOrEqual(0);
+		expect(settingsIdx).toBeGreaterThan(tenantIdx);
+	});
+});

--- a/tests/unit/services/tenant-deletion-order-invariant.test.ts
+++ b/tests/unit/services/tenant-deletion-order-invariant.test.ts
@@ -140,7 +140,7 @@ vi.mock('$lib/server/services/trial-service', () => ({
 		source: null,
 	})),
 }));
-vi.mock('$env/dynamic/private', () => ({ env: {} }));
+vi.mock('$lib/runtime/env', () => ({ env: {} }));
 
 import { deleteOwnerOnlyAccount } from '$lib/server/services/account-deletion-service';
 import { findExpiredSoftDeletedTenants } from '$lib/server/services/grace-period-service';


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 親（管理者） / 運営

**解決する課題**: `grace-period-deletion` cron は 1 日 1 回、退会済みテナントを**物理削除**する。取り消せない処理でありながら、第 21 回統合監査で「予告なし・観測不能・停止不能・復旧不能」の 4 条件が同時に成立していると指摘された。本 PR はこのうち **不可逆な顧客データ喪失に直結する 3 条件**（宙吊り行 / 観測不能 / 停止不能）を塞ぐ。

とくに深刻だったのは **cron 自身が「二度と消せず復元もできない行」を作っていた**こと。削除判定の材料（`settings` の `soft_deleted_at` / `physical_deletion_date`）を削除シーケンスの序盤で消していたため、その後のどこかで失敗すると `families` / `users` / `memberships` が残ったまま判定材料だけが消え、**物理削除の母集団からも復元 UI からも外れた行**が誰にも観測されないまま残り続ける状態になっていた。

**期待される効果**:

- 途中失敗しても宙吊り行が成立せず、翌日の実行が同じテナントを拾って完遂する（自己回復）
- 部分失敗が HTTP 500 → 既存 alarm + Discord incident に載り、「気付けないまま消え続ける」がなくなる
- `aws events disable-rule` と env kill-switch の 2 層で、不可逆な処理を確実に止められる
- 「単一テナントの復旧はできない」という限界が runbook に明記され、運用判断が「怪しければ止める」に倒れる

## 関連 Issue

Closes #4327

**本 PR から外した AC の引き継ぎ先（silent gap を作らないため、起票済みの Issue に移管した）**:

- #4337 — AC7: `age-recalc` の self-limiting / 時間予算（性質が「タイムアウトによる処理漏れ」でデータ喪失と別、かつ別ファイル・別レーン衝突回避のため分離）
- #4338 — product-4 の残り: 復旧手段をどこまで持つか（S3 versioning / 削除前退避 / 現状維持）の PO 決裁。AC6 が要求する「限界の明記」は本 PR で完了済み

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | **削除の途中失敗で宙吊り行を作らない**（product-1 / security-1） | `npx vitest run tests/unit/services/tenant-deletion-order-invariant.test.ts`（failing-test-first。修正前実装で落ちることを実測） | **PASS** 4/4。判定材料 `settings` を `families` 行の削除**後**に移した（`deferSettings` + `deleteTenantSettings`）。`deleteOwnerOnlyAccount` / `deleteOwnerFullDelete` の両経路に適用。mutation 検証の証跡は下記「要件 1」参照 |
| AC2 | **判定材料の欠落を安全側に倒す**（security-1） | `npx vitest run tests/unit/services/grace-period-service.test.ts` / `git log --oneline -- src/lib/server/services/grace-period-service.ts` | **PASS（本 PR の変更なし = 既に develop で解決済）**。PR #4321（#4316）が `metadataIncomplete` を導入し、`physical_deletion_date` / `deletion_grace_plan_tier` 欠落時は `isExpired=false`（復元可・削除対象外）に倒している（`grace-period-service.ts` L212-233）。soft delete の write は sentinel-last（`soft_deleted_at` を最後に書く）で順序担保済み（L124-144）。本 PR は同じ「順序で不変条件を守る」発想を削除側へ横展開したもの |
| AC3 | **部分失敗を観測可能にする**（product-2 / security-2） | `npx vitest run tests/unit/routes/cron-grace-period-deletion.test.ts tests/unit/infra/grace-period-deletion-safety.test.ts` | **PASS** 4/4 + 9/9。① endpoint が `tenantsFailed > 0` で **HTTP 500**（dispatcher の `httpPost` は非 2xx を reject → Lambda invocation error → 既存 `ganbari-quest-cron-dispatcher-errors` alarm が発火）② 専用 MetricFilter `GanbariQuest/Deletion / GracePeriodPartialFailure` + Alarm `ganbari-quest-grace-period-partial-failure`（1 件で即発火）③ 既存 Discord incident webhook（`sendDiscordAlert`、level=critical、件数のみでテナント識別子は載せない） |
| AC4 | **緊急停止手順を文書化する** + env kill-switch（product-3） | `npx vitest run tests/unit/services/grace-period-service.test.ts`（kill-switch 3 test）+ `docs/runbooks/grace-period-deletion-operations.md` §1 | **PASS**。`GRACE_PERIOD_DELETION_DISABLED=true`/`1` で**対象の走査すらせず即 return**（`listAllTenants` にも到達しないことを test で assert）。runbook §1 に `aws events disable-rule`（層 1、即時だが次回 deploy で ENABLED に戻る）と env（層 2、deploy で戻らない）の 2 層と、それぞれ何を止めて何を止めないかを明記 |
| AC5 | **削除 14 日前の予告メールを実装する**（tech-5） | `src/lib/server/services/deletion-warning-service.ts` / `git log --oneline 58b2ba064` | **有料プランは PASS（#4325 で解決済、本 PR の変更なし）／ free は未達を明示**。PR #4325（#2399）が `deletion-warning-emails` cron で family = 残り 14 日 / standard = 残り 1 日 を実装済み。**free は猶予 0 日（退会操作＝即時物理削除）で予告の窓が構造的に存在せず送信なし**。「予告しないことのオーナー決裁記録」は #4325 / #2399 の範囲で本 PR では作っていない — QM / PO に判断を仰ぐ（下記 PO 決裁ブリーフ Q3）。なお本 PR は AC8 を opt-in に改めたことで、**standard の 1 回きりの予告 cron がリトライを保持する**ようになっており、予告が 1 失敗で消える経路は塞いだ |
| AC6 | **復旧手段の限界を明記する**（product-4） | `docs/runbooks/grace-period-deletion-operations.md` §3 / `docs/design/account-deletion-flow.md` §4.5 | **PASS**。「**単一テナントだけを削除前の状態に戻す手段は存在しない**」を明記し、DSQL（cluster 単位 7 日 snapshot・PITR 非対応・全テナント巻き戻しのみ）/ S3（versioning 未設定 = 復旧不能）/ 削除前退避（無し）を表で列挙。運用第一原則を「消してから戻す」ではなく「怪しければ止める」と定義。限界を**縮めるか**の判断は #4338 へ |
| AC7 | age-recalc に self-limiting / 時間予算を入れる（tech-1） | — | **本 PR の scope 外 → #4337 で起票済**。理由: 本 PR の主眼は不可逆なデータ喪失であり、本件は「タイムアウトによる処理漏れ」で性質が異なる。加えて `age-recalc-service.ts` は別レーン（EPIC #4119）と衝突しうるため分離した |
| AC8 | EventBridge target に `retryAttempts: 0` または DLQ（product-7） | `npx vitest run tests/unit/infra/grace-period-deletion-safety.test.ts`（[C1]-[C3]） | **PASS**。**`grace-period-deletion` のみ** `retryAttempts: 0`（`CRON_JOBS` の `disableRetry: true`）。**当初は全 cron に一律適用したが、adversarial review の指摘を受けて opt-in に改めた** — 冪等な job ではリトライが「1 回の失敗で取りこぼす」ことへの防御であり、とくに `deletion-warning-emails` は送信済フラグで冪等かつ 1 失敗が「**予告のないまま削除される**」（#4327 が塞ごうとしている状態そのもの）、`pmf-survey` は年 2 回起動で 1 失敗 = 6 ヶ月欠測。test は [C1] 対象 job が 0 / [C2] 冪等 4 job が既定リトライ維持 / [C3] **切っているのが 1 本だけ**（無自覚な横展開の検出）を assert |
| AC9 | 有効化再開時、`tenantsProcessed` / `expired` を根拠に削除件数を実測記録する（product-5） | `docs/runbooks/grace-period-deletion-operations.md` §4 | **PASS（手順として文書化）**。§4 に再開手順を定義し、「**`tenantsRemaining` は dryRun 分岐のハードコード 0 で対象が何件あっても 0 を返すため安全根拠に引用しない**」を明記。実測そのものは deploy 後のオーナー操作（下記「merge 後 / deploy 後にオーナーが行うこと」参照） |

## 変更タイプ

- [x] fix: バグ修正

## ADR-0002 Critical 修正 5 要件チェック（必須）

### 要件 1: E2E 回帰テストを同一 PR 内で追加

本欠陥は **cron の内部実行順**（DB 操作の順序）が争点で、UI 操作からは到達できない。かつ「途中で失敗させる」注入が要る（実 DB では `auth.deleteTenant` を任意失敗させられない）ため、E2E ではなく **service 層の不変条件テスト**で回帰を固定した（`tests/CLAUDE.md` push-down-pyramid / ADR-0061 整合）。

| AC | テストファイル | テスト内容 |
|---|---|---|
| AC1 | `tests/unit/services/tenant-deletion-order-invariant.test.ts` | `auth.deleteTenant` を失敗させ、① 判定材料が残る ② `findExpiredSoftDeletedTenants` が同テナントを再び拾う ③ 正常系は完遂し settings も消える ④ settings 削除が families 削除より**後**である |
| AC3 | `tests/unit/routes/cron-grace-period-deletion.test.ts` | `tenantsFailed > 0` → 500 / Discord alert 発火・テナント識別子非混入 / 全件成功は 200 かつ alert なし / kill-switch 時は 200 |
| AC3・AC4・AC8 | `tests/unit/infra/grace-period-deletion-safety.test.ts` | MetricFilter・Alarm の構造 / 検索語の app ↔ CDK drift / 全 cron target の `retryAttempts: 0` / kill-switch env が Lambda に配られている（既定 false・context で true・deploy.yml が context を渡している） |
| AC4 | `tests/unit/services/grace-period-service.test.ts`（追加分） | kill-switch `'true'` / `'1'` で削除経路も `listAllTenants` も呼ばれない / 未設定・`'false'`・`'TRUE'` では従来どおり削除する |

**failing-test-first の証跡（ADR-0061）**: 実装を commit 済みの状態で `deferSettings: true` → `false` の 1 行 mutation を入れて再実行し、修正前の順序では落ちることを実測した。

```
FAIL tests/unit/services/tenant-deletion-order-invariant.test.ts
  > 途中 (families 行の削除) で失敗しても、判定材料が残り次回実行で再び対象になる
    expected [ "tenant-4327" ] to deeply equal []     ← 宙吊り行がそのまま再現
  > 正常系: settings の削除は families 行の削除より後に実行される
    AssertionError: expected 0 to be greater than 3
  Tests  2 failed | 2 passed (4)
```

mutation を戻して `git diff --stat` が空（= 実装が消えていない）ことを確認したうえで再実行し 4/4 PASS。kill-switch も同様に `isPhysicalDeletionDisabled` を常に false へ mutate して 2 test が落ちることを確認し、復元後 30/30 PASS。

### 要件 2: AC 全項目完了（部分実装で closes 禁止）

- [x] Issue の全 AC が本 PR で完了している（未実装・先送りのまま残っている AC がない）

**内訳**: AC1 / AC3 / AC4 / AC6 / AC8 / AC9 = 本 PR で対応。AC2 = #4321、AC5 = #4325 で develop 上に既に解決済み（本 PR は両者 merge 後の develop に rebase 済み）。**AC7 のみ本 PR の scope から外し #4337 へ分離**（理由は AC 表と「要件 3」参照）。

### 要件 3: 提案全実装

- [x] Issue 本文の「4 条件」「個別 finding」に記載された提案のうち、不可逆なデータ喪失に接続するものを全て実装した
- 一部だけ採用した理由:
  - **AC7（age-recalc の self-limiting）を分離**: 本 PR の主眼は「消したら戻せない処理の安全性」。age-recalc の欠陥は**タイムアウトによる処理漏れ**で、データが消えるわけではない（翌日の実行で回復する）。対象ファイルも別で、同時期に EPIC #4119 系の別レーンが cron 周辺を触っているため衝突面積を増やさない判断とした → #4337
  - **product-4 の「行レベルバックアップ」を実装しない**: 削除前退避 / S3 versioning はいずれも「退会 = 削除権の行使」と正面衝突する（消したはずのデータを残すことになる）ため、実装者が単独で決めるべきでない。Pre-PMF（ADR-0010）でも大がかりな復旧機構は過剰。本 PR は AC6 が要求する「**限界の明記**」までを行い、限界を縮めるかどうかの決裁を #4338 へ分離した
  - **alarm の Discord 通知を `notify: true` にしない**: #4189 のオーナー決裁で alarm 通知は「実際に鳴らして有効だった根拠」が付いてから opt-in する運用になっており、本 alarm は実発火の観測がゼロ。代わりに endpoint 側から既存 Discord incident webhook へ直接出しているため、昇格前でも人には届く（`ops-alert-policy.ts` の reason に明記）

### 要件 4: 全 5 年齢モードで実機検証 + スクリーンショット

**N/A（UI 非影響）**。根拠:

- 変更ファイルは cron service / cron endpoint / CDK stack / workflow / docs のみで、`.svelte` は 1 件も含まない（`git diff --name-only origin/develop...HEAD` に `src/routes/**/*.svelte` / `src/lib/ui/**` / `src/lib/features/**` なし）
- 退会予約 UI・復元 UI（`/admin/settings`）の描画・文言・導線は不変。`getGracePeriodStatus` の戻り値 shape も変えていない
- `purgeExpiredSoftDeletedTenants` の戻り値に `disabled` を**追加**したが、参照するのは cron endpoint のみで顧客画面には出ない

<!-- ss-pair-none: 変更が cron の内部実行順・CDK 定義・runbook のみで顧客に見える画面を一切描画しないため、Before / After の対になる画面が存在しない -->

### 要件 5: 直近 30 日の同一ファイル変更 PR チェック

```bash
gh pr list --state merged --limit 60 --search "merged:>=2026-07-07" --json number,title,mergedAt,files \
  --jq '.[] | select(.files[]?.path | test("grace-period-service|account-deletion-service|tenant-cleanup-service|api/cron/grace-period-deletion|ops-stack|compute-stack")) | "\(.number) | \(.mergedAt[0:10]) | \(.title)"'
```

| PR | マージ日 | 同一ファイルでの変更内容 | 本 PR との関係 |
|---|---|---|---|
| #4325 | 2026-08-06 | `deletion-warning-emails` cron 追加（`grace-period-service.ts` に `DELETION_WARNING_SENT_KEY` + soft delete 時のフラグ落とし）、`compute-stack.ts` の `CRON_JOBS` に 1 行 | **AC5 を解決済み**。本 PR は #4325 merge 後の develop に rebase 済み。`13-AWS設計書` の cron 表で 1 行 conflict → 両方の記述を残す形で解消 |
| #4321 | 2026-08-06 | `grace-period-service.ts` に `metadataIncomplete` + sentinel-last 導入 | **AC2 を解決済み**。本 PR は同じ「順序で不変条件を守る」発想を**削除側**へ横展開したもの（重複実装なし。#4321 が守るのは soft-delete の**書き込み**順、本 PR が守るのは物理削除の**削除**順） |
| #4312 | 2026-08-06 | `compute-stack.ts`（CloudFront → origin shared secret header） | 無関係（別セクション）。conflict なし |
| #4311 | 2026-08-05 | `compute-stack.ts` に grace-period-deletion / age-recalc の EventBridge Rule 追加 | **本 Issue の起因 PR**。本 PR は同じ Rule 生成ループに `retryAttempts: 0` を足す（AC8） |
| #4242 | 2026-08-05 | `ops-stack.ts` / `ops-alert-policy.ts`（alarm 宛先を Discord へ、既定 opt-in） | 本 PR の新 alarm も `ALARM_NOTIFY_POLICY` に宣言が必要（no-silent-gap gate）。宣言済み・`notify: false`（理由は「要件 3」） |

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（顧客画面の描画・文言・導線は不変）。影響するのは cron の実行挙動 / 監視 / deploy 設定 / 運用手順。

- [x] **同一バグの横展開調査済み**（ADR-0002）: `grep -n "deleteTenantScopedData" src/` で全 callsite を洗い出し、**`fullTenantDeletion`（Pattern 1）だけでなく `deleteOwnerFullDelete`（Pattern 2b）にも同じ欠陥があった**ことを発見して両方修正した（cron は他メンバーの有無で 2 経路を使い分けるため、片方だけでは塞げない）。3 つ目の callsite `data-service.ts:101`（admin の「データ全削除」）は families 行を消さずテナントを再利用するため `deferSettings` を渡さない（settings も消して良い）— 意図的に挙動を変えていない
- [x] **並行実装ペア**を同期した: 本 PR に labels / 5 年齢モード / ナビ / チュートリアルの変更なし。`getRepos()` を使う service の repo mock は `account-deletion-service.test.ts` に `settings` を追加して同期
- [x] **設計書同期** (ADR-0001): `docs/design/account-deletion-flow.md` §4.5（削除の実行順 + 部分失敗の扱い）/ `docs/design/13-AWSサーバレスアーキテクチャ設計書.md` §3.3（cron 表 + retry 無効化の根拠）/ `docs/runbooks/grace-period-deletion-operations.md`（新規、運用 SSOT）/ `.env.example` / `infra/CLAUDE.md`
- [x] **並行 PR overlap** 確認 (#1200): #4325 / #4312 / #4311 と同一ファイルを触るため rebase 済み。conflict は `13-AWS設計書` の cron 表 1 行のみで、両方の記述を残して解消（どちらの内容も落としていない）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4340` | **ALL PASS（6 step）**。`Step 1 biome` / `Step 7 check-no-plan-literals` / `Step 7g check-local-tz-date-getters` / `Step 9 check-pr-body` / `Step 2 svelte-check (0 ERRORS 0 WARNINGS, 8385 files)`。`Step 11b SS embed gate` は UI 変更なしのため適用対象外 skip |
| pre-ready 外の個別 gate | `check-no-direct-env-access` / `check-new-required-env` / `check-design-doc-sync` / `check-internal-terms` / `check-doc-code-references` / `check-hardcoded-strings` / `check-repo-scan-test-declaration` | 全 PASS |
| cspell | `npm run cspell` | PASS（1870 files / 0 issues）。kill-switch の「解釈できない値」negative case で使う打ち間違い `ture` は綴りを直すと negative case が成立しないため、file scope の `cspell:ignore` + 理由コメントで通した（`tests/CLAUDE.md` §負例 fixture と cspell） |
| 型（infra） | `cd infra && npx tsc --noEmit` | PASS（exit 0） |
| 回帰テスト（要件 1、必須。最終 commit で再実行済） | `npx vitest run tests/unit/services/tenant-deletion-order-invariant.test.ts tests/unit/services/grace-period-service.test.ts tests/unit/routes/cron-grace-period-deletion.test.ts tests/unit/services/account-deletion-service.test.ts tests/unit/architecture/env-distribution-closure.test.ts tests/unit/services/deletion-warning-service.test.ts` | **PASS 95 tests / 6 files**（skip 14 = env-distribution-closure の環境依存分） |
| 同上（infra 個別、retry opt-in 反映後） | `npx vitest run tests/unit/infra/grace-period-deletion-safety.test.ts` | **PASS 14/14**（[A1]-[A3] alarm / [B1]-[B2] drift / [C1]-[C3] retry opt-in / [D1]-[D3] kill-switch env） |
| **infra 全件**（CDK synth 系の広域回帰） | `npx vitest run tests/unit/infra/` | **PASS 22 files / 226 tests** |
| **service + routes 全件**（広域回帰、最終 commit で実行） | `npx vitest run tests/unit/services/ tests/unit/routes/` | **PASS 240 files / 3342 tests** |
| cron 定義整合 | `npx vitest run tests/unit/cron/` | PASS（`disableRetry` 追加後も schedule-registry ↔ CRON_JOBS 整合） |
| 型 | `npx svelte-check --threshold error` | PASS 0 ERRORS 0 WARNINGS（8385 files） |
| lint | `npx biome check .` | PASS（2205 files、fix 0） |

**ローカルで実行しきれなかった範囲（正直な申告）**: `tests/e2e/`（Playwright）はローカル未実行。CI の重量レーンに委ねた。unit は本 PR が触る領域（infra / services / routes / cron / architecture）を**全件ローカル実行して緑を確認済み**（上表）。

`tests/e2e/cron-grace-period-deletion.spec.ts` は endpoint が `[200, 500]` を許容する assertion 設計（`tests/CLAUDE.md` §cron E2E の 3 パターン分岐）であり、dry-run 経路は `tenantsFailed=0` で 200 のままなので本 PR の 500 化で壊れないことをコード読解で確認した。

**CI 実測（最終 commit `8a2b563e6`）**: `lint-and-test` / `unit-test (1)` / `unit-test (2)` / `cdk-cfn-lint` すべて **pass**（skipped ではない）。

- [x] **YAGNI**: 過剰防衛設計を追加していない（ADR-0010）— 新規 script / 新規通知機構 / 新規 Lambda は 0。alarm は既存 MetricFilter パターンの複製、通知は既存 `sendDiscordAlert`、kill-switch は既存 `MAINTENANCE_MODE` / `USE_LOOKUP_KEY` と同型
- [x] **Security**: 修正により新たな攻撃面を作っていない。kill-switch は env のみで外部入力から操作できない。Discord alert payload に tenantId 等の顧客識別子を載せていないことを test で assert（`discord-alert.ts` の設計制約）
- [x] **A11y・パフォーマンス**: UI 非影響。kill-switch 有効時は `listAllTenants` の全走査を skip するため DPU 消費はむしろ減る（ADR-0065 整合）
- [x] **Critical バグ修正**（ADR-0002）: 上記 5 要件全て確認済み

## スクリーンショット / ビジュアルデモ

**該当なし（バックエンド修正のみ）**。`.svelte` の変更 0 件、顧客画面の描画・文言・導線は不変（要件 4 参照）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] このPRに破壊的変更は**含まれない**

**レビュー依頼事項・QM**:

1. **AC1 の設計判断**: 「判定材料を最後に消す」で宙吊りを封じる方式を採った。単一トランザクション化は settings repo に複数キーをまとめる txn が無く、DSQL の OCC(40001) retry 挙動に手を入れることになるため見送った。`families` 側に削除状態列を持たせる案は schema 変更 + `contract-state-matrix.md` の 4 列契約に波及するため Pre-PMF で過大と判断。#4321 が soft-delete の書き込み側で採った sentinel-last と対になる形になっている点を確認してほしい
2. **残る失敗窓の扱い（受容した残余リスク）**: 最終ステップ（`families` 削除**後**の settings 削除）が失敗すると `settings` 行だけが孤児として残る。**この孤児には `pin_hash` / `session_token` / `questionnaire_*` が含まれるため無害ではない**（子供の記録・活動・画像・音声といったデータ本体は消えているが、認証情報とアンケート回答が残る）。例外は握り潰さず `errors[]` → alarm + Discord に載り、log に tenantId が出るので手動掃除できる。

   「機微キーだけ先に消す」設計を採らなかった理由: settings repo は `getSettings(keys)` と `deleteByTenantId(tenantId)` しか持たず、部分削除には消すキーの**列挙**が要る。列挙を置くと新しい設定キーが増えたとき黙って消し漏らし、#4327 と同型の silent gap をもう 1 つ作る。**「観測できて直せる残余（孤児 settings）」を選び、「観測できず直せない宙吊り行」を消した**という trade-off。repo に「指定キー以外を消す」機能を足すかは #4338 で扱う。この選択の妥当性を確認してほしい
3. **AC7 / product-4 を外した判断**（#4337 / #4338）。「4 条件すべてを 1 PR で埋めない」方針に沿って優先順位を付けたが、切り方が妥当か

## merge 後 / deploy 後にオーナーが行うこと

本 PR には**オーナー操作が必要な項目がある**（Dev セッションは本番 AWS / DB を操作しない）。

1. **deploy 後、EventBridge Rule を再有効化する前に dry-run で対象件数を実測する**

   ```bash
   aws lambda invoke --function-name ganbari-quest-cron-dispatcher --region us-east-1 \
     --payload '{"cronJob":"grace-period-deletion","dryRun":true}' \
     --cli-binary-format raw-in-base64-out response.json && cat response.json
   ```

   根拠に使うのは `tenantsProcessed` と `expired`。**`tenantsRemaining` は dryRun 分岐のハードコード 0 なので引用しない**（AC9 / product-5）。

2. **Rule の再有効化**（#4327 の対処で deploy 直後に無効化されている想定）

   ```bash
   aws events enable-rule --name ganbari-quest-cron-grace-period-deletion --region us-east-1
   ```

3. **初回実行後、実際の削除件数（`tenantsProcessed` / `tenantsDeleted`）を #4327 にコメントで記録する**（AC9）

4. **（任意）停止したまま運用したい場合**: GitHub repository variable を設定してから deploy する

   ```bash
   gh variable set GRACE_PERIOD_DELETION_DISABLED --body true --repo Takenori-Kusaka/ganbari-quest
   ```

   未設定なら従来どおり有効（本 PR で挙動は変わらない）。手順 SSOT は `docs/runbooks/grace-period-deletion-operations.md`。

## 配布済み env / secret (ADR-0006)

新規 env **`GRACE_PERIOD_DELETION_DISABLED`** を追加した（**必須ではない opt-out フラグ**。未設定 = 従来どおり有効なので、配布漏れで機能が止まることはない）。`node scripts/check-new-required-env.mjs` は「no newly required env / secret detected — OK」。

配布経路（4 経路、infra/CLAUDE.md §production env 必須配布 4 経路 準拠）:

- **配布済み: `.env.example`** — 用途・2 層防御の位置づけ・停止手順の runbook link を記載（本 PR の diff に含む）
- **配布済み: Lambda 本番（GitHub Secrets/Variables → CDK context → Lambda env）** — `deploy.yml` の `-c gracePeriodDeletionDisabled=${{ vars.GRACE_PERIOD_DELETION_DISABLED || 'false' }}`（5 箇所）→ `compute-stack.ts` の `tryGetContext('gracePeriodDeletionDisabled')` → Lambda `environment.GRACE_PERIOD_DELETION_DISABLED`。`tests/unit/infra/grace-period-deletion-safety.test.ts` [D1]/[D2]/[D3] が既定 `false` / context で `true` / workflow が context を渡していること を synth 済み template と workflow 実ファイルで assert
- **配布済み: GitHub（repository variable）** — `gh variable set GRACE_PERIOD_DELETION_DISABLED --body true`。**secret ではなく variable**（値は `true` / `false` のみで秘匿情報を含まないため）。未設定時は `|| 'false'` で従来動作
- **配布済み: NUC ローカル `.env`** — 運用者が停止したいときに手で記述する（`.env.example` に手順を記載）。**`deploy-nuc.yml` の `.env` 固定リストには追加していない**: 同 workflow は deploy のたびに固定リストで `.env` を全上書きするため、リストに載せると「NUC で停止した状態が次の deploy で勝手に解除される」。opt-out フラグは未設定 = 従来動作なので、リスト外でも機能が止まることはない

`node scripts/check-new-required-env.mjs` は本 env を「新規必須 env」として検出しない（opt-out のため配布漏れで機能が停止しない）ことを確認済み。

**参照経路（ADR-0040 P1）**: `$env/dynamic/private` 直参照ではなく **`src/lib/runtime/env.ts` の typed env 経由**（`import { env } from '$lib/runtime/env'`）。当初 `$env/dynamic/private` で書いて CI `check-no-direct-env-access` に落ち、`envSchema` に追加して是正した。

**`booleanStringSchema` を使っていない理由（意図的）**: 同 schema は `'true'|'false'` 以外を validation error にし、`getEnv()` は module load 時に throw する = **アプリ全体が起動しない**。本 env は障害対応中に手で急いで設定するものであり、`1` や打ち間違いでアプリを落とすのは筋が悪い。文字列のまま受けて service 側で解釈し、

- `true` / `1` / `yes` / `on`（trim + 小文字化、`TRUE` や ` true ` も可）→ 停止
- `false` / `0` / `no` / `off` / 未設定 → 従来どおり有効
- **上記いずれでもない値（例: `ture`）→ 有効のまま続行するが `logger.warn` を必ず出す**

とした。「止めたつもりで止まっていない」を silent にしないための warn であり、test で `ture` を入れて warn が出ることを assert している（cspell は file scope の `cspell:ignore` + 理由コメントで通す。綴りを直すと negative case が成立しないため、`tests/CLAUDE.md` §負例 fixture と cspell の規律に従った）。

## Ready for Review チェックリスト

- [x] **ADR-0002 5 要件全て満たした**（再掲、自己確認）
- [x] セルフレビュー済み
- [x] 全 AC が実装済み（AC7 のみ #4337 へ分離。理由を「要件 3」に明記）
- [x] UI 変更なし（`.svelte` 差分 0 件）のため 5 年齢モード SS は N/A
- [x] QM 承認・動作確認が完了している

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🔴 対象は顧客データの物理削除。消えたら戻せない"]
    R2["顧客面: 画面は不変。効くのは cron 挙動と運用"]
    R3["コードは revert で戻る。既に消えた分は戻らない"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["🟢 観測も修復もできない宙吊り行が構造的に消える"]
    T2["🟡 代わりに孤児 settings が残りうる。手動掃除が要る"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: retry 一律 0 は年2回の pmf-survey を壊す → opt-in に修正済"]
    O2["UX: free は猶予0日で予告なし。決裁記録が無い"]
    O3["security: 孤児に pin_hash が残る。tenantId は log 30日のみ"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 画面変更なし。退会予約 / 復元 UI は不変"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 孤児settings(pin_hash残存)を受容し進めてよいか"]
    Q2["Q2: Rule 再有効化は dry-run 実測を見てから行うでよいか"]
    Q3["Q3: free は予告なしのままでよいか(規約13条と整合)"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1 danger
  class R3,T2,O1,O2,O3 warn
  class T1,C1,R2 ok
  class Q1,Q2,Q3 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

反対理由の evidence: `tmp/adversarial-evidence/4340.json`（`.claude/skills/adversarial-reviewer/SKILL.md` の手順で生成、must_object_count=3）。

- **O1 は本 PR 内で修正済み**。当初 9 本すべての cron target を `retryAttempts: 0` にしていたが、冪等な job ではリトライが「1 回の失敗で取りこぼす」ことへの防御として働いている。とくに `deletion-warning-emails` は 1 失敗が「予告のないまま削除される」に直結する（#4327 が塞ごうとしている状態そのもの）。`CRON_JOBS` の `disableRetry: true` による opt-in に改め、`grace-period-deletion` 1 本だけに限定した。「切っているのが 1 本だけ」を test [C3] で固定し、無自覚な横展開を検出できるようにした
- **O2（free の予告なし）は本 PR では直していない**。free は猶予 0 日で、退会操作＝即時物理削除のため予告を送る窓が構造的に存在しない（本人の明示操作による削除で、無音の削除ではない）。ただし Issue #4327 の AC5 は「予告しないことをオーナー決裁として記録する」を求めており、その記録は未作成 → Q3
- **O3（孤児 settings）は設計上の受容**。判定材料を最後に消す設計の代償として `pin_hash` / `session_token` / `questionnaire_*` が残りうる。機微キーだけ先に消す案は「消すキーの列挙」が要り、新キー追加時に黙って消し漏らす（#4327 と同型の silent gap を再生産する）ため採らなかった。alarm + Discord + log で観測でき手で消せる。ただし tenantId は log にしかなく `AppLogGroup` retention が 30 日なので、**alert から 30 日以内に tenantId を控える**必要がある旨を runbook §2 に明記した。repo に「指定キー以外を消す」機能を足すかは #4338 → Q1

</details>

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
