### PR TITLE
docs(process): #4355 QM spawn テンプレの死んだ見出し参照と共有クローン作業指定を是正する

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -122,7 +122,7 @@ gh issue view <N> --json body --jq '.body' | grep -c '^- \[ \]'
 
 - `required_approving_review_count=1` 強制。Copilot の `COMMENTED` は APPROVED にならない
 - admin bypass 完全禁止（`bypass_actors: []`）。`ganbariquestsupport-lab`（QM 専用）が approve → squash merge
-- approve body は `docs/sessions/qm-session.md` Tier 2 手順 5 の 5 手順（Issue 照合 / SS 実視認 / SS 欠落検知 / CI 確認 / 承認判断）必須
+- approve body は `docs/sessions/qm-session.md` §「Per-PR Review Agent（5 手順）」の 5 手順（Issue 照合 / SS 実視認 / SS 欠落検知 / CI 確認 / 承認判断）必須
 - 500 行超 PR は `pr-info.yml` が自動警告コメント
 
 ### コマンド例

--- a/docs/sessions/dev-process/github-api-head-staleness.md
+++ b/docs/sessions/dev-process/github-api-head-staleness.md
@@ -36,6 +36,6 @@ PR ブランチの最新コミットを正確に把握するためには、`gh p
 
 ## 適用箇所
 
-- Tier 2 QM Re-Review Agent による PR HEAD 検証
-- CI Fix Agent による Push 後のコミット反映確認
+- QM 再レビュー subagent による PR HEAD 検証
+- CI Fix subagent による Push 後のコミット反映確認
 - その他、自動化スクリプト等で PR の最新コミットを厳密に照合する必要があるすべてのケース

--- a/docs/sessions/qm-agent-templates.md
+++ b/docs/sessions/qm-agent-templates.md
@@ -1,23 +1,23 @@
 # QM Agent spawn テンプレート
 
-> Orchestrator が Tier 2 Review Agent / CI Fix Agent を spawn する際の定型プロンプト。`<>` を実値に置換してコピー。
+> lead が レビュー subagent / 修正・再レビュー subagent / CI Fix subagent を spawn する際の定型プロンプト。`<>` を実値に置換してコピー。
 >
-> SSOT: @docs/sessions/qm-session.md
+> SSOT: @docs/sessions/qm-session.md（本ファイルが名指しする見出しは全て同ファイルに実在すること）
 
-## Review Agent（PR ごとに spawn）
+## レビュー subagent（PR ごとに spawn）
 
 ```
-あなたは PR #<num> の QM Review Agent です。
+あなたは PR #<num> の QM レビュー subagent です。
 
 ## 担当 PR
 - 番号: #<num>
 - タイトル: <title>
 - ブランチ: <headRefName>
 - リポジトリ: Takenori-Kusaka/ganbari-quest
-- 作業ディレクトリ: C:\Users\kokor\OneDrive\Document\GitHub\ganbari-quest
+- 作業ディレクトリ: `/c/tmp/` 配下に切った worktree（例: `/c/tmp/qm-<num>`）。**共有クローンで `git checkout` / `git merge` しない**
 
 ## 必須: PR Head の Authoritative 検証 (#2557)
-GitHub API の `headRefOid` は反映遅延 (stale cache) を起こすため、Tier 2 5 手順に着手する前に必ず以下で cross-check を行ってください:
+GitHub API の `headRefOid` は反映遅延 (stale cache) を起こすため、5 手順に着手する前に必ず以下で cross-check を行ってください:
 1. `git ls-remote origin refs/heads/<branch>` で authoritative な最新コミット SHA を取得
 2. `gh pr view <num> --json headRefOid` の値と比較
 3. 乖離がある場合は ls-remote を信頼し、`git fetch origin <branch>` で最新を取得してから手順 1 (Issue 照合) に進む
@@ -26,15 +26,15 @@ GitHub API の `headRefOid` は反映遅延 (stale cache) を起こすため、T
 ヘルパー: `node scripts/verify-pr-head.mjs <num> <branch>` で自動 cross-check 可能 (exit 2 で乖離警告)。
 
 ## ミッション
