### PR TITLE
chore(arch): #4432 「一度見せたら次から出さない」機構の実態調査 — 共通化しない判断を記録する

### DIFF
--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -572,13 +572,15 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 
 | 何を記録するか | 媒体 | 実体 | 例 |
 |---|---|---|---|
-| 特定の 1 行を見せたか | A: その行に timestamp 列 | `src/lib/server/db/schema.ts` + sqlite / dsql / demo の 3 repo | `parent_messages.shown_at` / `sibling_cheers.shown_at` / `child_challenges.celebration_shown_at` / `special_rewards.shown_at` / `reward_redemption_requests.shown_to_child_at` |
+| 特定の 1 行を見せたか | A: その行に timestamp 列 | `src/lib/server/db/schema.ts` + sqlite / dsql / demo の 3 repo | `parent_messages.shown_at` / `sibling_cheers.shown_at` / `child_challenges.celebration_shown_at` / `special_rewards.shown_at` |
 | 子 / テナントに 1 本の一時的な未読告知 | **B: settings KV**（列追加は不可逆なので避ける） | `settings` テーブル + `export-format.ts` の分類 3 配列 | `habit_certificate_notice:<childId>` / `ui_mode_change_notice:<childId>` / `premium_welcome_shown` ほか |
 | 端末ローカルで十分な UI ガイド（機種変で再表示されてよい） | C: localStorage | 各コンポーネント / store | `ganbari-page-guide-completed` / `gq:milestone-seen:*` |
 
+**列だけが残っているものを「前例」として真似しない**: `reward_redemption_requests.shown_to_child_at` は A の 5 例目だったが、read / write とも production 呼び出し元ゼロの到達不能経路だった。経路の撤去は #4435 / PR #4440 で行い、**列はバックアップ往復（export/import）の忠実性のためだけに残す**（撤去の終了条件は `schema.ts` の当該列コメント）。子への承認 / 却下の伝達は、ごほうびショップのカードのバッジ（`latestRequestStatus`）と履歴画面が担う。
+
 **A（行に timestamp）を選んだ場合に必ず満たす 3 条件**:
 
-1. **冪等にする** — `UPDATE ... WHERE ... AND <col> IS NULL`。再送で「最初に見せた時刻」を上書きしない
+1. **冪等にする** — `UPDATE ... WHERE ... AND <col> IS NULL`。再送で「最初に見せた時刻」を上書きしない。**行を返す mark は、guard で 0 行になったときに所有権を満たす行を読み直すところまでが条件**（`markRewardShown` / `markMessageShown`）。読み直さないと「既に既読」と「他人の子の行」がどちらも 0 行になり、呼び出し側の 404 が所有権シグナルとして機能しなくなる（#2845）。void を返す mark（`markCelebrationShown` / `markShown`）は単文で足りる
 2. **所有権を検証する** — WHERE に `(child_id, <id>)` の複合キーを含めるか、service 層で `findById` → `childId` 一致を確認する。`family_id` だけでは同一家族内の別の子の行を閉じられる
 3. **表示可否の根拠を client の `$state` に置かない** — load 側で `IS NULL` を解決する（#4410 で確立）。`$state` はマウントのたび初期値へ戻るため、根拠にすると毎回再表示される（ADR-0012 違反）
 
@@ -592,7 +594,7 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 - [ ] 媒体を上表から選んだか（「既存が A だから A」で決めない。子に 1 本の一時告知なら B）
 - [ ] A なら 3 条件を満たしたか。sqlite / dsql / demo の 3 repo + interface を同期したか
 - [ ] B なら `export-format.ts` の分類に追加したか
-- [ ] 既存実装のコメントが「〜と同型」と書いていても**信じない** — 冪等性と所有権は実際に 5 例で食い違っている（#4432 実測）
+- [ ] 既存実装のコメントが「〜と同型」と書いていても**信じない** — 冪等性と所有権は実際に 5 例で食い違っていた（#4432 実測 / 是正は #4435）
 
 ---
 

--- a/docs/design/parallel-implementations.md
+++ b/docs/design/parallel-implementations.md
@@ -564,6 +564,38 @@ grep -n "bottom-nav\|data-testid" src/lib/ui/components/BottomNav.svelte
 
 ---
 
