### PR TITLE
fix(ops): MFA 未設定 403 画面の依頼先文言からリポジトリパスを消す

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4400,8 +4400,13 @@ export const OPS_MFA_SETUP_LABELS = {
 	],
 	/** 再ログインは MFA チャレンジを経て `amr` を載せ直す唯一の出口。汎用 403 と同じ文言を再利用する */
 	loginAgainLabel: ERROR_PAGE_LABELS.btnLoginAgain,
-	runbookHint:
-		'手順の詳細と、自分で設定できない場合の依頼先は運用手順書 docs/runbooks/ops-mfa-setup.md にあります。',
+	/**
+	 * #4335 follow-up: 旧文言はリポジトリ内ファイルパス（`docs/runbooks/ops-mfa-setup.md`）を
+	 * そのまま出しており、403 画面を見ている運営者がその場で開けなかった（クローンを持たない
+	 * 環境 / スマートフォンからの閲覧では特に）。依頼先を画面内で完結させる（runbook の詳細手順
+	 * は変えず、画面には「自分でできない場合に誰に頼むか」だけを直接書く）。
+	 */
+	runbookHint: '自分で設定できない場合は、AWS アカウントのオーナーに設定を依頼してください。',
 } as const;
 
 // ============================================================


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（AWS アカウントのオーナー / ops group メンバー）

**解決する課題**: #4335 で `/ops` が MFA 未設定の運営者に対して設定手順を出す `OpsMfaSetupNotice` を追加したが、最後の 1 行だけがリポジトリ内ファイルパス（`docs/runbooks/ops-mfa-setup.md`）をそのまま出していた。403 画面を見ている運営者はブラウザからそのパスをその場で開けず（クローンを持たない環境 / スマートフォンからの閲覧では特に）、「自分で設定できない場合の依頼先」が実質分からないまま復旧導線が途切れていた。

**期待される効果**: 依頼先（AWS アカウントのオーナー）を画面内の文言として直接示し、リポジトリのパスを見せずに完結させる。

## 関連 Issue

本 PR を closes する Issue はありません。#4335 の follow-up として、オーナー指示（approve コメント止まりにせず直せるものは PR で出す方針）に基づき直接是正しています。

<!-- no-issue-close: #4335 の follow-up。オーナー指示で follow-up はコメント止まりにせず直接 PR にする方針のため、新規 Issue は起票していない -->

## AC 検証マップ (ADR-0004)

<!-- 本 PR は #4335 の follow-up であり、Issue 起票を経ていないため Issue 由来の AC は存在しない。是正内容そのものを検証項目として記載する。 -->

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `OPS_MFA_SETUP_LABELS.runbookHint` からリポジトリ内ファイルパス（`docs/runbooks/ops-mfa-setup.md`）の文字列表示を削除する | `git diff` を目視 / `grep -n "docs/runbooks" src/lib/domain/labels.ts` の該当行が消えていることを確認 | PASS。HEAD `3970a528` / `src/lib/domain/labels.ts` の `runbookHint` を「自分で設定できない場合は、AWS アカウントのオーナーに設定を依頼してください。」に置換 |
| AC2 | 依頼先（誰に頼むか）を画面内の文言として直接示す。個人のメールアドレス / Discord ID 等の直書きはしない | 上記差分を目視 | PASS。「AWS アカウントのオーナー」という役割名を使用（`docs/runbooks/staging-live-verification.md` の既存の「オーナーに依頼する」表現と同型）。個人識別子は含まない |
| AC3 | 既存のコンポーネント test（`OPS_MFA_SETUP_LABELS.runbookHint` を参照するのみで固定文字列に依存していない）が壊れない | `tests/unit/components/ops-mfa-setup-notice.test.ts` の該当 assertion (`expect(screen.getByText(OPS_MFA_SETUP_LABELS.runbookHint)).toBeTruthy()`) を確認 | PASS（テスト自体が定数参照のため文言変更で自動的に緑のまま。ローカルで `npx vitest` を実行しようとしたが `heavy-run-lock` が他セッションの重い検証で占有中のため実行できず、CI の `unit-test` で確認する） |
| AC4 | Before / After の実画面を SS で確認する（`npm run dev:cognito` の `ops-no-mfa@example.com`） | `scripts/capture-specs/flows/ops-mfa-setup-notice-4282.mjs` を使い、before は `develop` の `labels.ts`、after は本 PR の `labels.ts` を一時的に切り替えて撮影 | PASS。下記「スクリーンショット」参照。desktop / mobile ともリポジトリパスが画面から消え、「自分で設定できない場合は、AWS アカウントのオーナーに設定を依頼してください。」に置き換わっていることを目視確認 |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `/ops`（MFA 未設定で 403 になったときの `OpsMfaSetupNotice` コンポーネント）のみ。