-`docs/sessions/qm-session.md` の Tier 2 5 手順を最初から読み、PR #<num> に対し手順 1〜5 を全て実行する。
+`docs/sessions/qm-session.md` の §「Per-PR Review Agent（5 手順）」を最初から読み、PR #<num> に対し手順 1〜5 を全て実行する。
 
 ## 責務境界（#2756 / #2815 Q-1 / ADR-0056 §E 追補）
-あなたの責務は **V-0〜V-6（手順 1〜5 の semantic verify + Adversarial evidence 生成・報告）で完結**します。
-**approve / merge コマンドは実行しない**でください（V-7 approve action は QM Orchestrator 本体があなたの完了報告と evidence を verify した後に直接実行します）。
+あなたの責務は **検証と evidence 生成・報告まで（手順 1〜5 の semantic verify + Adversarial evidence 生成）で完結**します。
+**approve / merge コマンドは実行しない**でください（approve / merge は lead 専権であり、lead 本体があなたの完了報告と evidence を verify した後に直接実行します）。
 
-## 完了報告（最後にテキストで Orchestrator に返す）
+## 完了報告（最後にテキストで lead に返す）
 - 手順 1〜4 の各判定（Pass / Block + 根拠 1 行）
-- 最終アクション: `V-0〜V-6 完遂（verify PASS、evidence: tmp/adversarial-evidence/<num>.json）` または `BLOCK（指摘コメント投稿済み）`
+- 最終アクション: `検証・evidence 生成 完遂（verify PASS、evidence: tmp/adversarial-evidence/<num>.json）` または `BLOCK（指摘コメント投稿済み）`
 - Block 時: 指摘内容要約
 
 ## 注意
@@ -43,10 +43,10 @@ GitHub API の `headRefOid` は反映遅延 (stale cache) を起こすため、T
 - SS は Read tool で実際に開く（URL だけ確認は不可）
 ```
 
-## Re-Review Agent（BLOCK 後の再検証）
+## 再レビュー subagent（BLOCK 後の再検証）
 
 ```
-あなたは PR #<num> の QM Re-Review Agent です。
+あなたは PR #<num> の QM 再レビュー subagent です。
 
 ## 担当 PR
 - 番号: #<num>
@@ -61,26 +61,39 @@ GitHub API の `headRefOid` は反映遅延 (stale cache) を起こすため、�
 3. 乖離がある場合は ls-remote を信頼し、`git fetch origin <branch>` で最新を取得してから検証を開始する
 
 ## ミッション
-`docs/sessions/qm-session.md` の Tier 2「Re-Review」手順を読み、前回 BLOCK 箇所の修正を検証する。
+`docs/sessions/qm-session.md` の §「Re-Review（ADR-0026 / #1750）」を読み、前回 BLOCK 箇所の修正を検証する。
 - 修正が PR に含まれているか、最新 HEAD で確認
 - 該当箇所の静的検査 / E2E 等をローカル実行
 - **全 Fix item の物理 verification（#2690 / #2815 D-5）**: Dev 完遂報告に「全件解消 / 全件追加」が含まれる場合、その検証 grep を独立に再実行し件数を突合（Dev の Fix 完遂検証 log と不一致なら再 BLOCK）
 
 ## 責務境界（#2756 / #2815 Q-1 / ADR-0056 §E 追補）
-あなたの責務は **再検証 + evidence 生成・報告で完結**します。**approve / merge コマンドは実行しない**でください（V-7 approve action は QM Orchestrator 本体が実行します）。
+あなたの責務は **再検証 + evidence 生成・報告で完結**します。**approve / merge コマンドは実行しない**でください（approve / merge は lead 専権であり、lead 本体が実行します）。
+
+## 修正も任される場合（②③ を同じ subagent で回すとき）
+`docs/sessions/qm-session.md` の §「②③ 修正・再レビュー subagent へ渡すもの」に従うこと。特に:
+- **作業は `/c/tmp/` 配下の worktree**。共有クローンで `git checkout` / `git merge` しない
+- **commit author は `ganbariquestsupport-lab`**（ADR-0022 Amendment 6）。push は lab で試し、pre-push hook に弾かれたら `Takenori-Kusaka` に切替（author は lab のまま）
+- **`--no-verify` は禁止**。gate に止められたら止まったまま報告する
+- push 前に自分で検証する（CI に丸投げしない）
 
 ## 完了報告
 - 前回 BLOCK 箇所の修正状況（Pass / 再 BLOCK）+ 物理 verification の件数突合結果
 - 再 BLOCK 時は具体的な乖離やエラーを提示
 ```
 
-## CI Fix Agent（Tier 2 手順 4 で CI red 検知時）
+## CI Fix subagent（手順 4 で CI red 検知時）
 
 ```
