### PR TITLE
fix: #4261 習慣化で増えた残高の理由を Push 未達家庭にも 1 回だけ伝え、閾値 10 日の再評価トリガーを置く

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -838,6 +838,17 @@ admin リソース管理 3 画面（活動 / チェックリスト / ごほう�
 
 **ShareCard 表示:** 視覚的なカード形式で名前・タイトル・統計を表示。スクリーンショット/ダウンロード対象。公開ビュー: `/view/[token]`
 
+#### 習慣化告知バナー（HabitCertificateNoticeBanner）
+
+月間の習慣化証明書で増えた残高の理由を、子供ホーム上部で**次回起動時に 1 回だけ**静かに伝える（親への Push が届かない家庭で無音になるのを防ぐ）。
+
+**Props:** `visible: boolean` / `uiMode: Exclude<UiMode,'baby'>` / `amount: string`（`pointSettings` に沿って整形済み）
+
+- **描画**: `Alert` primitive（`variant="success"`、`role="status"`）。`data-testid="habit-certificate-notice"`
+- **閉じるボタンを持たない**。既読化は表示できた時点で親（`+page.svelte`）が `?/ackHabitCertificateNotice` を 1 回呼ぶ
+- アニメーション・音・CTA を持たない（ADR-0012）。誕生日バナー表示回と `?screenshot=*` では出さない
+- 仕様・抑止条件の SSOT は [26-ゲーミフィケーション設計書 §16.2](26-ゲーミフィケーション設計書.md)
+
 **コンポーネント:** `src/lib/features/certificate/CertificateCard.svelte`, `src/lib/features/certificate/ShareCard.svelte`
 
 ### 4.15 きょうだいおうえん（SiblingCelebration / SiblingCheerOverlay）

--- a/docs/design/26-ゲーミフィケーション設計書.md
+++ b/docs/design/26-ゲーミフィケーション設計書.md
@@ -1144,6 +1144,22 @@ claimBirthdayBonus():
 サービス: `certificate-service.ts`, `viewer-token-service.ts`
 コンポーネント: `CertificateCard.svelte`, `ShareCard.svelte`
 
+### 16.2 月間の習慣化証明書と、子への 1 回だけの告知
+
+その月に記録した日数が `MONTHLY_HABIT_DAYS_THRESHOLD`（10 日）以上で自動発行し、`MONTHLY_HABIT_POINTS`（50pt）を付与する。閾値の根拠と再評価トリガー（有料家庭 3 世帯以上で 1 ヶ月分 / `MONTHLY_HABIT_THRESHOLD_REVIEW_DEADLINE` = 2026-11-05 のいずれか早い方）は `src/lib/domain/constants/habit-milestones.ts` が SSOT。
+
+親には Web Push で通知する。**Push を許可していない家庭では 1 通も届かず、子は残高が増えた理由を知る手段が無い**ため、子には次回起動時に静かに 1 回だけ伝える。
+
+| 項目 | 仕様 |
+|----|----|
+| pending の保持 | settings KV `habit_certificate_notice:<childId>`（`habit-certificate-notice-service.ts`）。発行時に書き、既読は空文字 upsert |
+| 表示 | 子供ホームの `HabitCertificateNoticeBanner.svelte`（`Alert` primitive）。文言は `HABIT_CERTIFICATE_NOTICE_LABELS`（年齢モード別、baby は非対象） |
+| 既読 | **閉じる操作を挟まない**（ADR-0012「記録する → 数秒で閉じる」を伸ばさない）。表示できた時点で `?/ackHabitCertificateNotice` を 1 回呼ぶ |
+| 抑止 | 誕生日ボーナス未受取の回と `?screenshot=*` では表示せず、**既読にもしない**（次回起動へ繰り越す） |
+| Push との関係 | pending は Push の可否に関わらず 1 件。届いた家庭で二重に演出しない |
+
+判定の純関数は `src/lib/features/child-home/habit-certificate-notice.ts`。Anti-engagement 境界は §4e.4 と同じ（演出・音・連続ダイアログを足さない）。
+
 ---
 
 ## 17. 離脱防止

--- a/scripts/capture-specs/flows/child-home-habit-notice-4261.mjs
+++ b/scripts/capture-specs/flows/child-home-habit-notice-4261.mjs
@@ -1,0 +1,82 @@
+/**
+ * scripts/capture-specs/flows/child-home-habit-notice-4261.mjs (#4261 ③)
+ *
+ * 習慣化告知バナーを 4 つの子供向け年齢モードで撮る。
+ * `AUTH_MODE=local` (`npm run dev`) で動作。
+ *
+ * ## 事前条件 (撮影者が用意する)
+ *
+ * dev DB (`data/ganbari-quest.db`) に 4 モードの子供と pending の告知が入っていること:
+ *
+ *   children: id 1=preschool / 2=elementary / 3=junior / 4=senior
+ *   settings: `habit_certificate_notice:<childId>` = {"yearMonth":"2026-08","points":50}
+ *   settings: `pin_gate_onboarding_seen` = 'true' (初回訪問 dialog を出さない)
+ *
+ * ## このフローが撮るもの
+ *
+ * 1 周目 (`after-*`) — pending がある回。バナーが出る
+ * 2 周目 (`before-*`) — 同じ画面を再訪。**表示した時点で既読になっている**ため出ない
+ *   (= 修正前 / develop と同じ描画。かつ「1 回だけ」の実機証跡になる)
+ *
+ * 既読化 (`?/ackHabitCertificateNotice`) のレスポンスを待ってから次へ進むため、
+ * 固定待ちを使わずに 2 周目の状態が決定的になる。
+ *
+ * 使用例:
+ *   node scripts/capture.mjs --pr <N> \
+ *     --flow child-home-habit-notice-4261 \
+ *     --url /switch \
+ *     --actions scripts/capture-specs/flows/child-home-habit-notice-4261.mjs \
+ *     --presets mobile
+ */
+
+const CHILDREN = [
+	{ childId: 1, uiMode: 'preschool' },
+	{ childId: 2, uiMode: 'elementary' },
+	{ childId: 3, uiMode: 'junior' },
+	{ childId: 4, uiMode: 'senior' },
+];
+
+const NOTICE = '[data-testid="habit-certificate-notice"]';
+
+/** @param {import('playwright').Page} page */
+async function selectChild(page, childId, uiMode) {
+	// FlowRecorder の context は baseURL を持たないため絶対 URL で遷移する
+	await page.goto(new URL('/switch', page.url()).href, { waitUntil: 'domcontentloaded' });
+	await page.locator(`[data-testid="child-select-${childId}"]`).click();
+	// 遷移完了後に waitForURL を呼ぶと取りこぼすため、home の testid 出現で待つ
+	await page.locator(`[data-testid="${uiMode}-home-page"]`).waitFor({ state: 'visible' });
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// デモ Cookie が残っていると isDemo=true になり child 一覧が空になる
+	await page.context().clearCookies();
+	// 本 PR の対象ではない使い方ガイドのバナーを画面から外す (localStorage 由来)
+	await page.addInitScript(() => {
+		try {
+			for (const id of [1, 2, 3, 4]) localStorage.setItem(`child_tutorial_hint_shown_${id}`, '1');
+		} catch {
+			/* localStorage 不可の環境では何もしない */
+		}
+	});
+
+	// 1 周目: pending あり → バナーが出る
+	for (const { childId, uiMode } of CHILDREN) {
+		const acked = page.waitForResponse((r) => r.url().includes('ackHabitCertificateNotice'));
+		await selectChild(page, childId, uiMode);
+		await page.locator(NOTICE).waitFor({ state: 'visible' });
+		await capture(`after-${uiMode}`);
+		// 既読化が着地するまで待つ (着地前に離脱すると 2 周目にまた出る)
+		await acked;
+	}
+
+	// 2 周目: 既読化済 → 出ない (= 修正前と同じ描画 / 「1 回だけ」の実機証跡)
+	for (const { childId, uiMode } of CHILDREN) {
+		await selectChild(page, childId, uiMode);
+		await page.locator(NOTICE).waitFor({ state: 'detached' });
+		await capture(`before-${uiMode}`);
+	}
+};

