### PR TITLE
fix(infra): #4364 origin-verify の旧値が残置しても誰も気付かない (#4369 follow-up)

### DIFF
--- a/docs/runbooks/origin-verify-secret-rotation.md
+++ b/docs/runbooks/origin-verify-secret-rotation.md
@@ -120,7 +120,15 @@ deploy する。
 
 段 3 まで完了して**初めてローテーションが終わる**。旧値には TTL も有効期限も無いため、**残したまま放置すると漏れた旧値が無期限に有効なまま** = ローテーションの目的が達成されない。
 
-**残置の検知**: 旧値が配られている間、アプリは起動後 1 回だけ以下の warn を出す。CloudWatch Logs でこれが出続けている = 段 3 が未実施である。
+**残置の検知 (2 経路、#4369 follow-up)**:
+
+1. **deploy 時点 (CDK synth warning)**: `originVerifySecretPrevious` context が空でないまま synth すると、`ComputeStack` が `cdk.Annotations.of(this).addWarning(...)` で以下の warning を出す。deploy を止めはしない (ローテーション中の段 1〜2 はこの状態が正常なため hard-fail にはしていない) が、`cdk diff` / deploy workflow のログに毎回出るため、段 3 を忘れたまま次の (無関係な) deploy を回したときに気付ける。
+
+   ```
+   [ComputeStack] ORIGIN_VERIFY_SECRET_PREVIOUS (originVerifySecretPrevious context) が設定されたままです。ローテーションが完了しているなら空にしてください …
+   ```
+
+2. **runtime (CloudWatch Logs)**: 旧値が配られている間、アプリは起動後 1 回だけ以下の warn を出す。CloudWatch Logs でこれが出続けている = 段 3 が未実施である。
 
 ```
 [front-door] ORIGIN_VERIFY_SECRET_PREVIOUS が設定されています = 旧 secret を並行受理中 …

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -226,6 +226,33 @@ export class ComputeStack extends cdk.Stack {
 		// (黙って捨てるとローテーション中に 404 になる silent skip、ADR-0024)。
 		const originVerifyPreviousSecret = resolveOriginVerifyPreviousSecret(this.node);
 
+		// #4369 follow-up: `ORIGIN_VERIFY_SECRET_PREVIOUS` はローテーション手順の 3 段中間
+		// (docs/runbooks/origin-verify-secret-rotation.md 段 1〜2) でのみ設定されるべき値で、
+		// 段 3 (旧値を空にする) を忘れて deploy し続けても synth は成功し警告も出なかった。
+		// 失効させたはずの旧 secret が front door を無期限に通り続ける = ローテーションの
+		// 目的が達成されないまま気付けない状態が放置される。
+		//
+		// hard-fail (addError) にはしない: ローテーション中 (段 1〜2) はこの状態が**正常**であり、
+		// 途中で deploy を止めると窓が開く側の事故になる (runbook §1 参照)。warning に留め、
+		// 「設定されたままであること」自体を synth 時点で可視化するだけに留める。
+		// runtime 側の 1 回だけの warn ログ (`ORIGIN_VERIFY_SECRET_PREVIOUS が設定されています`、
+		// src/lib/server/security/origin-verify.ts) と二重の検知経路になる (CloudWatch Logs は
+		// deploy 後に見に行く必要があるが、synth warning は `cdk diff` / deploy workflow の出力に
+		// 都度出るため気付く機会が増える)。
+		//
+		// 設定日を持たせる (新規 env を追加する) かは検討したが見送った: 既存の CloudWatch Logs
+		// 検知 (runbook §残置の検知) で「出続けている = 未完了」は既に分かっており、開始日時を
+		// 別途配布する新 env を増やすコストに見合わない。必要になれば
+		// `ORIGIN_VERIFY_SECRET_PREVIOUS_SET_AT` 等を追加ローテーションで検討する。
+		if (originVerifyPreviousSecret) {
+			cdk.Annotations.of(this).addWarning(
+				'[ComputeStack] ORIGIN_VERIFY_SECRET_PREVIOUS (originVerifySecretPrevious context) が' +
+					'設定されたままです。ローテーションが完了しているなら空にしてください' +
+					' (docs/runbooks/origin-verify-secret-rotation.md 段 3)。' +
+					'旧 secret を無期限に受理し続けると、漏れた旧値がいつまでも front door を通ります。',
+			);
+		}
+
 		// --- DSQL backend 配線 (EPIC #3424 / #3438 Phase 2A で無条件既定化) ---
 		// DSQL は本番の唯一の DB backend。DATA_SOURCE=dsql + DSQL_ENDPOINT + dsql:DbConnect を
 		// **無条件**で配線する。旧 `dsqlEnabled` flag と「flag なしは DATA_SOURCE=dynamodb fallback」

--- a/tests/unit/infra/origin-verify-header.test.ts
+++ b/tests/unit/infra/origin-verify-header.test.ts
@@ -17,7 +17,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { ComputeStack } from '../../../infra/lib/compute-stack';
 import { NetworkStack } from '../../../infra/lib/network-stack';
@@ -336,5 +336,68 @@ describe('#4280 deploy workflow の全 cdk 実行が context を渡す', () => {
 		expect(yml).toContain('ORIGIN_VERIFY_SECRET');
 		// `for s in ... ORIGIN_VERIFY_SECRET ...` の必須ループに載っていること
 		expect(yml).toMatch(/for s in [^\n]*ORIGIN_VERIFY_SECRET/);
+	});
+});
+
+describe('#4369 follow-up: ORIGIN_VERIFY_SECRET_PREVIOUS 残置の CDK synth warning', () => {
+	/** ComputeStack を synth する。前提 context (dsql / parentGateCookieSecret 等) は他 describe と揃える。 */
+	function buildCompute(extraContext: Record<string, unknown> = {}): cdk.Stack {
+		const app = new cdk.App({
+			context: {
+				opsSecretKey: 'test-ops-secret-key',
+				parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+				dsqlEndpoint: 'testcluster1234.dsql.us-east-1.on.aws',
+				dsqlClusterArn: 'arn:aws:dsql:us-east-1:000000000000:cluster/testcluster1234',
+				[originVerifyContextKey]: SECRET,
+				...extraContext,
+			},
+		});
+		const storage = new StorageStack(app, 'WarnStorage', { env });
+		return new ComputeStack(app, 'WarnCompute', {
+			env,
+			assetsBucket: storage.assetsBucket,
+			repository: storage.repository,
+		}) as unknown as cdk.Stack;
+	}
+
+	// #4369 follow-up: CDK は cross-stack reference の feature-flag 案内など、本 PR と無関係な
+	// warning を常に 1 件以上出す (`crossStackReferencesDefaultStrong` 等)。`findWarning('*', anyValue())`
+	// で 0 件を assert すると無関係な CDK 標準 warning に誤爆するため、**本 PR が出す warning のパターンだけ**
+	// を matcher に絞る (anyValue ではなく stringLikeRegexp)。
+	const OUR_WARNING_PATTERN = Match.stringLikeRegexp('ORIGIN_VERIFY_SECRET_PREVIOUS');
+
+	it('originVerifySecretPrevious が設定されていると synth warning が出る (段 3 未実施の可視化)', () => {
+		const compute = buildCompute({
+			[originVerifyPreviousContextKey]: 'origin-verify-previous-secret-for-unit-test',
+		});
+		Annotations.fromStack(compute).hasWarning('*', OUR_WARNING_PATTERN);
+	});
+
+	it('未指定 (定常状態) なら本 warning は出ない (CDK 標準 warning は対象外)', () => {
+		const compute = buildCompute();
+		const warnings = Annotations.fromStack(compute).findWarning('*', OUR_WARNING_PATTERN);
+		expect(warnings).toHaveLength(0);
+	});
+
+	it('warning が出ても synth は止まらない (addError にはしていない、ローテーション中は正常な状態のため)', () => {
+		// buildCompute が例外を投げずに完了すること自体が実証 (addWarning は Annotations に積むだけで
+		// deploy を止めない。addError であればここで throw する)。
+		const compute = buildCompute({
+			[originVerifyPreviousContextKey]: 'origin-verify-previous-secret-for-unit-test',
+		});
+		const errors = Annotations.fromStack(compute).findError('*', Match.anyValue());
+		expect(errors).toHaveLength(0);
+	}, 30_000);
+
+	it('warning メッセージが対処方法 (runbook 段 3) を含む', () => {
+		const compute = buildCompute({
+			[originVerifyPreviousContextKey]: 'origin-verify-previous-secret-for-unit-test',
+		});
+		const warnings = Annotations.fromStack(compute).findWarning('*', OUR_WARNING_PATTERN);
+		expect(warnings.length).toBeGreaterThan(0);
+		const messages = warnings.map((w) => (w as { entry?: { data?: string } }).entry?.data ?? '');
+		expect(messages.some((m) => m.includes('docs/runbooks/origin-verify-secret-rotation.md'))).toBe(
+			true,
+		);
 	});
 });


### PR DESCRIPTION
<!-- no-issue-close: follow-up 修正のため新規 Issue を起票していない。#4364 は既に #4369 で Closed 済 -->

## 顧客価値・目的

**対象ユーザー**: 運営（オーナー、front door secret のローテーション実行者）

**解決する課題**: PR #4369 (#4364) で `ORIGIN_VERIFY_SECRET_PREVIOUS` の新旧 2 値受理を入れ、`docs/runbooks/origin-verify-secret-rotation.md` に 3 段の手順（段 1: 旧値をコピー → deploy / 段 2: 新値に切替 → deploy / 段 3: 旧値を空にする → deploy）を書いた。しかし **段 2 で止めたまま放置しても deploy は成功し、警告も出ない**。失効させたつもりの旧 secret が無期限に front door を通り続けるのに、それに気付く手段が「CloudWatch Logs を能動的に見に行く」の 1 経路しかなかった。

**期待される効果**: `ORIGIN_VERIFY_SECRET_PREVIOUS` が設定されたまま `cdk synth` すると `cdk diff` / deploy workflow のログに毎回 warning が出るようになる。運用者が能動的に CloudWatch Logs を見に行かなくても、次の (無関係な) deploy のたびに「段 3 が未実施である」ことが視界に入る。

## 関連 Issue

related #4364 / follow-up of #4369

新規 Issue は起票していない (follow-up 修正、上記 no-issue-close 参照)。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | `originVerifySecretPrevious` context が空でない場合、CDK synth 時点で warning が出る | `npx vitest run tests/unit/infra/origin-verify-header.test.ts`（新規 describe `#4369 follow-up`） | PASS。`originVerifySecretPrevious が設定されていると synth warning が出る` |
| AC2 | 未指定 (定常状態) では本 warning が出ない（CDK 標準の無関係な warning に誤爆しない） | 同上 `未指定 (定常状態) なら本 warning は出ない` | PASS。実装当初は `findWarning('*', anyValue())` で 0 件を assert していたが、CDK が常に出す `crossStackReferencesDefaultStrong` 案内 warning に誤爆して FAIL することを実測（デバッグ dump で確認）。matcher を本 PR の warning 文言に絞る `stringLikeRegexp('ORIGIN_VERIFY_SECRET_PREVIOUS')` に変更して解消 |
| AC3 | `--strict` フラグの有無に関わらず deploy を止めない（`addError` ではなく `addWarning`） | 同上 `warning が出ても synth は止まらない` — `Annotations.findError('*', anyValue())` が 0 件であることを assert | PASS |
| AC4 | warning メッセージが対処方法 (runbook 段 3) を含む | 同上 `warning メッセージが対処方法 (runbook 段 3) を含む` | PASS |
| AC5 | runbook に「この状態が続くと warning が出る」旨を追記する | `docs/runbooks/origin-verify-secret-rotation.md` §残置の検知 を 2 経路 (deploy 時点 = CDK synth warning / runtime = CloudWatch Logs) に構成し直し | PASS |

## 既存資産 (`check-lambda-env-drift.mjs`) で賄えないかの検討

依頼時点で提示された `scripts/check-lambda-env-drift.mjs` (#4352) への寄せ方を検討したが、**意味論が異なるため流用しなかった**。

- `check-lambda-env-drift.mjs` は「CDK テンプレート (IaC) と live Lambda env の**差分**」を検出する gate。IaC 外で誰かが `aws lambda update-function-configuration` を直接叩いて env を足した/消したケースを検出する
- `ORIGIN_VERIFY_SECRET_PREVIOUS` は **CDK テンプレート自体が正規に定義する env**（`originVerifyPreviousSecret` context 経由で `infra/lib/compute-stack.ts` が条件付き注入）であり、drift（IaC と live の不一致）は一切発生していない。テンプレートどおりに live へ反映されている状態そのものが「一時的であるべきなのに一時的でなくなっている」という、drift とは別種の懸念
- したがって drift 検出の仕組みをそのまま再利用することはできず、依頼時点で示唆された代替案（`compute-stack.ts` 内で `cdk.Annotations.of(this).addWarning(...)` を CDK synth 時点で出す）を採用した。新規スクリプトは追加していない（`infra/lib/compute-stack.ts` 内の追記のみ）

## 判断が割れた点

1. **設定日を持たせる (新規 env を追加する) か**: 見送った。既存の CloudWatch Logs 検知 (runbook §残置の検知、runtime 側の起動時 1 回 warn ログ) で「出続けている = 未完了」は既に分かっており、開始日時を別途配布する新 env (`ORIGIN_VERIFY_SECRET_PREVIOUS_SET_AT` 等) を増やすコストに見合わないと判断した。必要になれば追加ローテーションで検討する旨をコードコメントに残した。
2. **CDK synth warning は誰も見ないのでは (deploy workflow の出力に出す方がよいのでは)**: `cdk.Annotations.of(this).addWarning(...)` は `cdk synth` / `cdk diff` / deploy workflow の cdk 実行ステップの標準出力に **常に** 出る（`aws-cdk-lib` 標準機構、`--strict` を付けなくても出力自体はされる。`--strict` は warning を error 扱いにして deploy を止めるオプションだが、本 PR は意図的に使わない）。既存パターン（同ファイル内の staging Stripe test mode allowlist が `addError` を使う類似箇所）に倣い CDK 標準の Annotations 機構に乗せる方が、deploy workflow 側に新しい shell 検査ロジックを足すより一貫性があると判断し、こちらを採用した。

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし。CDK synth 時の warning 出力と runbook のドキュメントのみ。Lambda env の注入ロジック・front door の判定ロジックは無変更。

- [x] **並行実装ペア**を同期した — **N/A**: UI・ラベル・年齢モード・DB スキーマのいずれにも触れない。infra のみ
- [x] **設計書同期** (ADR-0001): `docs/runbooks/origin-verify-secret-rotation.md` §残置の検知 を同 PR で更新
- [x] **LP ↔ アプリ整合** (ADR-0013): N/A（`site/**` 無変更）
- [x] **重量 e2e 敏感領域**: N/A。e2e spec は無変更
- [ ] N/A — 上記いずれも影響範囲外

## テスト・品質セルフチェック

**本 PR は GitHub Actions incident (webhook throttling) 中に作成したため CI 未確認です。** ローカルで以下を実行し確認しました（heavy-run-lock により機械全体で 1 本の排他制御があるため、他セッションと交互に実行）。

| テスト種別 | コマンド | 結果 |
|---|---|---|
| lint | `npx biome check infra/lib/compute-stack.ts tests/unit/infra/origin-verify-header.test.ts docs/runbooks/origin-verify-secret-rotation.md` | PASS (0 error) |
| 型 | `cd infra && npx tsc --noEmit` | PASS (0 error) |
| 追加・変更テスト | `npx vitest run tests/unit/infra/origin-verify-header.test.ts` | PASS (35 passed)。その後 biome 自動整形（フォーマットのみ、ロジック無変更）を適用したが、heavy-run-lock が他セッション保持中のため整形後の再実行はできていません。diff は改行位置のみで assertion / matcher は不変であることを目視確認済み |
| pre-ready | 未実行 | heavy-run-lock 保持中のため未実行。CI (`unit-test` / `lint-and-test`) を正としてください |

- [x] **SOLID / DRY / YAGNI**: 追加ロジックは `if (originVerifyPreviousSecret) { addWarning(...) }` の 1 分岐のみ。新規抽象化・新規 script は追加していない
- [x] **Security（OSS 公開前提）**: secret 値そのものは warning メッセージに含めない（「設定されたままです」の状態のみを通知、値は出力しない）
- [x] **A11y・パフォーマンス**: N/A（UI 変更なし、infra のみ）
- [x] **Critical バグ修正**(ADR-0002): N/A（`priority:critical` ではない。予防的な可観測性向上の follow-up）

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: UIの変更を含まないインフラ変更のため -->

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる → 影響範囲・マイグレーション手順・既存データへの影響を以下に記載

`addWarning` は deploy を止めません。`originVerifySecretPrevious` context が未指定の定常状態では warning も出ないため、merge しても現在稼働中の環境の挙動は一切変わりません。

**レビュー依頼事項**:

1. warning ではなく deploy workflow 側 (GitHub Actions step) でチェックする代替案も検討しましたが、CDK Annotations 機構（同ファイル内の staging Stripe allowlist と同型）に寄せる方が一貫性があると判断しました。異論があれば教えてください
2. 設定日 (いつから残置されているか) を持たせていません。CloudWatch Logs 側の既存検知で「出続けている = 未完了」は分かる前提です

## 配布済み env / secret (ADR-0006)

新規 env / secret は追加していません。既存の `ORIGIN_VERIFY_SECRET_PREVIOUS` (PR #4369 で追加済) の可観測性を向上させただけです。

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: — **N/A（UI 変更なし）**
- [x] 認証画面変更時: — **N/A（認証画面の変更なし）**
- [x] QM 承認・動作確認が完了している（Dev 側の完遂宣言。作成時は GitHub Actions incident で CI 未確認だったが、その後 `unit-test` / `lint-and-test` / `cdk-cfn-lint` を含む全 job pass を実測確認済み。pre-ready はローカル heavy-run-lock 保持中のため未実行で、CI を正とする）

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — revert だけで完全に戻る"]
    R2["顧客面: 🟢無変化 — 子供/親/課金/データ 全て無影響"]
    R3["ロールバック: 🟢データ破壊なし・警告文が消えるだけ"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 段3忘れが deploy 毎に目に入る"]
    T2["捨てる: 検知は人がログを読む前提のまま"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: 警告だけで強制力ゼロ"]
    O2["UX: 段1〜2 も出続け警告が慣れになる"]
    O3["security: 旧値の無期限有効は未解決"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["🟢家族には何も変わらない・運営ログのみ"]
  end
  subgraph ASK["⑤ PO 判断依頼 (Yes/No)"]
    Q1["Q1: 警告のみで今回は良いか?"]
    Q2["Q2: 期限超過で deploy 停止は不要か?"]
    Q3["Q3: 残置開始日の記録は見送って良いか?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class T2,O1,O2,O3 warn
  class R1,R2,R3,T1,C1 ok
  class Q1,Q2,Q3 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

**なぜ `po-decision:required` が付いたか**: `infra/**` を変更したため `.github/labeler.yml` の高リスクパス判定で自動付与された。実変更は `ComputeStack` に `if (previous) addWarning(...)` の 1 分岐と、その unit test / runbook の追記のみで、front door の判定ロジック (`src/lib/server/security/origin-verify.ts`) と Lambda env の注入経路は無変更。`countMatchingSecrets()` が boolean ではなく一致数を返す timing attack 耐性設計にも手を入れていない。

**③ の出典**: `tmp/adversarial-evidence/4382.json` (`node scripts/verify-adversarial-output.mjs --pr 4382` PASS)。要旨:

- **business**: warning 1 行に強制力はなく、CDK が常時出す無関係な warning に埋没しうる。人のログ閲覧に依存しない経路 (期限超過で error 昇格 / 日次 cron) を選ばなかった理由が body にない。
- **UX**: 段 1〜2 は数分〜数日続くのが正常で、その間ずっと同じ warning が出る。正常状態と段 3 忘れを文言で区別していないため、肝心の局面では既に無視されている恐れがある。
- **security**: 検知経路が 1 本増えただけで、漏れた旧値が無期限に通り続ける根本欠陥は残る。設定日を持たないため、インシデント時に露出期間を証明できない。

**Q2 / Q3 の背景**: いずれも本 PR では意図的に見送っている (deploy を止めるとローテーション中に窓が開く / 新 env 追加コストに見合わない、という Dev 判断)。PO が「後で必要」と判断した場合は本 PR を merge したうえで follow-up の起票判断をお願いします。

</details>

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)

