### PR TITLE
fix(ci): #4348 PR body gate 3 箇所の見出し判定を部分一致から行完全一致にする

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -139,14 +139,20 @@ gh pr ready <PR番号>
 
 | ジョブ | 検証 |
 |---|---|
-| 必須セクション存在確認 | `## ` 見出し削除なし |
+| 必須セクション存在確認 | `## ` 見出し削除なし（**行全体の完全一致**で判定。HTML コメント / code block / 本文中の言及 / 前方一致する別見出し `## X の補足` は「存在する」と数えない、#4348） |
 | 関連 Issue 番号 | `closes #` に番号、または `#\d+` 参照 |
 | 変更タイプ | `[x]` 1 つ以上 |
 | 顧客価値・目的 | プレースホルダー残存なし |
-| テスト実行結果 | `<!-- PASS / FAIL -->` 残存なし（type:docs は skip） |
+| テスト実行結果 | `<!-- PASS / FAIL -->` 残存なし（type:docs は skip）。**section が本文に無ければ skip ではなく fail**。結果列が HTML コメントだけの行は未記入として検出する。integration lane は feature 用見出しではなく `## マージ判定エビデンス表` を読む（#4348 で是正。それまで統合 PR では **一度も**この分岐に入っていなかった） |
 | closing keyword の記入 (feat/fix) | develop 向け `type:feat`/`type:fix` PR は `## 関連 Issue` に行頭 closing keyword（`Closes #N` / `Fixes #N` / `Resolves #N`、コロン形 / 全角 `＃` 許容）必須。bare `#N` / `関連: #N` のみは fail。issue を閉じない PR は `<!-- no-issue-close: 理由 -->` 宣言で skip。検出規約は `integration-pr-body.mjs` `extractClosedIssues` と共有（#3458 / #3423 AC1） |
 
 AC 検証マップ (`pr-ac-verification-check.yml`) も hard-fail。
+
+### PR body の見出しを読む判定は共有 util を使う（#4348）
+
+PR body の構造化識別子（`## ` 見出し）を探す gate は **`scripts/lib/ci/pr-body-sections.mjs`** を import する（`hasH2Section` / `extractSection` / `extractH2Section`）。判定規約は ① HTML コメント / fenced code block を除去 ② 見出しは行全体の完全一致 ③ 見つからなければ **fail**（「検査できなかった」を pass にしない）。
+
+`body.indexOf('## X')` / `body.includes('## X')` のような部分一致を新しく書くと `tests/unit/architecture/pr-body-partial-match-guard.test.ts`（ADR-0061 same-class-N→guard）が落ちる。prose（自然文）を本文全体から探す正当な用途は、同 test の `ALLOWLIST` に**理由付きで**登録する。
 
 セットアップ: Branch Ruleset の `required_status_checks` に 6 ジョブ追加（管理者作業。`closing keyword の記入 (feat/fix)` は #3458 で新設、required 化には ruleset 追加登録が必要）。
 

--- a/.github/INTEGRATION_PR_TEMPLATE.md
+++ b/.github/INTEGRATION_PR_TEMPLATE.md
@@ -15,8 +15,9 @@ lane-aware gate との接続 (Phase A/A-3):
   - pr-merge-gate.yml (integration lane): env MERGE_GATE_INTEGRATION_SECTIONS で指定した
     section の未チェック `- [ ]` を検証する。本 template は §5 (NG / カバレッジ宣言) を接続する。
 
