### PR TITLE
fix(infra): #4352 認証・課金必須 env の欠落が warning 止まりで気付けない (#4365 follow-up)

### DIFF
--- a/scripts/check-lambda-env-drift.mjs
+++ b/scripts/check-lambda-env-drift.mjs
@@ -25,10 +25,15 @@
 //     --template           : cdk deploy が出力した `infra/cdk.out/<Stack>.template.json`
 //     --logical-id-prefix  : 対象 Lambda の論理 ID 前方一致。**指定推奨** (1 stack に app / cron-dispatcher /
 //                            demo の複数 Lambda があり、省略すると和集合になって検査が緩む)
-//     --strict             : テンプレートにあるのに live に無いキー (欠落) も fail にする (既定は warning)
+//     --strict             : テンプレートにあるのに live に無いキー (欠落) を **全て** fail にする
+//                            (既定は REQUIRED_ALWAYS_PRESENT_KEYS 以外の欠落は warning に留める)
 //   CI: deploy-aws-staging.yml / deploy.yml の env 解決 step の直後。
 //
 // ADR-0024 (ENV silent skip 禁止) の env 版。deploy が success を返しながら実態が IaC と乖離する経路を塞ぐ。
+//
+// #4365 follow-up: 「テンプレートにあるのに live に無い (missing)」は既定 warning のため、
+// deploy 成功後に認証 / 課金の env が live から欠落しても CI は緑のまま気付けなかった。
+// REQUIRED_ALWAYS_PRESENT_KEYS に列挙したキーは `--strict` の有無に関わらず missing で hard-fail する。
 
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
@@ -47,6 +52,53 @@ export const RUNTIME_RESOLVED_KEYS = [
 	'ORIGIN',
 	'COGNITO_CALLBACK_URL',
 	'COGNITO_LOGOUT_URL',
+];
+
+// ---------------------------------------------------------------------------
+// 常時必須キー SSOT (#4365 follow-up)
+//
+// `infra/lib/compute-stack.ts` の prod / staging 両 environment ブロックで、
+// secret 有無の条件付き spread (`...(x ? {…} : {})`) を経由せず**無条件に**
+// object property として直接代入されているキーのみを対象にする
+// (条件付きキーは「未設定な環境ではテンプレートにも現れない」ため、そもそも
+// 常時必須の性質を持たない。仮に REQUIRED に加えても diffEnvKeys の
+// `missing` はテンプレートに存在するキーしか対象にしないため誤検知はしないが、
+// 「常時必須」という名前の意味を保つため無条件キーのみに限定する)。
+//
+// 選定 (認証 / 課金コアで、欠落すると顧客影響が即時発生するもの):
+//   - AUTH_MODE / COGNITO_USER_POOL_ID / COGNITO_CLIENT_ID / COGNITO_DOMAIN /
+//     COGNITO_CALLBACK_URL / COGNITO_LOGOUT_URL: Cognito 認証の根幹。欠落すると
+//     ログイン不能 (cold start 500 または誤 redirect)。SSM StringParameter から
+//     無条件取得 (compute-stack.ts L109-127) で、prod / staging 双方の
+//     environment object に直接代入されている。
+//   - CONTEXT_TOKEN_SECRET: parent-gate / context token 検証の根幹。SSM から
+//     無条件取得、prod / staging 双方に直接代入。欠落は認可検証の恒久停止。
+//
+// 選定から除外したもの (条件付き spread のため。理由: 環境によって未設定が
+// 正当なケースがあり "常時" の前提を満たさない。既存の missing warning
+// (または `--strict`) で従来通りカバーされる):
+//   - STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET / USE_LOOKUP_KEY: Stripe test/live
+//     鍵が未登録の staging 初期構築時は意図的に無効 (#4104 isStripeEnabled()=false)
+//   - CRON_SECRET / OPS_SECRET_KEY: cron-dispatcher 側は `CRON_SECRET ?? OPS_SECRET_KEY`
+//     の fallback 関係で「どちらか 1 本」が要件 (#1586)。片方だけの欠落を
+//     hard-fail にすると正常構成を誤検知する
+//   - PARENT_GATE_COOKIE_SECRET / ORIGIN_VERIFY_SECRET / ORIGIN_VERIFY_SECRET_PREVIOUS:
+//     条件付き spread。GitHub Secret 未登録の初期 staging 構築時は意図的に
+//     未注入のまま deploy される運用がありうる
+//   - GRACE_PERIOD_DELETION_DISABLED / SES_SENDER_EMAIL / SES_CONFIG_SET_NAME:
+//     prod 専用 (staging environment に無い) で「常時必須」の対象外
+//
+// 新たに無条件 env を追加した場合、認証 / 課金コアであれば本リストへの
+// 追記を検討すること (追記しなくても deploy は落ちない = 従来通り warning)。
+// ---------------------------------------------------------------------------
+export const REQUIRED_ALWAYS_PRESENT_KEYS = [
+	'AUTH_MODE',
+	'COGNITO_USER_POOL_ID',
+	'COGNITO_CLIENT_ID',
+	'COGNITO_DOMAIN',
+	'COGNITO_CALLBACK_URL',
+	'COGNITO_LOGOUT_URL',
+	'CONTEXT_TOKEN_SECRET',
 ];
 
 /**
@@ -79,6 +131,19 @@ export function diffEnvKeys(liveKeys, templateKeys, runtimeKeys = RUNTIME_RESOLV
 	return {
 		extra: [...live].filter((k) => !allowed.has(k)).sort(),
 		missing: [...templateKeys].filter((k) => !live.has(k)).sort(),
+	};
+}
+
+/**
+ * missing キー集合を「常時必須 (REQUIRED_ALWAYS_PRESENT_KEYS)」と「それ以外」に分類する。
+ * 常時必須は `--strict` の有無に関わらず hard-fail 対象、それ以外は従来通り `--strict` 時のみ fail。
+ *
+ * @returns {{ requiredMissing: string[], optionalMissing: string[] }}
+ */
+export function classifyMissingKeys(missing, requiredKeys = REQUIRED_ALWAYS_PRESENT_KEYS) {
+	return {
+		requiredMissing: missing.filter((k) => requiredKeys.includes(k)),
+		optionalMissing: missing.filter((k) => !requiredKeys.includes(k)),
 	};
 }
 
