### PR TITLE
fix(security): #4363 T4 の再評価トリガに発火経路を与える（/ops アクセス拒否の観測）

### DIFF
--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -560,7 +560,7 @@ MFA 要求は #4266 で CloudFront の IP allowlist を恒久廃止した際の�
 | T1 | 有料家庭が **10 世帯**を超えた | `/ops` のデータが「自分の実験データ」から「他人の取引記録」に変わる境界 |
 | T2 | ops group メンバーが **2 人以上**になった | パスワード管理が自分の管理外に出る。TOTP 登録の手番も分散できる |
 | T3 | `/ops` に**書込操作 / 顧客個人情報の表示**が増えた | read-only の集計閲覧という被害想定が崩れる |
-| T4 | ops アカウントの**認証失敗・不審ログインを 1 件でも観測**した | 実害の兆候。他トリガーを待たずに戻す。**観測経路**: `requireOpsAccess()` の拒否が `[auth-alert] ops-access-denied` を出し、`ops-stack.ts` の MetricFilter (`GanbariQuest/Auth` / `OpsAccessDenied`) 経由で alarm `ganbari-quest-ops-access-denied` が 5 分内 1 件で鳴る。log には識別子を載せない |
+| T4 | ops アカウントの**認証失敗・不審ログインを 1 件でも観測**した | 実害の兆候。**自分の操作でないことを確認したうえで**、他トリガーを待たずに戻す。alarm は「ops group でない誰かが `/ops` を踏んだ」ことしか区別しないため、**ログイン済みの顧客が誤って踏んだ / bot のパススキャン**も 1 件として数える。まず自分の直近の操作と時刻を突き合わせ、心当たりが無い場合に戻す。**観測経路**: `requireOpsAccess()` の拒否が `[auth-alert] ops-access-denied` を出し、`ops-stack.ts` の MetricFilter (`GanbariQuest/Auth` / `OpsAccessDenied`) 経由で alarm `ganbari-quest-ops-access-denied` が 5 分内 1 件で鳴る。log には識別子を載せない（T4 が求める対応は「MFA を戻す」であって「誰かを特定する」ではない） |
 
 **戻し方**: `src/lib/policy/capabilities.ts` の **`OPS_MFA_REQUIRED` を `true` にするだけ**。判定機構は撤去していない（下記）。
 

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -560,7 +560,7 @@ MFA 要求は #4266 で CloudFront の IP allowlist を恒久廃止した際の�
 | T1 | 有料家庭が **10 世帯**を超えた | `/ops` のデータが「自分の実験データ」から「他人の取引記録」に変わる境界 |
 | T2 | ops group メンバーが **2 人以上**になった | パスワード管理が自分の管理外に出る。TOTP 登録の手番も分散できる |
 | T3 | `/ops` に**書込操作 / 顧客個人情報の表示**が増えた | read-only の集計閲覧という被害想定が崩れる |
-| T4 | ops アカウントの**認証失敗・不審ログインを 1 件でも観測**した | 実害の兆候。他トリガーを待たずに戻す |
+| T4 | ops アカウントの**認証失敗・不審ログインを 1 件でも観測**した | 実害の兆候。他トリガーを待たずに戻す。**観測経路**: `requireOpsAccess()` の拒否が `[auth-alert] ops-access-denied` を出し、`ops-stack.ts` の MetricFilter (`GanbariQuest/Auth` / `OpsAccessDenied`) 経由で alarm `ganbari-quest-ops-access-denied` が 5 分内 1 件で鳴る。log には識別子を載せない |
 
 **戻し方**: `src/lib/policy/capabilities.ts` の **`OPS_MFA_REQUIRED` を `true` にするだけ**。判定機構は撤去していない（下記）。
 

--- a/infra/lib/ops-alert-policy.ts
+++ b/infra/lib/ops-alert-policy.ts
@@ -87,6 +87,11 @@ export const ALARM_NOTIFY_POLICY: Record<string, AlarmNotifyPolicy> = {
 		notify: false,
 		reason: 'cron 失敗は顧客影響が出るまで時間差がある。まず失敗頻度の実績を取る',
 	},
