### PR TITLE
fix(ci): scripts/__tests__ の 13 file を全件走らせ、未実行のまま壊れていた 3 件を直す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,23 +318,24 @@ jobs:
         # 二重防御: tests/unit/scripts/check-guide-copy.test.ts も baseline 0 を vitest で検証。
         run: npx tsx scripts/check-guide-copy.ts --fail-on-violation
 
-      - name: Scripts unit tests (node:test for check-doc-code-references.mjs) (#2259 C3)
-        # #2259 C3 fix: vitest config は tests/unit/** / tests/integration/** のみで
-        # scripts/__tests__/*.test.mjs は vitest 対象外。node --test を CI gate に組み込む。
-        # 本 step は scripts/check-doc-code-references.mjs の CLI 動作 (path-set diff /
-        # sandbox 隔離 / Deprecated marker / fenced code 除外 / inline/bare 区別) を検証する。
-        run: node --test scripts/__tests__/check-doc-code-references.test.mjs
-
-      - name: Scripts unit tests (node:test for orphan-utils.mjs) (#4030 AC6)
-        # orphan baseline の免除理由 gate の **生成側** (`--update-baseline` が検出理由を
-        # 免除理由の欄に流用しないこと) を検証する。vitest から import すると checkJs が
-        # orphan-utils.mjs の pre-existing 型エラーを拾うため node:test 側に置いている。
+      - name: Scripts unit tests (node:test, scripts/__tests__/ 全件)
+        # vitest config は tests/unit/** / tests/integration/** のみを見るため
+        # scripts/__tests__/*.test.mjs は vitest の対象外 (#2259 C3)。node --test を CI gate に
+        # 組み込む。
         #
-        # NOTE: 本 step も上と同じく file 名の literal 指定である。scripts/__tests__/ には
-        # 現在 13 file あり、CI から実行されているのは本 step を入れて 3 file だけ。
-        # glob 化 (`node --test scripts/__tests__/*.test.mjs`) は残り 3 test の drift 修正が
-        # 要るため別 PR に分ける (Issue #4030 のコメントに実測値付きで記録)。
-        run: node --test scripts/__tests__/check-orphan-utils.test.mjs
+        # **glob で渡す (file 名の literal 列挙をしない)**。旧実装は literal path を 2〜3 行
+        # 書いていただけで、13 file 中 10 file がどこからも実行されず、そのうち 3 file は
+        # 実行されないまま drift して壊れていた (#4084 で意図的に変えた skip→fail に test が
+        # 追随していない 等)。「テストがある」と「検査されている」が一致しない状態を作らない。
+        #
+        # glob は quote する — shell ではなく node 側に展開させることで、実行対象が
+        # runner の shell 挙動に依存しなくなる。
+        # 対応関係 (= 全 file が本 step でカバーされること) は
+        # tests/unit/architecture/scripts-node-test-ci-coverage.test.ts が機械検証する。
+        #
+        # NOTE: check-cdk-cfn-lint.test.mjs は cfn-lint (Python) 不在時に自ら skip するため、
+        # 本 job (cfn-lint 未 install) では skip、cdk-cfn-lint job では実検証される。
+        run: node --test "scripts/__tests__/**/*.test.mjs"
 
       - name: LP SSOT HTML baseline check (#1465 Phase A)
         run: node scripts/check-lp-ssot.mjs

--- a/scripts/__tests__/check-ss-blob-sha-uniqueness.test.mjs
+++ b/scripts/__tests__/check-ss-blob-sha-uniqueness.test.mjs
@@ -295,14 +295,48 @@ describe('checkSsBlobShaUniqueness (E2E)', () => {
 		assert.equal(result.status, 'skip');
 	});
 
-	it('before-only (single side) → skip (AC4: ペアなし)', async () => {
+	// #4084 AC1 で挙動を変えた: SS が embed されているのにペアが 0 件 = 偽装検知を 1 度も
+	// 実行できていない状態であり、それを skip (= pass 扱い) で通すと gate が黙って無効化される
+	// (実測: PR #4080 は SS 20 枚 embed 済で 1 ペアも検査されないまま通っていた)。
+	// 旧 test はこの変更前の `skip` 期待のまま CI 未実行下で drift していた。
+	it('before-only (single side) → fail (#4084 AC1: ペア 0 件は検査未実行なので通さない)', async () => {
 		const body = '![before](https://raw.githubusercontent.com/o/r/screenshots/pr-1/before-x.png)';
 		const result = await checkSsBlobShaUniqueness({
 			body,
 			labels: [],
 			fetcher: makeMockFetcher({ 'pr-1/before-x.png': 'sha1' }),
 		});
-		assert.equal(result.status, 'skip');
+		assert.equal(result.status, 'fail');
+		assert.match(result.reason, /ペアが 0 件/);
+		assert.equal(result.pairingHelp, true);
+	});
+
+	it('ペア 0 件 + 理由付き ss-pair-none 宣言 → pass (#4084 AC1 の明示経路)', async () => {
+		const body = [
+			'![before](https://raw.githubusercontent.com/o/r/screenshots/pr-1/before-x.png)',
+			'<!-- ss-pair-none: 新規画面のため修正前の画面が存在しない -->',
+		].join('\n');
+		const result = await checkSsBlobShaUniqueness({
+			body,
+			labels: [],
+			fetcher: makeMockFetcher({ 'pr-1/before-x.png': 'sha1' }),
+		});
+		assert.equal(result.status, 'pass');
+		assert.match(result.reason, /ss-pair-none/);
+	});
+
+	it('ペア 0 件 + 定型 stub の ss-pair-none → fail (理由の非強制を作らない、#3956)', async () => {
+		const body = [
+			'![before](https://raw.githubusercontent.com/o/r/screenshots/pr-1/before-x.png)',
+			'<!-- ss-pair-none: TODO -->',
+		].join('\n');
+		const result = await checkSsBlobShaUniqueness({
+			body,
+			labels: [],
+			fetcher: makeMockFetcher({ 'pr-1/before-x.png': 'sha1' }),
+		});
+		assert.equal(result.status, 'fail');
+		assert.match(result.reason, /理由が空 \/ 定型 stub/);
 	});
 
 	it('複数ペアで一部のみ偽装 → fail (該当ペアのみ violation)', async () => {

--- a/scripts/__tests__/generate-lp-labels.test.mjs
+++ b/scripts/__tests__/generate-lp-labels.test.mjs
@@ -23,6 +23,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
 	isTemplateLiteral,
+	parseAllNamespacesResolved,
 	parseBlock,
 	parseBlockLine,
 	resolveAllTemplates,
@@ -227,12 +228,12 @@ describe('parseBlock — template literal 統合 (#1917 AC6)', () => {
 		const fixture = `
 export const PLAN_TERMS = {
 	standard: 'スタンダード',
-	family: 'ファミリー',
+	premium: 'プレミアム',
 };
 
 export const LP_PLAN_LABELS = {
 	standardLabel: \`\${PLAN_TERMS.standard}プラン\`,
-	familyLabel: \`\${PLAN_TERMS.premium}プラン\`,
+	premiumLabel: \`\${PLAN_TERMS.premium}プラン\`,
 	mixedNote: 'これは静的テキスト',
 };
 `;
@@ -246,7 +247,7 @@ export const LP_PLAN_LABELS = {
 
 		assert.equal(resolved.PLAN_TERMS.standard, 'スタンダード');
 		assert.equal(resolved.LP_PLAN_LABELS.standardLabel, 'スタンダードプラン');
-		assert.equal(resolved.LP_PLAN_LABELS.familyLabel, 'ファミリープラン');
+		assert.equal(resolved.LP_PLAN_LABELS.premiumLabel, 'プレミアムプラン');
 		assert.equal(resolved.LP_PLAN_LABELS.mixedNote, 'これは静的テキスト');
 	});
 
@@ -297,12 +298,22 @@ export const LP_HERO_PRICE_BAND_LABELS = {
 });
 
 // ---------------------------------------------------------------------------
-// AC5: shared-labels.js 出力差分ゼロ（本 PR 単独では terms.ts 未導入のため、
-//      既存 labels.ts に template literal が混入していないことを確認）
+// 実 labels.ts / terms.ts を通した解決 (旧 #1917 AC5 の再照準)
+//
+// 旧 test は「labels.ts に template literal が混入していないこと」を assert していた。これは
+// terms.ts 導入前 (#1916 の前) の過渡状態を固定したもので、#1916 / ADR-0045 で labels.ts が
+// terms.ts atom を interpolation 参照する compound になった時点で意味が反転している
+// (今は template literal があるのが正しい)。本 file は CI で実行されていなかったため
+// 反転に気づけないまま残っていた。
+//
+// 実装を古い仕様に戻すのではなく、今守るべき不変条件に照準し直す:
+//   1. 実 labels.ts の LP namespace に template literal が現に存在する (ADR-0045 の atom 参照が
+//      効いている = 「全部 plain string に戻した」退行を検出する)
+//   2. 実 labels.ts + terms.ts を通したとき、全 namespace の全 value が解決済みの string になる
+//      (未解決の interpolation が LP へ配信されない)
 // ---------------------------------------------------------------------------
-describe('既存 labels.ts は template literal を含まない (#1917 AC5)', () => {
-	it('parseBlock の戻り値は string のみ (TemplateLiteralValue 不在)', async () => {
-		// 実 labels.ts を読み込んで全 namespace を検査
+describe('実 labels.ts / terms.ts は template literal を含み、かつ全て解決できる (ADR-0045)', () => {
+	it('LP namespace に template literal が現に存在する (atom 参照が生きている)', async () => {
 		const fs = await import('node:fs');
 		const path = await import('node:path');
 		const url = await import('node:url');
@@ -310,7 +321,6 @@ describe('既存 labels.ts は template literal を含まない (#1917 AC5)', ()
 		const labelsTs = path.resolve(__dirname, '../../src/lib/domain/labels.ts');
 		const src = fs.readFileSync(labelsTs, 'utf-8');
 
-		// ランダム抽出: 主要 LP namespace を 5 件チェック
 		const samples = [
 			'LP_RETENTION_LABELS',
 			'LP_CORELOOP_LABELS',
@@ -318,13 +328,30 @@ describe('既存 labels.ts は template literal を含まない (#1917 AC5)', ()
 			'LP_PRICING_LABELS',
 			'LP_FAQ_LABELS',
 		];
+		let templateCount = 0;
 		for (const name of samples) {
 			const block = parseBlock(src, name);
+			assert.ok(Object.keys(block).length > 0, `${name} が parseBlock で読めていない`);
+			for (const value of Object.values(block)) {
+				if (isTemplateLiteral(value)) templateCount += 1;
+			}
+		}
+		assert.ok(
+			templateCount > 0,
+			'LP namespace に template literal が 1 件も無い。terms.ts atom 参照 (ADR-0045) が文字列直書きへ退行した可能性がある',
+		);
+	});
+
+	it('parseAllNamespacesResolved の結果は全て解決済み string (未解決の interpolation が残らない)', () => {
+		const resolved = parseAllNamespacesResolved();
+		assert.ok(Object.keys(resolved).length > 0, 'namespace が 1 件も解決されていない');
+		const unresolvedPattern = /\$\{/;
+		for (const [ns, block] of Object.entries(resolved)) {
 			for (const [key, value] of Object.entries(block)) {
-				assert.equal(
-					typeof value,
-					'string',
-					`labels.ts ${name}.${key} should be plain string (not template literal yet — #1916 で導入予定)`,
+				assert.equal(typeof value, 'string', `${ns}.${key} が解決後も string になっていない`);
+				assert.ok(
+					!unresolvedPattern.test(String(value)),
+					`${ns}.${key} に未解決の interpolation が残っている: ${value}`,
 				);
 			}
 		}

--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -814,8 +814,12 @@ if (invokedAsCli) {
 
 // #1772: 単体テスト用に parseBlock / parseSimpleBlock をエクスポート
 // #1917: template literal 解決ロジックも追加 (parseBlockLine / resolveTemplateLiteralValue / resolveAllTemplates / isTemplateLiteral)
+// 実 labels.ts + terms.ts を通した解決結果 (= 生成パイプラインそのもの) を test から検査するため
+// parseAllNamespacesResolved も公開する。個々の parser だけを検査すると「実データでは解決できない」
+// 状態を通してしまう。
 export {
 	isTemplateLiteral,
+	parseAllNamespacesResolved,
 	parseBlock,
 	parseBlockLine,
 	parseSimpleBlock,

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -77,6 +77,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: '#4085 実測 例4 (5533ms で timeout)。.github + scripts を走査する scanner の健全性検査 (#4007)',
 	},
+	'tests/unit/architecture/scripts-node-test-ci-coverage.test.ts': {
+		scope: 'repo',
+		note: 'scripts/__tests__ を再帰 readdir し、ci.yml の node --test 引数が全 file をカバーするか検査する。走査は 1 dir で有界だが静的判定は保守的に repo と見なすため、判定に合わせて明示 timeout を置く',
+	},
 	'tests/unit/architecture/cloudfront-s3-user-content-bypass-fitness.test.ts': {
 		scope: 'repo',
 		note: 'infra 配下の CDK 定義を走査して配信経路の bypass を検出する',

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -48,6 +48,15 @@ CI ログでも同 warning が出るため、PR の CI fail 調査時にまず�
 判断: 実サーバー必要 → E2E / 不要 + モックで完結 → Integration / それ以外 → Unit。
 `tests/e2e/integration/upgrade-checkout.spec.ts` は `page.route()` で Stripe モック (Integration 相当) だが cognito-dev 認証必要のため `playwright.cognito-dev.config.ts` 管理。
 
+### `scripts/__tests__/` の node:test（vitest 管轄外）
+
+`scripts/*.mjs` の CLI 動作テストは `scripts/__tests__/*.test.mjs` に置き、**node:test で書く**（vitest の include は `tests/unit/**` / `tests/integration/**` のみで、ここは対象外）。
+
+- **CI では `ci.yml` の `Scripts unit tests (node:test, scripts/__tests__/ 全件)` step が glob で全件走らせる。** file を足せば自動で対象に入るので **ci.yml を触る必要はない**
+- **実行対象を literal path の列挙に戻さない。** 旧実装は literal を 2〜3 行書いていただけで、13 file 中 10 file が未実行、うち 3 file は実行されないまま drift して壊れていた
+- 対応関係は `tests/unit/architecture/scripts-node-test-ci-coverage.test.ts` が機械検証する（未カバー file / literal 列挙への退行で fail）
+- ローカル実行: `node --test "scripts/__tests__/**/*.test.mjs"`（glob は quote する — shell ではなく node 側に展開させる）
+
 ## repo 走査 test (実行コストが入力サイズに比例する test) — #4085
 
 ### 定義

--- a/tests/unit/architecture/scripts-node-test-ci-coverage.test.ts
+++ b/tests/unit/architecture/scripts-node-test-ci-coverage.test.ts
@@ -68,7 +68,7 @@ function extractNodeTestPatterns(workflowSrc: string): string[] {
 	// `(.+)$` が丸ごと不成立になり「引数 0 件」= 検査が黙って消える。改行を先に正規化する。
 	for (const line of workflowSrc.replace(/\r\n?/g, '\n').split('\n')) {
 		const m = line.match(/node\s+--test\s+(.+)$/);
-		if (!m) continue;
+		if (!m?.[1]) continue;
 		const args = m[1].trim();
 		for (const raw of args.split(/\s+/)) {
 			const arg = raw.replace(/^["']|["']$/g, '');

--- a/tests/unit/architecture/scripts-node-test-ci-coverage.test.ts
+++ b/tests/unit/architecture/scripts-node-test-ci-coverage.test.ts
@@ -1,0 +1,134 @@
+/**
+ * tests/unit/architecture/scripts-node-test-ci-coverage.test.ts
+ *
+ * 「テストが書かれている」と「テストが実行されている」が一致していることを機械で固定する。
+ *
+ * ## 何が起きていたか（実測）
+ *
+ * `scripts/__tests__/` には 13 file の `*.test.mjs` があるが、`ci.yml` は
+ * `node --test <literal path>` を 3 行書いていただけで、**10 file はどこからも実行されて
+ * いなかった**（`vitest.config` の include も `tests/unit/**` / `tests/integration/**` のみで
+ * 対象外）。実行されない期間に仕様が変わり、**3 file が壊れたまま気づかれずに残っていた**:
+ *
+ * - `check-ss-blob-sha-uniqueness` — #4084 で意図的に `skip → fail` へ変えた挙動に test が未追随
+ * - `generate-lp-labels` × 2 — fixture の key 不整合 / #1916 (ADR-0045) で意味が反転した assert
+ *
+ * ## 本 test が固定すること
+ *
+ * 実行対象が **人手で維持される literal list** である限り、今日の 3 件を直しても
+ * 「次に test を足した人が ci.yml に 1 行足し忘れる」で同じ状態に戻る。そこで
+ * **「新しい test file を足したら自動で実行対象に入る」ことそのもの**を検査する:
+ *
+ * 1. `scripts/__tests__/**\/*.test.mjs` の全 file が、`ci.yml` のいずれかの `node --test`
+ *    コマンドの引数（glob 含む）でカバーされていること
+ * 2. カバーしているコマンドが **glob であること**（literal 列挙に戻すと、追加時の 1 行漏れで
+ *    また実行されない file が生まれるため、literal だけで全件カバーしていても fail させる）
+ *
+ * ADR-0061（same-class-N→guard / fitness function）。同 class の先行例:
+ * `ci-unit-test-path-filter-closure.test.ts`（#4007、path filter の closure）。
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+// #4085: repo 走査 test の区分宣言 (scripts/lib/ci/repo-scan-test-registry.mjs) に合わせた明示 timeout。
+vi.setConfig({ testTimeout: 20_000 });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+const SCRIPTS_TESTS_DIR = 'scripts/__tests__';
+const CI_WORKFLOW = '.github/workflows/ci.yml';
+
+/** `scripts/__tests__/` 配下の test file（repo 相対、POSIX 区切り）を再帰列挙する。 */
+function listScriptTestFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(path.join(REPO_ROOT, dir), { withFileTypes: true })) {
+		const rel = `${dir}/${entry.name}`;
+		if (entry.isDirectory()) {
+			out.push(...listScriptTestFiles(rel));
+		} else if (entry.name.endsWith('.test.mjs')) {
+			out.push(rel);
+		}
+	}
+	return out.sort();
+}
+
+/**
+ * ci.yml から `node --test <args...>` の引数群を抽出する。
+ *
+ * quote (`"..."` / `'...'`) は剥がし、`node` のオプション (`--test-*` 等) は落とす。
+ */
+function extractNodeTestPatterns(workflowSrc: string): string[] {
+	const patterns: string[] = [];
+	// CRLF で読んだ場合、`.` は `\r` にマッチしない (JS regex では line terminator 扱い) ため
+	// `(.+)$` が丸ごと不成立になり「引数 0 件」= 検査が黙って消える。改行を先に正規化する。
+	for (const line of workflowSrc.replace(/\r\n?/g, '\n').split('\n')) {
+		const m = line.match(/node\s+--test\s+(.+)$/);
+		if (!m) continue;
+		const args = m[1].trim();
+		for (const raw of args.split(/\s+/)) {
+			const arg = raw.replace(/^["']|["']$/g, '');
+			if (!arg || arg.startsWith('-')) continue;
+			patterns.push(arg);
+		}
+	}
+	return patterns;
+}
+
+/**
+ * node の test runner が受け取る glob（`*` / `**`）を、対象 path にマッチするか判定する。
+ *
+ * `*` は `/` を跨がず、`**` は跨ぐ（node / picomatch と同じ意味）。
+ */
+function matchesPattern(pattern: string, filePath: string): boolean {
+	if (!pattern.includes('*')) return pattern === filePath;
+	const regexSrc = pattern
+		.split('/')
+		.map((seg) => {
+			if (seg === '**') return '(?:.*)';
+			return seg
+				.split('*')
+				.map((s) => s.replace(/[.+?^${}()|[\]\\]/g, '\\$&'))
+				.join('[^/]*');
+		})
+		.join('/')
+		// `a/**/b` の `**` が 0 セグメントにもマッチするようにする
+		.replace(/\/\(\?:\.\*\)\//g, '/(?:.*/)?');
+	return new RegExp(`^${regexSrc}$`).test(filePath);
+}
+
+describe('scripts/__tests__ の全 test file が CI の実行対象に入っている', () => {
+	const testFiles = listScriptTestFiles(SCRIPTS_TESTS_DIR);
+	const workflowSrc = readFileSync(path.join(REPO_ROOT, CI_WORKFLOW), 'utf8');
+	const patterns = extractNodeTestPatterns(workflowSrc);
+
+	it('前提: 走査対象の test file と ci.yml の node --test 引数がどちらも 1 件以上ある', () => {
+		// 走査が空振りしたまま「違反 0 件」で緑になる silent-pass を塞ぐ (#4007 と同 class)。
+		expect(testFiles.length).toBeGreaterThan(0);
+		expect(patterns.length).toBeGreaterThan(0);
+	});
+
+	it('全 file がいずれかの node --test 引数でカバーされている', () => {
+		const uncovered = testFiles.filter((f) => !patterns.some((p) => matchesPattern(p, f)));
+		expect(
+			uncovered,
+			`ci.yml の node --test から実行されない test file がある。実行されない test は` +
+				` drift しても気づけない (実測: 10 file 未実行 / うち 3 file が壊れていた)。` +
+				` glob (${SCRIPTS_TESTS_DIR}/**/*.test.mjs) で渡すこと`,
+		).toEqual([]);
+	});
+
+	it('カバーしているのが glob である（literal 列挙に戻さない）', () => {
+		const globPatterns = patterns.filter((p) => p.includes('*') && p.startsWith(SCRIPTS_TESTS_DIR));
+		const coveredByGlob = testFiles.filter((f) => globPatterns.some((p) => matchesPattern(p, f)));
+		expect(
+			coveredByGlob,
+			`literal path の列挙は「test を足したら 1 行足す」を人の注意に依存させるため禁止する。` +
+				` ci.yml では node --test "${SCRIPTS_TESTS_DIR}/**/*.test.mjs" のように glob で渡すこと`,
+		).toEqual(testFiles);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: Dev / QM（CI 検証装置の利用者）

**解決する課題**: `scripts/__tests__/` には node:test の CLI テストが **13 file** あるが、`ci.yml` は `node --test <literal path>` を **3 行書いていただけ**で、**10 file はどこからも実行されていなかった**（`vitest.config` の include も `tests/unit/**` / `tests/integration/**` のみで対象外）。実行されない期間に対象実装の仕様が変わり、**3 file が壊れたまま気づかれずに残っていた**。「テストがある」ことが「検査されている」ことを意味しない状態だった。

**期待される効果**: 13 file すべてが CI で走る。かつ **実行対象が人手で維持される literal list であること自体**を fitness function で禁止したので、新しい test を足したら自動で対象に入る（ci.yml を触る必要がない）。今日の 3 件を直すだけでは「次に test を足した人が 1 行足し忘れる」で同じ状態に戻るため、そこを機械で塞いだ。

## 関連 Issue

<!-- no-issue-close: チーム憲章 docs/sessions/README.md §0 ルール 7 に従い Issue を起票せず PR で直接出している（装置・プロセスの改善は Issue を介さない）。同ルールで #4323 が close 済み。#4030 のコメントに本件の実測が記録されているが、#4030 の残 scope は AC6 のみで PR #4346 が消化済みであり、そこに相乗りする余地はない -->

本 PR は Issue を close しません（§0 ルール 7: 装置・プロセスの改善は気づいた時点で PR を出す）。観察の出所は #4030 のコメント（AC6 実装時の副次発見。「glob 化は別 PR に分ける」と明記されている）で、#4030 自体の残 scope は AC6 のみで PR #4346 が消化済みです。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 修正前の実測: `scripts/__tests__/*.test.mjs` は 13 file あるが CI 対象は 3 file のみ | `ls scripts/__tests__/*.test.mjs \| wc -l` / `grep -n "node --test" .github/workflows/ci.yml`（origin/develop 時点） | file 数 **13**。ci.yml の `node --test` 実行行は **3 行**（`check-doc-code-references` / `check-orphan-utils` = lint-and-test job、`check-cdk-cfn-lint` = cdk-cfn-lint job）。差 **10 file が未実行** |
| AC2 | 修正前の実測: 全件走らせると 3 件 fail する | `node --test "scripts/__tests__/**/*.test.mjs"`（origin/develop 時点） | `# tests 237 / # pass 234 / # fail 3`。fail の内訳 = `check-ss-blob-sha-uniqueness` 1 件 + `generate-lp-labels` 2 件（下 AC4〜AC6） |
| AC3 | CI が 13 file 全件を走らせる。かつ literal 列挙をやめ、新規 file が自動で対象に入る | `ci.yml` の該当 step を `node --test "scripts/__tests__/**/*.test.mjs"` に置換（glob は node 側に展開させるため quote）。修正後に同コマンドを実行 | ローカル `# tests 240 / # pass 240 / # fail 0`（13 file 全件）。**CI 実測**（run 31090909183 の `lint-and-test` step `Scripts unit tests (node:test, scripts/__tests__/ 全件)`）= `# tests 240 / # pass 238 / # fail 0`（差 2 = cfn-lint 未 install による自己 skip）。cdk-cfn-lint job の literal step は据置（cfn-lint 実 install 環境での検証を残すため。lint-and-test 側では当該 test が自ら skip する設計） |
| AC4 | fail 1: `check-ss-blob-sha-uniqueness` — **test 側**を新仕様に合わせる（実装を古い仕様に戻さない） | test 修正 → `node --test scripts/__tests__/check-ss-blob-sha-uniqueness.test.mjs` | 原因 = #4084 が「SS embed 済でペア 0 件 = 偽装検知が 1 度も実行できていない」を **skip → fail** に意図的に変えたのに test が `skip` 期待のまま。**test を fail 期待に是正**し、あわせて #4084 が用意した escape hatch の coverage を **2 件追加**（理由付き `ss-pair-none` → pass / 定型 stub `TODO` → fail）。`# tests 25 / # pass 25 / # fail 0`（22 → 25 に増加、assertion は削っていない） |
| AC5 | fail 2: `generate-lp-labels` fixture — 生成物と test のどちらが古いかを実測してから直す | fail message を実測（`Unresolved PLAN_TERMS.premium in LP_PLAN_LABELS.familyLabel: key premium not in PLAN_TERMS`） | **test 側の fixture が自己矛盾**していた（fixture 内で `PLAN_TERMS = { standard, family }` を定義しながら `${PLAN_TERMS.premium}` を参照）。生成物 (`site/shared-labels.js`) は無関係で、`node scripts/generate-lp-labels.mjs --check` は修正前から **`✓ site/shared-labels.js は最新です`**。fixture の key を現行 SSOT（`terms.ts` の `PLAN_TERMS.premium = 'プレミアム'`）に合わせて是正 |
| AC6 | fail 3: `generate-lp-labels` の「labels.ts は template literal を含まない」assert — どちらが古いかを実測してから直す | `src/lib/domain/labels.ts` / `terms.ts` / ADR-0045 / DESIGN.md §6 を確認 | **test が古い**。当該 assert は terms.ts 導入前の過渡状態を固定したもので（失敗メッセージ自身が「#1916 で入る想定」の旨を書いている）、**#1916 / ADR-0045 で labels.ts が atom を interpolation 参照する compound になった時点で意味が反転**していた（今は template literal があるのが正しい）。**skip / 削除せず、今守るべき不変条件に照準し直した**: ① LP namespace に template literal が現に存在する（= 文字列直書きへの退行検出）② 実 labels.ts + terms.ts を通した `parseAllNamespacesResolved()` の全 value が解決済み string で未解決の interpolation が残らない（生成パイプラインそのものを検査） |
| AC7 | fitness function の mutation 実測（実行対象から 1 本外すと落ちる） | ci.yml を 3 方向に mutate して `npx vitest run tests/unit/architecture/scripts-node-test-ci-coverage.test.ts` | **A**: glob → literal 2 本（11 file を対象外）→ **fail**（未カバー 10 file を列挙）／ **B**: 13 file 全部を literal 列挙（カバー率 100%）→ **fail**（「literal 列挙への退行」を検出。カバーできていても落とす）／ **C**: 新規 test file を `scripts/__tests__/` に追加 → **pass** かつ `node --test` の実行数が 240 → **241** に自動追随。mutation 後は ci.yml を復元し 3/3 pass を再確認 |
| AC8 | 走査が空振りしたまま「違反 0 件」で緑になる silent-pass を作らない | fitness function に前提 assert を置き、CRLF 読み込み時の regex 不成立を実機で発見・修正 | mutation A の初回試行で **前提 assert が発火**（`patterns.length` 0）。原因は書き戻しで混入した CRLF に対し JS regex の `.` が `\r` にマッチせず `(.+)$` が丸ごと不成立 = 「引数 0 件」で検査が黙って消える経路。改行正規化で是正し、前提 assert 自体をそのまま残した |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [x] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（顧客に見える挙動の変更は 0。CI 実行対象と test / fitness function のみ）

- `scripts/generate-lp-labels.mjs` は **`parseAllNamespacesResolved` の export 追加のみ**で、生成ロジック・生成物は不変（`--check` が修正前後とも `✓ site/shared-labels.js は最新です`）
- 並行レーンとの衝突回避: #4348 が触っている `scripts/check-pr-screenshot.mjs` / `pr-template-gate-checks.mjs` / `check-merge-gate-checklist.mjs` / `check-admin-bypass-evidence.mjs` には**一切触れていない**（それらの test file も本 PR では変更なし。glob 化で実行対象に入るだけで、現状 pass 済み）
- [x] N/A — 並行実装ペア・LP 整合・重量 e2e は影響範囲外。設計書同期は `tests/CLAUDE.md` に運用ルールを追記済（下記）

**設計書同期**: `tests/CLAUDE.md` §テスト分類 に「`scripts/__tests__/` の node:test（vitest 管轄外）」を追加（glob で全件実行 / literal 列挙に戻さない / 機械検証の所在 / ローカル実行コマンド）。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| scripts node:test 全件（修正前、origin/develop） | `node --test "scripts/__tests__/**/*.test.mjs"` | `# tests 237 / # pass 234 / # fail 3` |
| scripts node:test 全件（修正後） | `node --test "scripts/__tests__/**/*.test.mjs"` | **`# tests 240 / # pass 240 / # fail 0`** |
| 新規 fitness function | `npx vitest run tests/unit/architecture/scripts-node-test-ci-coverage.test.ts` | PASS（3/3）。mutation A/B で fail、C で pass を実測（AC7） |
| architecture fitness 全件（回帰確認） | `npx vitest run tests/unit/architecture/` | PASS（47 files / 366 tests） |
| repo 走査 test 区分宣言 gate | `node scripts/check-repo-scan-test-declaration.mjs` | PASS（47 件すべて宣言済、新規 test を registry に追加） |
| LP labels 生成物 drift | `node scripts/generate-lp-labels.mjs --check` | PASS（`✓ site/shared-labels.js は最新です`） |
| doc-code-references | `node scripts/check-doc-code-references.mjs` | PASS（baseline 内、新規違反なし） |
| lint | `npx biome check .` | PASS（2216 files / errors 0） |

- [x] **SOLID / DRY / YAGNI**: 新規 script は追加していない（fitness function は既存の `tests/unit/architecture/` 慣行に相乗り、先行例 `ci-unit-test-path-filter-closure.test.ts` と同型）
- [x] **Security（OSS 公開前提）**: N/A（秘密情報なし。CI の実行対象拡大のみ）
- [ ] **A11y・パフォーマンス**: N/A（UI 変更なし）。CI 実行時間の増分は node:test 全件で約 7 秒
- [ ] **Critical バグ修正**(ADR-0002): N/A（`priority:critical` ではない）

**ADR-0006（assertion 弱体化禁止）の遵守**: 露出した赤を **test の削除 / skip / assertion 弱体化で消していない**。`check-ss-blob-sha-uniqueness` は test 件数が 22 → 25 に増え、`generate-lp-labels` は意味が反転した assert を「実データを通した解決の全数検査」に置換して**強めている**。

## スクリーンショット / ビジュアルデモ

該当なし（CI / test の変更のみで、描画される画面に差分がない）。

<!-- ss-pair-none: CI 実行対象と node:test / fitness function の変更のみで描画される画面が存在しないため -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる

**レビュー依頼事項**:

1. **AC6 の向きの妥当性**（最重要）。「labels.ts に template literal が無いこと」を assert していた test を、「template literal が現にあり、かつ全て解決できること」に**反転**させています。ADR-0045 / DESIGN.md §6 の現行仕様が正しいという前提の判断です。
2. **cdk-cfn-lint job の literal step を残した判断**。glob step（lint-and-test）でも同 file は走りますが、cfn-lint 未 install のため自己 skip します。実検証は cfn-lint pin install 済の `cdk-cfn-lint` job 側の literal step が担う、という二重掲載です。
3. **fitness function が「カバーしていても literal 列挙なら fail」にしている点**。今回の再発機序が「literal list の維持を人に頼る」ことなので意図的に厳しくしています（mutation B で実測）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし。mutation 用の一時 file / ci.yml の書き換えは復元済み）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認（N/A、UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` で実ブラウザ操作した SS を添付（N/A）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
