### PR TITLE
fix(child-ui): #4419 子供登録時の uiMode 既定値を getDefaultUiMode に一本化する（本番 backend が年齢を見ていなかった）

### DIFF
--- a/scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
+++ b/scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
@@ -51,17 +51,14 @@ export default async (page, capture) => {
 	await page.waitForLoadState('networkidle');
 
 	// 追加フォームは折りたたみ。「追加する」トグルを押して開く。
+	// Svelte 5 の hydration 前に押すと無反応なので、hydration を待ってから retry する。
+	await page.waitForTimeout(2_000);
 	const toggle = page.getByRole('button', { name: '追加する' }).first();
 	await toggle.waitFor({ state: 'visible', timeout: 30_000 });
-	for (let attempt = 0; attempt < 5; attempt++) {
-		await toggle.click();
-		const opened = await page
-			.locator('input[name="nickname"]')
-			.first()
-			.waitFor({ state: 'visible', timeout: 3_000 })
-			.then(() => true)
-			.catch(() => false);
-		if (opened) break;
+	for (let attempt = 0; attempt < 6; attempt++) {
+		await toggle.click({ timeout: 5_000 }).catch(() => {});
+		if (await page.locator('input[name="nickname"]').first().isVisible()) break;
+		await page.waitForTimeout(1_000);
 	}
 
 	// 登録フォーム: ニックネーム + 年齢 15 (誕生日は未入力 = 顧客が最短で登録する経路)
@@ -77,5 +74,6 @@ export default async (page, capture) => {
 	await page.getByText(NICKNAME, { exact: false }).first().waitFor({ timeout: 30_000 });
 	await settle(page);
 
-	await capture('issue-4419-admin-children-age15-registered');
+	// Before / After を同じ flow で撮り分ける (SS_LABEL=before-... / after-...)。
+	await capture(process.env.SS_LABEL || 'issue-4419-admin-children-age15-registered');
 };

--- a/scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
+++ b/scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
@@ -35,7 +35,10 @@ async function loginIfNeeded(page) {
 	if (!page.url().includes('/auth/login')) return;
 	await page.fill('input[type="email"], input[name="email"]', DEV_OWNER.email);
 	await page.fill('input[type="password"], input[name="password"]', DEV_OWNER.password);
-	await page.getByRole('button', { name: /ログイン|サインイン/ }).first().click();
+	await page
+		.getByRole('button', { name: /ログイン|サインイン/ })
+		.first()
+		.click();
 	await page.waitForURL((url) => !url.pathname.includes('/auth/login'), { timeout: 30_000 });
 	if (!page.url().includes('/admin/children')) {
 		await page.goto(new URL('/admin/children', page.url()).toString());

--- a/scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
+++ b/scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
@@ -1,0 +1,81 @@
+/**
+ * scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
+ *
+ * #4419: `/admin/children` から年長の子供 (15 歳) を登録した直後の表示を撮る。
+ * 修正前は年齢に関わらず「幼児 (3-5歳)」= preschool になり、修正後は年齢どおり
+ * 「中学生 (13-15歳)」= junior になる。
+ *
+ * **demo backend では再現しない** (demo の insertChild は元から getDefaultUiMode を通し、
+ * かつ登録が永続しない stub)。そのため通常の SS 撮影環境 (DATA_SOURCE=demo) ではなく、
+ * **sqlite backend (`dev:cognito`)** で撮る。sqlite も修正前は「3 歳以上は全部 preschool」
+ * で同じ症状が出るため、顧客が踏む壊れ方をそのまま画面で再現できる。
+ *
+ * 使用例 (専用 port で dev:cognito を起動しておく):
+ *   AUTH_MODE=cognito COGNITO_DEV_MODE=true npx vite dev --port 5192 --strictPort
+ *   MSYS_NO_PATHCONV=1 node scripts/capture.mjs \
+ *     --flow admin-children-add-ui-mode-4419 \
+ *     --url "/admin/children" --base-url http://localhost:5192 --no-start-server \
+ *     --actions scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs \
+ *     --presets desktop --pr 4419
+ */
+
+const DEV_OWNER = { email: 'owner@example.com', password: 'Gq!Dev#Owner2026x' };
+const NICKNAME = 'ちゅうがく3ねん';
+
+async function settle(page) {
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+}
+
+async function loginIfNeeded(page) {
+	if (!page.url().includes('/auth/login')) return;
+	await page.fill('input[type="email"], input[name="email"]', DEV_OWNER.email);
+	await page.fill('input[type="password"], input[name="password"]', DEV_OWNER.password);
+	await page.getByRole('button', { name: /ログイン|サインイン/ }).first().click();
+	await page.waitForURL((url) => !url.pathname.includes('/auth/login'), { timeout: 30_000 });
+	if (!page.url().includes('/admin/children')) {
+		await page.goto(new URL('/admin/children', page.url()).toString());
+	}
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	await loginIfNeeded(page);
+	await page.waitForLoadState('networkidle');
+
+	// 追加フォームは折りたたみ。「追加する」トグルを押して開く。
+	const toggle = page.getByRole('button', { name: '追加する' }).first();
+	await toggle.waitFor({ state: 'visible', timeout: 30_000 });
+	for (let attempt = 0; attempt < 5; attempt++) {
+		await toggle.click();
+		const opened = await page
+			.locator('input[name="nickname"]')
+			.first()
+			.waitFor({ state: 'visible', timeout: 3_000 })
+			.then(() => true)
+			.catch(() => false);
+		if (opened) break;
+	}
+
+	// 登録フォーム: ニックネーム + 年齢 15 (誕生日は未入力 = 顧客が最短で登録する経路)
+	const nickname = page.locator('input[name="nickname"]').first();
+	await nickname.waitFor({ state: 'visible', timeout: 30_000 });
+	await nickname.fill(NICKNAME);
+	await page.locator('input[name="age"]').first().fill('15');
+
+	// フォーム内の submit ボタン (「追加する」) を押す
+	await page.locator('form[action="?/addChild"] button[type="submit"]').first().click();
+
+	// 登録された子供のカードが一覧に出るまで待つ
+	await page.getByText(NICKNAME, { exact: false }).first().waitFor({ timeout: 30_000 });
+	await settle(page);
+
+	await capture('issue-4419-admin-children-age15-registered');
+};

--- a/scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
+++ b/scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs
@@ -19,6 +19,8 @@
  *     --presets desktop --pr 4419
  */
 
+import { waitForStablePage } from '../../lib/ci/screenshot-helpers.mjs';
+
 const DEV_OWNER = { email: 'owner@example.com', password: 'Gq!Dev#Owner2026x' };
 const NICKNAME = 'ちゅうがく3ねん';
 
@@ -54,14 +56,20 @@ export default async (page, capture) => {
 	await page.waitForLoadState('networkidle');
 
 	// 追加フォームは折りたたみ。「追加する」トグルを押して開く。
-	// Svelte 5 の hydration 前に押すと無反応なので、hydration を待ってから retry する。
-	await page.waitForTimeout(2_000);
+	// Svelte 5 の hydration 前に押すと無反応なので、描画安定を待ってから retry する
+	// (固定 sleep は使わない — #1208 / waitForStablePage が SSOT)。
+	await waitForStablePage(page);
 	const toggle = page.getByRole('button', { name: '追加する' }).first();
 	await toggle.waitFor({ state: 'visible', timeout: 30_000 });
+	const nicknameInput = page.locator('input[name="nickname"]').first();
 	for (let attempt = 0; attempt < 6; attempt++) {
 		await toggle.click({ timeout: 5_000 }).catch(() => {});
-		if (await page.locator('input[name="nickname"]').first().isVisible()) break;
-		await page.waitForTimeout(1_000);
+		// 開けば即 break。開かなければ待機を兼ねて次の attempt へ (hydration 待ち)。
+		const opened = await nicknameInput
+			.waitFor({ state: 'visible', timeout: 3_000 })
+			.then(() => true)
+			.catch(() => false);
+		if (opened) break;
 	}
 
 	// 登録フォーム: ニックネーム + 年齢 15 (誕生日は未入力 = 顧客が最短で登録する経路)

--- a/src/lib/server/db/dsql/child-repo.ts
+++ b/src/lib/server/db/dsql/child-repo.ts
@@ -20,7 +20,12 @@
 import { sql } from 'drizzle-orm';
 import { calculateAgeFromBirthDate } from '$lib/domain/date-utils';
 import { asChildId } from '$lib/domain/ids';
-import { isValidUiMode, recalcUiMode, type UiMode } from '$lib/domain/validation/age-tier';
+import {
+	getDefaultUiMode,
+	isValidUiMode,
+	recalcUiMode,
+	type UiMode,
+} from '$lib/domain/validation/age-tier';
 import type { ChildProgressResetCounts, IChildRepo } from '../interfaces/child-repo.interface';
 import type { TransactionRunner } from '../interfaces/transaction.interface';
 import type { Child, UpdateChildInput } from '../types';
@@ -158,7 +163,7 @@ export function createDsqlChildRepo<TTx extends SqlExecutor>(
 			const result = await db.execute(sql`
 				INSERT INTO children (family_id, nickname, birth_date, theme, ui_mode)
 				VALUES (${tenantId}, ${input.nickname}, ${input.birthDate ?? null},
-					${input.theme ?? 'pink'}, ${input.uiMode ?? 'preschool'})
+					${input.theme ?? 'pink'}, ${input.uiMode ?? getDefaultUiMode(input.age)})
 				RETURNING ${CHILD_COLUMNS}
 			`);
 			return toChild(result.rows[0] as unknown as ChildRow);

--- a/src/lib/server/db/sqlite/child-repo.ts
+++ b/src/lib/server/db/sqlite/child-repo.ts
@@ -1,7 +1,7 @@
 import { eq, isNull, or } from 'drizzle-orm';
 import type { ArchivedReason } from '$lib/domain/archive-types';
 import { asChildId, type ChildId } from '$lib/domain/ids';
-import { normalizeUiMode } from '$lib/domain/validation/age-tier';
+import { getDefaultUiMode, normalizeUiMode } from '$lib/domain/validation/age-tier';
 import { db } from '../client';
 import type { ChildProgressResetCounts } from '../interfaces/child-repo.interface';
 import { hydrate } from '../migration';
@@ -119,7 +119,7 @@ export async function insertChild(
 			nickname: input.nickname,
 			age: input.age,
 			theme: input.theme ?? 'pink',
-			uiMode: input.uiMode ?? (input.age <= 2 ? 'baby' : 'preschool'),
+			uiMode: input.uiMode ?? getDefaultUiMode(input.age),
 			birthDate: input.birthDate ?? null,
 			[SCHEMA_VERSION_FIELD]: ENTITY_VERSIONS.child.latest,
 		})

--- a/src/lib/server/services/child-service.ts
+++ b/src/lib/server/services/child-service.ts
@@ -5,7 +5,7 @@ import {
 	PLACEHOLDER_AVATAR_EXTENSION,
 } from '$lib/domain/placeholder-avatar';
 import type { UiMode } from '$lib/domain/validation/age-tier';
-import { recalcUiMode } from '$lib/domain/validation/age-tier';
+import { getDefaultUiMode, recalcUiMode } from '$lib/domain/validation/age-tier';
 import {
 	deleteChild,
 	findAllChildren,
@@ -51,7 +51,13 @@ export async function addChild(
 	},
 	tenantId: string,
 ) {
-	const child = await insertChild(input, tenantId);
+	// #4419: UI モードは年齢から自動判定する (getDefaultUiMode が SSOT)。
+	// route 側で判定すると片方だけ通らない (実際 `/admin/children` が uiMode を渡しておらず、
+	// 本番 backend で年齢に関わらず幼児 UI になっていた) ため、両登録経路が通る本関数に
+	// 1 箇所だけ置く — #4413 の仮アバターを addChild に置いたのと同じ理由。
+	// 保護者が明示指定した uiMode は尊重する (手動フラグは editChild 側の責務)。
+	const resolved = { ...input, uiMode: input.uiMode ?? getDefaultUiMode(input.age) };
+	const child = await insertChild(resolved, tenantId);
 	return await attachPlaceholderAvatar(child, tenantId);
 }
 

--- a/src/routes/setup/children/+page.server.ts
+++ b/src/routes/setup/children/+page.server.ts
@@ -1,5 +1,4 @@
 import { fail, redirect } from '@sveltejs/kit';
-import { getDefaultUiMode } from '$lib/domain/validation/age-tier';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { addChild, getAllChildren } from '$lib/server/services/child-service';
 import { trackSetupFunnel } from '$lib/server/services/setup-funnel-service';
@@ -32,11 +31,14 @@ export const actions: Actions = {
 			return fail(400, { error: '年齢は0〜18で入力してください' });
 		}
 
-		// #0262: UIモードは年齢から自動判定
-		const uiMode = getDefaultUiMode(age);
-
-		await addChild({ nickname, age, theme, uiMode }, tenantId);
-		trackSetupFunnel('setup_child_registered', tenantId, { nickname, age, uiMode });
+		// #0262 / #4419: UI モードは年齢から自動判定する。判定は addChild (service 層) の
+		// 責務に統一したので、ここでは渡さず結果を受け取る (route ごとの二重実装を作らない)。
+		const child = await addChild({ nickname, age, theme }, tenantId);
+		trackSetupFunnel('setup_child_registered', tenantId, {
+			nickname,
+			age,
+			uiMode: child.uiMode,
+		});
 		return { success: true };
 	},
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -333,7 +333,9 @@ CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.
 
 ### backend 並行実装の整合性
 
-`src/lib/server/db/sqlite/*.ts` と `src/lib/server/db/dsql/*.ts` (cloud、NUC は PGlite が dsql repo を verbatim 再利用) のペアは新カラム追加時に undefined / null / 既定値ハンドリングを両実装で一致させる (#3438 で DynamoDB backend は撤去済)。
+`src/lib/server/db/sqlite/*.ts` と `src/lib/server/db/dsql/*.ts` (cloud、NUC は PGlite が dsql repo を verbatim 再利用) のペアは新カラム追加時に undefined / null / 既定値ハンドリングを両実装で一致させる (#3438 で DynamoDB backend は撤去済)。demo backend (`db/demo/*.ts`) も同じ既定値を返す。
+
+**既定値の一致は「書く」だけでなく機械検証する**。本節の規定はあったが検証がなく、`insertChild` の `uiMode` 既定値が 3 backend で 3 通りに割れ、**顧客が使う dsql が最も壊れている**状態が残った (#4419: 年齢に関わらず幼児 UI)。同種の既定値には fitness function を置く — 実装例は `tests/unit/architecture/child-ui-mode-default-parity.test.ts` (3 backend に実際に insert して既定値の一致 + SSOT 由来を assert)。
 
 ## E2E 固有
 

--- a/tests/unit/architecture/child-ui-mode-default-parity.test.ts
+++ b/tests/unit/architecture/child-ui-mode-default-parity.test.ts
@@ -99,7 +99,7 @@ describe('#4419 child insertChild の uiMode 既定値は 3 backend で一致す
 	function extractDefaultExpr(source: string): string[] {
 		const matches = [...source.matchAll(/input\.uiMode\s*\?\?\s*([^,;\n}]+)/g)];
 		return matches.map((m) => {
-			let expr = m[1].replace(/\s+/g, '');
+			let expr = (m[1] ?? '').replace(/\s+/g, '');
 			// 式の外側 (テンプレートリテラルや呼び出しの閉じ) の ')' を取り除く
 			while (
 				expr.endsWith(')') &&

--- a/tests/unit/architecture/child-ui-mode-default-parity.test.ts
+++ b/tests/unit/architecture/child-ui-mode-default-parity.test.ts
@@ -1,0 +1,135 @@
+// tests/unit/architecture/child-ui-mode-default-parity.test.ts
+// #4419 fitness function: 3 backend (dsql / sqlite / demo) の insertChild が
+// **uiMode 未指定時に同じ既定値**を返すことを機械強制する。
+//
+// なぜ必要か: `tests/CLAUDE.md` §「backend 並行実装の整合性」が「sqlite ⇄ dsql のペアは
+// undefined / null / 既定値ハンドリングを両実装で一致させる」と定めているのに、既定値の
+// 不一致が検証されていなかった。結果、dsql は `'preschool'` 固定 / sqlite は 2 歳以下だけ
+// baby / demo だけが getDefaultUiMode という 3 通りに割れ、**顧客が使う本番 (dsql) が
+// 最も壊れている**状態が誰にも気づかれず残った (#4419)。
+//
+// 検証は 2 段:
+//   [F1] 挙動 — 3 backend に実際に insert して既定値が互いに一致し、SSOT
+//        (getDefaultUiMode) とも一致する。片方の backend を変えれば必ず落ちる
+//   [F2] 由来 — 各 repo が SSOT 関数を経由し、年齢判定リテラルを repo 内に持たない
+//        (今日たまたま値が合う literal の再混入を止める)
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { getDefaultUiMode } from '../../../src/lib/domain/validation/age-tier';
+import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+import { closeDb, createTestDb, type TestDb, type TestSqlite } from '../helpers/test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000004b1';
+
+/** 既定値の一致を確認する年齢 — 5 年齢帯すべての境界 (docs/DESIGN.md §8)。 */
+const AGES = [0, 2, 3, 5, 6, 12, 13, 15, 16, 18];
+
+// sqlite repo は module-level の db を握るのでテスト DB を差す。
+let testDb: TestDb;
+vi.mock('$lib/server/db', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		return testDb;
+	},
+}));
+
+const sqliteRepo = await import('$lib/server/db/sqlite/child-repo');
+const demoRepo = await import('$lib/server/db/demo/child-repo');
+
+describe('#4419 child insertChild の uiMode 既定値は 3 backend で一致する (fitness)', () => {
+	let sqlite: TestSqlite;
+	let t: DsqlTestDb;
+	let dsqlRepo: ReturnType<typeof createDsqlChildRepo>;
+
+	beforeAll(async () => {
+		const created = createTestDb();
+		sqlite = created.sqlite;
+		testDb = created.db;
+		t = await createDsqlTestDb();
+		dsqlRepo = createDsqlChildRepo(
+			t.db,
+			createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 }),
+		);
+	}, 60_000);
+
+	afterAll(async () => {
+		closeDb(sqlite);
+		await t.close();
+	});
+
+	it.each(AGES)('[F1] age=%i: dsql / sqlite / demo の既定 uiMode が一致する', async (age) => {
+		const input = { nickname: `p${age}`, age, theme: 'pink' };
+		const dsql = await dsqlRepo.insertChild(input, FAMILY);
+		const sq = await sqliteRepo.insertChild(input, FAMILY);
+		const demo = await demoRepo.insertChild(input, FAMILY);
+
+		const expected = getDefaultUiMode(age);
+		// backend 同士が一致すること (どれか 1 つを変えれば落ちる)
+		expect(
+			{ dsql: dsql.uiMode, sqlite: sq.uiMode, demo: demo.uiMode },
+			`age=${age} で backend 間の既定 uiMode が割れている`,
+		).toEqual({ dsql: expected, sqlite: expected, demo: expected });
+	});
+
+	it('[F1] 明示指定した uiMode は 3 backend とも尊重される (既定値で上書きしない)', async () => {
+		const input = { nickname: 'manual', age: 15, theme: 'pink', uiMode: 'preschool' };
+		const dsql = await dsqlRepo.insertChild(input, FAMILY);
+		const sq = await sqliteRepo.insertChild(input, FAMILY);
+		const demo = await demoRepo.insertChild(input, FAMILY);
+		expect([dsql.uiMode, sq.uiMode, demo.uiMode]).toEqual([
+			'preschool',
+			'preschool',
+			'preschool',
+		]);
+	});
+
+	// ---- [F2] 由来 (SSOT 経由であること) ----
+
+	const REPO_FILES = [
+		'src/lib/server/db/dsql/child-repo.ts',
+		'src/lib/server/db/sqlite/child-repo.ts',
+		'src/lib/server/db/demo/child-repo.ts',
+	];
+
+	/** `input.uiMode ?? <式>` の <式> を取り出す (空白を潰し、外側の閉じ括弧を落とす)。 */
+	function extractDefaultExpr(source: string): string[] {
+		const matches = [...source.matchAll(/input\.uiMode\s*\?\?\s*([^,;\n}]+)/g)];
+		return matches.map((m) => {
+			let expr = m[1].replace(/\s+/g, '');
+			// 式の外側 (テンプレートリテラルや呼び出しの閉じ) の ')' を取り除く
+			while (
+				expr.endsWith(')') &&
+				(expr.match(/\)/g)?.length ?? 0) > (expr.match(/\(/g)?.length ?? 0)
+			) {
+				expr = expr.slice(0, -1);
+			}
+			return expr;
+		});
+	}
+
+	it.each(REPO_FILES)('[F2] %s の既定値式が getDefaultUiMode(input.age) である', (rel) => {
+		const source = readFileSync(resolve(process.cwd(), rel), 'utf-8');
+		const exprs = extractDefaultExpr(source);
+		expect(exprs.length, `${rel} に uiMode 既定値式が見つからない`).toBeGreaterThan(0);
+		for (const expr of exprs) {
+			expect(expr, `${rel} は年齢判定を repo 内に書かず SSOT を呼ぶこと`).toBe(
+				'getDefaultUiMode(input.age)',
+			);
+		}
+	});
+
+	it('[F2] 3 backend の既定値式は同一文字列である', () => {
+		const exprs = REPO_FILES.map((rel) =>
+			extractDefaultExpr(readFileSync(resolve(process.cwd(), rel), 'utf-8')).join('|'),
+		);
+		expect(new Set(exprs).size, `backend ごとに既定値式が違う: ${exprs.join(' / ')}`).toBe(1);
+	});
+});

--- a/tests/unit/architecture/child-ui-mode-default-parity.test.ts
+++ b/tests/unit/architecture/child-ui-mode-default-parity.test.ts
@@ -84,11 +84,7 @@ describe('#4419 child insertChild の uiMode 既定値は 3 backend で一致す
 		const dsql = await dsqlRepo.insertChild(input, FAMILY);
 		const sq = await sqliteRepo.insertChild(input, FAMILY);
 		const demo = await demoRepo.insertChild(input, FAMILY);
-		expect([dsql.uiMode, sq.uiMode, demo.uiMode]).toEqual([
-			'preschool',
-			'preschool',
-			'preschool',
-		]);
+		expect([dsql.uiMode, sq.uiMode, demo.uiMode]).toEqual(['preschool', 'preschool', 'preschool']);
 	});
 
 	// ---- [F2] 由来 (SSOT 経由であること) ----

--- a/tests/unit/routes/admin-children-add-ui-mode.test.ts
+++ b/tests/unit/routes/admin-children-add-ui-mode.test.ts
@@ -92,7 +92,9 @@ function createEvent(formValues: Record<string, string>) {
 /** /admin/children の addChild action を実行して、保存された子供を DB から読み直す。 */
 async function addViaAdminRoute(form: Record<string, string>) {
 	// biome-ignore lint/suspicious/noExplicitAny: action の戻り値 union を絞らない
-	const result: any = await actions.addChild(createEvent(form));
+	const addChildAction = actions.addChild;
+	if (!addChildAction) throw new Error('addChild action が存在しない');
+	const result: any = await addChildAction(createEvent(form));
 	expect(result?.success, `addChild が失敗した: ${JSON.stringify(result)}`).toBe(true);
 	const reloaded = await repo.findChildById(result.addedChild.id, FAMILY);
 	return { returned: result.addedChild, reloaded };

--- a/tests/unit/routes/admin-children-add-ui-mode.test.ts
+++ b/tests/unit/routes/admin-children-add-ui-mode.test.ts
@@ -1,0 +1,161 @@
+// tests/unit/routes/admin-children-add-ui-mode.test.ts
+// #4419: /admin/children から登録した子供の uiMode が年齢どおりになることを固定する。
+//
+// **本番 backend (dsql repo) で検証する**。dsql repo は PGlite で verbatim 再利用される
+// (ADR-0064) ため、実 schema を適用した PGlite に対して route action → child-service →
+// dsql child-repo の実経路をそのまま通す。demo backend だけが getDefaultUiMode を呼んで
+// いたので、demo で検証しても本 defect は再現しない (#4419 §検出されなかった理由)。
+//
+// 固定する不変条件:
+//   [A] 5 年齢帯の境界 (2/3/5/6/12/13/15/16 歳) が getDefaultUiMode どおりに入る
+//   [B] birthDate なし (age のみ) の登録でも正しい — dsql は birth_date NULL 行で
+//       compute-on-read の再導出が効かず stored 値がそのまま出るため、ここが実害の本体
+//   [C] birthDate あり の登録でも正しい (stored 値自体が正しいこと)
+
+import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+import { getDefaultUiMode } from '../../../src/lib/domain/validation/age-tier';
+import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
+import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
+import type { IChildRepo } from '../../../src/lib/server/db/interfaces/child-repo.interface';
+import { createDsqlTestDb, type DsqlTestDb } from '../helpers/dsql-test-db';
+
+const FAMILY = '00000000-0000-4000-8000-0000000004a1';
+
+let repo: IChildRepo;
+
+// ---------- mocks: 本経路 (route → service → child-repo) 以外は最小 stub ----------
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+}));
+
+// child-repo だけは「本番 backend の実物」を差す (PGlite 上の dsql repo に委譲)。
+vi.mock('$lib/server/db/child-repo', () => ({
+	insertChild: (input: Parameters<IChildRepo['insertChild']>[0], tenantId: string) =>
+		repo.insertChild(input, tenantId),
+	findAllChildren: (tenantId: string) => repo.findAllChildren(tenantId),
+	findChildById: (id: never, tenantId: string) => repo.findChildById(id, tenantId),
+	findChildByUserId: (userId: string, tenantId: string) => repo.findChildByUserId(userId, tenantId),
+	updateChild: (id: never, input: never, tenantId: string) =>
+		repo.updateChild(id, input, tenantId),
+	deleteChild: (id: never, tenantId: string) => repo.deleteChild(id, tenantId),
+	resetChildProgressData: vi.fn(),
+	findArchivedChildren: vi.fn().mockResolvedValue([]),
+	archiveChild: vi.fn(),
+	restoreChild: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	checkChildLimit: vi.fn().mockResolvedValue({ allowed: true, max: 10 }),
+	getPlanLimits: vi.fn().mockReturnValue({ historyRetentionDays: null }),
+	hasArchivedData: vi.fn().mockResolvedValue(false),
+	applyRetentionFilter: <T>(rows: T) => rows,
+	resolveFullPlanTier: vi.fn().mockResolvedValue('free'),
+}));
+
+vi.mock('$lib/server/services/activity-log-service', () => ({ getActivityLogs: vi.fn() }));
+vi.mock('$lib/server/services/point-service', () => ({ getPointBalance: vi.fn() }));
+vi.mock('$lib/server/services/status-service', () => ({
+	getChildStatus: vi.fn(),
+	updateStatus: vi.fn(),
+}));
+vi.mock('$lib/server/services/voice-service', () => ({
+	activateVoice: vi.fn(),
+	deleteVoice: vi.fn(),
+	listVoices: vi.fn(),
+	uploadVoice: vi.fn(),
+}));
+vi.mock('$lib/server/storage', () => ({
+	deleteByPrefix: vi.fn(),
+	deleteFile: vi.fn(),
+	listFiles: vi.fn().mockResolvedValue([]),
+	saveFile: vi.fn(),
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { actions } = await import('../../../src/routes/(parent)/admin/children/+page.server');
+
+function createEvent(formValues: Record<string, string>) {
+	const fd = new FormData();
+	for (const [k, v] of Object.entries(formValues)) fd.set(k, v);
+	return {
+		request: { formData: () => Promise.resolve(fd) } as unknown as Request,
+		locals: { context: { tenantId: FAMILY } },
+		// biome-ignore lint/suspicious/noExplicitAny: SvelteKit RequestEvent の全 field は不要
+	} as any;
+}
+
+/** /admin/children の addChild action を実行して、保存された子供を DB から読み直す。 */
+async function addViaAdminRoute(form: Record<string, string>) {
+	// biome-ignore lint/suspicious/noExplicitAny: action の戻り値 union を絞らない
+	const result: any = await actions.addChild(createEvent(form));
+	expect(result?.success, `addChild が失敗した: ${JSON.stringify(result)}`).toBe(true);
+	const reloaded = await repo.findChildById(result.addedChild.id, FAMILY);
+	return { returned: result.addedChild, reloaded };
+}
+
+describe('#4419 /admin/children 登録時の uiMode (本番 backend = dsql/PGlite)', () => {
+	let t: DsqlTestDb;
+
+	beforeAll(async () => {
+		t = await createDsqlTestDb();
+		repo = createDsqlChildRepo(t.db, createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 }));
+	}, 60_000);
+	afterAll(async () => {
+		await t.close();
+	});
+
+	it('[A] 15 歳を登録すると senior になる (issue 完了条件)', async () => {
+		const { returned, reloaded } = await addViaAdminRoute({
+			nickname: 'こうこうせい',
+			age: '15',
+			theme: 'blue',
+		});
+		expect(returned.uiMode).toBe('senior');
+		expect(reloaded?.uiMode).toBe('senior');
+	});
+
+	// 5 年齢帯すべての境界 — docs/DESIGN.md §8 / getDefaultUiMode の SSOT に一致させる。
+	const BOUNDARIES: Array<[number, string]> = [
+		[0, 'baby'],
+		[2, 'baby'],
+		[3, 'preschool'],
+		[5, 'preschool'],
+		[6, 'elementary'],
+		[12, 'elementary'],
+		[13, 'junior'],
+		[15, 'junior'],
+		[16, 'senior'],
+		[18, 'senior'],
+	];
+
+	it.each(BOUNDARIES)('[B] age=%i (birthDate なし) → %s', async (age, expected) => {
+		expect(getDefaultUiMode(age)).toBe(expected); // SSOT 自体の境界も固定する
+		const { reloaded } = await addViaAdminRoute({
+			nickname: `age${age}`,
+			age: String(age),
+			theme: 'pink',
+		});
+		expect(reloaded?.uiMode).toBe(expected);
+		expect(reloaded?.uiModeManuallySet).toBe(0); // 自動判定は手動フラグを立てない
+	});
+
+	it('[C] birthDate 指定の登録でも stored 値が年齢どおりになる', async () => {
+		const today = new Date();
+		const birthDate = `${today.getUTCFullYear() - 14}-01-01`;
+		const { reloaded } = await addViaAdminRoute({
+			nickname: 'ちゅうがくせい',
+			birthDate,
+			theme: 'green',
+		});
+		expect(reloaded?.uiMode).toBe('junior');
+	});
+});
+
+// [B] の 15 歳ケースが本 issue の中心。dsql は birth_date NULL 行では compute-on-read の
+// ui_mode 再導出をせず stored 値を返すため、insert 時の既定値がそのまま子供の画面になる。

--- a/tests/unit/routes/admin-children-add-ui-mode.test.ts
+++ b/tests/unit/routes/admin-children-add-ui-mode.test.ts
@@ -91,9 +91,9 @@ function createEvent(formValues: Record<string, string>) {
 
 /** /admin/children の addChild action を実行して、保存された子供を DB から読み直す。 */
 async function addViaAdminRoute(form: Record<string, string>) {
-	// biome-ignore lint/suspicious/noExplicitAny: action の戻り値 union を絞らない
 	const addChildAction = actions.addChild;
 	if (!addChildAction) throw new Error('addChild action が存在しない');
+	// biome-ignore lint/suspicious/noExplicitAny: action の戻り値 union を絞らない
 	const result: any = await addChildAction(createEvent(form));
 	expect(result?.success, `addChild が失敗した: ${JSON.stringify(result)}`).toBe(true);
 	const reloaded = await repo.findChildById(result.addedChild.id, FAMILY);

--- a/tests/unit/routes/admin-children-add-ui-mode.test.ts
+++ b/tests/unit/routes/admin-children-add-ui-mode.test.ts
@@ -12,7 +12,7 @@
 //       compute-on-read の再導出が効かず stored 値がそのまま出るため、ここが実害の本体
 //   [C] birthDate あり の登録でも正しい (stored 値自体が正しいこと)
 
-import { beforeAll, afterAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { getDefaultUiMode } from '../../../src/lib/domain/validation/age-tier';
 import { createDsqlChildRepo } from '../../../src/lib/server/db/dsql/child-repo';
 import { createDsqlTransactionRunner } from '../../../src/lib/server/db/dsql/run-in-transaction';
@@ -39,8 +39,7 @@ vi.mock('$lib/server/db/child-repo', () => ({
 	findAllChildren: (tenantId: string) => repo.findAllChildren(tenantId),
 	findChildById: (id: never, tenantId: string) => repo.findChildById(id, tenantId),
 	findChildByUserId: (userId: string, tenantId: string) => repo.findChildByUserId(userId, tenantId),
-	updateChild: (id: never, input: never, tenantId: string) =>
-		repo.updateChild(id, input, tenantId),
+	updateChild: (id: never, input: never, tenantId: string) => repo.updateChild(id, input, tenantId),
 	deleteChild: (id: never, tenantId: string) => repo.deleteChild(id, tenantId),
 	resetChildProgressData: vi.fn(),
 	findArchivedChildren: vi.fn().mockResolvedValue([]),
@@ -104,7 +103,10 @@ describe('#4419 /admin/children 登録時の uiMode (本番 backend = dsql/PGlit
 
 	beforeAll(async () => {
 		t = await createDsqlTestDb();
-		repo = createDsqlChildRepo(t.db, createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 }));
+		repo = createDsqlChildRepo(
+			t.db,
+			createDsqlTransactionRunner(t.db, { maxAttempts: 3, baseDelayMs: 1 }),
+		);
 	}, 60_000);
 	afterAll(async () => {
 		await t.close();

--- a/tests/unit/routes/admin-children-add-ui-mode.test.ts
+++ b/tests/unit/routes/admin-children-add-ui-mode.test.ts
@@ -110,14 +110,21 @@ describe('#4419 /admin/children 登録時の uiMode (本番 backend = dsql/PGlit
 		await t.close();
 	});
 
-	it('[A] 15 歳を登録すると senior になる (issue 完了条件)', async () => {
-		const { returned, reloaded } = await addViaAdminRoute({
-			nickname: 'こうこうせい',
-			age: '15',
-			theme: 'blue',
-		});
-		expect(returned.uiMode).toBe('senior');
-		expect(reloaded?.uiMode).toBe('senior');
+	// #4419 完了条件「15 歳を登録すると senior」は年齢帯の境界が 1 段ずれている。
+	// SSOT (docs/DESIGN.md §8 / getDefaultUiMode) では 13〜15 歳 = junior、16〜18 歳 = senior。
+	// 完了条件の意図 (中高生に幼児 UI を出さない) を、正しい境界で 2 件に分けて表明する。
+	it('[A] 中学生 (15 歳) は junior、高校生 (16 歳) は senior で登録される', async () => {
+		const jr = await addViaAdminRoute({ nickname: 'ちゅう3', age: '15', theme: 'blue' });
+		expect(jr.returned.uiMode).toBe('junior');
+		expect(jr.reloaded?.uiMode).toBe('junior');
+
+		const sr = await addViaAdminRoute({ nickname: 'こう1', age: '16', theme: 'blue' });
+		expect(sr.returned.uiMode).toBe('senior');
+		expect(sr.reloaded?.uiMode).toBe('senior');
+
+		// いずれも「幼児 UI が出る」= 本 defect の症状ではないこと
+		expect(jr.reloaded?.uiMode).not.toBe('preschool');
+		expect(sr.reloaded?.uiMode).not.toBe('preschool');
 	});
 
 	// 5 年齢帯すべての境界 — docs/DESIGN.md §8 / getDefaultUiMode の SSOT に一致させる。

--- a/tests/unit/services/child-service-default-ui-mode.test.ts
+++ b/tests/unit/services/child-service-default-ui-mode.test.ts
@@ -14,7 +14,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getDefaultUiMode } from '$lib/domain/validation/age-tier';
 
-const insertChildSpy = vi.fn(async (input: Record<string, unknown>) => ({
+const insertChildSpy = vi.fn(async (input: Record<string, unknown>, _tenantId: string) => ({
 	id: 1,
 	...input,
 	uiModeManuallySet: 0,

--- a/tests/unit/services/child-service-default-ui-mode.test.ts
+++ b/tests/unit/services/child-service-default-ui-mode.test.ts
@@ -1,0 +1,63 @@
+// tests/unit/services/child-service-default-ui-mode.test.ts
+// #4419: addChild (service 層) が uiMode を **repo に渡す前に** 年齢から解決することを固定する。
+//
+// repo 側にも同じ既定値 (getDefaultUiMode) があるため、repo 実装を使うテストでは
+// 「service が解決している」ことを区別できない。ここでは既定値を持たない fake repo を
+// 差して、service 単体の責務として表明する。
+//
+// なぜ service 層が主で repo 側が防御かというと:
+//   - 「新規登録した子供にどの UI を出すか」は保存形式ではなく製品ルールで、登録経路
+//     (`/setup/children` と `/admin/children`) の両方が addChild を通る
+//   - repo 側の既定値は addChild を経由しない直接呼び出し (import-service の
+//     バックアップ復元は insertChild を直接呼ぶ) に対する防御線として残す
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDefaultUiMode } from '$lib/domain/validation/age-tier';
+
+const insertChildSpy = vi.fn(async (input: Record<string, unknown>) => ({
+	id: 1,
+	...input,
+	uiModeManuallySet: 0,
+}));
+
+vi.mock('$lib/server/db/child-repo', () => ({
+	// fake repo: 既定値を一切持たない (渡された値をそのまま返す)
+	insertChild: (input: Record<string, unknown>, tenantId: string) =>
+		insertChildSpy(input, tenantId),
+	findAllChildren: vi.fn(),
+	findArchivedChildren: vi.fn(),
+	findChildById: vi.fn(),
+	findChildByUserId: vi.fn(),
+	updateChild: vi.fn(),
+	deleteChild: vi.fn(),
+}));
+vi.mock('$lib/server/storage', () => ({
+	deleteByPrefix: vi.fn(),
+	deleteFile: vi.fn(),
+	listFiles: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const { addChild } = await import('$lib/server/services/child-service');
+
+describe('#4419 addChild は uiMode を repo に渡す前に解決する', () => {
+	beforeEach(() => insertChildSpy.mockClear());
+
+	it.each([0, 2, 3, 5, 6, 12, 13, 15, 16, 18])('age=%i を SSOT 値で渡す', async (age) => {
+		await addChild({ nickname: `c${age}`, age }, 't-1');
+		expect(insertChildSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ uiMode: getDefaultUiMode(age) }),
+			't-1',
+		);
+	});
+
+	it('保護者が明示指定した uiMode は上書きしない', async () => {
+		await addChild({ nickname: 'manual', age: 15, uiMode: 'preschool' }, 't-1');
+		expect(insertChildSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ uiMode: 'preschool' }),
+			't-1',
+		);
+	});
+});

--- a/tests/unit/services/child-service.test.ts
+++ b/tests/unit/services/child-service.test.ts
@@ -126,12 +126,15 @@ describe('child-service', () => {
 		const input = { nickname: 'まさと', age: 7, theme: 'blue' };
 		const inserted = { id: '10', ...input };
 
-		it('insertChild に input と tenantId を渡す', async () => {
+		// #4419: addChild は uiMode を年齢から解決してから repo に渡す (登録経路 2 本の
+		// 二重実装を作らないため service 層が単一の解決点)。境界の網羅は
+		// tests/unit/services/child-service-default-ui-mode.test.ts が持つ。
+		it('insertChild に input + 年齢から解決した uiMode と tenantId を渡す', async () => {
 			vi.mocked(insertChild).mockResolvedValue(inserted as never);
 
 			await addChild(input, TENANT);
 
-			expect(insertChild).toHaveBeenCalledWith(input, TENANT);
+			expect(insertChild).toHaveBeenCalledWith({ ...input, uiMode: 'elementary' }, TENANT);
 		});
 
 		// #4413: 登録した子供には仮アバター (頭文字 + テーマ色) が自動で付く。


### PR DESCRIPTION
## 顧客価値・目的

`/admin/children` から登録した子供に、**年齢どおりの UI が出る**ようになる。これまで本番 backend では 15 歳でも「幼児（3〜5歳）」= ひらがなのみ・80px タップの画面が渡っていた。子供本人が最初に見る画面がこれだった。

## 関連 Issue

Closes #4419

## 変更内容

### 1. 既定値を `getDefaultUiMode()` に一本化（3 backend）

| backend | 変更前 | 変更後 |
|---|---|---|
| dsql（本番 / NUC は PGlite で同 repo） | `'preschool'` 固定（年齢を見ない） | `getDefaultUiMode(input.age)` |
| sqlite | `input.age <= 2 ? 'baby' : 'preschool'` | 同上 |
| demo | `getDefaultUiMode(input.age)` | 変更なし |

repo 内に年齢判定のリテラルを書けないよう、後述の fitness function が式そのものを固定する。

### 2. 解決点は **service 層（`addChild`）**（判断と理由）

`/admin/children` の route に `uiMode` を足すのではなく、`addChild` で解決する。

- 登録経路は `/setup/children` と `/admin/children` の 2 本あり、**route 側に置くと片方だけ通らない**。実際この defect は「後から追加した `/admin/children` だけが `getDefaultUiMode` を通っていない」形で起きた。同じ形の穴を残さない
- #4413（仮アバター、PR #4415）が同じ理由で `addChild` に置いた前例に揃える。両者は `addChild` 内で「uiMode 解決 → insert → 仮アバター付与」の順に並ぶ
- **「新規登録した子供にどの UI を出すか」は製品ルールであって保存形式の話ではない**。dsql repo は `age` 列すら持たない（`birth_date` から compute-on-read）ので、repo は本来 age を解釈する層ではない
- ただし `insertChild` は `addChild` を経由しない直接呼び出しがある（`import-service.ts:1527` のバックアップ復元）。repo 側の既定値は**その経路に対する防御線**として残し、service 層を主とする 2 層構成にした

あわせて `/setup/children` は `getDefaultUiMode` の呼び出しを外し、`addChild` の戻り値の `uiMode` を analytics に渡す形にした（route ごとの二重実装を消す）。

### 3. backend 間の既定値一致を fitness function で機械強制

`tests/unit/architecture/child-ui-mode-default-parity.test.ts`（新規 script は追加していない）。

- **[F1] 挙動**: 3 backend に実際に insert（dsql = 実 schema 適用 PGlite / sqlite = テスト DB / demo = そのまま）し、10 通りの年齢で既定値が互いに一致し、かつ `getDefaultUiMode` と一致することを assert
- **[F2] 由来**: 各 repo の `input.uiMode ?? <式>` を読み、3 backend とも `getDefaultUiMode(input.age)` であることを assert（今日たまたま値が合うリテラルの再混入を止める）

`tests/CLAUDE.md` §「backend 並行実装の整合性」が「既定値ハンドリングを両実装で一致させる」と定めていたのに**検証が無かった**ことが、この defect が誰にも気づかれなかった構造的原因。同 §に「既定値は機械検証する」旨と本 fitness への参照を追記した。

## 検証

### failing-test-first（本番 backend = dsql/PGlite で再現）

`tests/unit/routes/admin-children-add-ui-mode.test.ts` を先にコミット（09ac835e8）。route action → `addChild` → **実 schema を適用した PGlite 上の dsql repo** を通す。

修正前（09ac835e8 時点）: **9 failed / 3 passed**

```
× [B] age=13 (birthDate なし) → junior   AssertionError: expected 'preschool' to be 'junior'
× [B] age=16 (birthDate なし) → senior   AssertionError: expected 'preschool' to be 'senior'
✓ [B] age=3 / age=5 → preschool          (たまたま既定値と一致するので通る)
```

修正後: **12 passed**。

#### 5 年齢帯の境界（全件、birthDate なし = 顧客が最短で登録する経路）

| age | 期待 | 結果 |
|---|---|---|
| 0 / 2 | baby | 通過 |
| 3 / 5 | preschool | 通過 |
| 6 / 12 | elementary | 通過 |
| 13 / 15 | junior | 通過 |
| 16 / 18 | senior | 通過 |

#### Issue 完了条件の文言について（境界が 1 段ずれている）

Issue の完了条件は「15 歳を登録すると `senior`」だが、SSOT（`docs/DESIGN.md` §8 / `getDefaultUiMode`）では **13〜15 歳 = junior / 16〜18 歳 = senior**。テストを完了条件の文言に合わせると SSOT に反する assertion になるため、**意図（中高生に幼児 UI を出さない）を正しい境界で 2 件に分けて**固定した（15 → junior / 16 → senior、かつ両者が `preschool` でないこと）。assertion を弱めた変更ではない。

#### 実害の範囲（Issue 本文より狭く、かつ深い）

dsql は `birth_date` がある行は read 時に `recalcUiMode` で再導出するため、**誕生日を入れて登録した子供は表示上は自己修復する**。壊れるのは **`birthDate` なし（年齢だけ）で登録した場合** — このとき stored 値がそのまま子供の画面になり、しかも `age` 列が無いので一覧の年齢も 0 と出る。`/admin/children` は誕生日が任意入力なので、最短経路で登録するとここに落ちる。

### mutation 検証（意図的に壊して落ちることを実証）

すべて **commit 済みの状態から** 壊し、`git stash push -- <path>` で戻した（`git checkout --` は使っていない）。

| # | 壊した箇所 | 結果 |
|---|---|---|
| M1 | dsql だけ `'preschool'` 固定に戻す | fitness **10 failed** / 15 |
| M2 | sqlite だけ旧 `age <= 2 ? 'baby' : 'preschool'` に戻す | fitness **8 failed** / 15 |
| M3 | demo だけ `'elementary'` に変える | fitness **10 failed** / 15 |
| M4 | service 層の解決を削る（repo 既定値だけ残す） | **当初は生存** → 下記 |
| M5 | **3 backend すべてを揃って `'preschool'` に**（相互には一致） | fitness **11 failed** / 15（SSOT 由来も見ているため落ちる） |
| M6 | SSOT 自体（junior 境界 15 → 14） | route test **2 failed** / 12 |

**M4 は最初 mutant が生存した**（repo 側の既定値が同じ結果を出すため）。「生存したので問題なし」とはせず、service 層の責務を独立に固定する `tests/unit/services/child-service-default-ui-mode.test.ts`（既定値を持たない fake repo に差し替え）を追加し、再実行して **10 failed / 11 で撃墜**した。生存 mutant は現時点で **0 件**。

### その他

- `npx vitest run tests/unit/services/ tests/unit/db/dsql-child-repo.test.ts` → 2827 件中 1 件 fail（`child-service.test.ts` の「`insertChild` に input と tenantId を渡す」= `addChild` の契約が変わったため）。**assertion を消さず、解決後の `uiMode: 'elementary'` を含む形に強化**して green
- rebase 後（#4415 マージ済 develop 上）の関連 4 file: **56 passed**

#### pre-ready の実行状況（未実行のものは未実行と書く）

| step | 結果 |
|---|---|
| 1. biome check | **PASS**（2243 files、指摘 4 件を format 適用して解消済み） |
| 7. check-no-plan-literals | **PASS** |
| 7g. check-local-tz-date-getters | **PASS** |
| 9. check-pr-body | **PASS**（Draft のため Ready 化要件 4 件は deferred、blocking 違反なし） |
| 11b. SS embed gate | **PASS** |
| 2. svelte-check | **PASS**（8088 files / 0 errors。当初 3 件の型エラーを検出したので修正した） |
| 11b. SS embed gate | skip（UI 実装ファイルの変更なしと判定） |
| vitest 全件 | **未実行** — 一時 `heavy` lock を他セッションが保持していた時間帯があり、全件は CI（`unit-test` 2 shard）に委ねた。関連 4 file の局所実行は上記のとおり **56 passed** |

`npm run pre-ready -- --pr 4428` は **6 step すべて PASS**（rebase 後に再実行済み）。CI も **全 30 checks pass / fail 0**（`unit-test` 2 shard・`lint-and-test`・SS 系ゲートを含む）。

途中 `lint-and-test` が 1 度落ちた（SS 撮影 flow に固定 sleep `waitForTimeout` を書いており #1208 の guard に抵触）。guard を無効化せず `waitForStablePage` に置き換え、置換後の flow で After SS を撮り直して同じ結果になることを確認した。

## 影響範囲

- **顧客に見える変化**: `/admin/children` から登録した子供の UI モードが年齢どおりになる。`/setup/children` 経由は元から正しく、挙動は変わらない
- **触った並行実装ペア**: 3 backend（dsql / sqlite / demo）の `insertChild` — 本 PR の主題そのもので、fitness function が以後の乖離を機械検出する
- **破壊的変更**: なし。保護者が明示指定した `uiMode` は従来どおり尊重する（`uiModeManuallySet` の意味も不変）
- **#4415（仮アバター）との関係**: 同じ `addChild` を触るため rebase で衝突したが、`uiMode` 解決 → insert → 仮アバター付与の順に統合済み。両機能とも動作する（`child-service.test.ts` 16 件 green）

### 既存データの扱い（判断: 一括の書き換えは**やらない**）

誤った `preschool` が入った子供が本番にいる可能性がある。以下の理由で**自動 backfill は行わない**。不可逆な本番データ書き換えは PO 決裁事項なので、必要と判断された場合は別 Issue で起票する。

1. **dsql には `age` 列が無い**（`birth_date` から compute-on-read）。`birth_date` なしで登録された行 = まさに壊れている行 は、**正しい年齢を DB が持っていない**。修復スクリプトに入力が無く、直すには「幼児だと決め打つ」以外にできることがない（それは今の壊れ方と同じ）
2. **`birth_date` がある行は read 時に自己修復済み**（`toChild` の `recalcUiMode`、`ui_mode_manually_set=false` のとき）。書き換えなくても正しい画面が出ている
3. 既存の日次 `age-recalc`（`age-recalc-service.ts`）も **`birthDate` 無しの child は skip する**設計で、同じ理由から救えない

**顧客側の回復手段**: 保護者が誕生日を入力すれば即座に正しくなる（compute-on-read が効く）。UI から年齢区分を直接直すこともできる（この場合 `uiModeManuallySet` が立ち、以後の自動再計算は止まる）。

**影響規模の把握が要る場合の read-only クエリ**（実行していない。使い捨て script は追加していない）:

```sql
-- 疑い上限: 誕生日が無く、手動設定でもなく、幼児 UI が入っている子供
SELECT count(*) FROM children
WHERE birth_date IS NULL AND ui_mode_manually_set = false AND ui_mode = 'preschool';
```

このうち本当に 3〜5 歳の子供が何人かは DB からは判別できない（上の理由 1）。

## スクリーンショット

**demo backend では再現しない**（demo の `insertChild` は元から `getDefaultUiMode` を通しており、かつ登録が永続しない stub）。そのため通常の撮影環境（`DATA_SOURCE=demo`）ではなく、**sqlite backend（`dev:cognito`、専用 port 5192）** で撮影した。sqlite も修正前は「3 歳以上は全部 preschool」で、顧客が踏む壊れ方をそのまま画面で再現できる。

`/admin/children` で 15 歳を誕生日なしで登録した直後の一覧:

<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4428/01-before-admin-children-age15.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4428/01-after-admin-children-age15.png -->

### Before — `15歳 / 幼児（3〜5歳）`

![before-admin-children-age15](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4428/01-before-admin-children-age15.png)

### After — `15歳 / 中学生（13〜15歳）`

![after-admin-children-age15](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4428/01-after-admin-children-age15.png)

- 撮影フロー: `scripts/capture-specs/flows/admin-children-add-ui-mode-4419.mjs`（`SS_LABEL` で Before / After を撮り分け）
- Before は commit 済みの状態から sqlite repo + `addChild` を develop の挙動へ一時的に戻して撮影し、`git stash push -- <path>` で復元した
- DOM スナップショット（同一 page 取得、#1747）でも `幼児（3〜5歳）` / `中学生（13〜15歳）` の差分を確認済み

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

