### PR TITLE
fix(ci): #4030 AC6 orphan baseline の免除理由を機械強制する（guard 自身の生成物で欄が埋まるのをやめる）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,17 @@ jobs:
         # sandbox 隔離 / Deprecated marker / fenced code 除外 / inline/bare 区別) を検証する。
         run: node --test scripts/__tests__/check-doc-code-references.test.mjs
 
+      - name: Scripts unit tests (node:test for orphan-utils.mjs) (#4030 AC6)
+        # orphan baseline の免除理由 gate の **生成側** (`--update-baseline` が検出理由を
+        # 免除理由の欄に流用しないこと) を検証する。vitest から import すると checkJs が
+        # orphan-utils.mjs の pre-existing 型エラーを拾うため node:test 側に置いている。
+        #
+        # NOTE: 本 step も上と同じく file 名の literal 指定である。scripts/__tests__/ には
+        # 現在 13 file あり、CI から実行されているのは本 step を入れて 3 file だけ。
+        # glob 化 (`node --test scripts/__tests__/*.test.mjs`) は残り 3 test の drift 修正が
+        # 要るため別 PR に分ける (Issue #4030 のコメントに実測値付きで記録)。
+        run: node --test scripts/__tests__/check-orphan-utils.test.mjs
+
       - name: LP SSOT HTML baseline check (#1465 Phase A)
         run: node scripts/check-lp-ssot.mjs
 

--- a/scripts/__tests__/check-orphan-utils.test.mjs
+++ b/scripts/__tests__/check-orphan-utils.test.mjs
@@ -16,8 +16,15 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const { parseArgs, loadBaseline, saveBaseline, walkDir, escapeRegex, collectReferences } =
-	await import('../lib/ci/orphan-utils.mjs');
+const {
+	parseArgs,
+	loadBaseline,
+	saveBaseline,
+	walkDir,
+	escapeRegex,
+	collectReferences,
+	reportFindings,
+} = await import('../lib/ci/orphan-utils.mjs');
 
 describe('parseArgs', () => {
 	it('--report → report=true', () => {
@@ -74,6 +81,50 @@ describe('loadBaseline / saveBaseline', () => {
 			// クリーンアップ — Windows 対応で fileURLToPath 経由
 			const p = path.join(path.dirname(__dirname), 'orphan-baselines', `${cat}.json`);
 			if (fs.existsSync(p)) fs.unlinkSync(p);
+		}
+	});
+});
+
+describe('#4030 AC6 --update-baseline は免除理由を自動投入しない', () => {
+	// 生成側にも検査側と同じ規律を置く。検査 (check mode) だけ直して生成側が
+	// 検出理由 / 'auto-added by --update-baseline' を書き込み続けると、
+	// **「追加した瞬間に落ちる entry」を量産する**だけで運用が改善しない。
+	it('検出理由を reasons に流用せず、未記入のまま exit 1 を返す', () => {
+		const cat = `__test_ac6_${process.pid}_${Date.now()}`;
+		const baselinePath = path.join(path.dirname(__dirname), 'orphan-baselines', `${cat}.json`);
+		const writeOut = process.stdout.write.bind(process.stdout);
+		const writeErr = process.stderr.write.bind(process.stderr);
+		process.stdout.write = () => true;
+		process.stderr.write = () => true;
+		try {
+			const code = reportFindings(
+				cat,
+				[
+					{
+						name: 'src/lib/server/db/dsql/example-repo.ts',
+						// script が組み立てる「検出理由」= 機械が書いた現象の説明
+						reason:
+							'repo file "example-repo.ts" は db facade / factory から import されていません。',
+						allowlisted: false,
+					},
+				],
+				{ mode: 'update-baseline', baseline: { allowed: [], reasons: {}, version: '1.0.0' } },
+			);
+			process.stdout.write = writeOut;
+			process.stderr.write = writeErr;
+
+			assert.equal(code, 1, '理由未記入のまま baseline を更新したのに 0 を返している');
+			const saved = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+			assert.deepEqual(saved.allowed, ['src/lib/server/db/dsql/example-repo.ts']);
+			assert.deepEqual(
+				saved.reasons,
+				{},
+				'検出理由 / auto-added 文字列を免除理由の欄に書き込んでいる',
+			);
+		} finally {
+			process.stdout.write = writeOut;
+			process.stderr.write = writeErr;
+			if (fs.existsSync(baselinePath)) fs.unlinkSync(baselinePath);
 		}
 	});
 });

--- a/scripts/lib/ci/exclusion-reason.mjs
+++ b/scripts/lib/ci/exclusion-reason.mjs
@@ -1,0 +1,95 @@
+/**
+ * scripts/lib/ci/exclusion-reason.mjs (#4030 AC6 — 除外理由の非強制を塞ぐ SSOT)
+ *
+ * 「除外してよい」と決めた記録 (allowlist / baseline / 免除リスト) の **reason** が
+ * 理由として成立しているかを判定する。判定規則をここ 1 箇所に置き、
+ * script 側 (orphan baseline) と test 側 (実装 export の除外リスト) が同じ規則を使う。
+ *
+ * ## なぜ「非空」だけでは足りないか
+ *
+ * - `TODO` / `n/a` / `-` は**非空だが理由ではない**。非空チェックだけだと抜け道が残る (#3956)
+ * - **guard 自身の生成物**で埋まった reason も理由ではない。`--update-baseline` は検出理由
+ *   (「どこからも import されていません」= 機械が書いた現象の説明) を免除理由の欄に
+ *   コピーしていた。**「なぜ免除してよいか」を誰も書いていないのに欄は埋まる**状態で、
+ *   reason 機構が形骸化する (#4030 AC6、PO 決裁 = 案 A「自動投入を理由なしとして弾く」)
+ *
+ * 現象の説明 (detection reason) と免除の正当化 (exclusion reason) は別物である。
+ */
+
+/**
+ * 「理由として通用しない」定型 stub。
+ * 完全一致 (trim + 小文字化) で判定する — 部分一致にすると正当な理由文中の語で誤検出する。
+ */
+export const STUB_REASONS = [
+	'todo',
+	'tbd',
+	'n/a',
+	'na',
+	'-',
+	'—',
+	'未定',
+	'なし',
+	'?',
+	'??',
+	'fixme',
+	'wip',
+];
+
+/**
+ * 機械が生成した文字列 (= 人が理由を書いていない証拠) を表す marker。
+ *
+ * `--update-baseline` が過去に自動投入していた文字列と、検出理由の定型末尾を含む。
+ * **生成側 (saveBaseline 経路) と検査側 (check mode) の双方がこの表を参照する**ため、
+ * 「生成は止めたが既存データは通る」という片肺状態にならない。
+ */
+export const MACHINE_GENERATED_REASON_MARKERS = [
+	'auto-added by --update-baseline',
+	'から import されていません',
+	'は外部から参照されていません',
+	'どこからも import されていません',
+	'dead code の疑い',
+];
+
+/** 理由として最低限必要な文字数。実データの最短は 20 字前後なので十分に緩い下限 (#4237)。 */
+export const MIN_REASON_LENGTH = 8;
+
+/**
+ * 理由として成立しているか判定する。成立しない場合は「なぜ駄目か」を返す。
+ *
+ * @param {unknown} reason
+ * @returns {string | null} 欠陥の説明 (成立していれば null)
+ */
+export function findReasonDefect(reason) {
+	if (typeof reason !== 'string') return `文字列ではありません (${typeof reason})`;
+	const trimmed = reason.trim();
+	if (trimmed.length === 0) return '空です';
+	if (STUB_REASONS.includes(trimmed.toLowerCase())) return `定型 stub です (「${trimmed}」)`;
+	const machine = MACHINE_GENERATED_REASON_MARKERS.find((m) => trimmed.includes(m));
+	if (machine) {
+		return (
+			`機械が生成した文字列です (「${machine}」を含む)。` +
+			'検出理由 (何が起きているか) ではなく、**なぜ免除してよいか** を人が書いてください'
+		);
+	}
+	if (trimmed.length < MIN_REASON_LENGTH) {
+		return `短すぎます (${trimmed.length} 字: 「${trimmed}」)`;
+	}
+	return null;
+}
+
+/**
+ * baseline (allowed[] + reasons{}) 全体を検査し、欠陥のある entry を列挙する。
+ *
+ * @param {{ allowed?: string[], reasons?: Record<string, unknown> }} baseline
+ * @returns {Array<{ entry: string, defect: string }>}
+ */
+export function findBaselineReasonDefects(baseline) {
+	const allowed = baseline?.allowed ?? [];
+	const reasons = baseline?.reasons ?? {};
+	const out = [];
+	for (const entry of allowed) {
+		const defect = findReasonDefect(reasons[entry]);
+		if (defect) out.push({ entry, defect });
+	}
+	return out;
+}

--- a/scripts/lib/ci/orphan-utils.mjs
+++ b/scripts/lib/ci/orphan-utils.mjs
@@ -16,6 +16,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { escapeRegExp } from './escape-regexp.mjs';
+import { findBaselineReasonDefects } from './exclusion-reason.mjs';
 
 // REPO_ROOT 解決 — scripts/lib/ci/ から 3 階層上
 const __filename = fileURLToPath(import.meta.url);
@@ -162,15 +163,17 @@ export function reportFindings(category, findings, options) {
 	const newOrphans = findings.filter((f) => !f.allowlisted);
 
 	if (mode === 'update-baseline') {
+		// #4030 AC6 (PO 決裁 = 案 A): **検出理由を免除理由の欄にコピーしない**。
+		//
+		// 旧実装は `f.reason` (= 「どこからも import されていません」等、機械が書いた現象の説明)
+		// あるいは 'auto-added by --update-baseline' を reasons に自動投入していた。
+		// **「なぜ免除してよいか」を誰も書いていないのに欄が埋まる**ため、reason 機構が形骸化する。
+		// 新規 entry は reason を空のまま追加し、人が書くまで check mode が落ちる。
 		const newAllowed = newOrphans.map((f) => f.name);
 		const allAllowed = [...baseline.allowed, ...newAllowed];
-		const newReasons = { ...baseline.reasons };
-		for (const f of newOrphans) {
-			newReasons[f.name] = f.reason || 'auto-added by --update-baseline';
-		}
 		const savedPath = saveBaseline(category, {
 			allowed: allAllowed,
-			reasons: newReasons,
+			reasons: { ...baseline.reasons },
 			version: baseline.version,
 		});
 		process.stdout.write(
@@ -178,7 +181,17 @@ export function reportFindings(category, findings, options) {
 		);
 		process.stdout.write(`  added ${newOrphans.length} new entries\n`);
 		for (const f of newOrphans) {
-			process.stdout.write(`    - ${f.name}: ${f.reason || '(no reason)'}\n`);
+			process.stdout.write(`    - ${f.name}\n`);
+			process.stdout.write(`      検出理由 (機械): ${f.reason || '(none)'}\n`);
+		}
+		if (newOrphans.length > 0) {
+			process.stderr.write(
+				`\n[check-orphan-${category}] 未完了 — ${newOrphans.length} 件の "reasons" が空のままです。\n` +
+					`  ${path.relative(REPO_ROOT, savedPath)} の "reasons" に **なぜ免除してよいか** を書いてください。\n` +
+					'  上記の「検出理由」は機械が書いた現象の説明であり、免除の正当化ではありません。\n' +
+					'  書くまで check mode (CI) は落ちます。\n',
+			);
+			return 1;
 		}
 		return 0;
 	}
@@ -224,6 +237,22 @@ export function reportFindings(category, findings, options) {
 		process.stderr.write(
 			`\n対応: scripts/orphan-baselines/${category}.json の "allowed" / "reasons" から該当 entry を削除する\n` +
 				'  (対象が消えている以上、その entry は何も免除していない)。\n',
+		);
+		return 1;
+	}
+
+	// #4030 AC6: baseline の免除は **理由が書かれていて初めて免除**。
+	// 空 / 定型 stub / 機械生成文字列 は「理由なし」として弾く (判定 SSOT = exclusion-reason.mjs)。
+	// 理由の無い免除は、次に読む人が「意図的な例外」と「消し忘れ」を区別できない。
+	const reasonDefects = findBaselineReasonDefects(baseline);
+	if (reasonDefects.length > 0) {
+		process.stderr.write(
+			`[check-orphan-${category}] NG — baseline の免除理由が ${reasonDefects.length} 件、理由として成立していません:\n`,
+		);
+		for (const d of reasonDefects) process.stderr.write(`  - ${d.entry}: ${d.defect}\n`);
+		process.stderr.write(
+			`\n対応: scripts/orphan-baselines/${category}.json の "reasons" に **なぜ免除してよいか** を書く\n` +
+				'  (検出理由の貼り付けではなく、免除の正当化を書く。理由の無い免除は消し忘れと区別できない)。\n',
 		);
 		return 1;
 	}

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -61,6 +61,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'docs / .claude / scripts / tests / src を走査し、ロールを指す QA 表記の再混入を検出する (#4177)',
 	},
+	'tests/unit/architecture/exclusion-reason-nonempty.test.ts': {
+		scope: 'repo',
+		note: 'scripts/orphan-baselines/*.json を走査して免除理由の非空 / 非 stub を検査する (#4030 AC5 / AC6)。走査自体は 1 dir で有界だが、判定は保守的に repo 扱いとし明示 timeout を置く',
+	},
 	'tests/unit/architecture/action-primary-white-text-contrast.test.ts': {
 		scope: 'repo',
 		note: 'src 配下の .svelte を走査して配色コントラスト違反を検出する',

--- a/tests/unit/architecture/exclusion-reason-nonempty.test.ts
+++ b/tests/unit/architecture/exclusion-reason-nonempty.test.ts
@@ -26,38 +26,48 @@
 // は import すると当該 test file の describe が二重実行されるため、**各 test file 内に
 // assertion を置く**（データを持つ file が自分で守る）。どこにあるかは PR body に列挙した。
 
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
 import { NON_RESOURCE_ADMIN_PAGE_ROUTES } from '$lib/features/admin/admin-resource-model-registry';
 import { LOW_RISK_THIRD_PARTY_ALLOWLIST } from '../../../scripts/check-action-sha-pin.mjs';
+import {
+	findBaselineReasonDefects,
+	findReasonDefect,
+} from '../../../scripts/lib/ci/exclusion-reason.mjs';
 
-/**
- * 「理由として通用しない」文字列。
- *
- * 空 / 空白のみ に加えて、**定型 stub** を弾く。非空チェックだけだと
- * `TODO` を書いて通す抜け道が残り、gate が形骸化する (#3956 教訓)。
- */
-const STUB_REASONS = ['todo', 'tbd', 'n/a', 'na', '-', '—', '未定', 'なし', '?', '??'];
+// #4030 AC6: 判定規則は `scripts/lib/ci/exclusion-reason.mjs` に一本化した。
+// 旧実装は本 file 内に同じ規則の copy を持っていたが、orphan baseline 側 (script) が
+// 同じ規則を使う必要が出たため SSOT を module に移した。**規則が 2 つあると、
+// 片方だけ緩めて通す抜け道になる**。
+//
+// 各 fitness test file 内 (`EXEMPT_GUIDE_PATHS` / `MUTATION_ALLOWLIST` / `PREDICATE_ALLOWLIST`)
+// にある同型判定は #4237 の意図的な分散のまま (test file 同士を import すると describe が
+// 二重実行される)。それらは判定関数を持つのではなく「データを持つ file が自分で守る」形。
 
-/** 理由として成立しているか。成立しない場合は理由文字列を返す。 */
-function findReasonDefect(reason: unknown): string | null {
-	if (typeof reason !== 'string') return `文字列ではありません (${typeof reason})`;
-	const trimmed = reason.trim();
-	if (trimmed.length === 0) return '空です';
-	if (STUB_REASONS.includes(trimmed.toLowerCase())) return `定型 stub です (「${trimmed}」)`;
-	// 「除外した」だけで何も説明していない極端な短文を弾く。
-	// 実データの最短は 20 字前後なので 8 字は十分に緩い下限。
-	if (trimmed.length < 8) return `短すぎます (${trimmed.length} 字: 「${trimmed}」)`;
-	return null;
-}
+// repo 走査 test の区分宣言 (#4085、SSOT = scripts/lib/ci/repo-scan-test-registry.mjs)。
+// 並列 worker との CPU / FS 競合で既定 5s を超えうるため明示 timeout を置く。
+vi.setConfig({ testTimeout: 60_000 });
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const BASELINE_DIR = path.join(REPO_ROOT, 'scripts', 'orphan-baselines');
 
 describe('#4030 AC5 除外理由は空でも stub でもないこと', () => {
-	it('findReasonDefect が空 / stub / 極端な短文を弾く (非トートロジー証明)', () => {
+	it('findReasonDefect が空 / stub / 極端な短文 / 機械生成を弾く (非トートロジー証明)', () => {
 		expect(findReasonDefect('')).not.toBeNull();
 		expect(findReasonDefect('   ')).not.toBeNull();
 		expect(findReasonDefect('TODO')).not.toBeNull();
 		expect(findReasonDefect('n/a')).not.toBeNull();
 		expect(findReasonDefect('未定')).not.toBeNull();
 		expect(findReasonDefect(undefined)).not.toBeNull();
+		// #4030 AC6: guard 自身が書いた文字列は「人が理由を書いた」ことにならない
+		expect(findReasonDefect('auto-added by --update-baseline')).not.toBeNull();
+		expect(
+			findReasonDefect(
+				'repo file "src/lib/server/db/dsql/foo-repo.ts" は db facade / factory / interfaces から import されていません。',
+			),
+		).not.toBeNull();
 		// 実データ相当は通る
 		expect(findReasonDefect('resource-list ではない admin page のため対象外')).toBeNull();
 	});
@@ -98,6 +108,50 @@ describe('#4030 AC5 除外理由は空でも stub でもないこと', () => {
 			defects,
 			'SHA pin の floating 許容理由が実質空です。**produce / write をしないこと**を' +
 				'説明してください。理由なしの許容は supply chain 防御の穴になります',
+		).toEqual([]);
+	});
+});
+
+// #4030 AC6 (PO 決裁 = 案 A): orphan baseline の免除理由も同じ規則で強制する。
+//
+// 旧実装の `--update-baseline` は検出理由 (機械が書いた現象の説明) / 'auto-added by --update-baseline'
+// を reasons に自動投入していた。**guard 自身の生成物で欄が埋まる**ため、
+// 「除外理由を書く」という運用が形骸化していた。
+//
+// 検査は `reportFindings` の check mode にも入っている (各 category の script が CI で実行される)
+// が、本 test は **10 category を 1 度に横断**して落とす。script が workflow から外れても
+// (= 検査が静かに消えても) ここで気づける (#4084「検査できなかったを pass にしない」)。
+describe('#4030 AC6 orphan baseline の免除理由も空 / stub / 機械生成でないこと', () => {
+	const baselineFiles = fs
+		.readdirSync(BASELINE_DIR)
+		.filter((f) => f.endsWith('.json'))
+		.sort();
+
+	it('baseline file の母数が 0 でない (検査対象が消えていない)', () => {
+		expect(
+			baselineFiles.length,
+			`${BASELINE_DIR} に baseline JSON がありません。dir 移動なら本 test の参照も直してください`,
+		).toBeGreaterThan(0);
+	});
+
+	it('全 category の全 allowed entry が理由を持つ', () => {
+		const defects: string[] = [];
+		let totalEntries = 0;
+		for (const file of baselineFiles) {
+			const parsed = JSON.parse(fs.readFileSync(path.join(BASELINE_DIR, file), 'utf8'));
+			totalEntries += (parsed.allowed ?? []).length;
+			for (const d of findBaselineReasonDefects(parsed)) {
+				defects.push(`${file} / ${d.entry}: ${d.defect}`);
+			}
+		}
+
+		// 全 category が空になったら「違反 0」ではなく「検査していない」
+		expect(totalEntries, '全 baseline の allowed が 0 件です').toBeGreaterThan(0);
+
+		expect(
+			defects,
+			'orphan baseline の免除理由が実質空です。**なぜ免除してよいか** を書いてください' +
+				'(検出理由の貼り付けではなく、免除の正当化を書く)',
 		).toEqual([]);
 	});
 });

--- a/tests/unit/architecture/exclusion-reason-nonempty.test.ts
+++ b/tests/unit/architecture/exclusion-reason-nonempty.test.ts
@@ -36,6 +36,7 @@ import {
 	findBaselineReasonDefects,
 	findReasonDefect,
 } from '../../../scripts/lib/ci/exclusion-reason.mjs';
+import { reportFindings } from '../../../scripts/lib/ci/orphan-utils.mjs';
 
 // #4030 AC6: 判定規則は `scripts/lib/ci/exclusion-reason.mjs` に一本化した。
 // 旧実装は本 file 内に同じ規則の copy を持っていたが、orphan baseline 側 (script) が
@@ -153,5 +154,43 @@ describe('#4030 AC6 orphan baseline の免除理由も空 / stub / 機械生成�
 			'orphan baseline の免除理由が実質空です。**なぜ免除してよいか** を書いてください' +
 				'(検出理由の貼り付けではなく、免除の正当化を書く)',
 		).toEqual([]);
+	});
+
+	// 生成側にも同じ assert を置く: 検査だけ直して生成側が stub を書き続けると、
+	// 「新規追加した瞬間に落ちる」状態が延々と量産される。
+	it('--update-baseline は検出理由を免除理由に流用せず、未記入のまま exit 1 を返す', () => {
+		const category = 'tmp-ac6-generation-assert';
+		const baselinePath = path.join(BASELINE_DIR, `${category}.json`);
+		const silence = { write: () => true };
+		const writeOut = process.stdout.write.bind(process.stdout);
+		const writeErr = process.stderr.write.bind(process.stderr);
+		process.stdout.write = silence.write as typeof process.stdout.write;
+		process.stderr.write = silence.write as typeof process.stderr.write;
+		try {
+			const code = reportFindings(
+				category,
+				[
+					{
+						name: 'src/lib/server/db/dsql/example-repo.ts',
+						// script が組み立てる「検出理由」= 機械が書いた現象の説明
+						reason:
+							'repo file "example-repo.ts" は db facade / factory から import されていません。',
+						allowlisted: false,
+					},
+				],
+				{ mode: 'update-baseline', baseline: { allowed: [], reasons: {}, version: '1.0.0' } },
+			);
+			expect(code, '理由未記入のまま baseline を更新したのに 0 を返しています').toBe(1);
+
+			const saved = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+			expect(saved.allowed).toEqual(['src/lib/server/db/dsql/example-repo.ts']);
+			expect(saved.reasons, '検出理由 / auto-added 文字列を免除理由の欄に書き込んでいます').toEqual(
+				{},
+			);
+		} finally {
+			process.stdout.write = writeOut;
+			process.stderr.write = writeErr;
+			if (fs.existsSync(baselinePath)) fs.unlinkSync(baselinePath);
+		}
 	});
 });

--- a/tests/unit/architecture/exclusion-reason-nonempty.test.ts
+++ b/tests/unit/architecture/exclusion-reason-nonempty.test.ts
@@ -36,7 +36,6 @@ import {
 	findBaselineReasonDefects,
 	findReasonDefect,
 } from '../../../scripts/lib/ci/exclusion-reason.mjs';
-import { reportFindings } from '../../../scripts/lib/ci/orphan-utils.mjs';
 
 // #4030 AC6: 判定規則は `scripts/lib/ci/exclusion-reason.mjs` に一本化した。
 // 旧実装は本 file 内に同じ規則の copy を持っていたが、orphan baseline 側 (script) が
@@ -156,41 +155,10 @@ describe('#4030 AC6 orphan baseline の免除理由も空 / stub / 機械生成�
 		).toEqual([]);
 	});
 
