### PR TITLE
docs(process): #4308 PR④ docs/sessions/ の重複0・網羅漏れ0を仕上げる

### DIFF
--- a/docs/sessions/agent-teams.md
+++ b/docs/sessions/agent-teams.md
@@ -40,13 +40,14 @@
 前提として、**team はロールごとに独立して構築する**。
 
 ```
-ganbari-quest-po     → PO の team    （lead = PO セッション）
-ganbari-quest-dev    → Dev の team   （lead = Dev セッション）
-ganbari-quest-qa     → QM の team    （lead = QM セッション）
-ganbari-quest-audit  → 監査の team   （lead = audit-manager）
+ganbari-quest-po        → PO の team        （lead = PO セッション）
+ganbari-quest-dev       → Dev の team       （lead = Dev セッション）
+ganbari-quest-qa        → QM の team        （lead = QM セッション。clone dir 名は歴史的経緯で `-qa`、role 名は QM が SSOT）
+ganbari-quest-audit     → 監査の team       （lead = audit-manager）
+ganbari-quest-platform  → Platform の team  （lead = Platform セッション）
 ```
 
-**4 つの team は互いを知らない。** 相互の受け渡しは引き続き [label-mailbox.md](label-mailbox.md) の `state:*` label で行う。Agent Teams はロール間通信の代替ではなく、**1 ロール内の並列化手段**である。
+**5 つの team は互いを知らない。** 相互の受け渡しは引き続き [label-mailbox.md](label-mailbox.md) の `state:*` label で行う。Agent Teams はロール間通信の代替ではなく、**1 ロール内の並列化手段**である。
 
 ### §3.1 ロールを跨ぐ team は組まない（最重要）
 
@@ -206,6 +207,7 @@ teammate の permission 要求は lead に上がる。**teammate は他の teamm
 | **Dev** | レーンが分かれた実装（A/B/C/D）/ 影響範囲調査（`impact-analysis` の 4 layer を分担） | 重い検証の並列化（§3.2）/ 逐次依存のある実装 |
 | **QM** | 多観点レビュー（security / perf / test-coverage）。**ただし approve と merge は lead 専権**（ADR-0056 §E と同型） | 自分の Fix Agent が作った PR の approve。作成者 ≠ 承認者は teammate では解けない |
 | **監査** | 8 領域監査の並列化 / **競合仮説の相互反証**（§4.1）。`audit-team.md` §3.1 の 8 チームは元々この形 | 不可逆 action（cut / merge / 起票の実行）。**audit-manager 専権**（§3.3） |
+| **Platform** | 装置の実測調査（`scripts/check-*` / workflow 一覧の棚卸し）を分担 | gate / guard / test の削除実行（`state:needs-owner` で渡す）。装置を守る装置を作る判断 |
 
 ---
 

--- a/docs/sessions/qm-session.md
+++ b/docs/sessions/qm-session.md
@@ -100,19 +100,7 @@ QM は PR の **base branch でレーンを判別**し、レーンごとに gate
 
 ## アーキテクチャ：subagent ループで 1 PR を閉じ切る
 
