### PR TITLE
fix(billing): #4118 契約状態の遷移を機械検証する（表 §5 の遷移列 × handler 実駆動の双方向照合）

### DIFF
--- a/docs/design/billing-redesign/contract-state-matrix.md
+++ b/docs/design/billing-redesign/contract-state-matrix.md
@@ -14,13 +14,13 @@
 
 `docs/design/billing-redesign/` には契約に関する設計文書が 47 本あり、**機能軸では網羅されている**（解約 / dunning / プラン変更 / 復帰 / 冪等性）。不足しているのは **1 枚の状態遷移表** — `families` の 4 列の**組み合わせとして許される状態の一覧**である。
 
-機能軸で分かれていると、**軸をまたぐ矛盾が設計レビューで検出できない**。列の組み合わせを並べた瞬間に見えるが、1 つの機能を見ている限り気づけない類の欠陥が実際に複数発生した（§5）。
+機能軸で分かれていると、**軸をまたぐ矛盾が設計レビューで検出できない**。「誰が」「どの列に」「何を書くか」を 1 枚に並べた瞬間に見えるが、1 つの機能を見ている限り気づけない類の欠陥が実際に複数発生した（`grace_period` の二重定義 / チャーンを書き手のいない状態で数える、など）。
 
 ### この設計書がないと何が困るか
 
 - 新しい webhook handler を足すとき、「書いてよい組み合わせ」の一覧が無いため、**既存の不正状態を再生産する**
 - `licenseStatus` / `planTier` は 4 列からの**導出値**であり、元の組み合わせが不正だと導出結果も無意味になる。しかし導出側だけ見ても元の不正には辿り着けない
-- KPI（チャーン / 課金ユーザー数）は `status` 単独で数えている。書き手が存在しない状態を数えていても誰も気づかない（§5 D3）
+- KPI（チャーン / 課金ユーザー数）を `status` 単独で数えると、書き手が存在しない状態を数えていても誰も気づかない（§4.2）
 
 ---
 
@@ -66,8 +66,8 @@
 |---|---|---|---|
 | **X1** | `sub` なし + `plan` あり | 契約が無いのにプランだけ残る。`licenseStatus=none` なのに `plan` を表示する経路が生まれる | 起きない（W5 が 4 列を網羅的にクリアし、後着 event は単一強制点の突合で弾かれる。#3982 / #4026） |
 | **X2** | `sub` あり + `plan` なし | 課金しているのにプラン不明。`planTier` が `standard` に丸められ、premium 契約者が standard 扱いになる | 起きうる（checkout の `metadata.planId` が未知のとき。alert は出る） |
-| **X3** | `status=active` + `exp` あり | `active` に期限は無い。dunning / 解約の残骸 | **起きる**（§5 D2） |
-| **X4** | `status=grace_period` + `sub` なし | 猶予の対象となる契約が存在しない | 起きうる |
+| **X3** | `status=active` + `exp` あり | `active` に期限は無い。dunning / 解約の残骸 | 現在の書き手からは起きない（W2 / W4 は `active` を書くとき `exp=null` を同時に書く）。過去に作られた行は §7 ③ の監査で検出する |
+| **X4** | `status=grace_period` + `sub` なし | 猶予の対象となる契約が存在しない | 現在の書き手からは起きない（W3 / W4 は現行契約と突合してから書くため `sub` が必ずある。#4026） |
 
 ### 4.1 S6 (`terminated`) は通常運用では観測されない
 
