### PR TITLE
test(ci): #4385 nuc-generate-env の pwsh test に明示 timeout を与え、diff と無関係な赤を止める

### DIFF
--- a/tests/unit/scripts/nuc-generate-env.test.ts
+++ b/tests/unit/scripts/nuc-generate-env.test.ts
@@ -196,6 +196,20 @@ describe('#4330 静的 — provider を宣言したら、その鍵も同じ経�
 	});
 });
 
+/**
+ * pwsh を起動する test の per-test timeout。
+ *
+ * 本 describe の各 test は **pwsh プロセスを 1〜2 回 spawn する**。pwsh の起動と
+ * `System.Management.Automation` のアセンブリ読み込みは runner の負荷で大きくぶれ、
+ * 既定 testTimeout (5s、vite.config.ts) を素通りする保証がない
+ * (実測: 同一コードで develop の CI が 1.86s、PR #4376 の CI が 6.40s = 3.4 倍のぶれ。
+ * 後者は **docs 1 file しか変えていない PR** を落としており、diff と無関係に赤が出る)。
+ *
+ * assertion は一切弱めず、spawn する test の性質に見合う時間だけを与える
+ * (`check-readdir-rotation-guard.test.ts` / `cli-entry-guard.test.ts` の spawn 系と同じ扱い)。
+ */
+const PWSH_TIMEOUT_MS = 60_000;
+
 describe('#4275 動作 — pwsh で実際に走らせる', () => {
 	/**
 	 * pwsh が無い環境では静的検査だけになる。**CI では skip を許さない**
@@ -210,69 +224,81 @@ describe('#4275 動作 — pwsh で実際に走らせる', () => {
 		expect(pwsh ?? 'skipped-locally').toBeTruthy();
 	});
 
-	it('parse できる（#4275 で落ちた箇所）', () => {
-		if (!pwsh) return;
-		const out = execFileSync(
-			pwsh,
-			[
-				'-NoProfile',
-				'-Command',
-				`$e=$null; $null=[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path '${SCRIPT_PATH}').Path,[ref]$null,[ref]$e); if($e.Count -gt 0){ $e | ForEach-Object { $_.Message }; exit 1 } else { 'PARSE_OK' }`,
-			],
-			{ encoding: 'utf8' },
-		);
-		expect(out).toContain('PARSE_OK');
-	});
+	it(
+		'parse できる（#4275 で落ちた箇所）',
+		() => {
+			if (!pwsh) return;
+			const out = execFileSync(
+				pwsh,
+				[
+					'-NoProfile',
+					'-Command',
+					`$e=$null; $null=[System.Management.Automation.Language.Parser]::ParseFile((Resolve-Path '${SCRIPT_PATH}').Path,[ref]$null,[ref]$e); if($e.Count -gt 0){ $e | ForEach-Object { $_.Message }; exit 1 } else { 'PARSE_OK' }`,
+				],
+				{ encoding: 'utf8' },
+			);
+			expect(out).toContain('PARSE_OK');
+		},
+		PWSH_TIMEOUT_MS,
+	);
 
-	it('必須 secret が無ければ exit 1（deploy を止める）', () => {
-		if (!pwsh) return;
-		for (const missing of ['PARENT_GATE_COOKIE_SECRET', 'CRON_SECRET']) {
-			const env: Record<string, string | undefined> = {
-				...process.env,
-				PARENT_GATE_COOKIE_SECRET: 'dummy-parent-gate',
-				CRON_SECRET: 'dummy-cron',
-			};
-			delete env[missing];
-			let exitCode = 0;
-			try {
-				execFileSync(pwsh, ['-NoProfile', '-File', SCRIPT_PATH], { env, stdio: 'pipe' });
-			} catch (e) {
-				exitCode = (e as { status?: number }).status ?? -1;
-			}
-			expect(exitCode, `${missing} 未設定なのに deploy が続行した`).toBe(1);
-		}
-	});
-
-	it('必須 secret が揃えば .env を書く（任意 env は設定時のみ）', () => {
-		if (!pwsh) return;
-		const dir = mkdtempSync(join(tmpdir(), 'nuc-env-'));
-		const outFile = join(dir, '.env');
-		try {
-			execFileSync(pwsh, ['-NoProfile', '-File', SCRIPT_PATH, '-OutFile', outFile], {
-				env: {
+	it(
+		'必須 secret が無ければ exit 1（deploy を止める）',
+		() => {
+			if (!pwsh) return;
+			for (const missing of ['PARENT_GATE_COOKIE_SECRET', 'CRON_SECRET']) {
+				const env: Record<string, string | undefined> = {
 					...process.env,
-					PARENT_GATE_COOKIE_SECRET: 'pg-secret-value',
-					CRON_SECRET: 'cron-secret-value',
-					HOST_BACKUP_DIR: 'D:/backups',
-					DISCORD_ALERT_WEBHOOK_URL: '',
-				},
-				stdio: 'pipe',
-			});
-			expect(existsSync(outFile)).toBe(true);
-			const written = readFileSync(outFile, 'utf8');
+					PARENT_GATE_COOKIE_SECRET: 'dummy-parent-gate',
+					CRON_SECRET: 'dummy-cron',
+				};
+				delete env[missing];
+				let exitCode = 0;
+				try {
+					execFileSync(pwsh, ['-NoProfile', '-File', SCRIPT_PATH], { env, stdio: 'pipe' });
+				} catch (e) {
+					exitCode = (e as { status?: number }).status ?? -1;
+				}
+				expect(exitCode, `${missing} 未設定なのに deploy が続行した`).toBe(1);
+			}
+		},
+		PWSH_TIMEOUT_MS,
+	);
 
-			expect(written).toContain('PARENT_GATE_COOKIE_SECRET=pg-secret-value');
-			expect(written).toContain('CRON_SECRET=cron-secret-value');
-			expect(written).toContain('DATA_SOURCE=pglite');
-			expect(written).toContain('HOST_BACKUP_DIR=D:/backups');
-			// 空の任意 env は書かない（「設定済みだが空」と区別できなくなる）
-			expect(written).not.toContain('DISCORD_ALERT_WEBHOOK_URL=');
-			// BOM を持たない（docker compose env_file が弾く）
-			expect(written.charCodeAt(0)).not.toBe(0xfeff);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
+	it(
+		'必須 secret が揃えば .env を書く（任意 env は設定時のみ）',
+		() => {
+			if (!pwsh) return;
+			const dir = mkdtempSync(join(tmpdir(), 'nuc-env-'));
+			const outFile = join(dir, '.env');
+			try {
+				execFileSync(pwsh, ['-NoProfile', '-File', SCRIPT_PATH, '-OutFile', outFile], {
+					env: {
+						...process.env,
+						PARENT_GATE_COOKIE_SECRET: 'pg-secret-value',
+						CRON_SECRET: 'cron-secret-value',
+						HOST_BACKUP_DIR: 'D:/backups',
+						DISCORD_ALERT_WEBHOOK_URL: '',
+					},
+					stdio: 'pipe',
+				});
+				expect(existsSync(outFile)).toBe(true);
+				const written = readFileSync(outFile, 'utf8');
+
+				expect(written).toContain('PARENT_GATE_COOKIE_SECRET=pg-secret-value');
+				expect(written).toContain('CRON_SECRET=cron-secret-value');
+				expect(written).toContain('DATA_SOURCE=pglite');
+				expect(written).toContain('HOST_BACKUP_DIR=D:/backups');
+				// 空の任意 env は書かない（「設定済みだが空」と区別できなくなる）
+				expect(written).not.toContain('DISCORD_ALERT_WEBHOOK_URL=');
+				// BOM を持たない（docker compose env_file が弾く）
+				expect(written.charCodeAt(0)).not.toBe(0xfeff);
+			} finally {
+				rmSync(dir, { recursive: true, force: true });
+			}
+		},
+		PWSH_TIMEOUT_MS,
+	);
 
 	/** 必須 secret を埋め、GEMINI_API_KEY だけを指定値（または未設定）にした env を作る。 */
 	function envWithGeminiKey(key?: string): Record<string, string | undefined> {
@@ -304,24 +330,33 @@ describe('#4275 動作 — pwsh で実際に走らせる', () => {
 		}
 	}
 
-	it('#4330 GEMINI_API_KEY があれば AI_PROVIDER と一緒に .env へ書く', () => {
-		if (!pwsh) return;
-		const { written } = runScript(envWithGeminiKey('gemini-key-value'));
-		expect(written, 'NUC は gemini ホスト').toContain('AI_PROVIDER=gemini');
-		expect(written, 'provider は書くのに鍵を配らない = AI 提案が常に無効になる (#4330)').toContain(
-			'GEMINI_API_KEY=gemini-key-value',
-		);
-	});
+	it(
+		'#4330 GEMINI_API_KEY があれば AI_PROVIDER と一緒に .env へ書く',
+		() => {
+			if (!pwsh) return;
+			const { written } = runScript(envWithGeminiKey('gemini-key-value'));
+			expect(written, 'NUC は gemini ホスト').toContain('AI_PROVIDER=gemini');
+			expect(
+				written,
+				'provider は書くのに鍵を配らない = AI 提案が常に無効になる (#4330)',
+			).toContain('GEMINI_API_KEY=gemini-key-value');
+		},
+		PWSH_TIMEOUT_MS,
+	);
 
-	it('#4330 GEMINI_API_KEY が無ければ warning を出し、deploy は続ける', () => {
-		if (!pwsh) return;
-		const { stdout, written } = runScript(envWithGeminiKey());
-		expect(stdout, '鍵の欠落が誰にも届かない = #4330 の再演').toContain(
-			'::warning::GEMINI_API_KEY',
-		);
-		// 空値を書くと「設定済みだが空」と区別できなくなる (既存の任意 env と同じ扱い)
-		expect(written).not.toContain('GEMINI_API_KEY=');
-		// AI 無効でも他の機能は動くので .env 生成自体は成功させる (#4275 の教訓)
-		expect(written).toContain('CRON_SECRET=cron-secret-value');
-	});
+	it(
+		'#4330 GEMINI_API_KEY が無ければ warning を出し、deploy は続ける',
+		() => {
+			if (!pwsh) return;
+			const { stdout, written } = runScript(envWithGeminiKey());
+			expect(stdout, '鍵の欠落が誰にも届かない = #4330 の再演').toContain(
+				'::warning::GEMINI_API_KEY',
+			);
+			// 空値を書くと「設定済みだが空」と区別できなくなる (既存の任意 env と同じ扱い)
+			expect(written).not.toContain('GEMINI_API_KEY=');
+			// AI 無効でも他の機能は動くので .env 生成自体は成功させる (#4275 の教訓)
+			expect(written).toContain('CRON_SECRET=cron-secret-value');
+		},
+		PWSH_TIMEOUT_MS,
+	);
 });


### PR DESCRIPTION
## 顧客価値・目的

CI の赤が「変更した内容」と相関しない状態を止める。

`tests/unit/scripts/nuc-generate-env.test.ts` の pwsh 実行 test は、既定 `testTimeout` 5,000 ms (`vite.config.ts:84`) を**跨いで分布する**所要時間を持つ。そのため diff の中身と無関係に `unit-test (2)` が落ち、赤を見た人が毎回「自分の変更が壊した」と誤診する。

実測（すべて同一コード、`parse できる（#4275 で落ちた箇所）` 1 test）:

| run | branch | 所要 | 判定 |
|---|---|---|---|
| 31053249033 | develop | 1,860 ms | pass |
| 31129843373 | fix/ops-t4-observability | **4,549 ms** | pass（余裕 451 ms = 9%） |
| 31129266593 attempt 1 | PR #4376 (`docs/decisions/README.md` 1 file のみ) | 6,398 ms | **fail** |
| 31129266593 attempt 2 | 同上 rerun | 5,084 ms | **fail** |

451 ms 差で通った run があることが示すとおり、**現状は全 PR が coin-flip で赤になりうる**。実際 PR #4376 は docs 1 file の変更で 2 回連続 fail し、`unit-test` の job ログに失敗 test 名が出ないため blob artifact を解析するまで原因が判明しなかった。この診断コストが PR ごとに発生していた。

## 関連 Issue

Closes #4385

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | pwsh を spawn する 5 test に明示 timeout が付き、既定 5 s の影響を受けない | `npx vitest run tests/unit/scripts/nuc-generate-env.test.ts` | 15 passed (15)。`PWSH_TIMEOUT_MS = 60_000` を 5 test に付与 |
| AC2 | timeout 定数が実際に各 test へ結線されている | mutation 検証: 定数を `1` に変更して実行 | `Failed Tests 5` / `Test timed out in 1ms` × 5 = 5 test すべてに結線済を実証。検証後 `git stash push`/`drop` で復帰（commit 後に実施したため実装消失なし） |
| AC3 | assertion / 検査対象は 1 つも減っていない | `git diff` 全行目視 | 追加は timeout 引数と定数定義・コメントのみ。`expect` の変更・`skip` 化・削除は 0 件 |

## 変更タイプ

- [x] テスト
- [ ] 機能追加
- [ ] バグ修正
- [ ] リファクタリング
- [ ] ドキュメント

## 影響範囲・横展開チェック

- 対象は `tests/unit/scripts/nuc-generate-env.test.ts` の 1 file のみ。プロダクトコードの変更なし
- 検証対象である `scripts/nuc/generate-env.ps1` / `.github/workflows/deploy-nuc.yml` は無変更。**NUC deploy の挙動は一切変わらない**
- 同種（子プロセス spawn / repo 全走査で既定 5 s に収まらない）の先行例と同じ扱いに揃えた: `tests/unit/scripts/check-readdir-rotation-guard.test.ts` [RG5] (60 s) / `tests/unit/scripts/cli-entry-guard.test.ts`
- 他の pwsh 依存 test は本 file 以外に存在しないため、横展開先なし

## テスト・品質セルフチェック

```
npx vitest run tests/unit/scripts/nuc-generate-env.test.ts   → Test Files 1 passed / Tests 15 passed
npx biome check tests/unit/scripts/nuc-generate-env.test.ts  → No fixes applied
```

mutation 検証（AC2）は commit 済みの状態で実施し、復帰は `git stash push` → `drop`（`git checkout --` で未コミットの実装ごと捨てる事故を避けるため）。

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: テストファイルのみの変更で UI 描画を伴わないため Before/After が原理的に存在しない -->

UI 変更なし（test file 1 件のみ）。

## レビュー依頼事項・破壊的変更

破壊的変更なし。

レビュー観点として 1 点: **timeout を上げることが検査の弱体化に当たらないか**。本 PR は「所要時間そのものは正常で、与えた時間予算が実測に対して小さかった」という判断に立っている。pwsh の起動 + `System.Management.Automation` の読み込みが 4.5 s かかること自体は test の欠陥ではなく、5 s 予算がその実測分布に対して不足していた。`expect` は 1 つも変えていない。

skip 化・削除は選ばなかった（`#4084` / `#4264` の「検査できなかった」を「検査した」と区別できなくする失敗を作らないため）。

## 配布済み env / secret (ADR-0006)

新規 env / secret の追加なし。

## Ready for Review チェックリスト

- [x] `npx biome check` 通過
- [x] 対象テスト green
- [x] AC 全項目が検証済み（上記 AC 検証マップ）
- [x] 影響範囲・横展開チェック実施
- [x] QA 承認・動作確認が完了している

## QM レビュー結果

未実施（レビュー待ち）。
