### PR TITLE
fix(security): #4363 /ops の MFA 要求を外し ops group 所属のみで守る（オーナー決裁）

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -132,7 +132,7 @@ npm run dev:cognito         # AUTH_MODE=cognito + COGNITO_DEV_MODE=true、port 5
 npm run dev:cognito-signup  # signup ページは COGNITO_DEV_MODE 無しが必要
 ```
 
-`DEV_USERS` SSOT: `src/lib/server/auth/providers/cognito-dev.ts`。owner / parent / child / free / standard / family / trial-expired / ops / ops-no-mfa（MFA 未設定の運営者 = `/ops` 拒否 → 設定導線の検証用、#4282）の 9 アカウントが定義されている（password / role / プラン状態は SSOT 参照）。
+`DEV_USERS` SSOT: `src/lib/server/auth/providers/cognito-dev.ts`。owner / parent / child / free / standard / family / trial-expired / ops / ops-no-mfa（MFA 未設定の運営者。現在は `/ops` に入れる = #4363 で MFA 要求を撤去。`OPS_MFA_REQUIRED` を戻したときの拒否 → 設定導線の検証用）の 9 アカウントが定義されている（password / role / プラン状態は SSOT 参照）。
 
 使用必須: 認証画面変更 PR の Ready 前 / SS 撮影 / login / signup / ops group / プラン別 UI / 管理画面の変更時。
 

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1435,7 +1435,7 @@ readiness probe（shallow、#3657）。**プロセスが HTTP を受けられる
 
 ### 3.16 運営管理ダッシュボード（#0176 / #820 / ADR-0033）
 
-> `/ops` 配下は **Cognito User Pool の `ops` group メンバー かつ MFA 済のみがアクセス可能**（#820 / #4266）。
+> `/ops` 配下は **Cognito User Pool の `ops` group メンバーのみがアクセス可能**（#820。MFA 追加要求は #4266 で導入し #4363 のオーナー決裁で撤去。判定と再評価トリガーは `docs/design/14-セキュリティ設計書.md` §5.2.9）。
 > 非メンバーは 403 Forbidden。判定は `src/lib/server/auth/ops-authz.ts` の `requireOpsAccess(locals)` に集約する。
 >
 > **API endpoint（`+server.ts`）は自分で `requireOpsAccess(locals)` を呼ぶこと（#4309）**。`+layout.server.ts` の gate は

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -366,7 +366,7 @@ dialog 内容 (`PIN_GATE_ONBOARDING_LABELS` SSOT):
 | `/admin/members` | owner, parent | `/auth/login` |
 | `/admin/**` | owner, parent | `/auth/login` |
 | `/child/**` | owner, parent, child | `/auth/login` |
-| `/ops/**`（運営ダッシュボード） | Cognito `ops` group **かつ MFA 済**（§5.2.9） | 403 |
+| `/ops/**`（運営ダッシュボード） | Cognito `ops` group 所属（§5.2.9） | 403 |
 | `/api/v1/admin/**` | owner, parent | 401 |
 | `/api/v1/**` | owner, parent, child | 401 |
 | `/tenants/**`（テナント静的ファイル配信、#3133） | owner, parent, child | `/auth/login` |
@@ -521,28 +521,70 @@ client 供給の opaque id（Cookie / POST form-field / URL param）は、uuid �
 - **fitness function**: `tests/unit/routes/admin-status-benchmark-authz.test.ts` が guard 単体（local / ops 許可、parent-admin / anonymous / 未認証 → 403）+ `updateBenchmark` action（parent-admin → 403 かつ `upsertBenchmark` 未到達 / ops・local → upsertBenchmark 到達）+ 読取 load（parent-admin・ops いずれも benchmarks 取得可）を機械検証する。
 
 
-#### 5.2.9 `/ops`（運営ダッシュボード）の認可 — ops group + MFA（#4266）
+#### 5.2.9 `/ops`（運営ダッシュボード）の認可 — ops group 所属（#4363）
 
 `/ops` は運営者専用の画面であり、**アプリ層の 1 つの述語だけ**で守る。ネットワーク層（CloudFront）に運営者 IP allowlist は置かない。
 
 | 判定 | 内容 |
 |---|---|
 | 単一強制点 | `src/lib/server/auth/ops-authz.ts` の `hasOpsAccess(identity)` |
-| 条件 | Cognito `ops` group 所属 **かつ** **このセッションが MFA を経て開始されている**。MFA は ID token の `amr` claim（RFC 8176）で判定し、受理する綴りは `mfa` / `software_token_mfa` / `sms_mfa` のみ（`otp` / `email_otp` は本アプリではアプリ層の email OTP を指し**二要素の証拠にならない**ため受理しない） |
-| セッション保持 | ログイン時に確定した MFA を **context token（署名付き、`context-token.ts`）の `mfaAuthenticated` claim** に焼き込み、`hasOpsAccess(identity, context)` が token 側と OR で判定する。silent refresh（`REFRESH_TOKEN_AUTH`）で再発行される ID token が `amr` を保持するかは AWS 公式ドキュメントで確定できないため、identity 側だけで判定すると運営者が無操作で締め出される。**claim が載っていない旧トークンは `undefined` = 拒否側**（fail-closed） |
-| 判定不能時 | **拒否**（`mfaAuthenticated` が `undefined` = 旧トークン / claim 欠落でも通さない、fail-closed） |
-| 拒否時の応答 | ops group には居るが MFA で落ちた場合のみ `403 Forbidden: ops access requires MFA` + 本文に `reason: 'ops-mfa-required'`（policy 層 `DenyReason` と同一文字列、SSOT は `capabilities.ts` の `OPS_MFA_REQUIRED_REASON`）。それ以外は `403 Forbidden`（reason 無し = 非 ops に ops group の存在を示唆しない） |
-| 拒否時の復旧導線 | `src/routes/+error.svelte` が上記 `reason` のときだけ `OpsMfaSetupNotice`（`src/lib/features/ops/`）を描画し、必要な設定・手順・再ログイン導線を画面上に出す。**403（データを一切 load しない fail-closed）は維持**し、表示だけを切り替える。実作業手順は [runbooks/ops-mfa-setup.md](../runbooks/ops-mfa-setup.md)。締め出して復旧できない状態を作らない（DESIGN.md §5 Dialog「閉じさせない modal には出口を用意する」と同じ規律） |
-| 強制箇所 | `requireOpsAccess(locals)`（`ops-authz.ts`）を **page（`src/routes/ops/+layout.server.ts`）と API（`src/routes/ops/**/+server.ts`）の両方**が呼ぶ。拒否時の `reason` も同関数が載せる（拒否の語彙を 2 箇所に持たない） / policy 層 `capabilities.ts` `access.ops_dashboard`・`view.ops_license_dashboard`（`ops-mfa-required`） |
-| Cognito 側 | user pool は `mfa: OPTIONAL` のまま（**顧客に MFA を強制しない**）。運営者だけがアプリ層で MFA を要求される |
+| 条件 | Cognito `ops` group 所属。**MFA は要求しない**（オーナー決裁、下記「MFA を要求しない決定」） |
+| 判定不能時 | **拒否**（identity=null / `local` / `groups` 欠落はすべて 403、fail-closed） |
+| 拒否時の応答 | `403 Forbidden`（reason 無し = 非 ops に ops group の存在を示唆しない） |
+| 強制箇所 | `requireOpsAccess(locals)`（`ops-authz.ts`）を **page（`src/routes/ops/+layout.server.ts`）と API（`src/routes/ops/**/+server.ts`）の両方**が呼ぶ / policy 層の写像は `capabilities.ts` の `access.ops_dashboard`・`view.ops_license_dashboard` |
+| Cognito 側 | user pool は `mfa: OPTIONAL`（**顧客に MFA を強制しない**）。ユーザー単位の MFA preference もアプリの判定に影響しない |
 
 - **IP allowlist を置かない理由**: 遮断対象に `/admin`（保護者 = 顧客の見守り画面）が含まれると全顧客が 403 になる。また運営者のグローバル IP は固定でなく、プロキシ経由では CloudFront が見る viewer IP が運営者の回線 IP と一致しない。
-- **この設計で守らないもの**: 未認証の第三者が `/ops` の URL に**到達すること自体**は防がない（到達しても認可で 403 になる）。
-- **運用上の注意**: MFA の再確認が必要になるのは **context token の TTL 切れ**（owner = 24 時間、`CONTEXT_TTL`）で再発行されたときである。その時点の ID token に `amr` が無ければ `/ops` は拒否され、**再ログインで復帰する**。拒否画面が MFA が理由であることと復旧手順を示す。
-- **ローカル検証**: `npm run dev:cognito` の `DEV_USERS` に MFA 済 ops（`ops@example.com`）と **MFA 未設定 ops（`ops-no-mfa@example.com`）** の両方があり、許可・拒否の両経路を実ブラウザで歩ける。
+- **この設計で守らないもの**: 未認証の第三者が `/ops` の URL に**到達すること自体**は防がない（到達しても認可で 403 になる）。**第 2 要素も持たない** — ops アカウントのパスワードが漏れれば `/ops` に入られる（下記）。
+- **ローカル検証**: `npm run dev:cognito` の `DEV_USERS` に `ops@example.com`（MFA 済）と `ops-no-mfa@example.com`（MFA 未設定）があり、**どちらでも `/ops` に入れる**ことを実ブラウザで確認できる。非 ops アカウントで 403 になることも同時に歩ける。
+
+##### MFA を要求しない決定（オーナー決裁 2026-08-06、#4363）
+
+MFA 要求は #4266 で CloudFront の IP allowlist を恒久廃止した際の代替として入ったが、運営 1 人・ops group メンバー 0 人の段階では TOTP 登録の運用コストに見合わないとして、オーナーが撤去を決裁した（選択肢 A: TOTP を登録する / B: MFA 要求を外す / C: `/ops` を使わない のうち **B**）。
+
+**これで弱くなること**: `/ops` が持つのは全顧客の売上・コホート・コスト・PL である。MFA を外すと防御は「Cognito 認証 + `ops` group 所属」だけになり、**多層防御が 1 層減る**。具体的には **ops アカウントのパスワード 1 つが漏れた時点で `/ops` に入られる**（MFA があればパスワード漏洩単独では入れなかった）。
+
+**残る防御**:
+
+| 層 | 内容 |
+|---|---|
+| Cognito 認証 | ID token 検証（`cognito-jwt.ts`）。未認証は入れない |
+| `ops` group 所属 | `isOpsMember()`。顧客（保護者）アカウントでは入れない |
+| 単一強制点 | `requireOpsAccess()` を page と API の両方が呼ぶ（適用範囲は fitness function が機械強制、#4309） |
+| front door header | CloudFront が付与する `x-origin-verify` をアプリ層が検査（§11.5.1）。Function URL 直叩きでの edge 迂回を `/ops` で拒否 |
+
+**再評価トリガー（いずれかを満たしたら MFA 要求を戻す）**:
+
+| # | トリガー | 理由 |
+|---|---|---|
+| T1 | 有料家庭が **10 世帯**を超えた | `/ops` のデータが「自分の実験データ」から「他人の取引記録」に変わる境界 |
+| T2 | ops group メンバーが **2 人以上**になった | パスワード管理が自分の管理外に出る。TOTP 登録の手番も分散できる |
+| T3 | `/ops` に**書込操作 / 顧客個人情報の表示**が増えた | read-only の集計閲覧という被害想定が崩れる |
+| T4 | ops アカウントの**認証失敗・不審ログインを 1 件でも観測**した | 実害の兆候。他トリガーを待たずに戻す |
+
+**戻し方**: `src/lib/policy/capabilities.ts` の **`OPS_MFA_REQUIRED` を `true` にするだけ**。判定機構は撤去していない（下記）。
+
+##### 保持している MFA 機構（要求 off の間も生かしておくもの、#4363）
+
+「外したら戻せない」を作らないため、以下は**残す**。フラグを `true` にすると同時に復活する。
+
+| 機構 | 実体 | 挙動（フラグ `true` 時） |
+|---|---|---|
+| `amr` claim 読み取り | `hasMfaAmr()`（`providers/cognito-jwt.ts`）→ `Identity.mfaAuthenticated` | RFC 8176 の `amr` で判定。受理する綴りは `mfa` / `software_token_mfa` / `sms_mfa` のみ（`otp` / `email_otp` は本アプリではアプリ層の email OTP を指し**二要素の証拠にならない**ため受理しない） |
+| セッション保持 | context token（署名付き、`context-token.ts`）の `mfaAuthenticated` claim | ログイン時に確定した MFA を焼き込み、identity 側と OR で判定（`hasMfaAuthenticatedSession()`）。silent refresh（`REFRESH_TOKEN_AUTH`）で `amr` が落ちても締め出されない。**claim の無い旧トークンは `undefined` = 拒否側**（fail-closed） |
+| 拒否理由の語彙 | `capabilities.ts` の `OPS_MFA_REQUIRED_REASON`（`'ops-mfa-required'`） | ops group には居るが MFA で落ちた場合のみ `403 Forbidden: ops access requires MFA` + 本文に `reason`。非 ops には載せない（ops group の存在を示唆しない） |
+| 復旧導線 | `src/routes/+error.svelte` → `OpsMfaSetupNotice`（`src/lib/features/ops/`） | 上記 `reason` のときだけ設定手順・再ログイン導線を描画する。403（データを一切 load しない fail-closed）は維持し表示だけを分ける。実作業手順は [runbooks/ops-mfa-setup.md](../runbooks/ops-mfa-setup.md) |
+
+要求 off の間、`reason` を載せる分岐と復旧導線は**到達しない**（`hasOpsAccess` が ops member を必ず通すため）。分岐を消さずフラグ条件を明示しているのは、戻すときに再実装を要さないようにするためである。
 - **`+layout.server.ts` は API を守らない（#4309）**: SvelteKit の `+layout.server.ts` は page の load にしか適用されず `+server.ts` には走らない。したがって `/ops` 配下の endpoint は**各自が `requireOpsAccess(locals)` を呼ぶ**。呼ばない endpoint は認可ゼロで外部公開される。認可はクエリ解釈・集計より**前**に置く（後に置くと 403 を返しても集計は走る）。
-- **認可層が `/ops` を通す理由（#4309）**: `authorizeCognito` の `isPublicRoute` は `/ops` を通過させるが、これは「認証不要」ではなく **「認証の担い手が route 側にある」**（`/api/cron/` と同型）。認可層の `RouteRule.roles` は owner / parent / child の 3 値しか持たず Cognito group も MFA も表現できないため、ここから外すと「認証済みの任意のテナントメンバーが通り、ライセンス期限切れの運営者は締め出される」という逆の結果になる。境界は `/ops` 完全一致 + `/ops/` に限定する（`/opsedit` 等の別 route を巻き込まない）。
-- **fitness function**: `tests/unit/routes/ops-mfa-guard.test.ts`（ops group のみ / MFA 不明 → 403、述語の真理値表 + 拒否 `reason` の伝搬と非 ops への非露出）+ `tests/unit/routes/error-page-ops-mfa.test.ts`（エラー画面が `reason` のときだけ導線に切り替わる配線）+ `tests/unit/components/ops-mfa-setup-notice.test.ts`（復旧導線が手順・出口・依頼先を欠かさない）+ **`tests/unit/architecture/ops-route-auth-fitness.test.ts`（`/ops/**/+server.ts` を FS 列挙し全件が `requireOpsAccess` を呼ぶこと = 適用範囲。#4309、`cron-route-auth-fitness.test.ts` と対の装置）** + `tests/unit/routes/ops-export-authz.test.ts`（`/ops/export` の 3 type × 未認証 / 非 ops / MFA 未済 → 403 かつ service 未到達）+ `tests/unit/infra/admin-no-ip-allowlist.test.ts`（CloudFront Function に `/admin` `/ops` の遮断・IP 照合が再混入しないこと）。**述語の真理値表だけでは適用範囲の穴を検出できない**（#4309 はまさにそれで見逃した）。
+- **認可層が `/ops` を通す理由（#4309）**: `authorizeCognito` の `isPublicRoute` は `/ops` を通過させるが、これは「認証不要」ではなく **「認証の担い手が route 側にある」**（`/api/cron/` と同型）。認可層の `RouteRule.roles` は owner / parent / child の 3 値しか持たず Cognito group を表現できないため、ここから外すと「認証済みの任意のテナントメンバーが通り、ライセンス期限切れの運営者は締め出される」という逆の結果になる。境界は `/ops` 完全一致 + `/ops/` に限定する（`/opsedit` 等の別 route を巻き込まない）。
+- **fitness function**:
+  - 現行条件（ops group のみで通す / 非 ops・local・未認証は 403）: `tests/unit/routes/ops-mfa-not-required.test.ts` + `tests/unit/routes/ops-layout-server.test.ts`
+  - フラグ 1 箇所の SSOT（実強制点と policy 層が同じ定数を読む = 判断が食い違わない）: `tests/unit/policy/ops-mfa-flag-consistency.test.ts`
+  - 保持している MFA 機構（`requireMfa=true` の真理値表 / context token 往復 / 拒否語彙）: `tests/unit/routes/ops-mfa-guard.test.ts` + `tests/unit/routes/error-page-ops-mfa.test.ts`（エラー画面が `reason` のときだけ導線に切り替わる配線）+ `tests/unit/components/ops-mfa-setup-notice.test.ts`（復旧導線が手順・出口・依頼先を欠かさない）
+  - **適用範囲**: **`tests/unit/architecture/ops-route-auth-fitness.test.ts`（`/ops/**/+server.ts` を FS 列挙し全件が `requireOpsAccess` を呼ぶこと。#4309、`cron-route-auth-fitness.test.ts` と対の装置）** + `tests/unit/routes/ops-export-authz.test.ts`（`/ops/export` の 3 type × 未認証 / 非 ops → 403 かつ service 未到達）
+  - ネットワーク層の再混入検出: `tests/unit/infra/admin-no-ip-allowlist.test.ts`（CloudFront Function に `/admin` `/ops` の遮断・IP 照合が戻っていないこと）
+  - **述語の真理値表だけでは適用範囲の穴を検出できない**（#4309 はまさにそれで見逃した）。
 
 ### 5.3 ライセンス状態による制限
 
@@ -1059,7 +1101,7 @@ subscribe API の保存前検証だけでは、過去レコード混入 / repo �
 | CloudFront Function | **CloudFront のみ** | query slash encode のみ | 同左 | SvelteKit の名前付き form action（`?/action`）を通すために必須 |
 | Cognito 認証（`/admin`） | アプリ層（全経路） | 必須 | 必須 | `AUTH_MODE=cognito` |
 | 親 PIN gate（`/admin`） | アプリ層（全経路） | 必須 | 必須 | §4.3 |
-| ops group + MFA（`/ops`） | アプリ層（全経路） | 必須 | 必須 | §5.2.9。**アプリ層のため両環境に同じく効く** |
+| ops group 所属（`/ops`） | アプリ層（全経路） | 必須 | 必須 | §5.2.9。**アプリ層のため両環境に同じく効く**。MFA 要求は #4363 で撤去（戻すトリガーは §5.2.9） |
 | front door header（`x-origin-verify`） | **CloudFront が付与 → アプリ層が検査** | `/admin` `/api/v1/admin` `/ops` で必須 | 同左 | CloudFront を経由しない到達をこの 3 prefix に限って拒否する（#4280、§11.5.1） |
 | Function URL 直叩き | — | 上記 3 prefix は 404 / その他は到達可 | 同左 | `authType: NONE` のため到達自体は防げない。到達しても Cognito 認証・認可は同じく効く（form action も通らない） |
 | Stripe / SES / Discord / Gemini | — | 注入する | **注入しない** | staging は外部サービス副作用ゼロ（`deploy-aws-staging.yml`） |
@@ -1067,7 +1109,7 @@ subscribe API の保存前検証だけでは、過去レコード混入 / repo �
 **CloudFront 層の防御は、CloudFront を経由しない到達経路には効かない（#4280）**: Lambda Function URL は `authType: FunctionUrlAuthType.NONE`（`infra/lib/compute-stack.ts`、本番 Fn / demo Fn の 2 箇所）で公開されている。したがって **上表「どこで効くか = CloudFront のみ」の層（地域制限 / CloudFront Function / 将来もし IP allowlist を戻す場合）は、Function URL のホスト名を知る者には掛からない**。この迂回は `/admin` `/api/v1/admin` `/ops` に限り front door header（§11.5.1）で塞いでいる。
 
 - **Function URL の推測困難さを防御層として数えない。** ログ / エラー画面 / ブラウザ履歴 / 過去の設定ファイル / 外部サービスへの登録値（Stripe webhook endpoint 等）から漏れた時点で無効になる。「ネットワーク層で守られている」を前提にした判断をしないこと
-- **`/admin` `/ops` の主防御はアプリ層**（Cognito 認証 + 親 PIN gate / ops group + MFA）。CloudFront 層は可用性・地域・form action の都合であって、認可の一部ではない。front door header も認可ではなく経路の限定である
+- **`/admin` `/ops` の主防御はアプリ層**（Cognito 認証 + 親 PIN gate / ops group 所属）。CloudFront 層は可用性・地域・form action の都合であって、認可の一部ではない。front door header も認可ではなく経路の限定である
 - **`authType: AWS_IAM` + OAC は不採用**（失敗時に全面 502 となるコストが Pre-PMF で重い、ADR-0010）。**再評価トリガーは有料家庭 20 世帯到達時**
 
 #### 11.5.1 front door header（CloudFront → origin の共有シークレット、#4280）
@@ -1076,14 +1118,14 @@ subscribe API の保存前検証だけでは、過去レコード混入 / repo �
 
 **仕組み**: CloudFront が Lambda を指す全 origin に `x-origin-verify: <ORIGIN_VERIFY_SECRET>` を付与し、`hooks.server.ts` が保護対象 path で一致を要求する。CloudFront は viewer が同名 header を送ってきても**設定値で上書き**するため、外部から偽装して通ることはできない。不一致は **404**（403 ではない — 存在自体を伏せる。切り分けはサーバ側 log の `front_door_missing_header` で行う）。
 
-**これは認証ではない**。保護対象 path の主防御は従来どおり Cognito + 親 PIN（`/admin`）/ ops group + MFA（`/ops`）であり、本 header が足すのは「edge 層の制御を迂回できない」1 点のみ。
+**これは認証ではない**。保護対象 path の主防御は従来どおり Cognito + 親 PIN（`/admin`）/ ops group 所属（`/ops`）であり、本 header が足すのは「edge 層の制御を迂回できない」1 点のみ。
 
 **保護対象と、対象外にした経路の根拠**（allow list 方式。列挙外は「front door 必須ではない」= 各自の認証で守る、という宣言）:
 
 | path | front door | その path 自身が持つ認証 |
 |---|---|---|
 | `/admin` / `/api/v1/admin` | **必須** | Cognito セッション + 親 PIN gate（§4.3） |
-| `/ops` | **必須** | ops group + MFA（§5.2.9） |
+| `/ops` | **必須** | ops group 所属（§5.2.9） |
 | `/api/stripe/webhook` | 対象外 | **Stripe 署名検証**（`STRIPE_WEBHOOK_SECRET`）。Stripe の送信元は米国で、CloudFront の地域制限を通れないため経路を CloudFront に寄せられない（本番・staging とも webhook endpoint は Function URL 直で登録されている） |
 | `/api/cron/*` | 対象外 | **CRON_SECRET**（`verifyCronAuth`、§9 表）。cron-dispatcher Lambda が Function URL 直で POST する |
 | `/api/health` / `/api/ready` | 対象外 | 公開情報のみ。Lambda Web Adapter の readiness と post-deploy smoke が Function URL 直で叩く |

--- a/docs/runbooks/ops-mfa-setup.md
+++ b/docs/runbooks/ops-mfa-setup.md
@@ -1,6 +1,8 @@
-# 運営者の多要素認証（MFA）設定 — `/ops` に入れるようにする
+# 運営者の多要素認証（MFA）設定 — `/ops` に MFA を戻すときの手順
 
-`/ops`（運営ダッシュボード）は **Cognito `ops` group 所属 かつ MFA を経て開始したセッション**でのみ開ける（`docs/design/14-セキュリティ設計書.md` §5.2.9）。TOTP が未設定の運営者は 403 になり、画面には設定導線（`OpsMfaSetupNotice`）が出る。本書はその導線が指す実作業の手順。
+**現在 `/ops` は MFA を要求しない**（`ops` group 所属のみで開ける。オーナー決裁 2026-08-06、#4363）。本書は **MFA 要求を戻すとき**、または個々の運営者アカウントに TOTP を設定しておきたいときの実作業手順である。
+
+MFA 要求を戻す判断基準（再評価トリガー T1〜T4）と、外している間に何が弱いかは `docs/design/14-セキュリティ設計書.md` §5.2.9 が SSOT。**アプリ側の切り替えは `src/lib/policy/capabilities.ts` の `OPS_MFA_REQUIRED` を `true` にするだけ**で、判定機構・拒否理由・復旧導線（`OpsMfaSetupNotice`）は残してある。要求を戻すと、TOTP 未設定の運営者は 403 になり画面に設定導線が出る。
 
 **顧客には影響しない。** Cognito user pool は `mfa: OPTIONAL` のままで、MFA を要求するのはアプリ層の `/ops` だけ（`infra/lib/auth-stack.ts`）。ここで `REQUIRED` に切り替えてはならない — 全顧客に MFA を強制することになる。
 
@@ -40,7 +42,9 @@ TOTP のシークレット登録（`AssociateSoftwareToken` → `VerifySoftwareT
 
 **設定しただけでは `/ops` に入れない。** MFA の有無は ID token の `amr` claim で判定し、その値はログイン時に確定してセッション（署名付き context token）に焼き込まれる。既存セッションのままでは古い値が残るので、ログアウト → 認証アプリのコードを入れてログインし直す。
 
-## 3. 設定したのに 403 のままのとき
+## 3. MFA 要求を戻したあと、設定したのに 403 のままのとき
+
+（`OPS_MFA_REQUIRED` が `false` の間は MFA 起因の 403 は起きない。以下は要求を戻した後の切り分け）
 
 | 症状 | 見るところ |
 |---|---|
@@ -50,6 +54,9 @@ TOTP のシークレット登録（`AssociateSoftwareToken` → `VerifySoftwareT
 
 `otp` / `email_otp` は**受理しない**。本アプリではアプリ層の email OTP を指し、二要素の証拠にならないため。
 
-## 4. ローカルで導線を確認する
+## 4. ローカルで確認する
 
-`npm run dev:cognito` の `DEV_USERS`（`src/lib/server/auth/providers/cognito-dev.ts`）に、MFA 未設定の ops アカウント `ops-no-mfa@example.com` がある。これでログインして `/ops` を開くと、本番と同じ判定経路を通って設定導線に着地する。
+`npm run dev:cognito` の `DEV_USERS`（`src/lib/server/auth/providers/cognito-dev.ts`）に、MFA 済 ops（`ops@example.com`）と MFA 未設定 ops（`ops-no-mfa@example.com`）がある。
+
+- 既定（`OPS_MFA_REQUIRED = false`）: **どちらでも `/ops` に入れる**
+- `OPS_MFA_REQUIRED` を `true` にした状態: `ops-no-mfa@example.com` は 403 になり、設定導線（`OpsMfaSetupNotice`）に着地する。要求を戻す PR ではこの経路を実ブラウザで確認する

--- a/scripts/capture-specs/flows/ops-mfa-not-required-4363.mjs
+++ b/scripts/capture-specs/flows/ops-mfa-not-required-4363.mjs
@@ -1,0 +1,76 @@
+/**
+ * scripts/capture-specs/flows/ops-mfa-not-required-4363.mjs (#4363)
+ *
+ * MFA を設定していない運営者 (`ops` group 所属) が `/ops` を開いたときの画面を撮る。
+ * 2 度実行して before / after を作る (`SS_PHASE` で切り替える):
+ *
+ *   SS_PHASE=before … `capabilities.ts` の `OPS_MFA_REQUIRED` を `true` にした状態
+ *                     = **本 PR 前 (#4266) の挙動**。403 になり設定導線 (#4282) に着地する
+ *   SS_PHASE=after  … 本 PR の状態 (`OPS_MFA_REQUIRED = false`)。
+ *                     同じアカウント・同じ URL で運営ダッシュボードが開く
+ *
+ * どちらも同一アカウント (`ops-no-mfa@example.com`) / 同一 URL (`/ops`) で撮り分ける。
+ * AUTH_MODE=cognito (npm run dev:cognito、#1026) で動作させる。
+ *
+ * 使用例 (起動済みサーバーに向ける):
+ *   SS_PHASE=after BASE_URL=http://localhost:5194 node scripts/capture.mjs --pr 4368 \
+ *     --flow ops-mfa-not-required \
+ *     --url /ops \
+ *     --actions scripts/capture-specs/flows/ops-mfa-not-required-4363.mjs \
+ *     --presets desktop,mobile
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+const PHASE = process.env.SS_PHASE === 'before' ? 'before' : 'after';
+
+/** cognito-dev のログインフォームを通す (ops-mfa-setup-notice-4282.mjs と同型) */
+async function login(page, email, password) {
+	await page.goto(`${BASE_URL}/auth/logout`).catch(() => {});
+	await page.goto(`${BASE_URL}/auth/login`);
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.waitForFunction(
+		() => document.querySelector('input[name="email"]')?.getAttribute('type') === 'email',
+		{ timeout: 15_000 },
+	);
+
+	await page.getByLabel('メールアドレス').click();
+	await page.keyboard.type(email, { delay: 20 });
+	await page.getByLabel('パスワード', { exact: true }).click();
+	await page.keyboard.type(password, { delay: 20 });
+
+	await page
+		.locator('button[type="submit"]:not([disabled])')
+		.first()
+		.waitFor({ state: 'visible', timeout: 30_000 });
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/(admin|ops|setup|billing|switch|child)/, { timeout: 30_000 });
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// ops group に居るが MFA 未設定の運営者 (dev SSOT: DEV_USERS)
+	await login(page, 'ops-no-mfa@example.com', 'Gq!Dev#OpsNoMfa26');
+	await page.goto(`${BASE_URL}/ops`);
+	await page.waitForLoadState('domcontentloaded');
+
+	if (PHASE === 'before') {
+		// OPS_MFA_REQUIRED = true (= #4266 の挙動) で 403 → 設定導線に着地する
+		await page.getByTestId('ops-mfa-setup-notice').waitFor({ state: 'visible', timeout: 15_000 });
+		await capture('before-ops-no-mfa-denied');
+		return;
+	}
+
+	// 本 PR: 同じアカウントで運営ダッシュボードが開く
+	await page.locator('h1').first().waitFor({ state: 'visible', timeout: 15_000 });
+	await capture('after-ops-no-mfa-allowed');
+
+	// 回帰: MFA 済 ops も従来どおり入れる (緩めた側で壊していないこと)
+	await login(page, 'ops@example.com', 'Gq!Dev#Ops2026xyz');
+	await page.goto(`${BASE_URL}/ops`);
+	await page.waitForLoadState('domcontentloaded');
+	await page.locator('h1').first().waitFor({ state: 'visible', timeout: 15_000 });
+	await capture('ops-with-mfa-still-allowed');
+};