--- a/scripts/capture-specs/flows/child-home-habit-notice-4261.mjs
+++ b/scripts/capture-specs/flows/child-home-habit-notice-4261.mjs
@@ -71,12 +71,12 @@ export default async (page, capture) => {
 
 	// 1 周目: pending あり → バナーが出る
 	for (const { childId, uiMode } of CHILDREN) {
-		const acked = page.waitForResponse((r) => r.url().includes('ackHabitCertificateNotice'));
+		const acknowledged = page.waitForResponse((r) => r.url().includes('ackHabitCertificateNotice'));
 		await selectChild(page, childId, uiMode);
 		await page.locator(NOTICE).waitFor({ state: 'visible' });
 		await capture(`after-${uiMode}${SUFFIX}`);
 		// 既読化が着地するまで待つ (着地前に離脱すると 2 周目にまた出る)
-		await acked;
+		await acknowledged;
 	}
 
 	// 2 周目: 既読化済 → 出ない (= 修正前と同じ描画 / 「1 回だけ」の実機証跡)

--- a/scripts/capture-specs/flows/child-home-habit-notice-4261.mjs
+++ b/scripts/capture-specs/flows/child-home-habit-notice-4261.mjs
@@ -38,6 +38,12 @@ const CHILDREN = [
 
 const NOTICE = '[data-testid="habit-certificate-notice"]';
 
+/**
+ * 同じ flow を preset 違いで 2 回流すと step 名が衝突し、後の run が前の run の SS を
+ * 上書きする (screenshots branch は file 名で同定する)。`CAPTURE_LABEL_SUFFIX` で分ける。
+ */
+const SUFFIX = process.env.CAPTURE_LABEL_SUFFIX ? `-${process.env.CAPTURE_LABEL_SUFFIX}` : '';
+
 /** @param {import('playwright').Page} page */
 async function selectChild(page, childId, uiMode) {
 	// FlowRecorder の context は baseURL を持たないため絶対 URL で遷移する
@@ -68,7 +74,7 @@ export default async (page, capture) => {
 		const acked = page.waitForResponse((r) => r.url().includes('ackHabitCertificateNotice'));
 		await selectChild(page, childId, uiMode);
 		await page.locator(NOTICE).waitFor({ state: 'visible' });
-		await capture(`after-${uiMode}`);
+		await capture(`after-${uiMode}${SUFFIX}`);
 		// 既読化が着地するまで待つ (着地前に離脱すると 2 周目にまた出る)
 		await acked;
 	}
@@ -77,6 +83,6 @@ export default async (page, capture) => {
 	for (const { childId, uiMode } of CHILDREN) {
 		await selectChild(page, childId, uiMode);
 		await page.locator(NOTICE).waitFor({ state: 'detached' });
-		await capture(`before-${uiMode}`);
+		await capture(`before-${uiMode}${SUFFIX}`);
 	}
 };

--- a/src/lib/domain/constants/habit-milestones.ts
+++ b/src/lib/domain/constants/habit-milestones.ts
@@ -30,15 +30,29 @@
 export const MONTHLY_HABIT_DAYS_THRESHOLD = 10;
 
 /**
- * 閾値の再評価トリガー (AC17)。
+ * 閾値を再評価する期日 (#4261 ② PO 決裁 2026-08-06)。
+ *
+ * **n=1 のまま据え置くのは構わないが、「いつ見直すか」が無いまま固定するのは認めない**
+ * (#4256 と同じ形 — 気づく仕組みが無い状態が既定になり、そのまま恒久化する)。
+ */
+export const MONTHLY_HABIT_THRESHOLD_REVIEW_DEADLINE = '2026-11-05';
+
+/** 期日より早く再評価に入る条件: 有料家庭がこの世帯数に達し 1 ヶ月分のデータが揃った時点。 */
+export const MONTHLY_HABIT_THRESHOLD_REVIEW_MIN_PAID_FAMILIES = 3;
+
+/**
+ * 閾値の再評価トリガー (AC17 / #4261 ②)。
  *
  * **n=1 で決めた値なので、動かす条件を先に決めておく。**
  * これが無いと「動かさない理由」を毎回考え直すことになる。
  *
+ * 見るのは `daysWithActivity` の分布 (達成率と、達成しなかった家庭の日数)。
  * 到達しない家庭が続くのは「その家庭ががんばっていない」ではなく
  * **閾値が実態に合っていない**可能性が高い、という前提で下げる方向に倒す。
  */
 export const MONTHLY_HABIT_THRESHOLD_REVIEW_TRIGGER =
+	`有料家庭が ${MONTHLY_HABIT_THRESHOLD_REVIEW_MIN_PAID_FAMILIES} 世帯以上で 1 ヶ月分のデータが揃った時点、` +
+	`または ${MONTHLY_HABIT_THRESHOLD_REVIEW_DEADLINE} のいずれか早い方で再評価する。` +
 	'3 ヶ月連続で誰も達成しなかったら 10 → 8 に下げる (n=1 で決めた値のため、下げる方向に倒す)';
 
 /**

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3805,6 +3805,35 @@ export const OPS_BUSINESS_LABELS = {
 	fetchedAt: (dateStr: string) => `最終取得: ${dateStr}`,
 } as const;
 
+/**
+ * #4261 ③: 月間の習慣化証明書で増えた残高の理由を、子に**次回起動で 1 回だけ**伝える文言。
+ *
+ * ADR-0012 との両立条件 (PO 決裁 2026-08-06) を文言側でも守る:
+ * **煽らない / 次を促さない / 演出語を足さない。** 起きた事実だけを静かに置く。
+ * baby は親向けの準備モードで子供向けホームを持たない (ADR-0011) ため対象外。
+ */
+export const HABIT_CERTIFICATE_NOTICE_LABELS: Record<
+	Exclude<UiMode, 'baby'>,
+	{ title: string; body: (amount: string) => string }
+> = {
+	preschool: {
+		title: 'こんげつ よく つづいたね',
+		body: (amount) => `${amount} を うけとったよ`,
+	},
+	elementary: {
+		title: '今月は しゅうかんに できたね',
+		body: (amount) => `つづけられたので ${amount} をうけとりました`,
+	},
+	junior: {
+		title: '今月は習慣にできました',
+		body: (amount) => `継続の記録として ${amount} を受け取りました`,
+	},
+	senior: {
+		title: '今月は習慣にできました',
+		body: (amount) => `継続の記録として ${amount} を受け取りました`,
+	},
+};
+
 export const CHILD_HOME_LABELS = {
 	// Baby mode: completed card aria-label
 	completedAriaLabel: (name: string) => `${name}（きろくずみ）`,

--- a/src/lib/features/child-home/habit-certificate-notice.ts
+++ b/src/lib/features/child-home/habit-certificate-notice.ts
@@ -1,0 +1,62 @@
+// src/lib/features/child-home/habit-certificate-notice.ts
+//
+// #4261 ③ — 習慣化告知を「いつ出すか」の純関数。保存側は
+// `$lib/server/services/habit-certificate-notice-service` が持つ。
+//
+// 判定を component から出しているのは、ADR-0012 との両立条件 (1 回だけ / 演出を重ねない /
+// 閉じる操作を挟まない) を **DOM 無しで固定できる形**にしておくため。同じ理由で
+// #4313 (`ui-mode-change-notice.ts`) も純関数を切り出している。
+
+import { HABIT_CERTIFICATE_NOTICE_LABELS } from '$lib/domain/labels';
+import type { UiMode } from '$lib/domain/validation/age-tier';
+
+/**
+ * 次回起動で 1 回だけ伝える内容。**顧客識別子は載せない** (#4174 / #4197 と同じ基準)。
+ *
+ * 型をここ (client 側) に置き、server service が import する。逆向き
+ * (`$lib/server/**` を client から import) は SvelteKit の illegal import になるため。
+ */
+export interface HabitCertificateNotice {
+	/** 達成した月 (YYYY-MM) */
+	yearMonth: string;
+	/** その達成で付与したポイント */
+	points: number;
+}
+
+export interface HabitCertificateNoticeVisibility {
+	/** 未読の告知 (無ければ null) */
+	notice: HabitCertificateNotice | null;
+	/** 誕生日ボーナスが未受取か */
+	birthdayPending: boolean;
+	/** `?screenshot=*` 撮影中か */
+	isScreenshotMode: boolean;
+}
+
+/**
+ * 告知を出すか。
+ *
+ * **出さないと決めた回では既読化もしない** — pending は次回起動へ繰り越す。
+ * 「出さなかったのに読んだことにする」と、その家庭では告知が永久に届かない
+ * (= Push 未達家庭の無音を別の形で再生産する)。
+ */
+export function shouldShowHabitCertificateNotice({
+	notice,
+	birthdayPending,
+	isScreenshotMode,
+}: HabitCertificateNoticeVisibility): boolean {
+	if (!notice) return false;
+	// 誕生日ボーナスと同じ回に 2 枚重ねない (ADR-0012: 連続演出にしない)。
+	if (birthdayPending) return false;
+	// 撮影日に依存して baseline が動くのを避ける (#3017 と同じ扱い)。
+	if (isScreenshotMode) return false;
+	return true;
+}
+
+/** 年齢モード別の文言。amount は呼び出し側で pointSettings に沿って整形した文字列。 */
+export function getHabitCertificateNoticeText(
+	uiMode: Exclude<UiMode, 'baby'>,
+	amount: string,
+): { title: string; body: string } {
+	const labels = HABIT_CERTIFICATE_NOTICE_LABELS[uiMode];
+	return { title: labels.title, body: labels.body(amount) };
+}

--- a/src/lib/features/child/HabitCertificateNoticeBanner.stories.svelte
+++ b/src/lib/features/child/HabitCertificateNoticeBanner.stories.svelte
@@ -1,0 +1,27 @@
+<script module>
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import { formatPointValue } from '$lib/domain/point-display';
+import HabitCertificateNoticeBanner from './HabitCertificateNoticeBanner.svelte';
+
+/**
+ * #4261 ③: 4 つの子供向け年齢モードで文言と折り返しが成立することを確認する。
+ * baby は親向けの準備モードで子供向けホームを持たない (ADR-0011) ため story を持たない。
+ */
+const POINT_AMOUNT = formatPointValue(50, 'point', 'JPY', 1);
+const CURRENCY_AMOUNT = formatPointValue(50, 'currency', 'JPY', 1);
+
+const { Story } = defineMeta({
+	title: 'Child/HabitCertificateNoticeBanner',
+	component: HabitCertificateNoticeBanner,
+	tags: ['autodocs'],
+	args: { visible: true, uiMode: 'elementary', amount: POINT_AMOUNT },
+});
+</script>
+
+<Story name="Preschool" args={{ visible: true, uiMode: 'preschool', amount: POINT_AMOUNT }} />
+<Story name="Elementary" args={{ visible: true, uiMode: 'elementary', amount: POINT_AMOUNT }} />
+<Story name="Junior" args={{ visible: true, uiMode: 'junior', amount: POINT_AMOUNT }} />
+<Story name="Senior" args={{ visible: true, uiMode: 'senior', amount: POINT_AMOUNT }} />
+<!-- ポイント表示をおこづかい (通貨) に切り替えている家庭 -->
+<Story name="CurrencyMode" args={{ visible: true, uiMode: 'elementary', amount: CURRENCY_AMOUNT }} />
+<Story name="Hidden" args={{ visible: false, uiMode: 'elementary', amount: POINT_AMOUNT }} />

--- a/src/lib/features/child/HabitCertificateNoticeBanner.svelte
+++ b/src/lib/features/child/HabitCertificateNoticeBanner.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+import type { UiMode } from '$lib/domain/validation/age-tier';
+import { getHabitCertificateNoticeText } from '$lib/features/child-home/habit-certificate-notice';
+import Alert from '$lib/ui/primitives/Alert.svelte';
+
+/**
+ * #4261 ③: 月間の習慣化で増えた残高の理由を、子に**次回起動で 1 回だけ**静かに伝える。
+ *
+ * ADR-0012 との両立条件 (PO 決裁 2026-08-06) をこの component の形で守る:
+ * **閉じるボタンを持たない** (子に閉じる操作をさせない) / **アニメーションを持たない**
+ * (紙吹雪・音・連続ダイアログを足さない) / 次の行動を促す CTA を置かない。
+ * 既読化は「表示できた」時点で呼び出し側が 1 回だけ行う。
+ */
+interface Props {
+	/** 表示するか (判定は `habit-certificate-notice.ts` の純関数が持つ) */
+	visible: boolean;
+	/** baby は子供向けホームを持たない (ADR-0011) */
+	uiMode: Exclude<UiMode, 'baby'>;
+	/** pointSettings に沿って整形済みの受取量 (例: `50ポイント`) */
+	amount: string;
+}
+
+let { visible, uiMode, amount }: Props = $props();
+
+const text = $derived(getHabitCertificateNoticeText(uiMode, amount));
+</script>
+
+{#if visible}
+	<div class="mt-2" data-testid="habit-certificate-notice">
+		<Alert variant="success">
+			<p class="font-bold">{text.title}</p>
+			<p class="opacity-80">{text.body}</p>
+		</Alert>
+	</div>
+{/if}

--- a/src/lib/server/services/certificate-service.ts
+++ b/src/lib/server/services/certificate-service.ts
@@ -269,6 +269,26 @@ export async function issueMonthlyHabitCertificateIfEligible(
 		tenantId,
 	);
 
+	// #4261 ③: **Push が届かない家庭でも子が残高の増えた理由を知れるようにする。**
+	// AC11' の「子への演出は出さない」は維持したまま、次回起動時に静かに 1 回だけ伝える
+	// pending を残す (PO 決裁 2026-08-06)。Push の可否に関わらず 1 件だけ書くため、
+	// 届いた家庭で二重に演出されることはない。
+	// 通知と同じく付帯物 — 失敗しても証明書と通貨は取り消さない。
+	try {
+		const { recordHabitCertificateNotice } = await import(
+			'$lib/server/services/habit-certificate-notice-service'
+		);
+		await recordHabitCertificateNotice(
+			{ childId, yearMonth, points: MONTHLY_HABIT_POINTS },
+			tenantId,
+		);
+	} catch (e) {
+		logger.warn('[certificate] 月間習慣化の子向け告知の保存に失敗', {
+			service: 'certificate',
+			error: e instanceof Error ? e.message : String(e),
+		});
+	}
+
 	// 通知は付帯物。失敗しても証明書と通貨は取り消さない。
 	try {
 		const { sendPushNotification } = await import('$lib/server/services/notification-service');

--- a/src/lib/server/services/habit-certificate-notice-service.ts
+++ b/src/lib/server/services/habit-certificate-notice-service.ts
@@ -1,0 +1,99 @@
+// src/lib/server/services/habit-certificate-notice-service.ts
+//
+// #4261 ③ — 月間の習慣化証明書 (#4172) で増えた残高の理由を、**Push が届かない家庭にも**
+// 伝えるための pending 保持。
+//
+// ## 何が壊れていたか
+//
+// #4172 AC11' は「親のみに通知し、子への演出は出さない」を選んだ (子に演出を出すと子の中で
+// 完結し、親が「1 ヶ月続いたね」と言う前にアプリが言ってしまう)。経路は Web Push のみで、
+// `/api/v1/notifications/subscribe` が child role を 403 で拒否する (#1593) ため親のみは
+// 構造的に保証されている。**ところが Push を許可していない家庭では 1 通も届かない。**
+// 子から見ると残高だけが 50pt 増え、理由を知る手段が無い。
+// **仕組みが動いていても伝わっていなければ、褒める機構は成立していない** (PO 決裁 2026-08-06)。
+//
+// ## なぜ「pending を残して次回起動で 1 回だけ」なのか
+//
+// 発行は活動記録の副作用として起きるため、子が画面を見ていないタイミングを含む。
+// バッチ的に起きた変化を次のセッション開始時に 1 回だけ伝える形は #4313
+// (`ui-mode-change-notice-service`) と同じ root class で、**その流儀に揃える**
+// (観測・保存の形を 2 つ持たない)。
+//
+// ADR-0012 (anti-engagement) との両立条件 (PO 決裁):
+//   - **1 回だけ。** 既読で消え、再表示しない → 本 service の clear が担う
+//   - **演出を足さない** (紙吹雪・音・連続ダイアログ不可) → 表示側の静的バナーが担う
+//   - **閉じる操作を挟まない** → 表示した時点で既読化する (子に × を押させない)
+//
+// ## 置き場所が settings KV である理由
+//
+// `children` への列追加は不可逆なスキーマ変更で、1 行 1 子の一時的な未読フラグには重い。
+// `grace-period-service` / `ui-mode-change-notice-service` と同じ settings KV の前例に従う。
+// settings repo に削除 API が無いため、**既読は空文字 upsert で表す** (前例と同じ)。
+
+import type { ChildId } from '$lib/domain/ids';
+// 型の SSOT は client 側に置く (client から `$lib/server/**` は import できないため)。
+import type { HabitCertificateNotice } from '$lib/features/child-home/habit-certificate-notice';
+import { getRepos } from '$lib/server/db/factory';
+
+export type { HabitCertificateNotice };
+
+const KEY_PREFIX = 'habit_certificate_notice:';
+
+/** 子ごとに 1 本。溜めずに最後の達成だけを持つ (連続表示しない、ADR-0012)。 */
+export function habitCertificateNoticeKey(childId: ChildId): string {
+	return `${KEY_PREFIX}${childId}`;
+}
+
+const YEAR_MONTH_PATTERN = /^\d{4}-\d{2}$/;
+
+/** 月間習慣化の達成を記録する。既存の pending は上書きする (最後の達成だけを伝える)。 */
+export async function recordHabitCertificateNotice(
+	notice: HabitCertificateNotice & { childId: ChildId },
+	tenantId: string,
+): Promise<void> {
+	const { childId, yearMonth, points } = notice;
+	const repos = getRepos();
+	await repos.settings.setSetting(
+		habitCertificateNoticeKey(childId),
+		JSON.stringify({ yearMonth, points }),
+		tenantId,
+	);
+}
+
+/**
+ * 未読の告知を読む。
+ *
+ * **壊れた値はすべて null に倒す。** 子供画面のホームは全機能の入口であり、
+ * 告知という付帯物のために画面全体が落ちてはならない。
+ */
+export async function getHabitCertificateNotice(
+	childId: ChildId,
+	tenantId: string,
+): Promise<HabitCertificateNotice | null> {
+	const repos = getRepos();
+	const raw = await repos.settings.getSetting(habitCertificateNoticeKey(childId), tenantId);
+	if (!raw) return null;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+
+	const { yearMonth, points } = parsed as Record<string, unknown>;
+	if (typeof yearMonth !== 'string' || !YEAR_MONTH_PATTERN.test(yearMonth)) return null;
+	if (typeof points !== 'number' || !Number.isFinite(points) || points < 0) return null;
+
+	return { yearMonth, points };
+}
+
+/** 既読にする。settings repo に削除 API が無いため空文字 upsert で表す。 */
+export async function clearHabitCertificateNotice(
+	childId: ChildId,
+	tenantId: string,
+): Promise<void> {
+	const repos = getRepos();
+	await repos.settings.setSetting(habitCertificateNoticeKey(childId), '', tenantId);
+}

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.server.ts
@@ -38,6 +38,10 @@ import {
 } from '$lib/server/services/child-challenge-service';
 import { getTodayMissions } from '$lib/server/services/daily-mission-service';
 import { getFamilyStreak, getNextMilestone } from '$lib/server/services/family-streak-service';
+import {
+	clearHabitCertificateNotice,
+	getHabitCertificateNotice,
+} from '$lib/server/services/habit-certificate-notice-service';
 import { claimLoginBonus, getLoginBonusStatus } from '$lib/server/services/login-bonus-service';
 import { getUnshownMessage } from '$lib/server/services/message-service';
 import { selectRecommendations } from '$lib/server/services/recommendation-service';
@@ -98,6 +102,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 			siblingRanking: null,
 			unshownCheers: [],
 			mustStatus: null,
+			habitCertificateNotice: null,
 		};
 
 	// baby モードは親向け準備ツール — ゲーミフィケーション DB 呼び出しをスキップ (#1300)
@@ -125,6 +130,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 			unshownCheers: [],
 			familyStreak: null,
 			mustStatus: null,
+			habitCertificateNotice: null,
 		};
 	}
 
@@ -148,6 +154,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 		activeChallenges,
 		unshownCheers,
 		familyStreakData,
+		habitCertificateNotice,
 	] = await Promise.all([
 		// #2471: per-child API に絞り込み (旧 getActivities(tenantId) は tenant 全 child を
 		// aggregate して同名 activity が child 数分重複 render される bug の根本原因)
@@ -172,6 +179,9 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 		getActiveChildChallengesWithSiblings(child.id, tenantId),
 		getUnshownCheers(child.id, tenantId),
 		getFamilyStreak(tenantId),
+		// #4261 ③: Push を許可していない家庭では、子は残高が増えた理由を知る手段が無い。
+		// 既存の Promise.all に相乗りさせる (往復を増やさない)。
+		getHabitCertificateNotice(child.id, tenantId),
 	]);
 
 	const sortedActivities = await sortActivitiesWithPreferences(rawActivities, child.id, tenantId);
@@ -301,6 +311,7 @@ export const load: PageServerLoad = async ({ parent, locals }) => {
 				}
 			: null,
 		mustStatus,
+		habitCertificateNotice,
 	};
 };
 