-あなたは PR #<num> の CI Fix Agent です。
+あなたは PR #<num> の CI Fix subagent です。
 
 ## 担当 PR
-- 番号 / タイトル / ブランチ / リポジトリ / 作業ディレクトリ（Review Agent と同じ）
+- 番号 / タイトル / ブランチ / リポジトリ / 作業ディレクトリ（レビュー subagent と同じ = `/c/tmp/` 配下の worktree）
+
+## 作業規律（qm-session.md §「②③ 修正・再レビュー subagent へ渡すもの」）
+- **作業は `/c/tmp/` 配下の worktree**。共有クローンで `git checkout` / `git merge` しない
+- **commit author は `ganbariquestsupport-lab`**（ADR-0022 Amendment 6）。push は lab で試し、pre-push hook に弾かれたら `Takenori-Kusaka` に切替（author は lab のまま）
+- **`--no-verify` は禁止**。gate に止められたら止まったまま報告する
+- **approve / merge は実行しない**（lead 専権）
 
 ## 失敗 CI checks
 <gh pr checks <num> の失敗行をコピー>
@@ -97,11 +110,11 @@ GitHub API の `headRefOid` は反映遅延 (stale cache) を起こすため、�
 - 修正内容要約 / KB 追記有無 (TA-NNN) / 本質的問題で修正しなかった場合の理由
 ```
 
-### CI Fix Agent 判断基準
+### CI Fix subagent 判断基準
 
 | CI 失敗種類 | 対処 |
 |---|---|
-| ラベル不足（`type:docs` 等） | Fix Agent がラベル追加 |
+| ラベル不足（`type:docs` 等） | CI Fix subagent がラベル追加 |
 | 生成ファイル同期漏れ（`shared-labels.js` 等） | 再生成コマンド実行 + commit |
 | テスト失敗 | 軽微なら修正、本質問題なら BLOCK |
 | 型/lint エラー | 修正可能なら対応 |

--- a/docs/sessions/webui-review-process.md
+++ b/docs/sessions/webui-review-process.md
@@ -186,7 +186,7 @@ PR 作成
 | 役割 | 担当 | レビュー段階 |
 |---|---|---|
 | **A〜D 仕分けの実施 + 還元先実装** | Dev | UI 系 fix / design PR の作成時。仕分け結果を PR body に記載する（dev-session.md §「必ず守ること」） |
-| **仕分けの妥当性レビュー** | QM / QA | per-PR review（`qm-session.md` Tier 2 手順 1〜2）。B/C/D を A で済ませていないか、還元先実装が同 PR にあるかを判定する |
+| **仕分けの妥当性レビュー** | QM / QA | per-PR review（`qm-session.md` §「Per-PR Review Agent（5 手順）」の手順 1〜2）。B/C/D を A で済ませていないか、還元先実装が同 PR にあるかを判定する |
 | **CUJ 横断 UX / a11y レビュー** | 外部品質監査チーム | develop → main 統合前（`audit-team.md` §3.1「ユーザビリティ・a11y」チーム）。CUJ を仮ユーザ persona で通し、NN/G 観点 + WCAG 2.2 AA を検査する |
 
 ### 5.1 「動くが分かりにくい」UX 破綻の捕捉（cognitive-walkthrough）


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（QM セッションとその subagent）／間接的にシステム全体

**解決する課題**: QM lead が subagent に渡す定型プロンプト (`docs/sessions/qm-agent-templates.md`) が、**#4336 で消えた見出しを名指ししたまま**で、かつ **#4336 が新設した「作業は `/c/tmp/` の worktree、共有クローンで `git checkout` / `git merge` させない」に真っ向から反する作業ディレクトリ（OneDrive 共有クローン）** を指定していた。テンプレートは SSOT 本文より先に subagent の目に入るため、レビュー手順を見失った状態で走らせ、かつ共有クローンを触らせる指示になっていた。

**期待される効果**: QM レビューは顧客に届く全変更が通る単一 gate であり、そこで subagent が手順を辿れる／共有クローンを壊さないことが、顧客に届く変更の品質と可逆性を守る。

## 関連 Issue

Closes #4355

Refs #4336（本 PR の起点。merged 2026-08-06、develop に `dbf3f8ad8` として着地済）

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `qm-agent-templates.md` に `Tier 1` / `Tier 2` / `V-0`〜`V-7` が 0 件 | `grep -cE 'Tier [12]\|V-[0-7]' docs/sessions/qm-agent-templates.md` | **PASS** = `0` |
| AC2 | 名指しする見出しが develop の `qm-session.md` に全て実在 | `git show origin/develop:docs/sessions/qm-session.md` に対し見出し 3 件を `grep -n -F` | **PASS**（下記 §参照生存の grep 結果） |
| AC3 | 作業ディレクトリが `/c/tmp/` worktree、OneDrive 共有クローン 0 件 | `grep -c 'OneDrive' …` / `grep -c '/c/tmp/' …` | **PASS** = `0` / `4` |
| AC4 | `.github/CLAUDE.md` が `Tier 2` を含まず現存見出しを参照 | `grep -c 'Tier 2' .github/CLAUDE.md` | **PASS** = `0`（L125 を §「Per-PR Review Agent（5 手順）」参照に是正） |
| AC5 | 規律 4 項目が保持されている（削除していない） | `grep -cE 'lead 専権\|no-verify\|ganbariquestsupport-lab\|PR #<num> のみ' docs/sessions/qm-agent-templates.md` | **PASS** = `8`（≥ 4） |
| AC6 | `qm-session.md` の diff が 0 行（#4336 と衝突させない） | `git diff origin/develop..HEAD --stat -- docs/sessions/qm-session.md` | **PASS** = 出力なし |
| AC7 | 残課題 3 件が再現可能な引用付きで Issue に記録されている | Issue #4355 §残課題（収束条件の自己矛盾 / ループ定義の SSOT 二重化 / 打ち切り条件の復路未接続） | **PASS** = Issue 本文に 3 件記載済 |
| AC8 | `npm run pre-ready -- --pr <num>` 全 step PASS + CI 全 green | `npm run pre-ready -- --pr 4356` / `gh pr checks 4356` | **PASS**（下記 §テスト・品質セルフチェック） |

### 参照生存の grep 結果（AC2 の実測、develop 現物に対して実行）

```
$ git show origin/develop:docs/sessions/qm-session.md > tmp/qm-session-develop.md
$ grep -n -F "## Per-PR Review Agent（5 手順）" tmp/qm-session-develop.md
132:## Per-PR Review Agent（5 手順）
$ grep -n -F "#### Re-Review（ADR-0026 / #1750）" tmp/qm-session-develop.md
361:#### Re-Review（ADR-0026 / #1750）
$ grep -n -F "## ②③ 修正・再レビュー subagent へ渡すもの" tmp/qm-session-develop.md
116:## ②③ 修正・再レビュー subagent へ渡すもの
```

本 PR で `qm-agent-templates.md` が名指しする見出しは上記 3 件のみで、**全て develop 現物に実在**する（是正前は `Tier 2 5 手順` / `Tier 2「Re-Review」手順` / `Tier 2 手順 4` を名指ししており、いずれも 0 件 = 死んだ参照だった）。

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（プロセス文書のみ）。影響を受けるのは QM セッションの subagent spawn 手順で、次回 QM セッション起動時から。

変更 4 ファイル:

| ファイル | 変更内容 |
|---|---|
| `docs/sessions/qm-agent-templates.md` | 語彙を lead / subagent + 現存見出しに同期、作業ディレクトリを `/c/tmp/` worktree に是正、修正を伴う subagent に規律 4 項目を明記 |
| `.github/CLAUDE.md` L125 | `Tier 2 手順 5 の 5 手順` → §「Per-PR Review Agent（5 手順）」の 5 手順 |
| `docs/sessions/webui-review-process.md` L189 | `qm-session.md Tier 2 手順 1〜2` → §「Per-PR Review Agent（5 手順）」の手順 1〜2 |
| `docs/sessions/dev-process/github-api-head-staleness.md` L39-40 | `Tier 2 QM Re-Review Agent` / `CI Fix Agent` → 再レビュー subagent / CI Fix subagent |

後半 2 件は当初 scope 外だったが、**同一 class（#4336 で消えた見出しを名指しする死んだ参照）を `grep -rn "Tier 2" docs/sessions/ .github/ .claude/` で sweep して検出**したため同 PR で是正した。`.claude/skills/dev-open-pr/SKILL.md:18` の `QM Tier 2 Review BLOCK` は**過去インシデントの経緯記述**（読ませる指示ではない）なので git 履歴 pointer として現状維持した。

**意図的に触っていないもの**:

- `docs/sessions/qm-session.md` 本体 — #4336 の diff と衝突させない（AC6 で 0 行を機械検証）
- ADR-0056 §E / `docs/sessions/audit-team.md` の `V-7` 語彙 — この 2 つは gate-approve hook が守る「不可逆 action の lead 専権」の**定義元**であり、書き換えると専権の根拠が追跡不能になるおそれがある。定義元が旧語彙のまま残っていることは Issue #4355 の残課題に記録済

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）→ N/A（コード変更なし）
- [x] **設計書同期** (ADR-0001): 影響する `docs/design/` を同 PR で更新 → 本 PR 自体が docs 同期。`docs/design/` 配下への影響なし
- [x] **LP ↔ アプリ整合** (ADR-0013): LP 記載が実装と一致。Aspirational を LP に新規追加していない → N/A（`site/**` 無変更）
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った → N/A（コード変更なし）
- [ ] N/A — 上記いずれも影響範囲外

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4356` | PASS（全 step） |
| 追加・変更テスト | N/A（docs のみ、コード変更 0 行） | N/A |
| 参照生存検証 | 上記 §参照生存の grep 結果（develop 現物に対する `grep -n -F` × 3） | PASS = 3/3 実在 |
| 同 class sweep | `grep -rn "Tier 2\|Tier 1" docs/sessions/ .github/ .claude/` | 残 1 件（`dev-open-pr/SKILL.md` の過去インシデント記述、意図的に維持） |

- [x] **SOLID / DRY / YAGNI**: 見出し参照の機械検証 gate 新設（案 C）は Pre-PMF で装置を増やすため見送り、同 class 2 例目で class-lock する条件を Issue に明記した（YAGNI）
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。むしろ**ローカル絶対パス（`C:\Users\kokor\OneDrive\...`）を削除**しており改善方向
- [x] **A11y・パフォーマンス**: N/A（docs のみ）
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:critical` ではない）

## スクリーンショット / ビジュアルデモ

**該当なし（docs のみ。`.svelte` / `.css` / `site/**` の変更 0 件で、顧客に見える UI は一切変わらない）**

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **規律を薄めていないかの確認**をお願いしたい。語彙だけを差し替え、approve / merge の lead 専権・`--no-verify` 禁止・commit author = `ganbariquestsupport-lab`・1 agent = 1 PR・SS は Read tool で実際に開く、は全て保持したつもり（AC5 で grep 検証）。むしろ CI Fix subagent 側には #4336 §②③ の規律を新規に明記して**強化**している
2. **ADR-0056 / `audit-team.md` の `V-7` 語彙を触らない判断**の妥当性。専権の定義元を書き換えると gate-approve hook の根拠が追跡不能になると考え本 PR では据え置き、Issue #4355 に残課題として記録した。QM 側で「定義元も同時に直すべき」判断があれば別 PR で対応する
3. 本 PR は**私（Dev lead）が #4336 の approve review 本文に書いたきり Issue にも PR にもしていなかった指摘**の完遂。label-mailbox.md §3.1.1 の「PR コメントは通知経路ではない」に自分で違反していた

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 → N/A（UI 変更なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 → N/A（認証画面無変更）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
