### PR TITLE
fix(infra): 通知の転送失敗を数えて alarm にする（#4399 の通知経路の内側に残った握り潰し）

### DIFF
--- a/docs/runbooks/ops-alert-notification.md
+++ b/docs/runbooks/ops-alert-notification.md
@@ -97,11 +97,48 @@ aws lambda get-function-configuration \
   --query 'keys(Environment.Variables)'
 ```
 
-## 6. 通知が来ないときの切り分け
+## 6. 転送そのものを数える（届いた通数 / 届かなかった通数）
+
+転送 Lambda は送信結果を 1 行の構造化 log に出し、`GanbariQuest/Ops` の metric に変換される。**alarm が鳴ったこと**ではなく **通知が人に届いたか**を見るための層。
+
+| metric | 意味 |
+|---|---|
+| `AlertForwardSucceeded` | Discord が 2xx を返した = 届いた |
+| `AlertForwardFailed` | 届かなかった（log の `reason=` で分類: `http-<status>` / `timeout` / `network` / `no-webhook` / `exception`） |
+
+### 流入量を実測する（1 週間の通数）
+
+一斉 ON（#4399）の条件である「初回 deploy 後 1 週間の流入量」は、この metric の Sum で読む。dashboard も集計スクリプトも要らない。
+
+```bash
+aws cloudwatch get-metric-statistics \
+  --namespace GanbariQuest/Ops --metric-name AlertForwardSucceeded \
+  --start-time "$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)" \
+  --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --period 86400 --statistics Sum --region us-east-1 \
+  --query 'sort_by(Datapoints,&Timestamp)[].{Day:Timestamp,Sum:Sum}'
+```
+
+日あたりの通数が捌けない量なら、**通知を止めるのではなく §2 の 1 → 2 → 3 の順で原因を直す**。どの alarm が量を占めるかは alarm ごとの `describe-alarm-history`（§3）で切り分ける。
+
+### `ganbari-quest-ops-alert-forward-failed` が鳴ったとき
+
+**通知が人に届いていない**というメッセージ。log の `reason=` で対処が分かれる。
+
+| reason | 意味 / 対処 |
+|---|---|
+| `http-429` | Discord の channel 単位 rate limit。多数の alarm が同時に鳴ったとき起きる。落ちた通知は CloudWatch の alarm 履歴で補完する |
+| `http-401` / `http-404` | webhook URL の失効・誤り。`gh secret set DISCORD_WEBHOOK_INCIDENT` で再設定して deploy |
+| `timeout` / `network` | Discord 側の輻輳 / egress の問題。単発なら経過観察、継続するなら Discord の status を見る |
+| `no-webhook` | secret 未設定で**全通知が 0 通**。deploy gate（§5）をすり抜けている。gate 自体を疑う |
+
+**自己参照の限界**: この alarm 自身も同じ転送経路を通る。Discord が完全に不達な間はこの通知も届かず、残るのは CloudWatch console の ALARM 状態と上記 metric だけになる。届くのは「一部だけ落ちた」場合（429 のバースト・単発 timeout・webhook 失効）で、実際に起きるのは主にこちら。
+
+## 7. 通知が来ないときの切り分け
 
 | 症状 | 見る場所 |
 |---|---|
-| alarm は ALARM だが Discord に出ない | 転送 Lambda の log。`suppressed alarm=...` があれば **仕様どおり抑止**（方針表が `notify: false`） |
+| alarm は ALARM だが Discord に出ない | 転送 Lambda の log。`suppressed alarm=...` があれば **仕様どおり抑止**（方針表が `notify: false`）。`forward-failed reason=...` があれば転送が失敗している（§6） |
 | log に `DISCORD_WEBHOOK_INCIDENT が未設定` | secret が未登録。deploy gate をすり抜けている（gate 自体を疑う） |
 | log が 1 行も無い | SNS subscription が無い。上記 §5 を確認 |
 
@@ -109,7 +146,7 @@ aws lambda get-function-configuration \
 
 ---
 
-## 7. 環境変数
+## 8. 環境変数
 
 | env | 用途 |
 |---|---|

--- a/infra/lambda/ops-alert-forwarder/index.ts
+++ b/infra/lambda/ops-alert-forwarder/index.ts
@@ -14,10 +14,35 @@
  *
  * `notify: false` の alarm も **CloudWatch 上には alarm として存在し**、本 Lambda の
  * log にも「抑止した」ことが残る。誰にも見えない場所に消えるわけではない。
+ *
+ * ## 転送失敗は「投げずに数える」(#4399 follow-up)
+ *
+ * 非 2xx / timeout / socket error のいずれでも **例外を投げず** `resolve()` する。この判断を
+ * 選んだ理由:
+ *
+ *   1. **呼び出し元が SNS の非同期呼び出しで、落として得るものが無い。** 例外を投げると
+ *      Lambda が最大 2 回 自動リトライするが、`handler` は `event.Records` を先頭から順に
+ *      処理し冪等性を持たないため、**複数 record のうち後ろだけ失敗した場合に、前の record が
+ *      再送されて同じ通知が重複して届く**。障害中に通知が二重に鳴るのは、届かないのとは別種の
+ *      「捌けない状態」を作る
+ *   2. **失敗の検知を Lambda のリトライ意味論に依存させたくない。** Errors metric に乗せても
+ *      「何回目のリトライで諦めたか」は分からず、結局どの失敗が起きたのか (429 / timeout /
+ *      webhook 失効) を切り分けられない
+ *   3. 一方で **握り潰したままにはしない** — 成否を構造化 log に出し、OpsStack 側の
+ *      MetricFilter で metric 化して、失敗は専用 alarm (`ganbari-quest-ops-alert-forward-failed`)
+ *      で拾う。「落とさない」と「気付けない」を切り離す
+ *
+ * 429 に対する retry-after 準拠の再送は、実測 (`GanbariQuest/Ops` の AlertForwardFailed) で
+ * 実際に起きることを確かめてから入れる。起きるか分からない再送機構を先に足さない (ADR-0010)。
  */
 
 import * as http from 'node:http';
 import * as https from 'node:https';
+import {
+	formatForwardFailureLog,
+	OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM,
+	type OpsAlertForwardFailureReason,
+} from '../../lib/ops-alert-log-terms';
 import { shouldNotifyToDiscord } from '../../lib/ops-alert-policy';
 
 const DISCORD_WEBHOOK_URL = process.env.DISCORD_WEBHOOK_INCIDENT ?? '';
@@ -103,11 +128,28 @@ export async function handler(event: SnsEvent): Promise<void> {
 	}
 }
 
+/**
+ * 転送失敗を **metric として数えられる形**で 1 行だけ残す。
+ *
+ * `reason` 以外 (alarm 名 / 通知本文 / webhook URL) は載せない。`[auth-alert]` 系と同じ規約で、
+ * 数えたいのは「届かなかった」ことと、その分類 (対処が分岐する単位) だけである。
+ */
+function logForwardFailure(reason: OpsAlertForwardFailureReason, detail?: unknown): void {
+	// detail (status body / error object) は metric 用の行に混ぜない。混ぜると filter が
+	// 本文中の語に反応しうるし、載せる必要のない文字列を CloudWatch に残すことになる。
+	//
+	// **detail 行には検索語を含めない**。含めると 1 回の失敗が 2 件として数えられ、
+	// metric が実態の 2 倍になる (この 2 重計上は test が実測で検出した)。
+	console.error(formatForwardFailureLog(reason));
+	if (detail !== undefined) console.error('[ops-alert] 転送失敗の詳細:', detail);
+}
+
 async function postDiscordEmbed(embed: object): Promise<void> {
 	if (!DISCORD_WEBHOOK_URL) {
 		// ここに来るのは deploy gate をすり抜けた場合のみ。**握り潰さず error で残す**
 		// (#4119 / #4174 の「通知経路はあるのに 0 通」を再演しない)。
 		console.error('[ops-alert] DISCORD_WEBHOOK_INCIDENT が未設定のため通知できません');
+		logForwardFailure('no-webhook');
 		return;
 	}
 
@@ -115,6 +157,28 @@ async function postDiscordEmbed(embed: object): Promise<void> {
 		const payload = JSON.stringify({ embeds: [embed] });
 
 		await new Promise<void>((resolve) => {
+			// 1 回の送信につき **結果は 1 件だけ数える**。
+			// `req.destroy()` (timeout 時) は直後に 'error' も発火させるため、素直に書くと
+			// 1 回の timeout が timeout + network の 2 件として metric に乗り、
+			// 「何通届かなかったか」が実態より多く見える (test が実測で検出した)。
+			let settled = false;
+			const settle = (
+				outcome:
+					| { ok: true }
+					| { ok: false; reason: OpsAlertForwardFailureReason; detail?: unknown },
+			) => {
+				if (settled) return;
+				settled = true;
+				if (outcome.ok) {
+					// 成功も数える。1 週間の Sum が「実際に何通届いたか」の実測になる
+					// (オーナー決裁 2026-08-07 が一斉 ON の条件にした流入量の観測)。
+					console.log(OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM);
+				} else {
+					logForwardFailure(outcome.reason, outcome.detail);
+				}
+				resolve(); // 通知失敗で Lambda を落とさない (理由は冒頭コメント)
+			};
+
 			const url = new URL(DISCORD_WEBHOOK_URL);
 			const isHttps = url.protocol === 'https:';
 			const client = isHttps ? https : http;
@@ -137,29 +201,32 @@ async function postDiscordEmbed(embed: object): Promise<void> {
 				});
 				res.on('end', () => {
 					if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-						resolve();
+						settle({ ok: true });
 					} else {
-						console.error('[ops-alert] Discord webhook failed:', res.statusCode, body);
-						resolve(); // 通知失敗で Lambda を落とさない
+						// 429 (channel 単位の rate limit) はここに来る。**16 alarm が同時に鳴る
+						// = 最も通知が要る瞬間**ほど起きるため、必ず数える。
+						settle({
+							ok: false,
+							reason: `http-${res.statusCode ?? 0}`,
+							detail: body.slice(0, 200),
+						});
 					}
 				});
 			});
 
 			req.on('timeout', () => {
-				req.destroy();
-				console.error('[ops-alert] Discord webhook timed out');
-				resolve();
+				settle({ ok: false, reason: 'timeout' });
+				req.destroy(); // destroy が誘発する 'error' は settled 済みなので数えない
 			});
 
 			req.on('error', (err) => {
-				console.error('[ops-alert] Discord webhook error:', err);
-				resolve();
+				settle({ ok: false, reason: 'network', detail: err });
 			});
 
 			req.write(payload);
 			req.end();
 		});
 	} catch (e) {
-		console.error('[ops-alert] Discord notification error:', e);
+		logForwardFailure('exception', e);
 	}
 }

--- a/infra/lib/ops-alert-log-terms.ts
+++ b/infra/lib/ops-alert-log-terms.ts
@@ -1,0 +1,61 @@
+// infra/lib/ops-alert-log-terms.ts
+// #4399 follow-up — 転送 Lambda が「通知を届けられたか」を log に残すための検索語 SSOT。
+//
+// ## なぜ要るのか
+//
+// #4399 で `ALARM_NOTIFY_POLICY` の既定が「届ける」になり、alarm は SNS → 転送 Lambda →
+// Discord webhook という一本道を通るようになった。ところが**その一本道の末端が失敗しても
+// 誰にも分からない**:
+//
+//   - 転送 Lambda は非 2xx / timeout / socket error のいずれも `console.error` で握り潰し、
+//     例外を投げない (= Lambda の Errors metric に 1 件も乗らない)
+//   - Discord webhook は channel 単位の rate limit を持つため、**16 alarm が同時に鳴る
+//     「最も通知が必要な瞬間」に 429 が返り、その通知だけが黙って捨てられる**
+//
+// これは #4119 / #4174 の「経路はあるのに 0 通」と同じ欠陥である。log 本文を唯一の情報源として
+// MetricFilter で metric 化し、失敗を alarm で拾えるようにする (entitlement fail-closed #3998 /
+// ops-access-denied #4363 と同じ手口)。
+//
+// ## この定数を lib 側に置く理由
+//
+// 検索語は **転送 Lambda (書き手) と OpsStack の MetricFilter (読み手) の両方**が使う。
+// アプリ側 (`src/`) の log 用語は CDK の tsconfig rootDir 制約で import できず literal +
+// drift 検証 test で担保しているが、ここは**どちらも `infra/` 配下**なので同じ定数を
+// import できる。literal の二重管理と drift 検証そのものが不要になる (SSOT 1 箇所)。
+//
+// OpsStack (`ops-stack.ts`) ではなく独立 module に置くのは、Lambda 側が import したときに
+// `aws-cdk-lib` を bundle に引き込まないため。
+//
+// ## 値は載せない
+//
+// alarm 名・通知本文・webhook URL は載せない (`[auth-alert]` 系の既存規約と同じ)。
+// 数えたいのは「届いた / 届かなかった」と、届かなかったときの**分類**だけである。
+
+/** 転送に成功した (Discord が 2xx を返した) ことを表す検索語。流入量の実測にも使う。 */
+export const OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM = '[ops-alert] forward-succeeded';
+
+/** 転送に失敗した (通知が人に届かなかった) ことを表す検索語。 */
+export const OPS_ALERT_FORWARD_FAILED_LOG_TERM = '[ops-alert] forward-failed';
+
+/**
+ * 転送失敗の分類。**対処が分岐する単位**で切る:
+ *
+ * - `http-<status>` … Discord が応答を返したうえで拒否した。429 = rate limit (同時多発時に起きる)、
+ *   401/404 = webhook URL が失効・誤り (再設定が要る)
+ * - `timeout` ……… 5 秒以内に応答が無い。Discord 側の輻輳
+ * - `network` ……… 接続自体が確立しない。DNS / egress の問題
+ * - `no-webhook` … `DISCORD_WEBHOOK_INCIDENT` が未設定。**全通知が最初から 0 通**になる状態で、
+ *   deploy gate をすり抜けた場合にだけ起きる (#4119 / #4174 の再演)
+ * - `exception` …… 上記以外の想定外例外
+ */
+export type OpsAlertForwardFailureReason =
+	| `http-${number}`
+	| 'timeout'
+	| 'network'
+	| 'no-webhook'
+	| 'exception';
+
+/** 失敗 log の 1 行を組み立てる (書き手と test で同じ形を共有するため関数にする)。 */
+export function formatForwardFailureLog(reason: OpsAlertForwardFailureReason): string {
+	return `${OPS_ALERT_FORWARD_FAILED_LOG_TERM} reason=${reason}`;
+}

--- a/infra/lib/ops-alert-policy.ts
+++ b/infra/lib/ops-alert-policy.ts
@@ -124,6 +124,11 @@ export const ALARM_NOTIFY_POLICY: Record<string, AlarmNotifyPolicy> = {
 		reason:
 			'オーナー決裁 2026-08-07「AI 不達のアラートは Discord の障害通知へ webhook で飛ばすべき」。(a) AI 不達は有料機能が事実上死んでいる状態で、顧客向け文言が「運営が検知済み」と伝えている以上、人に届かなければその一文が嘘になる。(b) 発生源の log は latch により理由ごとにプロセス内 1 回しか出ないため、構造的に鳴りっぱなしにならない。(c) 万一恒常発火したら通知を止めるのではなく、早期回復 / 例外処理の是正で応じる (同決裁: 恒常的に発生する障害は早期回復対象であって、通知を握りつぶしてよいという意味ではない)',
 	},
+	'ganbari-quest-ops-alert-forward-failed': {
+		notify: true,
+		reason:
+			'転送そのものが失敗した = 鳴った alarm が人に届いていない状態で、#4399 で既定を「届ける」に戻した意味が末端で失われている。Discord は channel 単位の rate limit を持つため、多数の alarm が同時に鳴る「最も通知が必要な瞬間」ほど 429 で消える。**自己参照の限界**: この alarm 自身も同じ転送経路を通るため、Discord が完全に不達な間はこの通知も届かない — その場合に残るのは CloudWatch console の ALARM 状態と GanbariQuest/Ops の AlertForwardFailed / AlertForwardSucceeded の Sum である。届くのは「一部だけ落ちた」場合 (429 のバースト・単発 timeout・webhook 失効) で、実際に起きるのは主にこちら。届かない場合の検知を通知に足すこと (外形監視) は Pre-PMF では過剰と判断し、metric を残すところまでとする',
+	},
 	'ganbari-quest-static-assets-s3-4xx': {
 		notify: true,
 		reason:

--- a/infra/lib/ops-stack.ts
+++ b/infra/lib/ops-stack.ts
@@ -15,6 +15,18 @@ import * as sns from 'aws-cdk-lib/aws-sns';
 import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import type { Construct } from 'constructs';
+import {
+	OPS_ALERT_FORWARD_FAILED_LOG_TERM,
+	OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM,
+} from './ops-alert-log-terms';
+
+/**
+ * 転送そのものの観測 metric の namespace (#4399 follow-up)。
+ *
+ * アプリ由来の `GanbariQuest/Auth` などとは層が違う (通知経路の健全性であって、
+ * アプリの挙動ではない) ため分ける。
+ */
+const OPS_ALERT_FORWARD_METRIC_NAMESPACE = 'GanbariQuest/Ops';
 
 export interface OpsStackProps extends cdk.StackProps {
 	lambdaFn: lambda.Function;
@@ -155,6 +167,63 @@ export class OpsStack extends cdk.Stack {
 		opsTopic.addSubscription(new subscriptions.LambdaSubscription(opsAlertForwarder));
 
 		const alarmAction = new cw_actions.SnsAction(opsTopic);
+
+		// ================================================================
+		// 1.1 転送そのものの観測 (#4399 follow-up)
+		// ================================================================
+		//
+		// #4399 で全 alarm の既定が「届ける」になったが、通知は SNS → 転送 Lambda → Discord
+		// webhook の一本道を通り、**その末端が失敗しても誰にも分からない**状態が残っていた:
+		//
+		//   - 転送 Lambda は失敗を例外にしない (上記 index.ts の判断) ため Errors metric に乗らない
+		//   - 転送 Lambda 自身を監視する alarm も無かった
+		//   - Discord webhook は channel 単位の rate limit を持つため、**16 alarm が同時に鳴る
+		//     「最も通知が必要な瞬間」に 429 が返り、その通知だけが黙って捨てられる**
+		//
+		// = #4119 / #4174 の「経路はあるのに 0 通」と同じ欠陥。log 本文を唯一の情報源として
+		// metric 化する (entitlement fail-closed #3998 / ops-access-denied #4363 と同じ手口)。
+		const forwardSucceeded = new logs.MetricFilter(this, 'OpsAlertForwardSucceededFilter', {
+			logGroup: opsAlertForwarderLogGroup,
+			filterPattern: logs.FilterPattern.literal(`"${OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM}"`),
+			metricNamespace: OPS_ALERT_FORWARD_METRIC_NAMESPACE,
+			metricName: 'AlertForwardSucceeded',
+			metricValue: '1',
+			defaultValue: 0,
+		});
+		// 成功側に alarm は付けない。これは**流入量の実測**のための metric で、
+		// オーナー決裁 2026-08-07 が一斉 ON の条件にした「初回 deploy 後 1 週間の流入量」は
+		// この metric の Sum (1 週間) で読める。dashboard も集計 script も作らない。
+		void forwardSucceeded;
+
+		const forwardFailed = new logs.MetricFilter(this, 'OpsAlertForwardFailedFilter', {
+			logGroup: opsAlertForwarderLogGroup,
+			filterPattern: logs.FilterPattern.literal(`"${OPS_ALERT_FORWARD_FAILED_LOG_TERM}"`),
+			metricNamespace: OPS_ALERT_FORWARD_METRIC_NAMESPACE,
+			metricName: 'AlertForwardFailed',
+			metricValue: '1',
+			defaultValue: 0,
+		});
+
+		// 閾値: 1 件で即発火。**1 件 = 1 通の通知が人に届かなかった**という単位であり、
+		// 「継続したら鳴らす」形にすると、単発で消えた 1 通 (それが本番障害の第一報でありうる)
+		// が観測されないまま終わる。平常時は log 自体が出ないためデータ点が無く
+		// (NOT_BREACHING)、鳴りっぱなしにはならない。
+		const forwardFailedAlarm = new cloudwatch.Alarm(this, 'OpsAlertForwardFailed', {
+			alarmName: 'ganbari-quest-ops-alert-forward-failed',
+			alarmDescription:
+				'CloudWatch アラームの Discord 転送に失敗した (通知が人に届いていない): 5分内に1件以上 (#4399 follow-up)',
+			metric: forwardFailed.metric({
+				period: cdk.Duration.minutes(5),
+				statistic: 'Sum',
+			}),
+			threshold: 1,
+			evaluationPeriods: 1,
+			datapointsToAlarm: 1,
+			comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+			treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+		});
+		forwardFailedAlarm.addAlarmAction(alarmAction);
+		forwardFailedAlarm.addOkAction(alarmAction);
 
 		// ================================================================
 		// 2. CloudWatch Alarms (9 of 10 free-tier basic alarms)

--- a/tests/unit/infra/entitlement-fail-closed-alarm.test.ts
+++ b/tests/unit/infra/entitlement-fail-closed-alarm.test.ts
@@ -135,10 +135,26 @@ describe('#3998 [A] entitlement fail-closed の MetricFilter / Alarm が CDK に
 		});
 	});
 
-	it('[A3] appLogGroup 未指定なら MetricFilter も Alarm も作らない (監視 cost ゼロ)', () => {
+	it('[A3] appLogGroup 未指定なら アプリ log 由来の MetricFilter も Alarm も作らない (監視 cost ゼロ)', () => {
 		const template = withoutLogGroupTemplate;
 
-		template.resourceCountIs('AWS::Logs::MetricFilter', 0);
+		// #4399 follow-up で、**転送 Lambda 自身の LogGroup** に付く MetricFilter
+		// (GanbariQuest/Ops の AlertForwardSucceeded / AlertForwardFailed) が増えた。
+		// これは appLogGroup の有無と無関係に常に存在する (転送 Lambda は必ず作られる) ため、
+		// 「MetricFilter の総数 0」では本 test の意図 (= **アプリ log 由来**の監視を作らない) を
+		// 表せなくなった。総数で緩めるのではなく、**namespace で対象を特定して 0 を主張する**
+		// (ADR-0006: assertion を弱めない — 検査対象を正確にする)。
+		const appLogDerived = Object.values(template.findResources('AWS::Logs::MetricFilter')).filter(
+			(r) =>
+				(
+					(r.Properties as { MetricTransformations?: Array<{ MetricNamespace?: string }> })
+						.MetricTransformations ?? []
+				).some((t) => t.MetricNamespace !== 'GanbariQuest/Ops'),
+		);
+		expect(
+			appLogDerived,
+			'appLogGroup 未指定なのにアプリ log 由来の MetricFilter が作られています',
+		).toHaveLength(0);
 		const alarms = template.findResources('AWS::CloudWatch::Alarm');
 		const names = Object.values(alarms).map(
 			(r) => (r.Properties as { AlarmName: string }).AlarmName,

--- a/tests/unit/infra/ops-alert-forwarder-observability.test.ts
+++ b/tests/unit/infra/ops-alert-forwarder-observability.test.ts
@@ -1,0 +1,383 @@
+// tests/unit/infra/ops-alert-forwarder-observability.test.ts
+// #4399 follow-up — 「通知が届かなかったこと」に気付ける状態を固定する。
+//
+// #4399 で alarm の既定が「届ける」になったが、その通知は SNS → 転送 Lambda → Discord webhook
+// の一本道を通る。転送 Lambda は失敗を全経路で握り潰して例外を投げないため、**末端で捨てられた
+// 通知は Errors metric にも乗らず、誰にも分からない**。Discord は channel 単位の rate limit を
+// 持つので、16 alarm が同時に鳴る「最も通知が必要な瞬間」ほど 429 で消える。
+//
+// 3 層で固定する (ai-provider-unavailable-alarm.test.ts / entitlement-fail-closed-alarm.test.ts と同型):
+//
+//   [A] Lambda 実挙動 … 実 HTTP サーバ相手に成功 / 非 2xx / timeout / network を再現し、
+//                       metric 用の log が「出る / 出ない」を実測する
+//   [B] CDK 構造 …… MetricFilter 2 本 + 失敗 alarm が期待の namespace / 閾値 / 通知先で存在する
+//
+// [A] は CDK と同じ定数 (`ops-alert-log-terms.ts`) で実 log 行を照合するため、「filter を定義した
+// が 1 件もマッチしない」(= 作ったが効いていない) も同時に潰れる。書き手と読み手が同一 SSOT を
+// import しているので literal の drift 検証 test は要らない。
+
+import * as http from 'node:http';
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { ComputeStack } from '../../../infra/lib/compute-stack';
+import { NetworkStack } from '../../../infra/lib/network-stack';
+import {
+	OPS_ALERT_FORWARD_FAILED_LOG_TERM,
+	OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM,
+} from '../../../infra/lib/ops-alert-log-terms';
+import { ALARM_NOTIFY_POLICY } from '../../../infra/lib/ops-alert-policy';
+import { OpsStack } from '../../../infra/lib/ops-stack';
+import { StorageStack } from '../../../infra/lib/storage-stack';
+
+// cspell:ignore TESTPOOL
+
+const ALARM_NAME = 'ganbari-quest-ops-alert-forward-failed';
+const METRIC_NAMESPACE = 'GanbariQuest/Ops';
+
+// ================================================================
+// [A] Lambda 実挙動
+// ================================================================
+
+interface DiscordStub {
+	server: http.Server;
+	port: number;
+	received: number;
+}
+
+/**
+ * Discord webhook の代わりに応答する stub サーバ。
+ *
+ * - `statusCode` … その status を返す
+ * - `hang: true` … 応答を返さない (Lambda 側の 5 秒 timeout を実発火させる)
+ * - `destroy: true` … socket を切る (network error を実発火させる)
+ */
+async function startDiscordStub(
+	behavior: { statusCode?: number; hang?: boolean; destroy?: boolean } = {},
+): Promise<DiscordStub> {
+	const stub: DiscordStub = { server: null as unknown as http.Server, port: 0, received: 0 };
+
+	const server = http.createServer((req, res) => {
+		stub.received += 1;
+		req.resume();
+		if (behavior.destroy) {
+			req.socket.destroy();
+			return;
+		}
+		if (behavior.hang) return; // 応答を返さない
+		req.on('end', () => {
+			res.statusCode = behavior.statusCode ?? 204;
+			res.end(behavior.statusCode && behavior.statusCode >= 400 ? 'rate limited' : '');
+		});
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+	const addr = server.address();
+	if (typeof addr === 'string' || addr === null) throw new Error('stub address');
+	stub.server = server;
+	stub.port = addr.port;
+	return stub;
+}
+
+async function stopDiscordStub(stub: DiscordStub): Promise<void> {
+	stub.server.closeAllConnections?.();
+	await new Promise<void>((resolve) => stub.server.close(() => resolve()));
+}
+
+/** CloudWatch alarm を 1 件だけ含む SNS イベント。 */
+function snsEvent(alarmName = 'ganbari-quest-lambda-url-5xx') {
+	return {
+		Records: [
+			{
+				Sns: {
+					Message: JSON.stringify({
+						AlarmName: alarmName,
+						NewStateValue: 'ALARM',
+						NewStateReason: 'Threshold Crossed',
+						Region: 'US East (N. Virginia)',
+						StateChangeTime: '2026-08-07T00:00:00.000Z',
+					}),
+				},
+			},
+		],
+	};
+}
+
+async function loadHandler(webhookUrl: string | undefined, opts: { suppressAll?: boolean } = {}) {
+	vi.resetModules();
+	process.env.DISCORD_WEBHOOK_INCIDENT = webhookUrl ?? '';
+	if (opts.suppressAll) {
+		// 抑止 (notify: false) の挙動を、方針表の実 entry に依存せず再現する。
+		// #4399 で全件 notify: true になったため、表を読むだけでは抑止経路を踏めない。
+		vi.doMock('../../../infra/lib/ops-alert-policy', () => ({
+			shouldNotifyToDiscord: () => false,
+			ALARM_NOTIFY_POLICY: {},
+		}));
+	}
+	const mod = await import('../../../infra/lambda/ops-alert-forwarder/index.ts');
+	return mod.handler;
+}
+
+/** console.log / console.error / console.warn の出力を 1 本の配列にまとめて捕まえる。 */
+function captureConsole(): { lines: string[]; restore: () => void } {
+	const lines: string[] = [];
+	const record = (...args: unknown[]) => {
+		lines.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' '));
+	};
+	const spies = [
+		vi.spyOn(console, 'log').mockImplementation(record),
+		vi.spyOn(console, 'error').mockImplementation(record),
+		vi.spyOn(console, 'warn').mockImplementation(record),
+	];
+	return {
+		lines,
+		restore: () => {
+			for (const s of spies) s.mockRestore();
+		},
+	};
+}
+
+describe('[A] 転送 Lambda が「届いた / 届かなかった」を log に残す (#4399 follow-up)', () => {
+	const originalWebhook = process.env.DISCORD_WEBHOOK_INCIDENT;
+
+	afterEach(() => {
+		if (originalWebhook === undefined) delete process.env.DISCORD_WEBHOOK_INCIDENT;
+		else process.env.DISCORD_WEBHOOK_INCIDENT = originalWebhook;
+	});
+
+	it('2xx で返ったら成功 log が出る (失敗 log は出ない)', async () => {
+		const stub = await startDiscordStub({ statusCode: 204 });
+		const cap = captureConsole();
+		try {
+			const handler = await loadHandler(`http://127.0.0.1:${stub.port}/webhook`);
+			await handler(snsEvent());
+		} finally {
+			cap.restore();
+			await stopDiscordStub(stub);
+		}
+
+		expect(stub.received, 'stub に届いていません (テスト自体が成立していません)').toBe(1);
+		expect(
+			cap.lines.filter((l) => l.includes(OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM)),
+			'転送成功の log が出ていません。流入量 (1 週間の Sum) が数えられません',
+		).toHaveLength(1);
+		expect(
+			cap.lines.filter((l) => l.includes(OPS_ALERT_FORWARD_FAILED_LOG_TERM)),
+			'成功したのに失敗 log が出ています',
+		).toHaveLength(0);
+	});
+
+	it('429 (rate limit) で失敗 log が出る — 同時多発時に通知が消える経路', async () => {
+		const stub = await startDiscordStub({ statusCode: 429 });
+		const cap = captureConsole();
+		try {
+			const handler = await loadHandler(`http://127.0.0.1:${stub.port}/webhook`);
+			await handler(snsEvent());
+		} finally {
+			cap.restore();
+			await stopDiscordStub(stub);
+		}
+
+		const failed = cap.lines.filter((l) => l.includes(OPS_ALERT_FORWARD_FAILED_LOG_TERM));
+		expect(failed, '429 で捨てられたのに失敗 log が出ていません').toHaveLength(1);
+		expect(failed[0], '失敗の分類 (reason=http-429) が読み取れません').toContain('reason=http-429');
+		expect(
+			cap.lines.filter((l) => l.includes(OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM)),
+			'失敗したのに成功 log が出ています (流入量が過大に数えられます)',
+		).toHaveLength(0);
+	});
+
+	it('socket 断で failed reason=network が出る', async () => {
+		const stub = await startDiscordStub({ destroy: true });
+		const cap = captureConsole();
+		try {
+			const handler = await loadHandler(`http://127.0.0.1:${stub.port}/webhook`);
+			await handler(snsEvent());
+		} finally {
+			cap.restore();
+			await stopDiscordStub(stub);
+		}
+
+		const failed = cap.lines.filter((l) => l.includes(OPS_ALERT_FORWARD_FAILED_LOG_TERM));
+		expect(failed, 'socket 断で失敗 log が出ていません').toHaveLength(1);
+		expect(failed[0]).toContain('reason=network');
+	});
+
+	it('応答が返らないと failed reason=timeout が出る (実 timeout 5 秒)', async () => {
+		const stub = await startDiscordStub({ hang: true });
+		const cap = captureConsole();
+		try {
+			const handler = await loadHandler(`http://127.0.0.1:${stub.port}/webhook`);
+			await handler(snsEvent());
+		} finally {
+			cap.restore();
+			await stopDiscordStub(stub);
+		}
+
+		const failed = cap.lines.filter((l) => l.includes(OPS_ALERT_FORWARD_FAILED_LOG_TERM));
+		// 1 回の timeout を 1 件としてだけ数える。`req.destroy()` は直後に 'error' も
+		// 発火させるため、素朴に書くと timeout + network の 2 件になり、
+		// 「何通届かなかったか」が実態より多く見える (metric の信頼性が壊れる)。
+		expect(failed, 'timeout が 1 件として数えられていません').toHaveLength(1);
+		expect(failed[0]).toContain('reason=timeout');
+		expect(failed.join('\n'), 'timeout が network としても二重に数えられています').not.toContain(
+			'reason=network',
+		);
+	}, 20_000);
+
+	it('webhook 未設定なら failed reason=no-webhook が出る (#4119 の「0 通」を数える)', async () => {
+		const cap = captureConsole();
+		try {
+			const handler = await loadHandler(undefined);
+			await handler(snsEvent());
+		} finally {
+			cap.restore();
+		}
+
+		const failed = cap.lines.filter((l) => l.includes(OPS_ALERT_FORWARD_FAILED_LOG_TERM));
+		expect(
+			failed,
+			'webhook 未設定は「全通知が 0 通」だが失敗として数えられていません',
+		).toHaveLength(1);
+		expect(failed[0]).toContain('reason=no-webhook');
+	});
+
+	it('抑止 (notify: false) は成功にも失敗にも数えない', async () => {
+		// 抑止は「送っていない」であって「届かなかった」ではない。両者を混ぜると
+		// 流入量も失敗率も読めなくなる。
+		const stub = await startDiscordStub({ statusCode: 204 });
+		const cap = captureConsole();
+		try {
+			const handler = await loadHandler(`http://127.0.0.1:${stub.port}/webhook`, {
+				suppressAll: true,
+			});
+			await handler(snsEvent());
+
+			expect(stub.received, '抑止したのに送信されています').toBe(0);
+			expect(
+				cap.lines.filter(
+					(l) =>
+						l.includes(OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM) ||
+						l.includes(OPS_ALERT_FORWARD_FAILED_LOG_TERM),
+				),
+				'抑止が転送 metric に数えられています',
+			).toHaveLength(0);
+		} finally {
+			cap.restore();
+			await stopDiscordStub(stub);
+		}
+	});
+});
+
+// ================================================================
+// [B] CDK 構造
+// ================================================================
+
+const env: cdk.Environment = { account: '000000000000', region: 'us-east-1' };
+
+function makeApp(): cdk.App {
+	return new cdk.App({
+		context: {
+			'hosted-zone:account=000000000000:domainName=ganbari-quest.com:region=us-east-1': {
+				Id: '/hostedzone/Z00000000000000000000',
+				Name: 'ganbari-quest.com.',
+			},
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/user-pool-id:region=us-east-1':
+				'us-east-1_TESTPOOL',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/client-id:region=us-east-1':
+				'test-client-id',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/cognito/domain:region=us-east-1':
+				'auth.ganbari-quest.com',
+			'ssm:account=000000000000:parameterName=/ganbari-quest/context-token-secret:region=us-east-1':
+				'test-context-token-secret',
+			opsSecretKey: 'test-ops-secret-key',
+			parentGateCookieSecret: 'test-parent-gate-secret-do-not-use-do-not-use',
+		},
+	});
+}
+
+let template: Template;
+
+beforeAll(() => {
+	const app = makeApp();
+	const storage = new StorageStack(app, 'TestStorage', { env });
+	const compute = new ComputeStack(app, 'TestCompute', {
+		env,
+		assetsBucket: storage.assetsBucket,
+		repository: storage.repository,
+	});
+	const network = new NetworkStack(app, 'TestNetwork', {
+		env,
+		functionUrl: compute.functionUrl,
+		originVerifySecret: 'test-origin-verify-secret-0000000000000000',
+		domainName: 'ganbari-quest.com',
+		certificateArn: 'arn:aws:acm:us-east-1:000000000000:certificate/test',
+		demoFunctionUrl: compute.demoFunctionUrl,
+	});
+	const ops = new OpsStack(app, 'TestOps', {
+		env,
+		lambdaFn: compute.fn,
+		distribution: network.distribution,
+		functionUrl: compute.functionUrl,
+		cronDispatcherFn: compute.cronDispatcherFn,
+		appLogGroup: compute.appLogGroup,
+	});
+	template = Template.fromStack(ops);
+}, 180_000);
+
+describe('[B] 転送の成否が metric 化され、失敗が alarm になる', () => {
+	it('成功 / 失敗の MetricFilter が転送 Lambda の LogGroup に付いている', () => {
+		template.hasResourceProperties('AWS::Logs::MetricFilter', {
+			FilterPattern: `"${OPS_ALERT_FORWARD_SUCCEEDED_LOG_TERM}"`,
+			MetricTransformations: Match.arrayWith([
+				Match.objectLike({
+					MetricNamespace: METRIC_NAMESPACE,
+					MetricName: 'AlertForwardSucceeded',
+					MetricValue: '1',
+					DefaultValue: 0,
+				}),
+			]),
+		});
+
+		template.hasResourceProperties('AWS::Logs::MetricFilter', {
+			FilterPattern: `"${OPS_ALERT_FORWARD_FAILED_LOG_TERM}"`,
+			MetricTransformations: Match.arrayWith([
+				Match.objectLike({
+					MetricNamespace: METRIC_NAMESPACE,
+					MetricName: 'AlertForwardFailed',
+					MetricValue: '1',
+					DefaultValue: 0,
+				}),
+			]),
+		});
+	});
+
+	it('転送失敗 alarm が 1 件でも発火し、SNS に通知される', () => {
+		template.hasResourceProperties('AWS::CloudWatch::Alarm', {
+			AlarmName: ALARM_NAME,
+			MetricName: 'AlertForwardFailed',
+			Namespace: METRIC_NAMESPACE,
+			Threshold: 1,
+			EvaluationPeriods: 1,
+			ComparisonOperator: 'GreaterThanOrEqualToThreshold',
+			TreatMissingData: 'notBreaching',
+			AlarmActions: Match.anyValue(),
+			OKActions: Match.anyValue(),
+		});
+	});
+
+	it('方針表に entry があり notify: true (no-silent-gap gate が拾うことの確認)', () => {
+		const policy = ALARM_NOTIFY_POLICY[ALARM_NAME];
+		expect(
+			policy,
+			`${ALARM_NAME} が ALARM_NOTIFY_POLICY に未宣言です (ops-alert-policy.test.ts の ` +
+				'no-silent-gap がこれを検出するはずです)',
+		).toBeDefined();
+		expect(policy?.notify, '転送失敗の alarm を無音にしたら気付く手段が無くなります').toBe(true);
+		// 自己参照の限界 (この alarm 自身も同じ転送経路を通る) を reason に明記させる
+		expect(
+			policy?.reason ?? '',
+			'この alarm 自身が転送経路に依存するため、連鎖失敗時に何が起きるかを reason に書いてください',
+		).toMatch(/自己参照|同じ経路|同じ転送/);
+	});
+});