+#### 13. 「一度見せたら次から出さない」機構 (#4432)
+
+同じ目的の実装が **4 媒体・約 20 例**に散っている。**共通化しない判断を #4432 で確定済み**（5 例が同型でなく、抽象化しても列 / repo / テストが減らず、所有権と冪等性がコールサイトから読めなくなるため）。揃えるのは実装ではなく**選択基準と満たすべき条件**。判断根拠は [`docs/rationale/17-once-only-notice-rationale.md`](../rationale/17-once-only-notice-rationale.md)。
+
+**新規実装時はまず媒体を選ぶ**:
+
+| 何を記録するか | 媒体 | 実体 | 例 |
+|---|---|---|---|
+| 特定の 1 行を見せたか | A: その行に timestamp 列 | `src/lib/server/db/schema.ts` + sqlite / dsql / demo の 3 repo | `parent_messages.shown_at` / `sibling_cheers.shown_at` / `child_challenges.celebration_shown_at` / `special_rewards.shown_at` / `reward_redemption_requests.shown_to_child_at` |
+| 子 / テナントに 1 本の一時的な未読告知 | **B: settings KV**（列追加は不可逆なので避ける） | `settings` テーブル + `export-format.ts` の分類 3 配列 | `habit_certificate_notice:<childId>` / `ui_mode_change_notice:<childId>` / `premium_welcome_shown` ほか |
+| 端末ローカルで十分な UI ガイド（機種変で再表示されてよい） | C: localStorage | 各コンポーネント / store | `ganbari-page-guide-completed` / `gq:milestone-seen:*` |
+
+**A（行に timestamp）を選んだ場合に必ず満たす 3 条件**:
+
+1. **冪等にする** — `UPDATE ... WHERE ... AND <col> IS NULL`。再送で「最初に見せた時刻」を上書きしない
+2. **所有権を検証する** — WHERE に `(child_id, <id>)` の複合キーを含めるか、service 層で `findById` → `childId` 一致を確認する。`family_id` だけでは同一家族内の別の子の行を閉じられる
+3. **表示可否の根拠を client の `$state` に置かない** — load 側で `IS NULL` を解決する（#4410 で確立）。`$state` はマウントのたび初期値へ戻るため、根拠にすると毎回再表示される（ADR-0012 違反）
+
+**B（settings KV）を選んだ場合**:
+
+- 既読は**空文字 upsert**で表す（settings repo に削除 API が無いため。`ui-mode-change-notice-service.ts` / `habit-certificate-notice-service.ts` の前例）
+- 新規キーは `export-format.ts` の `EXPORTABLE_SETTING_KEYS` / `SECRET_SETTING_KEYS` / `NON_EXPORTABLE_SETTING_KEYS` のいずれかに**必ず分類**する（未分類は `settings-backup-classification.test.ts` が CI で fail）
+
+**修正時チェック**:
+
+- [ ] 媒体を上表から選んだか（「既存が A だから A」で決めない。子に 1 本の一時告知なら B）
+- [ ] A なら 3 条件を満たしたか。sqlite / dsql / demo の 3 repo + interface を同期したか
+- [ ] B なら `export-format.ts` の分類に追加したか
+- [ ] 既存実装のコメントが「〜と同型」と書いていても**信じない** — 冪等性と所有権は実際に 5 例で食い違っている（#4432 実測）
+
+---
+
 ## 🔥 重量 e2e 敏感領域 SSOT（軽量レーンをすり抜ける不変条件、#3172 / #3173）
 
 > **このリストは「軽量レーン緑 = 安全」と誤認してはいけない領域の SSOT**。