-	// 生成側にも同じ assert を置く: 検査だけ直して生成側が stub を書き続けると、
-	// 「新規追加した瞬間に落ちる」状態が延々と量産される。
-	it('--update-baseline は検出理由を免除理由に流用せず、未記入のまま exit 1 を返す', () => {
-		const category = 'tmp-ac6-generation-assert';
-		const baselinePath = path.join(BASELINE_DIR, `${category}.json`);
-		const silence = { write: () => true };
-		const writeOut = process.stdout.write.bind(process.stdout);
-		const writeErr = process.stderr.write.bind(process.stderr);
-		process.stdout.write = silence.write as typeof process.stdout.write;
-		process.stderr.write = silence.write as typeof process.stderr.write;
-		try {
-			const code = reportFindings(
-				category,
-				[
-					{
-						name: 'src/lib/server/db/dsql/example-repo.ts',
-						// script が組み立てる「検出理由」= 機械が書いた現象の説明
-						reason:
-							'repo file "example-repo.ts" は db facade / factory から import されていません。',
-						allowlisted: false,
-					},
-				],
-				{ mode: 'update-baseline', baseline: { allowed: [], reasons: {}, version: '1.0.0' } },
-			);
-			expect(code, '理由未記入のまま baseline を更新したのに 0 を返しています').toBe(1);
-
-			const saved = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
-			expect(saved.allowed).toEqual(['src/lib/server/db/dsql/example-repo.ts']);
-			expect(saved.reasons, '検出理由 / auto-added 文字列を免除理由の欄に書き込んでいます').toEqual(
-				{},
-			);
-		} finally {
-			process.stdout.write = writeOut;
-			process.stderr.write = writeErr;
-			if (fs.existsSync(baselinePath)) fs.unlinkSync(baselinePath);
-		}
-	});
+	// 生成側 (`--update-baseline` が検出理由を免除理由に流用しないこと) の assert は
+	// `scripts/__tests__/check-orphan-utils.test.mjs` に置く (node:test)。
+	// 本 file から `orphan-utils.mjs` を import すると svelte-check (checkJs) が
+	// 同 file の既存 JS を型検査して pre-existing error で落ちるため、
+	// **生成側の検査を消すのではなく、型検査の対象外レイヤーに置いて CI に載せた**
+	// (ci.yml の node:test step)。
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発・CI の防御線）

