### PR TITLE
fix(lint): tutorial-store の goto() 6 箇所を resolve() 経由にする（develop 側 lint 赤の是正）

### DIFF
--- a/src/lib/ui/tutorial/tutorial-store.svelte.ts
+++ b/src/lib/ui/tutorial/tutorial-store.svelte.ts
@@ -1,4 +1,5 @@
 import { goto } from '$app/navigation';
+import { resolve } from '$app/paths';
 import { TUTORIAL_CHAPTERS } from './tutorial-chapters';
 import type { TutorialChapter, TutorialStep } from './tutorial-types';
 
@@ -153,7 +154,7 @@ async function activateChapter(chapterId: number, quickMode: boolean) {
 
 	const step = getCurrentStep();
 	if (step?.page) {
-		await goto(step.page);
+		await goto(resolve(step.page));
 	}
 }
 
@@ -198,7 +199,7 @@ export async function continueFullTutorial() {
 		saveProgress(nextChapter.id, 0);
 		const step = getCurrentStep();
 		if (step?.page) {
-			await goto(step.page);
+			await goto(resolve(step.page));
 		}
 	} else {
 		await completeTutorial();
@@ -221,7 +222,7 @@ export async function resumeTutorial() {
 
 	const step = getCurrentStep();
 	if (step?.page) {
-		await goto(step.page);
+		await goto(resolve(step.page));
 	}
 }
 
@@ -303,7 +304,7 @@ export async function nextStep() {
 	if (step?.page && typeof window !== 'undefined') {
 		const currentPath = window.location.pathname;
 		if (currentPath !== step.page) {
-			await goto(step.page);
+			await goto(resolve(step.page));
 		}
 	}
 }
@@ -326,7 +327,7 @@ export async function prevStep() {
 	if (step?.page && typeof window !== 'undefined') {
 		const currentPath = window.location.pathname;
 		if (currentPath !== step.page) {
-			await goto(step.page);
+			await goto(resolve(step.page));
 		}
 	}
 }
@@ -341,7 +342,7 @@ export async function skipToChapter(chapterId: number) {
 
 	const step = getCurrentStep();
 	if (step?.page) {
-		await goto(step.page);
+		await goto(resolve(step.page));
 	}
 }
 

--- a/src/lib/ui/tutorial/tutorial-types.ts
+++ b/src/lib/ui/tutorial/tutorial-types.ts
@@ -24,6 +24,24 @@ export function meetsRequiredTier(planTier: PlanTier, requiredTier?: PlanTier): 
 	return TIER_ORDER[planTier] >= TIER_ORDER[requiredTier];
 }
 