--- a/docs/rationale/17-once-only-notice-rationale.md
+++ b/docs/rationale/17-once-only-notice-rationale.md
@@ -1,0 +1,119 @@
+# 「一度見せたら次から出さない」機構 設計経緯
+
+## 議論の発端
+
+- **日時**: 2026-08-07
+- **発端 Issue / セッション**: #4432（PR #4421 / #4410 で 4 例目が増えたことを受けた実態調査）
+- **問題意識**: `shown_at` 列 + 記録 action で「一度見せたら次から出さない」を実現する実装が 4 例に増えた。CLAUDE.md §補佐設計品質ガード 6 は「3 つ目の類似 service / component の前に Strategy / Factory / Registry 適用判断」を求めており、既に 1 例超えている。**共通化すべきか**を実測で判断する。
+
+**結論: 共通化しない。** 抽象ではなく「新規実装時の選択基準 + 満たすべき条件」で揃える。根拠は以下。
+
+---
+
+## 実態調査の結果
+
+### 発端の前提が誤っていた — 4 例ではない
+
+`shown_at` という**列名で探すと 4 例**だが、「一度見せたら次から出さない」を実現している実装を機能で探すと **4 種類の媒体にまたがる約 20 例**ある。
+
+| 媒体 | 例数 | 代表 |
+|---|---|---|
+| A. 行に「見せた時刻」を刻む（per-row timestamp 列） | **5** | `special_rewards.shown_at` / `parent_messages.shown_at` / `sibling_cheers.shown_at` / `child_challenges.celebration_shown_at` / `reward_redemption_requests.shown_to_child_at` |
+| B. settings KVS に「見せた」を置く | **11** | `ui_mode_change_notice:<childId>` / `habit_certificate_notice:<childId>` / `trial_expiration_modal_shown` / `premium_welcome_shown` / `pin_gate_onboarding_seen` / `onboarding_dismissed` ほか |
+| C. localStorage（端末ローカル） | 4 | `gq:milestone-seen:*`（2 コンポーネントに複製）/ `child_tutorial_hint_shown_*` / `ganbari-page-guide-completed` / `tutorial-progress-*` |
+| D. cookie | 1 | `trial_was_active`（active→inactive 遷移を 1 回だけ検知して delete） |
+
+つまり Issue が数えた「4」は **A の 5 例のうち 4 例**であり、`reward_redemption_requests.shown_to_child_at`（`integer` epoch、命名も `shown_to_child_at`）が漏れていた。列名 grep で数えたことが原因。
+
+**B / C は既にそれぞれ内部で揃っている。** B は `habit-certificate-notice-service.ts` 冒頭が「#4313 (`ui-mode-change-notice-service`) と同じ root class で、**その流儀に揃える**（観測・保存の形を 2 つ持たない）」と明記し、既読を空文字 upsert で表す規約まで文書化済み。さらに `export-format.ts` の `EXPORTABLE_SETTING_KEYS` / `SECRET_SETTING_KEYS` / `NON_EXPORTABLE_SETTING_KEYS` が全キーの分類 SSOT で、`settings-backup-classification.test.ts` が未分類キーを CI で fail させる（no-silent-gap）。**共通化の議論が意味を持つのは A の 5 例だけ**なので、以下は A に絞る。
+
+### 観点 1〜3: A の 5 例は同型ではない
+
+| # | 列 | 何を「見せた」と記録するか | 読み（表示対象の解決） | 書き手 | 冪等性 | 所有権の検証 | 稼働 |
+|---|---|---|---|---|---|---|---|
+| A1 | `special_rewards.shown_at` | 特別報酬付与の演出を 1 件 | repo SQL: `IS NULL` + `ORDER BY granted_at DESC LIMIT 1` | REST `POST /api/v1/special-rewards/[id]/shown`（fetch、失敗時 1 回再送 → warn） | **なし**（WHERE に `IS NULL` を含まず、再送で初回時刻を上書き） | WHERE に `(child_id, reward_id)` 複合 | **停止中**（load が `Promise.resolve(null)` 固定、#4172 決裁で子への演出を出さない） |
+| A2 | `parent_messages.shown_at` | 親からのメッセージを 1 件 | repo SQL: `IS NULL` + `ORDER BY sent_at DESC LIMIT 1`、加えて未読数 `COUNT(*)` | REST `POST /api/v1/messages/[id]/shown`（同上） | **なし** | WHERE に `(child_id, message_id)` 複合 | 稼働 |
+| A3 | `sibling_cheers.shown_at` | きょうだいのおうえんを**全件** | repo SQL: `IS NULL`（LIMIT なし、リストを返す） | form action `?/markCheersShown`（id 配列を CSV で受ける） | **なし** | **どのレイヤにも無い**（WHERE は `family_id` + `cheer_id IN (...)` のみ） | 稼働 |
+| A4 | `child_challenges.celebration_shown_at` | チャレンジ達成の祝福を 1 件 | **専用クエリなし**。既に読み済みの一覧に対し TS の `resolveCelebrationChallenge` が `allCompleted && celebrationShownAt === null` で絞る | form action `?/markChallengeCelebrationShown` | **あり**（WHERE に `IS NULL`、初回時刻を保つ） | service 層で `findById` → `childId` 比較（false なら 400） | 稼働 |
+| A5 | `reward_redemption_requests.shown_to_child_at` | 交換申請の承認/却下通知を 1 件 | repo SQL: `IS NULL` + `status IN ('approved','rejected')` + reward snapshot の `LEFT JOIN` + `ORDER BY resolved_at DESC LIMIT 1` | — | **なし** | WHERE に `(child_id, id)` 複合 | **死んでいる**（read `getUnshownRedemptionResult` / write `markRedemptionShown` とも production 呼び出し元ゼロ、参照は unit test のみ） |
+
+同型なのは **`IS NULL` を「まだ見せていない」の意味に使っている 1 点だけ**。それ以外は全部違う:
+
+- **読みの形が 4 通り**（最新 1 件 / 全件リスト / 専用クエリを持たず TS 側で追加述語つき filter / status 条件 + JOIN snapshot 付き 1 件）。A4 は「クエリ」ですらない
+- **書き手が 3 通り**（REST エンドポイント / form action・単一 id / form action・id 配列）。しかも A1・A2 の REST は 1 回再送、A4 は `use:enhance`、B の habit notice は `keepalive: true` の自動発火と、失敗時の届け方も揃っていない
+- **冪等性が 5 例中 1 例だけ**。A4 のみ `IS NULL` を WHERE に含む。他 4 例は再送で「最初に見せた時刻」が上書きされる
+- **所有権の検証が 3 通り**（WHERE の複合キー 3 / service 層 1 / **無し 1**）
+- **列の型すら違う**（A1〜A4 は `text` の ISO 文字列、A5 は `integer` epoch 秒）
+- **5 例中 2 例が生きていない**（A1 は経路を保持したまま読みを停止、A5 は完全に到達不能）
+
+**この非同型は既に実害を出している。** `child-challenge-repo.interface.ts` と `SiblingCelebration.svelte` のコメントは A4 を「`sibling_cheers.markShown` / `parent_messages` の `shown_at` と**同型**」と書いているが、実際には A4 だけが冪等で、A3 には所有権検証が無い。**名前の相似が実装の相似だと誤読された例が既に本体コード内にある。**
+
+### 観点 4: 共通化して何が減るか — ほとんど減らない
+
+A の read/write メソッドは `src/lib/server/db/` 配下 25 file に 67 箇所ある（sqlite / dsql / demo の 3 backend × interface）。仮に `ShownFlagRegistry<T>` 相当を作った場合に消せるのは:
+
+- **消せる**: `IS NULL` の述語 1 個 × 5 例。`markX` の「now() を set する」1 行 × 5 例
+- **残る**: 各 read の本体（`ORDER BY` / `LIMIT` / `LEFT JOIN` / `status IN` / A4 の TS filter）、3 backend 分の SQL 方言（sqlite は drizzle query builder、dsql は raw SQL、demo は fixture の in-memory filter）、interface 宣言、各エンドポイント / form action、テスト
+
+つまり**列定義は 1 本も減らず、repo メソッドは実質減らず、テストも減らない**。減るのは `isNull(...)` という 1 語であり、それを共有するために型パラメータ付きの registry を通すのは割に合わない。Issue の判定基準「減らないなら共通化しない」に該当する。
+
+### 観点 5: 共通化して何が固くなるか
+
+1. **差分が options bag に化ける。** 冪等性 (2 値) × 所有権の掛け方 (3 通り) × 読みの形 (4 通り) × 書き手 (3 通り) を 1 つの抽象で吸収すると、コールサイトは `registry.markShown(id, { idempotent: true, ownership: 'composite', ... })` になる。**「この機構は所有権を見ているか」がコールサイトから読めなくなる** — A3 の欠落を見つけられたのは repo の WHERE 句を直接読めたからで、options 越しでは埋もれる
+2. **DSQL の tenant 単一強制点が緩む。** dsql repo は raw SQL で `family_id = ${tenantId}` を必ず前置する（ADR-0063 の単一強制点、fitness function が静的検査する）。generic な shown-flag 層を挟むと述語の組み立てが動的になり、この検査が効かなくなる。**マルチテナント分離という一番落としてはいけない不変条件を、演出の重複排除のために弱める**取引になる
+3. **媒体の選択が隠れる。** A / B / C / D の選択（DB 行に紐づくのか、子に 1 本なのか、端末ローカルでよいのか）は寿命と粒度の設計判断で、これが新規実装で最初に間違えやすい点。A の中だけを抽象化すると「まず A を使う」が既定になり、settings KV で足りるものまで不可逆なスキーマ変更に流れる（`habit-certificate-notice-service.ts` が明示的に避けた失敗）
+
+---
+
+## 検討した代替案
+
+| 案 | 概要 | 検討した理由 |
+|----|------|-----------|
+| 案 A | `ShownFlagRegistry` / `ImportStrategy` 型の Registry に 5 例を寄せる | ADR-0052（marketplace 5 type）の前例。CLAUDE.md §補佐設計品質ガード 6 が求める検討対象 |
+| 案 B | repo に薄い共通 helper（`markShownIdempotent(table, idCol, where)` 等）だけ置く | 抽象を最小にして冪等性だけ揃える折衷案 |
+| **採用案** | **共通化しない。** 新規実装時の「媒体の選択基準」と「A を選んだ場合に満たすべき 3 条件」を規約として残し、既存の逸脱は個別に直す | 5 例が同型でなく、共通化しても減らないため |
+
+## 棄却理由
+
+- **案 A 棄却理由**: 上記「観点 4 / 5」の通り。減るのは述語 1 語、失うのは所有権・冪等性のコールサイト可読性と DSQL tenant 述語の静的検査。ADR-0052 が成立したのは marketplace 5 type が **同一の入出力契約（schema 検証 → child binding → 取込）を持っていた**からで、A の 5 例にはその共通契約が無い（読みの形が 4 通りある時点で契約が定義できない）
+- **案 B 棄却理由**: 冪等性を揃えたいだけなら、helper を作らず**各 repo の WHERE に `IS NULL` を足す**方が短く、diff も読める（A4 が既にその形）。helper は 3 backend の方言差（drizzle query builder / raw SQL / in-memory）を跨げず、結局 backend ごとに 3 実装になる。抽象の導入コストが節約分を上回る
+
+## 採用案とその理由
+
+**共通化せず、揃えるべきものを「抽象」ではなく「選択基準 + 条件」で揃える。**
+
+`docs/design/parallel-implementations.md` に「一度だけ見せる」機構の並行実装エントリを追加し、以下を記載する（本 rationale が Why、あちらが What）。
+
+### 媒体の選択基準（新規実装はここから）
+
+| 何を記録するか | 媒体 | 例 |
+|---|---|---|
+| 特定の 1 行（メッセージ・報酬・チャレンジ）を見せたか | A: その行に timestamp 列 | `parent_messages.shown_at` |
+| 子 / テナントに 1 本の一時的な未読告知 | **B: settings KV**（列追加は不可逆なので避ける） | `habit_certificate_notice:<childId>` |
+| 端末ローカルで十分な UI ガイド（機種変で再表示されてよい） | C: localStorage | `ganbari-page-guide-completed` |
+
+### A を選んだ場合に必ず満たす 3 条件
+
+1. **冪等にする** — `UPDATE ... WHERE ... AND <col> IS NULL`。再送で「最初に見せた時刻」を上書きしない
+2. **所有権を検証する** — WHERE に `(child_id, <id>)` の複合キーを含めるか、service 層で `findById` → `childId` 一致を確認する。`family_id` だけでは同一家族内の別の子の行を閉じられる
+3. **表示可否の根拠を client の `$state` に置かない** — load 側で `IS NULL` を解決する（#4410 で確立）。`$state` はマウントのたびに初期値へ戻るため、根拠にすると再表示される
+
+この 3 条件は 4 行のチェックリストであり、抽象を導入せずに次の実装者へ渡せる。**5 例目が来たときに参照すべきは registry ではなくこの表**。
+
+---
+
+## 残された懸念・フォローアップ
+
+本調査で見つかった A の規約逸脱。**本 Issue では実装しない**（#4432 は判断が成果物）。下 3 件は **#4435** に切り出した。
+
+- [ ] **A3 `sibling_cheers.markShown` に所有権検証が無い** — `?/markCheersShown` は cheer id の配列を受け、repo の WHERE は `family_id` + `cheer_id IN (...)` のみ。service も素通し。同一家族内の別の子の未読おうえんを既読化できる（IDOR、影響は「きょうだいの演出が出なくなる」で限定的だが、A1 / A2 / A5 が `#2845 課題①` で潰した穴が A3 だけ残っている）
+- [ ] **A1 / A2 / A3 / A5 の mark が非冪等** — WHERE に `IS NULL` が無く、再送・二重送信で初回表示時刻が上書きされる。A4 のみ対処済み。上記「条件 1」への横展開
+- [ ] **A5 が死んでいる** — `getUnshownRedemptionResult` / `markRedemptionShown` に production 呼び出し元が無く、参照は unit test のみ。子は交換申請の承認/却下を知る導線を持っていない可能性がある（意図的な撤去の残置か、配線漏れかの確認が要る）。列・repo・service・test が生きたまま残っているため、grep では「動いている機構」に見える
+- [ ] **C の `gq:milestone-seen:*` が 2 コンポーネントに複製されている** — `MilestoneBanner.svelte` と `MilestoneBellButton.svelte` が同じキー prefix の read/write を各自持つ。A の話とは別クラスターだが、同じ「一度だけ見せる」の重複として記録しておく
+
+## 関連
+
+- **後続 Issue**: #4435（A の規約逸脱 3 件の是正）
+- **議論源 Issue / PR**: #4432（本調査）/ #4421・#4410（A4 の追加）/ #4261 ③・#4313（B の 2 例）/ #4172（A1 の読み停止）/ #2845 課題①（A1・A2・A5 の所有権検証）
+- **影響を受ける設計書**: `docs/design/parallel-implementations.md`（「一度だけ見せる」機構のエントリ）
+- **関連 ADR**: [ADR-0012](../decisions/0012-anti-engagement-principle.md)（再表示は滞在時間の押し付け）/ [ADR-0052](../decisions/0052-marketplace-type-registry.md)（Registry が成立する条件との対比）/ [ADR-0063](../decisions/0063-dsql-pool-multitenant-isolation.md)（tenant 述語の単一強制点）