--- a/src/lib/features/ops/OpsMfaSetupNotice.svelte
+++ b/src/lib/features/ops/OpsMfaSetupNotice.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 /**
- * #4282 AC5: `/ops` が MFA 未設定で拒否されたときの復旧導線 (運営者専用)。
+ * `/ops` が MFA 未設定で拒否されたときの復旧導線 (運営者専用、#4282 AC5)。
+ *
+ * **現在は表示されない**: #4363 (オーナー決裁 2026-08-06) で /ops の MFA 要求を撤去したため、
+ * 拒否理由 `ops-mfa-required` が発生しない。`capabilities.ts` の `OPS_MFA_REQUIRED` を `true` に
+ * 戻すと拒否・導線が同時に復活する (戻すのに再実装を要さないよう本 component を残している)。
  *
  * `/ops` は #4266 で「Cognito ops group + MFA 済セッション」に絞られた (CloudFront の
  * IP allowlist を廃止した代替)。ただし拒否側は共通 403 画面のままで、TOTP 未設定の

--- a/src/lib/policy/capabilities.ts
+++ b/src/lib/policy/capabilities.ts
@@ -68,6 +68,29 @@ export type DenyReason =
  */
 export const OPS_MFA_REQUIRED_REASON: DenyReason = 'ops-mfa-required';
 
