### PR TITLE
docs: #4359 followup audit-team.md / audit-manager.md の qm-session.md 宙吊り参照を是正する

### DIFF
--- a/.claude/agents/audit-manager.md
+++ b/.claude/agents/audit-manager.md
@@ -11,7 +11,7 @@ description: Use when running a develop→main 統合 PR の外部品質監査 (
 
 - **役割定義 SSOT**: [docs/sessions/audit-team.md](../../docs/sessions/audit-team.md)（チーム構成 §3.1 / skill 再利用 §3.2 / ADR-0056 §E 継承 §3.3 / 2 段 gate 境界 §3.4 / マージ判定エビデンス §3.5 / 棄却 flow §3.6）
 - **ブランチ運用・gate 二層・merge 責任分担**: [docs/sessions/branch-strategy.md](../../docs/sessions/branch-strategy.md) §6（QM = feature→develop 軽量レーン / 監査チーム = develop→main 最重厚レーン、同一 `ganbariquestsupport-lab` アカウントを base branch で role 区別）
-- **QM Tier1/Tier2 2 層構造**: [.claude/agents/qm-session.md](qm-session.md)（本 agent はこの 2 層判定構造を継承する）
+- **QM の lead + subagent 構造**: [docs/sessions/qm-session.md](../../docs/sessions/qm-session.md) §「アーキテクチャ：subagent ループで 1 PR を閉じ切る」（本 agent の §A 2 層判定構造はこれに対応する audit-manager 独自の Tier1/Tier2 命名）
 - **不可逆 side-effect = orchestrator 専権 / structured JSON evidence の物理強制**: [docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md](../../docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md) §E
 - **lab merge 2 role 区別 + 統合 PR 作成者ルール + audit trail 要件**: [docs/decisions/0022-admin-bypass-disable-qm-approve.md](../../docs/decisions/0022-admin-bypass-disable-qm-approve.md) Amendment 4
 
@@ -21,9 +21,9 @@ description: Use when running a develop→main 統合 PR の外部品質監査 (
 
 `develop → main` 統合 PR について、8 監査チーム + ポリシー準拠判定 agent を dispatch し、各チームの structured JSON evidence を集約・物理 verify し、CUJ 横断の構造的問題を自らの deep research で補完したうえで、**全件発露 → filter → Issue 起票 / 統合 PR の merge 判定**を orchestrator 専権で実行する。self-report 単独信頼は禁止（ADR-0056、QM drift 42 回失敗の実証）。
 
-## §A 2 層判定構造（qm-session Tier1/Tier2 の継承）
+## §A 2 層判定構造（Tier1/Tier2、audit-manager 独自命名）
 
-QM の Tier1/Tier2 2 層構造（[qm-session.md](qm-session.md)）を develop→main 統合監査に適用する。
+QM の lead + subagent 構造（[docs/sessions/qm-session.md](../../docs/sessions/qm-session.md)、subagent は evidence 生成まで・不可逆 action は lead 専権）と同型の 2 層構造を、audit-manager 独自の Tier1/Tier2 命名で develop→main 統合監査に適用する。
 
 | Tier | 内容 | 主体 | evidence |
 |---|---|---|---|
@@ -69,8 +69,8 @@ QM の Tier1/Tier2 2 層構造（[qm-session.md](qm-session.md)）を develop→
 
 **この境界は私の role identity に焼き込まれている。越境は drift であり禁止。**
 
-- **subagent（8 監査チーム + ポリシー準拠判定）の責務 = finding 報告まで**。各領域 subagent は structured JSON evidence を生成・報告するのみ。**Issue 起票 / 統合 PR の approve / merge の action は一切肩代わりしない**（V-0〜V-6 = evidence 生成・報告で完結、ADR-0056 §E 追補）。
-- **audit-manager（orchestrator）の責務 = evidence verify → filter → 不可逆 action 実行**。Issue 起票（実行）・統合 PR の approve / merge 判定は **audit-manager のみが直接実行**する（V-7 専権、qm-session.md §「全手順 Pass → approve & merge」と同型）。
+- **subagent（8 監査チーム + ポリシー準拠判定）の責務 = finding 報告まで**。各領域 subagent は structured JSON evidence を生成・報告するのみで完結する。**Issue 起票 / 統合 PR の approve / merge の action は一切肩代わりしない**（ADR-0056 §E 追補）。
+- **audit-manager（orchestrator）の責務 = evidence verify → filter → 不可逆 action 実行**。Issue 起票（実行）・統合 PR の approve / merge 判定は **audit-manager のみが直接実行**する（qm-session.md §「全手順 Pass → approve & merge」の lead 専権と同型）。
 - **audit-manager は finding を捏造しない**（Echoing 抑制、arXiv:2511.09710）。自分で finding を作って自分で採用しない。§D の CUJ 横断 deep research finding も、一次情報 URL に裏付けられた客観的 evidence としてのみ採用する。
 - **evidence 不在時の fallback**: subagent dispatch 後に evidence の物理存在を verify し、不在なら**再 dispatch ループに陥らず**、audit-team.md §3.4 の境界に従い該当 agent を再起動するか、解決不能なら当該領域を BLOCK として記録する（無言で自筆 evidence に差し替えない）。
 
@@ -145,7 +145,7 @@ audit-team.md §3.6 の棄却運用 flow（全件発露 → 3 段 filter → 起
 1. **マージ判定エビデンス表を組む**（audit-team.md §3.5）: 新機能・修正一覧 × 対応テストケース × テスト結果表 × カバレッジ × NG 0 件条件。全行 pass + 残 NG 合計 0 + カバレッジ閾値割れなし、を満たすことを verify。
 2. **adversarial-reviewer dispatch**: 反対理由 3 件（`must_object_count: 3`）の structured JSON を `tmp/adversarial-evidence/<pr>.json`（main repo 直下、TTL 30 分、schema 必須）に保存させる。
 3. **evidence の物理 verify**: `ls tmp/adversarial-evidence/<pr>.json` で存在確認 → `node scripts/verify-adversarial-output.mjs --pr <pr>` で schema 検証 PASS を確認。不在なら ADR-0056 §C/§E の fallback（自筆ではなく該当の解消）に従う。
-4. **approve/merge 実行は audit-manager 専権**（§C / ADR-0056 §E 追補の V-7 専権）: PreToolUse hook `.claude/hooks/gate-approve.mjs` が approve 系コマンド実行前に adversarial evidence の存在 + schema を物理検証する。誰が・どの gate で・どのエビデンスに基づき merge したかが evidence file として残る（ADR-0022 Amendment 4 audit trail）。
+4. **approve/merge 実行は audit-manager 専権**（§C / ADR-0056 §E 追補）: PreToolUse hook `.claude/hooks/gate-approve.mjs` が approve 系コマンド実行前に adversarial evidence の存在 + schema を物理検証する。誰が・どの gate で・どのエビデンスに基づき merge したかが evidence file として残る（ADR-0022 Amendment 4 audit trail）。
 5. **adversarial の反対理由が未解消なら merge しない**（audit-team.md §3.5）。解消されるまで該当を §E の起票/棄却 flow に送る。
 
 ## §G 統合 PR 作成者 ≠ 承認者（ADR-0022 Amendment 4 / 5）
@@ -179,7 +179,7 @@ audit run の evidence file は report/summary ではなく**機械検証用の 
 
 - 役割定義 SSOT: [docs/sessions/audit-team.md](../../docs/sessions/audit-team.md)
 - ブランチ運用・merge 責任分担: [docs/sessions/branch-strategy.md](../../docs/sessions/branch-strategy.md) §6
-- QM Tier1/Tier2 2 層構造: [.claude/agents/qm-session.md](qm-session.md)
+- QM の lead + subagent 構造: [docs/sessions/qm-session.md](../../docs/sessions/qm-session.md)
 - ADR-0056（QM drift 構造的対処 / §E 役割分離 SSOT）: [docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md](../../docs/decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md)
 - ADR-0022 Amendment 4（lab merge 2 role / 統合 PR 作成者ルール / audit trail）: [docs/decisions/0022-admin-bypass-disable-qm-approve.md](../../docs/decisions/0022-admin-bypass-disable-qm-approve.md)
 - ADR-0010（Pre-PMF scope、監査体制 Bucket A 整合）: [docs/decisions/0010-pre-pmf-scope-judgment.md](../../docs/decisions/0010-pre-pmf-scope-judgment.md)

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -6,7 +6,7 @@
 >
 > **関連 Issue**: EPIC #2861 ｜ A1 = #2862 ｜ **関連 ADR**: ADR-0056（QM Orchestrator role drift の構造的対処）/ ADR-0022（QM Approve 体制・admin bypass 禁止）/ ADR-0010（Pre-PMF scope）
 >
-> **上流 SSOT**: ブランチ運用・gate 二層・merge 責任分担は [branch-strategy.md](branch-strategy.md)。QM Tier1/Tier2 の 2 層構造は [qm-session.md](qm-session.md)。本ファイルはこの 2 つを継承し、develop → main レーンの監査チーム側のみを定義する。
+> **上流 SSOT**: ブランチ運用・gate 二層・merge 責任分担は [branch-strategy.md](branch-strategy.md)。QM の lead + subagent 構造は [qm-session.md](qm-session.md)。本ファイルはこの 2 つを継承し、develop → main レーンの監査チーム側のみを定義する。
 >
 > **本ファイルの守備範囲**: 役割定義 SSOT。daily cron 自動化 / NUC・AWS staging 構築 / 最重厚テスト束ね / 判定エビデンス自動生成などの**実装**は EPIC #2861 の各 sub-issue（B 系 / C 系 / D 系 / E 系）が担う。本ファイルでは「誰が・何を・どの境界で判定するか」のみを確定する。
 
@@ -56,11 +56,11 @@ main = 本番（push 即 deploy、不変条件）であるにもかかわらず�
 
 - **統合前に CUJ（Critical User Journey）を横断する第三者監査層が存在しない**: QM は feature → develop PR 単位で「その PR の機能が AC どおりか」を毎時判定するが、複数 PR が develop に積み上がった後の「統合状態で顧客体験が崩れていないか」を横断検査する役割が不在だった。個別 PR が全て緑でも、統合後に画面間の整合・CUJ 通し体験が崩れる事故は per-PR review では原理的に捕捉できない。
 - **この役割定義がないと困ること**: 監査チームが「何を判定し、何を判定しないか」が曖昧だと、(1) 毎時 QM レビューと判定が衝突して二重判定になる（EPIC 失敗シナリオ⑤）、(2) self-review が形骸化したまま統合 merge される（同①、ADR-0056 が実証した QM drift 42 回再発の延長）、(3) 検出問題を 1 件で即棄却して残りを発露させず triage 不能に陥る（同⑥）。役割・境界・エビデンス基準を SSOT として固定して初めて、これらの構造的失敗を防げる。
-- **既存の `docs/sessions/` 同型**: PO / Dev / QM のロール定義が `docs/sessions/` 配下にあるのと同じく、監査チームのロール定義もここに置く。QM の Tier1/Tier2 2 層構造（[qm-session.md](qm-session.md)）と ADR-0056 §E（subagent ≠ orchestrator の役割分離）を継承し、独自の構造を増やさない。
+- **既存の `docs/sessions/` 同型**: PO / Dev / QM のロール定義が `docs/sessions/` 配下にあるのと同じく、監査チームのロール定義もここに置く。QM の lead + subagent 構造（[qm-session.md](qm-session.md) §「アーキテクチャ：subagent ループで 1 PR を閉じ切る」）と ADR-0056 §E（subagent ≠ orchestrator の役割分離）を継承し、独自の構造を増やさない。
 
 ## §2 設計原則
 
-- **マネージャ orchestrator 専権 + subagent は evidence 生成まで（ADR-0056 §E 継承）**: 不可逆 side-effect（統合 PR の approve / merge、Issue 起票の実行）は audit-manager orchestrator が直接実行する。8 チーム・ポリシー準拠判定の各 agent は finding（structured JSON evidence）を生成・報告するまでが責務で、approve / merge / 起票 action を肩代わりしない。これは QM Orchestrator の V-7 専権（[qm-session.md](qm-session.md) §「全手順 Pass → approve & merge」）と同型。
+- **マネージャ orchestrator 専権 + subagent は evidence 生成まで（ADR-0056 §E 継承）**: 不可逆 side-effect（統合 PR の approve / merge、Issue 起票の実行）は audit-manager orchestrator が直接実行する。8 チーム・ポリシー準拠判定の各 agent は finding（structured JSON evidence）を生成・報告するまでが責務で、approve / merge / 起票 action を肩代わりしない。これは QM lead 本体の専権（[qm-session.md](qm-session.md) §「全手順 Pass → approve & merge」）と同型。
 - **self-report 単独信頼の禁止（PO 判断 5 / ADR-0056）**: 監査チームの merge 判定は structured JSON evidence + adversarial verify を物理強制する。各 agent の「問題なし」自己申告だけでは merge しない。Echoing（arXiv:2511.09710）と Persona Drift を抑制するため、Adversarial Reviewer による反対理由生成を evidence の一部として要求する。
 - **2 段 gate の責務分離（PO 判断 6）**: QM = feature → develop（per-PR の機能正、毎時）、監査チーム = release/* → main（統合前の CUJ 横断、1 日 1 回。release ブランチ方式 = branch-strategy.md §3.1）。両者は同一 gh アカウント `ganbariquestsupport-lab` を base branch（= レビュー対象 PR の種別）で role 区別する（[branch-strategy.md](branch-strategy.md) §6 継承）。二重判定が起きないよう §3.4 の境界表で「監査チームが判定しないこと」を明示する。
 - **全件発露 → filter → 起票/棄却（PO 判断 7）**: 問題は 1 件で即棄却せず、まず全件を発露させる。その後 (1) 重複統合、(2) severity 閾値、(3) ポリシー準拠判定 filter を順に通し、残ったものを Issue 起票 + 棄却判定する。「あえてそうしている」プロダクトポリシー由来の挙動を誤起票しないことが filter の主目的。
@@ -112,7 +112,7 @@ EPIC #2861「既存資産再利用マップ」を本ファイルに正本化す�
 
 | チーム | 実装方針 | 再利用元（実在する SSOT を文言で参照） |
 |---|---|---|
-| audit-manager orchestrator | 新設 | qm-session.md の Tier1/Tier2 2 層構造を継承 |
+| audit-manager orchestrator | 新設 | qm-session.md の lead + subagent 構造を継承 |
 | 競合調査 | 新設（薄い skill、WebSearch ベース） | issue-triage skill の prior art 手順 |
 | 技術調査 | 再利用 | impact-analysis skill / regression-check skill |
 | プロダクト実装調査 | 再利用 | pr-review skill / regression-check skill |
@@ -150,7 +150,7 @@ ADR-0056 §E が定義する「subagent ≠ QM（役割分離 SSOT）」を、�
 | 判定の主眼 | per-PR の機能正しさ（AC 充足 / SS / CI 緑 / 場当たり対応検出） | 統合状態の CUJ 横断品質（画面間整合 / 第三者 CUJ 通し体験 / 8 領域監査） |
 | **判定すること** | その PR の AC・実装・テスト・UI の正しさ | 統合後の顧客体験・8 領域 finding・competitive gap・マージ判定エビデンス表 |
 | **判定しないこと** | 統合後の CUJ 横断品質（= 監査チームの領域） | per-PR 単位の AC 再判定（= QM が develop 取込時点で済ませた領域。監査チームは再判定せず統合状態のみを見る） |
-| 不可逆 action 主体 | QM Orchestrator 本体（V-7） | audit-manager orchestrator |
+| 不可逆 action 主体 | QM lead 本体（[qm-session.md](qm-session.md) §「④ 承認・merge（lead）」） | audit-manager orchestrator |
 | gh アカウント | `ganbariquestsupport-lab`（QM role） | `ganbariquestsupport-lab`（監査 role、base branch で区別） |
 
 - **二重判定の回避原則**: 監査チームは QM が develop 取込時に確定済みの per-PR AC を再判定しない。監査チームは「develop に積み上がった統合状態」を新しい検査対象として扱い、QM が見られない横断品質のみを担う。逆に QM は統合後の CUJ 横断を判定しない。
@@ -365,7 +365,7 @@ node scripts/check-pr-body.mjs --pr <N> --verify-closes-landed tmp/pr-bodies/<N>
 | 参照先 | 役割 |
 |---|---|
 | [branch-strategy.md](branch-strategy.md) | ブランチ運用・gate 二層・merge 責任分担の上流 SSOT（§6 役割分担を継承）。全 workflow の gate × lane 帰属・required context は [branch-strategy.md §4「全 workflow の gate × lane 対応表」](branch-strategy.md) を参照（#2948、本ファイルには workflow 一覧を置かない） |
-| [qm-session.md](qm-session.md) | QM Tier1/Tier2 2 層構造（audit-manager がこれを継承） |
+| [qm-session.md](qm-session.md) | QM の lead + subagent 構造（audit-manager がこれを継承） |
 | [../decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md](../decisions/0056-qm-drift-prevention-by-structural-agent-constraint.md) | §E 役割分離 SSOT（不可逆 side-effect = orchestrator 専権） |
 | [../decisions/0022-admin-bypass-disable-qm-approve.md](../decisions/0022-admin-bypass-disable-qm-approve.md) | 作成者 ≠ 承認者分離・admin bypass 禁止 |
 | [../decisions/0010-pre-pmf-scope-judgment.md](../decisions/0010-pre-pmf-scope-judgment.md) | Pre-PMF scope 判断（監査体制の bucket A 整合） |


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（QM / 監査チーム / Dev 各セッションの role SSOT を読む Agent）

**解決する課題**: `docs/sessions/qm-session.md` は #4336 で Tier1/Tier2・V-0〜V-7 の旧呼称を lead + subagent（①②③④）構造へ置換したが、参照元の `docs/sessions/audit-team.md`（2 箇所）と `.claude/agents/audit-manager.md`（7 箇所）に旧呼称への宙吊り参照が残存していた。監査チーム役割定義から存在しない呼称を指しているため、そのまま読むと現行の qm-session.md 構造と整合しない説明になる。

**期待される効果**: 監査チーム / audit-manager agent が qm-session.md を参照する際、現行の見出し・節名（§「アーキテクチャ：subagent ループで 1 PR を閉じ切る」/ §「④ 承認・merge（lead）」/ §「全手順 Pass → approve & merge」）に一致した記述を読めるようになる。

## 関連 Issue

<!-- no-issue-close: team-lead からの直接指示（PR-H）に基づく docs 是正。個別 Issue 番号の指定なし -->
本 PR は team-lead からの直接指示（PR-H）に基づく。#4336 / #4356 で qm-session.md の呼称変更が行われた際、audit-team.md には `V-7` 参照が2箇所、加えて棚卸で `.claude/agents/audit-manager.md` にも同種の `Tier1/Tier2`（qm-session からの継承と誤記載）/ `V-0〜V-6` / `V-7` 参照が計7箇所見つかったため、あわせて是正した。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | audit-team.md の `V-7` 参照 2 箇所を現行呼称に是正 | `git grep -n "Tier 1\|Tier 2\|V-\[0-7\]" -- docs/sessions/audit-team.md` | 是正後 0 件（本 PR HEAD、`docs/sessions/audit-team.md:63,153` を修正） |
| AC2 | docs/sessions/ 全体を走査し同種の宙吊り参照が他に無いか確認 | `git grep -n "qm-session.md" docs/sessions/` を全件目視 + `git grep -rln "Tier1/Tier2\|V-\[0-9\]" docs/ .claude/ .github/` | audit-team.md の残り 3 箇所（L9, L59, L115, L368 相当）と `.claude/agents/audit-manager.md` の 7 箇所を追加検出・是正。他ファイル（clone-setup.md / dev-session.md / label-mailbox.md / qm-agent-templates.md / qm-checklist-ui-quality.md / README.md / webui-review-process.md / anti-patterns.md / agent-teams.md / agent-concurrency.md）の `qm-session.md` 参照は現行見出し（手順 1〜5 / §「Per-PR Review Agent（5 手順）」等）と一致することを確認済み、変更不要 |

## 変更タイプ

- [ ] feat: 新機能
- [ ] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**:
UI 変更なし。`docs/sessions/audit-team.md` と `.claude/agents/audit-manager.md`（監査チーム / QM の role 定義 doc）のみ。

- [ ] 並行実装ペアを同期した
- [ ] 設計書同期 (ADR-0001)
- [ ] LP ↔ アプリ整合 (ADR-0013)
- [ ] 重量 e2e 敏感領域のローカル実行ログ
- [x] N/A — 上記いずれも影響範囲外（role 定義 doc の文言是正のみ、コード / UI / テスト影響なし）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr <num>` | N/A — GitHub Actions に Critical incident（webhook throttling）が発生中のため CI 未確認。incident 中に作成した PR であり、QM が CI 復旧後に確認する |
| 追加・変更テスト | なし（doc 文言修正のみ、コード変更なし） | N/A |

- [x] **SOLID / DRY / YAGNI**: N/A（doc 修正のみ）
- [x] **Security（OSS 公開前提）**: N/A（秘密情報・URL変更なし）
- [x] **A11y・パフォーマンス**: N/A（UI変更なし）
- [x] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: markdown ドキュメントの文言修正のみで UI 変更を伴わないため撮影対象が存在しない -->
該当なし（UI 変更を含まない docs 修正のため）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない
- [ ] 含まれる

**レビュー依頼事項**:
- `.claude/agents/audit-manager.md` §A の Tier1/Tier2 という命名自体は audit-manager 独自の用語として維持した（実装で広く使われている自己完結した用語のため）。修正したのは「qm-session.md から継承した呼称」という**由来説明のみ**が誤りだった点。命名自体の統一・廃止が必要かどうかは QM の判断を仰ぎたい。
- CI 未確認のため merge 前に `gh pr checks` での確認をお願いします（incident 復旧後）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み（未実装・先送りの AC がない）
- [x] UI 変更時: N/A（UI 変更なし）
- [x] 認証画面変更時: N/A（認証画面変更なし）

## QM レビュー結果

<!-- QM が記入。5 手順の approve body フォーマットは docs/sessions/qm-session.md 参照 -->

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