@@ -651,6 +662,27 @@ export const actions: Actions = {
 		}
 
 		await markCheersShown(cheerIds, tenantId);
+		return { success: true };
+	},
+
+	/**
+	 * #4261 ③: 習慣化告知を既読にする。
+	 *
+	 * **子に閉じる操作をさせない** (ADR-0012「記録する → 数秒で閉じる」を伸ばさない) ため、
+	 * × ボタンではなく**表示できた時点**で client が自動で 1 回だけ叩く。
+	 * 失敗しても画面は壊さず、次回起動でもう一度出す (安全側 = 無音より再掲)。
+	 */
+	ackHabitCertificateNotice: async ({ cookies, locals }) => {
+		const tenantId = requireTenantId(locals);
+		// #3581 ②: dsql backend の stale/非 uuid cookie を cookie clear + /switch redirect に正規化。
+		const childId = asChildId(
+			requireValidChildCookieFormat(cookies, 'route.home.ackHabitCertificateNotice'),
+		);
+		if (!childId) {
+			return fail(400, { error: 'パラメータが不正です' });
+		}
+
+		await clearHabitCertificateNotice(childId, tenantId);
 		return { success: true };
 	},
 

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -19,12 +19,12 @@ import BirthdayBanner from '$lib/features/birthday/BirthdayBanner.svelte';
 import SiblingCelebration from '$lib/features/challenge/SiblingCelebration.svelte';
 import HabitCertificateNoticeBanner from '$lib/features/child/HabitCertificateNoticeBanner.svelte';
 import TutorialHintBanner from '$lib/features/child/TutorialHintBanner.svelte';
