### PR TITLE
fix(infra): #4352 IaC 外で足された Lambda env が deploy で消えず re-commit される穴を塞ぐ

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -421,6 +421,23 @@ jobs:
             --region $AWS_REGION
           echo "::notice::staging ORIGIN resolved and applied: $ORIGIN"
 
+      # Step 13.5 (#4352): env drift 検査。**Step 13 の直後に置く**。
+      #
+      # Step 13 は live env を read-modify-write (`jq '. + {…}'`) するため、IaC の外で手で足された env は
+      # deploy のたびに正式な設定として **re-commit される**。CloudFormation もテンプレート無変更なら
+      # リソースを触らないので drift を戻さない。結果「IaC に無い env が恒久的に効き続ける」状態が
+      # deploy success のまま残る (#4117 E1 で実際に起きた: 検証用に注入した STRIPE_PRICE_* が
+      # full deploy を跨いで残り、staging で checkout が通るのを見て「#4286 が直った」と誤判定しうる
+      # 状態が続いた)。
+      #
+      # 本 step は cdk deploy が出力したテンプレートと live の **キー集合**を突き合わせる (値は読まない)。
+      - name: Lambda env drift check (staging, #4352)
+        run: |
+          node scripts/check-lambda-env-drift.mjs \
+            --function "$LAMBDA_FUNCTION" \
+            --template infra/cdk.out/GanbariQuestComputeStaging.template.json \
+            --region "$AWS_REGION"
+
       # Step 14: Post-deploy health check (deploy.yml Phase 5 pattern、5 retry)。
       # staging table は空だが /api/health はデータ非依存 (設計 §データ戦略)。
       - name: Health check (staging)

--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -436,6 +436,7 @@ jobs:
           node scripts/check-lambda-env-drift.mjs \
             --function "$LAMBDA_FUNCTION" \
             --template infra/cdk.out/GanbariQuestComputeStaging.template.json \
+            --logical-id-prefix SvelteKitFn \
             --region "$AWS_REGION"
 
       # Step 14: Post-deploy health check (deploy.yml Phase 5 pattern、5 retry)。

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -444,6 +444,24 @@ jobs:
             --function-name $LAMBDA_FUNCTION \
             --region $AWS_REGION
 
+      # #4352: IaC の外で足された env (out-of-band drift) の検出。
+      #
+      # CloudFormation はテンプレート無変更ならリソースを触らないため、`aws lambda
+      # update-function-configuration` で手で足した env は **次の deploy でも消えない**
+      # (staging では実際に検証用の STRIPE_PRICE_* が full deploy を跨いで残り、#4286 の
+      # 修正が効いているかを staging で判定できない状態が続いた、#4117 E1)。
+      #
+      # 上の "Incident webhook env verification" が「あるべきキーがあるか」を見るのに対し、
+      # 本 step は「**あるべきでないキーが無いか**」を見る (逆方向)。値は読まずキー名だけで判定する。
+      # 欠落 (テンプレートにあるが live に無い) は warning に留め、extra のみ hard-fail する。
+      - name: Lambda env drift check (production, #4352)
+        run: |
+          node scripts/check-lambda-env-drift.mjs \
+            --function "$LAMBDA_FUNCTION" \
+            --template infra/cdk.out/GanbariQuestCompute.template.json \
+            --logical-id-prefix SvelteKitFn \
+            --region "$AWS_REGION"
+
       # #4174: **synth の diff ではなく、deploy 済み Lambda の実 env** を読んで検証する。
       # compute-stack.ts は空値のとき env ごと落とす (`...(x ? {KEY: x} : {})`) ため、
       # 「context を渡し忘れた」「secret 名を間違えた」のいずれでも **deploy は成功したまま

--- a/infra/CLAUDE.md
+++ b/infra/CLAUDE.md
@@ -92,6 +92,21 @@ AWS 側の設定漏れは別レイヤで止める: `infra/bin/app.ts` の `resol
 
 `.env.example` 追加 / `ci.yml` env 追加 / `deploy.yml` test job env 追加 / `deploy.yml` deploy job `-c` 追加 / `compute-stack.ts` `tryGetContext` + `environment` 追加 / `deploy-nuc.yml` env 追加 / 本ファイル env 表追記 / PR 本文の "PO action required" に `gh secret set XXX --body <value> --repo Takenori-Kusaka/ganbari-quest` 明記。
 
+## Lambda env の SSOT は CDK — 手で足した env は deploy で消えない (#4352)
+
+**`aws lambda update-function-configuration` で env を直接足してはいけない。** 足したものは次の deploy でも消えない:
+
+1. **CloudFormation は out-of-band drift を戻さない。** テンプレートのプロパティが前回と同一なら CFN はそのリソースを触らない。`cdk deploy` が走っても env は CDK 定義に戻らない
+2. **deploy が drift を re-commit する。** `deploy-aws-staging.yml` の「Resolve ORIGIN from CloudFront」step は Function URL / CloudFront が synth 時未確定なため live env を read-modify-write する。手で足した env は deploy のたびに正式な設定として書き直される
+
+実害 (#4117 E1): 検証のため手で注入した `STRIPE_PRICE_*_MONTHLY` が full staging deploy (success) を跨いで残り、「staging で checkout が通る」ことが `#4286` の修正の証拠にならない状態が続いた。
+
+**機械強制**: `scripts/check-lambda-env-drift.mjs` が deploy の最後に `live の env キー ⊆ (CDK テンプレートのキー ∪ 実行時解決キー)` を assert する (`deploy-aws-staging.yml` Step 13.5)。値は読まずキー名だけで判定する。
+
+- 正式な設定なら **CDK (`infra/lib/compute-stack.ts`) に足す**。上記「新規 env 追加時 PR チェックリスト」に従う
+- deploy 後に解決して足す env を新設する場合は、`check-lambda-env-drift.mjs` の `RUNTIME_RESOLVED_KEYS` に追記する (追記しないと deploy が落ちる)
+- 検証のため一時的に注入した場合は、**検証が終わったら手で除去する**。「次の deploy で消える」は成り立たない
+
 ## AWS Cost Explorer API 使用制限
 
 | 制約 | 値 |

--- a/scripts/check-lambda-env-drift.mjs
+++ b/scripts/check-lambda-env-drift.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// @ts-nocheck — CLI gate script。unit test が import するため TS graph に入るが untyped JS の CLI ツール。
+//
+// scripts/check-lambda-env-drift.mjs (#4352)
+//
+// deploy 済み Lambda の環境変数キーが CDK テンプレートと一致しているかを実測し、
+// **IaC の外で足された env (out-of-band drift)** を hard-fail で可聴化する。
+//
+// 背景 (#4352 / #4117 E1):
+//   監査が #4286 の検証のため staging Lambda に手で `STRIPE_PRICE_*_MONTHLY` を注入した。
+//   「次の deploy で消える」という前提で残置したが、**full staging deploy (success) を跨いで残った**。
+//   原因は 2 つ:
+//     1. CloudFormation はテンプレート無変更ならリソースを触らない → drift は戻らない
+//     2. deploy workflow の「Resolve ORIGIN from CloudFront」step が live env を read-modify-write
+//        (`jq '. + {…}'`) しており、**手で足した env を毎回 re-commit する**
+//   結果として「IaC に書いていない env が恒久的に効き続ける」状態が誰にも気づかれないまま続き、
+//   staging で checkout が通るのを見て「#4286 が直った」と誤判定しうる状態になっていた。
+//
+// 本 gate は deploy の最後に「live の env キー集合 ⊆ (テンプレートのキー ∪ 実行時解決キー)」を assert する。
+// **値は一切読まない / 出力しない** (secret を CI ログに出さないため、キー名だけで判定する)。
+//
+// 使用:
+//   node scripts/check-lambda-env-drift.mjs --function <name> --template <cfn-template.json> [--region us-east-1] [--strict]
+//     --template : cdk deploy が出力した `infra/cdk.out/<Stack>.template.json`
+//     --strict   : テンプレートにあるのに live に無いキー (欠落) も fail にする (既定は warning)
+//   CI: deploy-aws-staging.yml の ORIGIN 解決 step の直後。
+//
+// ADR-0024 (ENV silent skip 禁止) の env 版。deploy が success を返しながら実態が IaC と乖離する経路を塞ぐ。
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
+
+// ---------------------------------------------------------------------------
+// 実行時解決キー SSOT
+//
+// CDK synth 時点では確定せず、deploy の後段 step が実測値で足すキー。
+// テンプレートに現れないが drift ではないため、本 gate では許容する。
+// 新たに「deploy 後に足す env」を増やしたら **必ず本リストに追記する** (追記しないと deploy が落ちる)。
+// ---------------------------------------------------------------------------
+export const RUNTIME_RESOLVED_KEYS = [
+	// deploy-aws-staging.yml / deploy.yml の「Resolve ORIGIN from CloudFront」step が
+	// CloudFront の DistributionDomainName から解決して注入する 3 本。
+	'ORIGIN',
+	'COGNITO_CALLBACK_URL',
+	'COGNITO_LOGOUT_URL',
+];
+
+/**
+ * CFN テンプレート (JSON) から Lambda 関数の env キー集合を抽出する。
+ * 複数の Lambda がある場合は全関数の和集合を返す (同一 stack 内の関数はどれも IaC 由来のため)。
+ */
+export function extractTemplateEnvKeys(template) {
+	const keys = new Set();
+	for (const res of Object.values(template?.Resources ?? {})) {
+		if (res?.Type !== 'AWS::Lambda::Function') continue;
+		for (const k of Object.keys(res?.Properties?.Environment?.Variables ?? {})) keys.add(k);
+	}
+	return [...keys].sort();
+}
+
+/**
+ * live env キーとテンプレート env キーの差分を取る。**値は扱わない。**
+ *
+ * @returns {{ extra: string[], missing: string[] }}
+ *   extra   : live にあるが IaC にも実行時解決リストにも無い = out-of-band drift
+ *   missing : IaC にあるが live に無い = deploy が最後まで適用されていない
+ */
+export function diffEnvKeys(liveKeys, templateKeys, runtimeKeys = RUNTIME_RESOLVED_KEYS) {
+	const allowed = new Set([...templateKeys, ...runtimeKeys]);
+	const live = new Set(liveKeys);
+	return {
+		extra: [...live].filter((k) => !allowed.has(k)).sort(),
+		missing: [...templateKeys].filter((k) => !live.has(k)).sort(),
+	};
+}
+
+function fetchLiveEnvKeys(functionName, region) {
+	const out = execFileSync(
+		'aws',
+		[
+			'lambda',
+			'get-function-configuration',
+			'--function-name',
+			functionName,
+			'--region',
+			region,
+			'--query',
+			'Environment.Variables',
+			'--output',
+			'json',
+		],
+		{ encoding: 'utf8' },
+	);
+	// 値は捨てる。以後キー名しか扱わない (secret を CI ログに出さない)
+	return Object.keys(JSON.parse(out) ?? {}).sort();
+}
+
+function parseArgs(argv) {
+	const get = (flag) => {
+		const i = argv.indexOf(flag);
+		return i >= 0 ? argv[i + 1] : undefined;
+	};
+	return {
+		functionName: get('--function'),
+		templatePath: get('--template'),
+		region: get('--region') ?? process.env.AWS_REGION ?? 'us-east-1',
+		strict: argv.includes('--strict'),
+	};
+}
+
+export function main(argv = process.argv.slice(2)) {
+	const { functionName, templatePath, region, strict } = parseArgs(argv);
+	if (!functionName || !templatePath) {
+		console.error(
+			'[check-lambda-env-drift] 使用: --function <name> --template <cfn-template.json> [--region <r>] [--strict]',
+		);
+		return 2;
+	}
+	if (!fs.existsSync(templatePath)) {
+		console.error(`[check-lambda-env-drift] ✗ テンプレートが見つかりません: ${templatePath}`);
+		return 2;
+	}
+
+	const templateKeys = extractTemplateEnvKeys(JSON.parse(fs.readFileSync(templatePath, 'utf8')));
+	if (templateKeys.length === 0) {
+		// テンプレートに Lambda env が 1 つも無い = 参照先を間違えている。素通しさせない。
+		console.error(
+			`[check-lambda-env-drift] ✗ テンプレートに Lambda の環境変数が 1 件もありません: ${templatePath}`,
+		);
+		return 2;
+	}
+
+	const liveKeys = fetchLiveEnvKeys(functionName, region);
+	const { extra, missing } = diffEnvKeys(liveKeys, templateKeys);
+
+	if (missing.length > 0) {
+		const msg = `IaC にあるのに配備されていない env: ${missing.join(', ')}`;
+		if (strict) {
+			console.error(`[check-lambda-env-drift] ✗ FAIL — ${msg}`);
+		} else {
+			console.warn(`[check-lambda-env-drift] ⚠ WARN — ${msg}`);
+		}
+		if (strict) return 1;
+	}
+
+	if (extra.length > 0) {
+		console.error(
+			`[check-lambda-env-drift] ✗ FAIL — IaC の外で足された env が ${extra.length} 件あります: ${extra.join(', ')}\n` +
+				`  (関数: ${functionName} / テンプレート: ${templatePath})\n` +
+				'  CloudFormation はテンプレート無変更ならリソースを触らず、deploy の ORIGIN 解決 step は\n' +
+				'  live env を read-modify-write するため、**この env は次の deploy でも消えません**。\n' +
+				'  対処: (a) 正式な設定なら CDK (infra/lib/*-stack.ts) に足す / (b) 検証用なら手で除去する:\n' +
+				`    aws lambda get-function-configuration --function-name ${functionName} --region ${region} --query 'Environment.Variables'\n` +
+				'    → 該当キーを除いた JSON で aws lambda update-function-configuration --environment file://…',
+		);
+		return 1;
+	}
+
+	console.log(
+		`[check-lambda-env-drift] ✓ PASS — ${functionName} の env キー ${liveKeys.length} 件は IaC と一致 ` +
+			`(テンプレート ${templateKeys.length} 件 + 実行時解決 ${RUNTIME_RESOLVED_KEYS.length} 件)`,
+	);
+	return 0;
+}
+
+if (isMainModule(import.meta.url)) {
+	process.exit(main());
+}

--- a/scripts/check-lambda-env-drift.mjs
+++ b/scripts/check-lambda-env-drift.mjs
@@ -83,6 +83,10 @@ export function diffEnvKeys(liveKeys, templateKeys, runtimeKeys = RUNTIME_RESOLV
 }
 
 function fetchLiveEnvKeys(functionName, region) {
+	// `keys()` を **AWS 側で**適用し、secret の平文を runner のプロセスに一切載せない。
+	// (`Environment.Variables` をそのまま取得して JS 側でキーだけ抜く実装は、
+	//  set -x / プロセスダンプ / 将来の console.log 追加のいずれでも平文が漏れる。
+	//  既存の deploy.yml "Incident webhook env verification" と同じ射影方式に揃える)
 	const out = execFileSync(
 		'aws',
 		[
@@ -93,14 +97,13 @@ function fetchLiveEnvKeys(functionName, region) {
 			'--region',
 			region,
 			'--query',
-			'Environment.Variables',
+			'keys(Environment.Variables)',
 			'--output',
-			'json',
+			'text',
 		],
 		{ encoding: 'utf8' },
 	);
-	// 値は捨てる。以後キー名しか扱わない (secret を CI ログに出さない)
-	return Object.keys(JSON.parse(out) ?? {}).sort();
+	return out.trim().split(/\s+/).filter(Boolean).sort();
 }
 
 function parseArgs(argv) {

--- a/scripts/check-lambda-env-drift.mjs
+++ b/scripts/check-lambda-env-drift.mjs
@@ -20,10 +20,13 @@
 // **値は一切読まない / 出力しない** (secret を CI ログに出さないため、キー名だけで判定する)。
 //
 // 使用:
-//   node scripts/check-lambda-env-drift.mjs --function <name> --template <cfn-template.json> [--region us-east-1] [--strict]
-//     --template : cdk deploy が出力した `infra/cdk.out/<Stack>.template.json`
-//     --strict   : テンプレートにあるのに live に無いキー (欠落) も fail にする (既定は warning)
-//   CI: deploy-aws-staging.yml の ORIGIN 解決 step の直後。
+//   node scripts/check-lambda-env-drift.mjs --function <name> --template <cfn-template.json> \
+//     [--logical-id-prefix SvelteKitFn] [--region us-east-1] [--strict]
+//     --template           : cdk deploy が出力した `infra/cdk.out/<Stack>.template.json`
+//     --logical-id-prefix  : 対象 Lambda の論理 ID 前方一致。**指定推奨** (1 stack に app / cron-dispatcher /
+//                            demo の複数 Lambda があり、省略すると和集合になって検査が緩む)
+//     --strict             : テンプレートにあるのに live に無いキー (欠落) も fail にする (既定は warning)
+//   CI: deploy-aws-staging.yml / deploy.yml の env 解決 step の直後。
 //
 // ADR-0024 (ENV silent skip 禁止) の env 版。deploy が success を返しながら実態が IaC と乖離する経路を塞ぐ。
 
@@ -48,12 +51,16 @@ export const RUNTIME_RESOLVED_KEYS = [
 
 /**
  * CFN テンプレート (JSON) から Lambda 関数の env キー集合を抽出する。
- * 複数の Lambda がある場合は全関数の和集合を返す (同一 stack 内の関数はどれも IaC 由来のため)。
+ *
+ * @param logicalIdPrefix 論理 ID の前方一致で対象関数を絞る (例 'SvelteKitFn')。
+ *   **指定を推奨**。1 stack に複数の Lambda (app / cron-dispatcher / demo) がある場合、
+ *   省略すると和集合になり「別関数にしか無いキー」を許容してしまう (検査が緩む)。
  */
-export function extractTemplateEnvKeys(template) {
+export function extractTemplateEnvKeys(template, logicalIdPrefix = '') {
 	const keys = new Set();
-	for (const res of Object.values(template?.Resources ?? {})) {
+	for (const [logicalId, res] of Object.entries(template?.Resources ?? {})) {
 		if (res?.Type !== 'AWS::Lambda::Function') continue;
+		if (logicalIdPrefix && !logicalId.startsWith(logicalIdPrefix)) continue;
 		for (const k of Object.keys(res?.Properties?.Environment?.Variables ?? {})) keys.add(k);
 	}
 	return [...keys].sort();
@@ -104,13 +111,14 @@ function parseArgs(argv) {
 	return {
 		functionName: get('--function'),
 		templatePath: get('--template'),
+		logicalIdPrefix: get('--logical-id-prefix') ?? '',
 		region: get('--region') ?? process.env.AWS_REGION ?? 'us-east-1',
 		strict: argv.includes('--strict'),
 	};
 }
 
 export function main(argv = process.argv.slice(2)) {
-	const { functionName, templatePath, region, strict } = parseArgs(argv);
+	const { functionName, templatePath, logicalIdPrefix, region, strict } = parseArgs(argv);
 	if (!functionName || !templatePath) {
 		console.error(
 			'[check-lambda-env-drift] 使用: --function <name> --template <cfn-template.json> [--region <r>] [--strict]',
@@ -122,11 +130,16 @@ export function main(argv = process.argv.slice(2)) {
 		return 2;
 	}
 
-	const templateKeys = extractTemplateEnvKeys(JSON.parse(fs.readFileSync(templatePath, 'utf8')));
+	const templateKeys = extractTemplateEnvKeys(
+		JSON.parse(fs.readFileSync(templatePath, 'utf8')),
+		logicalIdPrefix,
+	);
 	if (templateKeys.length === 0) {
-		// テンプレートに Lambda env が 1 つも無い = 参照先を間違えている。素通しさせない。
+		// テンプレートに Lambda env が 1 つも無い = 参照先 (または --logical-id-prefix) を間違えている。
+		// 「対象 0 件だから PASS」は検査していないのと同じなので素通しさせない。
 		console.error(
-			`[check-lambda-env-drift] ✗ テンプレートに Lambda の環境変数が 1 件もありません: ${templatePath}`,
+			`[check-lambda-env-drift] ✗ テンプレートに Lambda の環境変数が 1 件もありません: ${templatePath}` +
+				(logicalIdPrefix ? ` (--logical-id-prefix ${logicalIdPrefix})` : ''),
 		);
 		return 2;
 	}

--- a/tests/unit/scripts/check-lambda-env-drift.test.ts
+++ b/tests/unit/scripts/check-lambda-env-drift.test.ts
@@ -38,6 +38,29 @@ describe('#4352 extractTemplateEnvKeys', () => {
 	it('Lambda が無いテンプレートは空配列 (呼び出し側が参照先誤りとして扱う)', () => {
 		expect(extractTemplateEnvKeys({ Resources: { R: { Type: 'AWS::S3::Bucket' } } })).toEqual([]);
 	});
+
+	it('--logical-id-prefix で対象 Lambda を絞る (別関数のキーを許容しない)', () => {
+		// 1 stack に app / cron-dispatcher / demo が同居する実構成を模す
+		const multi = {
+			Resources: {
+				SvelteKitFn878D7344: {
+					Type: 'AWS::Lambda::Function',
+					Properties: { Environment: { Variables: { AUTH_MODE: 'cognito' } } },
+				},
+				CronDispatcherFn48591636: {
+					Type: 'AWS::Lambda::Function',
+					Properties: { Environment: { Variables: { FUNCTION_URL: 'https://…' } } },
+				},
+				SvelteKitDemoFn03A257DF: {
+					Type: 'AWS::Lambda::Function',
+					Properties: { Environment: { Variables: { DATA_SOURCE: 'demo' } } },
+				},
+			},
+		};
+		expect(extractTemplateEnvKeys(multi, 'SvelteKitFn')).toEqual(['AUTH_MODE']);
+		// prefix 省略時は和集合 = 検査が緩む。既定値の挙動を固定して意図しない緩和を検出する
+		expect(extractTemplateEnvKeys(multi)).toEqual(['AUTH_MODE', 'DATA_SOURCE', 'FUNCTION_URL']);
+	});
 });
 
 describe('#4352 diffEnvKeys', () => {

--- a/tests/unit/scripts/check-lambda-env-drift.test.ts
+++ b/tests/unit/scripts/check-lambda-env-drift.test.ts
@@ -1,0 +1,80 @@
+// tests/unit/scripts/check-lambda-env-drift.test.ts
+// #4352: deploy 済み Lambda の env が IaC の外で足されたまま残る drift の検出 gate 回帰ガード。
+//
+// 実障害 (#4117 E1): 監査が手で注入した STRIPE_PRICE_*_MONTHLY が full staging deploy (success) を
+// 跨いで残った。CFN はテンプレ無変更ならリソースを触らず、deploy の ORIGIN 解決 step は live env を
+// read-modify-write するため、手で足した env は deploy のたびに re-commit される。
+// 本テストは「extra キーを検出する / 実行時解決キーを誤検出しない」ことを機械検証する。
+
+import { describe, expect, it } from 'vitest';
+import {
+	diffEnvKeys,
+	extractTemplateEnvKeys,
+	RUNTIME_RESOLVED_KEYS,
+} from '../../../scripts/check-lambda-env-drift.mjs';
+
+const template = (vars: Record<string, unknown>) => ({
+	Resources: {
+		SvelteKitFn878D7344: {
+			Type: 'AWS::Lambda::Function',
+			Properties: { Environment: { Variables: vars } },
+		},
+		SomeRole: { Type: 'AWS::IAM::Role', Properties: {} },
+	},
+});
+
+describe('#4352 extractTemplateEnvKeys', () => {
+	it('Lambda の env キーのみを抽出する (他リソースは無視)', () => {
+		expect(extractTemplateEnvKeys(template({ AUTH_MODE: 'cognito', DATA_SOURCE: 'dsql' }))).toEqual(
+			['AUTH_MODE', 'DATA_SOURCE'],
+		);
+	});
+
+	it('値が Fn::* の intrinsic でもキーだけ取れる (値は読まない)', () => {
+		const t = template({ DSQL_ENDPOINT: { 'Fn::ImportValue': 'x' }, PORT: '3000' });
+		expect(extractTemplateEnvKeys(t)).toEqual(['DSQL_ENDPOINT', 'PORT']);
+	});
+
+	it('Lambda が無いテンプレートは空配列 (呼び出し側が参照先誤りとして扱う)', () => {
+		expect(extractTemplateEnvKeys({ Resources: { R: { Type: 'AWS::S3::Bucket' } } })).toEqual([]);
+	});
+});
+
+describe('#4352 diffEnvKeys', () => {
+	const tpl = ['AUTH_MODE', 'DATA_SOURCE', 'STRIPE_SECRET_KEY', 'USE_LOOKUP_KEY'];
+
+	it('IaC の外で足された env を extra として検出する (実障害の再現)', () => {
+		const live = [
+			...tpl,
+			...RUNTIME_RESOLVED_KEYS,
+			'STRIPE_PRICE_STANDARD_MONTHLY',
+			'STRIPE_PRICE_FAMILY_MONTHLY',
+		];
+		expect(diffEnvKeys(live, tpl).extra).toEqual([
+			'STRIPE_PRICE_FAMILY_MONTHLY',
+			'STRIPE_PRICE_STANDARD_MONTHLY',
+		]);
+	});
+
+	it('deploy 後に解決して足される 3 本 (ORIGIN 系) は drift 扱いしない', () => {
+		const live = [...tpl, ...RUNTIME_RESOLVED_KEYS];
+		expect(diffEnvKeys(live, tpl)).toEqual({ extra: [], missing: [] });
+	});
+
+	it('IaC にあるのに配備されていないキーを missing として返す', () => {
+		const live = ['AUTH_MODE', 'DATA_SOURCE', ...RUNTIME_RESOLVED_KEYS];
+		expect(diffEnvKeys(live, tpl).missing).toEqual(['STRIPE_SECRET_KEY', 'USE_LOOKUP_KEY']);
+	});
+
+	it('extra と missing は同時に報告される (片方で早期 return しない)', () => {
+		const live = ['AUTH_MODE', 'SOMETHING_MANUAL'];
+		const d = diffEnvKeys(live, tpl);
+		expect(d.extra).toEqual(['SOMETHING_MANUAL']);
+		expect(d.missing).toEqual(['DATA_SOURCE', 'STRIPE_SECRET_KEY', 'USE_LOOKUP_KEY']);
+	});
+
+	it('実行時解決キー SSOT に無い「後から足す env」を増やすと fail する (追記漏れを検出)', () => {
+		// 新しく deploy 後注入キーを増やしたのに RUNTIME_RESOLVED_KEYS へ追記しない場合を模す
+		expect(diffEnvKeys([...tpl, 'RESOLVED_LATER'], tpl).extra).toEqual(['RESOLVED_LATER']);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**IaC に書いていない設定が本番 / staging で恒久的に効き続け、誰も気づけない**状態を終わらせる。

E1 (#4117) の S-0 検証中に実測で判明した: 監査が手で注入した `STRIPE_PRICE_*_MONTHLY` が、**full staging deploy (success) を跨いで残っていた**。「次の deploy で消える」という残置判断の前提が成立しておらず、その結果「staging で checkout が通る」ことが #4286 の修正の証拠にならない状態が続いていた。

顧客に対しては、**課金の設定が IaC と食い違ったまま気づかれない**経路を塞ぐことが価値。7/26 の初回課金が無通知で落ちたのと同じ「deploy は success、実態は壊れている」型である。

## 関連 Issue

Closes #4352
Refs #4117 (E1 — 本件を発見した実測)、#4286 (誤判定しかけた対象)、ADR-0024 (ENV silent skip 禁止)

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | IaC 外で足された env を検出して deploy を止める | `tests/unit/scripts/check-lambda-env-drift.test.ts:46`（実障害 `STRIPE_PRICE_*` 注入の再現）+ 実 staging Lambda への CLI 実行 | ✅ 実 Lambda に対し extra 2 件で `✗ FAIL`、一致状態で `✓ PASS`（下記実測ログ）。**実障害そのもの（`STRIPE_PRICE_*` 残存）の FAIL は再現していない** — 検出機構を書く前に監査が該当 env を除去済のため、実 Lambda 側では別キーで同じ経路を通した |
| AC2 | deploy 後に解決して足す env (ORIGIN 系 3 本) を誤検出しない | `scripts/check-lambda-env-drift.mjs:44` `RUNTIME_RESOLVED_KEYS` + `tests/unit/scripts/check-lambda-env-drift.test.ts:59` | ✅ 実 staging (`ORIGIN` / `COGNITO_CALLBACK_URL` / `COGNITO_LOGOUT_URL` を含む 24 キー) で PASS |
| AC3 | 値を CI ログに出さない | `scripts/check-lambda-env-drift.mjs:104` `Object.keys(JSON.parse(out))`（値を破棄）+ 実行出力の目視 | ✅ 出力にキー名しか現れない（下記実測ログ） |
| AC4 | 対象 Lambda を取り違えない | `--logical-id-prefix` (`scripts/check-lambda-env-drift.mjs:57`) + `tests/unit/scripts/check-lambda-env-drift.test.ts:42`（app / cron-dispatcher / demo 同居構成） | ✅ 実 CFN テンプレート (`GanbariQuestCompute.template.json` = Lambda 3 本) で app のみ抽出を確認 |
| AC5 | 参照先を間違えたとき「対象 0 件 = PASS」で素通ししない | `scripts/check-lambda-env-drift.mjs:139`（template に Lambda env 0 件なら exit 2） | ✅ prefix 誤指定で exit 2 を確認 |

### 実測ログ (staging、2026-08-06)

```
# (a) extra 検出 — テンプレート側から 2 キーを外して live との差を作った実 Lambda 実行
[check-lambda-env-drift] ⚠ WARN — IaC にあるのに配備されていない env: ORIGIN_VERIFY_SECRET
[check-lambda-env-drift] ✗ FAIL — IaC の外で足された env が 2 件あります: STRIPE_SECRET_KEY, USE_LOOKUP_KEY

# (b) 一致 — 同一 context で synth したテンプレートと突合
[check-lambda-env-drift] ✓ PASS — ganbari-quest-staging-app の env キー 24 件は IaC と一致
    (テンプレート 25 件 + 実行時解決 3 件)

# (c) 参照先誤り — 対象 0 件を PASS にしない
[check-lambda-env-drift] ✗ テンプレートに Lambda の環境変数が 1 件もありません: … (--logical-id-prefix NoSuchFn)
exit=2
```

補足: (a) の `ORIGIN_VERIFY_SECRET` warning は drift ではなく **branch 差**。#4312（front door）は develop にあり main / staging 未到達のため、develop 基準の synth にだけ現れる。この種の差が日常的に出るため欠落は warning に留めている。

## 変更タイプ

- [x] バグ修正 (infra / CI gate)
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント (infra/CLAUDE.md)

## 影響範囲・横展開チェック

| 対象 | 影響 |
|---|---|
| `deploy-aws-staging.yml` | Step 13.5 追加 (ORIGIN 解決の直後、hard-fail)。**この step が落ちても image rollback は起きない** (rollback は health check 失敗時のみ) |
| `deploy.yml` (本番) | 同 gate を Lambda 更新待ちの直後に追加。既存の「Incident webhook env verification」(**あるべきキーがあるか**) と対の関係 (**あるべきでないキーが無いか**) |
| `scripts/check-lambda-env-drift.mjs` | 新規。既存 script の作法 (`@ts-nocheck` + `isMain` guard + 純関数 export) に合わせた |
| NUC (`deploy-nuc.yml`) | 影響なし (Lambda ではないため対象外) |

**横展開の判断**: 本番にも同時に入れた。staging だけに入れると「本番の drift は今後も誰も見ない」ままになり、#4117 で PO が指摘した「確認だけで終わらせない」に反する。本番の live env 33 キーは全て deploy.yml が渡す context 由来であることを実測で確認済 (`CRON_SECRET` / `DISCORD_WEBHOOK_*` / `FEEDBACK_DISCORD_WEBHOOK_URL` / `STRIPE_PRICE_*` / `STRIPE_SECRET_KEY` はいずれも `-c` で渡されるため CI の synth 結果に現れる = 誤検出しない)。

**欠落 (template にあるが live に無い) は warning に留めた**。release ブランチと develop で infra コードが異なる期間は正常に発生するため (実測: develop の #4312 front door が main 未到達のあいだ `ORIGIN_VERIFY_SECRET` が warning として出る)。hard-fail は extra のみ。

## テスト・品質セルフチェック

- [x] `npx vitest run tests/unit/scripts/check-lambda-env-drift.test.ts` — **9 passed**
- [x] `npx biome check` (変更 4 file) — PASS
- [x] `node scripts/check-repo-scan-test-declaration.mjs` — OK (48 件宣言済、本 test は repo 走査なし)
- [x] `npx cspell` — 新規 2 file に未知語なし
- [x] 実 staging Lambda に対する CLI 実行で FAIL / PASS 両方を確認 (上記 AC 検証マップ)
- [x] 実 CFN テンプレート (`cdk synth` 実行成果物) で `--logical-id-prefix` の絞り込みを確認

## スクリーンショット / ビジュアルデモ

UI 変更なし (infra / CI gate のみ)。

## レビュー依頼事項・破壊的変更

**破壊的変更**: なし。ただし **deploy が落ちうる条件が 1 つ増える**。

- 手で env を足したまま deploy すると **staging / 本番の deploy が赤くなる** (それが目的)。エラー文に除去コマンドを出している
- 今後 deploy 後に env を足す step を新設する場合は、`RUNTIME_RESOLVED_KEYS` への追記が必須 (追記漏れは deploy fail で気づく)

**レビューしてほしい点**: 本番を hard-fail にした判断 (上記「横展開の判断」)。もし「本番は初回 1 回だけ warning で観測したい」なら、`deploy.yml` 側の step にのみ `continue-on-error: true` を付ける形に変えられます。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。**既存 secret の値は一切読まない** (キー名のみ扱う)。

## Ready for Review チェックリスト

- [x] 根本原因を書いた (CFN が drift を戻さない + deploy が drift を re-commit する、の 2 つ)
- [x] 機械検証を付けた (unit test + 実環境実行)
- [x] 設計書同期 (`infra/CLAUDE.md` に env の SSOT 規約を追記)
- [x] 使い捨て script ではない (本番 / staging 双方から使う汎用 CLI、#1442)
- [x] UI 変更なし

## QM レビュー結果

(未実施)

---

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🟢可逆: revert 1 本で元に戻る"]
    R2["顧客面: 変化なし（CI gate のみ）"]
    R3["🟡本番 deploy が落ちうる関門が 1 つ増える"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: IaC 外設定の恒久残存を検知"]
    T2["捨てる: 過渡期に deploy が赤くなる余地"]
  end
  subgraph OBJ["③ 反対理由 (adversarial)"]
    O1["business: 本番未実測なら hotfix を止める"]
    O2["UX: 当直者に顧客影響が伝わらない"]
    O3["security: secret 平文を runner に載せる"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 UI 変更なし。課金設定の食い違いを早期検知"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 本番も hard-fail でよいか?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3 danger
  class T2,O1,O2 warn
  class R1,T1,C1 ok
  class Q1 ask
```

<details>
<summary>補足（PO は原則読まなくてよい — 図の根拠）</summary>

**③ の反対理由 3 件の処置**（`tmp/adversarial-evidence/4365.json`）:

| 軸 | 指摘 | 処置 |
|---|---|---|
| security | `Environment.Variables` を JSON 取得して JS 側でキーを抜く実装は、`set -x` / プロセスダンプ / 将来の `console.log` 追加で **本番 Stripe secret の平文が漏れる** | ✅ **修正済** (`4ee6dc4c`)。`--query 'keys(Environment.Variables)'` で AWS 側射影に変更し、平文が runner に載らない形にした（既存 `Incident webhook env verification` と同方式） |
| business | 本番 live env を gate で 1 度も通しておらず、過渡期に **hotfix の deploy を止めうる** | ✅ **実測で解消**。本番 Lambda (`ganbari-quest-app`、33 キー) を deploy 相当 context で synth したテンプレートと突合し **extra 0 件 = PASS**。今日 merge しても本番 deploy は赤くならない |
| UX | 失敗時の出力が「キー名 + 除去コマンド」のみで、当直者が顧客影響を判断できない | 🟡 **未対処（accepted-residual）**。現状は `infra/CLAUDE.md` の env 表を参照する運用。深夜対応での可読性改善は本 PR の scope 外とし、実際に踏んだ時点で改善する |

**本番実測ログ**:

```
[check-lambda-env-drift] ⚠ WARN — IaC にあるのに配備されていない env: GEMINI_API_KEY, GRACE_PERIOD_DELETION_DISABLED, ORIGIN_VERIFY_SECRET
[check-lambda-env-drift] ✓ PASS — ganbari-quest-app の env キー 33 件は IaC と一致 (テンプレート 36 件 + 実行時解決 3 件)
```

warning 3 件はいずれも **branch 差**（本 PR は develop 基準、本番は main 基準。`ORIGIN_VERIFY_SECRET` は #4312 front door が main 未到達）。extra が 0 件であることが hard-fail 判定にとっての合否。

</details>