+/**
+ * チュートリアルが遷移しうるページ。
+ *
+ * `string` のままだと `goto(step.page)` に SvelteKit の `resolve()` を通せず
+ * (`resolve` は route id / pathname リテラルを要求する)、
+ * `svelte/no-navigation-without-resolve` を満たせない。実在ルートの union に絞ることで
+ * 遷移先の typo をコンパイル時に落としつつ `resolve()` 経由の遷移に統一する。
+ */
+export type TutorialPage =
+	| '/admin'
+	| '/admin/activities'
+	| '/admin/cheer'
+	| '/admin/children'
+	| '/admin/points'
+	| '/admin/reports'
+	| '/admin/rewards'
+	| '/admin/settings';
+
 export interface TutorialStep {
 	id: string;
 	chapterId: number;
@@ -31,7 +49,7 @@ export interface TutorialStep {
 	title: string;
 	description: string;
 	position: 'top' | 'bottom' | 'left' | 'right' | 'auto';
-	page?: string;
+	page?: TutorialPage;
 	/** この手順を表示する最低プランティア（省略時は全プラン表示） */
 	requiredTier?: PlanTier;
 }


### PR DESCRIPTION
## 顧客価値・目的

develop 側に残っていた lint error 6 件を消し、**この file を触っていない PR のレビューでも同じ赤がログに出続ける状態**を解消する。レビュアが「自分の変更が壊した」と誤読して調査に時間を使うのを止めるのが目的。顧客に見える挙動は変わらない。

UI 変更なし。

## 関連 Issue

<!-- no-issue-close: develop 側 repo-wide lint 赤の是正。QM が #4418 レビュー中に発見（オーナー指示 2026-08-07「follow up は PR を発行する」）。Issue 未起票 -->

参照: #4418（本件を発見した PR。#4418 自身の CI 赤は別原因＝下記「検証」参照）

## 変更内容

`src/lib/ui/tutorial/tutorial-store.svelte.ts` の `goto()` 6 箇所が `svelte/no-navigation-without-resolve` に違反していた（最終変更は #982 / #984 / #955、数ヶ月前）。

1. **`TutorialStep.page` の型を `string` → 実在ルート 8 件の union `TutorialPage` に narrowing**（`tutorial-types.ts`）。`resolve()` は route id / pathname リテラルを要求するため、`string` のままでは型が通らない。副次的に遷移先 typo がコンパイル時に落ちるようになる
2. **`goto(step.page)` → `goto(resolve(step.page))` を 6 箇所**（`tutorial-store.svelte.ts`）。`resolve` は `$app/paths` から import

先例に合わせた書き方（独自の書き方は発明していない）:

- `src/lib/features/admin/components/CheckoutReconciliationBanner.svelte:75` — `replaceState(resolve('/admin/subscription'), page.state)`
- `src/lib/features/child-home/components/OverlaysSection.svelte:186` — `href={resolve('/admin/children')}`
- `src/routes/auth/invite/[code]/+page.svelte:30` — `href={resolve('/auth/logout')}`

## 検証

**この 6 件は lint-and-test job を落としていなかった**（実測）。`.ts` を見る step は `ci.yml:310` の SonarJS step だけで `continue-on-error: true`、`npm run lint:svelte` は `src/**/*.svelte` のみを対象とし本 file（`.ts`）を見ない。実際 #4393 / #4392 の `lint-and-test` は **pass** している。#4418 の fail の真因は同 job の後段 `npm run lint:svelte` で出た **#4418 自身の diff 由来の 2 error**（`local/no-hardcoded-jp-text` / `local/max-style-lines`）であり、本 PR とは無関係。

つまり本 PR は **CI を緑に戻すための緊急修正ではなく、`##[error]` 注釈でレビュアを誤誘導するノイズの除去**。

| 検証 | コマンド | 結果 |
|---|---|---|
| 対象 file の error 解消 | `npx eslint "src/lib/ui/tutorial/tutorial-store.svelte.ts"` | **6 errors → 0**（warning 1 = 既存 `sonarjs/no-duplicate-string` は本 PR 対象外） |
| 同 rule の repo 全体 sweep（.ts） | `npx eslint "src/**/*.ts"` \| grep no-navigation-without-resolve | **0 件**（他 file に同 rule の error なし。全体は 0 errors / 180 warnings） |
| 同 rule の repo 全体 sweep（.svelte） | `npx eslint "src/**/*.svelte"` \| grep no-navigation-without-resolve | **0 件** |
| 型 | `npx svelte-check --threshold warning` | **8424 files / 0 errors / 0 warnings** |
| lint | `npx biome check src/` / `npm run lint:svelte` | 両方 pass |
| unit test | `npx vitest run tests/unit/tutorial/ tests/unit/architecture/` | **59 files / 428 tests 全 pass** |

E2E（`tests/e2e/child-tutorial-verification.spec.ts`）はローカル未実行、CI に委ねる。

**遷移先が 1 文字も変わらない根拠**: `svelte.config.js` に `kit.paths` 設定が無く `base` は既定の `''`。`resolve()` は base を前置するだけなので `resolve('/admin') === '/admin'`。加えて union の 8 パスが全て実在ルート（`src/routes/(parent)/{admin,admin/activities,admin/cheer,admin/children,admin/points,admin/reports,admin/rewards,admin/settings}/+page.svelte`）であることを確認済で、実在しないパスを書けば svelte-check が落ちる。`currentPath !== step.page` の比較は**意図的に未変更**（base='' で等価、差分を最小に保つため）。

## 影響範囲

- 顧客に見える変化: **なし**。チュートリアルは全 5 年齢モードで走る導線だが、遷移先 URL は上記の通り不変
- 並行実装ペア: `tutorial-chapters.ts` は値の変更なし（型が narrowing されただけで既存 8 値は全て union 内）。`docs/design/parallel-implementations.md` の「チュートリアル → tutorial-chapters.ts + demo-guide-state.svelte.ts」に該当するが、`demo-guide-state.svelte.ts` は `step.page` を参照しないため変更不要
- 破壊的変更: なし。`TutorialStep.page` を外部から任意 string で組み立てている箇所は存在しない（`grep` で consumer は `tutorial-store.svelte.ts` のみ）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
