### PR TITLE
fix(child-ui): #4433 祝福とログインボーナスを重ねない (子供が祝福を閉じられない問題)

### DIFF
--- a/docs/design/06-UI設計書.md
+++ b/docs/design/06-UI設計書.md
@@ -886,6 +886,8 @@ admin リソース管理 3 画面（活動 / チェックリスト / ごほう�
 
 **表示回数（1 回のみ）:** 表示可否は load 側で `child_challenges.celebration_shown_at IS NULL` を条件に解決する（`resolveCelebrationChallenge`）。閉じる操作は `?/markChallengeCelebrationShown` action で同列に時刻を書き、以後はページ遷移・リロード・`invalidateAll`・別端末のいずれでも再表示されない。閉じる経路を submit ボタン 1 本に絞るため `closable={false}` + `closeOnEscape={false}`。ごほうび受取（`reward_claimed`）は停止条件に含めない。
 
+**表示の排他:** SiblingCelebration / SiblingCheerOverlay はいずれも `DialogFSM`（§4.x）の `celebration` / `siblingCheer` として enqueue され、ログインボーナス等と同時には開かない。先に出た演出を閉じた時点で次の 1 枚として出る。
+
 **SiblingCheerOverlay Props:**
 - `cheers: { id, stampLabel, stampEmoji, fromName }[]` — 受信したおうえんスタンプ
 - 「💌 おうえんがとどいたよ！」タイトルでスタンプ一覧表示
@@ -1074,7 +1076,13 @@ admin リソース管理 3 画面（活動 / チェックリスト / ごほう�
 5. birthday は自動トリガー対象外（バナークリックでのみ `fsm.transition('birthday', ...)` で開く）
 6. uiModeChange（§4.12a）は自動トリガー対象だが、**誕生日ボーナス未受取の回は呼び出し側で抑止**する（ADR-0012: 2 枚連続演出の禁止）
 
-**参照**: ADR-0002（ダイアログキュー必須）
+**子供ホームで自動的に開く全画面演出は、例外なく本 FSM の arbitration を通す**（`stampPress` / `specialReward` / `parentMessage` / `adventure` / `uiModeChange` / `siblingCheer` / `celebration`）。FSM の外で `{#if <データがある>}` だけを条件に描画してはならない。
+
+理由は z-index ではなく **pointer-events** にある。Ark UI（zag-js）の dismissable-layer は、開いているレイヤーのうち最上位以外に `pointer-events: none` を付与する（`@zag-js/dismissable` の `isBelowPointerBlockingLayer`）。この判定は**レイヤースタックへの登録順**で行われ z-index を見ない。したがって 2 枚同時に開くと、**手前に描画されている側でも後から開いた側に click を奪われる**。`--z-celebration`(200) の祝福が `--z-modal`(50) のログインボーナスに閉じるボタンを塞がれる、という形で顕在化する。z-index を上げても直らない（docs/DESIGN.md §10「侵襲的演出を重ねない」）。
+
+**描画は `fsm.current` を直接見ない。** `DialogFSM` は素の class instance で Svelte 5 の `$state` proxy が掛からず、`fsm.current` への代入は再描画を起こさない。`+page.svelte` が `currentDialog`（`$state`）に mirror し、FSM を進める操作は `openDialog()` / `closeDialog()` に集約する。`OverlaysSection` は FSM instance ではなく `current: DialogType` を prop で受ける。
+
+**参照**: ADR-0002（ダイアログキュー必須）/ ADR-0012（連続演出の禁止）/ docs/DESIGN.md §10
 
 ---
 

--- a/scripts/capture-specs/flows/child-celebration-click-intercept-4433.mjs
+++ b/scripts/capture-specs/flows/child-celebration-click-intercept-4433.mjs
@@ -104,7 +104,13 @@ export default async (page, capture) => {
 		await page
 			.locator(AUTO_OVERLAYS.map((o) => o.overlay).join(', '))
 			.first()
-			.waitFor({ state: 'visible', timeout: 20_000 });
+			.waitFor({ state: 'visible', timeout: 20_000 })
+			.catch(async () => {
+				await capture(`${PREFIX}-${uiMode}-NO-OVERLAY-debug${SUFFIX}`);
+				throw new Error(
+					`${uiMode}: 自動演出が 1 つも出ませんでした (seed 条件を満たしていない可能性)`,
+				);
+			});
 		await capture(`${PREFIX}-${uiMode}-landing${SUFFIX}`);
 
 		// ② 祝福が操作可能な状態になるまで、先に出ている演出を閉じていく
@@ -118,7 +124,7 @@ export default async (page, capture) => {
 				celebrationCaptured = true;
 			}
 			await page.locator(current.close).click();
-			await page.locator(current.overlay).waitFor({ state: 'detached', timeout: 15_000 });
+			await page.locator(current.overlay).waitFor({ state: 'hidden', timeout: 15_000 });
 		}
 
 		// ③ 閉じ切ったホーム — 子供が活動の記録に進める状態