-import { shouldShowHabitCertificateNotice } from '$lib/features/child-home/habit-certificate-notice';
 import BabyHomePage from '$lib/features/child-home/BabyHomePage.svelte';
 import OverlaysSection from '$lib/features/child-home/components/OverlaysSection.svelte';
 // Issue #2084 (ADR-0046 follow-up): 本番 child home の共通 UI を派生コンポーネントに集約
 import ProdDashboardSections from '$lib/features/child-home/components/ProdDashboardSections.svelte';
 import { DialogFSM } from '$lib/features/child-home/dialog-state-machine';
+import { shouldShowHabitCertificateNotice } from '$lib/features/child-home/habit-certificate-notice';
 import { getModeVariant } from '$lib/features/child-home/variants';
 import { getScreenshotMode } from '$lib/features/demo/screenshot-mode';
 // Issue #2084: 本番 ProductionDashboardService を Context に再注入 (todayRecorded を含む正しい snapshot)
@@ -109,8 +109,14 @@ let habitNoticeAcked = false;
 $effect(() => {
 	if (!showHabitCertificateNotice || habitNoticeAcked) return;
 	habitNoticeAcked = true;
-	// 失敗しても画面は壊さない。既読化できなければ次回起動でもう一度出る (無音より再掲)。
-	fetch('?/ackHabitCertificateNotice', { method: 'POST', body: new FormData() }).catch(() => {});
+	// `keepalive` が要る: 子供は「記録して数秒で閉じる」(ADR-0012) ため、既読化が届く前に
+	// 画面遷移・タブ終了が起きる。通常の fetch はそこで中断され、**次回また同じ告知が出る**
+	// (実機で観測済)。失敗しても画面は壊さない — 届かなければ次回に再掲する (無音よりまし)。
+	fetch('?/ackHabitCertificateNotice', {
+		method: 'POST',
+		body: new FormData(),
+		keepalive: true,
+	}).catch(() => {});
 });
 
 // Sibling cheer overlay

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -11,13 +11,15 @@ import {
 	getErrorNotifyLabels,
 	PAGE_TITLES,
 } from '$lib/domain/labels';
-import { formatPointValueWithSign } from '$lib/domain/point-display';
+import { formatPointValue, formatPointValueWithSign } from '$lib/domain/point-display';
 import { CONCEPT_ICONS } from '$lib/domain/terms';
 import { getCategoryById } from '$lib/domain/validation/activity';
 import type { UiMode } from '$lib/domain/validation/age-tier';
 import BirthdayBanner from '$lib/features/birthday/BirthdayBanner.svelte';
 import SiblingCelebration from '$lib/features/challenge/SiblingCelebration.svelte';
+import HabitCertificateNoticeBanner from '$lib/features/child/HabitCertificateNoticeBanner.svelte';
 import TutorialHintBanner from '$lib/features/child/TutorialHintBanner.svelte';
+import { shouldShowHabitCertificateNotice } from '$lib/features/child-home/habit-certificate-notice';
 import BabyHomePage from '$lib/features/child-home/BabyHomePage.svelte';
 import OverlaysSection from '$lib/features/child-home/components/OverlaysSection.svelte';
 // Issue #2084 (ADR-0046 follow-up): 本番 child home の共通 UI を派生コンポーネントに集約
@@ -93,6 +95,23 @@ function dismissTutorialHint() {
 	showTutorialHint = false;
 	if (typeof window !== 'undefined') localStorage.setItem(tutorialHintKey, '1');
 }
+
+// #4261 ③: 習慣化告知 — Push が届かない家庭でも残高が増えた理由を 1 回だけ伝える。
+// **閉じる操作を挟まない** (ADR-0012) ため、× ではなく「表示できた」時点で既読にする。
+const showHabitCertificateNotice = $derived(
+	shouldShowHabitCertificateNotice({
+		notice: data.habitCertificateNotice ?? null,
+		birthdayPending: Boolean(data.birthdayBonus),
+		isScreenshotMode,
+	}),
+);
+let habitNoticeAcked = false;
+$effect(() => {
+	if (!showHabitCertificateNotice || habitNoticeAcked) return;
+	habitNoticeAcked = true;
+	// 失敗しても画面は壊さない。既読化できなければ次回起動でもう一度出る (無音より再掲)。
+	fetch('?/ackHabitCertificateNotice', { method: 'POST', body: new FormData() }).catch(() => {});
+});
 
 // Sibling cheer overlay
 let showCheerOverlay = $state(true);