+/**
+ * `/ops` が MFA を要求するか (#4363、オーナー決裁 2026-08-06)。**現在は `false`**。
+ *
+ * MFA 要求は #4266 で CloudFront の IP allowlist を恒久廃止した際の代替として入ったが、
+ * 運営が 1 人・ops group メンバー 0 人の段階では TOTP 登録 (4 手順) の運用コストに見合わず、
+ * オーナーが「MFA 要求を外す」を選択した (「TOTP の対応は不要とします」)。
+ *
+ * **これで弱くなること**: `/ops` (売上・コホート・コスト・PL) の防御は
+ * 「Cognito 認証 + `ops` group 所属」だけになり、多層防御が 1 層減る
+ * (ops のパスワード 1 つが漏れた時点で入られる)。残る防御と再評価トリガーは
+ * `docs/design/14-セキュリティ設計書.md` §5.2.9 が SSOT。
+ *
+ * **戻し方**: 本定数を `true` にするだけでよい。判定機構
+ * (`amr` claim 読み取り / context token の `mfaAuthenticated` / 下記 `requireOpsGroup` /
+ * `hasOpsAccess` / 復旧導線 `OpsMfaSetupNotice`) は**すべて残してある**。
+ * 再評価トリガー (T1: 有料 10 世帯超 / T2: ops 2 人目 / T3: `/ops` に書込・個票が入る /
+ * T4: 不審ログイン観測) のいずれかを満たしたら戻す。
+ *
+ * 真偽値をここ 1 箇所に置き、実強制点 (`ops-authz.ts`) も本定数を import する
+ * (policy 層と実強制点で判断が食い違わない、`tests/unit/policy/ops-mfa-flag-consistency.test.ts`)。
+ */
+export const OPS_MFA_REQUIRED: boolean = false;
+
 export interface PolicyResult {
 	allowed: boolean;
 	reason?: DenyReason;
@@ -140,10 +163,11 @@ const evaluators: Record<Capability, CapabilityEvaluator> = {
 function requireOpsGroup(ctx: EvaluationContext): PolicyResult {
 	if (!ctx.user) return deny('unauthenticated');
 	if (!ctx.user.groups.includes('ops')) return deny('ops-only');
-	// #4266: CloudFront の admin IP allowlist を廃止したため、ops の主防御を MFA まで引き上げる。
-	// `undefined` (判定不能) も拒否 = fail-closed。route 側の実強制点は
-	// `hasOpsAccess()` (src/lib/server/auth/ops-authz.ts) で、本判定はその policy 層の写像。
-	if (ctx.user.mfaAuthenticated !== true) return deny('ops-mfa-required');
+	// MFA 追加要求はフラグ 1 箇所で切り替える (#4363、既定 false = 要求しない)。
+	// `true` に戻すと `undefined` (判定不能) も拒否 = fail-closed に復帰する。
+	// route 側の実強制点は `hasOpsAccess()` (src/lib/server/auth/ops-authz.ts) で、
+	// 本判定はその policy 層の写像 (同じ定数を読む)。
+	if (OPS_MFA_REQUIRED && ctx.user.mfaAuthenticated !== true) return deny('ops-mfa-required');
 	return ALLOW;
 }
 

--- a/src/lib/server/auth/authorization.ts
+++ b/src/lib/server/auth/authorization.ts
@@ -161,12 +161,12 @@ function isPublicRoute(path: string): boolean {
 		path.startsWith('/demo') ||
 		path.startsWith('/marketplace') ||
 		// #4309: `/api/cron/` と同じく「認証不要」ではなく **「認証の担い手が route 側にある」** の意。
-		// 本認可層は ops group / MFA を表現できない — `RouteRule.roles` が持つのは
-		// owner / parent / child の 3 値だけで、Cognito group も MFA 有無も語彙に無い。
+		// 本認可層は ops group を表現できない — `RouteRule.roles` が持つのは
+		// owner / parent / child の 3 値だけで、Cognito group は語彙に無い。
 		// ここから外すと `/ops` は「認証済みの任意のテナントメンバーなら通る」+ ライセンス状態
 		// (期限切れ → /admin/subscription へリダイレクト) に縛られ、運営者が締め出される一方で
 		// 顧客が入れてしまう。したがって判定は route 側の `requireOpsAccess`
-		// (ops-authz.ts、ops group + MFA / fail-closed) に集約し、本行はそこへ委譲する宣言である。
+		// (ops-authz.ts、ops group 所属 / fail-closed) に集約し、本行はそこへ委譲する宣言である。
 		// **page (`+layout.server.ts`) と API (`+server.ts`) の両方が呼ぶ必要がある** —
 		// layout の gate は `+server.ts` に走らず、それが #4309 の実害 (未認証で売上台帳 CSV 200)。
 		// 適用範囲は tests/unit/architecture/ops-route-auth-fitness.test.ts が FS 列挙で機械強制する。

--- a/src/lib/server/auth/ops-authz.ts
+++ b/src/lib/server/auth/ops-authz.ts
@@ -5,7 +5,7 @@
 // 将来の階層化（`ops-cs` / `ops-eng` など）に備え、名前は enum 化して 1 箇所で管理する。
 
 import { error } from '@sveltejs/kit';
-import { OPS_MFA_REQUIRED_REASON } from '$lib/policy/capabilities';
+import { OPS_MFA_REQUIRED, OPS_MFA_REQUIRED_REASON } from '$lib/policy/capabilities';
 import type { AuthContext, Identity } from './types';
 
 /**
@@ -35,15 +35,7 @@ export function isOpsMember(identity: Identity | null): boolean {
 }
 
 /**
- * `/ops` に入れるか判定する単一述語 (#4266)。**ops group 所属 かつ MFA 済**を要求する。
- *
- * CloudFront 層の IP allowlist (2 枚目の防御) を廃止したため、主防御であるアプリ層の
- * 強度を上げる。IP allowlist を廃止した理由:
- *   - 対象 path に `/admin` (= 保護者 = 顧客の見守り画面) が含まれ、有効化すると全顧客が 403
- *   - 運営者のグローバル IP が固定でなく、プロキシ経由では `event.viewer.ip` が回線 IP と一致しない
- *
- * 代替として MFA を要求する。運営者は TOTP を 1 度設定すれば、IP / 回線 / プロキシに縛られない。
- * Cognito user pool は `mfa: OPTIONAL` のまま (顧客に MFA を強制しない)、ops だけをここで縛る。
+ * このセッションが MFA を経て開始されたか (#4266)。
  *
  * **判定はセッション単位**: MFA を「今の ID token が MFA を経ているか」ではなく
  * **「このセッションが MFA を経て開始されたか」** で見る。silent refresh
@@ -53,18 +45,50 @@ export function isOpsMember(identity: Identity | null): boolean {
  * (`context-token.ts`、既存機構) が保持し、ここで OR を取る。
  *
  * **fail-closed**: identity / context のどちらからも MFA を確認できない (旧トークン /
- * claim 欠落 = `undefined`) 場合は拒否する。「不明なら通す」にすると防御が黙って消える
+ * claim 欠落 = `undefined`) 場合は `false`。「不明なら通す」にはしない
  * (ADR-0024 ENV silent skip 禁止と同じ規律)。
+ *
+ * #4363 で `/ops` の MFA 要求自体は既定 off になったが、**本判定は残す**
+ * (`OPS_MFA_REQUIRED` を `true` に戻せばそのまま効く)。
+ */
+export function hasMfaAuthenticatedSession(
+	identity: Identity | null,
+	context?: Pick<AuthContext, 'mfaAuthenticated'> | null,
+): boolean {
+	const tokenMfa = identity?.type === 'cognito' && identity.mfaAuthenticated === true;
+	const sessionMfa = context?.mfaAuthenticated === true;
+	return tokenMfa || sessionMfa;
+}
+
+/**
+ * `/ops` に入れるか判定する単一述語。**既定では ops group 所属のみ**を要求する
+ * (#4363、オーナー決裁 2026-08-06 で MFA 要求を撤去)。
+ *
+ * 経緯: #4266 で CloudFront 層の IP allowlist (2 枚目の防御) を廃止した際、その代替として
+ * MFA を要求した。IP allowlist を廃止した理由:
+ *   - 対象 path に `/admin` (= 保護者 = 顧客の見守り画面) が含まれ、有効化すると全顧客が 403
+ *   - 運営者のグローバル IP が固定でなく、プロキシ経由では `event.viewer.ip` が回線 IP と一致しない
+ *
+ * しかし運営 1 人・ops group メンバー 0 人の段階では TOTP 登録の運用コストに見合わず、
+ * オーナーが MFA 要求の撤去を決裁した。**結果として `/ops` の防御は
+ * 「Cognito 認証 + ops group 所属」だけになり、多層防御が 1 層減っている。**
+ * 残る防御・再評価トリガー (T1〜T4) は `docs/design/14-セキュリティ設計書.md` §5.2.9 が SSOT。
+ *
+ * **fail-closed は group 側で維持**: group が確認できない (identity=null / local /
+ * groups 欠落) 場合は拒否する。緩めたのは MFA の 1 条件だけである。
+ *
+ * `requireMfa` は既定で `OPS_MFA_REQUIRED` (現在 false)。呼び出し側で上書きするのは
+ * 「フラグを戻せば #4266 当時の判定に復帰する」ことを test で機械的に固定するため
+ * (`tests/unit/routes/ops-mfa-not-required.test.ts`)。**production の呼び出しでは指定しない**。
  */
 export function hasOpsAccess(
 	identity: Identity | null,
 	context?: Pick<AuthContext, 'mfaAuthenticated'> | null,
+	requireMfa: boolean = OPS_MFA_REQUIRED,
 ): boolean {
 	if (!isOpsMember(identity)) return false;
-	// isOpsMember が true ⇒ identity は cognito
-	const tokenMfa = identity?.type === 'cognito' && identity.mfaAuthenticated === true;
-	const sessionMfa = context?.mfaAuthenticated === true;
-	return tokenMfa || sessionMfa;
+	if (!requireMfa) return true;
+	return hasMfaAuthenticatedSession(identity, context);
 }
 
 /**
@@ -95,7 +119,12 @@ export function requireOpsAccess(locals: App.Locals): void {
 	// MFA 設定導線 (`OpsMfaSetupNotice`) に切り替える — メッセージ本文の文字列一致に
 	// 表示を依存させない。値は policy 層の deny reason と同一 (`OPS_MFA_REQUIRED_REASON`)。
 	// 403 (データを一切 load しない fail-closed) は変えず、表示だけを分ける。
-	if (isOpsMember(locals.identity)) {
+	//
+	// #4363: MFA 要求が off の間、`hasOpsAccess` は ops member を必ず通すため本分岐には
+	// 到達しない (= 復旧導線は表示されない)。分岐を消さずフラグ条件を明示しているのは、
+	// `OPS_MFA_REQUIRED` を `true` に戻したときに拒否理由と復旧導線 (`OpsMfaSetupNotice`)
+	// が同時に復活するようにするため (戻すのに再実装を要さない)。
+	if (OPS_MFA_REQUIRED && isOpsMember(locals.identity)) {
 		error(403, {
 			message: 'Forbidden: ops access requires MFA',
 			reason: OPS_MFA_REQUIRED_REASON,

--- a/src/lib/server/auth/providers/cognito-dev.ts
+++ b/src/lib/server/auth/providers/cognito-dev.ts
@@ -37,7 +37,7 @@ export interface DevUser {
 	groups?: string[];
 	/** #3025: federated (Google) 相当。Cognito パスワードを持たないユーザの再現 (PIN reset 分岐検証用) */
 	federated?: boolean;
-	/** #4266: MFA 設定済。/ops は ops group + MFA を要求するため ops ユーザには必須 */
+	/** MFA 設定済かどうか。/ops の判定は #4363 で group のみになったが、機構検証のため残す */
 	mfa?: boolean;
 }
 
@@ -124,11 +124,13 @@ export const DEV_USERS: DevUser[] = [
 		tenantId: 'dev-tenant-ops',
 		role: 'owner',
 		groups: ['ops'],
-		// #4266: /ops は ops group + MFA (hasOpsAccess) を要求する。
-		// 運営者は TOTP を 1 度設定すれば通るため、dev でも MFA 済として扱う。
+		// #4363 で /ops は group のみで通るが、MFA 済の運営者も再現できるよう true にしておく
+		// (OPS_MFA_REQUIRED を戻したときの許可経路をローカルで歩けるようにするため)。
 		mfa: true,
 	},
-	// ---------- #4282: MFA 未設定の運営者 (拒否 → 復旧導線の検証用) ----------
+	// ---------- MFA 未設定の運営者 ----------
+	// 現在 (#4363、MFA 要求 off) は /ops に入れる。OPS_MFA_REQUIRED を true に戻すと
+	// 403 → 復旧導線 (OpsMfaSetupNotice) に着地する経路の検証に使う。
 	// ops group には居るが TOTP 未設定。/ops を開くと 403 + 設定導線 (OpsMfaSetupNotice) に
 	// 着地する。この経路を実ブラウザ / E2E で歩けないと「締め出して復旧できない」状態を
 	// 作っていないことを確認できないため、dev の SSOT にアカウントを 1 つ用意する

--- a/src/lib/server/security/origin-verify.ts
+++ b/src/lib/server/security/origin-verify.ts
@@ -15,7 +15,7 @@
 // ## これは認証ではない
 //
 // 本検査は認証・認可を一切代替しない。保護対象 path は従来どおり Cognito セッション +
-// parent-gate PIN (`/admin`) / ops group + MFA (`/ops`) で守られる。本検査が足すのは
+// parent-gate PIN (`/admin`) / ops group 所属 (`/ops`) で守られる。本検査が足すのは
 // 「edge 層の制御を迂回できない」という 1 点だけである。
 //
 // ## なぜ「CloudFront を通らない到達を一律に拒否」しないか (重要)
@@ -57,7 +57,7 @@ export const ORIGIN_VERIFY_HEADER = 'x-origin-verify';
  *   - `/admin`        保護者の見守り画面 (Cognito セッション + parent-gate PIN)
  *   - `/api/v1/admin` 上記画面が呼ぶ管理 API (同上)
  *   - `/ops`          運営専用ダッシュボード。売上 / コホート / コストが出る
- *                     (ops group + MFA、src/lib/server/auth/ops-authz.ts)
+ *                     (ops group 所属、src/lib/server/auth/ops-authz.ts)
  *
  * ここに **列挙しない path は本検査の対象外**であり、それぞれが自前の認証を持つ
  * (Stripe 署名 / CRON_SECRET / Cognito セッション / 公開情報)。冒頭コメント参照。
@@ -113,7 +113,7 @@ export function evaluateFrontDoor(
 	// secret 未設定 = 検査不能。**fail-open** にする (詳細は下記)。
 	//
 	// なぜ fail-open が安全か:
-	//   1. 本検査は認証ではなく「経路の限定」。無効化しても Cognito + PIN / ops group + MFA
+	//   1. 本検査は認証ではなく「経路の限定」。無効化しても Cognito + PIN / ops group 所属
 	//      という主防御は 1 枚も剥がれない。fail-closed にした場合に失われるもの (全顧客の
 	//      /admin が 404) の方が、得られるもの (経路限定) より桁違いに大きい
 	//   2. **CloudFront が存在しない配備が正当に存在する**。NUC セルフホスト (LAN 内直配信) と

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -21,6 +21,7 @@ const isChild = $derived(role === 'child');
 
 /**
  * #4282: `/ops` が MFA 未設定で 403 になったときだけ、汎用の 403 ではなく設定導線を出す。
+ * #4363 で MFA 要求が off になったため現在この分岐には入らない (`OPS_MFA_REQUIRED` を戻すと復活)。
  * 判定キーは route guard が載せた reason のみ (メッセージ本文は表示しない = 内部例外の
  * 非露出、ADR-0062)。ops 以外の 403 は reason が付かないので従来表示のまま。
  */

--- a/src/routes/ops/+layout.server.ts
+++ b/src/routes/ops/+layout.server.ts
@@ -19,8 +19,8 @@ import { requireOpsAccess } from '$lib/server/auth/ops-authz';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals }) => {
-	// #4266: CloudFront の IP allowlist 廃止に伴い、主防御を ops group + MFA に強化した。
-	// MFA 情報が取れない場合も拒否する (fail-closed)。
+	// 主防御は ops group 所属 (#4363 でオーナー決裁により MFA 要求を撤去)。
+	// group が確認できない場合は拒否する (fail-closed)。
 	//
 	// #4309: 判定は requireOpsAccess (単一強制点) に集約する。本 layout は **page にしか
 	// 適用されない** ため、`+server.ts` (API endpoint) は同じ関数を各自で呼ぶ必要がある。

--- a/src/routes/ops/export/+server.ts
+++ b/src/routes/ops/export/+server.ts
@@ -15,7 +15,7 @@ import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ url, locals }) => {
 	// #4309: `+layout.server.ts` の ops gate は page にしか適用されず本 endpoint には走らない。
-	// 未認証で売上台帳 CSV が 200 で取れていたため、同じ判定 (ops group + MFA) をここで通す。
+	// 未認証で売上台帳 CSV が 200 で取れていたため、同じ判定 (ops group 所属、#4363) をここで通す。
 	// **クエリ解釈より前に置く** — 認可の前にデータ集計が走ると、403 を返しても情報は流れる。
 	requireOpsAccess(locals);
 

--- a/tests/unit/policy/capabilities.test.ts
+++ b/tests/unit/policy/capabilities.test.ts
@@ -193,10 +193,13 @@ describe('policy/capabilities can() — access.ops_dashboard / view.ops_license_
 			expect(can(ctx({ mode: 'aws-prod', user: opsOwner }), cap)).toEqual({ allowed: true });
 		});
 
