### PR TITLE
fix(cron): #4340 物理削除 kill-switch の解釈できない値を「停止」側に倒す

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -388,7 +388,12 @@ PORT=3000
 # GRACE_PERIOD_DELETION_DISABLED (#4327、既定 false = 有効)
 # ===================================================
 # 顧客データの物理削除 cron (grace-period-deletion、毎日 02:00 JST) の kill-switch。
-# `true` / `1` で **対象の走査すら行わずに即 return** する (EventBridge 経由でも手動 POST でも止まる)。
+# `true` / `1` / `yes` / `on` で **対象の走査すら行わずに即 return** する
+# (EventBridge 経由でも手動 POST でも止まる)。
+# `false` / `0` / `no` / `off` / 空文字 で有効。
+# **上記いずれにも当てはまらない値 (打ち間違い等) は「停止」として扱う** (#4340 follow-up)。
+# 取り消せない削除であり、止め忘れ (200 + disabled で観測できる) より
+# 止め損ない (削除が終わるまで観測できない) の方が回復不能なため。
 #
 # 消したら戻せない処理であり、止める手段が EventBridge Rule の手動 disable しか無かった。
 # Rule の disable が「cron を呼ばせない」防御なのに対し、本 env は「呼ばれても消させない」防御で

--- a/docs/runbooks/grace-period-deletion-operations.md
+++ b/docs/runbooks/grace-period-deletion-operations.md
@@ -33,6 +33,11 @@ aws events describe-rule --name ganbari-quest-cron-grace-period-deletion --regio
 `GRACE_PERIOD_DELETION_DISABLED=true` で、**対象の走査すら行わずに即 return** する
 （`purgeExpiredSoftDeletedTenants`）。手動 POST も止まる。
 