- [x] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）— 文言は `src/lib/domain/labels.ts`（`OPS_MFA_SETUP_LABELS`）の SSOT 1 箇所のみを変更。LP / 顧客向け画面には影響しない（運営専用画面のため `generate-lp-labels.mjs` / `sync-lp-fallback.mjs` の対象外）。年齢モード・ナビ・E2E seed・チュートリアルは対象外（運営専用画面、子供 / 親向け画面ではない）
- [x] **設計書同期** (ADR-0001): UI 文言の軽微な修正であり、`docs/design/06-UI設計書.md` 等に新規仕様として記載するレベルの変更ではない（既存の #4282 / #4335 の設計はそのまま）。N/A と判断
- [x] **LP ↔ アプリ整合** (ADR-0013): 該当なし（LP に影響する変更ではない）
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — 該当なし（labels.ts の文言 1 箇所の変更のみ、ルーティング・認可ロジックへの変更なし）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | 未実行（heavy-run-lock が他セッションの検証で占有中のため）。CI で確認する |
| 既存コンポーネント test | `npx vitest run tests/unit/components/ops-mfa-setup-notice.test.ts` | 未実行（同上）。定数参照のみのため content 変更で壊れないと判断（上記 AC3 参照） |
| biome | `npx biome check src/lib/domain/labels.ts` | PASS（push 時の pre-push hook で自動実行、fix なし） |
| eslint | 変更 file のみ | PASS（0 errors、既存の sonarjs/no-duplicate-string warning 31 件は本 PR の変更行とは無関係な既存箇所） |

- [x] **SOLID / DRY / YAGNI**: 単一の label 定数値を変更しただけ。新規の抽象化・設定項目なし
- [x] **Security（OSS 公開前提）**: 個人のメールアドレス / Discord ID 等を直書きしていない（AC2 参照）。秘密情報の追加なし
- [x] **A11y・パフォーマンス**: 表示テキストの変更のみ、DOM 構造・role 属性は不変
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:high` 未満の軽微な follow-up）

## スクリーンショット / ビジュアルデモ

<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-before-desktop/01-after-ops-mfa-denied.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-desktop/01-after-ops-mfa-denied.png -->
<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-before-mobile/01-after-ops-mfa-denied.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-mobile/01-after-ops-mfa-denied.png -->

| | モバイル (375px) | PC (1440px) |
|---|---|---|
| **修正前** | ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-before-mobile/01-after-ops-mfa-denied.png) | ![before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-before-desktop/01-after-ops-mfa-denied.png) |
| **修正後** | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-mobile/01-after-ops-mfa-denied.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-desktop/01-after-ops-mfa-denied.png) |

DOM スナップショット（SS と同一 page から取得、#1747 AC4）:
- [before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-before-desktop/01-after-ops-mfa-denied.dom.html) / [before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-before-mobile/01-after-ops-mfa-denied.dom.html)
- [after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-desktop/01-after-ops-mfa-denied.dom.html) / [after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4335-followup-mobile/01-after-ops-mfa-denied.dom.html)

撮影条件: `npm run dev:cognito`（`AUTH_MODE=cognito` + `COGNITO_DEV_MODE=true`）で `ops-no-mfa@example.com` としてログイン → `/ops` へ遷移。修正前は `src/lib/domain/labels.ts` を一時的に `origin/develop` の内容に差し替えた状態（本番相当）で撮影し、撮影後に本 PR の内容へ戻した。

**回帰確認**: 同フローの MFA 済 ops（`ops@example.com`）が従来どおり `/ops` に入れることも同時に撮影（`02-ops-with-mfa-still-allowed` ステップ、上記各フォルダに含まれる）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:
依頼先の書き方（「AWS アカウントのオーナー」という役割名）が妥当か確認してほしい。個人のメール / Discord ID は書かないという制約のもとでの選択。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認（内部コード露出なし・用語ハードコードなし・primitives 再実装なし・インラインスタイルなし）
- [x] 認証画面変更時: 該当なし（`/ops` は認証画面ではなく認可後の管理画面）。ただし Cognito 認証フロー経由での確認が必要なため `npm run dev:cognito` で実ブラウザ操作した SS を添付済み

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)