-		it(`${cap}: ops group でも MFA 未経由は ops-mfa-required (#4266 fail-closed)`, () => {
+		// #4363 (オーナー決裁 2026-08-06): /ops の MFA 要求を撤去。policy 層も実強制点
+		// (ops-authz.ts) と同じ `OPS_MFA_REQUIRED` を読むため、MFA 未経由でも allowed になる。
+		// フラグを戻したときの deny 挙動と 2 層の一致は
+		// tests/unit/policy/ops-mfa-flag-consistency.test.ts が固定する。
+		it(`${cap}: ops group なら MFA 未経由でも allowed (#4363)`, () => {
 			expect(can(ctx({ mode: 'aws-prod', user: opsOwnerNoMfa }), cap)).toEqual({
-				allowed: false,
-				reason: 'ops-mfa-required',
+				allowed: true,
 			});
 		});
 

--- a/tests/unit/policy/ops-mfa-flag-consistency.test.ts
+++ b/tests/unit/policy/ops-mfa-flag-consistency.test.ts
@@ -22,7 +22,12 @@ const opsCaps: Capability[] = ['access.ops_dashboard', 'view.ops_license_dashboa
 function ctxFor(user: { id: string; groups: string[]; mfaAuthenticated?: boolean }) {
 	return buildEvaluationContext({
 		mode: 'aws-prod',
-		user: { id: user.id, role: 'owner', groups: user.groups, mfaAuthenticated: user.mfaAuthenticated },
+		user: {
+			id: user.id,
+			role: 'owner',
+			groups: user.groups,
+			mfaAuthenticated: user.mfaAuthenticated,
+		},
 		plan: null,
 	});
 }
@@ -57,7 +62,9 @@ describe('#4363 フラグの単一 SSOT (実強制点 / policy 層が同じ定�
 
 	it('ops-authz.ts は自前の真偽値を持たず、capabilities.ts の定数を import する', () => {
 		const src = readFileSync(join(REPO_ROOT, 'src/lib/server/auth/ops-authz.ts'), 'utf8');
-		expect(src).toMatch(/import\s*\{[^}]*OPS_MFA_REQUIRED[^}]*\}\s*from\s*'\$lib\/policy\/capabilities'/s);
+		expect(src).toMatch(
+			/import\s*\{[^}]*OPS_MFA_REQUIRED[^}]*\}\s*from\s*'\$lib\/policy\/capabilities'/s,
+		);
 		// 別の名前で二重定義していないこと (`const requireMfa = false` のような握り潰し)
 		expect(src).not.toMatch(/const\s+OPS_MFA_REQUIRED\s*=/);
 	});