@@ -114,15 +114,45 @@ KPI service（`cohort-analysis` / `ops-analytics` / `pricing-trigger` / `stripe-
 
 | # | トリガ | 実装 | 書く内容 | 遷移 |
 |---|---|---|---|---|
-| W1 | `checkout.session.completed` | `stripe-service.ts` `handleCheckoutCompleted` | `sub` / `plan` / `status=active` / `trialUsedAt` | S1 → S2 |
-| W2 | `invoice.paid` | `stripe-service.ts` `handleInvoicePaid` | `status=active` + `plan`（未解決なら**保持**） + **`plan_expires_at=null`** | S3 → S2 / S2 → S2 |
-| W3 | `invoice.payment_failed` | `stripe-service.ts` `handlePaymentFailed` | `status=grace_period` / `exp = now + 7d` | S2 → S3 |
-| W4 | `customer.subscription.updated` | `stripe-service.ts` `handleSubscriptionUpdated` | 非終端: `plan`（未解決なら保持）+ `status`（Stripe status を正規化）+ **`plan_expires_at`**（`active` 復帰 → `null` / `grace_period` 入りで未設定なら `now+7d` / それ以外は無変更。`planExpiresAtPatchFor()`） / 終端: W5 と同じ 4 列 | S2 ⇄ S3 / → S4 / → S5 |
+| W1 | `checkout.session.completed` | `stripe-service.ts` `handleCheckoutCompleted` | `sub` / `plan` / `status=active` / `trialUsedAt` | S1 → S2 / S5 → S2 |
+| W2 | `invoice.paid` | `stripe-service.ts` `handleInvoicePaid` | `status=active` + `plan`（未解決なら**保持**） + **`plan_expires_at=null`** | S2/S3/S4 → S2 |
+| W3 | `invoice.payment_failed` | `stripe-service.ts` `handlePaymentFailed` | `status=grace_period` / `exp = now + 7d` | S2/S3/S4 → S3 |
+| W4 | `customer.subscription.updated` | `stripe-service.ts` `handleSubscriptionUpdated` | 非終端: `plan`（未解決なら保持）+ `status`（Stripe status を正規化）+ **`plan_expires_at`**（`active` 復帰 → `null` / `grace_period` 入りで未設定なら `now+7d` / それ以外は無変更。`planExpiresAtPatchFor()`） / 終端: W5 と同じ 4 列 | S2/S3/S4 → S2（`active` / `trialing`）/ S2/S3/S4 → S3（`past_due`）/ S2/S3/S4 → S4（`unpaid` / `paused` / `incomplete`）/ S2/S3/S4 → S5（終端） |
 | W5 | `customer.subscription.deleted` | `stripe-service.ts` `handleSubscriptionDeleted` | `sub=NULL` / `plan=NULL` / `exp=NULL` / `status=suspended`（`TERMINAL_CONTRACT_STATE` の 4 列を網羅、#4026） | S2/S3/S4 → S5 |
-| W6 | アプリ内解約 | `tenant/cancel/+server.ts` | **書かない**（Stripe に `cancel_at_period_end=true` を予約するのみ、#3991） | S2 → S2（期末に W5 で S5 へ） |
-| W7 | 解約取り消し | `tenant/reactivate/+server.ts` | **書かない**（Stripe の `cancel_at_period_end=false`、#3991） | S2 → S2 |
-| W8 | （欠番）退会猶予満了バッチ | — | **書き手なし**。退会の物理削除は `families` 行ごと削除するため status を書かない（§4.1） | — |
-| W9 | （テナント作成） | `createTenant` | `status=active` のみ | → S1 |
+| W6 | アプリ内解約 | `tenant/cancel/+server.ts` | **書かない**（Stripe に `cancel_at_period_end=true` を予約するのみ、#3991） | なし（期末に W5 が S5 へ移す） |
+| W7 | 解約取り消し | `tenant/reactivate/+server.ts` | **書かない**（Stripe の `cancel_at_period_end=false`、#3991） | なし |
+| W8 | （欠番）退会猶予満了バッチ | — | **書き手なし**。退会の物理削除は `families` 行ごと削除するため status を書かない（§4.1） | なし |
+| W9 | （テナント作成） | `createTenant` | `status=active` のみ | なし（行の新規作成。S1 を作る） |
+
+### 5.1 `遷移` 列の読み方と機械検証
+
+`遷移` 列は **`families` の 4 列が実際に書き換わる組み合わせ**を列挙する。書式は 2 つだけ:
+
+- `S2 → S3`（左辺は `S2/S3/S4 → S5` のように `/` で複数可）
+- `S2 ⇄ S3`（両向き）
+
+**契約状態を書かない書き手は「なし」**と書く。Stripe 側だけが変わる操作（W6 / W7）に遷移を書くと、
+表を読んだ人が「DB が動く」と誤解する。W9 は行の新規作成で開始状態が存在しないため遷移ではない。
+
+本列は `tests/unit/architecture/contract-transition-matrix-ssot.test.ts` が機械照合する。
+handler を実際に呼び、**開始状態 S1〜S5 × Stripe subscription status 8 種**を総当たりして
+書き込み前後を `classifyContractState()` で分類し、観測集合と本列を**双方向**で突き合わせる
+（表にあって実装に無い / 実装にあって表に無い、の両方で fail する）。
+
+検証が届かない範囲は同 test の `UNDRIVEN_WRITERS` に理由付きで列挙する。加えて、
+**状態クラスが同じで列の値だけが違う書き込み**（例: `grace_period` のまま猶予終了日を書き換える）は
+遷移としては同一に見えるため本列の対象外で、`tests/unit/services/stripe-contract-state-classification.test.ts`
+が列の値まで見る。
+
+読み取り上の注意:
+
+- **W2 / W3 / W4 の左辺に S4 が入るのは、event の到着順が保証されないため。** Stripe が
+  `unpaid` / `paused` を経た契約に後続の invoice event を送ることがあり、実装は現行 subscription を
+  SSOT として書き戻す（S4 → S2 は支払い成功による復帰であり、顧客の有料機能が戻る正しい遷移）
+- **W1 の左辺が S1 と S5 だけなのは、`createCheckoutSession()` が `sub` を持つテナントの
+  checkout を `ALREADY_SUBSCRIBED` で拒む**ため。S5（解約済）からの再購読はこの経路で S2 に戻る
+- S6（退会済）を開始状態とする遷移は本表に無い。§4.1 のとおり legacy 行としてしか存在せず、
+  `hooks.server.ts` が当該テナントを完全ブロックする
 
 ### 書き手を増やさない起動点: checkout reconciliation（#3958）
 
@@ -134,16 +164,19 @@ W1 と一致するため、片方だけ直る不整合が生まれない）。
 反映前に「session の subscription == `tenants.stripe_subscription_id`」を突合し、一致していれば
 書き込みも通知も行わない。webhook 先着・URL 再訪・リロードはいずれもこの突合で吸収される。
 
-### 表と実装のズレ（実読で確認、いずれも別 Issue で対処中）
+### `grace_period` は支払い失敗の dunning だけを意味する
 
-| ID | ズレ | 実装の事実 | Issue |
-|---|---|---|---|
-| **D2** | W6 と W3 が同じ `grace_period` に書く | **解消済**。W6 / W7 は DB の契約状態を書かなくなり、`grace_period` の書き手は W3 / W4 (`past_due`) = **支払い失敗の dunning のみ**に一意化された。「解約申請中か」の SSOT は Stripe の `cancel_at_period_end` | #3986 → #3991（解消済） |
-| **D3** | S6 (`terminated`) に書き手がいない | 退会の物理削除は行ごと消すため status を残せない（§4.1）。`terminated` だけを見ていた KPI 3 本は恒常 0 を返していた。**解約は S5 で数える**ように是正済（`isChurnedContract`、§4.2） | #3987（解消済） |
-| **D4** | S4 に実効果が無い | `authorization.ts:171-173` は `suspended` でも `allowed: true` を返す。「読み取り専用」というコメントと実装が不一致 | #3982 / #3993 |
-| **D5** | W3 が退会向け機構を誤発火させる | `grace_period` は `hooks.server.ts:430` の**読み取り専用ロック**と `tenant-cleanup` の**物理削除対象**のトリガでもある。支払い失敗しただけで子どもが記録できなくなる | **#3993（critical）** |
+`grace_period` を書くのは **W3 と W4 の `past_due` 分岐だけ**である（#3986 → #3991）。解約申請の
+猶予は Stripe の `cancel_at_period_end` が持ち、DB の契約状態には現れない。
 
-**これらは、機能軸の文書を個別に読んでいる限り見えない。** 本表のように「誰が」「どの列に」「何を書くか」を 1 枚に並べた時点で、W3 と W6 が同じセルに書いていること（D2）、S6 に書き手がいないこと（D3）が同時に見える。
+この status に退会（アカウント削除）向けの機構を接続してはならない。読み取り専用ロック
+（`hooks.server.ts`）と物理削除バッチ（`tenant-cleanup` → `purgeExpiredSoftDeletedTenants`）は
+どちらも settings の `soft_deleted_at` を条件とする（§6）。支払い失敗は子供の利用体験を止めない
+（`phase1-dunning-requirements.md` NFR-3 / US-4）。
+
+**S4（`suspended`）は読み取り専用ではない。** `authorization.ts` は `suspended` でも
+`allowed: true` を返す — 解約完了 = 無料プラン相当という扱いであり（#3993 PO 判断）、
+書き込みを止める分岐は存在しない。
 
 ---
 
@@ -157,7 +190,7 @@ W1 と一致するため、片方だけ直る不整合が生まれない）。
 | 書き手 | W1〜W9 | `softDeleteTenant()`（`grace-period-service.ts:67-110`） |
 | 猶予日数 | dunning 7 日（`config.ts`） | プラン別 free 0 / standard 7 / premium 30（`DELETION_GRACE_PERIOD_DAYS`） |
 
-**`softDeleteTenant()` は `families` を一切触らない。** したがって「退会申請済み」は本表のどの行にも現れない。読み取り専用ロックと物理削除がこちらではなく契約軸に繋がっているのが D5（#3993）である。
+**`softDeleteTenant()` は `families` を一切触らない。** したがって「退会申請済み」は本表のどの行にも現れない。読み取り専用ロックと物理削除は契約軸ではなくこちらを条件とする（#3993）。
 
 ---
 
@@ -171,7 +204,7 @@ W1 と一致するため、片方だけ直る不整合が生まれない）。
 | gate スクリプト | **不採用（単独では）** | 静的解析で「どの組み合わせが書かれるか」を導出するのは、`updateTenantStripe` の部分更新セマンティクス（`undefined` = 保持）があるため不可能に近い（「静的に読むと正しく見えるが効果が違う」形になる）。ただし「書き込み経路が単一関数を通ること」自体は静的に強制できる（`stripe-contract-write-single-enforcement.test.ts`、#4026） |
 | **判定関数 + 定期監査** | **採用** | 許容集合をドメイン層の SSOT にし、(a) 書き手の unit test が「書いた結果が許容集合に入る」ことを assert できる、(b) 運用側が本番行を突合できる、の両方に使える |
 
-### 実装（3 段のうち ①② が稼働、③ は未実装）
+### 実装（3 段とも稼働）
 
 | # | 手段 | 実体 |
 |---|---|---|
@@ -179,7 +212,8 @@ W1 と一致するため、片方だけ直る不整合が生まれない）。
 | ② | webhook handler の書き込み後状態を分類して assert | `tests/unit/services/stripe-contract-state-classification.test.ts`（#4181）。X1-X4 に分類されたら fail する。**「意図と効果の乖離」はここで落ちる** |
 | ③ | 定期監査（`/ops` or cron）で本番行を分類し X1-X4 を報告 | `contract-state-audit-service.ts` の `auditContractStates()`（`/ops` アクセス毎の on-demand 分類、#4249）。①② は「これから書く行」しか見ないため、既に不正な既存行はこの手だけが検出する |
 
-**③ は #3993 の後に入れる。** X3 を作る書き手が現役のうちに監査を回すと、本番で恒常的に不正を報告し続ける（狼少年になる）。
+①② に加えて、**書き手どうしの遷移**（どの状態からどの状態へ動くか）は
+`tests/unit/architecture/contract-transition-matrix-ssot.test.ts` が §5 の `遷移` 列と双方向照合する（§5.1）。
 
 検出した行への一次対応（確認手順・是正手順・決裁）は [`contract-state-audit-remediation.md`](../../runbooks/contract-state-audit-remediation.md) が SSOT。
 
@@ -193,8 +227,8 @@ W1 と一致するため、片方だけ直る不整合が生まれない）。
 
 ## 8. 関連
 
-- #4181（§7 ①② の実装）/ #4249（§7 ③ 定期監査の実装）
-- #3982 / #4026（W5 の終端 4 列 + 単一強制点）/ #3982（D4）/ #3986 → #3991（D2）/ #3987（D3）/ **#3993 critical（D5）**
+- #4181（§7 ①② の実装）/ #4249（§7 ③ 定期監査の実装）/ #4118（§5.1 遷移の機械照合）
+- #3982 / #4026（W5 の終端 4 列 + 単一強制点）/ #3986 → #3991（`grace_period` の一意化）/ #3987（チャーン判定）/ #3993（退会機構の付け替え）
 - `phase1-cancellation-requirements.md` FR-1 / NFR-2（期末解約）
 - `phase1-dunning-requirements.md` FR-1 / NFR-3 / US-1 / US-4（支払い失敗で子供の体験を止めない）
 - `docs/design/08-データベース設計書.md`（`families` 列定義）

--- a/docs/design/billing-redesign/contract-state-matrix.md
+++ b/docs/design/billing-redesign/contract-state-matrix.md
@@ -139,7 +139,7 @@ handler を実際に呼び、**開始状態 S1〜S5 × Stripe subscription statu
 書き込み前後を `classifyContractState()` で分類し、観測集合と本列を**双方向**で突き合わせる
 （表にあって実装に無い / 実装にあって表に無い、の両方で fail する）。
 
-検証が届かない範囲は同 test の `UNDRIVEN_WRITERS` に理由付きで列挙する。加えて、
+検証が届かない範囲は同 test の `UNCOVERED_WRITERS` に理由付きで列挙する。加えて、
 **状態クラスが同じで列の値だけが違う書き込み**（例: `grace_period` のまま猶予終了日を書き換える）は
 遷移としては同一に見えるため本列の対象外で、`tests/unit/services/stripe-contract-state-classification.test.ts`
 が列の値まで見る。

--- a/tests/unit/architecture/contract-transition-matrix-ssot.test.ts
+++ b/tests/unit/architecture/contract-transition-matrix-ssot.test.ts
@@ -451,6 +451,25 @@ describe('#4118 完了の定義 — 表に書かれた遷移だけが実装で�
 		}
 	});
 
+	it('駆動する書き手の下限が固定されている (未駆動側へ逃がして緑にできない)', () => {
+		// QM #4409 レビュー指摘。`UNCOVERED_WRITERS` は「駆動しない」を人が宣言する枠で、
+		// guard は理由の長さと DRIVEN との重複しか見ていない。下限が無いと、将来 W5
+		// (customer.subscription.deleted) が壊れて赤くなったとき、**DRIVEN から W5 を外し・
+		// 21 文字の理由を書き・表の W5 行を空にする 2 箇所の編集だけで緑に戻せる**。
+		//
+		// W5 は sub / plan / exp をクリアする唯一の書き手であり、黙って未検証になると
+		// 「解約したのに課金中プランが出続ける」が検出されなくなる。ここで下限を固定する。
+		const MUST_BE_DRIVEN = ['W1', 'W2', 'W3', 'W4', 'W5'] as const;
+		const drivenIds = DRIVEN.map((d) => d.writer);
+		for (const id of MUST_BE_DRIVEN) {
+			expect(
+				drivenIds,
+				`${id} は必ず実駆動で検証する。未駆動側 (UNCOVERED_WRITERS) へ移して緑にしてはならない。\n` +
+					'  実装が壊れて赤くなったなら実装を直す。表や列挙を弱めて通さない (ADR-0006)。',
+			).toContain(id);
+		}
+	});
+
 	it('駆動できない書き手が理由付きで列挙されている', () => {
 		for (const w of UNCOVERED_WRITERS) {
 			expect(w.reason.length, `${w.id} の理由が短すぎる (実質空の宣言を許さない)`).toBeGreaterThan(

--- a/tests/unit/architecture/contract-transition-matrix-ssot.test.ts
+++ b/tests/unit/architecture/contract-transition-matrix-ssot.test.ts
@@ -1,0 +1,465 @@
+// tests/unit/architecture/contract-transition-matrix-ssot.test.ts
+// EPIC #4118 完了の定義 —「状態遷移表が 1 枚存在し、**そこに書かれた遷移だけが実装で起こる**ことが
+// 機械検証されている」の後半を担う。
+//
+// ## 既存の装置との境界
+//
+// - `contract-state-matrix-ssot.test.ts` (#4181) は matrix §4 の **状態 (S* / X*) の集合**を照合する
+// - `stripe-contract-state-classification.test.ts` (#4181) は handler の**書き込み後が S1〜S6 に入る**ことを見る
+// - **本 file は「どの状態からどの状態へ」= 遷移そのもの**を、matrix §5 の `遷移` 列と突き合わせる
+//
+// 状態の集合が合っていても、遷移は別物である。`invoice.paid` が S4 (停止) から S2 (課金中) へ
+// 戻せることは、どちらの状態も表にある以上、上の 2 つでは検出できない。
+// 表を読んだ運用者は「S4 から復帰する経路は無い」と誤解したまま障害対応することになる。
+//
+// ## どうやって遷移を機械的に取るか（方式と、その限界）
+//
+// **方式: handler を実際に呼び、書き込み前後の 4 列を `classifyContractState()` で分類して観測する。**
+//
+// 静的解析は採らない。`updateTenantStripe` は差分 patch (`undefined` = 更新しない) を受けるため、
+// 書き込み後の行は「更新前の行 + patch」でしか決まらない。patch の字面から遷移先を導くと
+// 「静的に読むと正しく見えるが効果が違う」形になる (matrix §7 で gate スクリプトを退けた理由と同じ)。
+//
+// 観測は **入力領域を総当たり**する: 5 つの開始状態 (S1〜S5) × Stripe subscription status 8 種 ×
+// webhook 4 種 + checkout。「fixture を書いた遷移しか見えない」を避けるため、fixture は
+// 状態と status の直積から機械生成し、**書き込みが起きた組み合わせだけ**を遷移として記録する。
+//
+// **この方式で検出できること**:
+//   (a) 表に書いた遷移が実装で起こらない (表が実装より強い / 実装が壊れた)
+//   (b) 実装が表に無い遷移を起こす (表が実装に追いついていない)
+//
+// **この方式で検出できないこと** (silent に落とさないため明記する):
+//   - 状態クラスが同じで**列の値だけが違う**書き込み (例: 猶予終了日を延長するか据え置くか)。
+//     S3 → S3 としか見えない。列の値は `stripe-contract-state-classification.test.ts` 側の責務
+//   - 本 file が駆動しない書き手 (下の `UNDRIVEN_WRITERS`) と、開始状態 S6 (§4.1 legacy 行)
+//   - `metadata.planId` が未知の checkout (matrix §4 X2「起きうる」)。plan 解決の失敗であって
+//     状態遷移ではないため、駆動する入力領域から外す (X2 は alert で観測する)
+//
+// 装置 ratchet (チーム憲章 #4175 §4.5) に従い **新規 script は作らず** `tests/unit/architecture/` に置く。
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+
+// ---------- Mocks (stripe-contract-state-classification.test.ts と同型) ----------
+
+const mockFindTenantById = vi.fn();
+const mockUpdateTenantStripe = vi.fn();
+const mockFindTenantByStripeCustomerId = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		auth: {
+			findTenantById: mockFindTenantById,
+			updateTenantStripe: mockUpdateTenantStripe,
+			findTenantByStripeCustomerId: mockFindTenantByStripeCustomerId,
+		},
+		webhookEvent: {
+			findByEventId: async () => null,
+			claim: async () => true,
+			finalize: async () => {},
+			releaseClaim: async () => {},
+			incrementRetryCount: async () => {},
+			deleteOlderThan: async () => 0,
+		},
+	}),
+}));
+
+const mockSubscriptionsRetrieve = vi.fn();
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: () => true,
+	getStripeClient: () => ({ subscriptions: { retrieve: mockSubscriptionsRetrieve } }),
+}));
+
+vi.mock('$lib/server/stripe/config', () => ({
+	getPlans: () => ({
+		monthly: { priceId: 'price_monthly_123', amount: 500, interval: 'month', label: '月額' },
+	}),
+	planIdFromPriceId: (priceId: string) => (priceId === 'price_monthly_123' ? 'monthly' : null),
+	planIdFromLookupKey: () => null,
+	getWebhookSecret: () => 'whsec_test',
+	GRACE_PERIOD_DAYS: 7,
+	CURRENCY: 'jpy',
+}));
+
+vi.mock('$lib/server/stripe/alert', () => ({ notifyStripeAlert: vi.fn() }));
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyDiscord: vi.fn(),
+	notifyIncident: vi.fn(),
+}));
+
+// ---------- Import after mocks ----------
+
+import {
+	type ContractStateColumns,
+	classifyContractState,
+	VALID_CONTRACT_STATES,
+} from '$lib/domain/contract-state';
+import { handleWebhookEvent } from '../../../src/lib/server/services/stripe-service';
+
+const MATRIX = 'docs/design/billing-redesign/contract-state-matrix.md';
+
+// ============================================================
+// 1. 表 (§5 `遷移` 列) を読む
+// ============================================================
+
+/** `W2` などの書き手 id → その行が宣言する遷移集合 (`"S3→S2"`)。 */
+type DeclaredTransitions = Map<string, Set<string>>;
+
+/**
+ * §5 の表から `| W<n> | … | <遷移> |` を読み、遷移を集合に落とす。
+ *
+ * 受け付ける書式は 2 つだけ:
+ *   - `S2 → S3` / `S2/S3/S4 → S5` (左辺は `/` 区切りで複数可)
+ *   - `S2 ⇄ S3` (両向き)
+ *
+ * 左辺を省いた `→ S4` のような書き方は **採らない**。前の項から主語を引き継ぐ読み方は
+ * 人によって解釈が割れ、機械照合の基準にならない。
+ */
+function parseMatrixTransitions(): DeclaredTransitions {
+	const md = readFileSync(MATRIX, 'utf8');
+	const declared: DeclaredTransitions = new Map();
+
+	for (const line of md.split('\n')) {
+		const row = /^\|\s*(W\d+)\s*\|(.*)\|\s*$/.exec(line);
+		if (!row?.[1] || row[2] === undefined) continue;
+		const cells = row[2].split('|');
+		const transitionCell = cells[cells.length - 1] ?? '';
+
+		const set = new Set<string>();
+		const term = /(S\d(?:\s*\/\s*S\d)*)\s*(→|⇄)\s*(S\d)/g;
+		let m: RegExpExecArray | null = term.exec(transitionCell);
+		while (m !== null) {
+			const sources = (m[1] as string).split('/').map((s) => s.trim());
+			const arrow = m[2] as string;
+			const target = m[3] as string;
+			for (const from of sources) {
+				set.add(`${from}→${target}`);
+				if (arrow === '⇄') set.add(`${target}→${from}`);
+			}
+			m = term.exec(transitionCell);
+		}
+		declared.set(row[1], set);
+	}
+	return declared;
+}
+
+// ============================================================
+// 2. 実装を駆動して遷移を観測する
+// ============================================================
+
+const SUB = 'sub_current';
+const CUSTOMER = 'cus_123';
+const PRICE = 'price_monthly_123';
+
+/** Stripe subscription.status の全域 (SDK の union)。終端 2 値を含める。 */
+const STRIPE_STATUSES = [
+	'active',
+	'trialing',
+	'past_due',
+	'unpaid',
+	'paused',
+	'incomplete',
+	'canceled',
+	'incomplete_expired',
+] as const;
+
+/** 開始状態 (matrix §4)。S6 は §4.1 のとおり legacy 行のみのため駆動しない。 */
+const START_STATES: Record<string, Record<string, unknown>> = {
+	S1: { status: 'active', plan: null, stripeSubscriptionId: null, planExpiresAt: null },
+	S2: { status: 'active', plan: 'monthly', stripeSubscriptionId: SUB, planExpiresAt: null },
+	S3: {
+		status: 'grace_period',
+		plan: 'monthly',
+		stripeSubscriptionId: SUB,
+		planExpiresAt: '2026-09-01T00:00:00.000Z',
+	},
+	S4: { status: 'suspended', plan: 'monthly', stripeSubscriptionId: SUB, planExpiresAt: null },
+	S5: { status: 'suspended', plan: null, stripeSubscriptionId: null, planExpiresAt: null },
+};
+
+function makeTenant(state: string): Record<string, unknown> {
+	return {
+		tenantId: 't-test',
+		name: 'テスト家族',
+		ownerId: 'u-owner',
+		stripeCustomerId: CUSTOMER,
+		trialUsedAt: null,
+		createdAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-01T00:00:00Z',
+		...START_STATES[state],
+	};
+}
+
+/** 「更新前の行 + patch」。`undefined` は「更新しない」なので上書きしない。 */
+function mergePatch(
+	before: Record<string, unknown>,
+	patch: Record<string, unknown>,
+): Record<string, unknown> {
+	const merged = { ...before };
+	for (const [k, v] of Object.entries(patch)) {
+		if (v !== undefined) merged[k] = v;
+	}
+	return merged;
+}
+
+function toColumns(row: Record<string, unknown>): ContractStateColumns {
+	return {
+		status: String(row.status),
+		plan: (row.plan ?? null) as string | null,
+		stripeSubscriptionId: (row.stripeSubscriptionId ?? null) as string | null,
+		planExpiresAt: (row.planExpiresAt ?? null) as string | null,
+	};
+}
+
+/** subscription payload / retrieve 応答。 */
+function subscription(status: string): Record<string, unknown> {
+	return {
+		id: SUB,
+		customer: CUSTOMER,
+		status,
+		metadata: { tenantId: 't-test' },
+		items: { data: [{ price: { id: PRICE } }] },
+	};
+}
+
+function eventFor(writer: string, stripeStatus: string): Record<string, unknown> {
+	switch (writer) {
+		case 'W1':
+			return {
+				type: 'checkout.session.completed',
+				data: {
+					object: {
+						id: 'cs_test',
+						metadata: { tenantId: 't-test', planId: 'monthly' },
+						customer: CUSTOMER,
+						subscription: SUB,
+						customer_details: { email: 'test@example.com' },
+						customer_email: null,
+					},
+				},
+			};
+		case 'W2':
+			return {
+				type: 'invoice.paid',
+				data: {
+					object: {
+						id: 'in_paid',
+						customer: CUSTOMER,
+						parent: { subscription_details: { subscription: SUB } },
+					},
+				},
+			};
+		case 'W3':
+			return {
+				type: 'invoice.payment_failed',
+				data: {
+					object: {
+						id: 'in_failed',
+						customer: CUSTOMER,
+						parent: { subscription_details: { subscription: SUB } },
+					},
+				},
+			};
+		case 'W4':
+			return {
+				type: 'customer.subscription.updated',
+				data: { object: subscription(stripeStatus) },
+			};
+		case 'W5':
+			return {
+				type: 'customer.subscription.deleted',
+				data: { object: subscription(stripeStatus) },
+			};
+		default:
+			throw new Error(`driven writer ではありません: ${writer}`);
+	}
+}
+
+/**
+ * 1 組み合わせを駆動し、書き込みが起きたなら遷移を返す。
+ *
+ * 書き込みが起きなかった (突合で skip / 終端で早期 return) 場合は `null`。
+ * **「書かなかった」は遷移ではない**ので観測集合に入れない。
+ */
+async function observe(
+	writer: string,
+	startState: string,
+	stripeStatus: string,
+): Promise<string | null> {
+	vi.clearAllMocks();
+	const before = makeTenant(startState);
+	mockFindTenantById.mockResolvedValue(before);
+	mockFindTenantByStripeCustomerId.mockResolvedValue(before);
+	mockSubscriptionsRetrieve.mockResolvedValue(subscription(stripeStatus));
+
+	await handleWebhookEvent(eventFor(writer, stripeStatus) as never);
+
+	if (mockUpdateTenantStripe.mock.calls.length === 0) return null;
+
+	let row = before;
+	for (const call of mockUpdateTenantStripe.mock.calls) {
+		row = mergePatch(row, call[1] as Record<string, unknown>);
+	}
+	const from = classifyContractState(toColumns(before));
+	const to = classifyContractState(toColumns(row));
+	return `${from}→${to}`;
+}
+
+/**
+ * 駆動する書き手と、その入力領域。
+ *
+ * W1 (checkout) の開始状態を S1 / S5 に絞るのは、`createCheckoutSession()` が
+ * `if (tenant.stripeSubscriptionId) return { error: 'ALREADY_SUBSCRIBED' }` で
+ * **sub を持つテナントの checkout session 生成そのものを拒む**ため。
+ * sub ありから始まる checkout.session.completed は生成経路が無い。
+ */
+const DRIVEN: { writer: string; startStates: string[]; stripeStatuses: readonly string[] }[] = [
+	{ writer: 'W1', startStates: ['S1', 'S5'], stripeStatuses: ['active'] },
+	{ writer: 'W2', startStates: ['S1', 'S2', 'S3', 'S4', 'S5'], stripeStatuses: STRIPE_STATUSES },
+	{ writer: 'W3', startStates: ['S1', 'S2', 'S3', 'S4', 'S5'], stripeStatuses: STRIPE_STATUSES },
+	{ writer: 'W4', startStates: ['S1', 'S2', 'S3', 'S4', 'S5'], stripeStatuses: STRIPE_STATUSES },
+	{ writer: 'W5', startStates: ['S1', 'S2', 'S3', 'S4', 'S5'], stripeStatuses: STRIPE_STATUSES },
+];
+
+/**
+ * 駆動しない書き手。**空にできないなら理由を書く** (#4181 AC4 と同じ扱い)。
+ *
+ * ここに挙がっている限り「実装にあって表に無い遷移」は検出されない。
+ */
+const UNDRIVEN_WRITERS: { id: string; reason: string }[] = [
+	{
+		id: 'W6',
+		reason:
+			'アプリ内解約。契約状態を書かない (#3991、Stripe の cancel_at_period_end が SSOT)。書き込みが無い = 遷移が無いことは stripe-contract-write-single-enforcement.test.ts が構造で保証する',
+	},
+	{
+		id: 'W7',
+		reason:
+			'解約取り消し。W6 と同じく契約状態を書かない (#3991)。Stripe の cancel_at_period_end を false に戻すだけ',
+	},
+	{
+		id: 'W8',
+		reason:
+			'欠番。退会の物理削除は families 行ごと消すため status を書かない (matrix §4.1)。書き手が存在しない',
+	},
+	{
+		id: 'W9',
+		reason:
+			'createTenant。行を新規作成して S1 を作るため開始状態が存在せず、遷移として表現できない。webhook 経路でもないため handleWebhookEvent では駆動できない',
+	},
+];
+
+/** 駆動対象の全組み合わせを回し、書き手ごとの観測遷移集合を返す。 */
+async function observeAllTransitions(): Promise<Map<string, Set<string>>> {
+	const observed = new Map<string, Set<string>>();
+	for (const { writer, startStates, stripeStatuses } of DRIVEN) {
+		const set = new Set<string>();
+		for (const startState of startStates) {
+			// 開始状態の前提が崩れていたら、以降の観測は意味が無い
+			expect(
+				classifyContractState(toColumns(makeTenant(startState))),
+				`開始状態 fixture が ${startState} に分類されません`,
+			).toBe(startState);
+
+			for (const stripeStatus of stripeStatuses) {
+				const transition = await observe(writer, startState, stripeStatus);
+				if (transition) set.add(transition);
+			}
+		}
+		observed.set(writer, set);
+	}
+	return observed;
+}
+
+/**
+ * 観測した遷移の両端が正常状態 (S*) であることを確かめる。
+ *
+ * 遷移先が S* に収まること自体は #4181 AC3 の責務だが、X* / UNCLASSIFIED を
+ * 「表に無い遷移」として報告すると是正の当て先を誤るのでここでも切り分ける。
+ */
+function expectAllStatesValid(writer: string, transitions: Set<string>): void {
+	for (const transition of transitions) {
+		for (const state of transition.split('→')) {
+			expect(
+				(VALID_CONTRACT_STATES as readonly string[]).includes(state),
+				`${writer} が ${transition} を起こした (${state} は正常状態ではない)`,
+			).toBe(true);
+		}
+	}
+}
+
+// ============================================================
+// 3. 照合
+// ============================================================
+
+describe('#4118 完了の定義 — 表に書かれた遷移だけが実装で起こる', () => {
+	const declared = parseMatrixTransitions();
+
+	it('§5 の書き手 9 行すべてを読めている', () => {
+		// 母数が欠けると「一致している」ではなく「検査できていない」。表の書式が変わって
+		// 行を拾えなくなったとき、緑で素通りさせない (#4084 と同じ形)。
+		expect([...declared.keys()].sort(), `${MATRIX} §5 の書き手行を読めていません`).toEqual([
+			'W1',
+			'W2',
+			'W3',
+			'W4',
+			'W5',
+			'W6',
+			'W7',
+			'W8',
+			'W9',
+		]);
+	});
+
+	it('駆動する書き手は表に遷移が宣言されている', () => {
+		for (const { writer } of DRIVEN) {
+			expect(
+				declared.get(writer)?.size ?? 0,
+				`${writer} の遷移が ${MATRIX} §5 から 1 件も読めていません。` +
+					'書式は `S2 → S3` / `S2/S3/S4 → S5` / `S2 ⇄ S3` のいずれかです',
+			).toBeGreaterThan(0);
+		}
+	});
+
+	it('駆動しない書き手には遷移が宣言されていない', () => {
+		// 書き込まない書き手に遷移を書くと、表を読んだ人が「DB が動く」と誤解する。
+		for (const { id } of UNDRIVEN_WRITERS) {
+			expect(
+				[...(declared.get(id) ?? [])],
+				`${id} は契約状態を書かないのに ${MATRIX} §5 が遷移を宣言しています`,
+			).toEqual([]);
+		}
+	});
+
+	it('観測した遷移と表の宣言が双方向で一致する', async () => {
+		const observed = await observeAllTransitions();
+
+		for (const [writer, set] of observed) {
+			// 観測が空なら「一致」ではなく「駆動できていない」
+			expect(set.size, `${writer} を駆動したが書き込みが 1 度も起きていません`).toBeGreaterThan(0);
+			expectAllStatesValid(writer, set);
+
+			expect(
+				[...set].sort(),
+				`${writer} の遷移が ${MATRIX} §5 の宣言と食い違っています。\n` +
+					'  実装にあって表に無い → 表に足す (その遷移が正しいかを先に判断する)\n' +
+					'  表にあって実装に無い → 実装が壊れたか、表が実装より強い',
+			).toEqual([...(declared.get(writer) ?? [])].sort());
+		}
+	});
+
+	it('駆動できない書き手が理由付きで列挙されている', () => {
+		for (const w of UNDRIVEN_WRITERS) {
+			expect(w.reason.length, `${w.id} の理由が短すぎる (実質空の宣言を許さない)`).toBeGreaterThan(
+				20,
+			);
+		}
+		const drivenIds = DRIVEN.map((d) => d.writer);
+		for (const w of UNDRIVEN_WRITERS) {
+			expect(drivenIds, `${w.id} は駆動しているのに未駆動扱いになっています`).not.toContain(w.id);
+		}
+	});
+});

--- a/tests/unit/architecture/contract-transition-matrix-ssot.test.ts
+++ b/tests/unit/architecture/contract-transition-matrix-ssot.test.ts
@@ -31,7 +31,7 @@
 // **この方式で検出できないこと** (silent に落とさないため明記する):
 //   - 状態クラスが同じで**列の値だけが違う**書き込み (例: 猶予終了日を延長するか据え置くか)。
 //     S3 → S3 としか見えない。列の値は `stripe-contract-state-classification.test.ts` 側の責務
-//   - 本 file が駆動しない書き手 (下の `UNDRIVEN_WRITERS`) と、開始状態 S6 (§4.1 legacy 行)
+//   - 本 file が駆動しない書き手 (下の `UNCOVERED_WRITERS`) と、開始状態 S6 (§4.1 legacy 行)
 //   - `metadata.planId` が未知の checkout (matrix §4 X2「起きうる」)。plan 解決の失敗であって
 //     状態遷移ではないため、駆動する入力領域から外す (X2 は alert で観測する)
 //
@@ -329,7 +329,7 @@ const DRIVEN: { writer: string; startStates: string[]; stripeStatuses: readonly 
  *
  * ここに挙がっている限り「実装にあって表に無い遷移」は検出されない。
  */
-const UNDRIVEN_WRITERS: { id: string; reason: string }[] = [
+const UNCOVERED_WRITERS: { id: string; reason: string }[] = [
 	{
 		id: 'W6',
 		reason:
@@ -426,7 +426,7 @@ describe('#4118 完了の定義 — 表に書かれた遷移だけが実装で�
 
 	it('駆動しない書き手には遷移が宣言されていない', () => {
 		// 書き込まない書き手に遷移を書くと、表を読んだ人が「DB が動く」と誤解する。
-		for (const { id } of UNDRIVEN_WRITERS) {
+		for (const { id } of UNCOVERED_WRITERS) {
 			expect(
 				[...(declared.get(id) ?? [])],
 				`${id} は契約状態を書かないのに ${MATRIX} §5 が遷移を宣言しています`,
@@ -452,13 +452,13 @@ describe('#4118 完了の定義 — 表に書かれた遷移だけが実装で�
 	});
 
 	it('駆動できない書き手が理由付きで列挙されている', () => {
-		for (const w of UNDRIVEN_WRITERS) {
+		for (const w of UNCOVERED_WRITERS) {
 			expect(w.reason.length, `${w.id} の理由が短すぎる (実質空の宣言を許さない)`).toBeGreaterThan(
 				20,
 			);
 		}
 		const drivenIds = DRIVEN.map((d) => d.writer);
-		for (const w of UNDRIVEN_WRITERS) {
+		for (const w of UNCOVERED_WRITERS) {
 			expect(drivenIds, `${w.id} は駆動しているのに未駆動扱いになっています`).not.toContain(w.id);
 		}
 	});

--- a/tests/unit/services/stripe-service.test.ts
+++ b/tests/unit/services/stripe-service.test.ts
@@ -897,6 +897,51 @@ describe('handleWebhookEvent', () => {
 		expect(mockUpdateTenantStripe.mock.calls[0]?.[1]).toEqual(TERMINAL_STATE);
 	});
 
+	// #4118: 上の 2 件は tenant 側の割り当てが **既にクリア済み** (deleted 適用後) の後着を見ている。
+	// その形では終端判定を外しても #4026 の突合 (現行契約と event 対象の一致) が代わりに弾くため、
+	// **終端判定そのものが効いているかは検証されていなかった** (mutation で実測)。
+	//
+	// 検証すべきは `deleted` が**まだ届いていない**間に、Stripe 上では既に canceled になった
+	// subscription の invoice event が届く形。tenant はまだ sub を持つので突合は通り、
+	// 終端判定だけが「解約済み契約を課金中/猶予中として書き戻す」のを止めている。
+	// これを落とすと、顧客の画面は課金中のまま Stripe には契約が無い状態になる。
+
+	it('#3982 — deleted 未着でも、現行 subscription が canceled なら invoice.paid は書き込まない', async () => {
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: {
+				retrieve: vi
+					.fn()
+					.mockResolvedValue(makeSubscription('price_monthly_123', { status: 'canceled' })),
+			},
+		});
+		// tenant は sub_123 を保持したまま (deleted がまだ適用されていない)
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant());
+
+		await handleWebhookEvent(makeProrationInvoicePaidEvent() as never);
+
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
+	it('#3982 — deleted 未着でも、現行 subscription が canceled なら invoice.payment_failed は書き込まない', async () => {
+		mockGetStripeClient.mockReturnValue({
+			subscriptions: {
+				retrieve: vi
+					.fn()
+					.mockResolvedValue(makeSubscription('price_monthly_123', { status: 'canceled' })),
+			},
+		});
+		mockFindTenantById.mockResolvedValue(makeSubscribedTenant());
+		mockFindTenantByStripeCustomerId.mockResolvedValue(makeSubscribedTenant());
+
+		await handleWebhookEvent({
+			type: 'invoice.payment_failed',
+			data: { object: { parent: { subscription_details: { subscription: 'sub_123' } } } },
+		} as never);
+
+		expect(mockUpdateTenantStripe).not.toHaveBeenCalled();
+	});
+
 	it('#3982 — 終端でない subscription (past_due) の invoice.payment_failed は従来どおり grace_period にする', async () => {
 		// 終端判定が「解約以外まで巻き込んで無効化」していないことの対照 (guard の空振り検出)
 		mockGetStripeClient.mockReturnValue({


### PR DESCRIPTION
## 顧客価値・目的

契約状態（課金中 / 支払い失敗の猶予 / 停止 / 解約済）の遷移が、設計書 1 枚と実装で食い違わなくなる。食い違うと「解約したのに課金中と表示される」「支払いを直したのに期限が残ったまま警告が出る」といった、家族から見て理由の分からない状態が生まれる。

## 関連 Issue

EPIC #4118 の完了の定義「状態遷移表が 1 枚存在し、そこに書かれた遷移だけが実装で起こることが機械検証されている」を満たす。sub-issue は 6 件とも CLOSED だが、機械検証されていたのは表の **状態**（S1-S6 / X1-X4）までで、**遷移**（S1 → S2 等）は散文のままだった。

related #4118 / #4181 / #3986 / #3991 / #3982 / #3993 / #4026

<!-- no-issue-close: EPIC #4118 の close 判断は PO が実物を確認したうえで行う。本 PR は完了の定義の残部（遷移の機械検証）を満たすものであり、EPIC 自体は閉じない -->

## 変更内容

### 1. 遷移の機械検証（新規 fitness、`tests/unit/architecture/contract-transition-matrix-ssot.test.ts`）

**方式: handler を実際に呼び、書き込み前後の 4 列を `classifyContractState()` で分類して遷移を観測する。**

静的解析は採らない。`updateTenantStripe` は差分 patch（`undefined` = 更新しない）を受けるため、patch の字面から遷移先を導くと「静的に読むと正しく見えるが効果が違う」形になる（matrix §7 が gate スクリプトを退けた理由と同じ）。

観測は fixture を手書きせず、**開始状態 S1〜S5 × Stripe subscription status 8 種 × webhook 4 種 + checkout = 127 通り**を直積で生成し、書き込みが起きた組み合わせだけを遷移として記録する。表の宣言と**双方向**で突き合わせる（表にあって実装に無い / 実装にあって表に無い、の両方で fail）。

**この方式で検出できること**:

- 表に書いた遷移が実装で起こらない（実装が壊れた / 表が実装より強い）
- 実装が表に無い遷移を起こす（表が実装に追いついていない）
- 遷移先が不正状態（X1-X4）や未定義（UNCLASSIFIED）に落ちる

**この方式で検出できないこと**（test 本文にも `UNDRIVEN_WRITERS` として理由付きで残す）:

| 範囲 | 理由 |
|---|---|
| 状態クラスが同じで**列の値だけ違う**書き込み | S3 → S3 としか見えない。列の値は `stripe-contract-state-classification.test.ts` の責務 |
| W6 / W7（アプリ内解約・取り消し） | 契約状態を書かない（#3991）。書き込みが無いこと自体は `stripe-contract-write-single-enforcement.test.ts` が構造で保証する |
| W8 | 書き手が存在しない（退会の物理削除は families 行ごと消す） |
| W9（`createTenant`） | 行の新規作成で開始状態が無く、遷移として表現できない |
| 開始状態 S6（退会済） | legacy 行としてしか存在せず `hooks.server.ts` が完全ブロックする（matrix §4.1） |
| `metadata.planId` が未知の checkout | plan 解決の失敗であって遷移ではない（matrix §4 X2「起きうる」。alert で観測する） |

### 2. 表（§5 `遷移` 列）を実装に合わせて是正

fitness を先に書いたところ、**表が実装より弱い遷移が 6 件**あった（「検証」の failing-first 参照）。いずれも実装側が正しいと判断して表を直した（本番コードは変えていない）。判断理由:

- **W1 に `S5 → S2`**: 解約済み（S5）からの再購読。`createCheckoutSession()` の `ALREADY_SUBSCRIBED` ガードが通すのはこの経路であり、顧客が戻ってこられない方が害が大きい
- **W2 に `S4 → S2`**: 停止（`unpaid` / `paused`）から支払い成功で復帰する経路。有料機能が戻る正しい遷移
- **W3 に `S3 → S3` / `S4 → S3`**: dunning 中の再失敗、および停止中に届く支払い失敗。Stripe は配信順を保証せず、実装は現行 subscription を SSOT として書き戻す
- **W4 の `→ S4` / `→ S5`**: 左辺を省いた書き方（主語を前項から引き継ぐ読み方）は解釈が割れるため、`S2/S3/S4 → S4` のように明示した

あわせて `遷移` 列の書式と、検証が届く範囲・届かない範囲を §5.1 として明文化した。

### 3. 表の記述を現状に合わせる（`docs/CLAUDE.md` §docs SSOT 原則）

§5「表と実装のズレ」の 4 件と §7 の実装状況を、実装を 1 件ずつ読み直して確認した。**すべて解消済みで記述だけが残っていた**ため、経緯は git に委ねて現状の正解だけを残す形に整理した:

| 旧記述 | 実装の事実（確認箇所） |
|---|---|
| D2「W6 と W3 が同じ `grace_period` に書く」 | 解消済。`tenant/cancel/+server.ts` は契約状態を書かない |
| D3「S6 に書き手がいない」 | 解消済。チャーンは S5 で数える（`isChurnedContract`） |
| D4「S4 に実効果が無い」 | **解消済（意図的にそう決めた）**。`authorization.ts` の `suspended` 分岐は「解約完了 = 無料プラン相当なので読み取り専用にしない」という #3993 PO 判断のコメント付きで `allowed: true` を返す。表の「コメントと実装が不一致」という記述の方が古い |
| D5「W3 が退会向け機構を誤発火」 | **解消済**。`hooks.server.ts` の読み取り専用ロックは `soft_deleted_at` 判定に付け替え済、`tenant-cleanup/+server.ts` は `purgeExpiredSoftDeletedTenants()` に委譲済で `grace_period` を見ていない |
| §7「③ 定期監査は未実装」 | 実装済。`contract-state-audit-service.ts` が `/ops` に配線済（#4249） |
| §4 X3「**起きる**」/ X4「起きうる」 | 現在の書き手からは起きない（W2 / W4 は `active` を書くとき `exp=null` を同時に書く / W3・W4 は現行契約と突合してから書く）。過去に作られた行は §7 ③ の監査で検出する |

### 4. mutation で生き残った穴を塞ぐ（`tests/unit/services/stripe-service.test.ts` に 2 件追加）

`invoice.paid` / `invoice.payment_failed` の**終端 subscription skip**（#3982）を無効化しても、既存テストと新 fitness が**すべて緑のまま**だった。既存 2 件は tenant 側の割り当てが既にクリア済みの形を見ており、その形では #4026 の突合が代わりに弾くため、終端判定そのものは検証されていなかった。`deleted` がまだ届いていない（tenant は sub を保持したまま Stripe 側は canceled）形の回帰テストを 2 件追加した。これが無いと、顧客の画面は課金中のまま Stripe には契約が無い、という状態を作れる。

## 検証

### failing-first（先に fitness を書き、現状で落ちることを確認）

`遷移` 列を是正前（develop の内容）に戻して実行:

```
AssertionError: W3 の遷移が docs/design/billing-redesign/contract-state-matrix.md §5 の宣言と食い違っています。
+   "S3→S3",
+   "S4→S3",
      Tests  1 failed | 4 passed (5)