--- a/scripts/capture-specs/flows/child-celebration-click-intercept-4433.mjs
+++ b/scripts/capture-specs/flows/child-celebration-click-intercept-4433.mjs
@@ -1,0 +1,127 @@
+/**
+ * scripts/capture-specs/flows/child-celebration-click-intercept-4433.mjs (#4433)
+ *
+ * 「祝福ダイアログとログインボーナスが重なって click が届かない」の Before / After を
+ * 子供向け 4 年齢モードで撮る。`AUTH_MODE=local` (`npm run dev`) で動作。
+ * baby は `showSiblingFeatures=false` で祝福自体が出ない年齢帯のため対象外 (ADR-0011)。
+ *
+ * ## 事前条件 (撮影者が用意する)
+ *
+ * dev DB (`data/ganbari-quest.db`):
+ *
+ *   children: id 1=preschool / 3=elementary / 4=junior / 5=senior
+ *   child_challenges: completed=1 / reward_claimed=0 / celebration_shown_at=NULL /
+ *                     start_date <= 今日 <= end_date / source_template_id='ss-4433'
+ *   login_streaks:   last_login_date を前日に戻す (= ログインボーナスが必ず発火する)
+ *   settings:        `pin_gate_onboarding_seen` = 'true' (初回訪問 dialog を出さない)
+ *
+ * ## このフローが撮るもの
+ *
+ * 1. `*-landing` — ホーム着地直後
+ *    - 修正前 (develop): 祝福とログインボーナスが**同時に開く**。祝福が手前に見えるのに
+ *      pointer-events を失っていて閉じるボタンが押せない (本 Issue の症状)
+ *    - 修正後: 開いているのは 1 枚だけ
+ * 2. `*-celebration` — 祝福が操作可能な状態で見えているところ
+ * 3. `*-closed` — 自動演出をすべて閉じ切ってホームに戻ったところ (子供が記録に進める)
+ *
+ * 固定待ちは使わず、overlay の visible / detached を待って進む。
+ *
+ * 使用例:
+ *   MSYS_NO_PATHCONV=1 BASE_URL=http://localhost:5293 node scripts/capture.mjs --pr <N> \
+ *     --flow child-celebration-click-intercept-4433 \
+ *     --url /switch \
+ *     --actions scripts/capture-specs/flows/child-celebration-click-intercept-4433.mjs \
+ *     --presets mobile
+ */
+
+const CHILDREN = [
+	{ childId: 1, uiMode: 'preschool' },
+	{ childId: 3, uiMode: 'elementary' },
+	{ childId: 4, uiMode: 'junior' },
+	{ childId: 5, uiMode: 'senior' },
+];
+
+/** 子供ホームで自動的に開く全画面の演出と、その閉じるボタン。 */
+const AUTO_OVERLAYS = [
+	{ overlay: '[data-testid="stamp-press-overlay"]', close: '[data-testid="login-bonus-confirm"]' },
+	{ overlay: '[data-testid="cheer-overlay"]', close: '[data-testid="cheer-overlay-close"]' },
+	{
+		overlay: '[data-testid="sibling-celebration"]',
+		close: '[data-testid="sibling-celebration-close"]',
+	},
+];
+const CELEBRATION = '[data-testid="sibling-celebration"]';
+
+/** 修正前 (develop) を撮るときは `CAPTURE_LABEL_PREFIX=before` を渡す。既定は after。 */
+const PREFIX = process.env.CAPTURE_LABEL_PREFIX || 'after';
+/** 同 flow を preset 違いで流すときに step 名の衝突を避ける (#4410 flow と同方針)。 */
+const SUFFIX = process.env.CAPTURE_LABEL_SUFFIX ? `-${process.env.CAPTURE_LABEL_SUFFIX}` : '';
+
+/** @param {import('playwright').Page} page */
+async function selectChild(page, childId, uiMode) {
+	// FlowRecorder の context は baseURL を持たないため絶対 URL で遷移する
+	await page.goto(new URL('/switch', page.url()).href, { waitUntil: 'domcontentloaded' });
+	await page.locator(`[data-testid="child-select-${childId}"]`).click();
+	await page.locator(`[data-testid="${uiMode}-home-page"]`).waitFor({ state: 'visible' });
+}
+
+/** いま見えている自動演出のうち先頭 1 件を返す (無ければ null)。 */
+async function firstVisibleOverlay(page) {
+	for (const o of AUTO_OVERLAYS) {
+		if (
+			await page
+				.locator(o.overlay)
+				.isVisible()
+				.catch(() => false)
+		) {
+			return o;
+		}
+	}
+	return null;
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// デモ Cookie が残っていると isDemo=true になり child 一覧が空になる
+	await page.context().clearCookies();
+	// 本 PR の対象ではない使い方ガイドのバナーを画面から外す (localStorage 由来)
+	await page.addInitScript(() => {
+		try {
+			for (const id of [1, 2, 3, 4, 5])
+				localStorage.setItem(`child_tutorial_hint_shown_${id}`, '1');
+		} catch {
+			/* localStorage 不可の環境では何もしない */
+		}
+	});
+
+	for (const { childId, uiMode } of CHILDREN) {
+		await selectChild(page, childId, uiMode);
+
+		// ① 着地直後 — 修正前は祝福 + ログインボーナスが重なる / 修正後は 1 枚
+		await page
+			.locator(AUTO_OVERLAYS.map((o) => o.overlay).join(', '))
+			.first()
+			.waitFor({ state: 'visible', timeout: 20_000 });
+		await capture(`${PREFIX}-${uiMode}-landing${SUFFIX}`);
+
+		// ② 祝福が操作可能な状態になるまで、先に出ている演出を閉じていく
+		let celebrationCaptured = false;
+		for (let i = 0; i < AUTO_OVERLAYS.length + 1; i++) {
+			const current = await firstVisibleOverlay(page);
+			if (!current) break;
+
+			if (current.overlay === CELEBRATION && !celebrationCaptured) {
+				await capture(`${PREFIX}-${uiMode}-celebration${SUFFIX}`);
+				celebrationCaptured = true;
+			}
+			await page.locator(current.close).click();
+			await page.locator(current.overlay).waitFor({ state: 'detached', timeout: 15_000 });
+		}
+
+		// ③ 閉じ切ったホーム — 子供が活動の記録に進める状態
+		await capture(`${PREFIX}-${uiMode}-closed${SUFFIX}`);
+	}
+};

--- a/src/lib/features/child-home/components/OverlaysSection.svelte
+++ b/src/lib/features/child-home/components/OverlaysSection.svelte
@@ -3,7 +3,7 @@ import { resolve } from '$app/paths';
 import type { CategoryId } from '$lib/domain/ids';
 import { normalizeUiMode } from '$lib/domain/validation/age-tier-types';
 import BirthdayModal from '$lib/features/birthday/BirthdayModal.svelte';