+	'ganbari-quest-ops-access-denied': {
+		notify: false,
+		reason:
+			'log MetricFilter 由来で平常時はデータ点が無く、#4363 で観測経路自体を新設したばかりで実発火の実績がゼロ。まず本番で 1 サイクル観測してから昇格判断する。§5.2.9 T4 (認証失敗・不審ログインの観測) は「戻す判断」自体が人手の再評価であり、鳴った時点で運営者が CloudWatch console から状況を確認したうえで OPS_MFA_REQUIRED を戻すか判断する運用を先に確立する',
+	},
 	'ganbari-quest-static-assets-s3-4xx': {
 		notify: false,
 		reason: 'S3 origin offload 有効時のみ生成される。offload 自体が本番未適用で実績ゼロ',

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -60,6 +60,21 @@ export interface OpsStackProps extends cdk.StackProps {
 export const ENTITLEMENT_FAIL_CLOSED_LOG_TERM = '[auth-alert] auth-entitlement-db-unavailable';
 
 /**
+ * #4363 T4: `/ops` へのアクセス拒否を数えるための log 用語 (SSOT)。
+ *
+ * `docs/design/14-セキュリティ設計書.md` §5.2.9 の再評価トリガー T4 は
+ * 「ops アカウントの認証失敗・不審ログインを 1 件でも観測したら MFA を戻す」だが、
+ * **その観測をする経路が無かった** (#4368 merge 時点)。MFA 要求を外した現在、
+ * `/ops` の防御は Cognito 認証 + ops group 所属の 2 つだけであり、
+ * 対象は全顧客の売上・コホート・コスト・PL である。
+ *
+ * `requireOpsAccess()` が拒否したときにこの用語を含む log を 1 行出し、
+ * ここで metric 化する。**値は載せない** — 誰が / どの identity かは
+ * 一切含めず「拒否が起きた」ことだけを数える (`alert.ts` の既存規約と同じ)。
+ */
+export const OPS_ACCESS_DENIED_LOG_TERM = '[auth-alert] ops-access-denied';
+
+/**
  * #4327: 顧客データの物理削除 (grace-period-deletion cron) が**部分的に失敗**したことを表す
  * log の検索語。
  *
@@ -298,6 +313,45 @@ export class OpsStack extends cdk.Stack {
 			});
 			entitlementFailClosedAlarm.addAlarmAction(alarmAction);
 			entitlementFailClosedAlarm.addOkAction(alarmAction);
+
+			// #4363 T4: `/ops` アクセス拒否の観測。
+			//
+			// 設計書 §5.2.9 の T4 は「認証失敗・不審ログインを 1 件でも観測したら MFA を戻す」
+			// だが、#4368 で MFA 要求を外した時点では **観測経路そのものが無かった**。
+			// トリガーは発火しようが無く、記載だけが残る状態だった。
+			//
+			// 閾値の根拠:
+			//   `/ops` は運営者しか触らない画面で、正常運用では拒否は起きない。
+			//   1 件でも「入れない誰か」が居ることは、パスワード試行か group 設定の
+			//   取り違えのどちらかを意味する。どちらも T4 が想定する「実害の兆候」である。
+			//   そこで entitlement fail-closed と同じ形 (5 分 window / 1 件閾値) を使うが、
+			//   **datapointsToAlarm は 1** にする — あちらは「継続したら障害」だが、
+			//   こちらは単発でも見に行く価値がある (誤検知しても運営者 1 人が確認するだけ)。
+			const opsAccessDenied = new logs.MetricFilter(this, 'OpsAccessDeniedFilter', {
+				logGroup: props.appLogGroup,
+				filterPattern: logs.FilterPattern.literal(`"${OPS_ACCESS_DENIED_LOG_TERM}"`),
+				metricNamespace: 'GanbariQuest/Auth',
+				metricName: 'OpsAccessDenied',
+				metricValue: '1',
+				defaultValue: 0,
+			});
+
+			const opsAccessDeniedAlarm = new cloudwatch.Alarm(this, 'OpsAccessDenied', {
+				alarmName: 'ganbari-quest-ops-access-denied',
+				alarmDescription:
+					'/ops へのアクセスが拒否された: 5分内に1件以上 (#4363 T4 再評価トリガーの観測経路)',
+				metric: opsAccessDenied.metric({
+					period: cdk.Duration.minutes(5),
+					statistic: 'Sum',
+				}),
+				threshold: 1,
+				evaluationPeriods: 1,
+				datapointsToAlarm: 1,
+				comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+				treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+			});
+			opsAccessDeniedAlarm.addAlarmAction(alarmAction);
+			opsAccessDeniedAlarm.addOkAction(alarmAction);
 
 			// P0: 顧客データ物理削除の部分失敗 (#4327)
 			//

--- a/src/lib/server/auth/ops-authz.ts
+++ b/src/lib/server/auth/ops-authz.ts
@@ -6,6 +6,7 @@
 
 import { error } from '@sveltejs/kit';
 import { OPS_MFA_REQUIRED, OPS_MFA_REQUIRED_REASON } from '$lib/policy/capabilities';
+import { logger } from '$lib/server/logger';
 import type { AuthContext, Identity } from './types';
 
 /**
@@ -111,6 +112,20 @@ export function hasOpsAccess(
  */
 export function requireOpsAccess(locals: App.Locals): void {
 	if (hasOpsAccess(locals.identity, locals.context)) return;
+
+	// #4363 T4: 拒否を 1 件でも観測できるようにする。
+	//
+	// 設計書 §5.2.9 の再評価トリガー T4 は「ops アカウントの認証失敗・不審ログインを
+	// 1 件でも観測したら MFA 要求を戻す」だが、#4368 で MFA を外した時点では
+	// **その観測経路が無く、トリガーは発火しようが無かった**。ここが `/ops` 認可の
+	// 単一強制点なので、拒否の観測もここに置く (判定と観測を 2 箇所に分けない)。
+	//
+	// **識別子を一切載せない**: 誰が / どの group か / IP は出さず「拒否が起きた」
+	// ことだけを数える。`/ops` は全顧客の売上・PL を持つ画面であり、その拒否 log に
+	// identity を残すと log 自体が探索対象になる (`alert.ts` の既存規約と同じ)。
+	// metric 化と alarm は infra/lib/ops-stack.ts の `OPS_ACCESS_DENIED_LOG_TERM`。
+	logger.warn('[auth-alert] ops-access-denied');
+
 	// ops group には居るが MFA 判定で落ちた場合だけ理由を返す。運営者が「なぜ入れないか」を
 	// 画面から自力で判断できないと、TOTP 設定漏れ / トークン更新での claim 落ちを
 	// コードを読むまで切り分けられない。非 ops には理由を出さない (存在の示唆を避ける)。

--- a/tests/unit/infra/physical-name-ratchet.test.ts
+++ b/tests/unit/infra/physical-name-ratchet.test.ts
@@ -325,6 +325,8 @@ const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
 		'CloudWatch Alarm 固定名は ops runbook / Discord 通知の識別子 (infra/CLAUDE.md §CloudWatch Alarm)',
 		[
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-auth-entitlement-db-unavailable',
+			// #4363 T4: /ops アクセス拒否の観測 alarm (再評価トリガーの発火経路)
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-ops-access-denied',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-cloudfront-5xx',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-cron-dispatcher-errors',
 			// #4327: 顧客データ物理削除の部分失敗。runbook (grace-period-deletion-operations.md §2) が


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 全顧客（`/ops` は全顧客の売上・コホート・コスト・PL を持つ）/ 運営

**解決する課題**: #4368（オーナー決裁 2026-08-06）で `/ops` の MFA 要求を外し、`docs/design/14-セキュリティ設計書.md` §5.2.9 に再評価トリガー T1〜T4 を恒久記載した。しかし **T4「ops アカウントの認証失敗・不審ログインを 1 件でも観測したら戻す」は、その観測をする経路が実装されておらず、発火しようが無い状態**だった。MFA が外れた現在、`/ops` の防御は Cognito 認証 + ops group 所属の 2 つだけである。

**期待される効果**: `/ops` へのアクセス拒否が 1 件でも起きたら alarm が鳴り、T4 が実際に発火できるようになる。

## 関連 Issue

<!-- no-issue-close: 本 PR は #4368 の QM レビューで検出した follow-up であり、単独の課題 Issue を持たない。#4363 は #4368 で close 済みのため close 対象を持たない。 -->

**close する Issue はありません。** PR #4368 の QM 承認時に指摘した点（#4363 / #4368 の follow-up）の実装です。#4363 は #4368 で close 済みです。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 拒否が log に 1 行出る | `src/lib/server/auth/ops-authz.ts` の `requireOpsAccess()` を目視 | `hasOpsAccess()` が false のとき `logger.warn('[auth-alert] ops-access-denied')` を出す。**`/ops` 認可の単一強制点（#4309）と同じ関数**に置き、判定と観測を 2 箇所に分けていない |
| AC2 | log に識別子を載せない | 同上 | 引数は文字列 1 つのみ。`context` オブジェクトを渡していないため、識別子・IP・group 名はいずれも出力されない（`alert.ts` の既存規約と同じ） |
| AC3 | metric 化して alarm を鳴らす | `infra/lib/ops-stack.ts` を目視 | `OpsAccessDeniedFilter`（MetricFilter、`GanbariQuest/Auth` / `OpsAccessDenied`）+ `OpsAccessDenied`（Alarm、`ganbari-quest-ops-access-denied`）を追加。**#3998 の entitlement fail-closed と同じパターン**で、新しい仕組みは足していない |
| AC4 | 閾値の根拠が書かれている | 同上のコメント | 5 分 window / threshold 1 / **`datapointsToAlarm: 1`**。entitlement 側は「継続したら障害」なので 2 window を要求するが、`/ops` の拒否は正常運用では起きないため**単発でも見に行く**。理由をコード内コメントに明記 |
| AC5 | 設計書 §5.2.9 の T4 が観測経路を指す | `docs/design/14-セキュリティ設計書.md` の T4 行 | 「観測経路: `requireOpsAccess()` の拒否が `[auth-alert] ops-access-denied` を出し、MetricFilter 経由で alarm `ganbari-quest-ops-access-denied` が 5 分内 1 件で鳴る」を追記（ADR-0001） |
| AC6 | 新規 alarm 名を ratchet に登録 | `tests/unit/infra/physical-name-ratchet.test.ts` | `GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-ops-access-denied` を追加。既存エントリは 1 件も変更していない |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [x] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（顧客画面の描画・文言・導線は不変）。`/ops` の**認可判定そのものは 1 行も変えていない** — 拒否時に log を 1 行足すだけで、通す条件・403 の返し方は #4368 のまま。

- [ ] 並行実装ペアを同期した
- [ ] LP ↔ アプリ整合 (ADR-0013)
- [x] **設計書同期 (ADR-0001)**: `docs/design/14-セキュリティ設計書.md` §5.2.9 の T4 行
- [ ] 重量 e2e 敏感領域
- [ ] N/A

**並行 PR overlap (#1200)**: `ops-authz.ts` は #4368 が merge 済みで、本 PR は その上に載る。`ops-stack.ts` は #4340（grace-period alarm）が merge 済みで、**同じ `if (props.appLogGroup)` ブロック内に追記**しており衝突しない。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| infra unit test | `npx vitest run tests/unit/infra/physical-name-ratchet.test.ts` | **ローカル未実行**。本クローンは `@storybook/addon-vitest` 未インストールで `vite.config.ts` の読み込み自体が失敗する |
| biome | `npx biome check` | **ローカル未実行**（`@biomejs/biome` が本クローンに無い）。行長は `awk` で手動確認し、追加行はすべて 110 桁以内 |
| CI | `gh pr checks` | **未確認**。下記「レビュー依頼事項」参照 |

**⚠️ 本 PR は GitHub Actions の Critical incident（webhook throttling）中に作成したため、CI が 1 本も走っていません。** 緑の確認は incident 復旧後に行う必要があります。

- [x] **SOLID / DRY / YAGNI**: 新規 script / 新規通知機構 / 新規 Lambda は 0。既存 MetricFilter パターンの複製のみ
- [x] **Security（OSS 公開前提）**: log に識別子を載せない。秘密情報の hardcode なし
- [ ] **A11y・パフォーマンス**: N/A（UI 非影響）
- [ ] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: サーバー側の log 出力と CDK の alarm 追加のみで、描画される画面が存在しない -->

N/A（`.svelte` の変更 0 件）

## レビュー依頼事項・破壊的変更

**破壊的変更**: なし。

**確認してほしい点**:

1. **閾値 `datapointsToAlarm: 1` の妥当性**。`/ops` は運営者しか触らない画面で、正常運用では拒否が起きません。1 件でも「入れない誰か」が居ることは、パスワード試行か group 設定の取り違えのどちらかを意味し、**どちらも T4 が想定する「実害の兆候」**です。誤検知しても運営者 1 人が確認するだけなので、単発で鳴らす側に倒しました
2. **log に識別子を載せない判断**。「誰が拒否されたか」が分かるほうが調査は速いですが、**`/ops` は全顧客の売上・PL を持つ画面**であり、その拒否 log に identity を残すと **log 自体が探索対象**になります。`alert.ts` の既存規約（#4174 Q3）と揃えました
3. **CI 未確認**（incident 中）。merge 前に required 全件の pass を実測してください

## 配布済み env / secret (ADR-0006)

なし（新規 env / secret の追加なし）。alarm の通知先は既存の `alarmAction`（`discordWebhookIncident` 経由）をそのまま使う。

## Ready for Review チェックリスト

- [x] 既存 MetricFilter パターンを再利用し、新しい仕組みを足していないことを確認した
- [x] `/ops` の認可判定を変えていないことを確認した
- [x] log に識別子が入らないことを確認した

## QM レビュー結果

本 PR は **QM が #4368 のレビュー中に検出して起票**したものです。PR 作成は `Takenori-Kusaka`、commit author は `ganbariquestsupport-lab`。


## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — revert 1 回で全て消える"]
    R2["顧客面: 子供/親/課金/データ いずれも不変"]
    R3["ロールバック: alarm 削除のみ。データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: T4 が初めて発火可能になる"]
    T2["捨てる: alarm 1 本の保守。通知は当面 off"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: notify:false で誰にも届かない"]
    O2["UX: 鳴っても調査材料が 1 行も無い"]
    O3["security: 認証失敗自体は捉えていない"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["変化なし。.svelte 変更 0 件・認可判定も不変"]
  end
  subgraph ASK["⑤ PO 判断依頼 (Yes/No で回答可能に)"]
    Q1["Q1: 単発で鳴らす設計で進めてよいか"]
    Q2["Q2: log に識別子を載せない判断でよいか"]
    Q3["Q3: 通知 off のまま 1 サイクル観測でよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3 ok
  class R2,C1,T1 ok
  class T2,O1,O2,O3 warn
  class Q1,Q2,Q3 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

**背景**: #4368（オーナー決裁 2026-08-06）で `/ops` の MFA 要求を外し、設計書 §5.2.9 に再評価トリガー T1〜T4 を恒久記載した。うち T4「ops アカウントの認証失敗・不審ログインを 1 件でも観測したら戻す」だけは**観測経路が実装されておらず、発火しようが無い**状態だった。本 PR は `requireOpsAccess()` の拒否時に `[auth-alert] ops-access-denied` を 1 行出し、`ops-stack.ts` に MetricFilter + Alarm（`ganbari-quest-ops-access-denied`、5 分 window / threshold 1 / `datapointsToAlarm: 1`）を足す。**認可判定は 1 行も変えていない**。

**③ の出典**: `tmp/adversarial-evidence/4378.json`（`node scripts/verify-adversarial-output.mjs --pr 4378` PASS）。要約でなく原文は以下。

- **business**: `notify: false` で登録しているため alarm は Discord に飛ばず CloudWatch console にしか出ない。運営者が毎日 console を開く運用は無いので、T4 は依然として人が気づけない。にもかかわらず設計書に「観測経路」を恒久記載するため、MFA を外した代償の担保が実態のない名目になり、防御が 1 層減ったままであることを忘れる方向に働く。
- **UX**: 鳴った後の調査材料がゼロ。log 行は用語 1 語のみで、運営者にできるのは時刻を控えて Lambda の生 log を目視で突き合わせる手作業だけ。加えて `datapointsToAlarm: 1` かつ未認証アクセスでも発火するため、将来 `notify: true` に昇格した瞬間に alarm 疲れを起こしうる。
- **security**: T4 の文言は「認証失敗・不審ログイン」だが、本経路が捉えるのは Cognito 認証通過後の group 不一致と未認証アクセスだけ。Cognito 側のパスワード試行失敗は現れないため、これを「観測経路」と書くと false assurance になる。さらに `/ops` はグローバル認可層を意図的に通す設計（#4309）なので、外部から無認証でパスを叩くだけで metric を任意に発火させ、本物の兆候を雑音で埋没させられる。

**③ に対する現時点の立場**: business / UX の 2 件は `notify: false` を昇格させるかどうかの運用判断に収束するため Q3 として PO に上げた。security の「認証失敗自体は未カバー」は本 PR の scope では埋まらない（Cognito の CloudWatch metric を別途拾う必要がある）ため、Q1〜Q3 の回答後に follow-up Issue として起票する。

</details>