```

= 表に無い遷移が実装に存在していた（未検証だった gap の実在）。是正後は 5 passed。

### mutation（実装を壊して落ちることを確認。いずれも commit 済みの状態から実施し、確認後に戻した）

| # | 壊した箇所 | 結果 |
|---|---|---|
| M1 | 表 W3 の `S2/S3/S4 → S3` を `S2 → S3` に戻す | FAIL `W3 の遷移が … 食い違っています` |
| M2 | `handleInvoicePaid` の `planExpiresAt: null` を落とす | FAIL `W2 が S3→X3 を起こした` |
| M3 | `planExpiresAtPatchFor` の `grace_period` 分岐を `{}` に | FAIL `W4 が S2→UNCLASSIFIED を起こした` |
| M4 | `TERMINAL_CONTRACT_STATE.plan` を `undefined` に | FAIL `W4 が S2→X1 を起こした` |
| M5 | `handleInvoicePaid` の終端 skip を無効化 | **生存**（既存テストも全緑）→ 回帰テスト追加後は FAIL |
| M6 | `handlePaymentFailed` の終端 skip を無効化 | **生存** → 回帰テスト追加後は FAIL |

M5 / M6 の回帰テスト追加後の再実行では `× #3982 — deleted 未着でも、現行 subscription が canceled なら invoice.paid は書き込まない` ほか 1 件が FAIL（`Tests 2 failed | 45 passed`）。mutation を戻して 52 passed。

### テスト

`stripe-service.test.ts` + `contract-transition-matrix-ssot.test.ts` を実行して `Tests 52 passed (52)`。`npm run pre-ready -- --pr <本 PR>` は全 step PASS。

## 影響範囲

- **顧客に見える変化: なし**。本番コード（`src/`）の挙動は 1 行も変えていない。追加したのは test 2 file と設計書の是正
- 触った並行実装ペア: なし
- 破壊的変更: なし
- 以後、webhook handler を足す / 分岐を変える PR は、`contract-state-matrix.md` §5 の `遷移` 列を同じ PR で更新しないと CI が落ちる

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