-import type { DialogFSM } from '$lib/features/child-home/dialog-state-machine';
+import type { DialogType } from '$lib/features/child-home/dialog-state-machine';
 import {
 	resolveUiModeChangeMessage,
 	type UiModeChangeNotice,
@@ -61,7 +61,13 @@ interface LevelUpData {
 }
 
 interface Props {
-	fsm: DialogFSM;
+	/**
+	 * #4433: 「いま開いてよい 1 枚」。`DialogFSM` は素の class instance で `$state` proxy が
+	 * 効かず、`fsm.current` の変化は component 境界を越えて伝播しない (#4313 で実測)。
+	 * FSM instance を渡して各所で `fsm.current` を読むのをやめ、**親が持つ `$state` の
+	 * mirror を prop で受ける**。arbitration (同時に 1 枚) は引き続き FSM が担う。
+	 */
+	current: DialogType;
 	levelUpData: LevelUpData | null;
 	onLevelUpClose: () => void;
 	latestReward: LatestReward | null;
@@ -72,12 +78,7 @@ interface Props {
 	onBirthdayClose: () => void;
 	/** #4313: 誕生日で年齢帯 UI が切り替わったことの未読告知 (次回ログインで 1 回だけ) */
 	uiModeChangeNotice: UiModeChangeNotice | null;
-	/**
-	 * #4313: 表示状態。`DialogFSM` は素の class instance で `$state` proxy が効かず、
-	 * `fsm.current` の変化は component 境界を越えて伝播しない (実測: 本 component の
-	 * `$effect` は `current: 'idle'` のまま再実行されない)。arbitration (同時に 1 枚) は
-	 * 引き続き FSM が担い、**開閉の描画は親が持つ `$state` を prop で受ける**。
-	 */
+	/** #4313: 既読化済みなら再表示しない (`current` が uiModeChange でも出さない)。 */
 	uiModeChangeOpen: boolean;
 	onUiModeChangeClose: () => void;
 	nickname: string;
@@ -85,7 +86,7 @@ interface Props {
 }
 
 let {
-	fsm,
+	current,
 	levelUpData,
 	onLevelUpClose,
 	latestReward,
@@ -101,11 +102,11 @@ let {
 	uiMode,
 }: Props = $props();
 
-// Derive open states from FSM current dialog
-let levelUpOpen = $derived(fsm.current === 'levelUp');
-let rewardOpen = $derived(fsm.current === 'specialReward');
-let stampPressOpen = $derived(fsm.current === 'stampPress');
-let birthdayModalOpen = $derived(fsm.current === 'birthday');
+// Derive open states from the FSM's current dialog (mirrored into `current` by the parent)
+let levelUpOpen = $derived(current === 'levelUp');
+let rewardOpen = $derived(current === 'specialReward');
+let stampPressOpen = $derived(current === 'stampPress');
+let birthdayModalOpen = $derived(current === 'birthday');
 // #4313: 年齢帯 UI 切替の告知。FSM が「同時に 1 枚」を保証するため、誕生日モーダル等と
 // 重ならない (ADR-0012)。文言は切替**後**の uiMode を基準に labels.ts SSOT から解決する。
 let uiModeChangeMsg = $derived(

--- a/src/lib/ui/components/SiblingCheerOverlay.svelte
+++ b/src/lib/ui/components/SiblingCheerOverlay.svelte
@@ -71,7 +71,7 @@ function handleDialogChange(details: { open: boolean }) {
 			}}
 		>
 			<input type="hidden" name="cheerIds" value={cheerIds} />
-			<button type="submit" class="cheer-overlay__btn">{UI_COMPONENTS_LABELS.siblingCheerConfirmBtn}</button>
+			<button type="submit" class="cheer-overlay__btn" data-testid="cheer-overlay-close">{UI_COMPONENTS_LABELS.siblingCheerConfirmBtn}</button>
 		</form>
 	</Dialog>
 {/if}

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -597,8 +597,11 @@ $effect(() => {
 
 	// FSM が uiModeChange を current にできたときだけ描画する (他ダイアログが出る回は queue
 	// に入るだけで表示しない = 2 枚連続演出を作らない、ADR-0012)。既読化済みなら再表示しない。
+	// `currentDialog` ではなく `fsm.current` を読む: 本 $effect は `syncDialog()` で
+	// `currentDialog` を **書く** ため、ここで読むと自己依存になって再実行が連鎖しうる。
+	// FSM 側は非リアクティブなので読んでも依存に入らない。
 	if (!uiModeChangeDismissed) {
-		uiModeChangeOpen = currentDialog === 'uiModeChange';
+		uiModeChangeOpen = fsm.current === 'uiModeChange';
 	}
 
 	// If adventure is not showing and login bonus unclaimed, trigger it

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -1,4 +1,7 @@
 <script lang="ts">
+// cspell:ignore dismissable
+// ↑ `@zag-js/dismissable` は実在の package 名。英語としては dismissible が正しいが、
+//   参照している実装の名前なので綴りは変えない (global words には足さない = file scope)。
 import { tick } from 'svelte';
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';

--- a/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/home/+page.svelte
@@ -23,7 +23,7 @@ import BabyHomePage from '$lib/features/child-home/BabyHomePage.svelte';
 import OverlaysSection from '$lib/features/child-home/components/OverlaysSection.svelte';
 // Issue #2084 (ADR-0046 follow-up): 本番 child home の共通 UI を派生コンポーネントに集約
 import ProdDashboardSections from '$lib/features/child-home/components/ProdDashboardSections.svelte';
-import { DialogFSM } from '$lib/features/child-home/dialog-state-machine';
+import { DialogFSM, type DialogType } from '$lib/features/child-home/dialog-state-machine';
 import { shouldShowHabitCertificateNotice } from '$lib/features/child-home/habit-certificate-notice';
 import { shouldShowUiModeChangeNotice } from '$lib/features/child-home/ui-mode-change-notice';
 import { getModeVariant } from '$lib/features/child-home/variants';
@@ -70,7 +70,31 @@ const variant = $derived(getModeVariant((data.uiMode ?? 'preschool') as UiMode))
 const f = $derived(variant.features);
 
 // --- Dialog FSM: single source of truth for overlay state (#671) ---
-let fsm = $state(new DialogFSM());
+const fsm = new DialogFSM();
+
+/**
+ * #4433: FSM の `current` を描画用に mirror した `$state`。
+ *
+ * `DialogFSM` は素の class instance なので Svelte 5 の `$state` proxy が掛からず、
+ * `fsm.current` への代入は再描画を起こさない。従来は「他の `$state` が偶然更新される
+ * ついでに `{#if fsm.current === ...}` が再評価される」ことに依存しており、
+ * FSM を閉じただけのときは次の 1 枚が出なかった (#4313 は個別 flag で回避していた)。
+ *
+ * FSM を触ったら必ず `syncDialog()` を通し、**描画は本 `$state` だけを見る**。
+ */
+let currentDialog = $state<DialogType>('idle');
+function syncDialog() {
+	currentDialog = fsm.current;
+}
+/** FSM を進める操作は必ずこの 2 つを経由する (`fsm` を直接触ると描画が同期しない)。 */
+function openDialog(type: DialogType, payload?: unknown) {
+	fsm.transition(type, payload);
+	syncDialog();
+}
+function closeDialog() {
+	fsm.close();
+	syncDialog();
+}
 
 // First record special celebration (must be before celebEffect)
 let isFirstRecord = $state(false);
@@ -403,7 +427,7 @@ function handleResultClose() {
 
 	// レベルアップがあれば FSM 経由で表示
 	if (levelUpData) {
-		fsm.transition('levelUp', levelUpData);
+		openDialog('levelUp', levelUpData);
 	} else {
 		isFirstRecord = false;
 		resultData = null;
@@ -413,7 +437,7 @@ function handleResultClose() {
 }
 
 function handleLevelUpClose() {
-	fsm.close();
+	closeDialog();
 	levelUpData = null;
 	isFirstRecord = false;
 	resultData = null;
@@ -422,7 +446,7 @@ function handleLevelUpClose() {
 }
 
 function handleStampPressClose() {
-	fsm.close();
+	closeDialog();
 	invalidateAll();
 }
 
@@ -450,7 +474,7 @@ async function handleMessageClose() {
 	if (data.latestMessage) {
 		await postShown(`/api/v1/messages/${data.latestMessage.id}/shown`);
 	}
-	fsm.close();
+	closeDialog();
 	invalidateAll();
 }
 
@@ -458,11 +482,11 @@ async function handleRewardClose() {
 	if (data.latestReward) {
 		await postShown(`/api/v1/special-rewards/${data.latestReward.id}/shown`);
 	}
-	fsm.close();
+	closeDialog();
 }
 
 function handleAdventureClose() {
-	fsm.close();
+	closeDialog();
 	triggerLoginBonus();
 }
 
@@ -482,7 +506,7 @@ function triggerLoginBonus() {
 }
 
 function handleBirthdayOpen() {
-	fsm.transition('birthday', data.birthdayBonus);
+	openDialog('birthday', data.birthdayBonus);
 }
 
 // #4313: 年齢帯 UI 切替の告知を閉じる。閉じた時点で server 側の pending notice を既読化し、
@@ -496,7 +520,7 @@ let uiModeChangeOpen = $state(false);
 let uiModeChangeDismissed = $state(false);
 async function handleUiModeChangeClose() {
 	uiModeChangeOpen = false;
-	fsm.close();
+	closeDialog();
 	if (uiModeChangeDismissed) return;
 	uiModeChangeDismissed = true;
 	try {
@@ -544,22 +568,41 @@ $effect(() => {
 		isScreenshotMode,
 	});
 
+	// #4433: 達成祝福も FSM の arbitration に載せる。従来は FSM の外で
+	// `{#if celebrationChallenge}` だけを見て描画していたため、ログインボーナス
+	// (`stampPress`) と**同時に開く**ことがあった。Ark UI (zag-js) の dismissable-layer は
+	// 「最後に開いた layer」以外を `pointer-events: none` にするので、後から開いた
+	// ログインボーナスに祝福の click が吸われ、子供が祝福を閉じられなくなっていた
+	// (z-index では解決しない。docs/DESIGN.md §10「侵襲的演出を重ねない」)。
+	const shouldShowCelebration = f.showSiblingFeatures && celebrationChallenge;
+	// 兄弟の応援 overlay も同じ class の defect (FSM 外で開くため祝福と重なりうる) なので
+	// 同時に arbitration へ載せる (ADR-0061: 同 class は 1 件目で guard 化する)。
+	const shouldShowCheer =
+		!isScreenshotMode &&
+		f.showSiblingFeatures &&
+		showCheerOverlay &&
+		data.unshownCheers &&
+		data.unshownCheers.length > 0;
+
 	fsm.onDataLoad({
 		adventure: shouldShowAdventure ? { childName: data.child?.nickname ?? '' } : undefined,
 		specialReward: shouldShowReward ? data.latestReward : undefined,
 		parentMessage: shouldShowMessage ? data.latestMessage : undefined,
 		uiModeChange: shouldShowUiModeChange ? data.uiModeChangeNotice : undefined,
+		siblingCheer: shouldShowCheer ? data.unshownCheers : undefined,
+		celebration: shouldShowCelebration ? celebrationChallenge : undefined,
 		// birthday は自動トリガーから除外 — バナークリック(handleBirthdayOpen)でのみ開く
 	});
+	syncDialog();
 
 	// FSM が uiModeChange を current にできたときだけ描画する (他ダイアログが出る回は queue
 	// に入るだけで表示しない = 2 枚連続演出を作らない、ADR-0012)。既読化済みなら再表示しない。
 	if (!uiModeChangeDismissed) {
-		uiModeChangeOpen = fsm.current === 'uiModeChange';
+		uiModeChangeOpen = currentDialog === 'uiModeChange';
 	}
 
 	// If adventure is not showing and login bonus unclaimed, trigger it
-	// Note: use shouldShowAdventure (not fsm.current) to avoid circular $effect dependency
+	// Note: use shouldShowAdventure (not currentDialog) to avoid circular $effect dependency
 	if (
 		!shouldShowAdventure &&
 		data.loginBonusStatus &&
@@ -681,7 +724,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 	{/if}
 
 	<!-- Login stamp auto-claim form (hidden) — unified bonus + stamp -->
-	{#if bonusClaiming && fsm.current !== 'stampPress'}
+	{#if bonusClaiming && currentDialog !== 'stampPress'}
 		<form
 			method="POST"
 			action="?/loginStamp"
@@ -705,7 +748,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 							cardEntries: cardData?.entries ?? [],
 							weeklyRedeem: d.weeklyRedeem as { points: number; filledSlots: number; totalSlots: number; completeBonus: number } | null,
 						};
-						fsm.transition('stampPress', stampPressData);
+						openDialog('stampPress', stampPressData);
 					}
 					bonusClaiming = false;
 				};
@@ -1049,7 +1092,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 </Dialog>
 
 <OverlaysSection
-	{fsm}
+	current={currentDialog}
 	{levelUpData}
 	onLevelUpClose={handleLevelUpClose}
 	latestReward={data.latestReward}
@@ -1057,7 +1100,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 	{stampPressData}
 	onStampPressClose={handleStampPressClose}
 	birthdayBonus={data.birthdayBonus}
-	onBirthdayClose={() => fsm.close()}
+	onBirthdayClose={() => closeDialog()}
 	uiModeChangeNotice={data.uiModeChangeNotice ?? null}
 	{uiModeChangeOpen}
 	onUiModeChangeClose={handleUiModeChangeClose}
@@ -1066,7 +1109,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 />
 
 <!-- Adventure start overlay (first-time users, non-baby) -->
-{#if f.showAdventureStart && data.isFirstTime && fsm.current === 'adventure'}
+{#if f.showAdventureStart && data.isFirstTime && currentDialog === 'adventure'}
 	<AdventureStartOverlay
 		open={true}
 		childName={data.child?.nickname ?? ''}
@@ -1076,7 +1119,7 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 
 <!-- Parent message overlay (non-baby) -->
 <!-- #2097 PR-B1 hotfix: isScreenshotMode で抑止 (FSM-gated だが安全側で抑止) -->
-{#if !isScreenshotMode && f.showParentMessages && data.latestMessage && fsm.current === 'parentMessage'}
+{#if !isScreenshotMode && f.showParentMessages && data.latestMessage && currentDialog === 'parentMessage'}
 	<ParentMessageOverlay
 		open={true}
 		messageType={data.latestMessage.messageType}
@@ -1087,8 +1130,13 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 	/>
 {/if}
 
-<!-- Sibling celebration (all siblings complete, non-baby) -->
-{#if f.showSiblingFeatures && !celebrationDismissed && celebrationChallenge}
+<!--
+	Sibling celebration (all siblings complete, non-baby)
+	#4433: FSM が current にした回だけ描画する。ログインボーナス等と同時に開くと、
+	後から開いた側に click を吸われて子供が祝福を閉じられなくなる (DESIGN.md §10)。
+	他の演出が出ている回は queue に入り、それを閉じた時点で本祝福が出る。
+-->
+{#if f.showSiblingFeatures && !celebrationDismissed && celebrationChallenge && currentDialog === 'celebration'}
 	<SiblingCelebration
 		challengeId={celebrationChallenge.id}
 		challengeTitle={celebrationChallenge.title}
@@ -1097,16 +1145,16 @@ function handleRecordResult(result: { type: string; data?: Record<string, unknow
 			name: data.allChildren?.find((c: { id: ChildId }) => c.id === s.childId)?.nickname ?? `#${s.childId}`,
 			completed: s.completed === 1,
 		}))}
-		onDismiss={() => { celebrationDismissed = true; }}
+		onDismiss={() => { celebrationDismissed = true; closeDialog(); }}
 	/>
 {/if}
 
 <!-- Sibling cheer overlay (non-baby) -->
 <!-- #2097 PR-B1 hotfix: isScreenshotMode で抑止 (LP SS の overlay 被り対策) -->
-{#if !isScreenshotMode && f.showSiblingFeatures && showCheerOverlay && data.unshownCheers && data.unshownCheers.length > 0}
+{#if !isScreenshotMode && f.showSiblingFeatures && showCheerOverlay && data.unshownCheers && data.unshownCheers.length > 0 && currentDialog === 'siblingCheer'}
 	<SiblingCheerOverlay
 		cheers={data.unshownCheers}
-		onDismiss={() => { showCheerOverlay = false; }}
+		onDismiss={() => { showCheerOverlay = false; closeDialog(); }}
 	/>
 {/if}
 

--- a/tests/e2e/child-celebration-click-intercept.spec.ts
+++ b/tests/e2e/child-celebration-click-intercept.spec.ts
@@ -1,3 +1,6 @@
+// cspell:ignore dismissable
+// ↑ `@zag-js/dismissable` は実在の package 名。英語としては dismissible が正しいが、
+//   参照している実装の名前なので綴りは変えない (global words には足さない = file scope)。
 // tests/e2e/child-celebration-click-intercept.spec.ts
 //
 // #4433: ログインボーナス overlay が祝福ダイアログの click を intercept する回帰テスト。

--- a/tests/e2e/child-celebration-click-intercept.spec.ts
+++ b/tests/e2e/child-celebration-click-intercept.spec.ts
@@ -136,41 +136,49 @@ test.describe('#4433 祝福とログインボーナスが重なっても子供�
 		await selectElementaryChild(page);
 
 		const celebration = page.getByTestId('sibling-celebration');
-		// 祝福は seed (celebration_shown_at IS NULL) で必ず pending。出るまで待つ
-		// (他の演出が先に出る実装なら、下の loop でそれを閉じた後に出る)。
+		const loginBonus = page.getByTestId('stamp-press-overlay');
+
+		// ① 何かが出るまで待つ (どれが先に出るかは実装の判断に委ねる)
 		await expect
 			.poll(async () => (await visibleAutoOverlays(page)).length, { timeout: 30_000 })
 			.toBeGreaterThan(0);
 
-		// 見えている overlay を上から閉じていく。**見えているなら押せる**ことが本 spec の核心で、
-		// 現行実装は祝福が見えたまま click を intercept されるためここで落ちる (#4433 の defect)。
-		for (let i = 0; i < AUTO_OVERLAYS.length + 1; i++) {
-			if (await celebration.isHidden().catch(() => true)) {
-				// まだ祝福が出ていない (queue 待ち) 場合、他の overlay を閉じて次を出させる
-				const pending = AUTO_OVERLAYS.filter((o) => o.overlay !== 'sibling-celebration');
-				let closedAny = false;
-				for (const o of pending) {
-					if (
-						await page
-							.getByTestId(o.overlay)
-							.isVisible()
-							.catch(() => false)
-					) {
-						await page.getByTestId(o.close).click({ timeout: 5_000 });
-						await expect(page.getByTestId(o.overlay)).toBeHidden();
-						closedAny = true;
-						break;
-					}
+		// ② 祝福が出るまで、先に出ている演出を閉じて queue を進める
+		for (let i = 0; i < AUTO_OVERLAYS.length; i++) {
+			if (await celebration.isVisible().catch(() => false)) break;
+			const other = AUTO_OVERLAYS.filter((o) => o.overlay !== 'sibling-celebration');
+			let closedAny = false;
+			for (const o of other) {
+				if (
+					await page
+						.getByTestId(o.overlay)
+						.isVisible()
+						.catch(() => false)
+				) {
+					await page.getByTestId(o.close).click({ timeout: 5_000 });
+					await expect(page.getByTestId(o.overlay)).toBeHidden();
+					closedAny = true;
+					break;
 				}
-				if (!closedAny) break;
-				continue;
 			}
-			// 祝福が見えている → 押せなければならない
-			await page.getByTestId('sibling-celebration-close').click({ timeout: 5_000 });
-			break;
+			if (!closedAny) break;
 		}
 
+		// ③ 祝福は seed (celebration_shown_at IS NULL) で必ず pending なので、**必ず出る**。
+		//    ここを hard assertion にしておかないと「祝福が一度も出ない」実装でも素通りする。
+		await expect(celebration).toBeVisible();
+
+		// ④ 見えているなら押せる。現行実装は祝福が見えたまま click を intercept されて落ちる
+		//    (= #4433 の defect。z-index ではなく zag-js の layer 順で pointer-events を失う)。
+		await page.getByTestId('sibling-celebration-close').click({ timeout: 5_000 });
 		await expect(celebration).toBeHidden();
+
+		// ⑤ 祝福の裏で待たされていたログインボーナスが、閉じたあとに出て来て**閉じられる**。
+		//    seed で未受領を保証しているので必ず pending。ここが出なければ
+		//    「queue に積んだきり次を出さない」= 子供がボーナスを受け取れない別 dead-end になる。
+		await expect(loginBonus).toBeVisible();
+		await page.getByTestId('login-bonus-confirm').click({ timeout: 5_000 });
+		await expect(loginBonus).toBeHidden();
 	});
 
 	test('DESIGN.md §10: 侵襲的演出を 2 枚同時に開かない', async ({ page, workerDbPath }) => {
@@ -190,9 +198,15 @@ test.describe('#4433 祝福とログインボーナスが重なっても子供�
 			if (!current) break;
 			await page.getByTestId(current.close).click({ timeout: 5_000 });
 			await expect(page.getByTestId(current.overlay)).toBeHidden();
-			// 次の 1 枚が出るのを待つ (無ければ 0 枚で終わる)
-			await page.waitForTimeout(500);
-			if ((await visibleAutoOverlays(page)).length === 0) break;
+
+			// 次の 1 枚が出るのを待つ。出なければ (= queue が空) そこで終わり。
+			// 固定待ちは使わない (tests/CLAUDE.md: waitForTimeout 禁止)。
+			const hasNext = await expect
+				.poll(async () => (await visibleAutoOverlays(page)).length, { timeout: 5_000 })
+				.toBeGreaterThan(0)
+				.then(() => true)
+				.catch(() => false);
+			if (!hasNext) break;
 		}
 	});
 });

--- a/tests/e2e/child-celebration-click-intercept.spec.ts
+++ b/tests/e2e/child-celebration-click-intercept.spec.ts
@@ -1,0 +1,198 @@
+// tests/e2e/child-celebration-click-intercept.spec.ts
+//
+// #4433: ログインボーナス overlay が祝福ダイアログの click を intercept する回帰テスト。
+//
+// 症状: 子供のホームに「達成祝福 (SiblingCelebration)」と「ログインボーナス (StampPressOverlay)」が
+//   同時に立ち上がる。祝福は `--z-celebration` (200)、ログインボーナスは `--z-modal` (50) なので
+//   **祝福が手前に見えている**が、Ark UI (zag-js) の dismissable-layer は「最後に開いた layer」だけを
+//   操作可能にするため、下の layer になった祝福は pointer-events を失う。
+//   → 子供には押せるように見えて押せない。祝福を閉じられなければ、その先の活動記録にも進めない。
+//
+// 本 spec が固定する不変条件:
+//   ① 見えている dialog は必ず押せる (見えているのに click が intercept される状態を作らない)
+//   ② docs/DESIGN.md §10「侵襲的演出を重ねない」— 着地時に開いている全画面 dialog は 1 枚だけ
+//
+// seed 方針は child-challenge-celebration-once.spec.ts (#4410) と同型。あわせて
+// login_streaks を「昨日まで」に巻き戻し、ログインボーナスが必ず発火する状態を作る
+// (これをやらないと overlap 自体が起きず、テストが素通りする)。
+
+import { expect, test } from './fixtures';
+import { selectElementaryChild } from './helpers';
+
+const ELEMENTARY_NICKNAME = 'けんたくん';
+const SEED_SOURCE = 'e2e-4433-click-intercept';
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+/** 任意日数 offset の JST 日付を YYYY-MM-DD で返す (server の todayDateJST と同 offset)。 */
+function jstDate(offsetDays: number): string {
+	const ms = Date.now() + JST_OFFSET_MS + offsetDays * 24 * 60 * 60 * 1000;
+	return new Date(ms).toISOString().slice(0, 10);
+}
+
+/**
+ * 「祝福が未表示」かつ「ログインボーナス未受領」の状態を作る。
+ * 両方が同時に立ち上がる条件を DB 側で確定させ、overlap が偶然に左右されないようにする。
+ */
+async function seedBothPending(workerDbPath: string): Promise<{ challengeId: number }> {
+	const { default: Database } = await import('better-sqlite3');
+	const db = new Database(workerDbPath);
+	try {
+		const child = db
+			.prepare('SELECT id FROM children WHERE nickname = ? LIMIT 1')
+			.get(ELEMENTARY_NICKNAME) as { id: number } | undefined;
+		if (!child) throw new Error(`${ELEMENTARY_NICKNAME} not found in worker DB`);
+
+		// ログインボーナスを「今日はまだ受け取っていない」状態に戻す (#3330 counter 縮約後の table)。
+		db.prepare('UPDATE login_streaks SET last_login_date = ? WHERE child_id = ?').run(
+			jstDate(-1),
+			child.id,
+		);
+
+		const info = db
+			.prepare(
+				`INSERT INTO child_challenges (
+					child_id, title, description, challenge_type, period_type,
+					start_date, end_date, target_config, reward_config,
+					status, is_active, source_template_id,
+					current_value, target_value, completed, completed_at,
+					reward_claimed, reward_claimed_at, celebration_shown_at
+				) VALUES (?, ?, ?, 'cooperative', 'weekly', ?, ?, ?, ?, 'completed', 1, ?, ?, ?, 1, ?, 0, NULL, NULL)`,
+			)
+			.run(
+				child.id,
+				'E2E祝福重なりチャレンジ',
+				'#4433 click intercept',
+				jstDate(-3),
+				jstDate(10),
+				JSON.stringify({ metric: 'count', categoryId: 1, baseTarget: 5 }),
+				JSON.stringify({ points: 30, message: 'よくがんばったね' }),
+				SEED_SOURCE,
+				5,
+				5,
+				jstDate(0),
+			);
+		return { challengeId: Number(info.lastInsertRowid) };
+	} finally {
+		db.close();
+	}
+}
+
+async function cleanupSeededChallenges(workerDbPath: string): Promise<void> {
+	const { default: Database } = await import('better-sqlite3');
+	const db = new Database(workerDbPath);
+	try {
+		const rows = db
+			.prepare('SELECT id FROM child_challenges WHERE source_template_id = ?')
+			.all(SEED_SOURCE) as Array<{ id: number }>;
+		for (const { id } of rows) {
+			db.prepare(
+				"DELETE FROM point_ledger WHERE reference_id = ? AND type = 'child_challenge'",
+			).run(id);
+		}
+		db.prepare('DELETE FROM child_challenges WHERE source_template_id = ?').run(SEED_SOURCE);
+	} finally {
+		db.close();
+	}
+}
+
+/**
+ * 子供ホームで自動的に開く「全画面の侵襲的演出」と、その閉じるボタン。
+ * 出す順序は実装の判断に委ねるが、**同時に 2 枚開いてはいけない** (DESIGN.md §10)。
+ */
+const AUTO_OVERLAYS = [
+	{ name: 'ログインボーナス', overlay: 'stamp-press-overlay', close: 'login-bonus-confirm' },
+	{ name: '兄弟の応援', overlay: 'cheer-overlay', close: 'cheer-overlay-close' },
+	{ name: '達成祝福', overlay: 'sibling-celebration', close: 'sibling-celebration-close' },
+] as const;
+
+/** いま見えている自動 overlay の名前一覧 (同時に開いている枚数の判定に使う)。 */
+async function visibleAutoOverlays(page: import('@playwright/test').Page): Promise<string[]> {
+	const names: string[] = [];
+	for (const o of AUTO_OVERLAYS) {
+		if (
+			await page
+				.getByTestId(o.overlay)
+				.isVisible()
+				.catch(() => false)
+		)
+			names.push(o.name);
+	}
+	return names;
+}
+
+test.describe('#4433 祝福とログインボーナスが重なっても子供は祝福を閉じられる', () => {
+	// dev server の on-demand compile で初回遷移が長引くため (#4410 spec と同方針)。
+	test.slow();
+
+	test.afterEach(async ({ workerDbPath }) => {
+		await cleanupSeededChallenges(workerDbPath);
+	});
+
+	test('子供は必ず祝福を閉じられる (見えている overlay の click が intercept されない)', async ({
+		page,
+		workerDbPath,
+	}) => {
+		await seedBothPending(workerDbPath);
+		await selectElementaryChild(page);
+
+		const celebration = page.getByTestId('sibling-celebration');
+		// 祝福は seed (celebration_shown_at IS NULL) で必ず pending。出るまで待つ
+		// (他の演出が先に出る実装なら、下の loop でそれを閉じた後に出る)。
+		await expect
+			.poll(async () => (await visibleAutoOverlays(page)).length, { timeout: 30_000 })
+			.toBeGreaterThan(0);
+
+		// 見えている overlay を上から閉じていく。**見えているなら押せる**ことが本 spec の核心で、
+		// 現行実装は祝福が見えたまま click を intercept されるためここで落ちる (#4433 の defect)。
+		for (let i = 0; i < AUTO_OVERLAYS.length + 1; i++) {
+			if (await celebration.isHidden().catch(() => true)) {
+				// まだ祝福が出ていない (queue 待ち) 場合、他の overlay を閉じて次を出させる
+				const pending = AUTO_OVERLAYS.filter((o) => o.overlay !== 'sibling-celebration');
+				let closedAny = false;
+				for (const o of pending) {
+					if (
+						await page
+							.getByTestId(o.overlay)
+							.isVisible()
+							.catch(() => false)
+					) {
+						await page.getByTestId(o.close).click({ timeout: 5_000 });
+						await expect(page.getByTestId(o.overlay)).toBeHidden();
+						closedAny = true;
+						break;
+					}
+				}
+				if (!closedAny) break;
+				continue;
+			}
+			// 祝福が見えている → 押せなければならない
+			await page.getByTestId('sibling-celebration-close').click({ timeout: 5_000 });
+			break;
+		}
+
+		await expect(celebration).toBeHidden();
+	});
+
+	test('DESIGN.md §10: 侵襲的演出を 2 枚同時に開かない', async ({ page, workerDbPath }) => {
+		await seedBothPending(workerDbPath);
+		await selectElementaryChild(page);
+
+		await expect
+			.poll(async () => (await visibleAutoOverlays(page)).length, { timeout: 30_000 })
+			.toBeGreaterThan(0);
+
+		// 着地直後、および各 overlay を閉じた直後のいずれでも同時 2 枚にならない。
+		for (let i = 0; i < AUTO_OVERLAYS.length; i++) {
+			const open = await visibleAutoOverlays(page);
+			expect(open, `同時に開いている演出: ${open.join(' + ')}`).toHaveLength(1);
+
+			const current = AUTO_OVERLAYS.find((o) => o.name === open[0]);
+			if (!current) break;
+			await page.getByTestId(current.close).click({ timeout: 5_000 });
+			await expect(page.getByTestId(current.overlay)).toBeHidden();
+			// 次の 1 枚が出るのを待つ (無ければ 0 枚で終わる)
+			await page.waitForTimeout(500);
+			if ((await visibleAutoOverlays(page)).length === 0) break;
+		}
+	});
+});

--- a/tests/e2e/child-celebration-click-intercept.spec.ts
+++ b/tests/e2e/child-celebration-click-intercept.spec.ts
@@ -48,6 +48,18 @@ async function seedBothPending(workerDbPath: string): Promise<{ challengeId: num
 			child.id,
 		);
 
+		// 未表示の「兄弟の応援」も 1 件積む。**祝福より先に出る演出を必ず 1 つ作る**ことで、
+		// 「祝福が queue で待っている間は描画しない」ところまで検証範囲に入れる
+		// (これが無いと祝福が常に先頭になり、描画 gate を外しても overlap が起きず素通りする)。
+		const sender = db.prepare('SELECT id FROM children WHERE id != ? LIMIT 1').get(child.id) as
+			| { id: number }
+			| undefined;
+		if (!sender) throw new Error('応援の送り主にする別の子供が worker DB に居ません');
+		db.prepare(
+			`INSERT INTO sibling_cheers (from_child_id, to_child_id, stamp_code, tenant_id, sent_at, shown_at)
+			 VALUES (?, ?, 'sugoi', 'e2e-4433', CURRENT_TIMESTAMP, NULL)`,
+		).run(sender.id, child.id);
+
 		const info = db
 			.prepare(
 				`INSERT INTO child_challenges (
@@ -81,6 +93,9 @@ async function cleanupSeededChallenges(workerDbPath: string): Promise<void> {
 	const { default: Database } = await import('better-sqlite3');
 	const db = new Database(workerDbPath);
 	try {
+		// worker DB は spec 間で共有されるため、seed した応援も必ず除去する
+		// (tests/CLAUDE.md「共有 worker DB を汚染しない」)。
+		db.prepare("DELETE FROM sibling_cheers WHERE tenant_id = 'e2e-4433'").run();
 		const rows = db
 			.prepare('SELECT id FROM child_challenges WHERE source_template_id = ?')
 			.all(SEED_SOURCE) as Array<{ id: number }>;

--- a/tests/e2e/child-challenge-celebration-once.spec.ts
+++ b/tests/e2e/child-challenge-celebration-once.spec.ts
@@ -106,22 +106,19 @@ async function cleanupSeededChallenges(workerDbPath: string): Promise<void> {
 }
 
 /**
- * ログインボーナス (おみくじ) overlay を閉じる。
+ * ログインボーナス (おみくじ) overlay が開いていれば閉じる。
  *
- * 本 overlay は Ark UI の nested dialog で positioner が `fixed inset-0` のため、開いている間は
- * 祝福ダイアログのボタンへの click を intercept する (DESIGN.md §10「reward と tutorial を同時
- * 表示しない」の実装上の帰結)。実ユーザーも「やったね！」を押してから祝福を閉じるので、
- * 同じ順序で操作する。
+ * #4433 以降、子供ホームの自動演出は `DialogFSM` が「同時に 1 枚」に調停するため、
+ * 祝福が出ている回のログインボーナスは queue で待つ (= ここでは開いていない)。
+ * 一方、祝福より先にログインボーナスが出る回もありうるので、開いていれば閉じる形にしておく。
+ * 本 spec の関心は「祝福が 1 回だけか」であり、どちらが先かではない。
  */
 async function dismissLoginBonusOverlay(page: import('@playwright/test').Page): Promise<void> {
-	// 本 overlay はログイン直後に非同期で自動 claim → 表示されるため、出現を待ってから閉じる
-	// (既に受領済みの日は出ないので、待ちは bounded にして未出現を許容する)。
 	const confirm = page.getByTestId('login-bonus-confirm');
-	await confirm.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
 	if (await confirm.isVisible().catch(() => false)) {
 		await confirm.click();
+		await expect(page.getByTestId('stamp-press-overlay')).toBeHidden();
 	}
-	await expect(page.getByTestId('stamp-press-overlay')).toBeHidden();
 }
 
 /**

--- a/tests/unit/features/dialog-state-machine.test.ts
+++ b/tests/unit/features/dialog-state-machine.test.ts
@@ -1,3 +1,6 @@
+// cspell:ignore dismissable
+// ↑ `@zag-js/dismissable` は実在の package 名。英語としては dismissible が正しいが、
+//   参照している実装の名前なので綴りは変えない (global words には足さない = file scope)。
 import { asActivityId } from '$lib/domain/ids';
 // tests/unit/features/dialog-state-machine.test.ts
 // Dialog State Machine unit tests — #671 combo bonus infinite loop fix

--- a/tests/unit/features/dialog-state-machine.test.ts
+++ b/tests/unit/features/dialog-state-machine.test.ts
@@ -466,4 +466,41 @@ describe('DialogFSM', () => {
 			expect(fsm.current).toBe('idle');
 		});
 	});
+
+	// #4433: 達成祝福 / 兄弟の応援を FSM の arbitration に載せる。
+	// Ark UI (zag-js) の dismissable-layer は「最後に開いた layer」以外を pointer-events: none に
+	// するため、同時に 2 枚開くと先に開いた側の click が吸われる (z-index では解決しない)。
+	describe('celebration / siblingCheer arbitration (#4433)', () => {
+		it('祝福表示中にログインボーナスが来ても同時には開かず queue に積まれる', () => {
+			fsm.onDataLoad({ celebration: { id: 'c1' } });
+			expect(fsm.current).toBe('celebration');
+
+			// ログインボーナスは load 後の非同期 claim 完了で transition される
+			fsm.transition('stampPress', { stampRarity: 'N' });
+
+			expect(fsm.current).toBe('celebration');
+			expect(fsm.queue).toEqual(['stampPress']);
+		});
+
+		it('祝福を閉じると queue のログインボーナスが次に出る (どちらも閉じられる)', () => {
+			fsm.onDataLoad({ celebration: { id: 'c1' } });
+			fsm.transition('stampPress', { stampRarity: 'N' });
+
+			fsm.close();
+
+			expect(fsm.current).toBe('stampPress');
+			expect(fsm.queue).toEqual([]);
+		});
+
+		it('兄弟の応援と祝福が同時に pending でも開くのは 1 枚だけ', () => {
+			fsm.onDataLoad({ siblingCheer: [{ id: 1 }], celebration: { id: 'c1' } });
+
+			// PRIORITY_ORDER 上 siblingCheer が先。祝福は queue で待つ
+			expect(fsm.current).toBe('siblingCheer');
+			expect(fsm.queue).toEqual(['celebration']);
+
+			fsm.close();
+			expect(fsm.current).toBe('celebration');
+		});
+	});
 });


### PR DESCRIPTION
## 顧客価値・目的

子供が「みんなクリア！」の祝福ダイアログを**閉じられるようになる**。これまでは祝福が手前に見えているのに閉じるボタンが押せず、閉じられないまま次の操作（活動の記録）に進めない状態が起こりえた。

## 関連 Issue

Closes #4433

## 変更内容

### 何が起きていたか — z-index の問題ではない

祝福 `SiblingCelebration` は `zLayer="celebration"`（`--z-celebration` = 200）、ログインボーナス `StampPressOverlay` は既定の `zLayer="modal"`（`--z-modal` = 50）。**祝福のほうが手前に描画されている**。それでも click が届かないのは、Ark UI（zag-js）の dismissable-layer が z-index ではなく **レイヤースタックへの登録順**で操作可能な層を決めているため:

```js
// node_modules/@zag-js/dismissable/dist/pointer-event-outside.mjs
function getDesiredPointerEvents(node) {
  return layerStack.isBelowPointerBlockingLayer(node) ? "none" : "auto";
}
```

祝福は初期描画で開き、ログインボーナスは自動 claim の POST 応答後に**あとから**開く。あとから開いた側が最上位レイヤーになり、祝福の content は `pointer-events: none` を付与される。Playwright の実 click でも同じことが観測できる（修正前の実行ログ）:

```
<div data-testid="stamp-press-overlay"> from <div data-part="positioner"
  class="fixed inset-0 z-[var(--z-modal)] ..."> subtree intercepts pointer events
```

**`--z-modal`(50) の positioner が `--z-celebration`(200) の祝福の click を奪っている。** z-index を上げても直らない（見た目は既に手前で、失われているのは pointer-events）。

### 採った案: 重ねない（`docs/DESIGN.md` §10 の禁忌に従う）

祝福を `DialogFSM` の arbitration に載せ、**同時に開くのは常に 1 枚**にした。`DialogFSM` には元から `'celebration'` が `DialogType` / `PRIORITY_ORDER` / `DialogTriggers` に定義されていたが、祝福だけが FSM の外で `{#if celebrationChallenge}` を条件に描画されていて未接続だった。

- `fsm.onDataLoad({ celebration, siblingCheer, ... })` に祝福と兄弟の応援を追加
- 描画条件を `currentDialog === 'celebration'` に変更。他の演出が出ている回は queue に入り、それを閉じた時点で出る
- **z-index / `--z-*` トークンは 1 行も変更していない**（生数値の直書きも追加していない）。`tests/unit/ui/z-index-tokens.test.ts` の値も不変

### 副次: `fsm.current` を描画に使えるようにした

`DialogFSM` は素の class instance で Svelte 5 の `$state` proxy が掛からないため、`fsm.current` への代入は再描画を起こさない。従来は「他の `$state` が偶然更新されるついでに `{#if fsm.current === ...}` が再評価される」ことに依存しており、FSM を閉じただけでは次の 1 枚が出なかった（#4313 は `uiModeChangeOpen` という個別 flag でこれを回避していた）。

`currentDialog` という `$state` の mirror を 1 つ置き、`openDialog()` / `closeDialog()` 経由でのみ FSM を進めるようにした。`OverlaysSection` も `fsm` instance ではなく `current: DialogType` を prop で受ける。これが無いと「祝福を閉じる → queue のログインボーナスが出る」が動かない（mutation M3 で実証）。

### 兄弟の応援 (`SiblingCheerOverlay`) も同時に対処

FSM の外で開いていて祝福と重なりうる、**まったく同じ class の defect**。1 件目で guard 化する方針（ADR-0061 same-class-N→guard）に従い同 PR で arbitration に載せた。回帰テストのため閉じるボタンに `data-testid="cheer-overlay-close"` を追加。

### 変更ファイル

| ファイル | 変更 |
|---|---|
| `src/routes/(child)/[uiMode=uiMode]/home/+page.svelte` | FSM mirror (`currentDialog` / `openDialog` / `closeDialog`)、祝福・応援を `onDataLoad` に追加、描画 gate |
| `src/lib/features/child-home/components/OverlaysSection.svelte` | `fsm` instance prop → `current: DialogType` prop |
| `src/lib/ui/components/SiblingCheerOverlay.svelte` | 閉じるボタンに testid 追加 |
| `tests/e2e/child-celebration-click-intercept.spec.ts` | 新規回帰 spec（2 test） |
| `tests/e2e/child-challenge-celebration-once.spec.ts` | intercept を前提にしていた helper のコメント / 手順を是正 |
| `tests/unit/features/dialog-state-machine.test.ts` | celebration / siblingCheer の arbitration 3 case 追加 |
| `docs/design/06-UI設計書.md` | §4.x DialogFSM に「自動演出は例外なく FSM を通す / 理由は pointer-events」、§4.15 に排他を明記 |
| `scripts/capture-specs/flows/child-celebration-click-intercept-4433.mjs` | Before/After SS 撮影フロー（4 年齢モード） |

## 検証

### failing-test-first（先に落ちることを実証した）

`tests/e2e/child-celebration-click-intercept.spec.ts` は「重なって見える」ではなく「**見えているのに click が届かない**」を assert する。実装を revert した状態で実行し、**2 test とも落ちること**を確認した:

```
✘ 子供は必ず祝福を閉じられる (見えている overlay の click が intercept されない)
  TimeoutError: locator.click: Timeout 5000ms exceeded
  <div data-testid="stamp-press-overlay"> ... subtree intercepts pointer events

✘ DESIGN.md §10: 侵襲的演出を 2 枚同時に開かない
  Error: 同時に開いている演出: ログインボーナス + 達成祝福
  Expected length: 1 / Received: 2 / Received array: ["ログインボーナス", "達成祝福"]
```

### 実行したコマンドと結果

| 検証 | コマンド | 結果 |
|---|---|---|
| E2E 回帰（修正前 = 再現） | `E2E_BASE_PORT=5250 npx playwright test tests/e2e/child-celebration-click-intercept.spec.ts --project=tablet` | **2 failed**（上記） |
| E2E 回帰（修正後） | 同上 | **2 passed** |
| 既存 #4410 回帰 | 上記 + `tests/e2e/child-challenge-celebration-once.spec.ts` | **3 passed** (38.7s) |
| FSM 単体 | `npx vitest run tests/unit/features/dialog-state-machine.test.ts` | **41 passed** |
| lint | `npx biome check src/ tests/` | 0 error |
| 型 | `npx svelte-check` | 0 errors / 0 warnings |
| Ready 化前 | `npm run pre-ready -- --pr 4437` | 下記（Ready 化直前に実行） |

> `--project=mobile` は `dependencies: ['tablet']` を持ち tablet 全 938 test を先に走らせてしまうため、本 spec の実行には `--project=tablet` を使っている。

### mutation 検証（3 箇所以上を壊して落ちることを確認）

いずれも **先に commit してから** `perl -pi` で壊し、`git stash push` で退避して戻した（`git checkout --` は使っていない）。

| # | 壊した箇所 | 期待 | 結果 |
|---|---|---|---|
| M1 | `fsm.onDataLoad` から `celebration:` trigger を削除 | 祝福が出なくなる | **killed** — `expect(celebration).toBeVisible()` が `element(s) not found` |
| M2 | 描画 gate `&& currentDialog === 'celebration'` を削除 | 祝福が queue 中も描画され重なる | **1 回目は survive → テストを強化して killed**（下記） |
| M3 | `closeDialog()` から `syncDialog()` を削除 | 祝福を閉じても次の 1 枚が出ない | **killed** — 手順⑤ `expect(loginBonus).toBeVisible()` が失敗 |
| M4 | `DialogFSM.transition` の `queue.push` を `current = type` に | 排他が壊れる | **killed** — unit 41 中 11 failed |

**M2 が最初 survive したことと、その対処**: 初版の seed は「祝福が常に queue の先頭」になる条件しか作っていなかったため、描画 gate を外しても FSM trigger 側だけで重なりが起きず素通りしていた。**祝福より先に出る演出（未表示の兄弟の応援）を seed に 1 件足して**、祝福が queue で待つ経路を通るようにしたところ M2 は killed になった（`同時に開いている演出: 兄弟の応援 + 達成祝福` で 2 test とも fail）。生存 mutation は残っていない。

### 年齢モード

`src/lib/features/child-home/variants/index.ts` の `showSiblingFeatures` は `baby` のみ `false`。さらに `+page.server.ts` の load が `uiMode === 'baby'` の分岐で `celebrationChallenge: null` / `unshownCheers: []` を返すため、**baby は client / server の 2 層で祝福が出ない**。

残り 4 モードは実機（`npm run dev`、専用 port 5293）で Before / After を撮影して確認した:

| モード | Before（着地時） | After（着地時） | 祝福を閉じられるか |
|---|---|---|---|
| preschool | 祝福が手前・backdrop 二重（押せない） | 1 枚のみ | ✓ |
| elementary | 同上 | 1 枚のみ | ✓ |
| junior | 同上 | 1 枚のみ | ✓ |
| senior | 同上 | 1 枚のみ | ✓ |

## SS（4 年齢モード × Before / After）

`landing` = ホーム着地直後 / `celebration` = 祝福が操作可能な状態 / `closed` = 演出を閉じ切って記録に進める状態。

Before は backdrop が二重に暗くなっており、複数の全画面演出が同時に開いていることが見た目にも出ている。

### preschool

| Before | After |
|---|---|
| ![before-preschool-landing](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-preschool-landing.png) | ![after-preschool-landing](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-preschool-landing.png) |
| ![before-preschool-celebration](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-preschool-celebration.png) | ![after-preschool-celebration](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-preschool-celebration.png) |
| ![before-preschool-closed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-preschool-closed.png) | ![after-preschool-closed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-preschool-closed.png) |

### elementary

| Before | After |
|---|---|
| ![before-elementary-landing](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-elementary-landing.png) | ![after-elementary-landing](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-elementary-landing.png) |
| ![before-elementary-celebration](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-elementary-celebration.png) | ![after-elementary-celebration](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-elementary-celebration.png) |
| ![before-elementary-closed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-elementary-closed.png) | ![after-elementary-closed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-elementary-closed.png) |

### junior

| Before | After |
|---|---|
| ![before-junior-landing](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-junior-landing.png) | ![after-junior-landing](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-junior-landing.png) |
| ![before-junior-celebration](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-junior-celebration.png) | ![after-junior-celebration](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-junior-celebration.png) |
| ![before-junior-closed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-junior-closed.png) | ![after-junior-closed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-junior-closed.png) |

### senior

| Before | After |
|---|---|
| ![before-senior-landing](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-senior-landing.png) | ![after-senior-landing](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-senior-landing.png) |
| ![before-senior-celebration](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-senior-celebration.png) | ![after-senior-celebration](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-senior-celebration.png) |
| ![before-senior-closed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/before-senior-closed.png) | ![after-senior-closed](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4437/after-senior-closed.png) |

## 影響範囲

- **顧客に見える変化**: 子供ホームの自動演出（ログインボーナス / 兄弟の応援 / 達成祝福）が**重ならず 1 枚ずつ順に出る**。閉じるたびに次が出る。演出は増やしていない（ADR-0012: 目的は「閉じられるようにする」であって演出を増やすことではない）
- **出る順序**: FSM の `PRIORITY_ORDER` に従い adventure > stampPress > specialReward > parentMessage > birthday > uiModeChange > siblingCheer > celebration。ただしログインボーナスは load 後の非同期 claim 完了時に `transition` されるため、祝福が先に出ている回は queue に入る
- **触った並行実装ペア**: なし（`src/routes/demo/**` は #2097 PR-B3 で撤去済み。demo は同一ルートを env で駆動するため本修正がそのまま効く）
- **破壊的変更**: なし。DB スキーマ / API / labels の変更なし
- **z-index トークン**: 変更なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
