### PR TITLE
fix(billing): #4416 dunning 猶予の終了日を W3 / W4 で 1 規則に揃える (retry で猶予が延び続けるのを止める)

### DIFF
--- a/docs/design/billing-redesign/contract-state-matrix.md
+++ b/docs/design/billing-redesign/contract-state-matrix.md
@@ -116,8 +116,8 @@ KPI service（`cohort-analysis` / `ops-analytics` / `pricing-trigger` / `stripe-
 |---|---|---|---|---|
 | W1 | `checkout.session.completed` | `stripe-service.ts` `handleCheckoutCompleted` | `sub` / `plan` / `status=active` / `trialUsedAt` | S1 → S2 / S5 → S2 |
 | W2 | `invoice.paid` | `stripe-service.ts` `handleInvoicePaid` | `status=active` + `plan`（未解決なら**保持**） + **`plan_expires_at=null`** | S2/S3/S4 → S2 |
-| W3 | `invoice.payment_failed` | `stripe-service.ts` `handlePaymentFailed` | `status=grace_period` / `exp = now + 7d` | S2/S3/S4 → S3 |
-| W4 | `customer.subscription.updated` | `stripe-service.ts` `handleSubscriptionUpdated` | 非終端: `plan`（未解決なら保持）+ `status`（Stripe status を正規化）+ **`plan_expires_at`**（`active` 復帰 → `null` / `grace_period` 入りで未設定なら `now+7d` / それ以外は無変更。`planExpiresAtPatchFor()`） / 終端: W5 と同じ 4 列 | S2/S3/S4 → S2（`active` / `trialing`）/ S2/S3/S4 → S3（`past_due`）/ S2/S3/S4 → S4（`unpaid` / `paused` / `incomplete`）/ S2/S3/S4 → S5（終端） |
+| W3 | `invoice.payment_failed` | `stripe-service.ts` `handlePaymentFailed` | `status=grace_period` + **`plan_expires_at`**（未設定なら `now+7d` / 既にあれば無変更。W4 と共通の `graceExpiresAtPatch()`、§5.2） | S2/S3/S4 → S3 |
+| W4 | `customer.subscription.updated` | `stripe-service.ts` `handleSubscriptionUpdated` | 非終端: `plan`（未解決なら保持）+ `status`（Stripe status を正規化）+ **`plan_expires_at`**（`active` 復帰 → `null` / `grace_period` は `graceExpiresAtPatch()`（§5.2）/ それ以外は無変更。`planExpiresAtPatchFor()`） / 終端: W5 と同じ 4 列 | S2/S3/S4 → S2（`active` / `trialing`）/ S2/S3/S4 → S3（`past_due`）/ S2/S3/S4 → S4（`unpaid` / `paused` / `incomplete`）/ S2/S3/S4 → S5（終端） |
 | W5 | `customer.subscription.deleted` | `stripe-service.ts` `handleSubscriptionDeleted` | `sub=NULL` / `plan=NULL` / `exp=NULL` / `status=suspended`（`TERMINAL_CONTRACT_STATE` の 4 列を網羅、#4026） | S2/S3/S4 → S5 |
 | W6 | アプリ内解約 | `tenant/cancel/+server.ts` | **書かない**（Stripe に `cancel_at_period_end=true` を予約するのみ、#3991） | なし（期末に W5 が S5 へ移す） |
 | W7 | 解約取り消し | `tenant/reactivate/+server.ts` | **書かない**（Stripe の `cancel_at_period_end=false`、#3991） | なし |
@@ -153,6 +153,24 @@ handler を実際に呼び、**開始状態 S1〜S5 × Stripe subscription statu
   checkout を `ALREADY_SUBSCRIBED` で拒む**ため。S5（解約済）からの再購読はこの経路で S2 に戻る
 - S6（退会済）を開始状態とする遷移は本表に無い。§4.1 のとおり legacy 行としてしか存在せず、
   `hooks.server.ts` が当該テナントを完全ブロックする
+
+### 5.2 dunning 猶予の終了日は「最初の支払い失敗から 7 日」
+
+`grace_period` の `plan_expires_at` を決める規則は **1 つだけ**であり、W3 / W4 の両方が
+`stripe-service.ts` の `graceExpiresAtPatch()` を通す。
+
+- 猶予終了日が**未設定なら** `now + 7d` を立てる（S3 は `exp` あり必須）
+- 猶予終了日が**既にあるなら触らない**
+
+Stripe の dunning は同じ invoice を複数回 retry し、そのたび W3（`invoice.payment_failed`）と
+W4（`past_due` の updated）を送る。retry ごとに `now + 7d` を書き直すと猶予の終わりが先送りされ、
+**支払い失敗が続く間は猶予が一度も明けない**。`plan_expires_at` を読む唯一の顧客向け処理である
+期限前リマインドメール（`lifecycle-email-service`、残り 30/7/1 日）も、残り日数が 7 に張り付いて
+最終通知が届かなくなる。
+
+到達可否（entitlement）は `status` で判定され本列を読まないため、本規則は機能の可否を変えない。
+規則の固定は `tests/unit/services/stripe-contract-state-classification.test.ts`（#4416、W3 / W4 を
+同じ入力で駆動して突き合わせる）と `tests/unit/services/lifecycle-email-service.test.ts`（残り日数）。
 
 ### 書き手を増やさない起動点: checkout reconciliation（#3958）
 

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -1035,7 +1035,11 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
 	// 解約経路は DB status を一切書かなくなった。以後この状態を書いてよいのは本 handler と、
 	// 同じ dunning を表す `handleSubscriptionUpdated` の `past_due` 分岐だけである
 	// (いずれも #4077 の単一強制点 `applyTenantContractState` を経由する)。
-	const graceExpires = new Date(Date.now() + GRACE_PERIOD_DAYS * MS_PER_DAY).toISOString();
+	// #4416: 猶予終了日は **W4 と同じ規則** (`graceExpiresAtPatch`) で決める。
+	// 旧実装は無条件に `now + 7d` を書き直していたため、dunning retry のたびに猶予が
+	// 先送りされ、支払い失敗が続く間は 7 日の猶予が実質切れなかった。
+	const gracePatch = graceExpiresAtPatch(tenant);
+	const graceExpires = gracePatch.planExpiresAt ?? tenant.planExpiresAt;
 	const applied = await applyTenantContractState(
 		tenant,
 		// 同上: 終端は上で早期 return 済
@@ -1043,7 +1047,7 @@ async function handlePaymentFailed(invoice: Stripe.Invoice): Promise<void> {
 		'invoice.payment_failed',
 		() => ({
 			status: SUBSCRIPTION_STATUS.GRACE_PERIOD,
-			planExpiresAt: graceExpires,
+			...gracePatch,
 		}),
 	);
 	if (!applied) return;
@@ -1186,8 +1190,7 @@ function isSubscriptionTerminal(subscription: Stripe.Subscription): boolean {
  *   Stripe は `invoice.payment_failed` (W3) と `past_due` の updated を両方送り到着順を保証しないため、
  *   W4 が先着するとこの形になる。いつまで猶予なのかを画面にも出せず、W3 が届かなければ猶予が明けない
  *
- * 既に猶予終了日があるときは**触らない**。dunning 中 Stripe は retry のたび `past_due` を送るので、
- * 毎回書き直すと猶予が延び続け、未払いのまま使い続けられる (W3 と同じ 7 日を初回だけ与える)。
+ * 猶予終了日そのものの決め方は {@link graceExpiresAtPatch} が持つ (W3 と共通の 1 規則)。
  * `suspended` の `exp` は matrix で「任意」なので `undefined` = 更新しない。
  */
 function planExpiresAtPatchFor(
@@ -1195,10 +1198,36 @@ function planExpiresAtPatchFor(
 	tenant: Pick<Tenant, 'planExpiresAt'>,
 ): { planExpiresAt?: string | null } {
 	if (status === SUBSCRIPTION_STATUS.ACTIVE) return { planExpiresAt: null };
-	if (status === SUBSCRIPTION_STATUS.GRACE_PERIOD && !tenant.planExpiresAt) {
-		return { planExpiresAt: new Date(Date.now() + GRACE_PERIOD_DAYS * MS_PER_DAY).toISOString() };
-	}
+	if (status === SUBSCRIPTION_STATUS.GRACE_PERIOD) return graceExpiresAtPatch(tenant);
 	return {};
+}
+
+/**
+ * dunning 猶予 (`grace_period`) の終了日を決める**唯一の規則** (#4416)。
+ *
+ * **猶予は「最初の支払い失敗から 7 日」**であり、支払い失敗が繰り返されても延びない。
+ * 既に猶予終了日があるなら `{}` (= 更新しない) を返す。
+ *
+ * ## なぜ「毎回与え直す」ではなくこちらを採ったか
+ *
+ * Stripe の dunning は 1 回の失敗で終わらず、**同じ invoice を複数回 retry してそのたび
+ * `invoice.payment_failed` (W3) と `past_due` の `customer.subscription.updated` (W4) を送る**。
+ * retry のたびに `now + 7d` を書き直すと猶予の終わりが先送りされ続け、**支払い失敗が
+ * 続いている間は猶予が一度も明けない** (retry 間隔が 7 日を超えない限り無期限に使える)。
+ * それは「7 日の猶予」という仕様の意味を失わせるので採らない。
+ *
+ * 併せて、猶予終了日を読む唯一の顧客向け処理である期限前リマインドメール
+ * (`lifecycle-email-service`、残り 30/7/1 日で送信) が、据え置きなら 7 → 1 と数え下がるのに対し、
+ * 与え直しでは残り日数が 7 のまま張り付き **「残り 1 日」の最終通知が永久に届かない**。
+ *
+ * 本規則は W3 (`handlePaymentFailed`) と W4 (`planExpiresAtPatchFor` の `grace_period` 分岐) の
+ * **両方から呼ばれる**。両者は同じ dunning 状態を書くので、規則が分かれていると
+ * `plan_expires_at` を読む処理を足したときに、どちらが先に届いたかで結果が変わる
+ * (`contract-state-matrix.md` §5 W3 / W4)。
+ */
+function graceExpiresAtPatch(tenant: Pick<Tenant, 'planExpiresAt'>): { planExpiresAt?: string } {
+	if (tenant.planExpiresAt) return {};
+	return { planExpiresAt: new Date(Date.now() + GRACE_PERIOD_DAYS * MS_PER_DAY).toISOString() };
 }
 
 // ============================================================

--- a/tests/unit/services/lifecycle-email-service.test.ts
+++ b/tests/unit/services/lifecycle-email-service.test.ts
@@ -426,3 +426,57 @@ describe('#1601 lifecycle-email-service — dryRun', () => {
 		expect(settingsStore.get('t-1:marketing_email_count_2026')).toBeUndefined();
 	});
 });
+
+// ============================================================
+// #4416 dunning 猶予の残り日数リマインド
+// ============================================================
+
+describe('#4416 dunning 猶予の「残り N 日」は猶予終了日の据え置きに依存する', () => {
+	// 猶予終了日 (`plan_expires_at`) を読む唯一の顧客向け処理が本リマインド。
+	// stripe-service の W3 / W4 が retry のたびに `now + 7d` を書き直すと、
+	// 残り日数が 7 に張り付いて最終通知 (残り 1 日) が永久に届かない。
+	// 「据え置きなら数え下がる / 与え直しなら張り付く」を実サービスで固定する。
+	// W3 / W4 が実際に据え置くことは
+	// `stripe-contract-state-classification.test.ts` (#4416) が handler を駆動して固定する。
+	const FIRST_FAILURE = new Date('2026-04-27T01:00:00Z');
+	const GRACE_DAYS = 7;
+	const plusDays = (base: Date, days: number) =>
+		new Date(base.getTime() + days * 24 * 60 * 60 * 1000);
+
+	/** 猶予 6 日目 (残り 1 日)。 */
+	const SIXTH_DAY = plusDays(FIRST_FAILURE, 6);
+
+	it('据え置きなら猶予 6 日目に「残り 1 日」の最終リマインドが届く', async () => {
+		const fixedExpiry = plusDays(FIRST_FAILURE, GRACE_DAYS).toISOString();
+		setupSingleTenantWithOwner(
+			makeTenant({ plan: 'standard_monthly', planExpiresAt: fixedExpiry }),
+		);
+
+		const result = await runLifecycleEmails({ now: SIXTH_DAY });
+
+		expect(result.renewalSent, '最終リマインドが送られていない').toBe(1);
+		expect(mockSendRenewal).toHaveBeenCalledWith(expect.objectContaining({ daysRemaining: 1 }));
+	});
+
+	it('retry ごとに猶予終了日を与え直すと「残り 1 日」に到達しない', async () => {
+		// 旧 W3 の挙動 (無条件 `now + 7d`) を入力として再現する。6 日目に retry が来て
+		// 猶予終了日が「6 日目 + 7 日」に書き換わっている状態。
+		setupSingleTenantWithOwner(
+			makeTenant({
+				plan: 'standard_monthly',
+				planExpiresAt: plusDays(SIXTH_DAY, GRACE_DAYS).toISOString(),
+			}),
+		);
+
+		const result = await runLifecycleEmails({ now: SIXTH_DAY });
+
+		expect(result.renewalSent, '残り 7 日として再送されている').toBe(1);
+		expect(mockSendRenewal).toHaveBeenCalledWith(
+			expect.objectContaining({ daysRemaining: GRACE_DAYS }),
+		);
+		expect(
+			mockSendRenewal,
+			'与え直しでも残り 1 日が届くなら本 test は意味を失っている',
+		).not.toHaveBeenCalledWith(expect.objectContaining({ daysRemaining: 1 }));
+	});
+});

--- a/tests/unit/services/stripe-contract-state-classification.test.ts
+++ b/tests/unit/services/stripe-contract-state-classification.test.ts
@@ -18,7 +18,7 @@
 // patch 単体を分類すると、更新しなかった列を「なし」と誤読して**実在しない不正状態**を作る。
 // 実際の行は「更新前の行 + patch」なので、そのとおり merge してから分類する。
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---------- Mocks (stripe-service.test.ts と同型) ----------
 
@@ -361,6 +361,132 @@ describe('#4181 AC3 webhook handler の書き込み後は正常状態に分類�
 		const after = resultingColumns(before);
 		expect(after.planExpiresAt, '猶予終了日が再送で書き換わっている').toBe(existingExpiry);
 		expectWritesValidState('W4 (past_due 再送)', classifyContractState(after));
+	});
+});
+
+// ---------- #4416: 猶予終了日を書く 2 経路 (W3 / W4) が同じ規則に従う ----------
+
+describe('#4416 猶予終了日は「最初の支払い失敗から 7 日」で固定される', () => {
+	/** dunning 中の tenant (既に猶予終了日が立っている)。 */
+	const EXISTING_EXPIRY = '2026-09-01T00:00:00.000Z';
+
+	// `Date` だけを固定する。`setTimeout` まで止めると handler 内の await が進まなくなる。
+	beforeEach(() => {
+		vi.useFakeTimers({ toFake: ['Date'] });
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	/** W3 (`invoice.payment_failed`) を 1 回起こす。 */
+	async function firePaymentFailed(): Promise<void> {
+		await handleWebhookEvent({
+			type: 'invoice.payment_failed',
+			data: {
+				object: {
+					id: 'in_test',
+					customer: 'cus_123',
+					parent: { subscription_details: { subscription: SUB } },
+				},
+			},
+		} as never);
+	}
+
+	/** W4 (`customer.subscription.updated` status=past_due) を 1 回起こす。 */
+	async function fireSubscriptionPastDue(): Promise<void> {
+		await handleWebhookEvent({
+			type: 'customer.subscription.updated',
+			data: {
+				object: {
+					id: SUB,
+					metadata: { tenantId: 't-test' },
+					status: 'past_due',
+					items: { data: [{ price: { id: 'price_monthly_123' } }] },
+				},
+			},
+		} as never);
+	}
+
+	it('W3 の再送 (dunning retry) は猶予終了日を延長しない', async () => {
+		// Stripe の dunning は 1 回の失敗で終わらず、**同じ invoice を複数回 retry して
+		// そのたび `invoice.payment_failed` を送る**。毎回 now+7d を書き直すと猶予が先送りされ続け、
+		// **支払い失敗が続いている間は 7 日の猶予が実質切れない**。
+		const before = makeTenant({ status: 'grace_period', planExpiresAt: EXISTING_EXPIRY });
+		mockFindTenantById.mockResolvedValue(before);
+		mockFindTenantByStripeCustomerId.mockResolvedValue(before);
+
+		await firePaymentFailed();
+
+		const after = resultingColumns(before);
+		expect(after.planExpiresAt, 'W3 の再送で猶予終了日が延びている').toBe(EXISTING_EXPIRY);
+		expectWritesValidState('W3 (payment_failed 再送)', classifyContractState(after));
+	});
+
+	it('W3 の初回 (猶予終了日なし) は now+7d を与える', async () => {
+		// 「延長しない」は「与えない」ではない。S3 は `exp` あり必須なので、
+		// 期限が無い状態から猶予に入るときは必ず立てる。
+		const before = makeTenant();
+		mockFindTenantById.mockResolvedValue(before);
+		mockFindTenantByStripeCustomerId.mockResolvedValue(before);
+		const nowMs = Date.parse('2026-08-01T00:00:00.000Z');
+		vi.setSystemTime(nowMs);
+
+		await firePaymentFailed();
+
+		const after = resultingColumns(before);
+		expect(after.planExpiresAt, 'W3 の初回で猶予終了日が立っていない').toBe(
+			new Date(nowMs + 7 * 24 * 60 * 60 * 1000).toISOString(),
+		);
+		expect(classifyContractState(after)).toBe('S3');
+	});
+
+	it('W3 と W4 は同じ規則に従う (同じ入力に同じ猶予終了日を書く)', async () => {
+		// 本 Issue の本体。**同じ概念を書く 2 箇所が逆方針**だと、片方だけを読む処理を足したときに壊れる。
+		// 「初回は与える / 再送では延ばさない」を 2 経路とも満たすことを、同じ入力で突き合わせる。
+		vi.setSystemTime(Date.parse('2026-08-01T00:00:00.000Z'));
+
+		const results: Record<string, (string | null)[]> = { W3: [], W4: [] };
+		for (const [writer, fire] of [
+			['W3', firePaymentFailed],
+			['W4', fireSubscriptionPastDue],
+		] as const) {
+			for (const before of [makeTenant(), makeTenant({ planExpiresAt: EXISTING_EXPIRY })]) {
+				mockUpdateTenantStripe.mockClear();
+				mockFindTenantById.mockResolvedValue(before);
+				mockFindTenantByStripeCustomerId.mockResolvedValue(before);
+				await fire();
+				results[writer]?.push(resultingColumns(before).planExpiresAt);
+			}
+		}
+
+		expect(results.W3, 'W3 と W4 の猶予終了日の決め方が食い違っている').toEqual(results.W4);
+		// 規則そのものも固定する (両方とも「延ばし続ける」で一致しても駄目)。
+		expect(results.W3?.[1], '既存の猶予終了日が書き換わっている').toBe(EXISTING_EXPIRY);
+	});
+
+	it('W3 → W4 → W3 と混在して届いても猶予終了日は初回のまま', async () => {
+		// Stripe は W3 と W4 を両方送り到着順を保証しない。どの順で何回来ても猶予は延びない。
+		vi.setSystemTime(Date.parse('2026-08-01T00:00:00.000Z'));
+		const before = makeTenant();
+		mockFindTenantById.mockResolvedValue(before);
+		mockFindTenantByStripeCustomerId.mockResolvedValue(before);
+
+		await firePaymentFailed();
+		const firstExpiry = resultingColumns(before).planExpiresAt;
+		expect(firstExpiry, '初回で猶予終了日が立っていない').not.toBeNull();
+
+		// 3 日後に retry が 2 回届く。
+		vi.setSystemTime(Date.parse('2026-08-04T00:00:00.000Z'));
+		const afterFirst = { ...before, status: 'grace_period', planExpiresAt: firstExpiry };
+		mockUpdateTenantStripe.mockClear();
+		mockFindTenantById.mockResolvedValue(afterFirst);
+		mockFindTenantByStripeCustomerId.mockResolvedValue(afterFirst);
+		await fireSubscriptionPastDue();
+		await firePaymentFailed();
+
+		expect(resultingColumns(afterFirst).planExpiresAt, '再送で猶予終了日が延びている').toBe(
+			firstExpiry,
+		);
 	});
 });
 

--- a/tests/unit/services/stripe-contract-state-classification.test.ts
+++ b/tests/unit/services/stripe-contract-state-classification.test.ts
@@ -445,7 +445,7 @@ describe('#4416 猶予終了日は「最初の支払い失敗から 7 日」で�
 		// 「初回は与える / 再送では延ばさない」を 2 経路とも満たすことを、同じ入力で突き合わせる。
 		vi.setSystemTime(Date.parse('2026-08-01T00:00:00.000Z'));
 
-		const results: Record<string, (string | null)[]> = { W3: [], W4: [] };
+		const results: Record<string, ContractStateColumns['planExpiresAt'][]> = { W3: [], W4: [] };
 		for (const [writer, fire] of [
 			['W3', firePaymentFailed],
 			['W4', fireSubscriptionPastDue],


### PR DESCRIPTION
## 顧客価値・目的

支払いに失敗した家族の「猶予はあと何日か」が、Stripe の再試行のたびに先送りされて実質いつまでも切れない状態を止める。猶予は最初の失敗から 7 日で確定し、期限前リマインドメールの「残り N 日」も 7 → 1 と正しく数え下がる。

## 関連 Issue

Closes #4416

## 変更内容

`plan_expires_at`（dunning 猶予の終了日）を書く 2 経路が**逆方針**だった。

| 書き手 | 旧実装 |
|---|---|
| W3 `handlePaymentFailed`（`invoice.payment_failed`） | **無条件で `now + 7d` に書き直す** |
| W4 `planExpiresAtPatchFor`（`past_due` の `customer.subscription.updated`） | 既に期限があれば**据え置く**（「毎回書き直すと猶予が延び続ける」とコメントで明記） |

### 採った方針: W3 を W4 に合わせる（猶予は最初の失敗から 7 日、再試行で延ばさない）

理由は 3 点。**判断の根拠はコードコメント（`graceExpiresAtPatch()` の docstring）に残した** — 今後この 2 経路を触る人が「意図的なのか見落としなのか」を再び判別できなくならないようにするため。

1. **「7 日の猶予」という仕様が意味を失う。** Stripe の dunning は 1 回の失敗で終わらず、同じ invoice を複数回 retry してそのたび W3 / W4 を送る。retry ごとに `now + 7d` を書き直すと、retry 間隔が 7 日を超えない限り猶予は**一度も明けない**
2. **唯一の顧客向け読み手が壊れる。** `plan_expires_at` を読む顧客向け処理は期限前リマインドメール（`lifecycle-email-service`、残り 30/7/1 日）だけ。与え直しでは残り日数が 7 に張り付き、**最終通知（残り 1 日）が永久に届かない**
3. W4 側が既に理由付きで据え置きを選んでいた。「与え直し」を採るなら W4 の明示的な判断を覆す必要があるが、それを支持する根拠が無い

### 実装

猶予終了日の決め方を `graceExpiresAtPatch()` **1 箇所**に集約し、W3 / W4 の両方から呼ぶ（未設定なら `now+7d` を立て、既にあれば触らない）。規則が 2 箇所に分かれている限り、`plan_expires_at` を読む処理を足したときに「どちらが先に届いたか」で結果が変わる。

設計書 `contract-state-matrix.md` に §5.2 として規則を追記し、W3 / W4 行の記述を実装に合わせた。

## 検証

先に落ちるテストを書いてから直した（failing-test-first）。テスト追加時点で `stripe-contract-state-classification.test.ts` は **3 failed / 9 passed**、修正後 12 passed。

| 検証 | 結果 |
|---|---|
| `vitest run tests/unit/services/ tests/unit/routes/api-stripe-webhook.test.ts tests/unit/architecture/contract-transition-matrix-ssot.test.ts` | 175 files / 2848 tests passed |
| `vitest run tests/unit/services/stripe-contract-state-classification.test.ts` | 12 passed（うち #4416 で新規 4 件） |
| `vitest run tests/unit/services/lifecycle-email-service.test.ts` | 27 passed（うち #4416 で新規 2 件） |
| `pre-ready --pr 4438` | 全 step PASS |

### 追加したテスト

`stripe-contract-state-classification.test.ts`（Issue 指定どおり**列の値レベル**。遷移 fitness は S3 → S3 で同一のため見えない）:

- W3 の再送は猶予終了日を延長しない
- W3 の初回（期限なし）は `now+7d` を与える — 「延長しない」を「与えない」に退行させないため
- **W3 と W4 が同じ規則に従う**（同じ入力 2 種を両経路に流して突き合わせ、かつ規則そのものも固定 = 両方が「延ばし続ける」で一致しても落ちる）
- W3 → W4 → W3 と混在到着しても初回のまま

`lifecycle-email-service.test.ts`（dunning リマインドの「残り N 日」）:

- 据え置きなら猶予 6 日目に「残り 1 日」の最終リマインドが届く
- 与え直し（旧 W3 の出力を入力として再現）では残り 7 日に張り付き、残り 1 日に到達しない

### mutation 検証（4 箇所、生存 0）

commit 済みの状態から壊し、`git stash push -- <path>` で戻した。

| 壊した箇所 | 結果 |
|---|---|
| `graceExpiresAtPatch` の据え置きガードを削除（＝旧 W3 の挙動） | 4 failed |
| 猶予窓を `2 * GRACE_PERIOD_DAYS` に変更 | 1 failed |
| `planExpiresAtPatchFor` の `grace_period` 分岐を `{}` に（期限を与えない） | 2 failed |
| `RENEWAL_REMINDER_DAYS` から `1` を削除 | 3 failed |

## 影響範囲

UI 変更なし。

- **entitlement は変わらない。** 到達可否は `status`（`grace_period`）で判定され `plan_expires_at` を読まない。本 PR は日付列の書き方だけを変える
- **顧客に見える変化**: 期限前リマインドメールの「残り N 日」が正しく数え下がる（従来は 7 に張り付き最終通知が届かなかった）
- 物理削除バッチは `plan_expires_at` ではなく settings の `soft_deleted_at` を条件にしているため無関係（#3993）
- 破壊的変更なし。既に猶予中の行は据え置かれるだけで、新たに期限が消えたり短くなったりしない

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