--- a/docs/rationale/17-once-only-notice-rationale.md
+++ b/docs/rationale/17-once-only-notice-rationale.md
@@ -107,8 +107,8 @@ A の read/write メソッドは `src/lib/server/db/` 配下 25 file に 67 箇�
 本調査で見つかった A の規約逸脱。**本 Issue では実装しない**（#4432 は判断が成果物）。下 3 件は **#4435** に切り出した。
 
 - [ ] **A3 `sibling_cheers.markShown` に所有権検証が無い** — `?/markCheersShown` は cheer id の配列を受け、repo の WHERE は `family_id` + `cheer_id IN (...)` のみ。service も素通し。同一家族内の別の子の未読おうえんを既読化できる（IDOR、影響は「きょうだいの演出が出なくなる」で限定的だが、A1 / A2 / A5 が `#2845 課題①` で潰した穴が A3 だけ残っている）
-- [ ] **A1 / A2 / A3 / A5 の mark が非冪等** — WHERE に `IS NULL` が無く、再送・二重送信で初回表示時刻が上書きされる。A4 のみ対処済み。上記「条件 1」への横展開
-- [ ] **A5 が死んでいる** — `getUnshownRedemptionResult` / `markRedemptionShown` に production 呼び出し元が無く、参照は unit test のみ。子は交換申請の承認/却下を知る導線を持っていない可能性がある（意図的な撤去の残置か、配線漏れかの確認が要る）。列・repo・service・test が生きたまま残っているため、grep では「動いている機構」に見える
+- [ ] **A1 / A2 / A3 / A5 の mark が非冪等** — WHERE に `IS NULL` が無く、再送・二重送信で初回表示時刻が上書きされる。A4 のみ対処済み。上記「条件 1」への横展開。**なお guard を足すだけでは足りない mark がある**: 行を返す A1 / A2 は 0 行が「既に既読」と「他人の子の行」の両方を意味してしまい、`/shown` endpoint の 404 が担っていた所有権シグナル（#2845）が壊れる。guard + 0 行時に所有権を満たす行を読み直すところまでが是正の単位（#4440 で採用された形）
+- [ ] **A5 が死んでいる** — `getUnshownRedemptionResult` / `markRedemptionShown` に production 呼び出し元が無く、参照は unit test のみ。列・repo・service・test が生きたまま残っているため、grep では「動いている機構」に見える。**#4435 / PR #4440 の判断は「繋がずに撤去」**: 子への承認 / 却下の伝達はごほうびショップのカードのバッジ（`latestRequestStatus`）と履歴画面が既に担っており、ホームに一度きりの全画面 overlay を足すのは ADR-0012 に反するため。列だけは backup 往復の忠実性のため残置し、撤去の終了条件を `schema.ts` の列コメントに置く（#3442 と同じ書き方）
 - [ ] **C の `gq:milestone-seen:*` が 2 コンポーネントに複製されている** — `MilestoneBanner.svelte` と `MilestoneBellButton.svelte` が同じキー prefix の read/write を各自持つ。A の話とは別クラスターだが、同じ「一度だけ見せる」の重複として記録しておく
 
 ## 関連