-  注: gate は section 見出し文字列を本文から検索するため、この説明コメント内では
-  実際の `## ` 見出し文字列を再掲しない (誤マッチ回避)。各 section の正確な見出しは下記参照。
+  注 (#4348): gate は section 見出しを **行全体の完全一致** で判定し、HTML コメント /
+  fenced code block を判定前に除去する (scripts/lib/ci/pr-body-sections.mjs)。よって
+  「コメント内に見出し文字列を書かない」という書き手側の回避運用はもう不要。
 
 B-3 (#2871) が含有 PR 一覧 + サマリを、B-4 (#2876) がエビデンス表を自動生成・差込します。
 本 template が確定するまでは手動記入し、placeholder には「B-3/B-4 で自動生成」と注記します。

--- a/.github/workflows/pr-ac-verification-check.yml
+++ b/.github/workflows/pr-ac-verification-check.yml
@@ -54,6 +54,7 @@ jobs:
             scripts/check-ac-verification-map.mjs
             scripts/lib/is-main.mjs
             scripts/lib/ci/reason-declaration.mjs
+            scripts/lib/ci/pr-body-sections.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -53,6 +53,7 @@ jobs:
             scripts/pr-lane.mjs
             scripts/check-merge-gate-checklist.mjs
             scripts/lib/is-main.mjs
+            scripts/lib/ci/pr-body-sections.mjs
           sparse-checkout-cone-mode: false
 
       - name: Classify PR lane (A-1 SSOT)

--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -1,3 +1,8 @@
+import {
+	extractH2Section,
+	stripFencedCode,
+	stripHtmlComments,
+} from './lib/ci/pr-body-sections.mjs';
 import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
@@ -77,49 +82,13 @@ const NG_COUNT_DECLARATION = /残(?:り|る)?\s*(?:の)?[^\n|]{0,24}?NG[^\n|]{0,
 const ISSUE_REFERENCE_PATTERN = /#\d{2,}/;
 
 /**
- * HTML コメント（`<!-- ... -->`）を除去する（#4333 AC1）。
+ * section 探索 / 除去前処理は `scripts/lib/ci/pr-body-sections.mjs` が SSOT (#4348 で移設)。
  *
- * template の説明コメントは **顧客にも監査にも見えない**のに gate を緑にしていた。
- * 判定は「本文に書かれた宣言」だけを対象にする。
- *
- * @param {string} text
- * @returns {string}
+ * #4333 では本 file 内に置いていたが、同 class の緩い判定が他の gate にも残っていたため
+ * (`pr-template-gate-checks` / `check-merge-gate-checklist` 等)、判定の二重実装を作らないよう
+ * 共有 util へ移し、本 file は再 export で後方互換を保つ。
  */
-export function stripHtmlComments(text) {
-	return (text ?? '').replace(/<!--[\s\S]*?--!?>/g, '');
-}
-
-/**
- * fenced code block（``` ... ```）を除去する。
- * 本 gate や template の regex / 例文をコードブロックで引用しただけで緑にしない。
- *
- * @param {string} text
- * @returns {string}
- */
-export function stripFencedCode(text) {
-	return (text ?? '').replace(/^```[\s\S]*?^```/gm, '');
-}
-
-/**
- * `## <title>` の H2 section 本体を切り出す（**見出し行そのものは含まない**、#4333 AC2/AC3）。
- *
- * 見出しは `.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json` が宣言する構造化識別子なので
- * **行全体の完全一致**で探す（部分一致だと本文中の言及・引用・別セクションを拾う）。
- * 見つからない場合は `found: false` を返し、**呼び出し側は必ず fail に倒す**
- * （「検査できなかった」を pass にしない、#4084 と同じ思想）。
- *
- * @param {string} body
- * @param {string} title 見出し文字列（`## ` を除いた部分）
- * @returns {{ found: boolean; text: string }}
- */
-export function extractH2Section(body, title) {
-	const lines = (body ?? '').replace(/\r\n?/g, '\n').split('\n');
-	const start = lines.findIndex((l) => l.trim() === `## ${title}`);
-	if (start === -1) return { found: false, text: '' };
-	const rest = lines.slice(start + 1);
-	const end = rest.findIndex((l) => l.startsWith('## '));
-	return { found: true, text: (end === -1 ? rest : rest.slice(0, end)).join('\n') };
-}
+export { extractH2Section, stripFencedCode, stripHtmlComments };
 
 /**
  * section 本体から「残 NG N 件」の宣言を全件読み取る（#4333）。

--- a/scripts/check-merge-gate-checklist.mjs
+++ b/scripts/check-merge-gate-checklist.mjs
@@ -1,3 +1,4 @@
+import { extractH2Section } from './lib/ci/pr-body-sections.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /** feature / hotfix lane の対象 section（現行 2 section、AC5 で不変）。 */
@@ -61,11 +62,14 @@ export function shouldSkip({ labels, lane }) {
  * @returns {{ found: boolean; unchecked: number }}
  */
 function countUnchecked(body, section) {
-	const idx = body.indexOf(section);
-	if (idx === -1) return { found: false, unchecked: 0 };
-	const nextSection = body.indexOf('\n## ', idx + 1);
-	const sectionBody = nextSection === -1 ? body.slice(idx) : body.slice(idx, nextSection);
-	const unchecked = (sectionBody.match(/^\s*- \[ \]/gm) || []).length;
+	// #4348: 旧実装は `body.indexOf(section)` の部分一致で section 開始位置を決めていた。
+	// 説明文 / HTML コメント内に同じ文字列があると **そこから切り出してしまい**、
+	// checkbox の集計範囲が本来の section とずれる (別 section の `- [ ]` を数える /
+	// 本来の未チェックを数えない)。見出し行の完全一致に統一し、判定前に
+	// HTML コメント / code block を除去する (template の例示 checkbox を数えない)。
+	const { found, text } = extractH2Section(body, section);
+	if (!found) return { found: false, unchecked: 0 };
+	const unchecked = (text.match(/^\s*- \[ \]/gm) || []).length;
 	return { found: true, unchecked };
 }
 

--- a/scripts/lib/ci/pr-body-sections.mjs
+++ b/scripts/lib/ci/pr-body-sections.mjs
@@ -1,0 +1,130 @@
+/**
+ * scripts/lib/ci/pr-body-sections.mjs
+ *
+ * PR body の **構造化識別子 (`## ` 見出し) を読む判定の SSOT** (#4348)。
+ *
+ * # なぜ共有するか
+ *
+ * PR body を入力に取る gate が、それぞれ独自に `body.includes('## X')` /
+ * `body.indexOf('## X')` で見出しを探していた。部分一致は以下を全部「見出しがある」と誤判定する:
+ *
+ *   - HTML コメント内の見出し文字列 (`<!-- ## X を検証する -->`。顧客にも監査にも見えない)
+ *   - fenced code block 内の引用
+ *   - 本文中の言及 (`下記「X」参照` — AC 表のセルから section 切り出しが始まる実害を実測)
+ *   - 前方一致する別見出し (`## X の補足`)
+ *
+ * 実害は文書化されていた: `.github/INTEGRATION_PR_TEMPLATE.md` は「gate が本文検索するので
+ * 説明コメント内に見出しを再掲しない」という**書き手側の回避運用**を持っていた (#4348 で撤去)。
+ * 運用で避けている限り、誰かが 1 度コメントに見出しを書けば gate は空振りする。
+ *
+ * # 判定規約
+ *
+ *   1. 判定前に HTML コメント / fenced code block を除去する (`scrubPrBody`)
+ *   2. 見出しは **行全体の完全一致** (`line.trim() === '## ' + title`) で探す
+ *   3. 見つからない場合は `found: false` を返し、**呼び出し側は必ず fail に倒す**
+ *      (「検査できなかった」を pass にしない — #4084 / #4255 / #4333 と同じ思想)
+ *
+ * 利用側: `scripts/pr-template-gate-checks.mjs` / `scripts/check-merge-gate-checklist.mjs` /
+ *         `scripts/check-ac-verification-map.mjs`
+ */
+
+/**
+ * HTML コメント (`<!-- ... -->`) を除去する。
+ *
+ * template の説明コメントは顧客にも監査にも見えないのに gate を緑にしていた (#4333)。
+ * js/bad-tag-filter (CodeQL) 対策で `--!>` 終端も閉じタグとして扱う。
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripHtmlComments(text) {
+	return (text ?? '').replace(/<!--[\s\S]*?--!?>/g, '');
+}
+
+/**
+ * fenced code block (``` ... ```) を除去する。
+ * gate や template の例文をコードブロックで引用しただけで緑にしない。
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripFencedCode(text) {
+	return (text ?? '').replace(/^```[\s\S]*?^```/gm, '');
+}
+
+/**
+ * 判定用に PR body を正規化する (改行正規化 + コメント / code block 除去)。
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function scrubPrBody(text) {
+	return stripFencedCode(stripHtmlComments((text ?? '').replace(/\r\n?/g, '\n')));
+}
+
+/**
+ * 見出し指定を `{ level, title }` に分解する。
+ * SSOT (`PR_TEMPLATE_SECTIONS.json`) は `## X` 形式、script 内定数は `X` 形式が混在するため
+ * どちらでも受ける。`#` が無い場合は H2 (既定) とみなす。
+ *
+ * @param {string} heading
+ * @param {number} [defaultLevel]
+ * @returns {{ level: number; title: string }}
+ */
+export function parseHeadingSpec(heading, defaultLevel = 2) {
+	const trimmed = (heading ?? '').trim();
+	const m = trimmed.match(/^(#{1,6})\s+(.*)$/);
+	if (!m) return { level: defaultLevel, title: trimmed };
+	return { level: (m[1] ?? '').length, title: (m[2] ?? '').trim() };
+}
+
+/**
+ * 指定見出しの section 本体を切り出す (**見出し行そのものは含まない**)。
+ *
+ * 終端は **同レベル以上の見出し** (H2 指定なら `## ` か `# `) の直前。下位見出し (`### `) では
+ * 止めない (同一 section 内の小見出しは所属を変えないため)。
+ *
+ * @param {string} body PR 本文
+ * @param {string} heading 見出し (`## X` / `### X` / `X` のいずれか。`#` 省略時は H2)
+ * @param {{ scrub?: boolean }} [options] `scrub: false` で除去前処理を無効化 (既定 true)
+ * @returns {{ found: boolean; text: string }}
+ */
+export function extractSection(body, heading, options = {}) {
+	const scrub = options.scrub !== false;
+	const { level, title } = parseHeadingSpec(heading);
+	const source = scrub ? scrubPrBody(body) : (body ?? '').replace(/\r\n?/g, '\n');
+	const lines = source.split('\n');
+	const marker = '#'.repeat(level);
+	const start = lines.findIndex((l) => l.trim() === `${marker} ${title}`);
+	if (start === -1) return { found: false, text: '' };
+	const rest = lines.slice(start + 1);
+	const end = rest.findIndex((l) => {
+		const m = l.match(/^(#{1,6})\s/);
+		return m !== null && (m[1] ?? '').length <= level;
+	});
+	return { found: true, text: (end === -1 ? rest : rest.slice(0, end)).join('\n') };
+}
+
+/**
+ * `## <title>` の H2 section 本体を切り出す (`extractSection` の H2 固定版)。
+ *
+ * @param {string} body PR 本文
+ * @param {string} heading 見出し (`## X` / `X` どちらでも可)
+ * @param {{ scrub?: boolean }} [options]
+ * @returns {{ found: boolean; text: string }}
+ */
+export function extractH2Section(body, heading, options = {}) {
+	const { title } = parseHeadingSpec(heading);
+	return extractSection(body, `## ${title}`, options);
+}
+
+/**
+ * `## <title>` の H2 見出しが (コメント / code block の外に) 存在するか。
+ *
+ * @param {string} body
+ * @param {string} heading 見出し (`## X` / `X` どちらでも可)
+ * @returns {boolean}
+ */
+export function hasH2Section(body, heading) {
+	return extractH2Section(body, heading).found;
+}

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -85,6 +85,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'src 配下の import 境界を走査する',
 	},
+	'tests/unit/architecture/pr-body-partial-match-guard.test.ts': {
+		scope: 'repo',
+		note: '#4348 scripts 配下の .mjs を走査し、PR body の見出し / 宣言を部分一致で判定する新規コードを検出する',
+	},
 	'tests/unit/architecture/no-stray-control-chars.test.ts': {
 		scope: 'repo',
 		note: '#4119 docs / src / scripts / tests のテキスト資産を byte 単位で走査し C0 制御文字の紛れ込みを検出する',

--- a/scripts/pr-template-gate-checks.mjs
+++ b/scripts/pr-template-gate-checks.mjs
@@ -40,7 +40,9 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
+import { INTEGRATION_EVIDENCE_SECTION } from './check-ac-verification-map.mjs';
 import { extractClosedIssues } from './integration-pr-body.mjs';
+import { extractSection, hasH2Section } from './lib/ci/pr-body-sections.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /**
@@ -156,7 +158,13 @@ export function checkSectionPresence({
 		sourceLabel = 'PULL_REQUEST_TEMPLATE.md (fallback)';
 	}
 
-	const missing = sections.filter((s) => !body.includes(s));
+	// #4348: 旧実装は `body.includes(s)` の部分一致だった。HTML コメント内の説明文
+	// (`<!-- ## X を削除しない -->`) / code block の引用 / 本文中の言及 / 前方一致する別見出し
+	// (`## X の補足`) でも「見出しがある」と判定され、template を貼っただけで緑になりうる。
+	// 実際 `.github/INTEGRATION_PR_TEMPLATE.md` は「コメント内に見出しを再掲しない」という
+	// **書き手側の回避運用**でこの誤マッチを避けていた (#4348 で撤去)。
+	// 判定を H2 見出し行の完全一致 + コメント / code block 除去に統一する。
+	const missing = sections.filter((s) => !hasH2Section(body, s));
 	if (missing.length > 0) {
 		return {
 			ok: false,
@@ -166,6 +174,8 @@ export function checkSectionPresence({
 				`lane: ${lane} / 参照 SSOT: ${sourceLabel}\n\n` +
 				`削除されたセクション:\n${missing.map((s) => `  • ${s}`).join('\n')}\n\n` +
 				'PR テンプレートのセクション見出し (## ...) を削除しないでください。\n' +
+				'見出しは **行全体の完全一致** で判定します。HTML コメント / code block の中や\n' +
+				'本文中の言及は見出しとして数えません (#4348)。\n' +
 				'内容が該当しない場合は「N/A」または「該当なし」と記載してください。',
 		};
 	}
@@ -645,19 +655,32 @@ export function checkCustomerValue({ body, labels, template, lane }) {
  * @returns {string}
  */
 export function detectTestSectionKeyword(template) {
+	return detectTestSectionHeading(template).replace(/^#{1,6}\s+/, '');
+}
+
+/**
+ * template からテスト結果テーブルを含むセクションの **見出し行**（`## X` / `### X`）を取得する。
+ *
+ * #4348: section の切り出しを見出し行の完全一致で行うため、見出しの**レベルまで**必要になった
+ * （`detectTestSectionKeyword` は見出し文字列だけを返すため、H2 / H3 の区別が失われる）。
+ *
+ * @param {string} template
+ * @returns {string} 見出し行（例: `## テスト・品質セルフチェック`）
+ */
+export function detectTestSectionHeading(template) {
 	const lines = template.split('\n');
-	let keyword = 'テスト実行結果';
+	let heading = '## テスト実行結果';
 	const tableHeaderIdx = lines.findIndex((l) => /テスト種別.*コマンド.*結果/.test(l));
 	if (tableHeaderIdx !== -1) {
 		for (let i = tableHeaderIdx; i >= 0; i -= 1) {
 			const line = lines[i] ?? '';
 			if (/^###?\s/.test(line)) {
-				keyword = line.replace(/^###?\s+/, '').trim();
+				heading = line.trim();
 				break;
 			}
 		}
 	}
-	return keyword;
+	return heading;
 }
 
 /**
@@ -684,24 +707,34 @@ export function checkTestResults({ body, labels, template, lane }) {
 		return { ok: true, skipped: true, message: 'type:docs PR のためスキップ', lane };
 	}
 
-	const keyword = detectTestSectionKeyword(template);
-	const sectionIdx = body.indexOf(keyword);
-	if (sectionIdx === -1) {
+	// #4348: section の探索を「本文の部分一致 + 見つからなければ skip」から
+	// 「H2 見出し行の完全一致 + 見つからなければ fail」に変える。旧実装の壊れ方は 2 つあった:
+	//
+	//   (a) skip に倒れる: keyword が本文になければ pass 扱い。section-presence への「委譲」を
+	//       名目にしていたが、その section-presence 自身も部分一致だったため
+	//       「コメント内の文字列で section-presence が緑 + 本体不在で本 check が skip」の
+	//       二重空振りが成立していた (#4348 表 #5)。
+	//   (b) integration lane で常に skip: keyword は feature template から導出されるため
+	//       (`テスト・品質セルフチェック`)、その見出しを持たない統合 PR template では必ず
+	//       `indexOf === -1` になり、統合エビデンス表の検証分岐が **一度も実行されていなかった**
+	//       (実測: merged 統合 PR 12 本すべてで skip)。lane ごとに見る section を解決する。
+	const heading =
+		lane === 'integration'
+			? `## ${INTEGRATION_EVIDENCE_SECTION}`
+			: detectTestSectionHeading(template);
+	const keyword = heading.replace(/^#{1,6}\s+/, '');
+	const { found, text: section } = extractSection(body, heading);
+	if (!found) {
 		return {
-			ok: true,
-			skipped: true,
+			ok: false,
 			lane,
-			message: `「${keyword}」セクションが見つかりません (section-presence チェックに委譲)`,
+			message:
+				`❌ 「${heading}」セクションが PR 本文にありません。\n\n` +
+				`見出しは **行全体の完全一致** (\`${heading}\`) で判定します。\n` +
+				'HTML コメント / code block の中や本文中の言及は見出しとして数えません (#4348)。\n' +
+				'PR テンプレートのセクション見出しを削除せず、表に結果を記入してください。',
 		};
 	}
-
-	const afterSection = body.slice(sectionIdx + keyword.length + 1);
-	const nextSectionMatch = afterSection.search(/\n##\s/);
-	const sectionEnd =
-		nextSectionMatch !== -1
-			? sectionIdx + keyword.length + 1 + nextSectionMatch
-			: sectionIdx + 2000;
-	const section = body.slice(sectionIdx, sectionEnd);
 
 	const tableRows = section
 		.split('\n')

--- a/tests/unit/architecture/pr-body-partial-match-guard.test.ts
+++ b/tests/unit/architecture/pr-body-partial-match-guard.test.ts
@@ -1,0 +1,163 @@
+// tests/unit/architecture/pr-body-partial-match-guard.test.ts
+// #4348 AC6 (ADR-0061 same-class-N→guard): PR body の構造化識別子 (`## ` 見出し) や宣言を
+// **部分一致 / 本文全体への 1 本の正規表現**で判定するコードを機械で止める fitness function。
+//
+// 背景 (同 class 4 回):
+//   #4084  SS ペア 0 件を skip で通した            (検査できなかったのに pass)
+//   #4255  story 参照を「それっぽい文字列」で通した (実在性を見ない)
+//   #4333  見出しの存在だけで NG-0 を常に緑にした   (見出し行・コメント・否定文を拾う)
+//   #4348  上記と同 class が gate 6 箇所に残存      (本 guard の起票元)
+//
+// instance ごとの対処では止まらないので、**判定の形そのもの**を lock する:
+//   - PR body に対する `.indexOf(` / `.includes(` / `<regex>.test(body)` は
+//     ALLOWLIST に理由付きで登録されたものだけを許す
+//   - 新規に増やせば fail (是正済みの箇所を緩い判定に戻すことも fail)
+//   - ALLOWLIST に書いたのに現物が消えたら fail (stale = 実態と乖離した許可)
+//
+// 構造化識別子の正しい判定は `scripts/lib/ci/pr-body-sections.mjs` (見出し行の完全一致 +
+// HTML コメント / code block 除去) に集約してある。新規 gate はそれを import する。
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+// repo 走査 test。区分宣言は scripts/lib/ci/repo-scan-test-registry.mjs が SSOT (#4085)。
+vi.setConfig({ testTimeout: 60_000 });
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const SCAN_DIR = resolve(REPO_ROOT, 'scripts');
+
+/** PR body を指す変数名 (これらに対する部分一致判定を検出対象にする)。 */
+const BODY_IDENT = String.raw`(?:[A-Za-z_$][\w$]*)?[Bb]ody`;
+
+/** `<body>.indexOf(` / `<body>.includes(` — 部分一致で section / 宣言を探す形。 */
+const SUBSTRING_RE = new RegExp(String.raw`\b(${BODY_IDENT})\s*\.\s*(indexOf|includes)\s*\(`, 'g');
+/** `<regex or array>.test(<body>)` — 本文全体に 1 本の正規表現を当てる形。 */
+const WHOLE_BODY_TEST_RE = new RegExp(String.raw`\.test\(\s*(${BODY_IDENT})\s*\)`, 'g');
+
+/**
+ * 許可済み occurrence。key = `<repo 相対パス>::<空白正規化した該当行>`。
+ * 行番号は差分で動くので使わない。値は **なぜ許すか**（理由なしの許可は作らない、#3956）。
+ *
+ * 該当行を編集すると key が変わり unknown + stale の両方で落ちる。これは意図した挙動で、
+ * 「この判定を触ったならもう一度理由を書け」という強制になる。
+ */
+const ALLOWLIST: Record<string, string> = {
+	// --- #4348 で是正しなかった残置 (Issue #4348 に残件として記録、1 箇所ずつ corpus 比較して消化) ---
+	"scripts/check-ac-verification-map.mjs::const mapHeaderIdx = body.indexOf('AC 検証マップ');":
+		'#4348 残置 (対象 #6): feature lane の AC マップ section 探索。全 feature PR に波及するため別 PR で corpus 比較のうえ是正する',
+	'scripts/check-admin-bypass-evidence.mjs::return EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body));':
+		'#4348 残置 (対象 #3): admin bypass 証跡マーカーの存在検査。nightly 監査 script で PR gate とは別経路のため別 PR で是正する',
+	'scripts/check-pr-screenshot.mjs::return DOM_REF_PATTERN.test(body);':
+		'#4348 残置 (対象 #4): DOM スナップショット参照の存在検査。#4255 の兄弟関数と同様に実在検査へ寄せる別 PR で是正する',
+	'scripts/check-pr-screenshot.mjs::return INTEGRATION_VR_EVIDENCE_PATTERNS.some((p) => p.test(body));':
+		'#4348 残置 (対象 #4): 統合 PR の VR 証跡の存在検査。同上',
+
+	// --- 構造化識別子ではなく prose (自然文) を探す用途。本文全体を見るのが正しい ---
+	'scripts/check-pr-screenshot.mjs::hasBefore: BEFORE_LABEL_PATTERN.test(body),':
+		'prose 検査: 「修正前」ラベルの表記ゆれを本文から探す用途で、見出し等の構造化識別子ではない',
+	'scripts/check-pr-screenshot.mjs::hasAfter: AFTER_LABEL_PATTERN.test(body),':
+		'prose 検査: 「修正後」ラベルの表記ゆれを本文から探す用途で、構造化識別子ではない',
+	'scripts/check-pr-screenshot.mjs::return FUTURE_TENSE_PATTERNS.some((p) => p.test(body));':
+		'prose 検査: 「SS は後で push する」等の未来形記述を本文から探す用途 (#2918)',
+	'scripts/check-new-required-env.mjs::return re.test(prBody);':
+		'prose 検査: env 配布証跡の記述を本文から探す用途 (#4129)。構造化識別子ではない',
+	'scripts/pr-template-gate-checks.mjs::if (/^closes\\s+#\\s*$/im.test(body) || /closes\\s+#\\s*<!--/im.test(body)) {':
+		'prose 検査: `closes #` の空欄記入を行頭アンカー付きで探す。見出し探索ではない',
+
+	// --- section 探索だが #4348 の対象 6 箇所には含まれない残置 (同 class、後続で移行) ---
+	'scripts/check-pr-body.mjs::const startIdx = body.indexOf(startMatch[0]);':
+		'#4348 scope 外: check-pr-body の section 切り出し。同 class のため後続 PR で pr-body-sections.mjs へ寄せる',
+	'scripts/check-pr-body.mjs::const startIdx = body.indexOf(section);':
+		'#4348 scope 外: check-pr-body の section 切り出し。同上',
+	'scripts/pr-template-gate-checks.mjs::const start = body.indexOf(heading);':
+		'#4348 scope 外: sliceSection / detectChangeTypeHeading の見出し探索。同 class のため後続 PR で移行する',
+	"scripts/pr-template-gate-checks.mjs::const end = body.indexOf('\\n## ', start + 1);":
+		'#4348 scope 外: 上記 sliceSection の終端探索 (見出しの存在判定ではない)。同上',
+	'scripts/pr-template-gate-checks.mjs::const idx = body.indexOf(`**${field}**:`);':
+		'顧客価値 section の field 探索。`## ` 見出しではなく本文中の太字ラベルを探すため部分一致が妥当',
+};
+
+function walkMjs(dir: string, acc: string[]): string[] {
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const full = resolve(dir, entry.name);
+		if (entry.isDirectory()) {
+			if (entry.name === 'node_modules') continue;
+			walkMjs(full, acc);
+		} else if (entry.name.endsWith('.mjs')) {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+/** コメント行 (行コメント / block コメント本体) を除外する。 */
+function isCommentLine(line: string): boolean {
+	const t = line.trim();
+	return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
+type Occurrence = { key: string; file: string; line: number; text: string };
+
+function collectOccurrences(): Occurrence[] {
+	const out: Occurrence[] = [];
+	for (const file of walkMjs(SCAN_DIR, [])) {
+		const rel = relative(REPO_ROOT, file).replace(/\\/g, '/');
+		const lines = readFileSync(file, 'utf8').split('\n');
+		lines.forEach((line, i) => {
+			if (isCommentLine(line)) return;
+			for (const re of [SUBSTRING_RE, WHOLE_BODY_TEST_RE]) {
+				re.lastIndex = 0;
+				let m = re.exec(line);
+				while (m !== null) {
+					const snippet = line.trim().replace(/\s+/g, ' ');
+					out.push({ key: `${rel}::${snippet}`, file: rel, line: i + 1, text: snippet });
+					m = re.exec(line);
+				}
+			}
+		});
+	}
+	return out;
+}
+
+describe('#4348 fitness: PR body を部分一致で判定する新規コードを増やさない', () => {
+	const occurrences = collectOccurrences();
+
+	it('検出器が機能している (occurrence が 0 件なら regex が壊れている)', () => {
+		expect(occurrences.length).toBeGreaterThan(0);
+	});
+
+	it('ALLOWLIST 外の部分一致判定が存在しない', () => {
+		const unknown = occurrences.filter((o) => !(o.key in ALLOWLIST));
+		const detail = unknown.map((o) => `  ${o.file}:${o.line}  ${o.text}\n    key: ${o.key}`);
+		expect(
+			unknown,
+			[
+				'PR body の見出し / 宣言を部分一致で判定する新規コードを検出しました (#4348 / ADR-0061)。',
+				'',
+				'構造化識別子 (`## ` 見出し) を探すなら scripts/lib/ci/pr-body-sections.mjs の',
+				'hasH2Section / extractSection / extractH2Section を使ってください',
+				'(見出し行の完全一致 + HTML コメント / code block 除去 + 不在は fail)。',
+				'',
+				'prose (自然文) を探す正当な用途なら、本 test の ALLOWLIST に **理由付きで** 追加してください。',
+				'',
+				...detail,
+			].join('\n'),
+		).toEqual([]);
+	});
+
+	it('ALLOWLIST に stale なエントリがない (消えた occurrence の許可を残さない)', () => {
+		const present = new Set(occurrences.map((o) => o.key));
+		const stale = Object.keys(ALLOWLIST).filter((k) => !present.has(k));
+		expect(
+			stale,
+			`ALLOWLIST に現物のないエントリが残っています。是正が済んだなら該当行を削除してください:\n${stale.join('\n')}`,
+		).toEqual([]);
+	});
+
+	it('ALLOWLIST の全エントリが実体のある理由を持つ (理由の非強制を作らない)', () => {
+		const weak = Object.entries(ALLOWLIST).filter(([, reason]) => reason.trim().length < 12);
+		expect(weak.map(([k]) => k)).toEqual([]);
+	});
+});

--- a/tests/unit/github/pr-template-gate-checks.test.ts
+++ b/tests/unit/github/pr-template-gate-checks.test.ts
@@ -367,7 +367,12 @@ describe('integration lane: 観点切替・空洞化なし (#2944 AC2/AC3)', () 
 
 - [x] 重量レーン CI 緑
 
-### テスト実行結果
+## マージ判定エビデンス表
+
+<!-- #4348: 統合 PR の test-results 観点が読むのは統合 PR template の本 section
+     (.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json の SSOT)。旧 fixture は feature template の
+     H3「テスト実行結果」を流用しており、実 CI では **一度もこの分岐に入っていなかった**
+     (実測: merged 統合 PR 12 本すべてで skip)。fixture を実 template の形に揃える。 -->
 
 | 検証観点 | 集約結果 | エビデンス |
 |---|---|---|
@@ -448,8 +453,8 @@ describe('integration lane: 観点切替・空洞化なし (#2944 AC2/AC3)', () 
 	});
 	it('test-results FAIL: エビデンス表 0 行は integration で fail (skip でなく fail = 空洞化なし)', () => {
 		const noTable = INTEGRATION_BODY.replace(
-			/### テスト実行結果[\s\S]*?(?=## レビュー依頼事項)/,
-			'### テスト実行結果\n\n（表なし）\n\n',
+			/## マージ判定エビデンス表[\s\S]*?(?=## レビュー依頼事項)/,
+			'## マージ判定エビデンス表\n\n（表なし）\n\n',
 		);
 		const r = checkTestResults({ ...base, body: noTable });
 		expect(r.ok).toBe(false);
@@ -899,5 +904,116 @@ describe('実 PULL_REQUEST_TEMPLATE.md に対して gate が空洞化しない (
 	it('change-type / issue-reference の見出し解決も実 template で成立する', () => {
 		expect(detectChangeTypeHeading(realTemplate)).toBe('## 変更タイプ');
 		expect(detectIssueSectionHeading(realTemplate)).toBe('## 関連 Issue');
+	});
+});
+
+// =====================================================================
+// #4348: 見出し / section の探索を「本文の部分一致」から「見出し行の完全一致」に是正
+//
+// 旧実装:
+//   - section-presence: `sections.filter((s) => !body.includes(s))`
+//   - test-results:     `body.indexOf(keyword)` / 見つからなければ **skip (= pass)**
+//
+// いずれも HTML コメント / code block / 本文中の言及 / 前方一致する別見出しを
+// 「見出しがある」と誤判定した。実 corpus で観測した壊れ方は本 describe の各 it に対応する。
+// =====================================================================
+describe('#4348: 見出し探索は行の完全一致 + 見つからなければ fail', () => {
+	const SECTIONS = ['## 顧客価値・目的', '## テスト・品質セルフチェック'];
+	const base = {
+		labels: [],
+		template: readFileSync(
+			resolve(dirname(fileURLToPath(import.meta.url)), '../../../.github/PULL_REQUEST_TEMPLATE.md'),
+			'utf8',
+		),
+		ssotSections: SECTIONS,
+		lane: 'feature' as const,
+	};
+	const REAL_BODY = ['## 顧客価値・目的', '', '本文', '', '## テスト・品質セルフチェック', ''].join(
+		'\n',
+	);
+
+	it('section-presence: HTML コメント内の見出し文字列では「存在する」と判定しない', () => {
+		const body = [
+			'## 顧客価値・目的',
+			'',
+			'<!-- 次に ## テスト・品質セルフチェック を書く -->',
+			'',
+		].join('\n');
+		const r = checkSectionPresence({ ...base, body });
+		expect(r.ok, 'コメント内の文字列で section-presence が緑になっている').toBe(false);
+		expect(r.message).toContain('## テスト・品質セルフチェック');
+	});
+
+	it('section-presence: code block 内の引用でも「存在する」と判定しない', () => {
+		const body = [
+			'## 顧客価値・目的',
+			'',
+			'```markdown',
+			'## テスト・品質セルフチェック',
+			'```',
+			'',
+		].join('\n');
+		expect(checkSectionPresence({ ...base, body }).ok).toBe(false);
+	});
+
+	it('section-presence: 前方一致する別見出し (## X の補足) では満たさない', () => {
+		const body = ['## 顧客価値・目的', '', '## テスト・品質セルフチェック の補足', ''].join('\n');
+		expect(checkSectionPresence({ ...base, body }).ok).toBe(false);
+	});
+
+	it('section-presence: 見出しが実在すれば従来どおり PASS (回帰なし)', () => {
+		expect(checkSectionPresence({ ...base, body: REAL_BODY }).ok).toBe(true);
+	});
+
+	it('test-results: section 不在は skip でなく fail (検査できなかったものを pass にしない)', () => {
+		const r = checkTestResults({ ...base, body: '## 顧客価値・目的\n\n本文だけ\n' });
+		expect(r.skipped, 'skip に倒れると gate が no-op になる').toBeFalsy();
+		expect(r.ok).toBe(false);
+	});
+
+	it('test-results: 本文中の言及が見出しより前にあっても本物の表を読む (#4325 / #4311 実例)', () => {
+		// 実 merged PR で観測: AC 表のセルに「下記「テスト・品質セルフチェック」参照」があり、
+		// 旧実装はそのセルから section を切り出して表 0 行 → skip していた。
+		const body = [
+			'## 顧客価値・目的',
+			'',
+			'| AC1 | 内容 | 手段 | 下記「テスト・品質セルフチェック」参照 |',
+			'',
+			'## テスト・品質セルフチェック',
+			'',
+			'| テスト種別 | コマンド | 結果 |',
+			'|---|---|---|',
+			'| pre-ready | `npm run pre-ready` | |',
+			'',
+		].join('\n');
+		const r = checkTestResults({ ...base, body });
+		expect(r.skipped).toBeFalsy();
+		expect(r.ok, '結果列が空の行を検出できていない').toBe(false);
+	});
+
+	it('test-results: 結果列が HTML コメントだけの行は未記入として検出する (#4278 実例)', () => {
+		const body = [
+			'## テスト・品質セルフチェック',
+			'',
+			'| テスト種別 | コマンド | 結果 |',
+			'|---|---|---|',
+			'| pre-ready | `npm run pre-ready` | <!-- 実行後に記入 --> |',
+			'',
+		].join('\n');
+		expect(checkTestResults({ ...base, body }).ok).toBe(false);
+	});
+
+	it('test-results: integration lane は統合 PR template のエビデンス表を読む (feature 見出しを探さない)', () => {
+		const body = [
+			'## マージ判定エビデンス表',
+			'',
+			'| 含有 PR | 領域 | テスト | 結果 |',
+			'|---|---|---|---|',
+			'| #1 | admin | unit×3 | pass |',
+			'',
+		].join('\n');
+		const r = checkTestResults({ ...base, lane: 'integration', body });
+		expect(r.skipped, 'feature template の見出しを探して skip していた (#4348)').toBeFalsy();
+		expect(r.ok).toBe(true);
 	});
 });

--- a/tests/unit/scripts/check-merge-gate-checklist.test.ts
+++ b/tests/unit/scripts/check-merge-gate-checklist.test.ts
@@ -205,3 +205,55 @@ describe('shouldSkip integration lane = skip 無効化 (#3071)', () => {
 		expect(r.ok).toBe(false);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// #4348: section 探索を「本文の部分一致」から「H2 見出し行の完全一致」に是正した回帰。
+//
+// 旧実装は `body.indexOf(section)` で section 開始位置を決めていたため、説明文 / AC 表 /
+// HTML コメントに同じ文字列があると **そこから切り出して**しまい、checkbox の集計範囲が
+// 本来の section とずれた。以下 3 例はいずれも旧実装では誤判定する入力
+// (mutation 実測: countUnchecked を indexOf 版に戻すと 1 例目と 3 例目が red になる)。
+// ---------------------------------------------------------------------------
+
+describe('#4348: section 探索は H2 見出し行の完全一致', () => {
+	it('本文中の言及が見出しより前にあっても、集計は本物の section を数える', () => {
+		// 旧実装: AC 表のセルから切り出し → 直後の `\n## ` までに `- [ ]` が無く「全消化」と誤判定。
+		const body = [
+			'## AC 検証マップ (ADR-0004)',
+			'',
+			'| AC1 | 内容 | 手段 | 下記「## Ready for Review チェックリスト」参照 |',
+			'',
+			'## Ready for Review チェックリスト',
+			'- [x] CI 全緑',
+			'- [ ] pre-ready PASS',
+			'',
+		].join('\n');
+		const r = checkMergeGateChecklist({ body, labels: [], lane: 'feature' });
+		expect(r.ok).toBe(false);
+		expect(r.error ?? '').toContain('Ready for Review チェックリスト');
+	});
+
+	it('HTML コメント内の見出し文字列だけでは section が存在するとみなさない', () => {
+		const body = ['## 概要', '', '<!-- ## Ready for Review チェックリスト を書く -->', ''].join(
+			'\n',
+		);
+		const r = checkMergeGateChecklist({ body, labels: [], lane: 'feature' });
+		// feature lane は section 不在を warning にする (現行仕様)。found=false が warning に出ること。
+		expect((r.warnings ?? []).join('\n')).toContain('Ready for Review チェックリスト');
+	});
+
+	it('code block 内の未チェック checkbox は集計しない (template の例示で fail させない)', () => {
+		const body = [
+			'## Ready for Review チェックリスト',
+			'- [x] CI 全緑',
+			'- [x] pre-ready PASS',
+			'',
+			'```markdown',
+			'- [ ] これは書き方の例',
+			'```',
+			'',
+		].join('\n');
+		const r = checkMergeGateChecklist({ body, labels: [], lane: 'feature' });
+		expect(r.ok).toBe(true);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発・品質ゲート）

**解決する課題**: PR body を入力に取る gate が `## ` 見出しの存在を**部分一致**で判定していたため、HTML コメント・code block・本文中の言及でも「見出しがある」と成立し、検査が黙って空振りしていた。実際 `.github/INTEGRATION_PR_TEMPLATE.md` には「gate が本文検索するのでコメント内に見出しを再掲しない」という**書き手側の回避運用**が明文化されており、欠陥は既知のまま運用で避けられていた。

**期待される効果**: 「gate が緑」と「実際に検査した」が一致する。merged PR 81 本での実測で、統合 PR のテスト結果検証が **12 本すべてで一度も実行されていなかった**こと、feature PR 2 本が AC 表のセルから section を切り出して skip していたこと、1 本が結果列未記入のまま素通りしていたことが判明し、いずれも本 PR で検査されるようになる。

## 関連 Issue

Refs #4348（6 箇所のうち 3 箇所を是正。残り 3 箇所は Issue の「やらないこと」に従い後続 PR で 1 箇所ずつ消化するため、本 PR では Issue を close しない）

<!-- no-issue-close: #4348 は対象 6 箇所のうち 3 箇所のみ是正した部分消化であり、残件の追跡先として Issue を open のまま維持する -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | section / 宣言探索を H2 見出し行の完全一致に統一し、共通 util を 1 箇所に置いて各 gate が import する（判定の二重実装を作らない） | `npx vitest run tests/unit/github/pr-template-gate-checks.test.ts tests/unit/scripts/check-merge-gate-checklist.test.ts` | PASS（103 tests）。対象 6 箇所のうち **#1 / #2 / #5 の 3 箇所**を `scripts/lib/ci/pr-body-sections.mjs` の `hasH2Section` / `extractSection` に統一。残 3 箇所（#3 / #4 / #6）は本 PR の scope 外として `tests/unit/architecture/pr-body-partial-match-guard.test.ts` の ALLOWLIST に理由付きで記録し、#4348 を open のまま追跡先にする |
| AC2 | 判定前に HTML コメント / fenced code block を除去し、除去も共通 util 化する（#4333 で `check-ac-verification-map.mjs` に置いたものを共有先へ移す） | `npx vitest run tests/unit/scripts/check-ac-verification-map.test.ts` | PASS（55 tests）。`stripHtmlComments` / `stripFencedCode` / `extractH2Section` を `scripts/lib/ci/pr-body-sections.mjs` へ移設し、`check-ac-verification-map.mjs` は再 export で後方互換を維持（既存 test 無改変で緑） |
| AC3 | 「対象が見つからない」ケースを fail に倒す | `npx vitest run tests/unit/github/pr-template-gate-checks.test.ts -t "section 不在は skip でなく fail"` | PASS。`checkTestResults` の section 不在時 `{skipped:true}` を `{ok:false}` に変更。mutation（`ok:true, skipped:true` に戻す）で当該 test が red になることを実測（下記「mutation 実測」表 M3） |
| AC4 | 各箇所ごとに実在 merged PR corpus で旧/新判定を比較し、一斉赤化しないことを実測して本文に載せる | `node tmp/verdicts2.mjs`（HEAD の check 関数 vs `git show HEAD:scripts/...` の旧実装を同一入力で突き合わせ） | PASS。**merged 81 PR**（`PR_TEMPLATE_SECTIONS.json` 最終更新 2026-07-30 以降 = 当時 CI が見た section 集合と今日の SSOT が一致する期間、feature 62 / integration 3 / hotfix 16）で比較。詳細は下記「旧/新判定の比較（AC4）」 |
| AC5 | 各箇所に fail するケースの test を置き、guard を外す mutation で確かに落ちることを実測する | 下記「mutation 実測」表 M1〜M4 | PASS。3 mutation すべてで対象 test が red、実装を stash で戻して再度 green を確認（実装は先に commit 済） |
| AC6 | 同 class が今後入らないことを機械で止める。新規 script 本数は増やさない | `npx vitest run tests/unit/architecture/pr-body-partial-match-guard.test.ts` | PASS（4 tests）。`scripts/**/*.mjs` を走査し PR body への `.indexOf(` / `.includes(` / `<regex>.test(body)` を allowlist ratchet で固定。新規 script は追加せず既存 unit test lane に載せた。是正済み箇所を緩い判定に戻す mutation で red（表 M1 / M2） |
| AC7 | `.github/INTEGRATION_PR_TEMPLATE.md` の「コメント内に見出しを再掲しない」回避コメントを撤去する | `git diff HEAD~1 -- .github/INTEGRATION_PR_TEMPLATE.md` | PASS。当該 2 行を撤去し、「gate は行全体の完全一致で判定し、コメント / code block を除去するので回避運用は不要」と置き換えた |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: 顧客向け画面の変更なし。影響するのは PR gate 3 本（`pr-template-gate.yml` の必須セクション存在確認 / テスト実行結果の記入、`pr-merge-gate.yml` のチェックリスト検証）と、その判定 util を共有する `pr-ac-verification-check.yml`。

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）— いずれも本 PR の変更対象外（gate script のみ）
- [x] **設計書同期** (ADR-0001): `.github/CLAUDE.md` の gate 表 2 行を実挙動に合わせ、「PR body の見出しを読む判定は共有 util を使う」節を追加
- [x] **LP ↔ アプリ整合** (ADR-0013): LP 変更なし
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — e2e 非対象（gate script の純粋関数のみ）
- [ ] N/A — 上記いずれも影響範囲外

**横展開（同 class の残置を silent にしない）**: 判定 util を共有した副作用として `check-ac-verification-map.mjs` / `check-merge-gate-checklist.mjs` / `pr-template-gate-checks.mjs` の 3 script が同一規約になった。`pr-merge-gate.yml` / `pr-ac-verification-check.yml` の sparse-checkout に新 util を追加済（`node scripts/check-workflow-sparse-checkout-closure.mjs` で import 漏れ 0 件を確認）。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4357` | PASS（全 step） |
| 追加・変更テスト | `npx vitest run tests/unit/github/pr-template-gate-checks.test.ts tests/unit/scripts/check-merge-gate-checklist.test.ts tests/unit/scripts/check-ac-verification-map.test.ts tests/unit/architecture/pr-body-partial-match-guard.test.ts` | PASS（160 tests） |
| repo 走査 test 区分宣言 | `node scripts/check-repo-scan-test-declaration.mjs` | PASS（47 件すべて宣言済） |
| workflow sparse-checkout 閉包 | `node scripts/check-workflow-sparse-checkout-closure.mjs` | PASS（import 漏れ 0 件） |

- [x] **SOLID / DRY / YAGNI**: 判定を `scripts/lib/ci/pr-body-sections.mjs` の 1 モジュールに集約し 3 script が import。`grep -rn "extractH2Section\|stripHtmlComments\|stripFencedCode" scripts/` で重複定義 0 件を確認。新規 script / 新規宣言機構は作っていない
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。HTML コメント除去は CodeQL `js/bad-tag-filter` 対策の `--!>` 終端も扱う（#4333 からの継承）
- [x] **A11y・パフォーマンス**: N/A（CI script のみ、顧客向け画面なし）
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:high`、`priority:critical` ではない）

### 旧/新判定の比較（AC4）

対象: merged 81 PR（feature 62 / integration 3 / hotfix 16、dependabot lane 除外）。`PR_TEMPLATE_SECTIONS.json` の最終更新 `af127cd29`（2026-07-30、#4103）以降に merge された PR に限定した。それ以前の PR は当時 CI が見た section 集合が今日の SSOT と異なり、絶対判定（PASS / FAIL）を比較しても意味がないため。旧実装は `git show HEAD:scripts/...` を `tmp/scripts-old/` に展開し、**同一入力**で新旧の check 関数を呼び分けて突き合わせた。

| 箇所 | 判定が変わった PR | 内訳 |
|---|---|---|
| #1 `checkSectionPresence` | **0 / 81** | 一斉赤化なし。既存 PR の判定は完全一致。旧実装が実際に取りこぼしていたのは合成入力（コメント / code block / 前方一致見出し）で、corpus 上は潜在的な穴だった |
| #2 `countUnchecked`（merge gate） | **0 / 81** | 一斉赤化なし。判定完全一致 |
| #5 `checkTestResults` | **6 / 81** | 全件が欠陥事例（下表） |

`checkTestResults` で変わった 6 本の内訳:

| PR | lane | 旧 → 新 | 変わった理由（欠陥事例である根拠） |
|---|---|---|---|
| #4304 | integration | SKIP → PASS | keyword が feature template から導出される（`テスト・品質セルフチェック`）ため統合 PR template には存在せず、**統合エビデンス表の検証分岐に一度も入っていなかった**。corpus 全体（integration 12 本）で 12/12 が skip |
| #4253 | integration | SKIP → PASS | 同上 |
| #4152 | integration | SKIP → PASS | 同上 |
| #4325 | feature | SKIP → PASS | AC 表のセルに `下記「テスト・品質セルフチェック」参照` があり、旧実装は**そのセルから section を切り出して**表 0 行 → skip していた（実 body 抜粋: `L29` に言及 / `L58` に実見出し。旧 slice は `"テスト・品質セルフチェック」参照 \| PASS \|"` の 1 行だけ） |
| #4311 | feature | SKIP → PASS | 同上（`L27` に言及 / `L140` に実見出し） |
| #4278 | feature | PASS → **FAIL** | 結果列が `<!-- 実行後に記入 -->` のまま。旧 placeholder 検出は `PASS` / `FAIL` / `例:` を含むコメントしか見ておらずこの文言を素通りさせ、cell も「非空」と数えていた。新実装は判定前に HTML コメントを除去するため空欄として検出する |

新たに FAIL になった 1 本（#4278）は実 CI でも `テスト実行結果の記入 pass` で merge されており（[実 run](https://github.com/Takenori-Kusaka/ganbari-quest/actions/runs/31000670965/job/92288476620)）、未記入のまま通っていたことが裏取りできる。**一斉赤化に該当する箇所はないため、受容宣言の逃げ道は追加していない**（#4348 の「一斉赤化するなら採用しないか受容宣言を用意する」条件に対する結論）。

なお期間を全 108 PR に広げると `checkTestResults` の変化は 26 本になるが、増分 20 本は `PR_TEMPLATE_SECTIONS.json` 更新前の hotfix / feature で **旧実装でも `必須セクションの存在確認` が FAIL 判定になる**（= 今日の SSOT を当てた結果であり、当時の CI 判定ではない）。この 20 本を「新たに赤くなる PR」として数えるのは誤りなので、本文の実測は SSOT 不変期間に限定した。

### mutation 実測（AC5 / AC6）

実装を先に commit（`7931d2632`（rebase 後 `6ceb903e2`））してから壊し、`git stash push -- <path>` で退避して戻した（実装ごと消す事故の回避）。

| # | 壊した内容 | 結果 |
|---|---|---|
| M1 | `checkSectionPresence` の `hasH2Section(body, s)` を `body.includes(s)` に戻す | **red** — 回帰 test 3 件（コメント内 / code block 内 / 前方一致見出し）が fail |
| M2 | 同 M1 の状態で fitness function を実行 | **red** — `ALLOWLIST 外の部分一致判定が存在しない` が fail（是正済み箇所を緩い判定に戻すと必ず落ちる） |
| M3 | `checkTestResults` の section 不在時を `{ok:false}` → `{ok:true, skipped:true}` に戻す | **red** — `section 不在は skip でなく fail` が fail |
| M4 | `countUnchecked` の `extractH2Section` を `body.indexOf(section)` に戻す | **red** — 回帰 test 3 件 + fitness function が fail（計 4 件） |

## スクリーンショット / ビジュアルデモ

該当なし（CI / gate script の判定ロジック変更のみで、顧客に見える画面の変更を含まない）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

**レビュー依頼事項**:

1. **本 PR で是正しなかった 3 箇所を「残した」と明示している点**。Issue #4348 は「6 箇所を 1 PR で一括変更しない（AC4 の実測が箇所ごとに必要）」を「やらないこと」に挙げているため、影響が大きく比較で安全と確認できた #1 / #2 / #5 のみを本 PR に入れ、#3（`check-admin-bypass-evidence`）/ #4（`check-pr-screenshot` の 2 関数）/ #6（`check-ac-verification-map` の AC マップ section 探索）は残置した。残置は `tests/unit/architecture/pr-body-partial-match-guard.test.ts` の `ALLOWLIST` に **理由付きで機械登録**してあり、消えれば stale として fail する。追跡先は **Issue #4348 を open のまま維持**（本 PR は close しない）。
2. **`checkTestResults` の integration lane 分岐が実質デッドコードだった**点。lane 別に見る section を解決するよう直したので、統合 PR で初めてこの検証が動く。統合 PR 3 本（corpus 内）は新判定で PASS することを実測済みだが、次の統合 PR で想定外の赤が出ないかは QM 側でも確認いただきたい。
3. **fitness function の key 設計**。`<file>::<空白正規化した該当行>` を key にしているため、該当行を編集すると unknown + stale の両方で落ちる。「この判定を触ったならもう一度理由を書け」という強制を意図しているが、ノイズが多いと判断されるなら key を粗くする余地はある。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（AC1 / AC3 / AC4 / AC5 は本 PR scope の 3 箇所について完了。残 3 箇所の扱いは「レビュー依頼事項」1 に明記）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — UI 変更なしのため該当なし
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — 認証画面の変更なしのため該当なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