--- a/tests/unit/infra/physical-name-ratchet.test.ts
+++ b/tests/unit/infra/physical-name-ratchet.test.ts
@@ -341,6 +341,10 @@ const NAMED_RESOURCE_ALLOWLIST: readonly NamedResourceEntry[] = [
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-throttles',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-url-4xx-spike',
 			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-lambda-url-5xx',
+			// #4399 follow-up: 通知そのものが届かなかったことの観測 alarm。
+			// runbook (ops-alert-notification.md §6) と通知方針表 (ops-alert-policy.ts) が
+			// この名前で参照するため固定名が要る。
+			'GanbariQuestOps/AWS::CloudWatch::Alarm/ganbari-quest-ops-alert-forward-failed',
 		],
 	),
 	...group('SNS Topic 固定名は ops / SES notification 設定の識別子', [


### PR DESCRIPTION
## 顧客価値・目的

本番障害が起きたとき、**その通知が実際に人へ届いたか**が分かるようになる。届かなかった場合は「届かなかった」こと自体が alarm として鳴る。#4399 で「alarm は既定で Discord に届ける」に戻したが、その通知が通る一本道の末端（転送 Lambda → Discord webhook）は失敗を全経路で握り潰しており、**最も通知が必要な瞬間ほど黙って消える**構造が残っていた。

## 関連 Issue

<!-- no-issue-close: QM が #4399 approve 時に残した follow-up の PR 化（オーナー指示 2026-08-07「follow up は PR を発行する」）。Issue 未起票 -->

参照: #4399（既定を「届ける」に戻した本体）/ #4189（転送 Lambda 新設）/ #4119・#4174（「経路はあるのに 0 通」の先行事例）

## 変更内容

### 何が壊れていたか

- 転送 Lambda（`infra/lambda/ops-alert-forwarder/index.ts` の `postDiscordEmbed`）は **非 2xx / timeout / socket error のいずれでも `console.error` して `resolve()`** し、例外を投げない → **Lambda の Errors metric に 1 件も乗らない**
- **転送 Lambda 自身を監視する alarm が OpsStack に無い**（`grep` で確認: 監視対象はアプリ Lambda / cron dispatcher / CloudFront / S3 origin / app log 由来の 3 本のみ）
- Discord webhook は channel 単位の rate limit を持つため、**多数の alarm が同時に鳴る瞬間に 429 が返り、その通知だけが捨てられる**
- オーナー決裁 2026-08-07 の条件「初回 deploy 後 1 週間の流入量実測」を満たす手段が無い（転送件数を数える仕組みが無い）

### 何を変えたか

| 変更 | 内容 |
|---|---|
| `infra/lib/ops-alert-log-terms.ts`（新規） | 検索語 SSOT。**書き手（Lambda）と読み手（MetricFilter）が同じ定数を import** するため、literal の二重管理と drift 検証 test が要らない |
| `infra/lambda/ops-alert-forwarder/index.ts` | 送信結果を構造化 log で 1 行出す。成功 = `[ops-alert] forward-succeeded` / 失敗 = `[ops-alert] forward-failed reason=<http-NNN\|timeout\|network\|no-webhook\|exception>`。**識別子・通知本文は載せない**（`[auth-alert]` 系の既存規約と同じ） |
| `infra/lib/ops-stack.ts` | 転送 Lambda の LogGroup に MetricFilter 2 本（`GanbariQuest/Ops` の `AlertForwardSucceeded` / `AlertForwardFailed`）+ 失敗 alarm `ganbari-quest-ops-alert-forward-failed`（5 分 / 1 件 / NOT_BREACHING）を追加 |
| `infra/lib/ops-alert-policy.ts` | 上記 alarm を `notify: true` で追加（#4399 の doctrine どおり既定は「届ける」） |
| `docs/runbooks/ops-alert-notification.md` | §6 を新設: 流入量の実測コマンド（1 週間 Sum）と、転送失敗 alarm が鳴ったときの `reason` 別の対処 |
| `tests/unit/infra/physical-name-ratchet.test.ts` | 新 alarm 名を理由付きで allowlist に追加（[G2]/[G4] が新規明示物理名を検出したため。runbook / 方針表がこの名前で参照する） |
| `tests/unit/infra/entitlement-fail-closed-alarm.test.ts` | [A3] の「MetricFilter 総数 0」を「アプリ log 由来（`GanbariQuest/Ops` 以外の namespace）が 0」に**特定**。転送 Lambda 自身の LogGroup に付く filter は `appLogGroup` の有無と無関係に常に存在するため総数では意図を表せない。総数で緩めるのではなく検査対象を正確にした（ADR-0006: assertion を弱めない） |

### 例外を投げるか / 握り潰したまま metric にするか（判断と理由）

**握り潰したまま metric で観測する**を選んだ。理由は `index.ts` 冒頭コメントに記載:

1. **呼び出し元が SNS の非同期呼び出しで、落として得るものが無い。** 例外を投げると Lambda が最大 2 回 自動リトライするが、`handler` は `event.Records` を順に処理し冪等性が無いため、**後ろの record だけ失敗したとき前の record が再送されて同じ通知が重複する**（障害中の二重通知は「捌けない状態」の別形）
2. **失敗の検知を Lambda のリトライ意味論に依存させたくない。** Errors metric に乗せても 429 / timeout / webhook 失効の切り分けができない
3. ただし **握り潰したままにはしない** — 成否を metric 化し、失敗は専用 alarm で拾う（「落とさない」と「気付けない」を切り離す）

429 に対する retry-after 準拠の再送は、`AlertForwardFailed` の実測で実際に起きることを確かめてから入れる（起きるか分からない再送機構を先に足さない、ADR-0010）。

### 流入量の実測（オーナー決裁の条件 ②）

`AlertForwardSucceeded` の 1 週間 Sum で読む。**dashboard も集計 script も作らない**（runbook §6 にコマンドのみ）。

## 検証

### failing-test-first（追加 test が修正前の実装で落ちることの実測）

`tests/unit/infra/ops-alert-forwarder-observability.test.ts` を先に追加し、**実装前**に実行した結果（`npx vitest run ... -t "[A]"`、5 failed / 1 passed / 3 skipped）:

```
FAIL > 2xx で返ったら成功 log が出る (失敗 log は出ない)
AssertionError: 転送成功の log が出ていません。流入量 (1 週間の Sum) が数えられません: expected [] to have a length of 1 but got +0
FAIL > 429 (rate limit) で失敗 log が出る — 同時多発時に通知が消える経路
AssertionError: 429 で捨てられたのに失敗 log が出ていません: expected [] to have a length of 1 but got +0
FAIL > socket 断で failed reason=network が出る
AssertionError: socket 断で失敗 log が出ていません: expected [] to have a length of 1 but got +0
FAIL > 応答が返らないと failed reason=timeout が出る (実 timeout 5 秒)
AssertionError: timeout したのに失敗 log が出ていません: expected [] to have a length of 1 but got +0
FAIL > webhook 未設定なら failed reason=no-webhook が出る (#4119 の「0 通」を数える)
AssertionError: webhook 未設定は「全通知が 0 通」だが失敗として数えられていません: expected [] to have a length of 1 but got +0
 Test Files  1 failed (1)
      Tests  5 failed | 1 passed | 3 skipped (9)
```

（1 passed = 「抑止は成功にも失敗にも数えない」。抑止経路は元から log を出さないため実装前でも通る）

### test が実測で見つけた 2 件の実欠陥（同 PR 内で是正）

1. **詳細 log に検索語が入り、1 回の失敗が 2 件に数えられていた** — detail 行の prefix を検索語を含まない形に変更
2. **timeout 時の `req.destroy()` が誘発する `'error'` で timeout + network の 2 件に数えられていた** — 送信 1 回につき結果 1 件だけを数える `settle()` guard を導入。timeout test に「network として二重に数えない」assertion を追加

いずれも metric の件数が実態より多く見える（「何通届かなかったか」が信用できない）欠陥。

### 実行したコマンドと結果

| コマンド | 結果 |
|---|---|
| `npx vitest run tests/unit/infra/ops-alert-forwarder-observability.test.ts -t "[A]"`（**実装前**） | **5 failed / 1 passed**（上記ログ） |
| `npx vitest run tests/unit/infra/`（修正後、全 26 file） | **26 passed / 290 tests passed** |
| `npm run pre-ready -- --pr 4430` | **PASS**（6 step: pr-body / biome / plan-literals / local-tz-getters / svelte-check。ss-embed-gate は UI 変更なしで skip） |
| `npx biome check infra/ tests/unit/infra/` | 50 files, no fixes applied |

補足 1: 初回の全 infra 実行で `static-assets-s3-offload.test.ts` が 5s timeout で 1 件落ちたが、別セッションの重い検証と並走した時間帯であり（`heavy-run-lock` 競合中）、lock 解放後の再実行で 290 件全通過。

補足 2: pre-ready は最初 `biome check .` が「0 files / paths ignored」で落ちたが、これは worktree を `C:	mp\` 配下に置いたため biome.json の `!**/tmp` 除外が絶対パスに一致していたもの（lint 違反ではない）。worktree を `C:\gqwt-fwd-obs` に移して再実行し PASS。

### 既存 gate が拾うことの確認

`ALARM_NOTIFY_POLICY` の no-silent-gap（`tests/unit/infra/ops-alert-policy.test.ts`）は **synth した実テンプレートの alarm 名 ↔ 方針表**を双方向で照合する（未宣言 → fail、撤去済が表に残る → fail）。新 alarm を追加したので **方針表に entry を足さなければ CI が落ちる**構造であり、entry は追加済。加えて本 PR の test [B] が「entry があり `notify: true` であること」「自己参照の限界が reason に書かれていること」を独立に固定する。

## 影響範囲

- **UI 変更なし**（infra / Lambda / test / runbook のみ）
- 顧客に見える変化: なし。運営に見える変化として、転送失敗時に Discord へ 1 通増える
- 新規 AWS リソース: MetricFilter 2 本 + Alarm 1 本（無料枠 10 alarm の範囲外だが $0.10/alarm/月。log 由来 metric の追加コストは既存 3 本と同型）
- 並行実装ペア: なし。`ops-alert-policy.ts` は転送 Lambda に bundle されるため **deploy しないと反映されない**（runbook §3 既述）
- 破壊的変更: なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->



## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 (revert で元に戻る)"]
    R2["顧客面: 変化なし (運用監視のみ)"]
    R3["ロールバック: データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 通知が消えたら気付ける"]
    T2["得る: 流入量が Sum で読める"]
    T3["払う: alarm 1 本 ≒ 月 $0.10"]
  end
  subgraph OBJ["③ 反対理由"]
    O1["🟡 自己参照: 全断時はこの通知も届かない"]
    O2["🟡 429 の再送は入れていない"]
    O3["🟢 secret 追加なし・権限変更なし"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["UI 変更なし。運営に届く通知が 1 種増える"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: alarm 1 本の追加コストを許容するか"]
    Q2["Q2: 429 再送は実測後で良いか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R2,R3 ok
  class T1,T2 ok
  class T3,O1,O2 warn
  class O3,C1 ok
  class Q1,Q2 ask
```

<details><summary>補足</summary>

`po-decision:required` は `infra/**` 変更で自動付与された。新規 secret / IAM 権限 / データ破壊を伴う変更は無く、追加されるのは CloudWatch MetricFilter 2 本と Alarm 1 本のみ。**自己参照の限界**（Discord 全断時はこの alarm の通知も届かず、CloudWatch console と metric だけが残る）は `ops-alert-policy.ts` の reason と runbook §6 に明記した。

</details>