### PR DESCRIPTION
## 顧客価値・目的

「一度見せたら次から出さない」を次に実装する開発者が、5 分の調査で正しい媒体と条件を選べるようになる。これまでは既存実装のコメントが互いを「同型」と称していたが実際には冪等性も所有権も食い違っており、真似ると再表示バグ（ADR-0012 違反 = 子供に同じモーダルを何度も見せる）や IDOR を再生産する状態だった。

## 関連 Issue

Closes #4432

- #4435 / PR #4440（本調査で見つかった規約逸脱 3 件の是正。本 PR では実装しない。#4440 は §13 を SSOT として参照するため、下記「#4435 の実装との整合」で参照先を合わせた）
- #4421 / #4410（4 例目の追加。本 Issue の発端）

## 変更内容

**これは調査と判断の PR で、コードは変更していない。** 成果物は 2 つの doc。

### 1. `docs/rationale/17-once-only-notice-rationale.md`（新規）

実態調査の結果、比較表、共通化しない判断とその理由。5 例目が出たときに同じ調査を繰り返さないための記録（`docs/CLAUDE.md` §research 配置規律「棄却案比較 → `docs/rationale/`」に従い research には置いていない）。

**発端の前提が誤っていた。** `shown_at` という列名で探すと 4 例だが、機能で探すと **4 媒体・約 20 例**ある。