**解決する課題**: orphan 検査の「免除リスト」は `reasons` を持ち、運用上は「なぜ免除してよいかを書く」ことになっていた。しかし **value を読む検査が 0 件**で、しかも `--update-baseline` が **検出理由（機械が書いた現象の説明）や `'auto-added by --update-baseline'` を免除理由の欄にコピー**していた。**guard 自身の生成物で欄が埋まる**ため、「理由を書く」は事実上強制されておらず、次に読む人が「意図的な例外」と「消し忘れ」を区別できない。

**期待される効果**: 免除は **人が理由を書いて初めて成立**する。理由が無い / 定型 stub / 機械生成の免除は CI で落ちる。生成側（`--update-baseline`）も stub を書かなくなるため、「追加した瞬間に落ちる状態を量産する」形にならない。

## 関連 Issue

Closes #4030

**#4030 は 3 分割で消化してきた最後の 1 スライス（AC6）**。他は merge 済:

| slice | 内容 | 状態 |
|---|---|---|
| A-1 | `check-orphan-repos.mjs` の母数を実 FS 由来化 | PR #4040（merged） |
| A-2 | DSQL 系 3 guard の再帰化 | PR #4234（merged） |
| A-3 | restore registry の再帰化 | PR #4238（merged） |
| class B / AC5 | 除外理由の非空強制（5 箇所） | PR #4237（merged） |
| **AC6** | **`--update-baseline` 自動投入理由の扱い** | **本 PR** |