-**QM は指摘を Dev に返さず、自分の subagent で直して merge する**（憲章 §0 ルール 2）。lead が回すのは次の 4 ステップ。
-
-```
-① レビュー subagent    指摘を出す
-② 修正 subagent        指摘を直す（Dev の受信箱に戻さない）
-③ 再レビュー subagent  直ったか確認する
-④ lead 本体            CI 緑を実測して approve → merge
-```
-
-- **①〜③ を回すのは lead**。②③ は同じ agent を使い回してよい（1 PR = 1 agent、context を持ち越せる）
-- **収束条件**: 再レビューで BLOCK 3 類型が 0、かつ `gh pr checks` の**非 pass 行が 0**
-- **打ち切り条件**: **同じ指摘で 2 周したら実装方針の問題**。ルール 6 ① として Dev に返す。**3 周目を回さない**
-- **④ は lead 専権**。approve / merge を agent に委譲しない
+**4 ステップの subagent ループ本体（① レビュー→② 修正→③ 再レビュー→④ lead 承認）・収束条件・打ち切り条件は [チーム憲章 §0 ルール 2](README.md#ルール-2-の実行方法--qm-は-自分のクローン内の-subagent-ループで-1-pr-を閉じる) が SSOT。** ②③ は同じ agent を使い回してよい（1 PR = 1 agent、context を持ち越せる）。
 
 ### subagent の報告を成果の根拠にしない
 


### PR DESCRIPTION
## 顧客価値・目的

`docs/sessions/` を読む全ロールが「同じルールが 2 箇所にある」ことで、どちらが正か迷ったり、片方だけ更新されて食い違ったりするのを防ぐ。PO 決裁（issuecomment-5209441173）の完了判定 ③「重複0」を担当。①矛盾解消（#4379）②死んだ参照0（#4403）③凍結削除narrative（#4405）に続く4本直列の最後。

## 関連 Issue

Refs #4308

<!-- no-issue-close: 本PRは #4308 の直列4本目（最後）だが、①②③（#4379 / #4403 / #4405）がまだ develop に merge されていない時点でこのPRを出しているため、①②③merge後にこのPRのCIを再確認する必要がある。全4本のmerge完了を確認してから #4308 を close する。 -->

## 変更内容

PR①（#4379）body の「検出したが直さないもの（②③④の scope）」表が PR④ の担当と明記していた 2 件を処理した。

### 1. 重複の解消（QM subagent ループ、2 file がほぼ逐語）

`qm-session.md` の「アーキテクチャ：subagent ループで 1 PR を閉じ切る」節は、チーム憲章 `README.md` §0 ルール2（4 ステップ図・収束条件・打ち切り条件）とほぼ逐語だった。qm-session.md 側を **README.md への 1 行 pointer** に置換し、QM 固有の運用注記（agent を分ける理由 / 並行セッション前提 / subagent の報告を根拠にしない）はそのまま残した。

**触っていないもの**: 「ロールを跨いだ team は組まない」を含む 6 file の重複は `tests/unit/architecture/agent-teams-role-pointers.test.ts` が**要求している**（4 ロール file が §4.1 の 5 条件そのものを写していないことを CI が検査するため、この重複は消すと CI が落ちる）。PR① で確認済みのため本 PR では対象外。

### 2. 網羅漏れの解消（agent-teams.md、4 team しか列挙せず Platform が無い）

PR① body が「網羅漏れ（矛盾ではなく omission）、PR④ で判断」と記録していた箇所。

- §3.0（team 構成一覧）: PO / Dev / QM / 監査 の 4 team のみ列挙 → **Platform（`ganbari-quest-platform`）を追加**（`docs/sessions/clone-setup.md` の実 SSOT と照合し `ganbari-quest-platform` が正しいクローン名であることを確認）
- §5（ロール別の使いどころ表）: 同じく Platform 行が無かった → 追加（使う: 装置の実測調査の分担 / 使わない: gate 削除実行・装置を守る装置を作る判断）

**副作用の是正**: §3.0 編集中に QM クローン名を `ganbari-quest-qa` → `ganbari-quest-qm` に「修正」しかけたが、`docs/sessions/clone-setup.md`（クローン名の実 SSOT）を確認したところ **クローン dir 名は歴史的経緯で `-qa` のまま**（role 名だけ QM にリネーム済）と判明したため、`ganbari-quest-qa` を維持しコメントで理由を明記した。誤って直すと `clone-setup.md` との新規矛盾を作るところだった。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1（PO 決裁 判断3 ③） | 重複0 | PR① body が特定した 2 種の重複のうち、CI 非保護の 1 種（QM subagent ループ）を解消 | **PASS（scope 内）**。CI 保護されている「team を跨がない」6 file 重複は意図的に対象外（消すと `agent-teams-role-pointers.test.ts` が fail） |
| AC-omission | agent-teams.md の Platform 網羅漏れ | `grep -c Platform docs/sessions/agent-teams.md` | **PASS**。§3.0 / §5 双方に追加、`clone-setup.md` と整合確認済み |
| AC3 | ルールを silent に消さない | `git diff` 目視 | **PASS**。qm-session.md から削った内容はすべて README.md §0 ルール2 に既存（削除ではなく重複除去）で、QM 固有の追加情報は残置 |
| AC4 | リンク切れを出さない | 手動スクリプトで docs/sessions 全 22 file の相対リンク存在確認 + README.md §0 ルール2 見出しへの新規アンカーリンクの手計算検証（GitHub slug 規則: bold 除去→スペースをハイフン化、既存の動作確認済みパターンと同型） | **PASS**（missing 0 件） |

## 変更タイプ

- [x] docs: ドキュメント

## 影響範囲

**影響を受ける画面・機能**: なし（`docs/sessions/` のみ）

- [x] N/A — 並行実装・設計書同期・LP↔アプリ整合・重量 e2e いずれも影響範囲外

## 検証

| コマンド | 結果 |
|---|---|
| 手動リンク検証スクリプト（docs/sessions 全 22 file の相対リンク存在確認） | PASS（missing 0 件） |
| `git push`（pre-push hook 内 biome/eslint 変更 file 絞り込み） | PASS（対象 file なし、skip） |
| `npx vitest run tests/unit/architecture/label-mailbox-routes.test.ts tests/unit/architecture/agent-teams-role-pointers.test.ts tests/unit/hooks/qm-session-approve-hook-consistency.test.ts` | **heavy lock が他セッション（ganbari-quest-qm）に取られていたため未実行。待たずに CI（`unit-test`）へ委ねる**。特に `agent-teams-role-pointers.test.ts` は本 PR が触った file を直接対象にするため、CI 結果は必ず `gh pr checks` で pass 確認してから Ready 化する |
| `npm run pre-ready -- --pr <num>` | **同上の理由でローカル未実行。CI 全 job の pass を Ready 化前に `gh pr checks` で確認する** |

- [x] SOLID / DRY / YAGNI: docs のみ（本 PR 自体が重複除去）
- [x] Security: 秘密情報・内部 URL の追加なし
- [x] A11y・パフォーマンス: N/A
- [x] Critical バグ修正: N/A

## スクリーンショット / ビジュアルデモ

該当なし（docs のみ、`src/**` / `site/**` / `*.svelte` 変更 0 件）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:

1. **本 PR は #4379 の merge 後に develop へ merge する必要がある**（README.md §0 ルール2 見出しへのアンカーリンクが正しく解決するのは、その見出しが develop に存在している前提のため。現時点で develop には既に存在する見出しなので問題ないが、念のため確認してほしい）。
2. 「重複0」の全件消化は本 PR では完了していない（CI 保護された 6 file 重複を対象外にしたため）。**#4308 の完了判定「③重複0」を厳密に取るなら、この CI 保護重複自体を「許容される重複」として明示的に AC から除外する PO 判断が必要**かもしれない。判断を仰ぎたい。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)