| 媒体 | 例数 | 状態 |
|---|---|---|
| A. 行に timestamp 列 | **5**（Issue が数えた 4 + `reward_redemption_requests.shown_to_child_at`） | 揃っていない |
| B. settings KV | 11 | 既に揃っている（`habit-certificate-notice-service.ts` が「#4313 の流儀に揃える」と明記、`export-format.ts` の分類 3 配列 + `settings-backup-classification.test.ts` で機械強制） |
| C. localStorage | 4 | 端末ローカル、別クラスター |
| D. cookie | 1 | `trial_was_active` |

**共通化の議論が成立するのは A の 5 例だけ**だが、同型なのは `IS NULL` を「未表示」の意味に使う 1 点のみ:

| | 読みの形 | 冪等 | 所有権の検証 | 書き手 | 稼働 |
|---|---|---|---|---|---|
| `special_rewards` | 最新 1 件 | ✗ | WHERE 複合キー | REST | **停止中**（#4172） |
| `parent_messages` | 最新 1 件 + 未読数 | ✗ | WHERE 複合キー | REST | 稼働 |
| `sibling_cheers` | **全件リスト** | ✗ | **無し** | form action（id 配列） | 稼働 |
| `child_challenges` | **専用クエリ無し**（TS filter + `allCompleted`） | ✓ | service 層 | form action | 稼働 |
| `reward_redemption_requests` | status 条件 + JOIN snapshot 付き 1 件 | ✗ | WHERE 複合キー | — | **到達不能** |