+停止と解釈する値は `true` / `1` / `yes` / `on`、有効と解釈する値は `false` / `0` / `no` / `off` / 空文字。
+**どちらにも当てはまらない値（`tru` のような打ち間違い）は「停止」として扱う**（#4340 follow-up）。
+止め忘れは `200` + `disabled: true` で観測できるが、止め損ないは削除が終わるまで観測できないため、
+観測できる側に倒してある。いずれの場合も warn ログに実際の値が残る。
+
 即時に効かせる（次の Lambda 起動から反映。**次回 deploy で CDK 値に戻る**）:
 
 ```bash

--- a/src/lib/server/services/grace-period-service.ts
+++ b/src/lib/server/services/grace-period-service.ts
@@ -412,15 +412,24 @@ function isPhysicalDeletionDisabled(): boolean {
 	if (DISABLED_VALUES.has(normalized)) return true;
 	if (ENABLED_VALUES.has(normalized)) return false;
 
-	// 打ち間違いを **silent に「有効」へ倒さない**。停止したつもりの人が
-	// 「止まっていない」ことに気付けるよう、実行のたびに warn を残す。
-	// (throw しないのは、障害対応中の typo でアプリ全体を落とさないため。
-	//  env schema 側も同じ理由で booleanStringSchema を使っていない)
+	// #4340 follow-up: 解釈できない値は **「止める」側に倒す**。
+	//
+	// 対象が取り消せない顧客データの物理削除であり、この env は障害対応中に手で打つ。
+	// `=tru` のような打ち間違いを「有効」に倒すと、止めたつもりの運用者が
+	// 「止まっていない」ことに気付けないまま削除が走る (気付く手段が warn ログしかない)。
+	// 同じ #4327 の対処が `metadataIncomplete` で「判定材料の欠落は安全側に倒す」を
+	// 採っているのと同じ向きに揃える。
+	//
+	// throw しないのは変えていない (障害対応中の typo でアプリ全体を落とさないため)。
+	// 「throw しない」ことと「有効に倒す」ことは別で、止める側に倒しても throw は要らない。
+	//
+	// 止まったことは 200 + `disabled: true` で観測できる。逆に「止めたつもりで止まらない」は
+	// 削除が完了するまで観測できない — 非対称なので観測できる側に倒す。
 	logger.warn(
-		`[grace-period] ${GRACE_PERIOD_DELETION_DISABLED_ENV} の値を解釈できません。物理削除は「有効」として続行します`,
+		`[grace-period] ${GRACE_PERIOD_DELETION_DISABLED_ENV} の値を解釈できません。物理削除は「停止」として扱います`,
 		{ context: { value: raw, expected: [...DISABLED_VALUES].join(' / ') } },
 	);
-	return false;
+	return true;
 }
 
 export async function purgeExpiredSoftDeletedTenants(opts?: {

--- a/tests/unit/services/grace-period-service.test.ts
+++ b/tests/unit/services/grace-period-service.test.ts
@@ -557,16 +557,18 @@ describe('grace-period-service', () => {
 				expect(result.tenantsDeleted).toBe(1);
 			});
 
-			// 「止めたつもりだが止まっていない」を silent にしない。
-			// throw しない (障害対応中の typo でアプリ全体を落とさない) 代わりに warn を必ず出す。
-			it('解釈できない値は有効のまま続行するが、warn で観測可能にする', async () => {
+			// #4340 follow-up: 「止めたつもりだが止まっていない」を作らない。
+			// 対象が取り消せない削除であり、止め忘れ (200 + disabled で観測できる) より
+			// 止め損ない (削除が終わるまで観測できない) の方が回復不能なので、止める側に倒す。
+			// throw しないのは据え置き (障害対応中の typo でアプリ全体を落とさない) — warn は必ず出す。
+			it('解釈できない値は「停止」として扱い、1 件も削除せず warn で観測可能にする', async () => {
 				seedExpiredTenants(['t1']);
 				mockEnv.GRACE_PERIOD_DELETION_DISABLED = 'ture'; // よくある打ち間違い
 
 				const result = await purgeExpiredSoftDeletedTenants({ dryRun: false });
 
-				expect(result.disabled).toBe(false);
-				expect(result.tenantsDeleted).toBe(1);
+				expect(result.disabled).toBe(true);
+				expect(result.tenantsDeleted).toBe(0);
 				expect(logger.warn).toHaveBeenCalledWith(
 					expect.stringContaining('GRACE_PERIOD_DELETION_DISABLED'),
 					expect.objectContaining({ context: expect.objectContaining({ value: 'ture' }) }),


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 退会した家族（元利用者） / 運営

**解決する課題**: 顧客データの物理削除 cron の kill-switch `GRACE_PERIOD_DELETION_DISABLED` が、**解釈できない値を「有効（削除する）」側に倒していた**。`=tru` のような打ち間違いをすると、止めたつもりの運用者は**気付く手段が warn ログしか無いまま、取り消せない削除が走る**のを見過ごす。

**期待される効果**: 打ち間違いは「停止」として扱われ、削除は走らない。止まったことは cron の応答（`200` + `disabled: true`）で観測できるため、運用者は「止まりすぎ」にはすぐ気付ける。

## 関連 Issue

<!-- no-issue-close: PR #4340（Closes #4327）の QM レビューで検出した follow-up。#4327 は #4340 で close 済みのため、本 PR は新たに Issue を close しない。 -->

PR #4340 の QM 承認時に指摘した点の修正です（#4327 / #4340 の follow-up）。#4340 は既に merge 済みで、本 PR はその上に載ります。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 解釈できない値を「停止」として扱う | `src/lib/server/services/grace-period-service.ts` の `isPhysicalDeletionDisabled()` を目視 | 末尾の `return false` を `return true` に変更。`DISABLED_VALUES`（`true`/`1`/`yes`/`on`）と `ENABLED_VALUES`（`false`/`0`/`no`/`off`/`''`）の判定は不変 |
| AC2 | 未設定（`undefined`）の挙動は変えない | 同上 `if (raw === undefined) return false;` | **無変更**。未設定 = 従来どおり有効。本 PR が変えるのは「値はあるが解釈できない」場合のみ |
| AC3 | 打ち間違い時に 1 件も削除されないことをテストで固定 | `tests/unit/services/grace-period-service.test.ts` の `'ture'` negative case | `expect(result.disabled).toBe(true)` / `expect(result.tenantsDeleted).toBe(0)` に更新。warn が実際の値を含むことの assert は維持 |
| AC4 | warn の文言が新しい挙動と一致する | 同上 | 「物理削除は『有効』として続行します」→「物理削除は『停止』として扱います」 |
| AC5 | 配布ドキュメントを実装に合わせる | `.env.example` / `docs/runbooks/grace-period-deletion-operations.md` | 両方に「解釈できない値は停止として扱う」と、そう倒した理由（観測可能性の非対称）を追記 |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（顧客画面の描画・文言・導線は不変）。挙動が変わるのは `GRACE_PERIOD_DELETION_DISABLED` に**解釈できない値が入っているとき**だけで、現在この変数は GitHub Actions Variables に**未設定**（`gh variable list` で実測）。

- [ ] 並行実装ペアを同期した
- [ ] LP ↔ アプリ整合 (ADR-0013)
- [x] **設計書同期 (ADR-0001)**: `.env.example` / `docs/runbooks/grace-period-deletion-operations.md`
- [ ] 重量 e2e 敏感領域
- [ ] N/A

**並行 PR overlap (#1200)**: #4344（back-merge）が `infra/lib/compute-stack.ts` と `13-AWS設計書` を触りますが、本 PR は `grace-period-service.ts` / test / `.env.example` / runbook のみで**ファイル重複なし**。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| 該当 unit test | `npx vitest run tests/unit/services/grace-period-service.test.ts` | **ローカル未実行**。本クローンは `@storybook/addon-vitest` 未インストールで `vite.config.ts` の読み込み自体が失敗する（`ERR_MODULE_NOT_FOUND`）。CI の `unit-test` で判定する |
| biome | `npx biome check` | **ローカル未実行**（`@biomejs/biome` が本クローンに無く `node_modules/.bin/biome` が存在しない）。CI の `lint-and-test` で判定する |

**正直な申告**: 上記 2 つはローカルで回せていません。手で追った範囲では、変更は `return false` → `return true` の 1 行と、それに対応する test の期待値 2 行、warn 文言 1 箇所、docs 2 file です。`isPhysicalDeletionDisabled()` の他の分岐（`undefined` / `DISABLED_VALUES` / `ENABLED_VALUES`）には触れていません。

- [x] **SOLID / DRY / YAGNI**: 新規の機構を足していない。既存の分岐 1 つの戻り値を変えるだけ
- [x] **Security（OSS 公開前提）**: 秘密情報なし
- [ ] **A11y・パフォーマンス**: N/A（UI 非影響）
- [ ] **Critical バグ修正**(ADR-0002): N/A（#4340 が塞いだ穴の follow-up であり、単独では critical ではない）

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: サーバー側 cron の分岐 1 つの変更で、顧客に描画される画面が存在しない -->

N/A（バックエンド修正のみ。`.svelte` の変更 0 件）

## レビュー依頼事項・破壊的変更

**破壊的変更**: なし。**未設定時の挙動は変えていません**（未設定 = 有効、従来どおり）。変わるのは「値はあるが `true`/`1`/`yes`/`on`/`false`/`0`/`no`/`off`/空文字 のどれでもない」場合だけです。

**確認してほしい点**:

1. **倒す向きの妥当性**。止め忘れ（削除されない）と止め損ない（削除される）を比べると、**止め忘れは `200` + `disabled: true` で観測できるのに対し、止め損ないは削除が完了するまで観測できません**。回復不能な側を避ける判断で「停止」に倒しました。逆に「止まりすぎて保持期間ポリシーから外れる」リスクは、観測できるぶん回復可能と考えています

2. **#4340 の設計判断を覆している点**。#4340 のコメントは「throw しないのは障害対応中の typo でアプリ全体を落とさないため」と説明していますが、**throw しないことと有効に倒すことは別**で、止める側に倒しても throw は不要です。#4340 自身が `metadataIncomplete` で「判定材料の欠落は安全側に倒す」を採っており、kill-switch のパースだけが逆向きでした。その向きを揃えています

## 配布済み env / secret (ADR-0006)

**新規 env なし。** `GRACE_PERIOD_DELETION_DISABLED` は #4340 で配布済み（`.env.example` / `deploy.yml` 5 箇所 / `compute-stack.ts`）。本 PR は既存 env の**解釈**だけを変えます。

なお `gh variable list --repo Takenori-Kusaka/ganbari-quest` で実測した結果、この変数は現在 GitHub Actions Variables に**設定されていません**（= 未設定 = 有効、従来どおり）。

## Ready for Review チェックリスト

- [x] 変更が 1 分岐に閉じていることを diff で確認した
- [x] 未設定時の挙動を変えていないことを確認した
- [x] 配布ドキュメント（`.env.example` / runbook）を実装に同期した

## QM レビュー結果

本 PR は **QM が #4340 のレビュー中に検出して起票**したものです。**approve は Dev / PO 側にお願いします**（ADR-0022 作成者 ≠ 承認者）。PR 作成は `Takenori-Kusaka`、commit author は `ganbariquestsupport-lab`。


## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 (revert で戻る)"]
    R2["顧客面: 退会テナントの物理削除の起動可否"]
    R3["ロールバック: revert のみ。データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 打ち間違いで削除が走る事故を封じる"]
    T2["捨てる: 打ち間違いで削除が止まる方に倒れる"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: 止まったまま放置され保持が積む"]
    O2["UX: 有効化したつもりで止まる逆誤解"]
    O3["security: QM 起票を QM が承認する形"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["変化なし。env が不正値のときだけ挙動が変わる"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 不正値は止める側で倒してよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R2,T2,O1,O2,O3 warn
  class R1,R3,T1,C1 ok
  class Q1 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

**倒す向きの根拠は観測可能性の非対称**です。止め忘れ（削除されない）は cron の応答 `200` + `disabled: true` で観測できますが、止め損ない（削除される）は削除が完了するまで観測できません。回復不能な側を避けています。

**#4340 自身が `metadataIncomplete` で「判定材料の欠落は安全側に倒す」を採っており、kill-switch のパースだけが逆向き**でした。その向きを揃えています。

**`throw しない` 点は据え置き**です。#4340 のコメントは「throw しないのは障害対応中の typo でアプリ全体を落とさないため」と説明していますが、throw しないことと有効に倒すことは別で、止める側でも throw は要りません。

**未設定時の挙動は変えていません**（未設定 = 有効、従来どおり）。変わるのは「値はあるが `true`/`1`/`yes`/`on`/`false`/`0`/`no`/`off`/空文字 のどれでもない」場合だけです。

③ の反対理由は `tmp/adversarial-evidence/4351.json` から転記しています。

</details>