--- a/tests/unit/policy/ops-mfa-flag-consistency.test.ts
+++ b/tests/unit/policy/ops-mfa-flag-consistency.test.ts
@@ -1,0 +1,78 @@
+// tests/unit/policy/ops-mfa-flag-consistency.test.ts
+// #4363: /ops の MFA 要求は **1 箇所のフラグ** (`OPS_MFA_REQUIRED`) で決まり、
+//        実強制点 (ops-authz.ts) と policy 層の写像 (capabilities.ts) が食い違わないことを固定する。
+//
+// なぜ必要か: MFA 判定は 2 箇所にある。
+//   - 実強制点: `hasOpsAccess()` / `requireOpsAccess()` (src/lib/server/auth/ops-authz.ts)
+//   - policy 層の写像: `can(ctx, 'access.ops_dashboard')` (src/lib/policy/capabilities.ts)
+// 片方だけを外すと「UI は入れると言うが load は 403」/ その逆が起き、再評価トリガーで
+// 戻すときにも片方だけ戻る。したがって**同一定数を両者が import している**ことを
+// ソース構造レベルで assert する (真偽値の二重定義を作らせない)。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { type Capability, can, OPS_MFA_REQUIRED } from '../../../src/lib/policy/capabilities';
+import { buildEvaluationContext } from '../../../src/lib/runtime/evaluation-context';
+
+const REPO_ROOT = join(import.meta.dirname, '../../..');
+
+const opsCaps: Capability[] = ['access.ops_dashboard', 'view.ops_license_dashboard'];
+
+function ctxFor(user: { id: string; groups: string[]; mfaAuthenticated?: boolean }) {
+	return buildEvaluationContext({
+		mode: 'aws-prod',
+		user: { id: user.id, role: 'owner', groups: user.groups, mfaAuthenticated: user.mfaAuthenticated },
+		plan: null,
+	});
+}
+
+describe('#4363 policy 層も MFA を要求しない (実強制点と同じ判断)', () => {
+	for (const cap of opsCaps) {
+		it(`${cap}: MFA 未設定の ops group は allowed`, () => {
+			expect(can(ctxFor({ id: 'u-ops-no-mfa', groups: ['ops'] }), cap)).toEqual({ allowed: true });
+		});
+
+		it(`${cap}: mfaAuthenticated=false の ops group も allowed`, () => {
+			expect(
+				can(ctxFor({ id: 'u-ops-false', groups: ['ops'], mfaAuthenticated: false }), cap),
+			).toEqual({ allowed: true });
+		});
+
+		it(`${cap}: 非 ops は従来どおり ops-only で拒否 (緩めない)`, () => {
+			expect(can(ctxFor({ id: 'u-parent', groups: [], mfaAuthenticated: true }), cap)).toEqual({
+				allowed: false,
+				reason: 'ops-only',
+			});
+		});
+	}
+});
+
+describe('#4363 フラグの単一 SSOT (実強制点 / policy 層が同じ定数を読む)', () => {
+	it('OPS_MFA_REQUIRED は capabilities.ts が 1 度だけ定義する', () => {
+		const src = readFileSync(join(REPO_ROOT, 'src/lib/policy/capabilities.ts'), 'utf8');
+		const defs = src.match(/export const OPS_MFA_REQUIRED\b/g) ?? [];
+		expect(defs).toHaveLength(1);
+	});
+
+	it('ops-authz.ts は自前の真偽値を持たず、capabilities.ts の定数を import する', () => {
+		const src = readFileSync(join(REPO_ROOT, 'src/lib/server/auth/ops-authz.ts'), 'utf8');
+		expect(src).toMatch(/import\s*\{[^}]*OPS_MFA_REQUIRED[^}]*\}\s*from\s*'\$lib\/policy\/capabilities'/s);
+		// 別の名前で二重定義していないこと (`const requireMfa = false` のような握り潰し)
+		expect(src).not.toMatch(/const\s+OPS_MFA_REQUIRED\s*=/);
+	});
+
+	it('capabilities.ts の ops 判定はフラグ経由でのみ MFA を見る', () => {
+		const src = readFileSync(join(REPO_ROOT, 'src/lib/policy/capabilities.ts'), 'utf8');
+		const opsGuard = src.slice(src.indexOf('function requireOpsGroup'));
+		const body = opsGuard.slice(0, opsGuard.indexOf('\n}'));
+		if (body.includes('mfaAuthenticated')) {
+			expect(body).toContain('OPS_MFA_REQUIRED');
+		}
+	});
+
+	it('フラグは boolean で、現在の値は false (決裁の状態)', () => {
+		expect(typeof OPS_MFA_REQUIRED).toBe('boolean');
+		expect(OPS_MFA_REQUIRED).toBe(false);
+	});
+});

--- a/tests/unit/routes/ops-export-authz.test.ts
+++ b/tests/unit/routes/ops-export-authz.test.ts
@@ -125,11 +125,16 @@ describe('/ops/export の認可 (#4309)', () => {
 		}
 	});
 
