### PR TITLE
fix(ci): #4333 統合 PR の「残 NG 0 件」gate を存在検査から件数検査にする

### DIFF
--- a/.github/INTEGRATION_PR_TEMPLATE.md
+++ b/.github/INTEGRATION_PR_TEMPLATE.md
@@ -91,6 +91,15 @@ severity 3-4 + policy_compliant=false の未解決 finding が 0 件 +
 カバレッジ ratchet 閾値割れなしの宣言 (audit-team.md §3.5 #4/#5)。
 pr-merge-gate.yml (integration lane) が下記 `- [ ]` の全消化を機械検証する
 (env MERGE_GATE_INTEGRATION_SECTIONS が本 section を指す)。
+
+残 NG の件数は pr-ac-verification-check.yml (integration lane) が **本 section 内から
+「残 NG N 件」を読み取って N=0 を検証する** (#4333)。以下に注意:
+  - 判定は本 section の**本文のみ**。見出し行 / HTML コメント / code block は対象外
+    (旧実装は本文全体の正規表現 1 本で、この説明コメントや見出しだけで緑になっていた)
+  - 件数を書き換えれば gate に反映される。「残 NG 1 件」と書けば **red になる**
+  - 残 NG > 0 のまま merge する判断をした場合は、**嘘の 0 件宣言に倒さず**、
+    理由 + 追跡 Issue 番号を伴う受容宣言を本文に置くこと:
+      <!-- ng-nonzero-accepted: <なぜ本 release で塞がないのか> (#追跡Issue番号) -->
 -->
 
 - 残 NG 合計 0 件 (severity 3-4 + policy_compliant=false の未解決 finding なし)

--- a/.github/workflows/pr-ac-verification-check.yml
+++ b/.github/workflows/pr-ac-verification-check.yml
@@ -53,6 +53,7 @@ jobs:
             scripts/pr-lane.mjs
             scripts/check-ac-verification-map.mjs
             scripts/lib/is-main.mjs
+            scripts/lib/ci/reason-declaration.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)

--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -1,7 +1,25 @@
+import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /** 統合 PR の検証で要求する section 見出し（暫定。統合 PR template 確定は Phase B #2871）。 */
 export const INTEGRATION_EVIDENCE_SECTION = 'マージ判定エビデンス表';
+
+/**
+ * 残 NG 件数の宣言を読む section 見出し（#4333 AC2）。
+ * SSOT: `.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json` の `## NG 0 件 / カバレッジ宣言`。
+ * 同期は `tests/unit/scripts/check-ac-verification-map.test.ts` の生成側 assert が固定する。
+ */
+export const NG_DECLARATION_SECTION = 'NG 0 件 / カバレッジ宣言';
+
+/**
+ * 残 NG > 0 のまま merge することを明示的に受容する宣言 key（#4333）。
+ *
+ * gate を hard-fail のみにすると「正直に 残 NG 1 件 と書くと merge できない」ため、
+ * **嘘の 0 件宣言に倒すインセンティブ**が生まれる（#4304 は正直に書いたのに gate が緑だった
+ * のが問題であって、正直さを罰するのが目的ではない）。よって逃げ道は塞がず、
+ * **理由 + 追跡 Issue を伴う明示宣言でのみ通す**（#4084 の 4 宣言と同じ思想・同じ SSOT）。
+ */
+export const NG_NONZERO_ACCEPTED_KEY = 'ng-nonzero-accepted';
 
 /**
  * #1539: AC マップ 4 列目（結果/エビデンス列）の未完了表記検出パターン。
@@ -36,8 +54,93 @@ function stripInlineCode(cell) {
 	return cell.replace(/`[^`]*`/g, '');
 }
 
-/** integration lane の「残 NG 0 件」明示を検出するパターン（audit-team.md §3.5 #5）。 */
-const NG_ZERO_PATTERN = /残\s*NG\s*(?:合計\s*)?0\s*件|残\s*NG[^\n|]*[:：]?\s*0\b|NG\s*0\s*件/;
+/**
+ * 残 NG **件数** の宣言を読み取るパターン（#4333）。件数を capture group 1 で取り出す。
+ *
+ * 旧実装は `/残\s*NG[^\n|]*[:：]?\s*0\b|NG\s*0\s*件/` を **本文全体**に `test()` するだけで、
+ * 「0 という文字が本文のどこかにあるか」しか見ていなかった。実測された素通り経路:
+ *
+ *   - `## NG 0 件 / カバレッジ宣言`（**見出しそのもの**。template を貼れば必ず存在する）
+ *   - `<!-- 残 NG 0 件 明示を検証する -->`（template の HTML コメント。誰にも見えない）
+ *   - `**「残 NG 0」を偽って宣言しない。**`（**否定文**。文意と逆に判定される）
+ *   - `残 NG は 10 件`（`[^\n|]*` が「は 1」を食い、続く `0\b` に一致して **10 件が 0 件扱い**）
+ *
+ * つまり NG-0 gate は全統合 PR で常に緑だった（#4304 で severity 4 の残 NG を正直に宣言した
+ * PR がそのまま緑になったことで発覚）。存在検査をやめ、**宣言された件数を読んで 0 か判定する**。
+ *
+ * `[^\n|]` で行と table cell を跨がせないのは、宣言は prose であって表のセル結合ではないため。
+ * 数値は最短一致側から拾うので `残 NG は 10 件` は 10 と読む（0 を拾わない）。
+ */
+const NG_COUNT_DECLARATION = /残(?:り|る)?\s*(?:の)?[^\n|]{0,24}?NG[^\n|]{0,24}?(\d+)\s*件/g;
+
+/** 受容宣言の理由に要求する追跡 Issue 参照（「どこで追うのか」を書かせる）。 */
+const ISSUE_REFERENCE_PATTERN = /#\d{2,}/;
+
+/**
+ * HTML コメント（`<!-- ... -->`）を除去する（#4333 AC1）。
+ *
+ * template の説明コメントは **顧客にも監査にも見えない**のに gate を緑にしていた。
+ * 判定は「本文に書かれた宣言」だけを対象にする。
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripHtmlComments(text) {
+	return (text ?? '').replace(/<!--[\s\S]*?--!?>/g, '');
+}
+
+/**
+ * fenced code block（``` ... ```）を除去する。
+ * 本 gate や template の regex / 例文をコードブロックで引用しただけで緑にしない。
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripFencedCode(text) {
+	return (text ?? '').replace(/^```[\s\S]*?^```/gm, '');
+}
+
+/**
+ * `## <title>` の H2 section 本体を切り出す（**見出し行そのものは含まない**、#4333 AC2/AC3）。
+ *
+ * 見出しは `.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json` が宣言する構造化識別子なので
+ * **行全体の完全一致**で探す（部分一致だと本文中の言及・引用・別セクションを拾う）。
+ * 見つからない場合は `found: false` を返し、**呼び出し側は必ず fail に倒す**
+ * （「検査できなかった」を pass にしない、#4084 と同じ思想）。
+ *
+ * @param {string} body
+ * @param {string} title 見出し文字列（`## ` を除いた部分）
+ * @returns {{ found: boolean; text: string }}
+ */
+export function extractH2Section(body, title) {
+	const lines = (body ?? '').replace(/\r\n?/g, '\n').split('\n');
+	const start = lines.findIndex((l) => l.trim() === `## ${title}`);
+	if (start === -1) return { found: false, text: '' };
+	const rest = lines.slice(start + 1);
+	const end = rest.findIndex((l) => l.startsWith('## '));
+	return { found: true, text: (end === -1 ? rest : rest.slice(0, end)).join('\n') };
+}
+
+/**
+ * section 本体から「残 NG N 件」の宣言を全件読み取る（#4333）。
+ *
+ * 1 件でも 0 以外があれば残 NG は 0 ではない、と扱う（本文が「0 件」と「1 件」を
+ * 同時に主張している状態を pass にしない）。
+ *
+ * @param {string} sectionText 見出し行を含まない section 本体
+ * @returns {{ count: number; line: string }[]}
+ */
+export function parseNgCountDeclarations(sectionText) {
+	const scrubbed = stripFencedCode(stripHtmlComments(sectionText));
+	/** @type {{ count: number; line: string }[]} */
+	const found = [];
+	for (const line of scrubbed.split('\n')) {
+		for (const m of line.matchAll(NG_COUNT_DECLARATION)) {
+			found.push({ count: Number(m[1]), line: line.trim() });
+		}
+	}
+	return found;
+}
 
 /**
  * 次の `## ` 見出し（H2）の直前までを切り出す。見出しが無ければ全体を返す。
@@ -79,6 +182,16 @@ function extractFourColumnRows(body, fromIdx) {
 		afterHeading === -1
 			? rest
 			: rest.slice(0, afterHeading + 1) + sliceUntilNextH2(rest.slice(afterHeading + 1));
+	return pickFourColumnRows(section);
+}
+
+/**
+ * section 本体から 4 列のデータ行を拾う（header / separator を除く）。
+ *
+ * @param {string} section
+ * @returns {string[]}
+ */
+function pickFourColumnRows(section) {
 	return section
 		.split('\n')
 		.filter((l) => /^\|[^|]+\|[^|]+\|[^|]+\|[^|]+\|/.test(l))
@@ -238,8 +351,8 @@ export function checkPerPrAcMap(body, lane) {
  * @returns {AcCheckResult}
  */
 export function checkIntegrationEvidenceTable(body) {
-	const sectionIdx = body.indexOf(INTEGRATION_EVIDENCE_SECTION);
-	if (sectionIdx === -1) {
+	const evidence = extractH2Section(body, INTEGRATION_EVIDENCE_SECTION);
+	if (!evidence.found) {
 		return {
 			ok: false,
 			lane: 'integration',
@@ -251,7 +364,7 @@ export function checkIntegrationEvidenceTable(body) {
 		};
 	}
 
-	const rows = extractFourColumnRows(body, sectionIdx);
+	const rows = pickFourColumnRows(evidence.text);
 	const emptyRows = findEmptyRows(rows);
 	const info = [
 		`integration evidence rows found: ${rows.length}, empty/placeholder rows: ${emptyRows.length}`,
@@ -282,23 +395,105 @@ export function checkIntegrationEvidenceTable(body) {
 		};
 	}
 
-	if (!NG_ZERO_PATTERN.test(body)) {
-		return {
-			ok: false,
-			lane: 'integration',
-			info,
-			error:
-				'❌ 統合 PR の本文に「残 NG 0 件」の明示がありません (#2945 AC3 / audit-team.md §3.5 #5)\n\n' +
-				'8 領域 finding のうち severity 閾値以上の未解決 NG が 0 件であることを明記してください。\n' +
-				'（例:「残 NG 合計 0 件」をエビデンス表 / 本文に記載）',
-		};
+	const ng = checkNgZeroDeclaration(body);
+	info.push(...(ng.info ?? []));
+	if (!ng.ok) {
+		return { ok: false, lane: 'integration', info, error: ng.error };
 	}
 
 	return {
 		ok: true,
 		lane: 'integration',
 		info,
-		reason: 'マージ判定エビデンス表: 4 列全行 + 残 NG 0 件 明示 ✓',
+		reason: `マージ判定エビデンス表: 4 列全行 ✓ / ${ng.reason}`,
+	};
+}
+
+/**
+ * 「残 NG 0 件」宣言の検証（#4333、audit-team.md §3.5 #5）。
+ *
+ * **存在検査ではなく件数検査**である。`## NG 0 件 / カバレッジ宣言` section 内から
+ * HTML コメント / code block を除いたうえで「残 NG N 件」を全件読み、
+ *
+ *   - section が無い / 宣言が 1 件も無い → **fail**（検査できないものを pass にしない）
+ *   - 1 件でも N > 0 → **fail**（ただし明示的な受容宣言があれば pass、下記）
+ *
+ * 受容宣言 `<!-- ng-nonzero-accepted: <理由 + 追跡 Issue> -->` は、
+ * 残 NG があることを認めたうえで merge する場合の唯一の経路。理由の実体判定は
+ * `scripts/lib/ci/reason-declaration.mjs`（#4084 の 4 宣言と同一 SSOT）に委譲し、
+ * さらに追跡 Issue 参照（`#NNNN`）を要求する。**宣言は本文に残るので後から grep できる** —
+ * 「見出しがあるだけで緑」だった旧実装との決定的な違いはここにある。
+ *
+ * @param {string} body PR 本文
+ * @returns {{ ok: boolean; reason?: string; error?: string; info?: string[] }}
+ */
+export function checkNgZeroDeclaration(body) {
+	const section = extractH2Section(body, NG_DECLARATION_SECTION);
+	if (!section.found) {
+		return {
+			ok: false,
+			error:
+				`❌ 統合 PR の本文に「## ${NG_DECLARATION_SECTION}」section がありません (#4333 / audit-team.md §3.5 #5)\n\n` +
+				'残 NG 件数の宣言はこの section 内でのみ読み取ります（本文の他の場所・HTML コメント・見出しは対象外）。\n' +
+				'.github/INTEGRATION_PR_TEMPLATE.md の該当 section を復元してください。',
+		};
+	}
+
+	const declarations = parseNgCountDeclarations(section.text);
+	const info = [
+		`NG declarations found: ${declarations.length} (${declarations.map((d) => d.count).join(',') || 'none'})`,
+	];
+
+	if (declarations.length === 0) {
+		return {
+			ok: false,
+			info,
+			error:
+				`❌ 「## ${NG_DECLARATION_SECTION}」section に残 NG 件数の宣言がありません (#4333)\n\n` +
+				'見出しがあるだけでは通しません（旧実装は見出しの文字列だけで緑になっていました）。\n' +
+				'section 本体に件数を明記してください。例:「残 NG 合計 0 件 (severity 3-4 の未解決 finding なし)」\n' +
+				'HTML コメント内 / code block 内の記述は判定対象外です。',
+		};
+	}
+
+	const nonZero = declarations.filter((d) => d.count !== 0);
+	if (nonZero.length === 0) {
+		return { ok: true, info, reason: '残 NG 0 件 宣言 ✓' };
+	}
+
+	const accepted = parseReasonDeclaration(body, NG_NONZERO_ACCEPTED_KEY);
+	const details = nonZero
+		.map((d) => `  残 NG ${d.count} 件: 「${d.line.slice(0, 100)}」`)
+		.join('\n');
+
+	if (!accepted.present) {
+		return {
+			ok: false,
+			info,
+			error:
+				`❌ 残 NG が 0 件ではありません (#4333 / audit-team.md §3.5 #5)\n\n${details}\n\n` +
+				'残 NG > 0 のまま merge するなら、本文に受容宣言を明記してください（嘘の 0 件宣言に倒さないための経路です）:\n' +
+				`  <!-- ${NG_NONZERO_ACCEPTED_KEY}: <なぜ本 release で塞がないのか> (#追跡Issue番号) -->\n` +
+				'宣言しない場合は §3.6 起票/棄却 flow に送り、残 NG を 0 にしてから merge してください。',
+		};
+	}
+
+	if (!accepted.valid || !ISSUE_REFERENCE_PATTERN.test(accepted.reason)) {
+		return {
+			ok: false,
+			info,
+			error:
+				`❌ \`${NG_NONZERO_ACCEPTED_KEY}\` 宣言の理由が受理できません (#4333)\n\n${details}\n\n` +
+				`  ${MIN_REASON_LENGTH} 文字以上で「なぜ本 release で塞がないのか」を書き、追跡 Issue 番号 (#NNNN) を含めてください\n` +
+				'  (空欄 / TODO / n/a 等の定型 stub は受理しません、#3956 教訓)。\n' +
+				`  現在の理由: 「${accepted.reason.slice(0, 100)}」`,
+		};
+	}
+
+	return {
+		ok: true,
+		info,
+		reason: `残 NG ${nonZero.map((d) => d.count).join('/')} 件（受容宣言あり: ${accepted.reason.slice(0, 60)}）`,
 	};
 }
 

--- a/tests/unit/scripts/check-ac-verification-map.test.ts
+++ b/tests/unit/scripts/check-ac-verification-map.test.ts
@@ -1,10 +1,17 @@
 // Issue #2945 (Phase A/A-3、親 #2942) AC3/AC4: lane-aware AC 検証マップ judge の unit test。
 // feature/hotfix lane = 現行 AC マップ観点 (回帰ゼロ)、integration lane = マージ判定エビデンス表観点。
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
 	checkAcVerification,
 	checkIntegrationEvidenceTable,
 	checkPerPrAcMap,
+	extractH2Section,
+	INTEGRATION_EVIDENCE_SECTION,
+	NG_DECLARATION_SECTION,
+	NG_NONZERO_ACCEPTED_KEY,
+	parseNgCountDeclarations,
 	shouldSkip,
 } from '../../../scripts/check-ac-verification-map.mjs';
 
@@ -133,6 +140,15 @@ const FEATURE_AC_MAP_INLINE_CODE_PLUS_PROSE_TODO = `
 | AC1 | ログイン | vitest | \`RANGE_SSOT_TODO\` は集約済、残りは後で対応 |
 `;
 
+// #4333: 残 NG 件数の宣言は `## NG 0 件 / カバレッジ宣言` section 内でのみ読む。
+// 実在の統合 PR (#4253 / #3931 / #3866 …) が使っている形をそのまま fixture にする。
+const NG_ZERO_SECTION = `
+## NG 0 件 / カバレッジ宣言
+
+- 残 NG 合計 0 件 (severity 3-4 + policy_compliant=false の未解決 finding なし)
+- [x] adversarial evidence の反対理由が全件解消済みである
+`;
+
 const INTEGRATION_EVIDENCE_PASS = `
 ## 概要
 develop → main 統合 PR
@@ -143,9 +159,7 @@ develop → main 統合 PR
 |---|---|---|---|
 | 機能 A（#3001） | admin/activities | unit×3 / e2e×1 | pass |
 | 修正 B（#3002） | child-home | unit×2 | pass |
-
-残 NG 合計 0 件。adversarial evidence の反対理由は解消済。
-`;
+${NG_ZERO_SECTION}`;
 
 // #4243: evidence 表の **後ろ** に別の 4 列表がある body。
 // 統合 PR template は「Accepted residual (Pre-PMF)」表を後続に持ち、その例示行が
@@ -160,14 +174,12 @@ develop -> main 統合 PR
 |---|---|---|---|
 | 機能 A（#3001） | admin/activities | unit×3 / e2e×1 | pass |
 
-残 NG 合計 0 件。adversarial evidence の反対理由は解消済。
-
 ## Accepted residual (Pre-PMF)
 
 | finding (要約) | severity (1-2 のみ) | 受容理由 (Pre-PMF) | 関連 root class |
 |---|---|---|---|
 | <!-- 例: 命名精度 --> | <!-- 2 --> | <!-- dev-only 診断値 --> | <!-- 完全性 --> |
-`;
+${NG_ZERO_SECTION}`;
 
 // #4243: evidence 表が **空** なのに、後続表には埋まった 4 列行がある body。
 // 走査が閉じていないと `rows.length === 0` を後続表の行が満たしてしまい **見逃す**。
@@ -179,14 +191,12 @@ develop -> main 統合 PR
 
 （まだ埋めていない）
 
-残 NG 合計 0 件。
-
 ## Accepted residual (Pre-PMF)
 
 | finding (要約) | severity (1-2 のみ) | 受容理由 (Pre-PMF) | 関連 root class |
 |---|---|---|---|
 | 命名精度 | 2 | dev-only 診断値 | 完全性 |
-`;
+${NG_ZERO_SECTION}`;
 
 const INTEGRATION_EVIDENCE_MISSING_SECTION = `
 ## 概要
@@ -199,9 +209,7 @@ const INTEGRATION_EVIDENCE_EMPTY_ROW = `
 | 含有 PR | 対象領域 | 対応テストケース | 結果 |
 |---|---|---|---|
 | 機能 A（#3001） | admin/activities |  | pass |
-
-残 NG 0 件。
-`;
+${NG_ZERO_SECTION}`;
 
 const INTEGRATION_EVIDENCE_NO_NG_ZERO = `
 ## マージ判定エビデンス表
@@ -215,8 +223,7 @@ const INTEGRATION_EVIDENCE_NO_ROWS = `
 ## マージ判定エビデンス表
 
 （表をまだ埋めていない）
-残 NG 0 件。
-`;
+${NG_ZERO_SECTION}`;
 
 // --- feature / hotfix lane (AC4 回帰ゼロ) ---
 
@@ -349,10 +356,179 @@ describe('checkIntegrationEvidenceTable (integration lane、AC3)', () => {
 		expect(r.error).toContain('空欄');
 	});
 
-	it('FAIL: 残 NG 0 件 明示が無い', () => {
+	it('FAIL: 残 NG 宣言 section が無い', () => {
 		const r = checkIntegrationEvidenceTable(INTEGRATION_EVIDENCE_NO_NG_ZERO);
 		expect(r.ok).toBe(false);
-		expect(r.error).toContain('残 NG 0 件');
+		expect(r.error).toContain('NG 0 件 / カバレッジ宣言');
+	});
+});
+
+// --- #4333: 「残 NG 0 件」gate が内容を検証していなかった件 ---
+//
+// 旧実装は本文全体への 1 本の正規表現 `test()` で「0 という字があるか」だけを見ており、
+// 下記 5 ケースが **すべて緑**だった（実測: `node tmp/repro-4333.mjs` on develop）。
+// ここは「fail するケース」の固定が本題である（AC4）— 直すだけでは壊れても誰も気づかない。
+
+/** 4 列を満たす evidence 表（NG 宣言以外の条件は満たす。NG 判定だけを裸にするための土台）。 */
+const EVIDENCE_TABLE_ONLY = `
+## マージ判定エビデンス表
+
+| 含有 PR | 対象領域 | 対応テストケース | 結果 |
+|---|---|---|---|
+| 機能 A（#3001） | admin/activities | unit×3 | pass |
+`;
+
+const withNgSection = (bodyOfSection: string) =>
+	`${EVIDENCE_TABLE_ONLY}\n## NG 0 件 / カバレッジ宣言\n\n${bodyOfSection}\n`;
+
+describe('#4333 残 NG 0 件 gate は件数を検証する（見出しがあるだけで緑にしない）', () => {
+	it('FAIL: 「残 NG は 10 件」と正直に書いた本文を通さない（旧実装は 0 と読んでいた）', () => {
+		const r = checkIntegrationEvidenceTable(
+			withNgSection('- 残 NG は 10 件 (未解決 finding あり)'),
+		);
+		expect(r.ok, '「10 件」の末尾 0 を 0 件として読んでいます').toBe(false);
+		expect(r.error).toContain('残 NG が 0 件ではありません');
+		expect(r.error).toContain('10 件');
+	});
+
+	it('FAIL: 残 NG 合計 1 件（#4304 の実際の宣言。severity 4 = #4309 を残したまま merge した）', () => {
+		const r = checkIntegrationEvidenceTable(
+			withNgSection(
+				'**残 NG 合計 1 件**: `security-1`（/ops/export 未認証、severity 4）→ **#4309**',
+			),
+		);
+		expect(r.ok, '#4304 は正直に 1 件と宣言したのに緑だった。それを再現してはいけない').toBe(false);
+	});
+
+	it('FAIL: 見出しはあるが section 本体に件数の宣言が無い（検査できないものを pass にしない）', () => {
+		const r = checkIntegrationEvidenceTable(withNgSection('（まだ書いていない）'));
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain('残 NG 件数の宣言がありません');
+	});
+
+	it('FAIL: HTML コメント内の template 説明文では通らない（AC1）', () => {
+		const r = checkIntegrationEvidenceTable(
+			withNgSection('<!-- 4 列のデータ行 + 残 NG 0 件 明示を検証する -->'),
+		);
+		expect(r.ok, 'template の HTML コメントは顧客にも監査にも見えない').toBe(false);
+	});
+
+	it('FAIL: code block 内で本 gate の regex を引用しただけでは通らない', () => {
+		const r = checkIntegrationEvidenceTable(
+			withNgSection('```\nconst NG = /残 NG 合計 0 件/;\n```'),
+		);
+		expect(r.ok).toBe(false);
+	});
+
+	it('FAIL: 否定文（「残 NG 0 件」を偽って宣言しない）を宣言として拾わない（AC2）', () => {
+		const r = checkIntegrationEvidenceTable(
+			`${EVIDENCE_TABLE_ONLY}\n**「残 NG 0 件」を偽って宣言しない。**\n`,
+		);
+		expect(r.ok, 'section 外の否定文を宣言として読んでいます').toBe(false);
+	});
+
+	it('FAIL: 見出し行そのもの（## NG 0 件 / カバレッジ宣言）を match 源にしない（AC3）', () => {
+		const r = checkIntegrationEvidenceTable(
+			`${EVIDENCE_TABLE_ONLY}\n## NG 0 件 / カバレッジ宣言\n`,
+		);
+		expect(r.ok, '見出し文字列だけで緑になっています（本欠陥そのもの）').toBe(false);
+	});
+
+	it('FAIL: 0 件 と 1 件 を同時に主張している本文は通さない', () => {
+		const r = checkIntegrationEvidenceTable(
+			withNgSection('- 残 NG 合計 0 件\n- ただし残 NG 1 件 は次 release へ繰り延べる'),
+		);
+		expect(r.ok).toBe(false);
+	});
+
+	it('PASS: 実在の統合 PR (#4253) と同形の宣言は従来どおり通る（回帰）', () => {
+		const r = checkIntegrationEvidenceTable(
+			withNgSection(
+				'- 残 NG 合計 0 件 (severity 3-4 + policy_compliant=false の未解決 finding なし)\n' +
+					'- [x] 8 領域 finding のうち severity 閾値以上の未解決 NG が **0 件**である',
+			),
+		);
+		expect(r.ok, r.error).toBe(true);
+	});
+
+	it('PASS: 実在の統合 PR (#3357) の言い回し「残る blocking NG = 0 件」も通る（回帰）', () => {
+		const r = checkIntegrationEvidenceTable(
+			withNgSection(
+				'- diff 起因の sev4=0。実害直結 sev3 は 1 件（ux-2）を follow-up #3361 化。残る blocking NG = 0 件',
+			),
+		);
+		expect(r.ok, r.error).toBe(true);
+	});
+});
+
+describe('#4333 残 NG > 0 の受容宣言（正直な宣言を罰して嘘に倒させない）', () => {
+	const NONZERO = '**残 NG 合計 1 件**: security-1（severity 4）';
+
+	it('PASS: 理由 + 追跡 Issue 付きの受容宣言があれば通る', () => {
+		const r = checkIntegrationEvidenceTable(
+			`<!-- ng-nonzero-accepted: /ops/export の認可修正は本 release の scope 外で #4309 で追跡する -->\n${withNgSection(NONZERO)}`,
+		);
+		expect(r.ok, r.error).toBe(true);
+		expect(r.reason).toContain('受容宣言あり');
+	});
+
+	it('FAIL: 受容宣言の理由が定型 stub（TODO）なら通さない', () => {
+		const r = checkIntegrationEvidenceTable(
+			`<!-- ng-nonzero-accepted: TODO -->\n${withNgSection(NONZERO)}`,
+		);
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain('理由が受理できません');
+	});
+
+	it('FAIL: 追跡 Issue 番号を含まない理由は通さない', () => {
+		const r = checkIntegrationEvidenceTable(
+			`<!-- ng-nonzero-accepted: 次のリリースでまとめて対応するので今回は見送る -->\n${withNgSection(NONZERO)}`,
+		);
+		expect(r.ok).toBe(false);
+		expect(r.error).toContain('理由が受理できません');
+	});
+
+	it('受容宣言は 残 NG 0 件 の PR には不要（宣言なしでも通る）', () => {
+		const r = checkIntegrationEvidenceTable(withNgSection('- 残 NG 合計 0 件'));
+		expect(r.ok, r.error).toBe(true);
+	});
+});
+
+// --- 生成側 assert (#4333): template / SECTIONS.json と judge のズレを検出する ---
+//
+// judge 側だけ直しても、template の見出しや宣言文が変われば **判定が空振り**する。
+// #4324 (#4255) で SS gate に入れたのと同じ「生成側にも assert を置く」対処。
+
+describe('#4333 生成側 assert: 統合 PR template と judge の同期', () => {
+	const templatePath = resolve(process.cwd(), '.github/INTEGRATION_PR_TEMPLATE.md');
+	const sectionsPath = resolve(process.cwd(), '.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json');
+	const template = readFileSync(templatePath, 'utf8');
+	const sections: string[] = JSON.parse(readFileSync(sectionsPath, 'utf8')).sections;
+
+	it('SECTIONS.json が judge の見る見出しを宣言している', () => {
+		expect(sections).toContain(`## ${NG_DECLARATION_SECTION}`);
+		expect(sections).toContain(`## ${INTEGRATION_EVIDENCE_SECTION}`);
+	});
+
+	it('template に judge と同一文字列の見出しが行として存在する', () => {
+		const lines = template.split('\n').map((l) => l.trim());
+		expect(lines).toContain(`## ${NG_DECLARATION_SECTION}`);
+		expect(lines).toContain(`## ${INTEGRATION_EVIDENCE_SECTION}`);
+	});
+
+	it('template の既定宣言文が judge に「0 件」として読み取れる（文言変更で空振りしない）', () => {
+		const section = extractH2Section(template, NG_DECLARATION_SECTION);
+		expect(section.found).toBe(true);
+		const declarations = parseNgCountDeclarations(section.text);
+		expect(
+			declarations.length,
+			'template の「残 NG 合計 0 件」行が judge の宣言パターンから外れています',
+		).toBeGreaterThan(0);
+		expect(declarations.every((d) => d.count === 0)).toBe(true);
+	});
+
+	it('template は受容宣言の書き方を案内している（宣言 key の drift 検出）', () => {
+		expect(template).toContain(NG_NONZERO_ACCEPTED_KEY);
 	});
 });
 

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -1206,15 +1206,18 @@ describe('lane-aware 化 (#4130)', () => {
 	});
 
 	it('[LN5] integration lane は「残 NG 0 件」明示欠落を検出する (AC2)', () => {
-		// 注意 (実測): 再利用 SSOT の NG-0 判定は `## NG 0 件 / カバレッジ宣言` という
-		// **見出し文字列自体**にもマッチする (checkIntegrationEvidenceTable の NG_ZERO_PATTERN)。
-		// そのため「本文の宣言だけを消す」入力では落ちない。本 test は本 CLI が SSOT の
-		// NG-0 判定を確かに通していることを、判定が成立し得ない入力で固定する。
-		// SSOT 側の判定強度そのものは本 PR の scope 外 (#2945 の所管)。
-		const noNgZero = INTEGRATION_BODY.replace(/残 NG 合計 0 件/g, '残 NG は監査 run 参照')
-			.replace('## NG 0 件 / カバレッジ宣言', '## NG / カバレッジ宣言')
-			.replace(/未解決 NG が \*\*0 件\*\*である/, '未解決 NG を監査 run 側で確認した');
+		// #4333 以前は、SSOT の NG-0 判定が `## NG 0 件 / カバレッジ宣言` という **見出し文字列
+		// 自体**にマッチしたため「本文の宣言だけを消す」入力では落ちず、本 test は見出しごと
+		// 壊した入力でしか固定できなかった (旧コメントは「判定強度は scope 外」と明記していた)。
+		// 判定が section 本文の件数読み取りになった今は、**宣言行を消すだけで落ちる**。
+		const noNgZero = INTEGRATION_BODY.replace(/残 NG 合計 0 件/g, '残 NG は監査 run 参照');
 		const { ids } = violate(noNgZero, 'integration');
+		expect(ids).toContain('integration-evidence-missing');
+	});
+
+	it('[LN5b] integration lane は「残 NG 1 件」と正直に書いた本文を検出する (#4333)', () => {
+		const nonZero = INTEGRATION_BODY.replace(/残 NG 合計 0 件/g, '残 NG 合計 1 件');
+		const { ids } = violate(nonZero, 'integration');
 		expect(ids).toContain('integration-evidence-missing');
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（リリース判断）/ システム全体

**解決する課題**: 統合 PR（develop → main）の merge 条件である「残 NG 0 件」を機械検証しているはずの gate が、**内容を一切検証していなかった**。判定は本文全体への正規表現 1 本で、`## NG 0 件 / カバレッジ宣言` という**見出しが本文にある限り常に緑**になる。統合 PR は template をそのまま使うため見出しは必ず存在し、したがって **NG-0 gate は全統合 PR で常に緑**だった。第 21 回統合監査（#4304）が severity 4 の未解決 finding（#4309）を**正直に「残 NG 合計 1 件」と宣言したのに gate は緑のまま** merge に進めたことで発覚した。

**期待される効果**: 「残 NG がある状態のリリース」が gate をすり抜けなくなる。gate は宣言された**件数を読む**ようになり、0 でなければ red になる。監査が自ら本文に書かなければ誰にも見えなかった残 NG が、機械で止まる。

## 関連 Issue

Closes #4333

## 何をしたか

### 1. 存在検査 → 件数検査

```js
// before: 本文全体に対して「0 という字があるか」だけを見ていた
const NG_ZERO_PATTERN = /残\s*NG\s*(?:合計\s*)?0\s*件|残\s*NG[^\n|]*[:：]?\s*0\b|NG\s*0\s*件/;
if (!NG_ZERO_PATTERN.test(body)) { ...fail... }

// after: 宣言された件数を読み、0 以外が 1 件でもあれば fail
const NG_COUNT_DECLARATION = /残(?:り|る)?\s*(?:の)?[^\n|]{0,24}?NG[^\n|]{0,24}?(\d+)\s*件/g;
```

判定は `## NG 0 件 / カバレッジ宣言` **section 本体に限定**（見出し行は除外、HTML コメントと fenced code block は除去）。section 欠落 / 宣言 0 件はいずれも **fail** に倒す（「検査できなかった」を pass にしない、#4084 と同じ思想）。

### 2. 正直な nonzero 宣言の逃げ道（AC6、本 PR で補った AC）

hard-fail のみにすると「正直に書くと merge できない」ため**嘘の 0 件宣言に倒すインセンティブ**が生まれる。#4304 は正直に書いた側なので、罰する設計は本 Issue の趣旨と逆。理由（12 文字以上、実体判定は `scripts/lib/ci/reason-declaration.mjs` = #4084 の SS 系 4 宣言と同一 SSOT）+ 追跡 Issue 番号を伴う明示宣言でのみ通す:

```
<!-- ng-nonzero-accepted: /ops/export の認可修正は本 release の scope 外で #4309 で追跡する -->
```

### 3. 同 class の横展開（同ファイル内）

evidence 表 section の探索も `body.indexOf('マージ判定エビデンス表')` = 本文中どこでも部分一致だったため、**H2 見出し行の完全一致**に変更（構造化識別子を緩い一致で判定しない）。

### 4. 生成側 assert（AC7、本 PR で補った AC）

judge 側だけ厳密化しても template の見出し / 既定宣言文が変われば判定が黙って空振りする。`.github/INTEGRATION_PR_TEMPLATE.md` と `INTEGRATION_PR_TEMPLATE_SECTIONS.json` の見出し・既定宣言文が judge から読めることを test で固定した（#4324 が SS gate に対して行ったのと同じ形）。

### 補った AC（Issue にコメント済: #4333#issuecomment-5201228488）

AC6（nonzero 受容宣言）/ AC7（生成側 assert）/ AC8（実在 merged PR での旧新比較）。補った理由は Issue コメント参照。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | HTML コメントを除去してから判定する（template のコメント文言で緑になる経路を塞ぐ） | `npx vitest run tests/unit/scripts/check-ac-verification-map.test.ts` の `FAIL: HTML コメント内の template 説明文では通らない（AC1）` + mutation M2 | PASS（`stripHtmlComments` 除去を外す mutation M2 で 3 件 fail = 非トートロジー実測済） |
| AC2 | 判定対象を `## NG 0 件 / カバレッジ宣言` section 内に限定する | 同 test の `FAIL: 否定文（…）を宣言として拾わない（AC2）` + mutation M3 | PASS（section 限定を外す mutation M3 で 1 件 fail。`extractH2Section` が H2 見出し行の完全一致で切り出す） |
| AC3 | 見出し行そのものを判定対象から除外する | 同 test の `FAIL: 見出し行そのもの（## NG 0 件 / カバレッジ宣言）を match 源にしない（AC3）` + mutation M4 | PASS（見出し行を section 本体に含める mutation M4 で 16 件 fail） |
| AC4 | fail するケースの test を置く（「残 NG 1 件」で red になることを固定する） | `npx vitest run tests/unit/scripts/check-ac-verification-map.test.ts tests/unit/scripts/check-pr-body.test.ts` | PASS（176 passed / 0 failed。#4333 describe に fail ケース 8 件 + 回帰 PASS ケース 2 件。修正前は 5 経路すべて緑だった実測を「実測ログ」節に掲載） |
| AC5 | 同型の穴が他の gate に無いか `scripts/check-*.mjs` から洗い出す | Explore agent による `scripts/check-*.mjs` + `scripts/lib/ci/*.mjs` 全数調査（判定基準 4 条件: 全文 `test`/`includes` で pass 側 / コメント・引用・見出し未除去 / 否定文を拾う緩さ / 対象欠落を skip・pass） | 完了。結果は「AC5: 同型の穴の洗い出し結果」節に掲載。**本 PR の scope は #4333 の根治**であり、他 gate の是正は別 Issue に切り出す |
| AC6（補） | 残 NG > 0 を正直に宣言したまま merge する経路を、理由 + 追跡 Issue 番号を伴う明示宣言でのみ許す | 同 test の `#4333 残 NG > 0 の受容宣言` describe（4 件） + mutation M6 | PASS（理由 stub `TODO` / Issue 番号なしはいずれも fail。理由検証を外す mutation M6 で 2 件 fail） |
| AC7（補） | 生成側にも assert を置き、template 文言の変更で判定が空振りしないようにする | 同 test の `#4333 生成側 assert: 統合 PR template と judge の同期` describe（4 件、実 template / 実 SECTIONS.json を読む） | PASS（`## NG 0 件 / カバレッジ宣言` の SECTIONS.json 宣言 / template 内実在 / 既定宣言文が judge で 0 件として読める / 受容宣言 key の記載 を固定） |
| AC8（補） | 実在の merged 統合 PR で旧/新判定を比較し、一斉赤化しないことを実測する | `node tmp/compare-4333.mjs`（`git show origin/develop:scripts/check-ac-verification-map.mjs` の旧実装と新実装を同一 body で突き合わせ） | PASS（merged 統合 PR 14 本中 **判定が変わったのは 1 本（#4304）のみ**。他 13 本は変化なし。比較表は「実測ログ」節） |

## 実測ログ

### (a) failing-test-first — 修正前は 5 経路すべて緑（`node tmp/repro-4333.mjs` on `origin/develop`）

```
🟢 PASS(緑)  A: 残 NG は 10 件 と正直に宣言
🟢 PASS(緑)  B: 見出しだけ (宣言本体なし)
🟢 PASS(緑)  C: HTML コメント内の template 文言だけ
🟢 PASS(緑)  D: 否定文（宣言しないと書いてある）
🟢 PASS(緑)  E: 残 NG 合計 1 件 と正直に宣言 (#4304 実態)
```

同じ入力を修正後の実装に通した結果:

```
🔴 FAIL(赤)  A: 残 NG は 10 件 と正直に宣言
🔴 FAIL(赤)  B: 見出しだけ (宣言本体なし)
🔴 FAIL(赤)  C: HTML コメント内の template 文言だけ
🔴 FAIL(赤)  D: 否定文（宣言しないと書いてある）
🔴 FAIL(赤)  E: 残 NG 合計 1 件 と正直に宣言 (#4304 実態)
```

「A: 残 NG は 10 件」が緑だったのは、旧 pattern の `残\s*NG[^\n|]*[:：]?\s*0\b` が `[^\n|]*` で「は 1」を食い、続く `0\b` が **10 の末尾 0** に一致していたため。新実装は最短一致側から数値を拾うので 10 と読む。

### (b) 旧/新判定の比較 — merged 統合 PR 14 本（`node tmp/compare-4333.mjs`）

| PR | 旧判定 | 新判定 | 差分 | 新判定の理由 |
|---|---|---|---|---|
| #4304 | PASS | FAIL | **変化** | ❌ 残 NG が 0 件ではありません（本 Issue が「red であるべきだった」と名指しした PR） |
| #4253 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #4152 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #4126 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3931 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3914 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3866 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3762 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3686 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3570 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3357 | PASS | PASS |  | 残 NG 0 件 宣言 ✓（「残る blocking NG = 0 件」という template と違う言い回しも読める） |
| #3281 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3068 | PASS | PASS |  | 残 NG 0 件 宣言 ✓ |
| #3011 | FAIL | FAIL |  | エビデンス表 section 自体が無い（template 導入前、旧実装でも FAIL） |

**変化 1 / 14。一斉赤化していない。** 実在の言い回しを fixture に取り込んである（#4253 の template 準拠形 / #3357 の「残る blocking NG = 0 件」の 2 パターンを回帰 test に固定）。

### (c) mutation — guard を 1 つずつ壊して確かに落ちるか（`node tmp/mutate-4333.mjs`）

```
✅ 落ちる  M1 件数検査 → 旧「存在すれば OK」検査に戻す  — 7 failed / 169 passed
✅ 落ちる  M2 HTML コメント除去をやめる (AC1)            — 3 failed / 173 passed
✅ 落ちる  M3 section 限定をやめ本文全体を見る (AC2)      — 1 failed / 175 passed
✅ 落ちる  M4 見出し行を section 本体に含める (AC3)       — 16 failed / 160 passed
✅ 落ちる  M5 宣言 0 件を fail ではなく pass にする        — 5 failed / 171 passed
✅ 落ちる  M6 受容宣言の理由検証をやめる                  — 2 failed / 174 passed
```

6 mutation すべて検出。トートロジーな guard ではない（mutation は commit 後に実行し、実行後に `git checkout --` で復元 = 未コミットの実装を消していない）。

## AC5: 同型の穴の洗い出し結果

調査対象: `scripts/check-*.mjs` + `scripts/lib/ci/*.mjs`。判定基準は Issue の 4 条件（① 全文 `test()`/`includes()` で **pass 側**に倒す / ② HTML コメント・code block・引用・見出し行を除去せず判定 / ③ 否定文を拾う緩さ / ④ 対象が見つからないときに skip・pass）。

| # | 箇所 | 判定式 | 誤って緑になりうる入力 | 深刻度 |
|---|---|---|---|---|
| 1 | `scripts/pr-template-gate-checks.mjs:159` | `sections.filter((s) => !body.includes(s))` | 必須 `## ` 見出しの存在を**部分一致**で見るため、**HTML コメント内に見出し文字列があるだけで「削除されていない」と判定**される。`.github/INTEGRATION_PR_TEMPLATE.md` の冒頭コメントには「gate は section 見出し文字列を本文から検索するため、この説明コメント内では実際の `## ` 見出し文字列を再掲しない（誤マッチ回避）」と**回避策が明文で運用されており、この class が現に存在することが文書化されている**（gate を直す代わりに書き手が避けている状態）。#4333 と同一 class（統合 PR の必須 section 検証） | **高**（統合 PR / 全 PR の必須セクション gate） |
| 2 | `scripts/check-merge-gate-checklist.mjs:64` | `const idx = body.indexOf(section)` → 以降を section 本体として `- [ ]` を数える | section 見出しを部分一致で探すため、**説明文や HTML コメント内の同一文字列が先にヒットするとそこから section 本体を切り出す**。統合 lane で `## NG 0 件 / カバレッジ宣言` の未チェック `- [ ]` を数える gate（= #4333 と同じ section を見る兄弟 gate）であり、切り出し位置がずれれば checkbox 検証も空振りする | **高**（統合 PR merge gate、#4333 と同 section） |
| 3 | `scripts/check-admin-bypass-evidence.mjs:168` | `EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body))` | 証跡マーカーの**存在だけ**を本文全体で見る。コメント / 引用 / 否定文（「証跡を書かずに bypass しない」）に marker 文字列があれば緑。ADR-0022 / archive-0044 の admin bypass 証跡運用を守る gate なので、性質は #4333 と同じ「宣言の存在だけ見る」 | **高**（admin bypass の証跡） |
| 4 | `scripts/check-pr-screenshot.mjs:417` `hasDomSnapshotReference` / `:465` `hasIntegrationVrEvidence` | `PATTERN.test(body)` / `PATTERNS.some((p) => p.test(body))` | どちらも本文全体でパターンの**存在**を見る。統合 PR の visual regression 証跡（`hasIntegrationVrEvidence`）は「観点の移譲であって検証の放棄ではない」と設計コメントに明記されているのに、判定は存在検査のみ。#4255（story 参照を「それっぽい文字列」で通していた）と同じ形で、実在性・文脈を見ていない | 中（#4255 で `hasStorybookStoryReference` は実在パス検査に是正済。同ファイル内の兄弟 2 関数が未是正） |
| 5 | `scripts/pr-template-gate-checks.mjs:688` | `const sectionIdx = body.indexOf(keyword); if (sectionIdx === -1) return { ok: true, skipped: true }` | 「テスト実行結果」section が見つからないと **pass（skip）** に倒れる。section-presence チェックへの委譲が意図だが、判定基準 ④「検査できなかったのに pass」に該当する。#1 の緩さと組み合わさると、コメント内文字列で #1 が緑 + 本体不在で本 check が skip、という二重の空振りが成立しうる | 中 |
| 6 | `scripts/check-ac-verification-map.mjs:266`（本 PR で未変更） | `body.indexOf('AC 検証マップ')` | feature lane の AC マップ section 探索が部分一致のまま。**本 PR では意図的に変更していない**（全 feature PR に影響するため、締めすぎたときの被害が統合 PR より広い）。integration 側だけ先に厳密化した | 低〜中（feature lane、影響範囲が広いため #4348 で個別に扱う） |

**本 PR の scope 外とする理由**: #4333 は「統合 PR の NG-0 gate」の根治であり、上記 1〜6 を同一 PR で変えると、統合 PR / 全 feature PR の必須 section 判定を同時に締めることになる。実在 PR での旧新比較（AC8）を各 gate で個別に取らずに一括変更するのは、この Issue が問題にしている「検証していない gate」を「誤検知する gate」に置き換えるだけになる。**class として #4348 に切り出し済**（1 件ずつ実在 PR corpus で旧新比較したうえで是正する / 同 class 3 回目のため ADR-0061 same-class-N→guard で class 単位の fitness function まで含む）。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客に見える画面の変更なし。影響するのは統合 PR（develop / release/* → main）に対する CI required check `Verify AC map in PR body`（integration lane）のみ。feature / hotfix lane の AC 検証マップ判定は不変（`checkPerPrAcMap` に変更なし、既存 test 全 PASS）。

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）— N/A（UI 非該当）。同ロジックの二重実装先である `check-pr-body.mjs` は本 SSOT を import しており（[LN6] test が一致を固定）、両者の判定は同期している
- [x] **設計書同期** (ADR-0001): `.github/INTEGRATION_PR_TEMPLATE.md` の当該 section に、判定範囲（section 本体のみ / コメント・見出しは対象外）と受容宣言の書き方を追記
- [x] **LP ↔ アプリ整合** (ADR-0013): N/A
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — N/A（E2E 非該当、unit のみ）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4347` | PASS |
| 追加・変更テスト | `npx vitest run tests/unit/scripts/check-ac-verification-map.test.ts tests/unit/scripts/check-pr-body.test.ts` | PASS（176 passed / 0 failed） |

- [x] **SOLID / DRY / YAGNI**: 判定は `check-ac-verification-map.mjs` の 1 SSOT に集約（`check-pr-body.mjs` は import して再実装しない、[LN6] test が固定）。理由の実体判定は既存 `reason-declaration.mjs` に委譲し新設していない
- [x] **Security（OSS 公開前提）**: 秘密情報の hardcode なし。正規表現は入力長に線形（`[^\n|]{0,24}?` で上限あり、catastrophic backtracking なし）
- [x] **A11y・パフォーマンス**: N/A（CI script）
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:critical` label なし）

## スクリーンショット / ビジュアルデモ

**該当なし（CI gate の判定ロジック修正であり、顧客に見える UI の変更を含まない）**。挙動の変化は上記「実測ログ」の (a) 修正前後の判定出力 / (b) 実在 PR 14 本の旧新比較 / (c) mutation で示している。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

（統合 PR の書き方に対しては要求が増える。ただし実在 14 本のうち 13 本は現行の書き方のまま通ることを実測済で、残り 1 本は本来 red であるべきだった #4304。）

**レビュー依頼事項**:
1. **AC6 の受容宣言を設ける判断**（正直な nonzero 宣言を hard-fail にせず、理由 + 追跡 Issue 付き宣言で通す）。「残 NG > 0 なら merge しない」と定める audit-team.md §3.5 に対しては緩和方向なので、gate として hard-fail 一本にすべきという判断もありうる。**現状の設計意図は「嘘の 0 件宣言に倒すインセンティブを作らない」**こと。
2. 宣言パターン `残(?:り|る)?…NG…(\d+) 件` の受容幅。実在 14 本の言い回しに合わせてあるが、想定外の書き方は「宣言 0 件 → fail」に倒れる（安全側だが統合 PR を止める）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — N/A（認証画面 非該当）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
