### PR TITLE
docs(runbook): #4117 staging webhook の登録先を Function URL 直に是正（runbook どおりに操作すると課金が止まる）

### DIFF
--- a/docs/runbooks/staging-live-verification.md
+++ b/docs/runbooks/staging-live-verification.md
@@ -178,14 +178,20 @@ staging には **test mode の Stripe 資格情報だけ**を配備する。test
 
 **staging の URL は初回 deploy まで確定しない**ため、本手順は staging deploy 後に実施する。
 
-1. staging deploy 完了後、CloudFront の URL を取得する:
+> **webhook の登録先は Lambda Function URL 直。CloudFront ではない。**
+>
+> 画面操作の入口は CloudFront（§1）だが、**Stripe webhook だけは例外**である。Stripe の送信元は米国にあり、CloudFront の地域制限（JP）を通れないため経路を CloudFront に寄せられない。`/api/stripe/webhook` は front door header（`x-origin-verify`、#4280）の**対象外**として設計されており、保護は Stripe 署名検証（`STRIPE_WEBHOOK_SECRET`）が担う。SSOT は `docs/design/14-セキュリティ設計書.md` §11.5.1 の保護対象表。
+>
+> **CloudFront の URL を登録すると課金 webhook が全滅する。** 到達しないか 403 が続き、Stripe は連続失敗した endpoint を無効化する。本番・staging とも Function URL 直で登録すること。
+
+1. staging deploy 完了後、Lambda Function URL を取得する:
 
 ```bash
-aws cloudformation describe-stacks --stack-name GanbariQuestNetworkStaging   --region us-east-1   --query "Stacks[0].Outputs[?OutputKey=='DistributionDomainName'].OutputValue" --output text
+aws lambda get-function-url-config --function-name ganbari-quest-staging-app   --region us-east-1 --query FunctionUrl --output text
 ```
 
 2. Stripe Dashboard を **test mode** に切り替え、Developers → Webhooks → 「Add endpoint」
-3. Endpoint URL に `https://<DistributionDomainName>/api/stripe/webhook` を入力
+3. Endpoint URL に `<FunctionUrl>api/stripe/webhook` を入力（`FunctionUrl` は末尾スラッシュ付きで返る）
 4. 購読 event は `docs/design/billing-redesign/` の購読 event 一覧（#3990 で整合済）に合わせる
 5. 発行された signing secret を登録し、staging を再 deploy する:
 


### PR DESCRIPTION
## 顧客価値・目的

**runbook のとおりに手を動かすと課金 webhook が止まる**状態を消す。

`docs/runbooks/staging-live-verification.md` §9.2 は Stripe webhook の Endpoint URL に **CloudFront の `DistributionDomainName`** を入力せよと書いている。しかし #4280（`22f6e870`）の決定と `docs/design/14-セキュリティ設計書.md` §11.5.1 の保護対象表では、`/api/stripe/webhook` は front door 検査の**対象外**であり、**Stripe の送信元が米国で CloudFront の地域制限（JP）を通れないため経路を CloudFront に寄せられない**（本番・staging とも Function URL 直で登録するのが正）。

CloudFront を登録すると webhook が到達せず、**Stripe は連続失敗した endpoint を無効化する**。次に S-0 を実施する人が踏む地雷が runbook に載っている状態だった。

## 関連 Issue

Refs #4117（E1 — close 前の是正として PO が指定）、#4280（front door の対象外決定）
<!-- no-issue-close: #4117 は E1 EPIC で、本 PR はその close 条件の 1 つを満たすだけ。close は運用行為 2 件（staging Cognito ユーザー削除 / test 契約解約）の完了後に PO が判断する -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | runbook §9.2 の登録先が Function URL 直になっている | `docs/runbooks/staging-live-verification.md:186`（`aws lambda get-function-url-config`）+ `:193`（`<FunctionUrl>api/stripe/webhook`） | ✅ CloudFront の `DistributionDomainName` を使う記述を削除し、Function URL 取得コマンドに置換 |
| AC2 | なぜ CloudFront ではないのかが読んだ人に伝わる | §9.2 冒頭の引用ブロック（`:180`-`:184`） | ✅ 「Stripe の送信元は米国 / 地域制限を通れない / front door 対象外 / 保護は署名検証」+ SSOT（設計書 §11.5.1）へのポインタを明記 |
| AC3 | 間違えた場合に何が起きるかが書いてある | 同上（`:184`） | ✅ 「CloudFront の URL を登録すると課金 webhook が全滅する。Stripe は連続失敗した endpoint を無効化する」 |
| AC4 | 他に同じ誤りが残っていない | `grep -rn "DistributionDomainName>/api/stripe/webhook\|CloudFront.*stripe/webhook" docs/ .github/` | ✅ 本 PR 適用後の残存は設計書 §11.5.1 の**正しい**記述 1 件のみ（`14-セキュリティ設計書.md:1087`） |
| AC5 | 実態と一致している | staging の webhook endpoint を Stripe API で実測 | ✅ `we_1TcfvF…` の url は `https://gua6t7lom7g6trib52crs3fwta0flnil.lambda-url.us-east-1.on.aws/api/stripe/webhook`（Function URL 直）。この構成で S-0 の `checkout.session.completed` が `pending_webhooks=0` で配信済（#4117 実測） |

## 変更タイプ

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント

## 影響範囲・横展開チェック

| 対象 | 影響 |
|---|---|
| `docs/runbooks/staging-live-verification.md` §9.2 | 登録手順のみ変更。§9.1 / §9.3 / §9.4（S-0〜S-5）は不変 |
| `docs/design/14-セキュリティ設計書.md` §11.5.1 | **変更なし**（こちらが SSOT で、runbook 側が矛盾していた） |
| 本番の webhook endpoint | **変更なし**。既に Function URL 直で登録されており、本 PR は記述を実態に合わせるだけ |
| #4117 本文 | 同じ誤りを含んでいたため **本 PR と同時に訂正済み**（Issue body に訂正注記を追記、2026-08-07）。GitHub Issue のため diff 外 |

**横展開**: `grep` で docs / .github 全体を確認し、CloudFront 登録を指示する記述は §9.2 の 1 箇所のみだった。

## テスト・品質セルフチェック

- [x] `grep -rn` で同種記述の残存 0 件を確認（上記 AC4）
- [x] 実 staging の webhook endpoint URL を Stripe API で実測し、記述と一致することを確認（AC5）
- [x] 設計書 §11.5.1 の保護対象表と矛盾しないことを確認
- [x] docs のみの変更（コード / workflow への影響なし）

## スクリーンショット / ビジュアルデモ

UI 変更なし（runbook の記述のみ）。

## レビュー依頼事項・破壊的変更

破壊的変更なし。

**レビューしてほしい点**: 「CloudFront に寄せられない」理由の説明が、次に S-0 を実施する人にとって十分かどうか。ここを軽く書くと「CloudFront 経由の方が綺麗では」と考えた人が再び付け替えてしまう。

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。

## Ready for Review チェックリスト

- [x] 根本原因を書いた（runbook が #4280 の決定より前の前提のまま残っていた）
- [x] SSOT（設計書 §11.5.1）と一致させた
- [x] 間違えたときの結果（課金 webhook 全滅）を明記した
- [x] UI 変更なし

## QM レビュー結果

(未実施)