AC6 は PO 決裁（2026-08-05、Issue #4030 コメント）で **案 A（自動投入を「理由なし」として弾く）** に確定済み。

- #4025 — 本 class の起点（silent-pass 2 件）
- #4237 — 本 PR が SSOT 集約する `findReasonDefect` の初出
- #3956 — 「理由の非強制を作らない」
- #4084 — 「検査できなかった」を pass にしない

**#4323 との関係**: #4323（check-* 66 本の全数走査で見つかった 18 件）は **2026-08-05 に PO がルール 7 で close**（装置・プロセスの改善は起票せずその場で PR）。したがって #4030 と #4323 は並走していない。#4333 が触っている `scripts/check-ac-verification-map.mjs` には本 PR は一切触れていない。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `check-orphan-repos.mjs` の母数を実 FS 由来に変える | — | **本 PR scope 外**（PR #4040 で完遂、`resolveRepoLayerDirs()`） |
| AC2 | AC1 で orphan が新規検出されたら切り出す | `node scripts/check-orphan-repos.mjs --report` | **発動せず**（新規 orphan 0 件、切り出し不要） |
| AC3 | DSQL 系 3 guard を再帰化 | — | **本 PR scope 外**（PR #4234 で完遂） |
| AC4 | 再帰化で新規検出されたら allowlist 判断 | — | **発動せず**（PR #4234 で 3 guard とも新規 violation 0 件） |
| AC5 | reason フィールドを持つものに非空 assertion | — | **本 PR scope 外**（PR #4237 で 5 箇所完遂） |
| **AC6** | `--update-baseline` 自動投入理由を「理由なし」として扱うか決める | 実装 + 実測（下記） | ✅ **案 A で実装**。検査側（check mode + vitest 横断）と生成側（update-baseline）の両方 |
| **AC7** | mutation 実出力を添える | 実測（下記 §mutation） | ✅ **旧 exit 0（素通り）→ 新 exit 1** を同一入力で対比 |
| **AC8** | `npm run pre-ready -- --pr <num>` 全 Step PASS | `npm run pre-ready -- --pr 4346` | ✅ 全 Step PASS（下記表） |