@@ -641,6 +660,13 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 			<Button type="submit" id="claim-bonus-btn" variant="ghost" size="sm">claim</Button>
 		</form>
 	{/if}
+
+	<!-- #4261 ③: 習慣化告知 (次回起動で 1 回だけ / 閉じる操作なし) -->
+	<HabitCertificateNoticeBanner
+		visible={showHabitCertificateNotice}
+		uiMode={data.uiMode as Exclude<UiMode, 'baby'>}
+		amount={formatPointValue(data.habitCertificateNotice?.points ?? 0, ps.mode, ps.currency, ps.rate)}
+	/>
 
 	<!-- Tutorial hint banner (one-time) -->
 	<TutorialHintBanner visible={showTutorialHint} onDismiss={dismissTutorialHint} />

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -105,10 +105,10 @@ const showHabitCertificateNotice = $derived(
 		isScreenshotMode,
 	}),
 );
-let habitNoticeAcked = false;
+let habitNoticeAcknowledged = false;
 $effect(() => {
-	if (!showHabitCertificateNotice || habitNoticeAcked) return;
-	habitNoticeAcked = true;
+	if (!showHabitCertificateNotice || habitNoticeAcknowledged) return;
+	habitNoticeAcknowledged = true;
 	// `keepalive` が要る: 子供は「記録して数秒で閉じる」(ADR-0012) ため、既読化が届く前に
 	// 画面遷移・タブ終了が起きる。通常の fetch はそこで中断され、**次回また同じ告知が出る**
 	// (実機で観測済)。失敗しても画面は壊さない — 届かなければ次回に再掲する (無音よりまし)。

--- a/tests/e2e/child-home-habit-certificate-notice.spec.ts
+++ b/tests/e2e/child-home-habit-certificate-notice.spec.ts
@@ -1,0 +1,93 @@
+// tests/e2e/child-home-habit-certificate-notice.spec.ts
+//
+// #4261 ③ — 習慣化告知は「次回起動で 1 回だけ」。既読で消え、再表示しない (PO 決裁 2026-08-06)。
+//
+// ## なぜ e2e でなければ捕まらないか
+//
+// 既読化は **表示できた時点で client が自動で 1 回だけ** `?/ackHabitCertificateNotice` を叩く
+// (ADR-0012「記録する → 数秒で閉じる」を伸ばさないため、子に × を押させない)。
+// この経路は hydration → fetch → server action → settings KV という実ブラウザの往復であり、
+// unit では再現できない。実際に**初回実装は表示直後の画面遷移で fetch が中断され、
+// 次回また同じ告知が出ていた** (実機で観測 → `keepalive: true` で修正)。
+// 「バナーが出ること」だけを見る test では本欠陥を検出できないため、
+// **再訪して出ないこと**を assert する。
+
+import { expect, test } from './fixtures';
+
+const NICKNAME = 'けんたくん'; // elementary
+const NOTICE = '[data-testid="habit-certificate-notice"]';
+const NOTICE_KEY_PREFIX = 'habit_certificate_notice:';
+
+async function childIdOf(workerDbPath: string): Promise<number> {
+	const { default: Database } = await import('better-sqlite3');
+	const db = new Database(workerDbPath, { readonly: true });
+	try {
+		const row = db.prepare('SELECT id FROM children WHERE nickname = ? LIMIT 1').get(NICKNAME) as
+			| { id: number }
+			| undefined;
+		if (!row) throw new Error(`${NICKNAME} not found in worker DB`);
+		return row.id;
+	} finally {
+		db.close();
+	}
+}
+
+async function seedNotice(workerDbPath: string, childId: number): Promise<void> {
+	const { default: Database } = await import('better-sqlite3');
+	const db = new Database(workerDbPath);
+	try {
+		db.prepare(
+			"INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES (?, ?, datetime('now'))",
+		).run(`${NOTICE_KEY_PREFIX}${childId}`, JSON.stringify({ yearMonth: '2026-08', points: 50 }));
+	} finally {
+		db.close();
+	}
+}
+
+/** 自分が足した行だけを消して worker DB を seed 状態へ戻す (tests/CLAUDE.md §worker DB 共有) */
+async function cleanupNotice(workerDbPath: string, childId: number): Promise<void> {
+	const { default: Database } = await import('better-sqlite3');
+	const db = new Database(workerDbPath);
+	try {
+		db.prepare('DELETE FROM settings WHERE key = ?').run(`${NOTICE_KEY_PREFIX}${childId}`);
+	} finally {
+		db.close();
+	}
+}
+
+async function openChildHome(page: import('@playwright/test').Page): Promise<void> {
+	await page.goto('/switch');
+	await page.locator('[data-testid^="child-select-"]').filter({ hasText: NICKNAME }).click();
+	await page.locator('[data-testid="elementary-home-page"]').waitFor({ state: 'visible' });
+}
+
+test.describe('#4261 ③ 習慣化告知は 1 回だけ', () => {
+	test('表示 → 再訪で出ない (既読化が画面遷移で失われない)', async ({ page, workerDbPath }) => {
+		const childId = await childIdOf(workerDbPath);
+		await seedNotice(workerDbPath, childId);
+
+		try {
+			// 1 回目: 出る
+			const acked = page.waitForResponse((r) => r.url().includes('ackHabitCertificateNotice'));
+			await openChildHome(page);
+			await expect(page.locator(NOTICE)).toBeVisible();
+			// 閉じる操作をしていないのに既読になる (× を押させない、ADR-0012)
+			await acked;
+
+			// 2 回目: 出ない
+			await openChildHome(page);
+			await expect(page.locator(NOTICE)).toHaveCount(0);
+		} finally {
+			await cleanupNotice(workerDbPath, childId);
+		}
+	});
+
+	test('pending が無ければ出ない', async ({ page, workerDbPath }) => {
+		const childId = await childIdOf(workerDbPath);
+		await cleanupNotice(workerDbPath, childId);
+
+		await openChildHome(page);
+
+		await expect(page.locator(NOTICE)).toHaveCount(0);
+	});
+});

--- a/tests/e2e/child-home-habit-certificate-notice.spec.ts
+++ b/tests/e2e/child-home-habit-certificate-notice.spec.ts
@@ -68,11 +68,13 @@ test.describe('#4261 ③ 習慣化告知は 1 回だけ', () => {
 
 		try {
 			// 1 回目: 出る
-			const acked = page.waitForResponse((r) => r.url().includes('ackHabitCertificateNotice'));
+			const acknowledged = page.waitForResponse((r) =>
+				r.url().includes('ackHabitCertificateNotice'),
+			);
 			await openChildHome(page);
 			await expect(page.locator(NOTICE)).toBeVisible();
 			// 閉じる操作をしていないのに既読になる (× を押させない、ADR-0012)
-			await acked;
+			await acknowledged;
 
 			// 2 回目: 出ない
 			await openChildHome(page);

--- a/tests/e2e/child-home-habit-certificate-notice.spec.ts
+++ b/tests/e2e/child-home-habit-certificate-notice.spec.ts
@@ -61,6 +61,24 @@ async function openChildHome(page: import('@playwright/test').Page): Promise<voi
 	await page.locator('[data-testid="elementary-home-page"]').waitFor({ state: 'visible' });
 }
 
+/** 既読 = 空文字 upsert (settings repo に削除 API が無いため、#4261 ③) */
+async function isRead(workerDbPath: string, childId: number): Promise<boolean> {
+	const { default: Database } = await import('better-sqlite3');
+	const db = new Database(workerDbPath, { readonly: true });
+	try {
+		const row = db
+			.prepare('SELECT value FROM settings WHERE key = ?')
+			.get(`${NOTICE_KEY_PREFIX}${childId}`) as { value: string } | undefined;
+		return row?.value === '';
+	} finally {
+		db.close();
+	}
+}
+
+// /switch → home を 2 往復するため既定 30s では足りない (実測 ~35s、初回 compile 込み)。
+// 同 worker DB の settings 行を共有するため serial (並行だと後続の cleanup が先行 test を壊す)。
+test.describe.configure({ mode: 'serial', timeout: 120_000 });
+
 test.describe('#4261 ③ 習慣化告知は 1 回だけ', () => {
 	test('表示 → 再訪で出ない (既読化が画面遷移で失われない)', async ({ page, workerDbPath }) => {
 		const childId = await childIdOf(workerDbPath);
@@ -68,13 +86,11 @@ test.describe('#4261 ③ 習慣化告知は 1 回だけ', () => {
 
 		try {
 			// 1 回目: 出る
-			const acknowledged = page.waitForResponse((r) =>
-				r.url().includes('ackHabitCertificateNotice'),
-			);
 			await openChildHome(page);
 			await expect(page.locator(NOTICE)).toBeVisible();
-			// 閉じる操作をしていないのに既読になる (× を押させない、ADR-0012)
-			await acknowledged;
+			// 閉じる操作をしていないのに既読になる (× を押させない、ADR-0012)。
+			// network event ではなく **server 側の状態**を見る (既読化の結果そのもの)。
+			await expect.poll(() => isRead(workerDbPath, childId), { timeout: 30_000 }).toBe(true);
 
 			// 2 回目: 出ない
 			await openChildHome(page);

--- a/tests/unit/features/habit-certificate-notice.test.ts
+++ b/tests/unit/features/habit-certificate-notice.test.ts
@@ -1,0 +1,92 @@
+// tests/unit/features/habit-certificate-notice.test.ts
+//
+// #4261 ③ — 表示側の契約。ADR-0012 (anti-engagement) との両立条件を固定する。
+//
+// PO 決裁 (2026-08-06) の 3 条件:
+//   1 回だけ。既読で消える / 演出を足さない / 閉じる操作を挟まない
+//
+// 「1 回だけ」の保存側は habit-certificate-notice-service が持つ。本 test は
+// **いつ出すか / いつ出さないか**を固定する。
+//
+//   [D1] pending があれば出す
+//   [D2] 誕生日ボーナス未受取の回は出さない (演出を 2 枚重ねない) — かつ pending は消さない
+//   [D3] `?screenshot=*` では出さない (visual regression baseline を日付依存にしない)
+//   [D4] 文言は 5 年齢モードすべてで成立する (baby は子供向け画面を持たないため対象外)
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	getHabitCertificateNoticeText,
+	shouldShowHabitCertificateNotice,
+} from '$lib/features/child-home/habit-certificate-notice';
+
+const notice = { yearMonth: '2026-08', points: 50 };
+
+describe('#4261 ③ 習慣化告知の表示条件', () => {
+	it('[D1] pending があれば出す', () => {
+		expect(
+			shouldShowHabitCertificateNotice({
+				notice,
+				birthdayPending: false,
+				isScreenshotMode: false,
+			}),
+		).toBe(true);
+	});
+
+	it('[D1] pending が無ければ出さない', () => {
+		expect(
+			shouldShowHabitCertificateNotice({
+				notice: null,
+				birthdayPending: false,
+				isScreenshotMode: false,
+			}),
+		).toBe(false);
+	});
+
+	it('[D2] 誕生日ボーナス未受取の回は出さない (演出を 2 枚重ねない)', () => {
+		expect(
+			shouldShowHabitCertificateNotice({
+				notice,
+				birthdayPending: true,
+				isScreenshotMode: false,
+			}),
+		).toBe(false);
+	});
+
+	it('[D3] screenshot モードでは出さない', () => {
+		expect(
+			shouldShowHabitCertificateNotice({
+				notice,
+				birthdayPending: false,
+				isScreenshotMode: true,
+			}),
+		).toBe(false);
+	});
+});
+
+describe('#4261 ③ 告知文言 (5 年齢モード)', () => {
+	// baby は親向けの準備モードで子供向けホームを持たない (ADR-0011)。
+	const childModes = ['preschool', 'elementary', 'junior', 'senior'] as const;
+
+	it.each(childModes)('[D4] %s の文言が空でなく、受け取った量を含む', (uiMode) => {
+		const text = getHabitCertificateNoticeText(uiMode, '50ポイント');
+
+		expect(text.title.length).toBeGreaterThan(0);
+		expect(text.body).toContain('50ポイント');
+	});
+
+	it('[D4] preschool はひらがな中心 — 漢字を含めない', () => {
+		const { title, body } = getHabitCertificateNoticeText('preschool', '50ポイント');
+
+		// 量の表記 (引数) を除いた地の文に漢字が無いこと
+		const plain = `${title}${body}`.replace('50ポイント', '');
+		expect(plain).not.toMatch(/[一-龯]/);
+	});
+
+	it('[D4] 演出語 (紙吹雪・音・連打を促す語) を含めない — ADR-0012', () => {
+		for (const uiMode of childModes) {
+			const { title, body } = getHabitCertificateNoticeText(uiMode, '50ポイント');
+			expect(`${title}${body}`).not.toMatch(/もっと|つづけて|あと[0-9０-９]/);
+		}
+	});
+});

--- a/tests/unit/services/habit-certificate-notice-service.test.ts
+++ b/tests/unit/services/habit-certificate-notice-service.test.ts
@@ -1,0 +1,123 @@
+// tests/unit/services/habit-certificate-notice-service.test.ts
+//
+// #4261 ③ — Push が届かない家庭で「褒める体験が完全に無音」になるのを止める。
+//
+// ## なぜこの契約が要るのか
+//
+// #4172 AC11' により、月間の習慣化証明書は**親への Web Push のみ**で伝える設計になっている
+// (子への演出を出すと子の中で完結し、親が「1 ヶ月続いたね」と言う前にアプリが言ってしまう)。
+// ところが `/api/v1/notifications/subscribe` を許可していない家庭では Push が 1 通も届かず、
+// **子は残高が 50pt 増えた理由を知る手段が無い**。仕組みが動いていても伝わっていなければ
+// 褒める機構は成立していない (PO 決裁 2026-08-06)。
+//
+// ## 本 test が固定する契約
+//
+//   [N1] 発行時に「次回起動で 1 回だけ伝える」pending を残す
+//   [N2] 壊れた値 / 空 / 未設定は null に倒す (画面が落ちない)
+//   [N3] 既読化すると消え、二度と出ない
+//   [N4] Push の可否に関わらず pending は 1 件 (届いた家庭だけ二重に演出しない)
+//
+// ADR-0012 との両立条件 (1 回だけ / 演出を足さない / 閉じる操作を挟まない) のうち、
+// 「1 回だけ」を保証するのが本 service。表示側の条件は
+// `tests/unit/features/habit-certificate-notice.test.ts` が持つ。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { asChildId } from '$lib/domain/ids';
+
+const settingsStore = new Map<string, string>();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		settings: {
+			getSetting: async (key: string) => settingsStore.get(key),
+			setSetting: async (key: string, value: string) => {
+				settingsStore.set(key, value);
+			},
+		},
+	}),
+}));
+
+import {
+	clearHabitCertificateNotice,
+	getHabitCertificateNotice,
+	habitCertificateNoticeKey,
+	recordHabitCertificateNotice,
+} from '$lib/server/services/habit-certificate-notice-service';
+
+const CHILD_ID = asChildId('11111111-1111-4111-8111-111111111111');
+const TENANT = 't-habit-notice';
+const KEY = habitCertificateNoticeKey(CHILD_ID);
+
+beforeEach(() => {
+	settingsStore.clear();
+});
+
+describe('#4261 ③ 習慣化証明書の「次回起動で 1 回だけ」告知', () => {
+	it('[N1] 記録すると、次回起動で読み出せる', async () => {
+		await recordHabitCertificateNotice(
+			{ childId: CHILD_ID, yearMonth: '2026-08', points: 50 },
+			TENANT,
+		);
+
+		expect(await getHabitCertificateNotice(CHILD_ID, TENANT)).toEqual({
+			yearMonth: '2026-08',
+			points: 50,
+		});
+	});
+
+	it('[N2] 未設定なら null', async () => {
+		expect(await getHabitCertificateNotice(CHILD_ID, TENANT)).toBeNull();
+	});
+
+	it.each([
+		['空文字 (既読の表現)', ''],
+		['JSON でない', 'not-json'],
+		['yearMonth が形式外', '{"yearMonth":"2026/08","points":50}'],
+		['points が数値でない', '{"yearMonth":"2026-08","points":"50"}'],
+		['points が負', '{"yearMonth":"2026-08","points":-1}'],
+		['配列', '[]'],
+	])('[N2] 壊れた値 (%s) は null に倒す — 画面を落とさない', async (_name, raw) => {
+		settingsStore.set(KEY, raw);
+
+		expect(await getHabitCertificateNotice(CHILD_ID, TENANT)).toBeNull();
+	});
+
+	it('[N3] 既読化すると消え、二度と出ない', async () => {
+		await recordHabitCertificateNotice(
+			{ childId: CHILD_ID, yearMonth: '2026-08', points: 50 },
+			TENANT,
+		);
+		await clearHabitCertificateNotice(CHILD_ID, TENANT);
+
+		expect(await getHabitCertificateNotice(CHILD_ID, TENANT)).toBeNull();
+		// 既読化を 2 回踏んでも復活しない (多重 POST された場合)
+		await clearHabitCertificateNotice(CHILD_ID, TENANT);
+		expect(await getHabitCertificateNotice(CHILD_ID, TENANT)).toBeNull();
+	});
+
+	it('[N4] 同じ月を 2 回記録しても pending は 1 件 (キーが月ではなく子で 1 本)', async () => {
+		await recordHabitCertificateNotice(
+			{ childId: CHILD_ID, yearMonth: '2026-08', points: 50 },
+			TENANT,
+		);
+		await recordHabitCertificateNotice(
+			{ childId: CHILD_ID, yearMonth: '2026-09', points: 50 },
+			TENANT,
+		);
+
+		// 最後に達成した月だけを伝える。溜めて連続表示しない (ADR-0012)。
+		expect(await getHabitCertificateNotice(CHILD_ID, TENANT)).toEqual({
+			yearMonth: '2026-09',
+			points: 50,
+		});
+		expect([...settingsStore.keys()]).toEqual([KEY]);
+	});
+
+	it('キーは子ごとに分かれる — 兄弟の告知が混ざらない', () => {
+		const sibling = asChildId('22222222-2222-4222-8222-222222222222');
+
+		expect(habitCertificateNoticeKey(CHILD_ID)).not.toBe(habitCertificateNoticeKey(sibling));
+		expect(habitCertificateNoticeKey(CHILD_ID)).toContain(CHILD_ID);
+	});
+});

--- a/tests/unit/services/monthly-habit-certificate.test.ts
+++ b/tests/unit/services/monthly-habit-certificate.test.ts
@@ -54,6 +54,10 @@ vi.mock('$lib/server/services/notification-service', () => ({
 	sendPushNotification: vi.fn(),
 }));
 
+vi.mock('$lib/server/services/habit-certificate-notice-service', () => ({
+	recordHabitCertificateNotice: vi.fn(),
+}));
+
 vi.mock('$lib/server/logger', () => ({
 	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
@@ -61,10 +65,14 @@ vi.mock('$lib/server/logger', () => ({
 import {
 	MONTHLY_HABIT_DAYS_THRESHOLD,
 	MONTHLY_HABIT_POINTS,
+	MONTHLY_HABIT_THRESHOLD_REVIEW_DEADLINE,
+	MONTHLY_HABIT_THRESHOLD_REVIEW_MIN_PAID_FAMILIES,
+	MONTHLY_HABIT_THRESHOLD_REVIEW_TRIGGER,
 } from '$lib/domain/constants/habit-milestones';
 import { hasCertificate, issueCertificate } from '$lib/server/db/certificate-repo';
 import { insertPointEntry } from '$lib/server/db/point-repo';
 import { issueMonthlyHabitCertificateIfEligible } from '$lib/server/services/certificate-service';
+import { recordHabitCertificateNotice } from '$lib/server/services/habit-certificate-notice-service';
 import { sendPushNotification } from '$lib/server/services/notification-service';
 import { getMonthlyReport } from '$lib/server/services/report-service';
 
@@ -199,11 +207,60 @@ describe('#4172 月間の習慣化を褒める (記録の量ではなく日数)'
 		expect(insertPointEntry).toHaveBeenCalledTimes(1);
 	});
 
+	// #4261 ③: AC11' の「子への演出は出さない」は維持したまま、Push が届かない家庭でも
+	// 子が残高の増えた理由を知れるようにする (PO 決裁 2026-08-06)。
+	it('[H7] 発行時に「次回起動で 1 回だけ」の pending を残す (Push の可否に関わらず 1 件)', async () => {
+		vi.mocked(getMonthlyReport).mockResolvedValue(monthlyReport(20));
+
+		await issueMonthlyHabitCertificateIfEligible(CHILD_ID, MONTH, TENANT);
+
+		expect(recordHabitCertificateNotice).toHaveBeenCalledTimes(1);
+		expect(recordHabitCertificateNotice).toHaveBeenCalledWith(
+			{ childId: CHILD_ID, yearMonth: MONTH, points: MONTHLY_HABIT_POINTS },
+			TENANT,
+		);
+	});
+
+	it('[H7] 発行しなかった月は pending を残さない (残高が動いていないのに告知しない)', async () => {
+		vi.mocked(getMonthlyReport).mockResolvedValue(monthlyReport(MONTHLY_HABIT_DAYS_THRESHOLD - 1));
+
+		await issueMonthlyHabitCertificateIfEligible(CHILD_ID, MONTH, TENANT);
+
+		expect(recordHabitCertificateNotice).not.toHaveBeenCalled();
+	});
+
+	it('[H7] 告知の保存に失敗しても証明書と通貨は取り消さない (告知は付帯物)', async () => {
+		vi.mocked(getMonthlyReport).mockResolvedValue(monthlyReport(20));
+		vi.mocked(recordHabitCertificateNotice).mockRejectedValue(new Error('kv failed'));
+
+		const result = await issueMonthlyHabitCertificateIfEligible(CHILD_ID, MONTH, TENANT);
+
+		expect(result).not.toBeNull();
+		expect(insertPointEntry).toHaveBeenCalledTimes(1);
+		// 告知が落ちても親への Push は送る (2 経路が相互に道連れにならない)
+		expect(sendPushNotification).toHaveBeenCalledTimes(1);
+	});
+
 	it('月次レポートが取れない月は何もしない', async () => {
 		vi.mocked(getMonthlyReport).mockResolvedValue(null);
 
 		expect(await issueMonthlyHabitCertificateIfEligible(CHILD_ID, MONTH, TENANT)).toBeNull();
 		expect(issueCertificate).not.toHaveBeenCalled();
 		expect(insertPointEntry).not.toHaveBeenCalled();
+	});
+});
+
+// #4261 ② — 「n=1 のまま据え置くのは構わないが、いつ見直すかが無いまま固定するのは認めない」
+// (PO 決裁 2026-08-06)。トリガーが本文から静かに消えたら赤にする。
+describe('#4261 ② 閾値 10 日の再評価トリガー', () => {
+	it('[H8] 期日と、期日より早く再評価に入る条件の両方が残っている', () => {
+		expect(MONTHLY_HABIT_THRESHOLD_REVIEW_DEADLINE).toBe('2026-11-05');
+		expect(MONTHLY_HABIT_THRESHOLD_REVIEW_MIN_PAID_FAMILIES).toBe(3);
+		expect(MONTHLY_HABIT_THRESHOLD_REVIEW_TRIGGER).toContain(
+			MONTHLY_HABIT_THRESHOLD_REVIEW_DEADLINE,
+		);
+		expect(MONTHLY_HABIT_THRESHOLD_REVIEW_TRIGGER).toContain(
+			String(MONTHLY_HABIT_THRESHOLD_REVIEW_MIN_PAID_FAMILIES),
+		);
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 子供（4 つの年齢モード）+ 親（管理者）

**解決する課題**: 月間の習慣化証明書は 50pt を付与するが、伝える経路が**親への Web Push だけ**だった。Push を許可していない家庭では 1 通も届かず、**子は残高が増えた理由を知る手段が無い**。仕組みが動いていても伝わっていなければ、褒める機構は成立していない。あわせて、閾値 10 日は n=1 で決めた値のまま「いつ見直すか」が無く、恒久固定に向かっていた。

**期待される効果**: Push の可否に関わらず、子が「今月は続いた → だから 50P 受け取った」を 1 回だけ静かに知る。親が「1 ヶ月続いたね」と声をかける前にアプリが完結させることもない（演出は足していない）。閾値は再評価の期日と早期条件が定数として残り、n=1 のまま黙って固定されない。

## 関連 Issue

Closes #4261

論点 1（付与失敗が無ログ）は PR #4298（merge 済）で対応済。本 PR は PO 決裁（2026-08-06）の残り 2 論点を実装し、Issue を完了させる。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 閾値 10 日の再評価トリガー（有料家庭 3 世帯以上で 1 ヶ月分 / 2026-11-05 のいずれか早い方）を残す | `npx vitest run tests/unit/services/monthly-habit-certificate.test.ts`（[H8]） | PASS（13 passed）。`MONTHLY_HABIT_THRESHOLD_REVIEW_DEADLINE='2026-11-05'` / `..._MIN_PAID_FAMILIES=3` を `src/lib/domain/constants/habit-milestones.ts` に定義 |
| AC2 | 証明書発行時に「次回起動で 1 回だけ」の pending を残す。Push の可否に関わらず 1 件 | 同上（[H7] 3 件） | PASS。mutation 検証: 書き込みを潰すと `[H7] 発行時に…pending を残す` が赤 |
| AC3 | 発行しなかった月は pending を残さない / 告知の保存が失敗しても証明書・通貨・Push は取り消さない | 同上（[H7]） | PASS |
| AC4 | 1 回だけ。既読で消え、再表示しない | `npx playwright test --project=tablet child-home-habit-certificate-notice`（2 passed / 34.4s）+ 実機 SS 2 周目（`before-*`） | PASS。**初回実装は表示直後の遷移で既読化が失われ 2 回出ていた**（実機で観測）→ `keepalive: true` で修正し、e2e で固定 |
| AC5 | 演出を足さない（紙吹雪・音・連続ダイアログ不可） | `HabitCertificateNoticeBanner.svelte` は `Alert` primitive のみ。アニメーション / 音 / CTA なし。文言の煽り語ガード = `npx vitest run tests/unit/features/habit-certificate-notice.test.ts`（[D4]） | PASS（10 passed）。誕生日バナーと同回に重ねない（[D2]） |
| AC6 | 閉じる操作を挟まない | 同 component に × ボタンを持たない。既読化は表示時に client が 1 回だけ `?/ackHabitCertificateNotice` を叩く | PASS（SS の `after-*` に × が無いこと / e2e が閉じる操作なしで既読化を確認） |
| AC7 | 4 つの子供向け年齢モードで文言・折り返しが成立（baby は子供向けホームを持たない、ADR-0011） | 実機 SS 4 モード × mobile/desktop + Storybook 6 story | PASS（下記 SS） |
| AC8 | 通貨の発行量が変わらない | `npx vitest run tests/unit/services/monthly-habit-certificate.test.ts`（[H4] `insertPointEntry` 1 回 / [H3] 冪等 / [H5] 書き込み順） | PASS。`insertPointEntry` の呼び出し・金額・順序は無変更（本 PR は告知の pending 書き込みを**その後ろに**足しただけ） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 子供ホーム（preschool / elementary / junior / senior）、`certificate-service` の月間習慣化発行経路

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
  - 文言は `HABIT_CERTIFICATE_NOTICE_LABELS`（`labels.ts`）に集約。年齢モード別 Record で 4 モードすべてを持ち、baby は型で除外（`Exclude<UiMode,'baby'>`）
  - DB スキーマ変更なし（settings KV のため e2e / unit seed の変更不要）
- [x] **設計書同期** (ADR-0001): `docs/design/26-ゲーミフィケーション設計書.md` §16.2（仕様 SSOT）/ `docs/design/06-UI設計書.md` §4.14（component）
- [x] **LP ↔ アプリ整合** (ADR-0013): LP に記載のある機能ではない。新規訴求の追加なし
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った（下表）
- [ ] N/A — 上記いずれも影響範囲外

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4350` | PASS（全 step） |
| 追加・変更テスト | `npx vitest run tests/unit/services/habit-certificate-notice-service.test.ts tests/unit/features/habit-certificate-notice.test.ts tests/unit/services/monthly-habit-certificate.test.ts` | PASS（34 passed） |
| 回帰（周辺全域） | `npx vitest run tests/unit/services/ tests/unit/features/ src/routes/` | PASS（175 files / 2813 passed） |
| 型 | `npx svelte-check --threshold error` | PASS（0 errors / 0 warnings） |
| e2e（新規） | `npx playwright test --project=tablet child-home-habit-certificate-notice` | PASS（2 passed / 34.4s） |
| e2e（全体） | `npx playwright test` | PASS（860 passed / 8 skipped / 16.3m） |
| Storybook | `npm run test:storybook` | PASS（43 files / 228 passed） |

**mutation 検証（failing-test-first の裏取り、実装を潰すと赤になることを確認）**

| 潰した実装 | 落ちたテスト |
|---|---|
| `recordHabitCertificateNotice` の呼び出し | `[H7] 発行時に「次回起動で 1 回だけ」の pending を残す` |
| 表示条件の誕生日 / screenshot ガード | `[D2] 誕生日ボーナス未受取の回は出さない` / `[D3] screenshot モードでは出さない` |
| pending の値域検証 | `[N2] 壊れた値は null に倒す` 3 件 |

- [x] **SOLID / DRY / YAGNI**: 保持（server service）/ 表示判定（純関数）/ 描画（component）を分離。#4313 の `ui-mode-change-notice` と同じ「settings KV + 次回起動で 1 回」の流儀に揃え、新しい観測・保存の形を増やしていない。汎用 pending-notice 基盤の先取りはしない（ADR-0010）
- [x] **Security（OSS 公開前提）**: pending に顧客識別子を載せない（`{yearMonth, points}` のみ、#4174 / #4197 と同じ基準）。既読化 action は `requireValidChildCookieFormat` + `requireTenantId` を通す。壊れた値は全て null に倒し、子供ホームを落とさない
- [x] **A11y・パフォーマンス**: `Alert` primitive の `role="status"`（緊急でない通知）。既存 `Promise.all` に相乗りさせ DB 往復を増やしていない
- [x] **Critical バグ修正**(ADR-0002): `priority:medium` のため N/A

## スクリーンショット / ビジュアルデモ

実機（`npm run dev` + `scripts/capture.mjs`）で 4 つの子供向け年齢モードを撮影。

- **`after-*`** = pending がある回（バナーが出る）
- **`before-*`** = 同じ画面を再訪した回。**表示した時点で既読になっているため出ない** = 修正前 / develop と同じ描画であり、同時に「1 回だけ」の実機証跡になる

<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/05-before-preschool-mobile.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/01-after-preschool-mobile.png -->
<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/05-before-preschool-desktop.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/01-after-preschool-desktop.png -->
<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/06-before-elementary-mobile.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/02-after-elementary-mobile.png -->
<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/06-before-elementary-desktop.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/02-after-elementary-desktop.png -->
<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/07-before-junior-mobile.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/03-after-junior-mobile.png -->
<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/07-before-junior-desktop.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/03-after-junior-desktop.png -->
<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/08-before-senior-mobile.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/04-after-senior-mobile.png -->
<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/08-before-senior-desktop.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/04-after-senior-desktop.png -->

| 年齢モード | | モバイル (375px) | PC (1440px) |
|---|---|---|---|
| **幼児 (preschool)** | 修正前 (既読後 = develop と同じ描画) | ![before-preschool-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/05-before-preschool-mobile.png) | ![before-preschool-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/05-before-preschool-desktop.png) |
| | 修正後 (告知あり) | ![after-preschool-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/01-after-preschool-mobile.png) | ![after-preschool-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/01-after-preschool-desktop.png) |
| **小学生 (elementary)** | 修正前 (既読後 = develop と同じ描画) | ![before-elementary-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/06-before-elementary-mobile.png) | ![before-elementary-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/06-before-elementary-desktop.png) |
| | 修正後 (告知あり) | ![after-elementary-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/02-after-elementary-mobile.png) | ![after-elementary-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/02-after-elementary-desktop.png) |
| **中学生 (junior)** | 修正前 (既読後 = develop と同じ描画) | ![before-junior-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/07-before-junior-mobile.png) | ![before-junior-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/07-before-junior-desktop.png) |
| | 修正後 (告知あり) | ![after-junior-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/03-after-junior-mobile.png) | ![after-junior-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/03-after-junior-desktop.png) |
| **高校生 (senior)** | 修正前 (既読後 = develop と同じ描画) | ![before-senior-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/08-before-senior-mobile.png) | ![before-senior-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/08-before-senior-desktop.png) |
| | 修正後 (告知あり) | ![after-senior-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/04-after-senior-mobile.png) | ![after-senior-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/04-after-senior-desktop.png) |

**DOM スナップショット** (SS と同一 page で取得、#1747 AC4):

- 幼児 (preschool): [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/01-after-preschool-mobile.dom.html) / [after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/01-after-preschool-desktop.dom.html) / [before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/05-before-preschool-mobile.dom.html) / [before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/05-before-preschool-desktop.dom.html)
- 小学生 (elementary): [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/02-after-elementary-mobile.dom.html) / [after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/02-after-elementary-desktop.dom.html) / [before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/06-before-elementary-mobile.dom.html) / [before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/06-before-elementary-desktop.dom.html)
- 中学生 (junior): [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/03-after-junior-mobile.dom.html) / [after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/03-after-junior-desktop.dom.html) / [before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/07-before-junior-mobile.dom.html) / [before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/07-before-junior-desktop.dom.html)
- 高校生 (senior): [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/04-after-senior-mobile.dom.html) / [after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/04-after-senior-desktop.dom.html) / [before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/08-before-senior-mobile.dom.html) / [before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4350/08-before-senior-desktop.dom.html)

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **既読化を「表示した時点」にした判断**。PO 決裁の「閉じる操作を挟まない」を満たすには × を置けないため、表示できた時点で client が 1 回だけ叩く形にしました。server の `load` 内で消す案は、リンク hover での投機的 preload が pending を消して**一度も表示されない**恐れがあるため採っていません。
2. **hydration 前に離脱した場合は次回に再掲されます**（既読化は hydration 後の `$effect` から出るため）。無音になるより再掲を選んだ判断です。
3. 表示は「最後に達成した月」1 件のみ（子ごとに KV 1 本）。溜めて連続表示しません（ADR-0012）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認
- [x] 認証画面変更時: N/A（子供ホームは `npm run dev` の local 認証で実機確認済。認証画面の変更なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
