### PR TITLE
docs(capture): 誕生日 uiMode 切替告知の capture-spec を追加 (#4332 QM follow-up)

### DIFF
--- a/scripts/capture-specs/flows/ui-mode-change-notice-4313.mjs
+++ b/scripts/capture-specs/flows/ui-mode-change-notice-4313.mjs
@@ -1,0 +1,136 @@
+/**
+ * scripts/capture-specs/flows/ui-mode-change-notice-4313.mjs (#4313)
+ *
+ * 誕生日で年齢帯 UI (uiMode) が切り替わったことを次回ログインで 1 回だけ告知する
+ * ダイアログを 4 つの子供向け年齢モードで撮る。
+ * `AUTH_MODE=local` (`npm run dev`) で動作。#4261 (habit-certificate-notice) と同じ
+ * 「次回起動で 1 回だけ」パターンのため、同ファイル (`child-home-habit-notice-4261.mjs`)
+ * の撮影方式を踏襲している。
+ *
+ * ## この画面が `DATA_SOURCE=demo` / `?screenshot=all` で撮れない理由 (#4332 QM follow-up)
+ *
+ * 3 つの制約が重なるため、既存の `child-home-per-child-pr2485.mjs` のような
+ * demo fixture + `?screenshot=all` の定番パターンがそのまま使えない。
+ *
+ * 1. **`?screenshot=all` では意図的に非表示になる**: `dialog-state-machine.ts` を経由する
+ *    自動トリガー系ダイアログは `isScreenshotMode` guard を持ち (`ui-mode-change-notice.ts`
+ *    の `shouldShowUiModeChangeNotice`)、LP 配信 SS を汚さないようにこのダイアログを常に
+ *    出さない設計になっている。→ **screenshot query を付けずに遷移する** (本ファイルの対応)
+ * 2. **`DATA_SOURCE=demo` の settings write は no-op stub** (ADR-0048 §決定 §2、
+ *    `src/lib/server/db/demo/settings-repo.ts`): 告知の実体は `settings` KV の
+ *    `ui_mode_change_notice:<childId>` レコードであり、demo backend では書き込めない
+ *    (`getSetting` は固定 fixture map からしか読めない)。→ **demo ではなく `AUTH_MODE=local`
+ *    の実 sqlite (`data/ganbari-quest.db`) を使い、事前条件セクションの手順で実際に
+ *    settings 行を挿入する** (本ファイルの対応)
+ * 3. **demo fixture の `SiblingCheerOverlay` が常に最優先表示される**: demo の
+ *    `DEMO_SIBLING_CHEERS` (`src/lib/server/demo/demo-data.ts`) は全ての demo 子供
+ *    (902/903/904/906) に未読エールを持たせており、`zLayer="tutorial"` (`--z-tutorial=100`)
+ *    が `--z-modal=50` より優先されるため、demo 経由だとこのダイアログより先に毎回
+ *    エール受信演出が全面に出て閉じても再出現する (demo の cheer write も no-op stub の
+ *    ため既読化されない)。→ **local mode + 空の DB なら未読エールは存在しないため
+ *    そもそも発生しない** (制約 2 の対処と同時に解消される)
+ *
+ * ## 事前条件 (撮影者が用意する) — 実機で動作確認済みの手順 (2026-08-06)
+ *
+ * `npm run db:push` で新規 sqlite (`data/ganbari-quest.db`) を作った直後は `categories`
+ * すら空なので、以下を **順番に** 満たす必要がある (足りない状態で試すと分かりにくい
+ * 症状で詰まるため、検証済みの完全な組み合わせとして残す):
+ *
+ *   1. `categories` に最低 1 行 (`id=1` を使うなら `undou` 等)。
+ *   2. `children`: id 1=preschool (from=baby) / 2=elementary (from=preschool) /
+ *      3=junior (from=elementary) / 4=senior (from=junior)。
+ *      `birthDate` は今日と一致しない値にする (誕生日ボーナスダイアログが同時に
+ *      enqueue されると `birthdayPending` 排他でこの告知が出なくなるため、
+ *      ADR-0012 ダイアログ 2 枚連続禁止)。
+ *   3. **`child_activities` + `activity_logs` を子供ごとに最低 1 件ずつ。**
+ *      これが無いと `hasAnyActivityRecords` が false → `data.isFirstTime` が true →
+ *      `AdventureStartOverlay` (`dialog-state-machine.ts` の `PRIORITY_ORDER` で
+ *      `uiModeChange` より優先) が `fsm.current` を握ったまま離さず、この告知は
+ *      queue に積まれるだけで表示されない (DOM に `ui-mode-change-dialog` 自体が
+ *      現れないため気づきにくい)。
+ *   4. `settings`: `ui_mode_change_notice:<childId>` =
+ *      {"from":"<切替前>","to":"<切替後=uiMode>","changedOn":"2026-08-06"}
+ *      (JST 暦日文字列。値は `ui-mode-change-notice-service.ts` の
+ *      `UiModeChangeNotice` 型と同じ shape)
+ *   5. `settings`: `pin_gate_onboarding_seen` = 'true' (初回訪問 dialog を出さない)
+ *
+ * 上記 1〜5 を満たす投入スクリプトの例は本 PR の説明 (投入手順) を参照。better-sqlite3 +
+ * drizzle で `db.insert(schema.<table>).values({...}).run()` を並べるだけで足りる。
+ *
+ * ## このフローが撮るもの
+ *
+ * 1 周目 (`after-*`) — pending がある回。ダイアログが出る
+ * 2 周目 (`before-*`) — 同じ画面を再訪。**表示して閉じた時点で既読になっている**ため出ない
+ *   (`?/dismissUiModeChangeNotice` action、= 修正前 / develop と同じ描画)
+ *
+ * 既読化 action のレスポンスを待ってから次へ進むため、固定待ちを使わずに
+ * 2 周目の状態が決定的になる。
+ *
+ * 使用例:
+ *   node scripts/capture.mjs --pr <N> \
+ *     --flow ui-mode-change-notice-4313 \
+ *     --url /switch \
+ *     --actions scripts/capture-specs/flows/ui-mode-change-notice-4313.mjs \
+ *     --presets mobile
+ */
+
+const CHILDREN = [
+	{ childId: 1, uiMode: 'preschool' },
+	{ childId: 2, uiMode: 'elementary' },
+	{ childId: 3, uiMode: 'junior' },
+	{ childId: 4, uiMode: 'senior' },
+];
+
+const DIALOG = '[data-testid="ui-mode-change-dialog"]';
+const CLOSE_BUTTON = '[data-testid="ui-mode-change-close-btn"]';
+
+/**
+ * 同じ flow を preset 違いで 2 回流すと step 名が衝突し、後の run が前の run の SS を
+ * 上書きする (screenshots branch は file 名で同定する)。`CAPTURE_LABEL_SUFFIX` で分ける。
+ */
+const SUFFIX = process.env.CAPTURE_LABEL_SUFFIX ? `-${process.env.CAPTURE_LABEL_SUFFIX}` : '';
+
+/** @param {import('playwright').Page} page */
+async function selectChild(page, childId, uiMode) {
+	// FlowRecorder の context は baseURL を持たないため絶対 URL で遷移する
+	await page.goto(new URL('/switch', page.url()).href, { waitUntil: 'domcontentloaded' });
+	await page.locator(`[data-testid="child-select-${childId}"]`).click();
+	// 遷移完了後に waitForURL を呼ぶと取りこぼすため、home の testid 出現で待つ
+	await page.locator(`[data-testid="${uiMode}-home-page"]`).waitFor({ state: 'visible' });
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// デモ Cookie が残っていると isDemo=true になり child 一覧が空になる
+	await page.context().clearCookies();
+	// 本 PR の対象ではない使い方ガイドのバナーを画面から外す (localStorage 由来)
+	await page.addInitScript(() => {
+		try {
+			for (const id of [1, 2, 3, 4]) localStorage.setItem(`child_tutorial_hint_shown_${id}`, '1');
+		} catch {
+			/* localStorage 不可の環境では何もしない */
+		}
+	});
+
+	// 1 周目: pending あり → ダイアログが出る
+	for (const { childId, uiMode } of CHILDREN) {
+		await selectChild(page, childId, uiMode);
+		await page.locator(DIALOG).waitFor({ state: 'visible' });
+		await capture(`after-${uiMode}-home-mobile${SUFFIX}`);
+
+		// 既読化が着地するまで待ってから閉じる (着地前に離脱すると 2 周目にまた出る)
+		const dismissed = page.waitForResponse((r) => r.url().includes('dismissUiModeChangeNotice'));
+		await page.locator(CLOSE_BUTTON).click();
+		await dismissed;
+	}
+
+	// 2 周目: 既読化済 → 出ない (= 修正前と同じ描画 / 「1 回だけ」の実機証跡)
+	for (const { childId, uiMode } of CHILDREN) {
+		await selectChild(page, childId, uiMode);
+		await page.locator(DIALOG).waitFor({ state: 'detached' });
+		await capture(`before-${uiMode}-home-mobile${SUFFIX}`);
+	}
+};


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発プロセス、直接の顧客影響なし）

**解決する課題**: PR #4332 (#4313 誕生日 uiMode 切替告知) の QM レビューで、この「次回起動で 1 回だけ」出るダイアログのスクリーンショットが、demo fixture + `?screenshot=all` の定番パターンでは撮れないことが判明した。撮影者（QM）はその場で一時的な demo fixture の source patch を当てて撮影後に revert する回り道をしたが、この手順が記録されていないと、次にこの画面を撮る人が同じ 3〜4 個の制約に遭遇し、同じ時間を消費してしまう。

**期待される効果**: `scripts/capture-specs/flows/` に再現可能な capture spec を追加することで、次回この告知ダイアログ（または類似の「次回起動で 1 回だけ」型ダイアログ）を撮影する人が、詰まった経緯を再体験せずに済む。

## 関連 Issue

<!-- no-issue-close: PR #4332 (#4313) の QM レビューで判明した知見を記録するドキュメント PR であり、close すべき既存 Issue はないため -->
本 PR は PR #4332（#4313 誕生日 uiMode 切替告知ダイアログ）の QM レビュー中に判明した撮影手順の知見を記録するドキュメント PR であり、close すべき既存 Issue はありません。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `?screenshot=all` を使わずにこの告知ダイアログを撮影できる spec を追加する | 実機検証 | HEAD `2afc2966` / `scripts/capture-specs/flows/ui-mode-change-notice-4313.mjs`。`AUTH_MODE=local` の実 sqlite dev server (`npx vite dev`) 上で `node scripts/capture.mjs --flow ui-mode-change-notice-4313 --url /switch --actions scripts/capture-specs/flows/ui-mode-change-notice-4313.mjs --presets mobile` を実行し、`preschool/elementary/junior/senior` 4 モード分の after (ダイアログ表示) / before (既読化済み・非表示) 計 8 枚を実撮影で確認した（PR #4332 の QM 対応 clone 上で実行、成果物は本 PR には含めない使い捨て検証） |
| AC2 | spec のヘッダコメントに、demo fixture + `?screenshot=all` パターンが使えない理由を明記する | コードレビュー | HEAD `2afc2966` / 同ファイル冒頭 §「この画面が `DATA_SOURCE=demo` / `?screenshot=all` で撮れない理由」に 3 制約（`isScreenshotMode` guard / demo settings write no-op stub / `SiblingCheerOverlay` 常時最優先）を記載 |
| AC3 | 事前条件（DB seed 手順）が実際に動作することを検証する | 実機検証 | 当初のドキュメント案には `categories` 行と `child_activities`/`activity_logs` 行の必要性が抜けており、実際に `npm run db:push` 直後の空 DB で試したところ FK 制約エラー、続いて `AdventureStartOverlay`（`dialog-state-machine.ts` の FSM 優先度で `uiModeChange` より上位）が `fsm.current` を握ったままダイアログが出ない事象に遭遇した。原因（`hasAnyActivityRecords` が false → `isFirstTime` が true → adventure が優先）を特定し、事前条件セクションに 5 項目（categories / children / **child_activities + activity_logs** / settings notice / settings pin_gate）として明記した上で、この手順どおりに再実行し 8 枚撮影に成功したことを確認した |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲・横展開チェック

**影響を受ける画面・機能**:
なし（新規ファイル追加のみ、既存コードへの変更なし）。`scripts/capture-specs/flows/` はドキュメント兼撮影自動化スクリプト置き場であり、アプリケーションのビルド・実行には含まれない。

- [ ] 並行実装ペアを同期した
- [ ] 設計書同期 (ADR-0001)
- [ ] LP ↔ アプリ整合 (ADR-0013)
- [ ] 重量 e2e 敏感領域
- [x] N/A — 新規 capture-spec ファイル 1 件の追加のみで、アプリケーションコード・テスト・設計書のいずれにも変更がないため

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | **未実行** — 作業クローンに `node_modules` が無く実行不能（下記詳細） |
| 追加・変更テスト | なし（`.mjs` capture spec の追加のみ、既存テストへの影響なし） | N/A |

**正直な申告**: 本 PR の作業クローンには `npm install` 済みの `node_modules` が存在せず、`vitest` / `biome` / `svelte-check` は実行できませんでした。ただし追加した `ui-mode-change-notice-4313.mjs` の**内容自体は**、`npm ci` 済みの検証用クローン（PR #4332 の QM 対応で使った worktree）上で `node scripts/capture.mjs --flow ui-mode-change-notice-4313 ...` を実際に走らせ、8 ステップ全て成功することを確認済みです（AC1/AC3 参照）。行幅 100 文字超過は `awk` で確認し 0 件でした。

- [ ] SOLID / DRY / YAGNI
- [ ] Security（OSS 公開前提）
- [ ] A11y・パフォーマンス
- [x] Critical バグ修正(ADR-0002): N/A（ドキュメント追加のみ）

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: capture spec スクリプトファイルの追加のみで、UI 描画やその変更を一切伴わないためスクリーンショット対象なし -->
該当なし（`scripts/` 配下への capture-spec ファイル追加のみで、UI 変更を含まないため）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:
- 恒久的な demo fixture 変更（`DEMO_SETTINGS` への notice 追加等）にはせず、`AUTH_MODE=local` + 実 sqlite 直接 seed 方式にした判断について — #4261 (habit-certificate-notice) の既存 `child-home-habit-notice-4261.mjs` が同じ「次回起動で 1 回だけ」パターンで同方式を採用済みだったため、それに倣いました。demo fixture を恒久的に変更すると、その子供の demo 訪問時に毎回この告知が出てしまい、通常の demo 体験を汚染するリスクがあったため採用しませんでした。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし。検証用の一時 DB / seed script / debug script は全て削除済み、`git status --porcelain` でクリーンを確認）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