### AC6 で実際に入れたもの

1. **生成側**: `--update-baseline` が `f.reason`（検出理由 = 機械が書いた現象の説明）/ `'auto-added by --update-baseline'` を `reasons` にコピーするのをやめた。reason 未記入のまま entry を追加し、**「書くまで check は落ちる」と伝えて exit 1** を返す
2. **検査側**: check mode が全 `allowed` entry の reason を検査し、空 / 空白のみ / 定型 stub / **機械生成文字列** / 8 字未満を弾く
3. **判定 SSOT**: `scripts/lib/ci/exclusion-reason.mjs` に集約。#4237 が test file 内に持っていた `findReasonDefect` の copy を削り、script 側と test 側が同じ規則を使う（**規則が 2 つあると片方だけ緩めて通す抜け道になる**）
4. **横断検査**: 10 category の baseline を 1 度に検査する vitest を追加（script が workflow から外れて検査が静かに消えても気づける、#4084 と同じ思想）。baseline file 0 件 / allowed 合計 0 件は「違反 0」ではなく fail

**新規 script は作っていない**（既存 `orphan-utils.mjs` + 既存 test file への相乗り、チーム憲章 §4.5 装置 ratchet）。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（CI の検査のみ。`src/` は 1 行も触っていない）

- [x] N/A — 並行実装ペア / 設計書 / LP / 重量 e2e いずれも影響範囲外

