### PR TITLE
fix(infra): #4352 drift 検査を deploy job の末尾へ移す（#4365 決裁の未到達分）

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -426,24 +426,6 @@ jobs:
             --region $AWS_REGION
           echo "::notice::staging ORIGIN resolved and applied: $ORIGIN"
 
-      # Step 13.5 (#4352): env drift 検査。**Step 13 の直後に置く**。
-      #
-      # Step 13 は live env を read-modify-write (`jq '. + {…}'`) するため、IaC の外で手で足された env は
-      # deploy のたびに正式な設定として **re-commit される**。CloudFormation もテンプレート無変更なら
-      # リソースを触らないので drift を戻さない。結果「IaC に無い env が恒久的に効き続ける」状態が
-      # deploy success のまま残る (#4117 E1 で実際に起きた: 検証用に注入した STRIPE_PRICE_* が
-      # full deploy を跨いで残り、staging で checkout が通るのを見て「#4286 が直った」と誤判定しうる
-      # 状態が続いた)。
-      #
-      # 本 step は cdk deploy が出力したテンプレートと live の **キー集合**を突き合わせる (値は読まない)。
-      - name: Lambda env drift check (staging, #4352)
-        run: |
-          node scripts/check-lambda-env-drift.mjs \
-            --function "$LAMBDA_FUNCTION" \
-            --template infra/cdk.out/GanbariQuestComputeStaging.template.json \
-            --logical-id-prefix SvelteKitFn \
-            --region "$AWS_REGION"
-
       # Step 14: Post-deploy health check (deploy.yml Phase 5 pattern、5 retry)。
       # staging table は空だが /api/health はデータ非依存 (設計 §データ戦略)。
       - name: Health check (staging)
@@ -636,6 +618,28 @@ jobs:
             exit "$STATUS"
           fi
           echo "::notice::DSQL staging 並行検証 test passed (${DURATION}s、#3683)"
+
+      # Step 15.9 (#4352): env drift 検査。**deploy job の末尾に置く** (PO 決裁 2026-08-07、#4365)。
+      #
+      # Step 13 (Resolve ORIGIN) は live env を read-modify-write (`jq '. + {…}'`) するため、IaC の外で
+      # 手で足された env は deploy のたびに正式な設定として **re-commit される**。CloudFormation も
+      # テンプレート無変更ならリソースを触らないので drift を戻さない。結果「IaC に無い env が恒久的に
+      # 効き続ける」状態が deploy success のまま残る (#4117 E1 で実際に起きた: 検証用に注入した
+      # STRIPE_PRICE_* が full deploy を跨いで残り、staging で checkout が通るのを見て「#4286 が直った」
+      # と誤判定しうる状態が続いた)。
+      #
+      # 本 step が落ちる時点でアプリ本体は既に live であり、早く落としても何も守られない。一方 job の
+      # 途中に置くと後続の検証 (health / smoke / PII guard / DSQL 並行検証) が丸ごと skip される。
+      # 末尾なら deploy は同じく赤くなり、他の検証は全て実行される。
+      #
+      # 突き合わせるのは cdk deploy が出力したテンプレートと live の **キー集合**のみ (値は読まない)。
+      - name: Lambda env drift check (staging, #4352)
+        run: |
+          node scripts/check-lambda-env-drift.mjs \
+            --function "$LAMBDA_FUNCTION" \
+            --template infra/cdk.out/GanbariQuestComputeStaging.template.json \
+            --logical-id-prefix SvelteKitFn \
+            --region "$AWS_REGION"
 
       # Step 16: Rollback on failure — staging ECR の previous digest に戻す
       # (deploy.yml Phase 5b 同型。staging repo は maxImageCount:3 のため直近 2 世代まで戻せる)。

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -449,24 +449,6 @@ jobs:
             --function-name $LAMBDA_FUNCTION \
             --region $AWS_REGION
 
-      # #4352: IaC の外で足された env (out-of-band drift) の検出。
-      #
-      # CloudFormation はテンプレート無変更ならリソースを触らないため、`aws lambda
-      # update-function-configuration` で手で足した env は **次の deploy でも消えない**
-      # (staging では実際に検証用の STRIPE_PRICE_* が full deploy を跨いで残り、#4286 の
-      # 修正が効いているかを staging で判定できない状態が続いた、#4117 E1)。
-      #
-      # 上の "Incident webhook env verification" が「あるべきキーがあるか」を見るのに対し、
-      # 本 step は「**あるべきでないキーが無いか**」を見る (逆方向)。値は読まずキー名だけで判定する。
-      # 欠落 (テンプレートにあるが live に無い) は warning に留め、extra のみ hard-fail する。
-      - name: Lambda env drift check (production, #4352)
-        run: |
-          node scripts/check-lambda-env-drift.mjs \
-            --function "$LAMBDA_FUNCTION" \
-            --template infra/cdk.out/GanbariQuestCompute.template.json \
-            --logical-id-prefix SvelteKitFn \
-            --region "$AWS_REGION"
-
       # #4174: **synth の diff ではなく、deploy 済み Lambda の実 env** を読んで検証する。
       # compute-stack.ts は空値のとき env ごと落とす (`...(x ? {KEY: x} : {})`) ため、
       # 「context を渡し忘れた」「secret 名を間違えた」のいずれでも **deploy は成功したまま
@@ -902,6 +884,30 @@ jobs:
             echo "::notice::recovery point OK: 最新は ${AGE_H}h 前 (< 48h)"
           fi
           echo "::notice::DSQL backup smoke test passed (#3808)"
+
+      # #4352: IaC の外で足された env (out-of-band drift) の検出。
+      #
+      # CloudFormation はテンプレート無変更ならリソースを触らないため、`aws lambda
+      # update-function-configuration` で手で足した env は **次の deploy でも消えない**
+      # (staging では実際に検証用の STRIPE_PRICE_* が full deploy を跨いで残り、#4286 の
+      # 修正が効いているかを staging で判定できない状態が続いた、#4117 E1)。
+      #
+      # 上の "Incident webhook env verification" が「あるべきキーがあるか」を見るのに対し、
+      # 本 step は「**あるべきでないキーが無いか**」を見る (逆方向)。値は読まずキー名だけで判定する。
+      # 欠落 (テンプレートにあるが live に無い) は warning に留め、extra のみ hard-fail する。
+      #
+      # **配置は deploy job の末尾** (PO 決裁 2026-08-07、#4365)。本 step が落ちる時点で
+      # アプリ本体は既に live であり、早く落としても何も守られない。一方 job の途中に置くと
+      # 後続の検証 (#4174 通知配線 / #4189 alarm 宛先 / demo Lambda image 更新 / #1586 cron smoke /
+      # #4280 front door / #3808 backup smoke) が丸ごと skip される。末尾なら deploy は同じく
+      # 赤くなり、他の検証は全て実行される。
+      - name: Lambda env drift check (production, #4352)
+        run: |
+          node scripts/check-lambda-env-drift.mjs \
+            --function "$LAMBDA_FUNCTION" \
+            --template infra/cdk.out/GanbariQuestCompute.template.json \
+            --logical-id-prefix SvelteKitFn \
+            --region "$AWS_REGION"
 
   e2e-production:
     needs: deploy

--- a/scripts/check-lambda-env-drift.mjs
+++ b/scripts/check-lambda-env-drift.mjs
@@ -247,9 +247,14 @@ export function main(argv = process.argv.slice(2)) {
 				`  (関数: ${functionName} / テンプレート: ${templatePath})\n` +
 				'  CloudFormation はテンプレート無変更ならリソースを触らず、deploy の ORIGIN 解決 step は\n' +
 				'  live env を read-modify-write するため、**この env は次の deploy でも消えません**。\n' +
-				'  対処: (a) 正式な設定なら CDK (infra/lib/*-stack.ts) に足す / (b) 検証用なら手で除去する:\n' +
-				`    aws lambda get-function-configuration --function-name ${functionName} --region ${region} --query 'Environment.Variables'\n` +
-				'    → 該当キーを除いた JSON で aws lambda update-function-configuration --environment file://…',
+				'\n' +
+				'  対処 (既定は (a)。まず「この env は今 live で何かを支えていないか」を確かめる):\n' +
+				'   (a) その設定を残すなら CDK に足す — infra/lib/compute-stack.ts の environment に追加し\n' +
+				'       deploy workflow の `-c` で値を渡す (infra/CLAUDE.md §新規 env 追加時 PR チェックリスト)。\n' +
+				'       **インシデント中に手で足した env はこちら**。消すと本番が壊れる。\n' +
+				'   (b) 検証用に一時注入したもので、消しても壊れないと確認できた場合のみ手で除去する:\n' +
+				`       aws lambda get-function-configuration --function-name ${functionName} --region ${region} --query 'Environment.Variables'\n` +
+				'       → 該当キーを除いた JSON で aws lambda update-function-configuration --environment file://…',
 		);
 		return 1;
 	}


### PR DESCRIPTION
## 顧客価値・目的

**PO が承認した配置と違うものが、いま本番 deploy に載っている**状態を解消する。

PR #4365 の決裁（[2026-08-07](https://github.com/Takenori-Kusaka/ganbari-quest/pull/4365#issuecomment-5209253147)）は「本番 hard-fail で入れてよい。ただし step を job 末尾へ」だった。`c5897937` で対応したが、**#4365 は 1 つ前の commit で既に merge されており、merge 済ブランチへの追加 push はどこにも流れなかった**（[PO 指摘](https://github.com/Takenori-Kusaka/ganbari-quest/pull/4365#issuecomment-5211447241)）。本 PR がその未到達分を develop に載せる。

顧客に対しては、**「本番が壊れていることを検出する経路」を drift 検査の巻き添えで失わない**ことが価値。現状の配置では drift 検査が落ちた時点で Health check と front door 検査（#4280）まで skip される。

## 関連 Issue

Refs #4352（gate 本体）、#4365（決裁と merge、内容は決裁済み）
<!-- no-issue-close: #4352 は #4365 の merge 時に close 済。本 PR はその決裁条件の未到達分を届けるだけで、新たに閉じる Issue は無い -->

## 変更内容

drift 検査 step を **deploy job の末尾へ移す**（判定内容は 1 文字も変えていない）。

| ファイル | 変更 |
|---|---|
| `.github/workflows/deploy.yml` | drift 検査 step を `DSQL backup smoke test` の後（deploy job 末尾）へ移動 |
| `.github/workflows/deploy-aws-staging.yml` | 同じ理由で `DSQL staging concurrency test` の後へ移動 |
| `scripts/check-lambda-env-drift.mjs` | FAIL メッセージのみ。対処 (a) を既定にし「**インシデント中に手で足した env はこちら**。消すと本番が壊れる」を明示。(b) は「消しても壊れないと確認できた場合のみ」に限定 |

**判定ロジックは変更なし。** extra = hard-fail / missing = warning（必須キーは develop 側の既存実装により strict 無指定でも fail）。`continue-on-error` も `if:` も付けていないので **hard-fail は維持**。`classifyMissingKeys` / `REQUIRED_ALWAYS_PRESENT_KEYS`（develop 側で別途追加済のもの）は触っていない。

**なぜ末尾か**: この step が落ちる時点でアプリ本体は既に live であり、早く落としても何も守られない。一方 job の途中に置くと後続の検証が丸ごと skip される。末尾なら deploy は同じく赤くなり、他の検証は全て実行される。

## 検証

| 確認事項 | 手段 | 結果 |
|---|---|---|
| 本番の drift 検査が deploy job の最終 step になっている | `yaml.safe_load` で step 名リストを抽出 | ✅ `deploy` job 38 step の末尾 3 件 = `Show deployment outputs` / `DSQL backup smoke test (#3808)` / **`Lambda env drift check (production, #4352)`** |
| staging も末尾側へ移動 | 同上 | ✅ `deploy-aws-staging` job 27 step の末尾 3 件 = `DSQL staging concurrency test (#3683)` / **`Lambda env drift check (staging, #4352)`** / `Rollback on failure`（`failure()` 条件のため実質最終） |
| 移動前に skip されていた step 数 | `grep -n "^      - name:"` で develop 実物（`deploy.yml:462` 以降）を列挙 | ✅ **9 step**。**当初報告の 6 は誤りで、実測して是正した**。commit message とコード comment の両方を 9 に直した |
| 判定ロジックの退行なし | `npx vitest run tests/unit/scripts/check-lambda-env-drift.test.ts` | ✅ **22 passed**（develop 側で追加済の `classifyMissingKeys` の test 込み = cherry-pick がそれを潰していないことの確認を兼ねる） |
| lint | `npx biome check` | ✅ PASS |

### 移動前に skip されていた 9 step（develop 実物、`deploy.yml:462` 時点）

```
485  Incident webhook env verification (production, #4174)
510  Ops alarm destination verification (production, #4189)
542  Update Lambda function image (demo)
564  Cron dispatcher smoke test              (#1586)
645  Demo Lambda smoke test (#2130)
686  Health check                             ← 本番が壊れていることを検出する経路
717  Front door enforcement check (#4280)     ← 同上
756  Post-deploy resource audit
794  Detect orphaned resources
829  Show deployment outputs
844  DSQL backup smoke test (#3808)
```

## 影響範囲

**顧客に見える変化: なし**（CI の実行順のみ。UI 変更 0 件）。**破壊的変更: なし**。

**横展開**: 同種の「途中で落ちると後続検証が消える」step が他に無いかを確認した。`deploy.yml` の既存 hard-fail step（#4174 / #4189）は**あるべきキーの欠落**を見るもので、欠落時点で通知経路が死んでいる = 早く落ちる価値があるため現状維持が正しい。**本 gate だけが「アプリ本体は健全なまま赤くする」性質**を持つ。

**運用ミスの再発防止**: merge 済み PR のブランチに追加 push しても届かない。今後は「決裁条件を反映する commit は、対象 PR が open であることを確認してから push する / merge 済なら新規 PR を切る」を守る。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

(QM 記入欄)

---

## PO 決裁ブリーフ (po-decision:required)

> **本 PR に新規の決裁事項はありません。**内容は #4365 で決裁済み（「本番 hard-fail で入れてよい。ただし step を job 末尾へ」）で、本 PR はその**未到達分を届けるだけ**です。PO からも「内容は決裁済みなので追加ブリーフは不要」と明示されています。label は `.github/workflows/deploy*.yml` の glob で自動付与されたもので、gate を満たすため以下を置きます。

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🟢可逆: step の位置を戻すだけ"]
    R2["顧客面: 変化なし（CI の実行順のみ）"]
    R3["🟢判定ロジック・hard-fail は不変"]
  end
  subgraph TRADE["② trade-off"]
    T1["得る: Health check と front door 検査が消えない"]
    T2["捨てる: drift の検出が deploy の最後になる"]
  end
  subgraph OBJ["③ 反対理由 (#4365 の evidence を継承)"]
    O1["business: 本番未実測なら hotfix を止める → 実測で解消"]
    O2["UX: 当直者に顧客影響が伝わらない → residual"]
    O3["security: secret 平文が runner に載る → 修正済"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 UI 変更なし。本番検証の欠落を防ぐ"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["新規の判断依頼なし（#4365 決裁の履行確認のみ）"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class T2 warn
  class R1,R2,R3,T1,C1 ok
  class O1,O2,O3 warn
  class Q1 ask
```

<details>
<summary>補足（PO は原則読まなくてよい）</summary>

③ は #4365 で生成した `tmp/adversarial-evidence/4365.json`（business / UX / security 3 軸）を継承。本 PR は同一変更の配置のみを変えるもので、新たな反対軸は生じていない。security 軸（`keys()` 射影）と business 軸（本番実測 extra 0 件）は #4365 内で解消済、UX 軸（FAIL 時に顧客影響が読み取れない）は accepted-residual のまま。

**②の trade-off の実質**: drift の検出が deploy の最後になるが、drift は「既に恒久的に残っている状態」であり、数分早く知ることに価値がない。一方 Health check / front door 検査の skip は「本番が壊れていることを検出できない」に直結する。

</details>

---

<!-- QM 追記 (2026-08-07): 本 body は #4322 (PR テンプレート 11 → 7 セクション再構成) 後の
     .github/PR_TEMPLATE_SECTIONS.json に合わせて QM が書き直した。元の 11 セクション版の内容は
     すべて新 7 セクションに移してあり、削った情報は無い。 -->