-	describe('ops group だが MFA 未済は 403 (#4266 fail-closed を API にも適用)', () => {
+	// #4363 (オーナー決裁 2026-08-06): /ops の MFA 要求を撤去したため、MFA 未済の ops も
+	// API に到達する。**弱めた条件は MFA の 1 つだけ**で、上の「未認証」「非 ops」の 403 は不変。
+	// MFA を要求する側の挙動 (フラグを戻した場合) は
+	// tests/unit/routes/ops-mfa-not-required.test.ts が predicate 層で保持している。
+	describe('#4363 ops group なら MFA 未済でも取得できる (決裁で MFA 要求を撤去)', () => {
 		for (const type of EXPORT_TYPES) {
-			it(`type=${type} は 403 を返す`, async () => {
-				expect(await statusOf(makeEvent(type, OPS_WITHOUT_MFA))).toBe(403);
-				expect(mockGetRevenueData).not.toHaveBeenCalled();
+			it(`type=${type} は 200 を返す`, async () => {
+				const res = await GET(makeEvent(type, OPS_WITHOUT_MFA));
+				expect(res.status).toBe(200);
+				expect(await res.text()).not.toBe('');
 			});
 		}
 	});

--- a/tests/unit/routes/ops-layout-server.test.ts
+++ b/tests/unit/routes/ops-layout-server.test.ts
@@ -4,8 +4,10 @@
 // 旧実装（OPS_SECRET_KEY Bearer）では Bearer token が一致すれば通過していた。
 // 新実装では locals.identity に ops group 所属の Cognito identity が居ることを要求する。
 //
-// #4266: CloudFront の IP allowlist 廃止に伴い条件を **ops group + MFA** に強化した
-// （弱めていない）。MFA を経ていない ops identity は 403 になる。fail-closed の網羅は
+// #4266 → #4363: 一度 **ops group + MFA** に強化したが、オーナー決裁 (2026-08-06) により
+// MFA 要求を撤去し、現在の条件は **ops group 所属のみ**。group 側の fail-closed
+// (非所属 / local / null は 403) は不変。現行条件の網羅は
+// tests/unit/routes/ops-mfa-not-required.test.ts、MFA 機構 (フラグを戻した場合) の網羅は
 // tests/unit/routes/ops-mfa-guard.test.ts。
 
 import { describe, expect, it } from 'vitest';
@@ -81,21 +83,19 @@ describe('#820 /ops/+layout.server.ts', () => {
 		}
 	});
 
-	it('cognito identity で groups=["ops"] でも MFA 未経由は 403 (#4266)', async () => {
-		try {
-			await load(
+	it('cognito identity で groups=["ops"] なら MFA 未経由でも通過する (#4363)', async () => {
+		// #4363 (オーナー決裁 2026-08-06) で /ops の MFA 要求を撤去した。緩めたのは MFA の
+		// 1 条件だけで、上の「group 非所属 / local / null は 403」は不変 (この file の他 it)。
+		await expect(
+			load(
 				makeEvent({
 					type: 'cognito',
 					userId: 'u-ops',
 					email: 'ops@example.com',
 					groups: ['ops'],
 				}),
-			);
-			expect.fail('403 がスローされるはず');
-		} catch (e) {
-			if (!isHttpError(e)) throw e;
-			expect(e.status).toBe(403);
-		}
+			),
+		).resolves.toEqual({});
 	});
 
 	it('cognito identity で groups=["ops"] かつ MFA 済は通過', async () => {

--- a/tests/unit/routes/ops-mfa-guard.test.ts
+++ b/tests/unit/routes/ops-mfa-guard.test.ts
@@ -1,19 +1,32 @@
 // tests/unit/routes/ops-mfa-guard.test.ts
-// #4266 (PO 決裁 2026-08-05): /ops の主防御を「Cognito ops group + MFA 必須」にする回帰テスト。
+// #4266 → #4363: /ops の **MFA 判定機構** の回帰テスト。
 //
-// 背景: CloudFront 層の admin IP allowlist を廃止した (顧客画面 /admin まで 403 にする設計誤り +
-// 運営者のグローバル IP が固定でない / プロキシ経由で event.viewer.ip が回線 IP と一致しない)。
-// IP 層 (2 枚目) を成立させられない以上、主防御であるアプリ層 (ops group) の強度を上げる。
+// 位置づけ (2026-08-06 オーナー決裁後):
+//   #4266 は CloudFront の admin IP allowlist 廃止の代替として /ops に MFA を要求した。
+//   #4363 (オーナー決裁) でその**要求**を撤去し、現在の /ops は ops group 所属のみで通る。
+//   ただし**判定機構は残してある** (`OPS_MFA_REQUIRED` を true に戻せば復帰する)。
 //
-// 不変条件 (fail-closed / ADR-0024 「設定が無ければ止める」):
-//   - ops group 所属でも、MFA を経ていない identity は /ops に入れない
+//   - 現行挙動 (要求 off) の網羅   → tests/unit/routes/ops-mfa-not-required.test.ts
+//   - policy 層との一致 / SSOT     → tests/unit/policy/ops-mfa-flag-consistency.test.ts
+//   - **本 file** = 機構そのもの (requireMfa=true を明示した場合の真理値表 + context token)
+//
+// 本 file を消してはいけない: 機構が腐ると「フラグを戻せば復帰する」という #4363 の前提
+// (= 弱くした防御をいつでも戻せる) が静かに壊れる。
+//
+// 不変条件 (フラグを true に戻したときの fail-closed / ADR-0024「設定が無ければ止める」):
+//   - ops group 所属でも、MFA を経ていない identity は入れない
 //   - MFA 情報が取れない (claim 欠落 = undefined) 場合も入れない (不明は拒否)
-//
-// failing-test-first (ADR-0061): 実装前は `hasOpsAccess` が存在せず import が解決できない (red)。
 
 import { describe, expect, it } from 'vitest';
-import { hasOpsAccess, isOpsMember } from '../../../src/lib/server/auth/ops-authz';
+import {
+	hasMfaAuthenticatedSession,
+	hasOpsAccess,
+	isOpsMember,
+} from '../../../src/lib/server/auth/ops-authz';
 import type { Identity } from '../../../src/lib/server/auth/types';
+
+/** MFA を要求する設定に戻した場合を明示する (production の既定は false)。 */
+const REQUIRE_MFA = true;
 
 const opsWithMfa: Identity = {
 	type: 'cognito',
@@ -39,78 +52,51 @@ const opsMfaUnknown: Identity = {
 	groups: ['ops'],
 };
 
-describe('#4266 hasOpsAccess — ops group + MFA', () => {
+describe('#4266 hasOpsAccess — MFA を要求する設定 (requireMfa=true) の真理値表', () => {
 	it('ops group かつ MFA 済は許可', () => {
-		expect(hasOpsAccess(opsWithMfa)).toBe(true);
+		expect(hasOpsAccess(opsWithMfa, undefined, REQUIRE_MFA)).toBe(true);
 	});
 
-	it('ops group でも MFA 未経由は拒否 (IP 層廃止に伴う主防御の強化)', () => {
-		expect(hasOpsAccess(opsWithoutMfa)).toBe(false);
+	it('ops group でも MFA 未経由は拒否', () => {
+		expect(hasOpsAccess(opsWithoutMfa, undefined, REQUIRE_MFA)).toBe(false);
 	});
 
 	it('ops group でも MFA 情報不明 (claim 欠落) は拒否 (fail-closed)', () => {
-		expect(hasOpsAccess(opsMfaUnknown)).toBe(false);
+		expect(hasOpsAccess(opsMfaUnknown, undefined, REQUIRE_MFA)).toBe(false);
 	});
 
 	it('非 ops group は MFA 済でも拒否', () => {
 		expect(
-			hasOpsAccess({
-				type: 'cognito',
-				userId: 'u-parent',
-				email: 'parent@example.com',
-				groups: [],
-				mfaAuthenticated: true,
-			}),
+			hasOpsAccess(
+				{
+					type: 'cognito',
+					userId: 'u-parent',
+					email: 'parent@example.com',
+					groups: [],
+					mfaAuthenticated: true,
+				},
+				undefined,
+				REQUIRE_MFA,
+			),
 		).toBe(false);
 	});
 
 	it('local identity は拒否 (/ops は Cognito 配信のみ)', () => {
-		expect(hasOpsAccess({ type: 'local' })).toBe(false);
+		expect(hasOpsAccess({ type: 'local' }, undefined, REQUIRE_MFA)).toBe(false);
 	});
 
 	it('identity=null は拒否', () => {
-		expect(hasOpsAccess(null)).toBe(false);
+		expect(hasOpsAccess(null, undefined, REQUIRE_MFA)).toBe(false);
 	});
 
 	it('isOpsMember は group 所属のみを判定する (MFA 条件は hasOpsAccess の責務)', () => {
 		// group 判定と MFA 判定を混ぜないことで、「なぜ弾かれたか」がログ / テストで分離できる
 		expect(isOpsMember(opsWithoutMfa)).toBe(true);
-		expect(hasOpsAccess(opsWithoutMfa)).toBe(false);
+		expect(hasOpsAccess(opsWithoutMfa, undefined, REQUIRE_MFA)).toBe(false);
 	});
 });
 
-describe('#4266 /ops layout guard', () => {
-	async function loadOps(identity: Identity | null) {
-		const mod = await import('../../../src/routes/ops/+layout.server');
-		// biome-ignore lint/suspicious/noExplicitAny: SvelteKit の LayoutServerLoad 引数を最小 stub で渡す
-		return (mod.load as any)({ locals: { identity } });
-	}
-
-	it('MFA 済 ops は通過する', async () => {
-		await expect(loadOps(opsWithMfa)).resolves.toEqual({});
-	});
-
-	it('MFA 未経由の ops は 403 で、理由が MFA だと分かる', async () => {
-		// 真っ白な Forbidden だと「TOTP 未設定」か「group 外」かを運営者が切り分けられない
-		await expect(loadOps(opsWithoutMfa)).rejects.toMatchObject({
-			status: 403,
-			body: { message: 'Forbidden: ops access requires MFA' },
-		});
-	});
-
-	it('MFA 情報不明の ops は 403 (fail-closed)', async () => {
-		await expect(loadOps(opsMfaUnknown)).rejects.toMatchObject({ status: 403 });
-	});
-
-	it('未認証は 403 で、MFA 理由を出さない (ops group の存在を示唆しない)', async () => {
-		await expect(loadOps(null)).rejects.toMatchObject({
-			status: 403,
-			body: { message: 'Forbidden' },
-		});
-	});
-});
-
-// ---------- #4266 追補: silent refresh で amr が落ちても締め出さない ----------
+// ---------- #4266 セッション単位判定 (silent refresh 対策) ----------
 // Cognito の REFRESH_TOKEN_AUTH で再発行される ID token が MFA チャレンジ情報 (`amr`) を
 // 保持するかは AWS 公式ドキュメントで確定できなかった (2026-08-05 調査)。保持しない場合、
 // 運営者が何もしていないのに突然 /ops から締め出され、再ログインまで戻れない。
@@ -128,13 +114,13 @@ describe('#4266 セッション単位の MFA 判定 (silent refresh 対策)', ()
 	};
 
 	it('identity の MFA が不明でも、context が MFA 済セッションなら許可', () => {
-		expect(hasOpsAccess(opsAfterRefresh, { mfaAuthenticated: true })).toBe(true);
+		expect(hasOpsAccess(opsAfterRefresh, { mfaAuthenticated: true }, REQUIRE_MFA)).toBe(true);
 	});
 
 	it('identity も context も MFA を示さなければ拒否 (fail-closed)', () => {
-		expect(hasOpsAccess(opsAfterRefresh, { mfaAuthenticated: false })).toBe(false);
-		expect(hasOpsAccess(opsAfterRefresh, undefined)).toBe(false);
-		expect(hasOpsAccess(opsAfterRefresh, {})).toBe(false);
+		expect(hasOpsAccess(opsAfterRefresh, { mfaAuthenticated: false }, REQUIRE_MFA)).toBe(false);
+		expect(hasOpsAccess(opsAfterRefresh, undefined, REQUIRE_MFA)).toBe(false);
+		expect(hasOpsAccess(opsAfterRefresh, {}, REQUIRE_MFA)).toBe(false);
 	});
 
 	it('context が MFA 済でも ops group でなければ拒否', () => {
@@ -142,20 +128,19 @@ describe('#4266 セッション単位の MFA 判定 (silent refresh 対策)', ()
 			hasOpsAccess(
 				{ type: 'cognito', userId: 'u-p', email: 'p@example.com', groups: [] },
 				{ mfaAuthenticated: true },
+				REQUIRE_MFA,
 			),
 		).toBe(false);
 	});
 
-	it('/ops layout は locals.context の MFA も見る (refresh 直後も通過する)', async () => {
-		const mod = await import('../../../src/routes/ops/+layout.server');
-		// biome-ignore lint/suspicious/noExplicitAny: SvelteKit の LayoutServerLoad 引数を最小 stub で渡す
-		const load = mod.load as any;
-		await expect(
-			load({ locals: { identity: opsAfterRefresh, context: { mfaAuthenticated: true } } }),
-		).resolves.toEqual({});
-		await expect(
-			load({ locals: { identity: opsAfterRefresh, context: { mfaAuthenticated: false } } }),
-		).rejects.toMatchObject({ status: 403 });
+	it('hasMfaAuthenticatedSession は identity / context の OR を取る (group 条件を含まない)', () => {
+		// 機構を単体で保持する述語。group 判定と混ざっていないことをここで固定する。
+		expect(hasMfaAuthenticatedSession(opsWithMfa)).toBe(true);
+		expect(hasMfaAuthenticatedSession(opsAfterRefresh, { mfaAuthenticated: true })).toBe(true);
+		expect(hasMfaAuthenticatedSession(opsAfterRefresh)).toBe(false);
+		expect(hasMfaAuthenticatedSession(opsWithoutMfa)).toBe(false);
+		expect(hasMfaAuthenticatedSession(null)).toBe(false);
+		expect(hasMfaAuthenticatedSession({ type: 'local' }, { mfaAuthenticated: true })).toBe(true);
 	});
 });
 
@@ -173,62 +158,19 @@ describe('#4266 context token が MFA 済セッションを保持する', () => 
 	});
 });
 
-// ---------- #4282 AC5: MFA 未設定の運営者に「拒否」ではなく復旧導線を出す ----------
-// #4266 で MFA 必須化までは入ったが、拒否された運営者が実際に見るのは共通の 403 画面
-// (「アクセスが きょか されていません」+「ログインし直す」) だけだった。TOTP が未設定の
-// まま「ログインし直す」を押しても同じ 403 に戻るため、画面からは復旧手段が分からない
-// (= 締め出して復旧できない状態)。
+// ---------- #4282 復旧導線の分岐キー (MFA を要求する設定に戻したときに効く) ----------
+// #4266 で MFA 必須化した際、拒否された運営者が見るのは共通の 403 画面だけで、画面からは
+// 復旧手段が分からなかった (= 締め出して復旧できない状態)。そこで 403 (データを一切
+// load しない fail-closed) は維持したまま、**MFA が理由の 403 のときだけ** 復旧導線を
+// 描けるよう、エラー本文に機械可読な reason を載せる設計を入れた。
 //
-// 403 (= データを一切 load しない fail-closed) は維持したまま、**MFA が理由の 403 のときだけ**
-// 復旧導線を描けるように、エラー本文へ機械可読な reason を載せる。値は policy 層
-// (`capabilities.ts` の `deny('ops-mfa-required')`) と同一文字列にし、2 つ目の語彙を作らない。
-describe('#4282 MFA 拒否の理由を機械可読に伝える (復旧導線の分岐キー)', () => {
-	async function loadOpsRaw(identity: Identity | null): Promise<unknown> {
-		const mod = await import('../../../src/routes/ops/+layout.server');
-		// biome-ignore lint/suspicious/noExplicitAny: SvelteKit の LayoutServerLoad 引数を最小 stub で渡す
-		return (mod.load as any)({ locals: { identity } });
-	}
-
-	async function rejectionOf(identity: Identity | null): Promise<{ body: { reason?: string } }> {
-		return (await loadOpsRaw(identity).then(
-			() => {
-				throw new Error('expected 403 but load resolved');
-			},
-			(e: unknown) => e,
-		)) as { body: { reason?: string } };
-	}
-
-	it('MFA 未経由の ops は body.reason=ops-mfa-required を伴う 403 になる', async () => {
-		await expect(loadOpsRaw(opsWithoutMfa)).rejects.toMatchObject({
-			status: 403,
-			body: { message: 'Forbidden: ops access requires MFA', reason: 'ops-mfa-required' },
-		});
-	});
-
-	it('MFA 情報不明 (claim 欠落) も同じ reason を伴う (復旧導線に着地させる)', async () => {
-		await expect(loadOpsRaw(opsMfaUnknown)).rejects.toMatchObject({
-			status: 403,
-			body: { reason: 'ops-mfa-required' },
-		});
-	});
-
-	it('非 ops / 未認証には reason を載せない (ops group の存在を示唆しない)', async () => {
-		const rejected = await rejectionOf(null);
-		expect(rejected.body.reason).toBeUndefined();
-	});
-
-	it('reason 文字列は policy 層の deny reason と同一 (語彙を二重に持たない)', async () => {
-		const { can } = await import('$lib/policy/capabilities');
-		const { buildEvaluationContext } = await import('$lib/runtime/evaluation-context');
-		const policyReason = can(
-			buildEvaluationContext({
-				mode: 'aws-prod',
-				user: { id: 'u-ops-2', role: 'owner', groups: ['ops'] },
-				plan: null,
-			}),
-			'access.ops_dashboard',
-		).reason;
-		const rejected = await rejectionOf(opsWithoutMfa);
-		expect(rejected.body.reason).toBe(policyReason);
+// #4363 で MFA 要求が off になったため `requireOpsAccess` はこの reason を出さない
+// (= 導線は表示されない)。**語彙と描画側は残す**: フラグを戻した瞬間に拒否理由と導線が
+// 同時に復活する必要があるため。描画側の回帰は
+// tests/unit/routes/error-page-ops-mfa.test.ts / tests/unit/components/ops-mfa-setup-notice.test.ts。
+describe('#4282 MFA 拒否理由の語彙 (policy 層と 1 語彙)', () => {
+	it('OPS_MFA_REQUIRED_REASON は policy 層の DenyReason と同一値', async () => {
+		const { OPS_MFA_REQUIRED_REASON } = await import('$lib/policy/capabilities');
+		expect(OPS_MFA_REQUIRED_REASON).toBe('ops-mfa-required');
 	});
 });

--- a/tests/unit/routes/ops-mfa-not-required.test.ts
+++ b/tests/unit/routes/ops-mfa-not-required.test.ts
@@ -1,0 +1,154 @@
+// tests/unit/routes/ops-mfa-not-required.test.ts
+// #4363 (オーナー決裁 2026-08-06): /ops の MFA 要求を外し、ops group 所属のみで判定する。
+//
+// 決裁の内容: 選択肢 A (TOTP を登録する) / B (MFA 要求を外す) / C (/ops を使わない) を提示し、
+// オーナーが B を選択した (「TOTP の対応は不要とします」)。ops group メンバーが 0 人で
+// /ops に誰も入れず、TOTP 有効化も 4 手順を要する (コンソール操作は InvalidParameterException
+// で失敗) ため、その手間を掛けない判断がなされた。
+//
+// **弱くなる点を隠さない**: #4266 が CloudFront の IP allowlist を廃止した代替が MFA だった。
+// これを外すと /ops (売上・コホート・コスト・PL) の防御は「Cognito 認証 + ops group 所属」
+// だけになり、多層防御が 1 層減る (ops のパスワード 1 つが漏れた時点で入られる)。
+// したがって本 test は次の 2 つを**同時に**固定する:
+//   (1) 現在の判定 = group のみ (決裁の実装)
+//   (2) MFA 判定の機構は生きており、フラグ 1 つで元に戻せる (再評価トリガー T1-T4 で戻す)
+//
+// fail-closed の性質は維持する: group が確認できなければ拒否 (ここまでは緩めない)。
+//
+// failing-test-first (ADR-0061): 実装前は `OPS_MFA_REQUIRED` が存在せず import が解決できない
+// / `hasOpsAccess(opsWithoutMfa)` が false を返すため red。
+
+import { describe, expect, it } from 'vitest';
+import { OPS_MFA_REQUIRED } from '../../../src/lib/policy/capabilities';
+import { hasOpsAccess, isOpsMember } from '../../../src/lib/server/auth/ops-authz';
+import type { Identity } from '../../../src/lib/server/auth/types';
+
+const opsWithMfa: Identity = {
+	type: 'cognito',
+	userId: 'u-ops-1',
+	email: 'ops@example.com',
+	groups: ['ops'],
+	mfaAuthenticated: true,
+};
+
+/** TOTP 未設定の運営者 (= 決裁後の実在アカウント kokorokagami+gqops の状態)。 */
+const opsWithoutMfa: Identity = {
+	type: 'cognito',
+	userId: 'u-ops-2',
+	email: 'ops2@example.com',
+	groups: ['ops'],
+	mfaAuthenticated: false,
+};
+
+/** MFA 情報が取れない (旧トークン / amr claim 欠落)。 */
+const opsMfaUnknown: Identity = {
+	type: 'cognito',
+	userId: 'u-ops-3',
+	email: 'ops3@example.com',
+	groups: ['ops'],
+};
+
+const parentWithMfa: Identity = {
+	type: 'cognito',
+	userId: 'u-parent',
+	email: 'parent@example.com',
+	groups: [],
+	mfaAuthenticated: true,
+};
+
+describe('#4363 /ops は ops group 所属のみで判定する (オーナー決裁で MFA 要求を撤去)', () => {
+	it('MFA 未設定の ops は /ops に入れる (決裁の本体)', () => {
+		expect(hasOpsAccess(opsWithoutMfa)).toBe(true);
+	});
+
+	it('MFA 情報不明 (amr claim 欠落) の ops も入れる — 旧トークンで締め出さない', () => {
+		expect(hasOpsAccess(opsMfaUnknown)).toBe(true);
+		expect(hasOpsAccess(opsMfaUnknown, undefined)).toBe(true);
+		expect(hasOpsAccess(opsMfaUnknown, {})).toBe(true);
+	});
+
+	it('MFA 済 ops は当然入れる (回帰)', () => {
+		expect(hasOpsAccess(opsWithMfa)).toBe(true);
+	});
+
+	// ---- ここから下は「緩めない」側の固定。決裁は MFA だけを外すものであり、
+	//      group 判定まで緩めることは含まない。
+	it('ops group 非所属は MFA 済でも拒否 (回帰、ここまで緩めない)', () => {
+		expect(hasOpsAccess(parentWithMfa)).toBe(false);
+	});
+
+	it('groups が空 / 未提供の cognito identity は拒否 (fail-closed)', () => {
+		expect(hasOpsAccess({ type: 'cognito', userId: 'u', email: 'u@e.com', groups: [] })).toBe(
+			false,
+		);
+		expect(hasOpsAccess({ type: 'cognito', userId: 'u', email: 'u@e.com' })).toBe(false);
+	});
+
+	it('local identity は拒否 (/ops は Cognito 配信のみ)', () => {
+		expect(hasOpsAccess({ type: 'local' })).toBe(false);
+	});
+
+	it('identity=null は拒否', () => {
+		expect(hasOpsAccess(null)).toBe(false);
+	});
+
+	it('判定は isOpsMember と一致する (group 以外の条件を足していない)', () => {
+		for (const id of [opsWithMfa, opsWithoutMfa, opsMfaUnknown, parentWithMfa, null]) {
+			expect(hasOpsAccess(id)).toBe(isOpsMember(id));
+		}
+	});
+});
+
+describe('#4363 MFA 判定の機構は残っており、フラグ 1 つで復帰できる', () => {
+	it('OPS_MFA_REQUIRED は現在 false (決裁の状態)', () => {
+		expect(OPS_MFA_REQUIRED).toBe(false);
+	});
+
+	it('requireMfa=true を渡すと #4266 当時の判定がそのまま復活する', () => {
+		// 再評価トリガー (T1: 有料 10 世帯超 / T2: ops 2 人目 / T3: /ops に書込・個票
+		// / T4: 不審ログイン観測) を満たしたら OPS_MFA_REQUIRED を true にするだけでよい、
+		// ことをここで機械的に保証する。実装を書き直す必要が無い = 機構を消していない。
+		expect(hasOpsAccess(opsWithMfa, undefined, true)).toBe(true);
+		expect(hasOpsAccess(opsWithoutMfa, undefined, true)).toBe(false);
+		expect(hasOpsAccess(opsMfaUnknown, undefined, true)).toBe(false); // fail-closed
+		expect(hasOpsAccess(parentWithMfa, undefined, true)).toBe(false);
+	});
+
+	it('requireMfa=true では context 側のセッション MFA も従来どおり見る (silent refresh 対策)', () => {
+		expect(hasOpsAccess(opsMfaUnknown, { mfaAuthenticated: true }, true)).toBe(true);
+		expect(hasOpsAccess(opsMfaUnknown, { mfaAuthenticated: false }, true)).toBe(false);
+	});
+
+	it('既定引数は OPS_MFA_REQUIRED である (別の真偽値を二重に持たない)', () => {
+		for (const id of [opsWithMfa, opsWithoutMfa, opsMfaUnknown, parentWithMfa]) {
+			expect(hasOpsAccess(id)).toBe(hasOpsAccess(id, undefined, OPS_MFA_REQUIRED));
+		}
+	});
+});
+
+describe('#4363 /ops layout guard も group のみで通す', () => {
+	async function loadOps(identity: Identity | null) {
+		const mod = await import('../../../src/routes/ops/+layout.server');
+		// biome-ignore lint/suspicious/noExplicitAny: SvelteKit の LayoutServerLoad 引数を最小 stub で渡す
+		return (mod.load as any)({ locals: { identity } });
+	}
+
+	it('MFA 未設定の ops が /ops を開ける (決裁の実効確認)', async () => {
+		await expect(loadOps(opsWithoutMfa)).resolves.toEqual({});
+	});
+
+	it('amr claim の無い ops も開ける', async () => {
+		await expect(loadOps(opsMfaUnknown)).resolves.toEqual({});
+	});
+
+	it('非 ops は 403 のまま (reason は載せない = ops group の存在を示唆しない)', async () => {
+		await expect(loadOps(parentWithMfa)).rejects.toMatchObject({
+			status: 403,
+			body: { message: 'Forbidden' },
+		});
+	});
+
+	it('未認証は 403 のまま', async () => {
+		await expect(loadOps(null)).rejects.toMatchObject({ status: 403 });
+	});
+});

--- a/tests/unit/routes/ops-mfa-not-required.test.ts
+++ b/tests/unit/routes/ops-mfa-not-required.test.ts
@@ -31,7 +31,7 @@ const opsWithMfa: Identity = {
 	mfaAuthenticated: true,
 };
 
-/** TOTP 未設定の運営者 (= 決裁後の実在アカウント kokorokagami+gqops の状態)。 */
+/** TOTP 未設定の運営者 (= 決裁時点で実在する唯一の ops アカウントの状態)。 */
 const opsWithoutMfa: Identity = {
 	type: 'cognito',
 	userId: 'u-ops-2',


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 運営（`/ops`）。顧客画面（`/admin` `/child`）への影響はありません。

**解決する課題**: `/ops` は #4266 で「Cognito `ops` group + MFA 済セッション」に絞られたが、**ops group メンバーは 0 人**で誰も入れない状態だった。オーナーが ops アカウントを作成し group 追加まで進んだものの、**TOTP 有効化がコンソールから `InvalidParameterException` で失敗**（デバイス未登録のまま preference を設定しようとした順序の問題。正しくは `associate-software-token` → 認証アプリ登録 → `verify-software-token` → preference の 4 手順）。この手間を掛けないという判断がオーナーから示された。

**期待される効果**: 運営が `/ops`（売上・コホート・コスト・PL）を実際に開けるようになる。**防御は 1 層減る**ため、何が弱くなるか・いつ戻すかを下記のとおり設計書に恒久記載した。

### オーナー決裁（2026-08-06）

選択肢 **A**（TOTP を登録する）/ **B**（MFA 要求を外す）/ **C**（`/ops` を使わない）を提示し、**オーナーが B を選択**した（「TOTP の対応は不要とします」と明言）。**本 PR は Dev の判断で防御を下げるものではなく、決裁の実装である。**

### 何が弱くなるか（隠さず書く）

MFA 要求は #4266 / PR #4284 で CloudFront の IP allowlist を恒久廃止した際の**代替**として入った。これを外すと:

- `/ops` の防御は **「Cognito 認証 + `ops` group 所属」だけ**になり、**多層防御が 1 層減る**
- 具体的な劣化: **ops アカウントのパスワード 1 つが漏れた時点で `/ops` に入られる**（MFA があればパスワード漏洩単独では入れなかった）
- 対象データは全顧客の売上・課金情報であり、漏洩時の影響は「1 家庭」ではなく「全顧客 + 事業数値」

**残る防御**（これだけになる、という一覧）:

| 層 | 内容 | 効く経路 | 本 PR での変更 |
|---|---|---|---|
| Cognito 認証 | ID token 検証（`cognito-jwt.ts`）。未認証は入れない | 全経路 | 無変更 |
| `ops` group 所属 | `isOpsMember()`。顧客（保護者）アカウントでは入れない | 全経路 | 無変更（唯一の条件になる） |
| 単一強制点 | `requireOpsAccess()` を page と API / form action の両方が呼ぶ（#4309 / PR #4326）。適用範囲は fitness function が FS 列挙で機械強制 | 全経路 | 無変更（mutation 5 で生存確認） |
| front door header | CloudFront が付与する `x-origin-verify` をアプリ層が検査（#4280 / PR #4312、merge 済） | AWS 経路 | 無変更 |
| `/ops/export` の認可 | 未認証で売上台帳 CSV を返していた穴は PR #4326 で塞ぎ済 | API | 無変更 |

**残らないもの**: 「パスワード以外の第 2 要素」。これが今回失われる唯一かつ最大の層。

### 再評価トリガー（いつ戻すか、設計書 §5.2.9 に恒久記載）

| # | トリガー | 理由 | 記載先 |
|---|---|---|---|
| T1 | 有料家庭が **10 世帯**を超えた | `/ops` のデータが「自分の実験データ」から「他人の取引記録」に変わる境界 | 設計書 §5.2.9 |
| T2 | ops group メンバーが **2 人以上**になった | パスワード管理が自分の管理外に出る。TOTP 登録の手番も分散できる | 設計書 §5.2.9 |
| T3 | `/ops` に**書込操作 / 顧客個人情報の表示**が増えた | read-only の集計閲覧という被害想定が崩れる | 設計書 §5.2.9 |
| T4 | ops アカウントの**認証失敗・不審ログインを 1 件でも観測**した | 実害の兆候。他トリガーを待たずに戻す | 設計書 §5.2.9 |

**戻し方は `src/lib/policy/capabilities.ts` の `OPS_MFA_REQUIRED` を `true` にする 1 行**。機構は撤去していない（下記 AC4）。

## 関連 Issue

Closes #4363

- #4266（CLOSED）/ PR #4284 — IP allowlist 廃止 + MFA 必須化。**本 PR がその要求部分だけを外す**
- #4282（OPEN）/ PR #4335（**MERGED**）— MFA 未設定運営者の復旧導線 `OpsMfaSetupNotice`。扱いは AC6
- #4309 / PR #4326（**MERGED**）— `/ops` 配下 API の認可を `requireOpsAccess` に集約。**本 PR はこの単一強制点を割らない**（AC3 で機械検証）
- #4280 / PR #4312（**MERGED**）— front door header。残る防御の 1 つ

**衝突面積**: 起票時の指示では PR #4326 / #4335 が「未 merge」とされていたが、**着手時点で 3 本とも develop に merge 済**（#4326 `2026-08-06T01:08:08Z` / #4312 `01:08:57Z` / #4335 merged）。本 PR は最新の origin/develop から分岐しており、rebase 済・衝突なし。`ops-authz.ts` は #4326 が作った `requireOpsAccess` を**そのまま使い**、判定 2 行の変更に留めている。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `hasOpsAccess()` が **`ops` group 所属のみ**で判定する。MFA 未設定 / `amr` claim 欠落（`undefined`）の ops ユーザーが `/ops` に入れる | `npx vitest run tests/unit/routes/ops-mfa-not-required.test.ts` | **PASS**。`hasOpsAccess(opsWithoutMfa)` / `(opsMfaUnknown)` / `(…, {})` すべて `true`、layout `load` も `{}` を resolve。failing-test-first の red → green は下表 |
| AC2 | **ops group 非所属 / `local` identity / 未認証は従来どおり拒否**される（fail-closed の性質は維持） | 同上 + `npx vitest run tests/unit/routes/ops-layout-server.test.ts` | **PASS**。非 ops（MFA 済でも）/ `groups: []` / `groups` 未提供 / `local` / `null` はすべて `false`、layout は `403 Forbidden`（reason 無し = ops group の存在を示唆しない）。`hasOpsAccess(id) === isOpsMember(id)` を全 fixture で assert し「group 以外の条件を足していない」ことも固定 |
| AC3 | `/ops` 配下の API・form action も**同じ単一強制点**を通る。fitness function が緑のまま | `npx vitest run tests/unit/architecture/ops-route-auth-fitness.test.ts tests/unit/routes/ops-export-authz.test.ts` | **PASS（15 tests）**。#4326 の適用範囲 gate（`/ops/**/+server.ts` + form action を FS 列挙し全件 `requireOpsAccess` 呼び出し）は無改変で緑。`/ops/export` は未認証 / 非 ops が 3 type とも 403 かつ service 未到達のまま。mutation 5（guard 呼び出しを 1 本外す）で **10 failed** = gate が生きていることを実測 |
| AC4 | **MFA 判定機構は削除しない**。フラグ 1 箇所を `true` に戻すだけで復帰でき、再実装が要らない | `npx vitest run tests/unit/routes/ops-mfa-guard.test.ts` | **PASS**。`hasMfaAuthenticatedSession()` として機構を独立 export（`amr` 由来 `identity.mfaAuthenticated` と context token の OR / 不明は `false`）。`hasOpsAccess(id, ctx, true)` で **#4266 当時の真理値表がそのまま復活する**ことを test で固定。context token の `mfaAuthenticated` 往復（旧トークンは `undefined` = 拒否側）も維持。mutation 4（`requireMfa` を握り潰し = 戻せない形にする）で **6 failed** |
| AC5 | policy 層の写像も**同じフラグ**に従い、実強制点と食い違わない | `npx vitest run tests/unit/policy/ops-mfa-flag-consistency.test.ts tests/unit/policy/capabilities.test.ts` | **PASS**。`capabilities.ts` が `OPS_MFA_REQUIRED` を**1 度だけ定義**し `ops-authz.ts` が import することをソース構造レベルで assert（別名での二重定義も検出）。`access.ops_dashboard` / `view.ops_license_dashboard` とも MFA 未設定 ops で `allowed`、非 ops は `ops-only` のまま。mutation 3（policy 層だけフラグを無視）で **7 failed** |
| AC6 | #4282 / PR #4335 の復旧導線の**扱いを決めて理由を明記**する | 下記「#4335 成果物の扱い」+ `npx vitest run tests/unit/routes/error-page-ops-mfa.test.ts tests/unit/components/ops-mfa-setup-notice.test.ts` | **PASS（判断 = (c) 残す、ただしフラグ条件を明示）**。理由は下記セクション。両 test は緑のまま（描画側は要求復帰時にそのまま効く） |
| AC7 | 設計書を実態に合わせる（ADR-0001）。「MFA で守っている」と書いたまま残さない | `grep -rn "MFA" docs/ src/ infra/ .github/` で全件突き合わせ | **PASS**。`14-セキュリティ設計書.md` §5.2.9 全面改訂 + §5.2 認可表 / §11.5 層マトリクス / §11.5.1 / fitness function 一覧、`07-API設計書.md` L1438、`runbooks/ops-mfa-setup.md`（「戻すときの手順」に位置づけ変更）、`docs/CLAUDE.md` の `DEV_USERS` 説明、`ops-authz.ts` / `authorization.ts` / `origin-verify.ts` / `ops/+layout.server.ts` / `ops/export/+server.ts` / `cognito-dev.ts` / `+error.svelte` / `OpsMfaSetupNotice.svelte` の docstring。残置した MFA 記述は「Cognito pool は `mfa: OPTIONAL`」（事実として不変）と「保持している MFA 機構」節のみ |
| AC8 | 再評価トリガー T1〜T4 を**設計書に恒久記載** | `grep -n "T1\|T4" docs/design/14-セキュリティ設計書.md` | **PASS**。§5.2.9「MFA を要求しない決定」に、弱くなること / 残る防御 / T1〜T4 / 戻し方を表で記載。Issue を閉じても残る |
| AC9 | **Cognito の設定は変更しない** | `git diff --stat origin/develop...HEAD` | **PASS**。`infra/` の変更**0 file**。AWS API も一切叩いていない（user pool の `mfa: OPTIONAL` / ユーザー単位 MFA preference は無変更） |
| AC10 | failing-test-first（ADR-0061） | commit `4fd0dc914`（test のみ）→ `2fe96ac0c`（実装） | **PASS**。test 単独 commit 時点で **13 failed / 13 passed**（`OPS_MFA_REQUIRED` 未定義 + `hasOpsAccess` が false を返す）→ 実装後 **26 passed**。下表参照 |

### failing-test-first の証跡（ADR-0061）

| commit | 内容 | 実測 | 判定 |
|---|---|---|---|
| `4fd0dc914` | AC1/AC2/AC4/AC5 の test だけを先に commit | **red: 13 failed / 13 passed（2 files）** | ✓ 実装前に落ちる |
| `2fe96ac0c` | 実装（フラグ + `hasMfaAuthenticatedSession` 抽出 + policy 写像 + 既存 test 更新 + 設計書同期） | **green: 26 passed** | ✓ 実装後に通る |

### mutation 実測（全 commit 後に壊して確認、`git stash push` → `drop` で復帰）

| # | 壊した箇所 | 期待 | 実測 |
|---|---|---|---|
| 1 | `isOpsMember` 判定を反転（group 非所属も通す） | AC2 の拒否 test が落ちる | **25 failed / 4 files** |
| 2 | `requireMfa` の既定をフラグ無視の `true` 固定 | AC1 の許可 test が落ちる | **10 failed / 3 files** |
| 3 | policy 層だけフラグを無視して MFA を要求 | AC5 の 2 層一致 test が落ちる | **7 failed / 2 files** |
| 4 | `requireMfa` を握り潰し常に許可（= 戻せない形） | AC4 の機構保持 test が落ちる | **6 failed / 2 files** |
| 5 | `/ops/export` の `requireOpsAccess()` 呼び出しを削除 | #4326 の適用範囲 gate が落ちる | **10 failed / 2 files** |

mutation はすべて **commit 済の状態**で入れ、`git stash push` → `drop` で復帰した（実装ごと消す事故の回避）。復帰後に `git status` clean を確認し、全 17 file 再実行して **243 passed**。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: `/ops`（運営ダッシュボード）配下の page / API / form action の**入場判定のみ**。`/admin` `/child` および LP は不変。`/ops` の画面内容も不変（誰が入れるかだけが変わる）。

- [x] **並行実装ペア**を同期した — 対象外。ラベル追加なし / 5 年齢モード・ナビ・seed・チュートリアルはいずれも無関係（運営専用の認可判定）。`DEV_USERS`（`cognito-dev.ts`）は既存 9 アカウントのまま、コメントの意味づけのみ更新
- [x] **設計書同期** (ADR-0001): `docs/design/14-セキュリティ設計書.md`（§5.2 / §5.2.9 全面 / §11.5 / §11.5.1 / fitness function）+ `docs/design/07-API設計書.md` + `docs/runbooks/ops-mfa-setup.md` + `docs/CLAUDE.md`
- [x] **LP ↔ アプリ整合** (ADR-0013): LP に `/ops` の記載なし
- [x] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った — `/ops` 系の検証は unit 層で完結（下表）。E2E spec で `/ops` を歩くものは無い（`grep -rn "'/ops" tests/e2e/` = 0 件）
- [ ] N/A

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4368` | **PASS（全 step）** |
| 追加・変更テスト | `npx vitest run tests/unit/routes/ops-mfa-not-required.test.ts tests/unit/policy/ops-mfa-flag-consistency.test.ts tests/unit/routes/ops-mfa-guard.test.ts tests/unit/routes/ops-layout-server.test.ts tests/unit/policy/capabilities.test.ts tests/unit/architecture/ops-route-auth-fitness.test.ts tests/unit/routes/ops-export-authz.test.ts tests/unit/routes/error-page-ops-mfa.test.ts tests/unit/components/ops-mfa-setup-notice.test.ts tests/unit/infra/admin-no-ip-allowlist.test.ts tests/unit/auth/` | **243 passed / 17 files** |
| biome / svelte-check | `npx biome check .` / `npx svelte-check --threshold error` | 0 errors（biome は既存の infos 3 件のみ）/ **0 ERRORS 0 WARNINGS** |
| cspell | `npm run cspell` | Issues found: **0** |

- [x] **SOLID / DRY / YAGNI**: 真偽値は `capabilities.ts` の `OPS_MFA_REQUIRED` **1 箇所**（二重定義をソース構造 test で禁止）。MFA 機構は `hasMfaAuthenticatedSession()` に単一責務で切り出し、`hasOpsAccess` は「group 判定 → フラグ → MFA 判定」の 3 行。新しい env / 抽象 / 機構は追加していない
- [x] **Security（OSS 公開前提）**: 本 PR は**意図的に防御を 1 層下げる**変更であり、失われるもの・残るもの・戻すトリガーを上記と設計書 §5.2.9 に明記した。**緩めたのは MFA の 1 条件だけ**で、group 判定の fail-closed（不明なら拒否）・非 ops への reason 非露出・API / form action の単一強制点はすべて維持（mutation 1 / 5 で実測）。秘密情報の hardcode なし（test コメントから実アカウント名も除去済）
- [x] **A11y・パフォーマンス**: UI 変更なし。判定は純関数で追加 I/O なし
- [x] **Critical バグ修正**(ADR-0002): 該当なし（`priority:high`）

## スクリーンショット / ビジュアルデモ

`npm run dev:cognito` 相当（`AUTH_MODE=cognito COGNITO_DEV_MODE=true`、port 5194、#1026）で実ブラウザ操作した実機 SS。撮影フロー: `scripts/capture-specs/flows/ops-mfa-not-required-4363.mjs`。

**`.svelte` の差分はコメント追記のみで描画は変わらない**（`git diff origin/develop...HEAD -- '*.svelte'` は全行がコメント）。したがって以下は「UI の見た目の before/after」ではなく、**本 PR が実際に変えたもの = 同じ運営者が `/ops` に入れるかどうか**の実機証跡である。

<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4368/01-before-ops-no-mfa-denied.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4368/01-after-ops-no-mfa-allowed.png -->

**同一アカウント（`ops-no-mfa@example.com` = MFA 未設定の ops）・同一 URL（`/ops`）で撮り分けた。** 修正前は `OPS_MFA_REQUIRED` を `true` にした状態（= #4266 / 本 PR 前の挙動）で撮影している。

| | PC (1280px) |
|---|---|
| **修正前**（MFA 要求あり = 403 で入れない） | ![before-ops-no-mfa-denied](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4368/01-before-ops-no-mfa-denied.png) |
| **修正後**（本 PR = 運営ダッシュボードが開く） | ![after-ops-no-mfa-allowed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4368/01-after-ops-no-mfa-allowed.png) |

**回帰（MFA 済 ops も従来どおり入れる = 緩めた側で壊していない）**: `ops@example.com` でログインし運営ダッシュボードが表示されることを実機で確認。

![ops-with-mfa-still-allowed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4368/02-ops-with-mfa-still-allowed.png)

DOM HTML スナップショット（SS と同一 page で取得、#1747 AC4 / #1766）:

- [01-before-ops-no-mfa-denied.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4368/01-before-ops-no-mfa-denied.dom.html)
- [01-after-ops-no-mfa-allowed.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4368/01-after-ops-no-mfa-allowed.dom.html)
- [02-ops-with-mfa-still-allowed.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4368/02-ops-with-mfa-still-allowed.dom.html)

DESIGN.md §9 禁忌 6 点の自己判定: 本 PR に UI 実装の追加・変更はない（hex 直書き / primitive 再実装 / 内部コード露出 / 用語ハードコード / インラインスタイル / `<style>` 50 行超 いずれも新規発生なし）。上記画面はいずれも既存実装のまま描画されている。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

拒否条件が緩む方向のみで、データ変更・マイグレーションなし。revert すれば #4266 の判定に戻る。

**レビュー依頼事項**:

### 1. #4335 成果物の扱い = **(c) 残す。ただしフラグ条件を明示**（判断と理由）

PR #4335（`OpsMfaSetupNotice` + `+error.svelte` の分岐 + `runbooks/ops-mfa-setup.md`）は**着手時点で merge 済**。MFA 要求が off の間、`requireOpsAccess` は `reason: 'ops-mfa-required'` を出さないため、**復旧導線は到達不能**になる。

- **(a) close / 撤去しない理由**: 撤去すると T1〜T4 で戻すときに **UI を再実装することになり、「フラグ 1 行で戻せる」という本 PR の前提（AC4）が崩れる**。防御を下げる判断は「安く戻せる」こととセットでなければ、実質的に片道になる
- **(b) 本 PR に統合しない理由**: #4335 は merged であり統合対象の差分が無い
- **(c) 採った形**: 到達しない分岐を**放置せず**、`requireOpsAccess` の条件を `if (OPS_MFA_REQUIRED && isOpsMember(...))` と**フラグ条件を明示した形**に書き換えた。読んだ人が「消し忘れた dead code」ではなく「フラグ連動で復活する経路」と判別できる。同じ意味づけを `OpsMfaSetupNotice.svelte` / `+error.svelte` の docstring と設計書 §5.2.9「保持している MFA 機構」表にも書いた
- **`runbooks/ops-mfa-setup.md`** は削除せず「**MFA 要求を戻すときの手順**」に位置づけを変更し、冒頭に現状（要求 off）と切り替え箇所を明記した

### 2. 復旧導線が到達しないことの是非

上記のとおり意図的に残しているが、「Pre-PMF で到達不能コードを抱えるのは負債」という判断もあり得る。その場合は T1〜T4 のいずれかで戻すまで**別 Issue で撤去 → 戻すときに再実装**という選択になる。**本 PR は「安く戻せる」を優先した**が、方針が違えば指摘してほしい。

### 3. `requireGlobalMasterWriteAccess()` は無変更

`market_benchmarks` 書込 guard は元から `isOpsMember`（group のみ）で MFA を見ていないため、本 PR の影響を受けない（#4284 のレビュー依頼事項 3 と同じ論点、射程外）。

### 4. ops group メンバーの実数

決裁時点で ops group は **1 人**（オーナーが作成したアカウント）。T2（2 人目）に到達したら MFA を戻す前提であることを、運用側でも認識しておいてほしい。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（フラグはコード定数。env にすると「設定を忘れると防御が消える」経路を作るため意図的に定数にした）

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし。mutation 復帰後に `git status` clean を確認）
- [x] 全 AC が実装済み（AC1〜AC10 を上表に実測付きで記載）
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認 — `.svelte` 差分はコメントのみだが、**判定変更の実機証跡**として同一アカウント・同一 URL の before/after SS + 回帰 SS + DOM HTML を添付した
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付 — `AUTH_MODE=cognito COGNITO_DEV_MODE=true` (port 5194) で実ログインして撮影済。加えて unit 層（layout `load` / API `GET` を実関数で呼ぶ）で網羅し mutation 5 種で検出力を実測した
- [x] QA 承認・動作確認が完了している

## PO 決裁ブリーフ (po-decision:required)

**本 PR はオーナー決裁済み（決裁日 2026-08-06）**。選択肢 A（TOTP を登録する）/ B（MFA 要求を外す）/ C（`/ops` を使わない）を提示し、**オーナーが B を選択**した（「TOTP の対応は不要とします」）。下図は決裁内容の再確認と、残った判断依頼である。

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢 フラグ 1 行で復帰<br/>(OPS_MFA_REQUIRED = true)"]
    R2["顧客面: 変化なし。/ops は運営専用"]
    R3["🔴 防御が 1 層減る — ops の<br/>パスワード漏洩単独で /ops に入られる"]
    R4["🟡 対象データ = 全顧客の売上・課金"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 運営が /ops を実際に開ける<br/>(現状 ops メンバー 0→1 人、誰も入れなかった)"]
    T2["捨てる: パスワード以外の第 2 要素"]
    T3["捨てない: 判定機構・復旧導線・runbook<br/>= 戻すのに再実装が要らない"]
  end
  subgraph OBJ["③ 反対理由 (自己 adversarial review)"]
    O1["security: 売上台帳を単一要素で<br/>守ることになる 🔴"]
    O2["運用: T1〜T4 の観測手段が<br/>人の記憶依存 (自動通知なし) 🟡"]
    O3["保守: 到達しない復旧導線が残る<br/>= dead code に見える負債 🟡"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["顧客画面の変化ゼロ。/admin /child /LP 不変"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 再評価トリガー T1=有料 10 世帯 /<br/>T2=ops 2 人目 でよいか"]
    Q2["Q2: 到達しない復旧導線を<br/>残す (本 PR) か撤去するか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3,O1 danger
  class R4,T2,O2,O3 warn
  class R1,R2,T1,T3,C1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- **Q1 の背景**: トリガーの閾値は Dev が置いた暫定値。「自分の実験データか、他人の取引記録か」の境界を有料 10 世帯に、「パスワード管理が自分の管理外に出る」境界を ops 2 人目に置いた。数字に意図があれば上書きしてほしい。**T4（不審ログイン観測）だけは他に優先して即時**の想定。
- **O2 の残懸念**: T1〜T4 の観測は現状 Dev / PO の目視依存で、自動通知は無い（Cognito の認証失敗アラームは未設定）。自動化するなら別 Issue になる。**本 PR ではトリガーを設計書 §5.2.9 に恒久記載するところまで**を行い、監視の自動化は範囲外とした（ADR-0010 Pre-PMF、監視機構の新設は過剰）。
- **O3 の扱い**: 「レビュー依頼事項 1」に判断と理由を記載（(c) 残す + フラグ条件を明示）。撤去する方針なら別 Issue で扱う。
- **③ は QM の adversarial-reviewer による第三者レビューではなく Dev 自身の自己反証**である。QM レビュー時に改めて dispatch される想定。

</details>

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)