### 一斉赤化しないことの実測

| 観点 | 実測 | 結果 |
|---|---|---|
| 現在の全 10 category | `check-orphan-{tables,services,repos,fixtures,labels,ui,assets,env,routes}` + `check-skip-deadlines` を個別実行 | **10/10 exit 0**（既存 60 entry は全件が人の書いた理由） |
| 履歴の baseline 内容 | 直近 60 commit（origin/develop）の baseline file を全て取り出して新判定を適用（**600 file version**） | **would-fail = 0** |
| open PR への影響 | open 7 本（#4344 / #4343 / #4341 / #4336 / #4335 / #4332 / #4322）の diff に `scripts/orphan-baselines/` が含まれるか | **0 本**（誰も触っていない） |

**新判定が既存 PR / 履歴を赤にすることはない。** 落ちるのは「今後、理由を書かずに免除を足したとき」だけ。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4346` | PASS（全 Step） |
| 追加・変更テスト | `npx vitest run tests/unit/architecture/exclusion-reason-nonempty.test.ts` | **6 passed** |
| 既存 script test | `node --test scripts/__tests__/check-orphan-utils.test.mjs` | **13 passed / 0 failed** |
| 走査 test 区分宣言 | `node scripts/check-repo-scan-test-declaration.mjs` | OK（46 件、`scope='repo'` は明示 timeout ≥ 20s 確認） |

### mutation（AC7 — failing-test-first、commit 後に実施）

`repos.json` の reason 1 件を `TODO` に差し替え、**同一入力**で旧実装（`origin/develop` の `orphan-utils.mjs`）と新実装を対比した。

| 実装 | 出力 | exit |
|---|---|---|
| **旧（origin/develop）** | `[check-orphan-repos] OK — 0 known orphan(s) all in baseline` | **0（素通り）** |
| **新（本 PR）** | `NG — baseline の免除理由が 1 件、理由として成立していません: src/lib/server/db/demo/webhook-event-repo.ts: 定型 stub です (「TODO」)` | **1** |
| **新（vitest 側）** | `repos.json / src/lib/server/db/demo/webhook-event-repo.ts: 定型 stub です (「TODO」)` | **1 failed / 5 passed** |

生成側は独立した assert で固定している（`--update-baseline` mode で `reportFindings` を呼び、**`reasons` が `{}` のまま** + exit 1 を assert）。この assert は、生成側が検出理由を書き戻す旧挙動に戻したら落ちる。

mutation は **commit 済みの状態で実施**し、復元は `git show HEAD:<path>` の書き戻しで行った（`git checkout --` を使わない）。復元後に `git status --porcelain` 空 + `check-orphan-repos` exit 0 を再確認済み。

- [x] **SOLID / DRY / YAGNI**: 判定規則を 1 module に集約し重複 copy を 1 件削除。新規 script / 新規依存なし
- [x] **Security（OSS 公開前提）**: 秘密情報なし
- [x] **A11y・パフォーマンス**: N/A（UI なし）
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: CI の検査 (scripts/lib/ci + tests/unit/architecture) のみの変更で、src/ も site/ も 1 行も触っていない。顧客に見える画面が存在しない。 -->

**該当なし（CI / gate の変更のみ。UI 変更なし）**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる

**レビュー依頼事項**:

1. **`--update-baseline` を exit 1 にした**点。CI は check mode しか実行しない（`orphan-check.yml` は 10 本とも引数なし）ので CI は落ちないが、ローカル運用者には「未完了」が exit code で伝わる。exit 0 + 警告表示のほうが好ましければ変えられる。
2. **機械生成 marker の持ち方**。`MACHINE_GENERATED_REASON_MARKERS` は現行 script の検出理由の定型句を列挙している。将来 script 側の文言が変わると marker が effect を失うため、**文言の側に marker を寄せる**（検出理由に sentinel prefix を付ける）ほうが堅い設計かもしれない。今回は既存出力を変えない方を選んだ。

### 本 PR で「残した」もの（silent gap を作らないための明示）

調査中に **本 PR の scope 外だが同 class の実害**を 2 件見つけた。追跡先を書いて残す。

| 残件 | 実測 | 追跡先 |
|---|---|---|
| **`scripts/__tests__/*.test.mjs` 13 本のうち CI が実行しているのは 2 本だけ**（`ci.yml` が `node --test <literal path>` を 2 行書いているだけで、glob ではない）。残り 11 本は**どこからも実行されていない**。実際に走らせると **3 test が fail**（`check-ss-blob-sha-uniqueness` は #4084 で `skip → fail` に変えた挙動に test が追随しておらず、`generate-lp-labels` は 2 件 drift） | `node --test scripts/__tests__/*.test.mjs` → `# tests 236 / # pass 233 / # fail 3` | **Issue #4030 にコメントで記録**（本 PR と混ぜると「workflow 変更 + 3 test の内容修正」が同居してレビュー不能になるため分離） |
| `scripts/orphan-baselines/repos.json` の `allowed` 3 件は `allowlisted: 0` = **もう検出されていない dead entry**（3 件とも reason に「結線完了時に本 entry を baseline から削除する」と自ら書いている） | `node scripts/check-orphan-repos.mjs --report` → `allowlisted: 0` | PO が「**本 Issue とは別 PR**」と明示（#4030 コメント、2026-08-01）。**未着手のまま** |

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面を触っていない）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
