### PR TITLE
fix(ci): #4390 base 鮮度検査を足し、pre-ready の保証範囲を出力に明示する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Ready 化前は依然として `npm run pre-ready -- --pr <num>` 全 step PASS �
 
 **Step 番号は表示上の識別子であり実行順ではない (#4048)**。実行は cheap-fail-first — PR body だけを見る検査 (Step 9) → 静的テキスト検査 (1 / 7 / 7g) → 型検査 (2) → SS 系 (11b) の順。
 
-**pre-ready の PASS は「CI 緑」ではない (#4390)**。6 step は worktree HEAD だけを入力にするため、負荷 / タイミング依存の失敗・CI 側 job・**Draft 中しか走らない検査** (`pr-template-gate` は `draft == false` で初めて走る) は原理的に見ていない。加えて step の前に **base 鮮度 preflight** が走り、base が進み、かつ進んだ差分に **pre-ready の検査基準** (`PULL_REQUEST_TEMPLATE.md` / `PR_TEMPLATE_SECTIONS.json` / 検査 script / `scripts/lib/ci/**`) が含まれる場合は **BLOCK する** (手元は旧基準・CI は新基準で判定するため、その PASS は成立しない)。検査基準が動いていなければ注記のみで止めない。
+**pre-ready の PASS は「CI 緑」ではない (#4390)**。6 step は worktree HEAD だけを入力にするため、負荷 / タイミング依存の失敗・CI 側 job・**Draft 中しか走らない検査** (`pr-template-gate` は `draft == false` で初めて走る) は原理的に見ていない。加えて step の前に **base 鮮度 preflight** が走り、base が進み、かつ進んだ差分に **pre-ready の検査基準** (`PULL_REQUEST_TEMPLATE.md` / `PR_TEMPLATE_SECTIONS.json` / 検査 script と**その import 閉包**) が含まれる場合は **BLOCK する** (手元は旧基準・CI は新基準で判定するため、その PASS は成立しない)。検査基準が動いていなければ注記のみで止めない。
 
 E2E / Storybook は別途 (`npx playwright test` / `npm run test:storybook`)。任意: `npx eslint "src/**/*.ts"` (#977) / `npm run type-coverage` / `npm run knip` (#970)。CI 自動拒否は `.github/workflows/ci.yml` 参照。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,8 @@ Ready 化前は依然として `npm run pre-ready -- --pr <num>` 全 step PASS �
 
 **Step 番号は表示上の識別子であり実行順ではない (#4048)**。実行は cheap-fail-first — PR body だけを見る検査 (Step 9) → 静的テキスト検査 (1 / 7 / 7g) → 型検査 (2) → SS 系 (11b) の順。
 
+**pre-ready の PASS は「CI 緑」ではない (#4390)**。6 step は worktree HEAD だけを入力にするため、負荷 / タイミング依存の失敗・CI 側 job・**Draft 中しか走らない検査** (`pr-template-gate` は `draft == false` で初めて走る) は原理的に見ていない。加えて step の前に **base 鮮度 preflight** が走り、base が進み、かつ進んだ差分に **pre-ready の検査基準** (`PULL_REQUEST_TEMPLATE.md` / `PR_TEMPLATE_SECTIONS.json` / 検査 script / `scripts/lib/ci/**`) が含まれる場合は **BLOCK する** (手元は旧基準・CI は新基準で判定するため、その PASS は成立しない)。検査基準が動いていなければ注記のみで止めない。
+
 E2E / Storybook は別途 (`npx playwright test` / `npm run test:storybook`)。任意: `npx eslint "src/**/*.ts"` (#977) / `npm run type-coverage` / `npm run knip` (#970)。CI 自動拒否は `.github/workflows/ci.yml` 参照。
 
 ## 並行実装チェックリスト（修正前必須）

--- a/scripts/lib/ci/resolve-base-branch.mjs
+++ b/scripts/lib/ci/resolve-base-branch.mjs
@@ -274,7 +274,8 @@ export function resolveBaseBranchAuto(opts = {}) {
 export function measureBaseDrift(base, opts = {}) {
 	const cwd = opts.cwd ?? process.cwd();
 	const doFetch = opts.fetch !== false;
-	if (!isAllowedBaseBranch(base)) return { available: false, behind: 0, files: [], fetchFailed: false };
+	if (!isAllowedBaseBranch(base))
+		return { available: false, behind: 0, files: [], fetchFailed: false };
 	/** @param {string} cmd 固定コマンド + validate 済 base 名のみ @param {number} [timeout] ms */
 	const run = (cmd, timeout) =>
 		execSync(cmd, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout }).trim();

--- a/scripts/lib/ci/resolve-base-branch.mjs
+++ b/scripts/lib/ci/resolve-base-branch.mjs
@@ -255,6 +255,55 @@ export function resolveBaseBranchAuto(opts = {}) {
 	});
 }
 
+/**
+ * base branch がどれだけ先に進んでいるか (`behind`) と、進んだ分で何が変わったかを測る (#4390)。
+ *
+ * `--verify-base` が `behind` だけを見て exit code を返していたのに対し、本関数は
+ * **base 側で変わった file 一覧**も返す。pre-ready は「base が動いた」ではなく
+ * 「base が動き、かつ**自分の検査基準**が動いた」かで判定を変えるため、件数だけでは足りない。
+ *
+ * - `HEAD...origin/<base>` (3 点) = merge-base から base 先端までの差分 = **base 側だけの変更**。
+ *   2 点 (`..`) にすると自 branch の変更が逆向きに混ざるため使わない。
+ * - offline / ref 不在は「測れなかった」を返す (`available: false`)。呼び出し側が
+ *   これを stale 扱いに倒すと、offline というだけで全員が止まるため。
+ *
+ * @param {string} base `isAllowedBaseBranch` を通過済みの branch 名 (shell 展開するため)
+ * @param {{ cwd?: string; fetch?: boolean }} [opts]
+ * @returns {{ available: boolean; behind: number; files: string[]; fetchFailed: boolean }}
+ */
+export function measureBaseDrift(base, opts = {}) {
+	const cwd = opts.cwd ?? process.cwd();
+	const doFetch = opts.fetch !== false;
+	if (!isAllowedBaseBranch(base)) return { available: false, behind: 0, files: [], fetchFailed: false };
+	/** @param {string} cmd 固定コマンド + validate 済 base 名のみ @param {number} [timeout] ms */
+	const run = (cmd, timeout) =>
+		execSync(cmd, { cwd, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'], timeout }).trim();
+
+	let fetchFailed = false;
+	if (doFetch) {
+		try {
+			run(`git fetch origin ${base}`, 30_000);
+		} catch {
+			fetchFailed = true; // offline 等。手元の ref で測る
+		}
+	}
+	try {
+		const behind = Number.parseInt(run(`git rev-list --count HEAD..origin/${base}`), 10);
+		if (!Number.isFinite(behind)) return { available: false, behind: 0, files: [], fetchFailed };
+		const files =
+			behind > 0
+				? run(`git diff --name-only HEAD...origin/${base}`)
+						.split('\n')
+						.map((s) => s.trim())
+						.filter(Boolean)
+				: [];
+		return { available: true, behind, files, fetchFailed };
+	} catch {
+		// origin/<base> 不在 (cutover 前 repo / clone 直後) 等 — 測れなかったとして返す
+		return { available: false, behind: 0, files: [], fetchFailed };
+	}
+}
+
 const isMain = isMainModule(import.meta.url);
 
 if (isMain) {

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -313,6 +313,7 @@ export function isGateSsotPath(file) {
  * | level | 意味 | pre-ready の挙動 |
  * |---|---|---|
  * | `fresh` | base の commit を取り込み済み | 何も出さない |
+ * | `unverified` | `git fetch` に失敗し、取り込み済かを判定できていない | 警告 + summary 注記 (**止めない**) |
  * | `behind-only` | base は進んだが検査基準は動いていない | 警告 + summary 注記 (**止めない**) |
  * | `gate-ssot-moved` | base が進み、検査基準まで動いた | **BLOCK** (判定が無効なので測り直す) |
  *
@@ -324,11 +325,14 @@ export function isGateSsotPath(file) {
  * `behind > 0` でも file 一覧が空 (差分取得失敗) なら `behind-only` に倒す。
  * 「測れなかった」を BLOCK にすると offline というだけで止まるため。
  *
- * @param {{ behind: number; baseChangedFiles: string[] }} input
- * @returns {{ level: 'fresh' | 'behind-only' | 'gate-ssot-moved'; gateFiles: string[] }}
+ * @param {{ behind: number; baseChangedFiles: string[]; fetchFailed?: boolean }} input
+ * @returns {{ level: 'fresh' | 'unverified' | 'behind-only' | 'gate-ssot-moved'; gateFiles: string[] }}
  */
-export function classifyBaseDrift({ behind, baseChangedFiles }) {
-	if (!(behind > 0)) return { level: 'fresh', gateFiles: [] };
+export function classifyBaseDrift({ behind, baseChangedFiles, fetchFailed = false }) {
+	// fetch できていないときの behind は「手元 ref との差」でしかない。0 だからといって
+	// base を取り込み済とは言えないので、`fresh` (= 取り込み済と断言する level) にしない。
+	// 断言してしまうと「検証していないことを検証済みとして出力に残す」ことになる (#4390 QM 指摘)。
+	if (!(behind > 0)) return { level: fetchFailed ? 'unverified' : 'fresh', gateFiles: [] };
 	const gateFiles = (baseChangedFiles ?? []).filter(isGateSsotPath);
 	if (gateFiles.length === 0) return { level: 'behind-only', gateFiles: [] };
 	return { level: 'gate-ssot-moved', gateFiles };
@@ -368,6 +372,23 @@ export function buildBaseDriftNote(base, behind) {
 	return (
 		`base 鮮度: origin/${base} が ${behind} commits 先に進んでいます (検査基準は不変のため止めません、#4390)。` +
 		` CI は rebase 後の内容で走るため、Ready 化の直前に \`git rebase origin/${base}\` して再測することを推奨します。`
+	);
+}
+
+/**
+ * `unverified` (git fetch 失敗) で表示する注記 (#4390、unit test 対象)。
+ *
+ * **「取り込み済」と書かない**のが本文言の要件。fetch できていない以上 `behind` は手元 ref
+ * との差でしかなく、実際には base が進んで検査基準が動いていても 0 と出る。ここで OK と
+ * 書くと、検証していない事実を検証済みとして summary に残すことになる (#4390 QM 指摘)。
+ *
+ * @param {string} base
+ * @returns {string}
+ */
+export function buildBaseUnverifiedNote(base) {
+	return (
+		`base 鮮度: 未検証 — \`git fetch origin ${base}\` に失敗したため手元の ref で測っています (#4390)。` +
+		` 取り込み済かどうかは判定できていません。オンラインで \`git fetch origin ${base}\` してから再実行してください。`
 	);
 }
 
@@ -1029,18 +1050,25 @@ async function main() {
 			`[pre-ready] base 鮮度: 測定不能 (origin/${baseBranch} 未取得 / lane 外 base) — 判定をスキップします (#4390)`,
 		);
 	} else {
-		if (drift.fetchFailed) {
-			console.warn(
-				`[pre-ready] WARN: git fetch origin ${baseBranch} 失敗 (offline?) — 手元 ref で鮮度を判定します (#4390)`,
-			);
-		}
-		const verdict = classifyBaseDrift({ behind: drift.behind, baseChangedFiles: drift.files });
+		const verdict = classifyBaseDrift({
+			behind: drift.behind,
+			baseChangedFiles: drift.files,
+			fetchFailed: drift.fetchFailed,
+		});
 		if (verdict.level === 'gate-ssot-moved') {
 			console.error(`\n${buildBaseDriftBlockMessage(baseBranch, drift.behind, verdict.gateFiles)}`);
 			return 1;
 		}
-		if (verdict.level === 'behind-only') {
+		if (verdict.level === 'unverified') {
+			// fetch 失敗。**OK と書かない** — summary にも注記として残し、
+			// 「測れなかった」ことが後から読む人 (QM) に見えるようにする (#4390)。
+			baseDriftNote = buildBaseUnverifiedNote(baseBranch);
+			console.warn(`[pre-ready] ⚠ ${baseDriftNote}`);
+		} else if (verdict.level === 'behind-only') {
 			baseDriftNote = buildBaseDriftNote(baseBranch, drift.behind);
+			if (drift.fetchFailed) {
+				baseDriftNote = `${baseDriftNote} (なお \`git fetch\` に失敗しているため、この commits 数は手元 ref 基準です)`;
+			}
 			console.warn(`[pre-ready] ⚠ ${baseDriftNote}`);
 		} else {
 			console.log(`[pre-ready] base 鮮度: OK (origin/${baseBranch} を取り込み済、#4390)`);

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -131,8 +131,8 @@ Steps (6 本。番号は既存の識別子を維持 — 実行順は下記「実
 step の前に走る preflight:
   依存 preflight (#3857)  隔離 worktree の node_modules 欠落を fail-fast
   base 鮮度 (#4390)       origin/<base> がどれだけ進んだかと、進んだ分に **pre-ready の検査基準**
-                          (PULL_REQUEST_TEMPLATE.md / PR_TEMPLATE_SECTIONS.json / 検査 script /
-                           scripts/lib/ci/**) が含まれるかを見る。
+                          (PULL_REQUEST_TEMPLATE.md / PR_TEMPLATE_SECTIONS.json / 検査 script と
+                           その import 閉包) が含まれるかを見る。
                             - 含まれる  → BLOCK。手元は旧基準、CI は新基準で判定するため測り直しが要る
                             - 含まれない → 警告 + summary 注記のみ (base は日に何度も進むので止めない)
 
@@ -276,21 +276,27 @@ export const PRE_READY_GATE_SSOT_PATHS = /** @type {const} */ ([
 	'scripts/check-local-tz-date-getters.mjs',
 	'scripts/pre-ready.mjs',
 	// 上記 script が import する sibling module (判定ロジック本体はこちら側にある)。
-	// `scripts/` 全体を prefix にすると無関係な script の変更まで BLOCK するため個別列挙し、
-	// 列挙漏れは tests/unit/scripts/pre-ready-base-freshness.test.ts [B13] が
-	// 実際の import 閉包と突き合わせて機械検出する (#4390)。
+	// ディレクトリ prefix (`scripts/` / `scripts/lib/ci/`) で一括指定すると、pre-ready が
+	// 一度も読まない script の変更まで BLOCK する。実際 `scripts/lib/ci/` 13 file のうち
+	// pre-ready の import 閉包に入るのは 4 file だけで、残り 9 file (ページガイド撮影ヘルパ等) を
+	// 直しただけで全 PR の pre-ready が止まっていた。**手元と CI で読む SSOT が食い違う**という
+	// 止める根拠が成立しない file で止めるのは「理由の分からない BLOCK」であり、
+	// gate への信頼を削って迂回行動を誘発する。よって閉包に実在する file だけを個別列挙する。
+	// 列挙漏れ / 余分な列挙は tests/unit/scripts/pre-ready-base-freshness.test.ts [B13] が
+	// 実際の import 閉包と両方向で突き合わせて機械検出する (#4390)。
 	'scripts/check-ac-verification-map.mjs',
 	'scripts/integration-pr-body.mjs',
 	'scripts/pr-lane.mjs',
 	'scripts/pr-template-gate-checks.mjs',
 	'scripts/lib/is-main.mjs',
+	'scripts/lib/ci/pr-body-sections.mjs',
+	'scripts/lib/ci/reason-declaration.mjs',
+	'scripts/lib/ci/resolve-base-branch.mjs',
+	'scripts/lib/ci/tz-invariance-cases.mjs',
 	// Step 1 / 2 の設定
 	'biome.json',
 	'tsconfig.json',
 ]);
-
-/** 配下すべてを検査基準とみなす prefix (個別列挙すると追加のたびに漏れる)。 */
-export const PRE_READY_GATE_SSOT_PREFIXES = /** @type {const} */ (['scripts/lib/ci/']);
 
 /**
  * path が pre-ready の検査基準かを判定する (#4390、unit test 対象)。
@@ -301,10 +307,7 @@ export const PRE_READY_GATE_SSOT_PREFIXES = /** @type {const} */ (['scripts/lib/
  */
 export function isGateSsotPath(file) {
 	const p = String(file).replace(/\\/g, '/');
-	return (
-		PRE_READY_GATE_SSOT_PATHS.includes(/** @type {never} */ (p)) ||
-		PRE_READY_GATE_SSOT_PREFIXES.some((prefix) => p.startsWith(prefix))
-	);
+	return PRE_READY_GATE_SSOT_PATHS.includes(/** @type {never} */ (p));
 }
 
 /**

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -275,6 +275,15 @@ export const PRE_READY_GATE_SSOT_PATHS = /** @type {const} */ ([
 	'scripts/check-no-plan-literals.mjs',
 	'scripts/check-local-tz-date-getters.mjs',
 	'scripts/pre-ready.mjs',
+	// 上記 script が import する sibling module (判定ロジック本体はこちら側にある)。
+	// `scripts/` 全体を prefix にすると無関係な script の変更まで BLOCK するため個別列挙し、
+	// 列挙漏れは tests/unit/scripts/pre-ready-base-freshness.test.ts [B13] が
+	// 実際の import 閉包と突き合わせて機械検出する (#4390)。
+	'scripts/check-ac-verification-map.mjs',
+	'scripts/integration-pr-body.mjs',
+	'scripts/pr-lane.mjs',
+	'scripts/pr-template-gate-checks.mjs',
+	'scripts/lib/is-main.mjs',
 	// Step 1 / 2 の設定
 	'biome.json',
 	'tsconfig.json',

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -44,6 +44,7 @@ import { fileURLToPath } from 'node:url';
 import {
 	isAllowedBaseBranch,
 	isSafeGitRefName,
+	measureBaseDrift,
 	resolveBaseBranchAuto,
 } from './lib/ci/resolve-base-branch.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
@@ -126,6 +127,14 @@ Steps (6 本。番号は既存の識別子を維持 — 実行順は下記「実
        ただし本 step は checkScreenshotEmbedReadiness まで見るため CI より広い —
        「未来形記述 (後で push する)」「該当なしマーカー」は本 step だけが hard-fail する。
        委譲の宣言 SSOT: scripts/lib/ci/workflow-judgment-registry.mjs
+
+step の前に走る preflight:
+  依存 preflight (#3857)  隔離 worktree の node_modules 欠落を fail-fast
+  base 鮮度 (#4390)       origin/<base> がどれだけ進んだかと、進んだ分に **pre-ready の検査基準**
+                          (PULL_REQUEST_TEMPLATE.md / PR_TEMPLATE_SECTIONS.json / 検査 script /
+                           scripts/lib/ci/**) が含まれるかを見る。
+                            - 含まれる  → BLOCK。手元は旧基準、CI は新基準で判定するため測り直しが要る
+                            - 含まれない → 警告 + summary 注記のみ (base は日に何度も進むので止めない)
 
 選定基準 (ADR-0007 §1-2 判断原則 v2、#4121):
   類型 1 (証跡の真正性 / 不可逆な損失) と 類型 2 (顧客に見える正しさ) のうち安価なものだけを
@@ -232,6 +241,124 @@ export function buildBaseClampNote(original, reason) {
 		'変更集合が PR の実差分と一致していません。条件付き step ' +
 		'(lp-dimensions / lp-fallback / lp-labels / ss-embed-gate / capture) の判定は ' +
 		'PR の実差分ではなく clamp 後の差分に基づきます (#4046)'
+	);
+}
+
+// ---------------------------------------------------------------------------
+// base 鮮度 (#4390)
+// ---------------------------------------------------------------------------
+
+/**
+ * pre-ready の 6 step が「判定の基準」として読むファイル (#4390)。
+ *
+ * pre-ready は branch を単体で見る。base が動いてもこの一覧が動いていなければ、
+ * 手元で出した判定は rebase 後もそのまま成立する。逆に**この一覧が base 側で動くと、
+ * 同じ branch・同じ PR body のまま手元 PASS / CI FAIL に化ける**。
+ *
+ * 実測 (#4322): develop 側で `PULL_REQUEST_TEMPLATE.md` と `PR_TEMPLATE_SECTIONS.json` が
+ * 11 → 7 セクションに作り替えられ、セクション名も入れ替わった。旧構成のまま残っていた 6 PR は
+ * branch tip では「旧 SSOT と旧 body」が整合するため pre-ready が通り、rebase した瞬間に
+ * `必須セクションの存在確認` が全滅した。
+ *
+ * 一覧は **pre-ready が実際に読む / spawn するもの**だけに絞る。「base が動いたら常に止める」は
+ * base が日に何度も動く以上 pre-ready を使い物にしなくするので採らない (#4390 決定)。
+ */
+export const PRE_READY_GATE_SSOT_PATHS = /** @type {const} */ ([
+	// Step 9 (check-pr-body) が読む必須セクション SSOT — #4322 で実際に動いた 2 本
+	'.github/PULL_REQUEST_TEMPLATE.md',
+	'.github/PR_TEMPLATE_SECTIONS.json',
+	'.github/INTEGRATION_PR_TEMPLATE.md',
+	'.github/INTEGRATION_PR_TEMPLATE_SECTIONS.json',
+	// pre-ready が spawn する検査 script 本体
+	'scripts/check-pr-body.mjs',
+	'scripts/check-pr-screenshot.mjs',
+	'scripts/check-no-plan-literals.mjs',
+	'scripts/check-local-tz-date-getters.mjs',
+	'scripts/pre-ready.mjs',
+	// Step 1 / 2 の設定
+	'biome.json',
+	'tsconfig.json',
+]);
+
+/** 配下すべてを検査基準とみなす prefix (個別列挙すると追加のたびに漏れる)。 */
+export const PRE_READY_GATE_SSOT_PREFIXES = /** @type {const} */ (['scripts/lib/ci/']);
+
+/**
+ * path が pre-ready の検査基準かを判定する (#4390、unit test 対象)。
+ * git の出力は `/` 区切りだが、呼び出し側が Windows 由来の `\` を渡しても同じ判定にする。
+ *
+ * @param {string} file
+ * @returns {boolean}
+ */
+export function isGateSsotPath(file) {
+	const p = String(file).replace(/\\/g, '/');
+	return (
+		PRE_READY_GATE_SSOT_PATHS.includes(/** @type {never} */ (p)) ||
+		PRE_READY_GATE_SSOT_PREFIXES.some((prefix) => p.startsWith(prefix))
+	);
+}
+
+/**
+ * base 鮮度を 3 分類する (#4390、unit test 対象)。
+ *
+ * | level | 意味 | pre-ready の挙動 |
+ * |---|---|---|
+ * | `fresh` | base の commit を取り込み済み | 何も出さない |
+ * | `behind-only` | base は進んだが検査基準は動いていない | 警告 + summary 注記 (**止めない**) |
+ * | `gate-ssot-moved` | base が進み、検査基準まで動いた | **BLOCK** (判定が無効なので測り直す) |
+ *
+ * hard-fail を `gate-ssot-moved` だけに絞る根拠 (#4390): base (develop) は日に何度も動くため
+ * 「behind > 0 で常に止める」は pre-ready の実行回数ぶんだけ rebase を強制し、CI 待ちを増やす。
+ * 一方 #4322 の実害 (6 PR × 1 サイクル) は **検査基準が動いた時にだけ**発生した。
+ * 止める条件を実害の形に一致させ、それ以外は注記で済ませる。
+ *
+ * `behind > 0` でも file 一覧が空 (差分取得失敗) なら `behind-only` に倒す。
+ * 「測れなかった」を BLOCK にすると offline というだけで止まるため。
+ *
+ * @param {{ behind: number; baseChangedFiles: string[] }} input
+ * @returns {{ level: 'fresh' | 'behind-only' | 'gate-ssot-moved'; gateFiles: string[] }}
+ */
+export function classifyBaseDrift({ behind, baseChangedFiles }) {
+	if (!(behind > 0)) return { level: 'fresh', gateFiles: [] };
+	const gateFiles = (baseChangedFiles ?? []).filter(isGateSsotPath);
+	if (gateFiles.length === 0) return { level: 'behind-only', gateFiles: [] };
+	return { level: 'gate-ssot-moved', gateFiles };
+}
+
+/**
+ * `gate-ssot-moved` で表示する BLOCK 文言 (#4390、unit test 対象)。
+ * 「何が動いたか」と「どうすれば直るか」を必ず両方書く。
+ *
+ * @param {string} base
+ * @param {number} behind
+ * @param {string[]} gateFiles
+ * @returns {string}
+ */
+export function buildBaseDriftBlockMessage(base, behind, gateFiles) {
+	return (
+		`[pre-ready] ✗ base 鮮度 FAIL — origin/${base} が ${behind} commits 先に進み、\n` +
+		`  pre-ready の検査基準そのものが動いています (#4390):\n` +
+		gateFiles.map((f) => `    - ${f}`).join('\n') +
+		'\n' +
+		'  この状態で出した PASS は rebase 後も成立するとは限りません。手元は旧基準で判定し、\n' +
+		'  CI は rebase 後の新基準で判定するためです (実測 #4322: 6 PR が同じ body のまま一斉に赤)。\n' +
+		'  対応:\n' +
+		`    git fetch origin ${base} && git rebase origin/${base}\n` +
+		'    # rebase 後、PR body を新しい必須セクション構成に合わせてから pre-ready を再実行する'
+	);
+}
+
+/**
+ * `behind-only` で表示する注記 (#4390、unit test 対象)。**止めない**ことを明示する。
+ *
+ * @param {string} base
+ * @param {number} behind
+ * @returns {string}
+ */
+export function buildBaseDriftNote(base, behind) {
+	return (
+		`base 鮮度: origin/${base} が ${behind} commits 先に進んでいます (検査基準は不変のため止めません、#4390)。` +
+		` CI は rebase 後の内容で走るため、Ready 化の直前に \`git rebase origin/${base}\` して再測することを推奨します。`
 	);
 }
 
@@ -576,7 +703,7 @@ export function skipStateOf({
  *
  * @param {{ totalSteps: number; skippedByFlag: string[]; skippedScriptMissing: string[];
  *           skippedPrMissing?: string[]; skippedNotApplicable: string[];
- *           failOpenCount?: number; pr?: string | null }} input
+ *           failOpenCount?: number; pr?: string | null; baseDriftNote?: string | null }} input
  * @returns {{ status: 'ALL_PASS' | 'PARTIAL_PASS'; text: string }}
  */
 export function buildSummary({
@@ -587,18 +714,23 @@ export function buildSummary({
 	skippedNotApplicable,
 	failOpenCount = 0,
 	pr = null,
+	baseDriftNote = null,
 }) {
-	// #4121: pre-ready 外 (CI 側 hard-fail) で走る検査の確認手順。step から外したことと
-	// 検査を消したことは別なので、外した先を必ず名指しする。
+	// #4121 / #4390: pre-ready が **何を保証しないか** を出す。step から外したことと検査を消したことは
+	// 別なので外した先を名指しし、あわせて「ローカルでは原理的に測れないもの」も並べる。
+	// 「ALL PASS」を CI 緑の予測と読まれるのが実害の起点だったため、保証範囲を毎回同じ位置に置く。
 	const ciSideBlock =
-		`  pre-ready 外の検査 (CI で hard-fail、#4121):\n` +
-		`    - unit-test        vitest (2 shard)\n` +
-		`    - lint-and-test    cspell / hardcoded-strings / doc-code-references / terminology-coherence /\n` +
-		`                       license-key-leak / CLI entry guard 系 / generate-lp-labels --check ほか\n` +
-		`    - lp-metrics       LP 寸法・禁止語 (LP 変更時)\n` +
-		`    - lp-fallback-check LP fallback 同期 (LP / labels.ts 変更時)\n` +
-		`    Ready 化前に \`gh pr checks ${pr ?? '<num>'}\` でこれらが **pass (skipped でない)** ことを確認する。\n` +
-		`    \`ci-gate\` は skipped を failure として数えないため、ci-gate green を根拠にしない。\n`;
+		`  pre-ready が保証するのは上の 6 step だけです。以下は保証しません:\n` +
+		`    - 負荷 / タイミング依存の失敗   空いた local では再現しない (実測 #4385: 同一 test が 1,860→6,398ms)\n` +
+		`    - vitest / e2e / Storybook / visual regression   CI (unit-test 2 shard / 重量レーン) で走る\n` +
+		`    - lint-and-test 系   cspell / hardcoded-strings / doc-code-references / terminology-coherence /\n` +
+		`                         license-key-leak / CLI entry guard 系 / generate-lp-labels --check ほか\n` +
+		`    - LP 系   lp-metrics (寸法・禁止語) / lp-fallback-check (fallback 同期)\n` +
+		`    - Draft 中しか見ていない検査   pr-template-gate は draft==false で初めて走る (#4390)\n` +
+		`    - base が動いた後の再測   base の検査基準が動くと同じ body でも CI は赤になる (#4322 で 6 PR 実測)\n` +
+		`    → \`gh pr checks ${pr ?? '<num>'}\` で上記が **pass (skipped でない)** ことを確認してから Ready 化する。\n` +
+		`      \`ci-gate\` は skipped を failure に数えないため、ci-gate green を根拠にしない。\n`;
+	const baseDriftLine = baseDriftNote ? `  ⚠ ${baseDriftNote}\n` : '';
 	// 適用対象外 (n/a) は「実行しなくてよいので実行していない」であり ALL PASS を妨げない。
 	const notApplicableLine =
 		skippedNotApplicable.length > 0
@@ -630,6 +762,7 @@ export function buildSummary({
 				`\n[pre-ready] PARTIAL PASS — 実行した ${ran} step は PASS しましたが、` +
 				`${detail} が未実行です。\n` +
 				notApplicableLine +
+				baseDriftLine +
 				`  これは開発中の部分確認結果であり、Ready 化 (gh pr ready) 判定には\n` +
 				`  skip なしの \`npm run pre-ready -- --pr ${pr ?? '<num>'}\` 全 step PASS が必要です。\n` +
 				ciSideBlock,
@@ -639,8 +772,12 @@ export function buildSummary({
 	return {
 		status: 'ALL_PASS',
 		text:
-			`\n[pre-ready] ALL PASS (pre-ready 6 step)${failOpenCount > 0 ? ` (fail-open ${failOpenCount} 件あり — 上記 ⚠ を確認)` : ''} — Ready for Review に進めます。\n` +
+			// #4390: 「ALL PASS」単独だと「CI 緑の予測」と読まれる (本日 6 PR が ALL PASS のまま CI red)。
+			// 保証の範囲を見出し行に書き切る。
+			`\n[pre-ready] PASS — pre-ready 6 step の範囲でのみ緑です (CI 緑の予測ではありません、#4390)` +
+			`${failOpenCount > 0 ? ` / fail-open ${failOpenCount} 件あり — 上記 ⚠ を確認` : ''}\n` +
 			notApplicableLine +
+			baseDriftLine +
 			ciSideBlock +
 			`  次の手順:\n` +
 			`    1. node scripts/check-gh-account-before-pr.mjs   # gh アカウント確認 (#1728)\n` +
@@ -874,6 +1011,33 @@ async function main() {
 	}
 	console.log(`[pre-ready] base branch: origin/${baseBranch} (#2959 SSOT 解決)`);
 
+	// #4390: base 鮮度。pre-ready は branch を単体で見るため、base が動くと判定が黙って無効になる。
+	// 検査基準 (PR テンプレート SSOT / 検査 script) まで動いていたら BLOCK、それ以外は注記のみ。
+	let baseDriftNote = null;
+	const drift = measureBaseDrift(baseBranch, { cwd: repoRoot });
+	if (!drift.available) {
+		console.log(
+			`[pre-ready] base 鮮度: 測定不能 (origin/${baseBranch} 未取得 / lane 外 base) — 判定をスキップします (#4390)`,
+		);
+	} else {
+		if (drift.fetchFailed) {
+			console.warn(
+				`[pre-ready] WARN: git fetch origin ${baseBranch} 失敗 (offline?) — 手元 ref で鮮度を判定します (#4390)`,
+			);
+		}
+		const verdict = classifyBaseDrift({ behind: drift.behind, baseChangedFiles: drift.files });
+		if (verdict.level === 'gate-ssot-moved') {
+			console.error(`\n${buildBaseDriftBlockMessage(baseBranch, drift.behind, verdict.gateFiles)}`);
+			return 1;
+		}
+		if (verdict.level === 'behind-only') {
+			baseDriftNote = buildBaseDriftNote(baseBranch, drift.behind);
+			console.warn(`[pre-ready] ⚠ ${baseDriftNote}`);
+		} else {
+			console.log(`[pre-ready] base 鮮度: OK (origin/${baseBranch} を取り込み済、#4390)`);
+		}
+	}
+
 	// 変更ファイル取得 (LP / UI 変更検知用)
 	const changedFiles = await getChangedFiles(baseBranch);
 	if (changedFiles.length === 0) {
@@ -936,6 +1100,7 @@ async function main() {
 		skippedNotApplicable,
 		failOpenCount: failOpenNotes.length,
 		pr: args.pr,
+		baseDriftNote,
 	});
 	console.log(summary.text);
 	return 0;

--- a/tests/unit/scripts/pre-ready-base-freshness.test.ts
+++ b/tests/unit/scripts/pre-ready-base-freshness.test.ts
@@ -3,33 +3,66 @@
  *
  * 背景 (実測): #4322 が develop 側で PR テンプレートを 11 → 7 セクションに作り替えたあと、
  * 旧構成のまま残っていた 6 PR が rebase した瞬間に `必須セクションの存在確認` で全滅した。
- * branch tip では「旧 SSOT と旧 body」が整合しているため pre-ready は ALL PASS を返し、
+ * branch tip では「旧 SSOT と旧 body」が整合しているため pre-ready は PASS を返し、
  * rebase して初めて赤になる。pre-ready が branch を単体でしか見ておらず、
  * **base の移動で自分の判定が黙って無効になることを検出できない**のが根本原因。
  *
- * 本 test は判定の中核 (`classifyBaseDrift`) を pin する:
+ * 本 test は判定の中核 (`classifyBaseDrift` / `isGateSsotPath`) を pin する:
  *   - base が動いていない通常ケースを止めない (回帰。ここで止まると全 PR が止まる)
  *   - base は動いたが検査基準は動いていない → 警告のみ (日に何度も動くので止めない)
  *   - base が動き、かつ **pre-ready の検査基準そのもの** が動いた → BLOCK (#4322 の実害形)
+ *
+ * ## 呼び出し方式
+ *
+ * `pre-ready.mjs` は plain .mjs (未 JSDoc 型) で、.ts から静的 import すると svelte-check の
+ * 型 program に取り込まれ既存の implicit-any を大量に露出する (実測 31 errors)。
+ * `pre-ready-skip-classification.test.ts` (#4018) と同じく node 子プロセスの dynamic import
+ * 経由で呼ぶ (isMain guard により import 時に main() は走らない)。
  */
 
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import {
-	buildBaseDriftBlockMessage,
-	buildBaseDriftNote,
-	classifyBaseDrift,
-	isGateSsotPath,
-	PRE_READY_GATE_SSOT_PREFIXES,
-} from '../../../scripts/pre-ready.mjs';
 
-describe('classifyBaseDrift — base 鮮度の 3 分類 (#4390)', () => {
-	it('base が動いていなければ fresh (通常ケースを止めない)', () => {
+const repoRoot = resolve(fileURLToPath(import.meta.url), '../../../..');
+const preReadyUrl = pathToFileURL(resolve(repoRoot, 'scripts/pre-ready.mjs')).href;
+
+/** pre-ready.mjs の named export を子プロセスで呼び、戻り値を JSON で受け取る。 */
+function callExport<T>(fnName: string, ...args: unknown[]): T {
+	const argList = args.map((a) => JSON.stringify(a)).join(', ');
+	const code = `const m = await import(${JSON.stringify(preReadyUrl)});
+process.stdout.write(JSON.stringify(m[${JSON.stringify(fnName)}](${argList})));`;
+	const out = execFileSync(process.execPath, ['--input-type=module', '-e', code], {
+		encoding: 'utf8',
+	});
+	return JSON.parse(out) as T;
+}
+
+/** pre-ready.mjs の named export (定数) を子プロセスで読み出す。 */
+function readExport<T>(name: string): T {
+	const code = `const m = await import(${JSON.stringify(preReadyUrl)});
+process.stdout.write(JSON.stringify(m[${JSON.stringify(name)}]));`;
+	const out = execFileSync(process.execPath, ['--input-type=module', '-e', code], {
+		encoding: 'utf8',
+	});
+	return JSON.parse(out) as T;
+}
+
+type Drift = { level: 'fresh' | 'behind-only' | 'gate-ssot-moved'; gateFiles: string[] };
+
+const classifyBaseDrift = (arg: { behind: number; baseChangedFiles: string[] }) =>
+	callExport<Drift>('classifyBaseDrift', arg);
+const isGateSsotPath = (file: string) => callExport<boolean>('isGateSsotPath', file);
+
+describe('#4390 classifyBaseDrift — base 鮮度の 3 分類', () => {
+	it('[B1] base が動いていなければ fresh (通常ケースを止めない)', () => {
 		const r = classifyBaseDrift({ behind: 0, baseChangedFiles: [] });
 		expect(r.level).toBe('fresh');
 		expect(r.gateFiles).toEqual([]);
 	});
 
-	it('base が動いても検査基準を含まなければ behind-only (警告のみ)', () => {
+	it('[B2] base が動いても検査基準を含まなければ behind-only (警告のみ)', () => {
 		const r = classifyBaseDrift({
 			behind: 12,
 			baseChangedFiles: ['src/lib/server/services/activity-service.ts', 'docs/CLAUDE.md'],
@@ -38,7 +71,7 @@ describe('classifyBaseDrift — base 鮮度の 3 分類 (#4390)', () => {
 		expect(r.gateFiles).toEqual([]);
 	});
 
-	it('base の差分が PR テンプレート SSOT を含めば gate-ssot-moved (#4322 の実害形)', () => {
+	it('[B3] base の差分が PR テンプレート SSOT を含めば gate-ssot-moved (#4322 の実害形)', () => {
 		const r = classifyBaseDrift({
 			behind: 3,
 			baseChangedFiles: [
@@ -48,27 +81,25 @@ describe('classifyBaseDrift — base 鮮度の 3 分類 (#4390)', () => {
 			],
 		});
 		expect(r.level).toBe('gate-ssot-moved');
+		// 「何が動いたか」を出せるよう、該当 file だけを残すこと
 		expect(r.gateFiles).toEqual([
 			'.github/PR_TEMPLATE_SECTIONS.json',
 			'.github/PULL_REQUEST_TEMPLATE.md',
 		]);
 	});
 
-	it('base の差分が pre-ready が spawn する検査 script を含めば gate-ssot-moved', () => {
-		const r = classifyBaseDrift({
-			behind: 1,
-			baseChangedFiles: ['scripts/check-pr-body.mjs'],
-		});
-		expect(r.level).toBe('gate-ssot-moved');
+	it('[B4] base の差分が pre-ready が spawn する検査 script を含めば gate-ssot-moved', () => {
+		expect(
+			classifyBaseDrift({ behind: 1, baseChangedFiles: ['scripts/check-pr-body.mjs'] }).level,
+		).toBe('gate-ssot-moved');
 	});
 
-	it('behind > 0 でも baseChangedFiles が空なら behind-only に倒す (差分取得失敗を BLOCK にしない)', () => {
-		const r = classifyBaseDrift({ behind: 5, baseChangedFiles: [] });
-		expect(r.level).toBe('behind-only');
+	it('[B5] behind > 0 でも差分一覧が空なら behind-only (差分取得失敗を BLOCK にしない)', () => {
+		// offline / ref 不在で「測れなかった」ときに全員が止まるのを避ける
+		expect(classifyBaseDrift({ behind: 5, baseChangedFiles: [] }).level).toBe('behind-only');
 	});
 
-	it('behind が 0 なら検査基準が動いていても fresh (自分の branch に取り込み済み)', () => {
-		// behind 0 = base の commit は既に HEAD に入っている。取り込み済みの変更で止めない。
+	it('[B6] behind が 0 なら検査基準が差分にあっても fresh (取り込み済みで止めない)', () => {
 		const r = classifyBaseDrift({
 			behind: 0,
 			baseChangedFiles: ['.github/PR_TEMPLATE_SECTIONS.json'],
@@ -77,37 +108,40 @@ describe('classifyBaseDrift — base 鮮度の 3 分類 (#4390)', () => {
 	});
 });
 
-describe('isGateSsotPath — 検査基準の判定 (#4390)', () => {
-	it('scripts/lib/ci/ 配下は prefix で一括して検査基準扱い', () => {
-		expect(PRE_READY_GATE_SSOT_PREFIXES).toContain('scripts/lib/ci/');
+describe('#4390 isGateSsotPath — 検査基準の判定', () => {
+	it('[B7] scripts/lib/ci/ 配下は prefix で一括して検査基準扱い', () => {
+		expect(readExport<string[]>('PRE_READY_GATE_SSOT_PREFIXES')).toContain('scripts/lib/ci/');
 		expect(isGateSsotPath('scripts/lib/ci/pr-body-sections.mjs')).toBe(true);
 	});
 
-	it('検査基準でない path は false (over-block しない)', () => {
+	it('[B8] 検査基準でない path は false (over-block しない)', () => {
 		expect(isGateSsotPath('src/lib/domain/labels.ts')).toBe(false);
 		expect(isGateSsotPath('docs/decisions/README.md')).toBe(false);
 		// 名前が似ているだけの path を拾わない
 		expect(isGateSsotPath('tests/unit/scripts/check-pr-body.test.ts')).toBe(false);
 	});
 
-	it('Windows の \\ 区切りでも同じ判定になる', () => {
+	it('[B9] Windows の \\ 区切りでも同じ判定になる', () => {
 		expect(isGateSsotPath('.github\\PR_TEMPLATE_SECTIONS.json')).toBe(true);
 		expect(isGateSsotPath('scripts\\lib\\ci\\resolve-base-branch.mjs')).toBe(true);
 	});
 });
 
-describe('BLOCK / 警告の文言 (#4390)', () => {
-	it('BLOCK 文言は「何が動いたか」と「どうすれば直るか」を両方持つ', () => {
-		const msg = buildBaseDriftBlockMessage('develop', 3, ['.github/PR_TEMPLATE_SECTIONS.json']);
+describe('#4390 BLOCK / 警告の文言', () => {
+	it('[B10] BLOCK 文言は「何が動いたか」と「どう直すか」を両方持つ', () => {
+		const msg = callExport<string>('buildBaseDriftBlockMessage', 'develop', 3, [
+			'.github/PR_TEMPLATE_SECTIONS.json',
+		]);
 		expect(msg).toContain('.github/PR_TEMPLATE_SECTIONS.json');
 		expect(msg).toContain('git rebase origin/develop');
 		// 「なぜ止めたか」= 判定が無効になっている、が読み取れること
 		expect(msg).toContain('検査基準');
 	});
 
-	it('警告文言は commit 数と base 名を持ち、rebase を促すが止めない旨を書く', () => {
-		const note = buildBaseDriftNote('develop', 12);
+	it('[B11] 警告文言は commit 数と base 名を持ち、止めない旨が読める', () => {
+		const note = callExport<string>('buildBaseDriftNote', 'develop', 12);
 		expect(note).toContain('12');
 		expect(note).toContain('develop');
+		expect(note).toContain('止めません');
 	});
 });

--- a/tests/unit/scripts/pre-ready-base-freshness.test.ts
+++ b/tests/unit/scripts/pre-ready-base-freshness.test.ts
@@ -1,0 +1,113 @@
+/**
+ * pre-ready の base 鮮度検査 (#4390)
+ *
+ * 背景 (実測): #4322 が develop 側で PR テンプレートを 11 → 7 セクションに作り替えたあと、
+ * 旧構成のまま残っていた 6 PR が rebase した瞬間に `必須セクションの存在確認` で全滅した。
+ * branch tip では「旧 SSOT と旧 body」が整合しているため pre-ready は ALL PASS を返し、
+ * rebase して初めて赤になる。pre-ready が branch を単体でしか見ておらず、
+ * **base の移動で自分の判定が黙って無効になることを検出できない**のが根本原因。
+ *
+ * 本 test は判定の中核 (`classifyBaseDrift`) を pin する:
+ *   - base が動いていない通常ケースを止めない (回帰。ここで止まると全 PR が止まる)
+ *   - base は動いたが検査基準は動いていない → 警告のみ (日に何度も動くので止めない)
+ *   - base が動き、かつ **pre-ready の検査基準そのもの** が動いた → BLOCK (#4322 の実害形)
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	PRE_READY_GATE_SSOT_PREFIXES,
+	buildBaseDriftBlockMessage,
+	buildBaseDriftNote,
+	classifyBaseDrift,
+	isGateSsotPath,
+} from '../../../scripts/pre-ready.mjs';
+
+describe('classifyBaseDrift — base 鮮度の 3 分類 (#4390)', () => {
+	it('base が動いていなければ fresh (通常ケースを止めない)', () => {
+		const r = classifyBaseDrift({ behind: 0, baseChangedFiles: [] });
+		expect(r.level).toBe('fresh');
+		expect(r.gateFiles).toEqual([]);
+	});
+
+	it('base が動いても検査基準を含まなければ behind-only (警告のみ)', () => {
+		const r = classifyBaseDrift({
+			behind: 12,
+			baseChangedFiles: ['src/lib/server/services/activity-service.ts', 'docs/CLAUDE.md'],
+		});
+		expect(r.level).toBe('behind-only');
+		expect(r.gateFiles).toEqual([]);
+	});
+
+	it('base の差分が PR テンプレート SSOT を含めば gate-ssot-moved (#4322 の実害形)', () => {
+		const r = classifyBaseDrift({
+			behind: 3,
+			baseChangedFiles: [
+				'src/routes/+page.svelte',
+				'.github/PR_TEMPLATE_SECTIONS.json',
+				'.github/PULL_REQUEST_TEMPLATE.md',
+			],
+		});
+		expect(r.level).toBe('gate-ssot-moved');
+		expect(r.gateFiles).toEqual([
+			'.github/PR_TEMPLATE_SECTIONS.json',
+			'.github/PULL_REQUEST_TEMPLATE.md',
+		]);
+	});
+
+	it('base の差分が pre-ready が spawn する検査 script を含めば gate-ssot-moved', () => {
+		const r = classifyBaseDrift({
+			behind: 1,
+			baseChangedFiles: ['scripts/check-pr-body.mjs'],
+		});
+		expect(r.level).toBe('gate-ssot-moved');
+	});
+
+	it('behind > 0 でも baseChangedFiles が空なら behind-only に倒す (差分取得失敗を BLOCK にしない)', () => {
+		const r = classifyBaseDrift({ behind: 5, baseChangedFiles: [] });
+		expect(r.level).toBe('behind-only');
+	});
+
+	it('behind が 0 なら検査基準が動いていても fresh (自分の branch に取り込み済み)', () => {
+		// behind 0 = base の commit は既に HEAD に入っている。取り込み済みの変更で止めない。
+		const r = classifyBaseDrift({
+			behind: 0,
+			baseChangedFiles: ['.github/PR_TEMPLATE_SECTIONS.json'],
+		});
+		expect(r.level).toBe('fresh');
+	});
+});
+
+describe('isGateSsotPath — 検査基準の判定 (#4390)', () => {
+	it('scripts/lib/ci/ 配下は prefix で一括して検査基準扱い', () => {
+		expect(PRE_READY_GATE_SSOT_PREFIXES).toContain('scripts/lib/ci/');
+		expect(isGateSsotPath('scripts/lib/ci/pr-body-sections.mjs')).toBe(true);
+	});
+
+	it('検査基準でない path は false (over-block しない)', () => {
+		expect(isGateSsotPath('src/lib/domain/labels.ts')).toBe(false);
+		expect(isGateSsotPath('docs/decisions/README.md')).toBe(false);
+		// 名前が似ているだけの path を拾わない
+		expect(isGateSsotPath('tests/unit/scripts/check-pr-body.test.ts')).toBe(false);
+	});
+
+	it('Windows の \\ 区切りでも同じ判定になる', () => {
+		expect(isGateSsotPath('.github\\PR_TEMPLATE_SECTIONS.json')).toBe(true);
+		expect(isGateSsotPath('scripts\\lib\\ci\\resolve-base-branch.mjs')).toBe(true);
+	});
+});
+
+describe('BLOCK / 警告の文言 (#4390)', () => {
+	it('BLOCK 文言は「何が動いたか」と「どうすれば直るか」を両方持つ', () => {
+		const msg = buildBaseDriftBlockMessage('develop', 3, ['.github/PR_TEMPLATE_SECTIONS.json']);
+		expect(msg).toContain('.github/PR_TEMPLATE_SECTIONS.json');
+		expect(msg).toContain('git rebase origin/develop');
+		// 「なぜ止めたか」= 判定が無効になっている、が読み取れること
+		expect(msg).toContain('検査基準');
+	});
+
+	it('警告文言は commit 数と base 名を持ち、rebase を促すが止めない旨を書く', () => {
+		const note = buildBaseDriftNote('develop', 12);
+		expect(note).toContain('12');
+		expect(note).toContain('develop');
+	});
+});

--- a/tests/unit/scripts/pre-ready-base-freshness.test.ts
+++ b/tests/unit/scripts/pre-ready-base-freshness.test.ts
@@ -149,9 +149,9 @@ describe('#4390 classifyBaseDrift — base 鮮度の 3 分類', () => {
 });
 
 describe('#4390 isGateSsotPath — 検査基準の判定', () => {
-	it('[B7] scripts/lib/ci/ 配下は prefix で一括して検査基準扱い', () => {
-		expect(readExport<string[]>('PRE_READY_GATE_SSOT_PREFIXES')).toContain('scripts/lib/ci/');
+	it('[B7] pre-ready が読む scripts/lib/ci/ の module は検査基準', () => {
 		expect(isGateSsotPath('scripts/lib/ci/pr-body-sections.mjs')).toBe(true);
+		expect(isGateSsotPath('scripts/lib/ci/resolve-base-branch.mjs')).toBe(true);
 	});
 
 	it('[B8] 検査基準でない path は false (over-block しない)', () => {
@@ -159,6 +159,15 @@ describe('#4390 isGateSsotPath — 検査基準の判定', () => {
 		expect(isGateSsotPath('docs/decisions/README.md')).toBe(false);
 		// 名前が似ているだけの path を拾わない
 		expect(isGateSsotPath('tests/unit/scripts/check-pr-body.test.ts')).toBe(false);
+	});
+
+	it('[B18] pre-ready が読まない scripts/lib/ci/ の module は検査基準ではない', () => {
+		// ディレクトリ prefix で一括指定していた頃は、ページガイド撮影ヘルパを直しただけで
+		// 全 PR の pre-ready が止まっていた。止める根拠 (手元と CI で読む SSOT が食い違う) が
+		// 成立しない file を BLOCK しない (#4390)。
+		expect(isGateSsotPath('scripts/lib/ci/page-guide-capture.mjs')).toBe(false);
+		expect(isGateSsotPath('scripts/lib/ci/brand-style-guide.js')).toBe(false);
+		expect(isGateSsotPath('scripts/lib/ci/workflow-judgment-registry.mjs')).toBe(false);
 	});
 
 	it('[B9] Windows の \\ 区切りでも同じ判定になる', () => {
@@ -197,15 +206,29 @@ describe('#4390 BLOCK / 警告の文言', () => {
  * list を手で足すだけでは同じ穴が再び開くので、**実際に import を辿って閉包を計算し**、
  * 全 file が検査基準に被覆されていることを機械で固定する (ADR-0061 同 class N→guard)。
  * 期待 list を test 側に手書きすると二重管理になるため、entry も閉包も source から導出する。
+ *
+ * 被覆は **両方向**で見る。片方向 (漏れのみ) だと、逆方向の穴 = pre-ready が一度も読まない
+ * file を検査基準に混ぜる over-block が素通りする (実際 `scripts/lib/ci/` の prefix 指定で
+ * 13 file 中 9 file が無関係に BLOCK 対象になっていた)。[B13] が漏れ、[B19] が余分を見る。
  */
-describe('#4390 検査基準 list は spawn する script の import 閉包を被覆する', () => {
-	/** pre-ready.mjs の source から、子プロセスで起動する script path を拾う。 */
+describe('#4390 検査基準 list は spawn する script の import 閉包と一致する', () => {
+	/**
+	 * pre-ready.mjs の source から、子プロセスで起動する script path を拾う。
+	 *
+	 * 単に `'scripts/....mjs'` という文字列リテラルを拾うと **`PRE_READY_GATE_SSOT_PATHS` の
+	 * 配列リテラル自身**を entry として読んでしまい、[B12] が「list に載っているものが list に
+	 * 載っている」を assert する tautology になる。実際に spawn するのは `run(...)` に渡す
+	 * `['node', 'scripts/xxx.mjs', …]` の argv だけなので、その形だけを拾う。
+	 *
+	 * pre-ready.mjs 自身は spawn 対象ではないが、6 step のオーケストレータであり
+	 * 判定順・合否条件そのものを持つため entry (= 閉包の起点) に含める。
+	 */
 	function readEntryScripts(): string[] {
 		const src = readFileSync(resolve(repoRoot, 'scripts/pre-ready.mjs'), 'utf8');
-		const found = [...src.matchAll(/['"`](scripts\/[A-Za-z0-9_./-]+\.mjs)['"`]/g)].flatMap((m) =>
-			m[1] ? [m[1]] : [],
-		);
-		return [...new Set(found)];
+		const spawned = [
+			...src.matchAll(/['"]node['"]\s*,\s*['"](scripts\/[A-Za-z0-9_./-]+\.mjs)['"]/g),
+		].flatMap((m) => (m[1] ? [m[1]] : []));
+		return [...new Set(['scripts/pre-ready.mjs', ...spawned])];
 	}
 
 	/** repo-relative な .mjs から相対 import を辿り、到達する全 file (entry 含む) を返す。 */
@@ -243,7 +266,9 @@ process.stdout.write(JSON.stringify(${JSON.stringify(files)}.map((f) => m.isGate
 
 	it('[B12] spawn する entry script 自体が検査基準に含まれる', () => {
 		const entries = readEntryScripts();
-		expect(entries.length).toBeGreaterThan(0);
+		// spawn 経路を絞ったので、entry が 0 本 / pre-ready.mjs 単体に縮退していたら
+		// 正規表現が argv の形と食い違っている (test 自体の空振り防止)
+		expect(entries.length).toBeGreaterThan(1);
 		const covered = isGateSsotPathAll(entries);
 		expect(entries.filter((_, i) => !covered[i])).toEqual([]);
 	});
@@ -254,5 +279,18 @@ process.stdout.write(JSON.stringify(${JSON.stringify(files)}.map((f) => m.isGate
 		expect(closure.length).toBeGreaterThan(readEntryScripts().length);
 		const covered = isGateSsotPathAll(closure);
 		expect(closure.filter((_, i) => !covered[i])).toEqual([]);
+	});
+
+	it('[B19] scripts/ 配下の検査基準に、閉包に無い file を余分に列挙していない (over-block 防止)', () => {
+		// [B13] は「列挙漏れ」だけを見る。片方向だと、prefix 指定や手書き追加で
+		// **pre-ready が一度も読まない file** が検査基準に紛れ込み、無関係な変更で
+		// 全 PR を止める over-block が再発する (#4390 の実害形)。
+		// `.github/*` や biome.json / tsconfig.json は import 閉包に現れない検査基準なので、
+		// 両方向 assert の対象は `scripts/` 配下に限る。
+		const closure = new Set(collectImportClosure(readEntryScripts()));
+		const listed = readExport<string[]>('PRE_READY_GATE_SSOT_PATHS').filter((p) =>
+			p.startsWith('scripts/'),
+		);
+		expect(listed.filter((p) => !closure.has(p))).toEqual([]);
 	});
 });

--- a/tests/unit/scripts/pre-ready-base-freshness.test.ts
+++ b/tests/unit/scripts/pre-ready-base-freshness.test.ts
@@ -15,11 +15,11 @@
 
 import { describe, expect, it } from 'vitest';
 import {
-	PRE_READY_GATE_SSOT_PREFIXES,
 	buildBaseDriftBlockMessage,
 	buildBaseDriftNote,
 	classifyBaseDrift,
 	isGateSsotPath,
+	PRE_READY_GATE_SSOT_PREFIXES,
 } from '../../../scripts/pre-ready.mjs';
 
 describe('classifyBaseDrift — base 鮮度の 3 分類 (#4390)', () => {

--- a/tests/unit/scripts/pre-ready-base-freshness.test.ts
+++ b/tests/unit/scripts/pre-ready-base-freshness.test.ts
@@ -50,10 +50,16 @@ process.stdout.write(JSON.stringify(m[${JSON.stringify(name)}]));`;
 	return JSON.parse(out) as T;
 }
 
-type Drift = { level: 'fresh' | 'behind-only' | 'gate-ssot-moved'; gateFiles: string[] };
+type Drift = {
+	level: 'fresh' | 'unverified' | 'behind-only' | 'gate-ssot-moved';
+	gateFiles: string[];
+};
 
-const classifyBaseDrift = (arg: { behind: number; baseChangedFiles: string[] }) =>
-	callExport<Drift>('classifyBaseDrift', arg);
+const classifyBaseDrift = (arg: {
+	behind: number;
+	baseChangedFiles: string[];
+	fetchFailed?: boolean;
+}) => callExport<Drift>('classifyBaseDrift', arg);
 const isGateSsotPath = (file: string) => callExport<boolean>('isGateSsotPath', file);
 
 describe('#4390 classifyBaseDrift — base 鮮度の 3 分類', () => {
@@ -61,6 +67,39 @@ describe('#4390 classifyBaseDrift — base 鮮度の 3 分類', () => {
 		const r = classifyBaseDrift({ behind: 0, baseChangedFiles: [] });
 		expect(r.level).toBe('fresh');
 		expect(r.gateFiles).toEqual([]);
+	});
+
+	it('[B14] git fetch に失敗していたら fresh を名乗らない (未検証を検証済みと書かない)', () => {
+		// fetch できていないときの behind=0 は「手元 ref との差が 0」でしかなく、
+		// base を取り込み済である証明にならない。ここで fresh を返すと pre-ready が
+		// 「base 鮮度: OK (取り込み済)」と出力し、**検証していない事実を検証済みとして残す**。
+		const r = classifyBaseDrift({ behind: 0, baseChangedFiles: [], fetchFailed: true });
+		expect(r.level).toBe('unverified');
+		expect(r.gateFiles).toEqual([]);
+	});
+
+	it('[B15] fetch 成功時は従来どおり fresh (fetchFailed の既定は false)', () => {
+		expect(classifyBaseDrift({ behind: 0, baseChangedFiles: [], fetchFailed: false }).level).toBe(
+			'fresh',
+		);
+		expect(classifyBaseDrift({ behind: 0, baseChangedFiles: [] }).level).toBe('fresh');
+	});
+
+	it('[B16] fetch 失敗でも検査基準が動いていれば BLOCK を維持する (安全側を弱めない)', () => {
+		const r = classifyBaseDrift({
+			behind: 3,
+			baseChangedFiles: ['.github/PULL_REQUEST_TEMPLATE.md'],
+			fetchFailed: true,
+		});
+		expect(r.level).toBe('gate-ssot-moved');
+	});
+
+	it('[B17] unverified の注記は「取り込み済」と書かない', () => {
+		const note = callExport<string>('buildBaseUnverifiedNote', 'develop');
+		expect(note).toContain('未検証');
+		expect(note).toContain('git fetch origin develop');
+		expect(note).not.toContain('取り込み済み');
+		expect(note).not.toContain('OK');
 	});
 
 	it('[B2] base が動いても検査基準を含まなければ behind-only (警告のみ)', () => {

--- a/tests/unit/scripts/pre-ready-base-freshness.test.ts
+++ b/tests/unit/scripts/pre-ready-base-freshness.test.ts
@@ -21,7 +21,8 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
@@ -143,5 +144,72 @@ describe('#4390 BLOCK / 警告の文言', () => {
 		expect(note).toContain('12');
 		expect(note).toContain('develop');
 		expect(note).toContain('止めません');
+	});
+});
+
+/**
+ * #4390 fitness function — 検査基準 list の網羅性
+ *
+ * 実測 (QM lead): `PRE_READY_GATE_SSOT_PATHS` は spawn する entry script だけを列挙しており、
+ * その script が import する sibling module (`pr-template-gate-checks.mjs` 等) を取りこぼしていた。
+ * CI の判定ロジック本体が develop 側で動いても `fresh` / `behind-only` を返して素通しするため、
+ * #4322 と同一クラスの障害が別 file 経由でそのまま再現する。
+ *
+ * list を手で足すだけでは同じ穴が再び開くので、**実際に import を辿って閉包を計算し**、
+ * 全 file が検査基準に被覆されていることを機械で固定する (ADR-0061 同 class N→guard)。
+ * 期待 list を test 側に手書きすると二重管理になるため、entry も閉包も source から導出する。
+ */
+describe('#4390 検査基準 list は spawn する script の import 閉包を被覆する', () => {
+	/** pre-ready.mjs の source から、子プロセスで起動する script path を拾う。 */
+	function readEntryScripts(): string[] {
+		const src = readFileSync(resolve(repoRoot, 'scripts/pre-ready.mjs'), 'utf8');
+		const found = [...src.matchAll(/['"`](scripts\/[A-Za-z0-9_./-]+\.mjs)['"`]/g)].map((m) => m[1]);
+		return [...new Set(found)];
+	}
+
+	/** repo-relative な .mjs から相対 import を辿り、到達する全 file (entry 含む) を返す。 */
+	function collectImportClosure(entries: string[]): string[] {
+		const seen = new Set<string>();
+		const queue = [...entries];
+		while (queue.length > 0) {
+			const current = queue.shift();
+			if (!current || seen.has(current)) continue;
+			seen.add(current);
+			const abs = resolve(repoRoot, current);
+			if (!existsSync(abs)) continue;
+			const src = readFileSync(abs, 'utf8');
+			// `from './x.mjs'` / `import('./x.mjs')` の相対 specifier のみ辿る
+			// (bare specifier = node_modules / 標準モジュールは対象外)
+			for (const m of src.matchAll(/(?:from|import)\s*\(?\s*['"](\.[^'"]+)['"]/g)) {
+				const target = relative(repoRoot, resolve(dirname(abs), m[1])).replace(/\\/g, '/');
+				if (!seen.has(target)) queue.push(target);
+			}
+		}
+		return [...seen].sort();
+	}
+
+	/** isGateSsotPath を 1 回の子プロセスで一括評価する (path ごとに spawn しない)。 */
+	function isGateSsotPathAll(files: string[]): boolean[] {
+		const code = `const m = await import(${JSON.stringify(preReadyUrl)});
+process.stdout.write(JSON.stringify(${JSON.stringify(files)}.map((f) => m.isGateSsotPath(f))));`;
+		const out = execFileSync(process.execPath, ['--input-type=module', '-e', code], {
+			encoding: 'utf8',
+		});
+		return JSON.parse(out) as boolean[];
+	}
+
+	it('[B12] spawn する entry script 自体が検査基準に含まれる', () => {
+		const entries = readEntryScripts();
+		expect(entries.length).toBeGreaterThan(0);
+		const covered = isGateSsotPathAll(entries);
+		expect(entries.filter((_, i) => !covered[i])).toEqual([]);
+	});
+
+	it('[B13] entry script が import する module も全て検査基準に含まれる (取りこぼし 0)', () => {
+		const closure = collectImportClosure(readEntryScripts());
+		// 閉包が entry だけに縮退していたら walker が壊れている (test 自体の空振り防止)
+		expect(closure.length).toBeGreaterThan(readEntryScripts().length);
+		const covered = isGateSsotPathAll(closure);
+		expect(closure.filter((_, i) => !covered[i])).toEqual([]);
 	});
 });

--- a/tests/unit/scripts/pre-ready-base-freshness.test.ts
+++ b/tests/unit/scripts/pre-ready-base-freshness.test.ts
@@ -163,7 +163,9 @@ describe('#4390 検査基準 list は spawn する script の import 閉包を�
 	/** pre-ready.mjs の source から、子プロセスで起動する script path を拾う。 */
 	function readEntryScripts(): string[] {
 		const src = readFileSync(resolve(repoRoot, 'scripts/pre-ready.mjs'), 'utf8');
-		const found = [...src.matchAll(/['"`](scripts\/[A-Za-z0-9_./-]+\.mjs)['"`]/g)].map((m) => m[1]);
+		const found = [...src.matchAll(/['"`](scripts\/[A-Za-z0-9_./-]+\.mjs)['"`]/g)].flatMap((m) =>
+			m[1] ? [m[1]] : [],
+		);
 		return [...new Set(found)];
 	}
 
@@ -181,7 +183,9 @@ describe('#4390 検査基準 list は spawn する script の import 閉包を�
 			// `from './x.mjs'` / `import('./x.mjs')` の相対 specifier のみ辿る
 			// (bare specifier = node_modules / 標準モジュールは対象外)
 			for (const m of src.matchAll(/(?:from|import)\s*\(?\s*['"](\.[^'"]+)['"]/g)) {
-				const target = relative(repoRoot, resolve(dirname(abs), m[1])).replace(/\\/g, '/');
+				const specifier = m[1];
+				if (!specifier) continue;
+				const target = relative(repoRoot, resolve(dirname(abs), specifier)).replace(/\\/g, '/');
 				if (!seen.has(target)) queue.push(target);
 			}
 		}

--- a/tests/unit/scripts/pre-ready-skip-classification.test.ts
+++ b/tests/unit/scripts/pre-ready-skip-classification.test.ts
@@ -135,7 +135,11 @@ describe('#4018 buildSummary — ALL PASS 到達可能性', () => {
 			pr: '3996',
 		});
 		expect(summary.status).toBe('ALL_PASS');
-		expect(summary.text).toContain('ALL PASS');
+		// #4390: 見出し文言は「ALL PASS」から「PASS — pre-ready 6 step の範囲でのみ緑」に変更した
+		// (「ALL PASS」が CI 緑の予測と読まれ、6 PR が ALL PASS のまま CI red になった実測)。
+		// 判定 (status) は不変なので、AC1「適用対象外だけなら到達できる」の検証強度は変わらない。
+		expect(summary.text).toContain('pre-ready 6 step の範囲でのみ緑');
+		expect(summary.text).toContain('CI 緑の予測ではありません');
 		// 「--skip 指定」という誤った説明を出さないこと (本 Issue の表面症状)
 		expect(summary.text).not.toContain('--skip 指定');
 	});


### PR DESCRIPTION
## 顧客価値・目的

開発者が `npm run pre-ready` の結果を「CI に出す前の答え合わせ」として信じられるようにする。いまは手元 PASS のまま CI red になる経路が構造的に残っており、そのぶん往復が増える。

## 関連 Issue

Closes #4390

## 変更内容

### ① base 鮮度 preflight（step の前に 1 回だけ走る）

`scripts/pre-ready.mjs` の 6 step は **worktree HEAD だけ**を入力にする。base が進んでも、進んだ結果として自分の判定基準が変わったことも見ていない。実測（#4322 = develop `f5f0ef152`）では PR テンプレートが 11 → 7 セクションに**再構成**され（`## AC 検証マップ (ADR-0004)` 等が消え `## 変更内容` / `## 検証` / `## 影響範囲` が新設）、旧構成のまま残っていた PR は **branch tip では旧 SSOT と旧 body が整合するので緑**、rebase した瞬間に `必須セクションの存在確認` で赤くなった。同 job は `if: draft == false` なので Draft 中に気づく機会も無い。

そこで base の `behind` と **base 側だけの差分 file 一覧**を測り、3 分類で扱いを変える。

| level | 条件 | 挙動 |
|---|---|---|
| `fresh` | `behind == 0` | 1 行 OK |
| `behind-only` | base は進んだが差分に検査基準を含まない | **警告 + summary 注記のみ。止めない** |
| `gate-ssot-moved` | base が進み、差分に **pre-ready の検査基準**を含む | **BLOCK（exit 1）** |

「検査基準」= `PULL_REQUEST_TEMPLATE.md` / `PR_TEMPLATE_SECTIONS.json`（+ integration 版）/ pre-ready が spawn する検査 script と**その import 閉包**（`scripts/lib/ci/` は配下 4 file のみ。理由は ④）/ `biome.json` / `tsconfig.json`。

**hard-fail を `gate-ssot-moved` に絞った根拠**: develop は日に何度も進むため「behind > 0 で常に止める」は pre-ready の実行回数ぶん rebase を強制し、CI 待ちだけが増える（止めすぎのコスト）。一方 #4322 の実害（6 PR × 1 サイクル）は**検査基準が動いたときにだけ**発生した。止める条件を実害の形と一致させ、それ以外は注記で済ませる。差分が取得できない場合（offline / ref 不在）は `behind-only` に倒す —「測れなかった」を BLOCK にすると offline というだけで全員が止まる。

**新規 script は作っていない**。既存 `scripts/lib/ci/resolve-base-branch.mjs`（`--verify-base` が `behind` を測っている、#2975）に `measureBaseDrift()` を 1 本足して相乗りした。同 SSOT は branch 作成時にしか呼ばれていなかった。

### ② 保証範囲を summary に明示

見出しを `ALL PASS — Ready for Review に進めます。` から **`PASS — pre-ready 6 step の範囲でのみ緑です (CI 緑の予測ではありません)`** に変更。既存の「CI 側 job 一覧」ブロックを「**保証しないもの**」の列挙に組み替えた（行数は据え置き。毎回出る出力に長文を足さない、#4308 の教訓）:

- 負荷 / タイミング依存の失敗（実測 #4385: 同一 test が 1,860 → 6,398ms。空いた local では再現しない）
- vitest / e2e / Storybook / visual regression
- lint-and-test 系 / LP 系
- **Draft 中しか見ていない検査**（`pr-template-gate` は `draft == false` で初めて走る）
- base が動いた後の再測

### ③ 検査基準 list の網羅性を fitness function で固定（QM レビュー指摘の反映）

初版の `PRE_READY_GATE_SSOT_PATHS` は **spawn する entry script だけ**を列挙しており、その script が import する sibling module を取りこぼしていた（実測: `scripts/check-ac-verification-map.mjs` / `integration-pr-body.mjs` / `pr-lane.mjs` / `pr-template-gate-checks.mjs` / `lib/is-main.mjs` の 5 本）。とくに `pr-template-gate-checks.mjs` は CI の `pr-template-gate.yml` が呼ぶ**判定ロジック本体**であり、develop 側でこれが動いても本 gate は `fresh` / `behind-only` を返して素通しする。#4322 と同一クラスの障害が別 file 経由でそのまま再現する状態だった。

list に 5 本を足したうえで（`scripts/` 全体を prefix にすると無関係な script の変更まで BLOCK するため個別列挙。理由はコードにコメントで明記）、**同じ穴が二度と開かないよう fitness function を追加**した（ADR-0061 同 class N→guard）。`tests/unit/scripts/pre-ready-base-freshness.test.ts` に:

- `[B12]` pre-ready.mjs の source から拾った entry script 自体が検査基準に含まれること
- `[B13]` entry から**相対 import を実際に辿って閉包を計算**し、その全 file が `PRE_READY_GATE_SSOT_PATHS` で被覆されていること（③ 時点では `PRE_READY_GATE_SSOT_PREFIXES` も対象だったが ④ で廃止）（node_modules / 標準モジュールは辿らない）

期待 list を test 側に手書きすると二重管理になるため、entry も閉包も source から導出している。修正前の実装で `[B13]` が上記 5 本を列挙して落ちることを実測済（failing-test-first）。

### ④ 検査基準を「pre-ready が実際に読む閉包」だけに絞る（over-block の除去、QM レビュー指摘の反映）

③ の時点では `scripts/lib/ci/` を **prefix で一括指定**していた。しかしこの prefix は配下 13 file 全部を検査基準に入れる一方、pre-ready の import 閉包に実在するのは **4 file**（`pr-body-sections.mjs` / `reason-declaration.mjs` / `resolve-base-branch.mjs` / `tz-invariance-cases.mjs`）だけで、残り 9 file（`page-guide-capture.mjs` / `brand-style-guide.js` / `workflow-judgment-registry.mjs` / `pr-trigger-lane-registry.mjs` / `repo-scan-test-registry.mjs` / `screenshot-helpers.mjs` / `orphan-utils.mjs` / `exclusion-reason.mjs` / `escape-regexp.mjs`）は pre-ready が一度も読まない。**ページガイド撮影ヘルパを直しただけで全 PR の pre-ready が止まる**状態だった。③ 自身が「`scripts/` 全体を prefix にすると無関係な script の変更まで BLOCK するため個別列挙した」と書いているのに、`scripts/lib/ci/` で同じことをしていた。

止める根拠は「手元と CI で読む SSOT が食い違う」であり、pre-ready が読まない file ではその根拠が成立しない。理由の分からない BLOCK は gate への信頼を削って迂回行動を誘発する。また base 側の実測（develop 直近 30 日 463 commit のうち prefix 込みの検査基準に触れた commit 51 件が活動日 23 日中 17 日 = 74% に分布）では、判定が merge-base→base 先端の**累積**である以上、1 日以上前に切った branch はほぼ確実に落ちる。これは #4390 が「止めすぎのコストが実害を上回る」として**明示的に不採用にした案 A（behind > 0 で常に止める）と運用上ほぼ等価**になる。

- `PRE_READY_GATE_SSOT_PREFIXES` を**廃止**（export ごと削除。`isGateSsotPath` は path の完全一致だけを見る）
- 閉包に実在する `scripts/lib/ci/*` の 4 file を `PRE_READY_GATE_SSOT_PATHS` に個別列挙
- **`[B19]` を追加し、被覆を両方向にした**: `[B13]`（列挙漏れ = 閉包にあるのに未列挙）に加え、`[B19]` が「余分な列挙 = 列挙されているのに閉包に無い」を検出する。片方向のままだと prefix 指定や手書き追加で over-block が再発する。`.github/*` / `biome.json` / `tsconfig.json` は import 閉包に現れない検査基準なので、両方向 assert の対象は `scripts/` 配下に限定した
- **`[B18]` を追加**: pre-ready が読まない `scripts/lib/ci/` の module（`page-guide-capture.mjs` 等）が検査基準に**入らない**ことを pin する

**検査基準集合の before / after**（`scripts/lib/ci/` 13 file のうち）:

| | 検査基準に入る | 入らない |
|---|---|---|
| before（prefix 指定） | 13 file | 0 file |
| after（閉包のみ） | **4 file** | **9 file** |

### ⑤ `[B12]` のトートロジー解消

`[B12]` の `readEntryScripts()` は `pre-ready.mjs` 内の `'scripts/….mjs'` という**文字列リテラル**を正規表現で拾っていたため、**`PRE_READY_GATE_SSOT_PATHS` の配列リテラル自身**を entry として読み込んでいた（=「list に載っているものが list に載っている」を assert していた）。実際に spawn するのは `run(...)` に渡す `['node', 'scripts/xxx.mjs', …]` の argv だけなので、その形だけを拾うよう正規表現を絞った（`pre-ready.mjs` 自身は spawn 対象ではないが 6 step のオーケストレータなので閉包の起点として明示的に足している）。空振り防止の下限も `> 0` から `> 1` に上げた。

絞り込みの前後で**閉包は同一（14 file）**であることを実測済（`STRICT entries` = 4 spawn script + `pre-ready.mjs` → 閉包 14 file、`LOOSE`（旧）→ 閉包 14 file）。したがって `[B13]` / `[B19]` の判定は変わらず、変わったのは `[B12]` が本当に spawn 経路を見るようになった点だけ。


### Draft/blocking の非対称そのものには触れていない（理由）

`pr-template-gate.yml` の `if: draft == false` は Draft PR に required check を課さないための設計、`#4121` / `#4214` の advisory / blocking 分離は本日決まったばかりの severity 判断。どちらを動かすのも本 Issue の射程を超え、かつ新しい決定を上書きすることになる。代わりに **pre-ready 側が「Draft 中しか走らない検査がある」と毎回出力する**ことで、非対称に気づけない状態を解消した。

## 検証

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 3 分類で扱いを変える / 新規 script を作らない | `git diff --stat` + `npx vitest run tests/unit/scripts/pre-ready-base-freshness.test.ts` | 変更は既存 2 ファイルへの追記のみ（新規 script 0）。`classifyBaseDrift` の 3 分類を 11 test で pin、全 PASS |
| AC2 | `gate-ssot-moved` で exit 1、出力に file 名と rebase コマンド | 実機: stale 状態（`f5f0ef152~1` = #4322 直前、`behind=11`）を作って実行 | **exit 1**。出力に `.github/PR_TEMPLATE_SECTIONS.json` / `.github/PULL_REQUEST_TEMPLATE.md` / `scripts/check-pr-body.mjs` / `scripts/lib/ci/*` の 5 件と `git fetch origin develop && git rebase origin/develop` を表示（下記ログ）|
| AC3 | `behind-only` では止めない | 実機: `origin/develop~2`（差分は deploy workflow / docs / terms.ts のみ、`behind=2`）で実行 | `⚠ base 鮮度: origin/develop が 2 commits 先に進んでいます (検査基準は不変のため止めません、#4390)` を出して**継続**（下記ログ）|
| AC4 | `behind == 0` の通常ケースが従来どおり通る（回帰） | 実機: 本 branch（origin/develop 取込済）で実行 | `[pre-ready] base 鮮度: OK (origin/develop を取り込み済、#4390)` → step 実行に進む。止まらない |
| AC5 | 差分取得不能を BLOCK にしない | unit: `classifyBaseDrift({ behind: 5, baseChangedFiles: [] })` | `behind-only` を返す（`level` assert 済） |
| AC6 | summary が保証範囲つき文言になり、保証しないものを毎回出す | 実機実行の出力 + `pre-ready-skip-classification.test.ts` | 見出しが `pre-ready 6 step の範囲でのみ緑` に変わり、「保証しないもの」5 項目を表示（下記ログ）。既存 test の assertion は文言に追従（`status` の判定強度は不変） |
| AC7 | failing-test-first（修正前は素通り / 修正後は検知） | 同一 stale 状態（`behind=11`）で修正前後を実測 | **修正前**: base 鮮度に一切言及せず素通り（下記ログ）/ **修正後**: exit 1 で BLOCK |
| AC8 | mutation で非トートロジー性 | 実装を 2 通り壊して test 実行 | ① gate 判定を落とす（`gateFiles.length === 0` → `true`）→ **2 test FAIL** / ② `isGateSsotPath` を常に true（over-block）→ **3 test FAIL**。いずれも `git stash push` で復元（`git checkout --` は使っていない） |

### 実測ログ

**AC7 修正前**（HEAD = `c865fd48d` = #4322 直前、`git rev-list --count HEAD..origin/develop` = 11）:

```
[pre-ready] base branch: origin/develop (#2959 SSOT 解決)
[pre-ready] WARN: origin/develop からの変更ファイルが取得できませんでした ...
[pre-ready] 実行順 (cheap-fail-first、#4048): pr-body → biome → ...
```
→ base が 11 commits 遅れ、うち PR テンプレート SSOT が動いていることに**一切言及せず通過**。

**AC2 / AC7 修正後**（同じ HEAD に本 PR の変更を cherry-pick）:

```
[pre-ready] ✗ base 鮮度 FAIL — origin/develop が 11 commits 先に進み、
  pre-ready の検査基準そのものが動いています (#4390):
    - .github/PR_TEMPLATE_SECTIONS.json
    - .github/PULL_REQUEST_TEMPLATE.md
    - scripts/check-pr-body.mjs
    - scripts/lib/ci/pr-trigger-lane-registry.mjs
    - scripts/lib/ci/workflow-judgment-registry.mjs
  この状態で出した PASS は rebase 後も成立するとは限りません。...
  対応:
    git fetch origin develop && git rebase origin/develop
```
（exit 1）

**AC3**（HEAD = `origin/develop~2`、差分に検査基準を含まない）:

```
[pre-ready] ⚠ base 鮮度: origin/develop が 2 commits 先に進んでいます (検査基準は不変のため止めません、#4390)。
  CI は rebase 後の内容で走るため、Ready 化の直前に `git rebase origin/develop` して再測することを推奨します。
[pre-ready] 実行順 (cheap-fail-first、#4048): ...   ← 止まらず継続
```

**AC4 / AC6**（本 branch = base 取込済）:

```
[pre-ready] base 鮮度: OK (origin/develop を取り込み済、#4390)
...
  pre-ready が保証するのは上の 6 step だけです。以下は保証しません:
    - 負荷 / タイミング依存の失敗   空いた local では再現しない (実測 #4385: 同一 test が 1,860→6,398ms)
    - vitest / e2e / Storybook / visual regression   CI (unit-test 2 shard / 重量レーン) で走る
    - lint-and-test 系   cspell / hardcoded-strings / doc-code-references / terminology-coherence / ...
    - LP 系   lp-metrics (寸法・禁止語) / lp-fallback-check (fallback 同期)
    - Draft 中しか見ていない検査   pr-template-gate は draft==false で初めて走る (#4390)
    - base が動いた後の再測   base の検査基準が動くと同じ body でも CI は赤になる (#4322 で 6 PR 実測)
```

### 実行したコマンド

- `npx vitest run tests/unit/scripts/` → **51 files / 1120 passed, 1 skipped**（既存 pre-ready test 5 file を含む回帰確認）
- `npx vitest run tests/unit/scripts/pre-ready-base-freshness.test.ts` → **11 passed**（実装前は 11 failed = failing-test-first）
- `npm run pre-ready -- --pr 4393` → **全 6 step PASS**（`biome` / `check-no-plan-literals` / `check-local-tz-date-getters` / `svelte-check` / Readiness gate、`ss-embed-gate` は UI 変更なしで適用対象外）。**自分の変更で自分が止まらないこと**も確認済（`base 鮮度: OK` を通過して step 実行に進んだ）

### 新規 test の呼び出し方式（途中で直した点）

`pre-ready-base-freshness.test.ts` は当初 `scripts/pre-ready.mjs` を静的 import していたが、**`.ts` から `.mjs` を静的 import すると svelte-check の型 program に取り込まれ既存の implicit-any が 31 件露出**して Step 2 が落ちた。`pre-ready-skip-classification.test.ts`（#4018）が同じ理由で採っている **node 子プロセス経由の dynamic import** に揃えた（`isMain` guard により import 時に `main()` は走らない）。mutation はこの書き換え後の test で再実施し、同じ 2 件 / 3 件が落ちることを確認済。

## 影響範囲

- **顧客に見える変化**: なし（CI / 開発者ツールのみ）。UI 変更なしのため SS は該当なし
- **触った並行実装ペア**: なし
- **破壊的変更**: `pre-ready` の出力文言が変わる（`ALL PASS` → `PASS — pre-ready 6 step の範囲でのみ緑`）。`ALL PASS` 文字列を参照していたのは `tests/unit/scripts/pre-ready-skip-classification.test.ts` の 1 assertion のみで、本 PR で追従済（repo 全体を grep 済。`scripts/native-dep-smoke.mjs` の同文字列は別機構）
- **新たに止まりうるケース**: base が進み、かつ差分に検査基準を含む場合に `pre-ready` が exit 1 する。対処は rebase 1 回で、CI が同じ理由で赤くなるのを前倒しで検出しているだけ
- **CI への影響**: なし（CI は `pre-ready` を呼んでいない）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->


