### PR TITLE
fix(process): CI 判定の jq が context 0 件を ALL GREEN と出していた

### DIFF
--- a/docs/sessions/qm-session.md
+++ b/docs/sessions/qm-session.md
@@ -64,15 +64,22 @@ QM が使ってよいのは **多観点レビュー**（security / perf / test-c
 gh pr view <N> --json statusCheckRollup --jq '
   [.statusCheckRollup[] | {n:(.name//.context), c:(.conclusion//""), s:(.status//""), t:(.completedAt//.startedAt//"")}]
   | group_by(.n) | map(sort_by(.t) | last)
-  | map(select(.c!="SUCCESS" and .c!="SKIPPED" and .c!="NEUTRAL"))
-  | if length==0 then "ALL GREEN" else .[] | "\(.n): \(if .c=="" then .s else .c end)" end'
+  | if length == 0 then "NOT RUN: context 0 件 — 起動していない。緑ではない"
+    else . as $all
+      | [$all[] | select(.c != "SUCCESS" and .c != "SKIPPED" and .c != "NEUTRAL")]
+      | if length == 0 then "ALL GREEN (\($all | length) context)"
+        else .[] | "\(.n): \(if .c == "" then .s else .c end)" end
+    end'
 ```
 
-- **件数そのものを見る。** context 総数が普段の PR より極端に少ない PR は、緑なのではなく**大半が起動していない**
+- **空集合を緑と読まない。** 「非 pass が 0 件」は context が 1 つも無いときにも真になる。上の jq は 0 件を `NOT RUN` として区別し、緑のときは **context 総数を併記**する
+- **その総数を、同じ base の直近 merge 済み PR と比べる。** 極端に少なければ緑なのではなく**大半が起動していない**
 - **最終的な可否は `mergeStateStatus` に従う。** `BLOCKED` のまま緑に見えるときは、こちらの読み方が間違っている
 - **再トリガは close/reopen が確実**。ただし進行中の run を concurrency が cancel するため、**cancel された run が出し直されるまで判定しない**
 
 **Why**: `#4383` で `gh pr checks` は 14 行すべて pass / skipping を返したが、実際には required の `lint-and-test` / `unit-test (1)(2)` を含む **60 context のうち 4 本が一度も起動していなかった**（Actions incident の残り）。approve は通り、merge を止めたのは branch protection だけだった。同じ PR を再トリガした後は、決着済みの古い FAILURE が rollup に残り続け、最新世代が SUCCESS でも赤に見えた。
+
+**空集合の扱いを後から足した理由**: 本節の初版（#4387）は「件数そのものを見る」と散文で書いただけで、jq 自体は `length==0` を `ALL GREEN` と出していた。**手順書が自分の警告に違反している**状態で、同日 `#4372` / `#4381` / `#4377`（いずれも context 0 件）を緑と誤判定した。散文の注意書きは、同じ場所にあるコマンドの出力には勝てない。
 
 ## レビュー対象レーン（git flow 二層、#2858）
 


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: QM / PO / Dev（merge 判断を行う全ロール）

**解決する課題**: #4387 で追加した CI 判定手順の初版は、**jq 自体が `length==0` を `ALL GREEN` と出していた**。本文には「件数そのものを見る」と散文で書いたが、**手順書が自分の警告に違反している**状態だった。同日、`#4372` / `#4381` / `#4377`（いずれも Actions incident の残りで check が 1 本も投稿されず context 0 件）を、この jq が緑と判定した。

**期待される効果**: 「1 本も走っていない」と「全部通った」が出力で区別される。

## 関連 Issue

<!-- no-issue-close: 本 PR は #4387 が残した欠陥を同日中に是正するもので、単独の課題 Issue を持たない。 -->

**close する Issue はありません。** #4387（本日 merge）が残した欠陥の是正です。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | context 0 件が緑と区別される | 新 jq を `#4372` / `#4381` / `#4377` に適用 | 3 本とも **`NOT RUN: context 0 件 — 起動していない。緑ではない`**。旧 jq は同じ 3 本に `ALL GREEN` を返していた |
| AC2 | 緑の判定は従来どおり動く | 新 jq を `#4378` / `#4382` に適用 | **`ALL GREEN (49 context)`** / **`ALL GREEN (50 context)`**。件数が併記される |
| AC3 | 実行中は緑にならない | 新 jq を `#4322`（実行中）に適用 | `lint-and-test: IN_PROGRESS` ほかを列挙。緑と出さない |
| AC4 | 件数の比較対象が書かれている | `docs/sessions/qm-session.md` 該当節 | 「その総数を、**同じ base の直近 merge 済み PR と比べる**」と明記。旧版は「普段の PR より極端に少なければ」で比較対象が曖昧だった |
| AC5 | 同じ失敗を繰り返さないための経緯が残る | 同節末尾 | 「**散文の注意書きは、同じ場所にあるコマンドの出力には勝てない**」を Why として記録 |
| AC6 | fixture 抽出テストを壊していない | `tests/unit/hooks/qm-session-approve-hook-consistency.test.ts` の抽出ロジックを再現実行 | 同 test は `#### 全手順 Pass → approve & merge` 以降の最初の bash ブロックを取る。本節の bash ブロックはそれより**前方**にあり slice に入らない（#4387 と同じ理由）。抽出結果が `gh auth switch --user ganbariquestsupport-lab` で始まることを実行して確認済み |

## 変更タイプ

- [x] fix: バグ修正
- [ ] feat: 新機能
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [x] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲・横展開チェック

**影響を受ける画面・機能**: なし（`docs/sessions/qm-session.md` 1 file のみ）。

- [ ] 並行実装ペアを同期した
- [ ] LP ↔ アプリ整合 (ADR-0013)
- [x] **設計書同期 (ADR-0001)**: `qm-session.md` が判定手順の SSOT。`label-mailbox.md` / `po-session.md` は節名で参照しており、**節名を変えていない**ため参照は有効なまま
- [ ] 重量 e2e 敏感領域
- [ ] N/A

**並行 PR overlap (#1200)**: `qm-session.md` は #4387（本日 merge 済み）の直上に載る。Draft の #4379 が同 file を触るため、後発側で rebase が要る。

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| 新 jq の実測 | open PR 6 本に適用 | **PASS**。context 0 件 3 本 → `NOT RUN` / 49・50 context 2 本 → `ALL GREEN (件数)` / 実行中 1 本 → `IN_PROGRESS` |
| 旧 jq との差分確認 | 同じ 3 本に旧 jq を適用 | 旧は `ALL GREEN` を返す（= 本 PR が直す欠陥の再現） |
| fixture 抽出の再現 | `node -e` で抽出ロジックを再実行 | **PASS**。抽出される bash ブロックは変更前と同一 |

- [x] **SOLID / DRY / YAGNI**: 新規 script / workflow / test の追加 0（§0 装置凍結）
- [x] **Security（OSS 公開前提）**: 秘密情報なし
- [ ] **A11y・パフォーマンス**: N/A
- [ ] **Critical バグ修正**(ADR-0002): N/A

## スクリーンショット / ビジュアルデモ

<!-- ss-pair-none: markdown ドキュメントのみの変更で、描画される画面が存在しない -->

N/A（`.svelte` の変更 0 件）

## レビュー依頼事項・破壊的変更

**破壊的変更**: なし。

**確認してほしい点**:

1. **jq が長くなったこと**。`if length == 0` の分岐で 4 行増えました。短さと安全のどちらを取るかですが、**短い版が実際に誤判定を出した**ので安全側に倒しています
2. **なぜ script にしないか**。§0 の装置凍結に従っています。ただし本 PR は「散文の注意書きは出力に勝てない」ことの実例でもあるので、同種の誤判定が再発するなら script 化の判断を PO に上げる余地はあります

## 配布済み env / secret (ADR-0006)

なし（新規 env / secret の追加なし）。

## Ready for Review チェックリスト

- [x] 旧 jq が誤判定を出すことを実 PR で再現して確認した
- [x] 新 jq が 3 分類（NOT RUN / ALL GREEN / 非 pass 列挙）を正しく出すことを実 PR 6 本で確認した
- [x] fixture 抽出テストの対象範囲を壊していないことを実行して確認した

## QM レビュー結果

本 PR は **QM が自分の直前の PR（#4387）の欠陥を検出**して起票したものです。PR 作成は `Takenori-Kusaka`、commit author は `ganbariquestsupport-lab`。