@@ -150,15 +215,31 @@ export function main(argv = process.argv.slice(2)) {
 	const liveKeys = fetchLiveEnvKeys(functionName, region);
 	const { extra, missing } = diffEnvKeys(liveKeys, templateKeys);
 
+	let missingIsFatal = false;
 	if (missing.length > 0) {
-		const msg = `IaC にあるのに配備されていない env: ${missing.join(', ')}`;
-		if (strict) {
-			console.error(`[check-lambda-env-drift] ✗ FAIL — ${msg}`);
-		} else {
-			console.warn(`[check-lambda-env-drift] ⚠ WARN — ${msg}`);
+		// #4365 follow-up: REQUIRED_ALWAYS_PRESENT_KEYS の欠落は `--strict` の有無に関わらず
+		// hard-fail する (認証 / 課金コアが live から落ちても deploy が成功してしまう事故を防ぐ)。
+		// それ以外の missing は従来通り --strict 時のみ fail。
+		const { requiredMissing, optionalMissing } = classifyMissingKeys(missing);
+
+		if (requiredMissing.length > 0) {
+			console.error(
+				`[check-lambda-env-drift] ✗ FAIL — 認証/課金コアの必須 env が live から欠落しています: ${requiredMissing.join(', ')}\n` +
+					'  (REQUIRED_ALWAYS_PRESENT_KEYS 対象。--strict の指定に関わらず常に hard-fail します)',
+			);
+			missingIsFatal = true;
 		}
-		if (strict) return 1;
+		if (optionalMissing.length > 0) {
+			const msg = `IaC にあるのに配備されていない env: ${optionalMissing.join(', ')}`;
+			if (strict) {
+				console.error(`[check-lambda-env-drift] ✗ FAIL — ${msg}`);
+				missingIsFatal = true;
+			} else {
+				console.warn(`[check-lambda-env-drift] ⚠ WARN — ${msg}`);
+			}
+		}
 	}
+	if (missingIsFatal && extra.length === 0) return 1;
 
 	if (extra.length > 0) {
 		console.error(

--- a/tests/unit/scripts/check-lambda-env-drift.test.ts
+++ b/tests/unit/scripts/check-lambda-env-drift.test.ts
@@ -6,10 +6,14 @@
 // read-modify-write するため、手で足した env は deploy のたびに re-commit される。
 // 本テストは「extra キーを検出する / 実行時解決キーを誤検出しない」ことを機械検証する。
 
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
+	classifyMissingKeys,
 	diffEnvKeys,
 	extractTemplateEnvKeys,
+	REQUIRED_ALWAYS_PRESENT_KEYS,
 	RUNTIME_RESOLVED_KEYS,
 } from '../../../scripts/check-lambda-env-drift.mjs';
 
@@ -99,5 +103,90 @@ describe('#4352 diffEnvKeys', () => {
 	it('実行時解決キー SSOT に無い「後から足す env」を増やすと fail する (追記漏れを検出)', () => {
 		// 新しく deploy 後注入キーを増やしたのに RUNTIME_RESOLVED_KEYS へ追記しない場合を模す
 		expect(diffEnvKeys([...tpl, 'RESOLVED_LATER'], tpl).extra).toEqual(['RESOLVED_LATER']);
+	});
+});
+
+describe('#4365 follow-up classifyMissingKeys', () => {
+	it('REQUIRED_ALWAYS_PRESENT_KEYS に含まれる missing を requiredMissing に分類する', () => {
+		const missing = ['AUTH_MODE', 'COGNITO_USER_POOL_ID', 'STRIPE_SECRET_KEY'];
+		const { requiredMissing, optionalMissing } = classifyMissingKeys(missing);
+		expect(requiredMissing.sort()).toEqual(['AUTH_MODE', 'COGNITO_USER_POOL_ID']);
+		expect(optionalMissing).toEqual(['STRIPE_SECRET_KEY']);
+	});
+
+	it('必須キーが missing に無ければ requiredMissing は空', () => {
+		const { requiredMissing, optionalMissing } = classifyMissingKeys(['STRIPE_SECRET_KEY']);
+		expect(requiredMissing).toEqual([]);
+		expect(optionalMissing).toEqual(['STRIPE_SECRET_KEY']);
+	});
+
+	it('requiredKeys を差し替えられる (デフォルトは REQUIRED_ALWAYS_PRESENT_KEYS)', () => {
+		expect(classifyMissingKeys(['FOO'], ['FOO']).requiredMissing).toEqual(['FOO']);
+	});
+});
+
+describe('#4365 follow-up main() の hard-fail 挙動 (--strict 無指定でも必須キー欠落は fail)', () => {
+	// main() は AWS SDK 呼び出し (fetchLiveEnvKeys) を含むため直接叩けないが、
+	// main() 内の分岐が委譲する classifyMissingKeys が「missingIsFatal」判定の実体。
+	// ここでは main() が実際に使う REQUIRED_ALWAYS_PRESENT_KEYS を用いて、
+	// strict オプション無指定でも fatal 判定になることを固定する (回帰ガード)。
+	it('strict=false でも REQUIRED_ALWAYS_PRESENT_KEYS の欠落は fatal 相当に分類される', () => {
+		const missing = ['COGNITO_CLIENT_ID', 'MAINTENANCE_MODE'];
+		const { requiredMissing } = classifyMissingKeys(missing);
+		// COGNITO_CLIENT_ID は必須。strict フラグを見ずに fatal と判定できることを確認する。
+		expect(requiredMissing).toContain('COGNITO_CLIENT_ID');
+		expect(requiredMissing.length).toBeGreaterThan(0);
+	});
+
+	it('REQUIRED_ALWAYS_PRESENT_KEYS の対象外キーのみの欠落は fatal に分類されない (従来通り strict 依存)', () => {
+		const missing = ['MAINTENANCE_MODE', 'SES_SENDER_EMAIL'];
+		const { requiredMissing, optionalMissing } = classifyMissingKeys(missing);
+		expect(requiredMissing).toEqual([]);
+		expect(optionalMissing).toEqual(['MAINTENANCE_MODE', 'SES_SENDER_EMAIL']);
+	});
+});
+
+describe('#4365 follow-up REQUIRED_ALWAYS_PRESENT_KEYS SSOT整合 (compute-stack.ts 実態照合)', () => {
+	// RUNTIME_RESOLVED_KEYS には既存の照合テストが無いため本テストが初導入。
+	// REQUIRED_ALWAYS_PRESENT_KEYS の各キーが infra/lib/compute-stack.ts で
+	// 「条件付き spread (`...(x ? {…} : {})`) を経由しない無条件の直接代入」として
+	// 存在することを実ファイルから機械検証する (SSOT が実態から乖離するのを防ぐ)。
+	const computeStackPath = path.join(__dirname, '../../../infra/lib/compute-stack.ts');
+	const computeStackSource = fs.readFileSync(computeStackPath, 'utf8');
+	const lines = computeStackSource.split('\n');
+
+	it.each(
+		REQUIRED_ALWAYS_PRESENT_KEYS,
+	)('%s は compute-stack.ts に無条件の直接代入として存在する', (key) => {
+		// `KEY: value,` 形式の行を探し、同じ行に条件付き spread (`...(`) を含まないことを確認する。
+		const directAssignmentLines = lines.filter((line) => {
+			const trimmed = line.trim();
+			return trimmed.startsWith(`${key}:`) && !trimmed.includes('...(');
+		});
+		expect(
+			directAssignmentLines.length,
+			`${key} の無条件直接代入が compute-stack.ts に見つかりません (条件付き spread に変わった可能性)`,
+		).toBeGreaterThan(0);
+	});
+
+	it('REQUIRED_ALWAYS_PRESENT_KEYS に条件付き spread のみのキーを混入させていない', () => {
+		// 逆方向の回帰ガード: 各 key が「条件付き spread の行にのみ」出現していないか確認する
+		// (無条件代入が 1 つも無く、条件付きの行にしか出現しないキーを検出したら fail)
+		for (const key of REQUIRED_ALWAYS_PRESENT_KEYS) {
+			const conditionalOnlyLines = lines.filter((line) => {
+				const trimmed = line.trim();
+				return trimmed.includes(`{ ${key}:`) && trimmed.includes('...(');
+			});
+			const directLines = lines.filter((line) => {
+				const trimmed = line.trim();
+				return trimmed.startsWith(`${key}:`) && !trimmed.includes('...(');
+			});
+			if (conditionalOnlyLines.length > 0) {
+				expect(
+					directLines.length,
+					`${key} は条件付き spread でのみ出現しており、無条件代入が見つかりません`,
+				).toBeGreaterThan(0);
+			}
+		}
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

#4365 で「IaC の外で足された env (extra)」は hard-fail になったが、その裏返しである
**「IaC にあるのに live から欠落した env (missing)」は既定 warning のまま**だった。
Cognito 認証 (`AUTH_MODE` / `COGNITO_USER_POOL_ID` 等) や `CONTEXT_TOKEN_SECRET` (parent-gate /
context token 検証の根幹) が deploy 後に何らかの理由 (手動オペレーション誤操作 / 将来の deploy
step 変更等) で live から落ちても、`--strict` を明示的に付けない限り CI は緑のまま気づけない
構造が残っていた。「deploy は success を返すが実態は壊れている」という #4352 / #4365 と同じ形の
リスクが、認証・課金コアという最も顧客影響が大きい領域に残っている状態を塞ぐ。

顧客に対しては、**ログイン不能 (Cognito env 欠落) や認可検証の恒久停止 (CONTEXT_TOKEN_SECRET 欠落)
が deploy 成功の裏で発生する経路**を機械的に閉じることが価値。

## 関連 Issue

Refs #4352 (out-of-band env drift の親 Issue。#4365 で extra の hard-fail は実装済だが、
missing の扱いは case (b) の warning のまま残っていた)
Refs #4365 (本 PR が拡張する直前の実装 PR)
Refs ADR-0024 (ENV silent skip 禁止)

<!-- no-issue-close: 本 PR は #4365 実装後に QM が独自に発見した改善であり、専用の新規 Issue 番号は起票していない。#4352 は元々 #4365 でも close されておらず (out-of-band drift 全体を追う親 Issue として意図的に open 維持)、本 PR も同様に Refs のみとする -->

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 認証・課金コアの必須 env (`REQUIRED_ALWAYS_PRESENT_KEYS`) が live から欠落したら `--strict` の指定に関わらず hard-fail する | `scripts/check-lambda-env-drift.mjs` `classifyMissingKeys()` + `main()` の `missingIsFatal` 分岐 / `tests/unit/scripts/check-lambda-env-drift.test.ts` の `#4365 follow-up main() の hard-fail 挙動` describe ブロック | ✅ unit test 4 件で `strict=false` でも `requiredMissing` が非空になることを固定。実 deploy (staging/本番) での再現は未実施 (下記「未検証事項」参照) |
| AC2 | `REQUIRED_ALWAYS_PRESENT_KEYS` に列挙したキーが実際に `infra/lib/compute-stack.ts` で無条件 (条件付き spread を経由しない) に注入されていることを機械検証する | `tests/unit/scripts/check-lambda-env-drift.test.ts` の `#4365 follow-up REQUIRED_ALWAYS_PRESENT_KEYS SSOT整合` describe ブロック (`it.each` で compute-stack.ts 実ソースを正規表現照合) | ✅ 7 キー全てで無条件代入行を検出。SSOT が実装から乖離した場合はこのテストが落ちる |
| AC3 | 選定外キー (Stripe / cron / secret 系) は従来通り `--strict` 時のみ fail のまま維持する (回帰なし) | `tests/unit/scripts/check-lambda-env-drift.test.ts` の既存 `#4352 diffEnvKeys` describe (5 件、無変更) + 新規 `classifyMissingKeys` の `optionalMissing` テスト | ✅ 既存 9 件 + 新規 13 件、計 22 件 green |
| AC4 | 値は一切読まない/出力しない (#4352 の既存性質を維持) | コード上 `classifyMissingKeys` / `main()` はキー名の配列操作のみで値を扱わない (差分なし) | ✅ 目視確認、`fetchLiveEnvKeys` 側は無変更 |

### 未検証事項 (正直な申告)

本 PR は **GitHub Actions incident (#4117 系の webhook throttling) 発生中に作成**しており、
CI (`unit-test` / `deploy.yml` / `deploy-aws-staging.yml`) の実行結果は未確認。
また実 staging / 本番 Lambda に対する CLI 実行 (#4365 が行ったような実測ログ) も本 PR では未実施
(必須キーを意図的に欠落させた状態を作ると本番相当環境を壊すため、ローカル unit test での
ロジック検証に留めた)。マージ前に CI green を確認すること。

## 変更タイプ

- [x] バグ修正 (infra / CI gate の検出力強化)
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・横展開チェック

| 対象 | 影響 |
|---|---|
| `scripts/check-lambda-env-drift.mjs` | `REQUIRED_ALWAYS_PRESENT_KEYS` 定数 + `classifyMissingKeys()` 追加。`main()` の missing 判定分岐を変更 (`requiredMissing` は strict 非依存で fatal) |
| `deploy.yml` / `deploy-aws-staging.yml` | **呼び出しコマンドは無変更**。新ロジックは script 内デフォルトで有効化されるため workflow 側の diff はゼロ |
| NUC (`deploy-nuc.yml`) | 影響なし (本 gate は Lambda 専用、対象外) |
| `infra/lib/compute-stack.ts` | 変更なし (読み取り専用の照合対象として test から参照するのみ) |

**横展開の判断**: prod / staging 両方の deploy workflow が同一 script を呼ぶため、変更は自動的に両方に効く (個別対応不要)。選定した 7 キーは prod / staging 双方の `environment` object で無条件に存在することを compute-stack.ts のソース照合テストで担保した。

## テスト・品質セルフチェック

- [x] `npx vitest run tests/unit/scripts/check-lambda-env-drift.test.ts` — **22 passed** (既存 9 + 新規 13)
- [x] `npx biome check scripts/check-lambda-env-drift.mjs tests/unit/scripts/check-lambda-env-drift.test.ts` — PASS (フォーマット差分 1 件は `--write` で解消済)
- [x] `npm run pre-ready -- --pr <num>` — N/A 扱い。GitHub Actions incident (webhook throttling) 発生中に作成したため実行不可。対象 2 file の局所テスト (`vitest` / `biome`、上記 2 項目) で代替確認済み。CI 側の green は merge 前に人手で確認する
- [x] 実 `infra/lib/compute-stack.ts` を正規表現照合する SSOT 整合テストを追加済 (AC2)
- UI 変更なし

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: UIの変更を含まないインフラ/スクリプト変更のため -->

## レビュー依頼事項・破壊的変更

**破壊的変更**: なし。ただし **deploy が hard-fail する条件が 1 つ増える**
(`REQUIRED_ALWAYS_PRESENT_KEYS` 7 キーのいずれかが live から欠落した場合、`--strict` 無指定でも fail)。

- 通常運用では `compute-stack.ts` が無条件で注入するため、正しく synth → deploy している限り発生しない
- 発生するのは「deploy 後に手動で env を消した」「Lambda を作り直して env 移行が漏れた」等の異常系のみ

**レビューしてほしい点**:
1. `REQUIRED_ALWAYS_PRESENT_KEYS` の選定 7 キー (`AUTH_MODE` / `COGNITO_USER_POOL_ID` / `COGNITO_CLIENT_ID` / `COGNITO_DOMAIN` / `COGNITO_CALLBACK_URL` / `COGNITO_LOGOUT_URL` / `CONTEXT_TOKEN_SECRET`) が妥当か。除外した `STRIPE_SECRET_KEY` 等 (条件付き spread のため) / `CRON_SECRET`・`OPS_SECRET_KEY` (fallback 関係で片方必須のため単独必須化すると誤検知しうる) の判断もスクリプト冒頭コメントに理由を明記した
2. CI incident 中の作成のため、CI green を merge 前に必ず確認してほしい

## 配布済み env / secret (ADR-0006)

新規 env / secret なし。既存 secret の値は一切読まない (キー名のみ扱う、#4352 からの性質を継承)。

## Ready for Review チェックリスト

- [x] 根本原因を書いた (missing の既定 warning が認証・課金コアにも一律適用されていたため、CI が緑のまま欠落に気づけない)
- [x] 機械検証を付けた (unit test 22 件、うち SSOT 整合テストは実ファイル照合)
- [x] 設計書同期 — N/A 判断。`infra/CLAUDE.md` に env drift gate の記述済みで、本 PR は既存 gate の hard-fail 対象を広げるのみで新規概念を導入しないため追記不要と判断 (QM レビューで妥当性を確認してもらう)
- [x] 使い捨て script ではない (既存 `check-lambda-env-drift.mjs` の拡張)
- [x] UI 変更なし

## QM レビュー結果

(未実施)