列の型すら `text` (ISO) と `integer` (epoch) で割れている。

**共通化しても減らない**: 消せるのは `isNull(...)` 1 語 × 5。残るのは各 read 本体（`ORDER BY` / `LIMIT` / `LEFT JOIN` / `status IN` / TS filter）、3 backend の方言（drizzle query builder / raw SQL / in-memory）、interface、エンドポイント、テスト。列定義は 1 本も減らない。

**共通化すると固くなる**: (a) 差分が options bag 化して「この機構は所有権を見ているか」がコールサイトから読めなくなる — A3 の欠落を見つけられたのは WHERE 句を直接読めたから、(b) dsql の `family_id` 前置という単一強制点（ADR-0063、fitness function が静的検査）が動的組み立てで緩む、(c) 媒体の選択が隠れて settings KV で足りるものまで不可逆なスキーマ変更に流れる。

→ **共通化しない。** ADR-0052（marketplace 5 type）が成立したのは 5 type が同一の入出力契約を持っていたからで、A には共通契約が定義できない。

### 2. `docs/design/parallel-implementations.md` §13（追記）

抽象の代わりに置くもの。新規実装が最初に見る場所なので rationale（Why）とは別に What を置いた。

- **媒体の選択基準**（行に紐づくなら A / 子に 1 本の一時告知なら B / 端末ローカルで十分なら C）
- **A を選んだ場合の 3 条件**: ①`WHERE ... AND <col> IS NULL` で冪等にする — ただし**行を返す mark は 0 行時に所有権を満たす行を読み直すところまでが条件**（単文だと 0 行が「既に既読」と「他人の子の行」の両方を意味し、`/shown` endpoint の 404 が担う所有権シグナル #2845 が壊れる）②所有権を `(child_id, <id>)` 複合キーか service 層で検証する（`family_id` だけでは同一家族の別の子の行を閉じられる）③表示可否の根拠を client の `$state` に置かず load 側で解決する（#4410 で確立）
- **B を選んだ場合**: 既読は空文字 upsert、新規キーは `export-format.ts` の分類 3 配列に必ず追加
- 修正時チェックに「既存のコメントが『〜と同型』と書いていても信じない」を含めた（実測で食い違っていたため）

### #4435 の実装（PR #4440）との整合

#4440 が §13 を SSOT として参照するコメントを実装側に置いたため、参照先を実装に合わせた（第 2 commit）。**両 PR がどちらの順で merge されても矛盾しない書き方**にしている。

- 媒体 A の例示から `reward_redemption_requests.shown_to_child_at` を外した。read/write 経路は #4440 で撤去され、**列は backup 往復の忠実性のためだけに残る**（撤去の終了条件は `schema.ts` の列コメント、#3442 と同じ書き方）。§13 に「列だけが残っているものを前例として真似しない」を明記
- 条件 1 に上記の但し書きを追加。#4440 の `markRewardShown` / `markMessageShown` が採った guard + 読み直しの形を条件として言語化した

## 検証

事実はすべて develop の実物を読んで確認した（推測で「同型」と書いていない）。

| 主張 | 確認方法 | 結果 |
|---|---|---|
| A は 4 例でなく 5 例 | `schema.ts` / `dsql/schema.ts` 全 timestamp 列の読み込み + `seen`/`dismissed`/`acknowledged`/`viewed`/`read_at` 等の別名 grep | 5 例。別名の列は 0 件 |
| 冪等なのは `child_challenges` だけ | 5 例の `mark*` 実装を sqlite / dsql とも全文読み | `IS NULL` guard は `markCelebrationShown` のみ |
| `sibling_cheers` に所有権検証が無い | form action → service → sqlite repo → dsql repo の 4 層を読み、WHERE 句を確認 | どの層にも `to_child_id` の照合なし |
| `reward_redemption_requests` が到達不能 | `getUnshownRedemptionResult` / `markRedemptionShown` の呼び出し元を `src/` `tests/` 全体で grep | production 参照 0、unit test のみ |
| `special_rewards` が停止中 | `home/+page.server.ts` の load を読む | `Promise.resolve<SpecialRewardResult \| null>(null)` 固定（#4172、経路は意図的に保持） |
| B / C が既に揃っている | `habit-certificate-notice-service.ts` / `ui-mode-change-notice-service.ts` の冒頭コメント + `export-format.ts` の分類 3 配列 + `settings-backup-classification.test.ts` | B は流儀が文書化済 + CI で未分類キーを fail |
| repo 実装の分量 | `src/lib/server/db/` 配下で 5 例の read/write メソッド名を grep | 25 file / 67 箇所（3 backend + interface） |

- `npm ci` — 完了（worktree 隔離のため）
- `npm run pre-ready -- --pr 4436` — **PASS**。Step 9 (check-pr-body) / Step 1 (biome, 2247 files) / Step 7 (check-no-plan-literals) / Step 7g (check-local-tz-date-getters) / Step 2 (svelte-check, 8090 files 0 errors) が緑。Step 11b (SS embed gate) は UI 変更なしのため適用対象外 (skip)
- E2E / vitest — **未実行**。コード変更 0 のため実行意味なし（`docs/**` のみの diff）

## 影響範囲

- **顧客に見える変化**: なし（`docs/**` のみ、コード変更 0）
- **触った並行実装ペア**: `docs/design/parallel-implementations.md` に §13 を新設。既存 §1〜§12 は変更なし
- **破壊的変更**: なし
- **後続への影響**: 本 PR は「共通化しない」を確定させる。5 例目の実装者は §13 のチェックリストを参照する。既存 5 例の逸脱是正は #4435

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
