### PR TITLE
fix(ui): #4417 セットアップウィザードとごほうびショップの 320px 横スクロールを解消する

### DIFF
--- a/playwright.demo.config.ts
+++ b/playwright.demo.config.ts
@@ -17,7 +17,12 @@
 
 import { defineConfig, devices } from '@playwright/test';
 
-const DEMO_BASE_URL = process.env.DEMO_BASE_URL ?? 'http://localhost:5180';
+// #4417: 並行 worktree agent が同 port (5180) で preview server を起動していると
+// `reuseExistingServer: !CI` が他 worktree の stale server を再利用してしまう。
+// playwright.config.ts の E2E_BASE_PORT (#2832) と同じ理由で port をずらせるようにする
+// (default 5180 は CI / 単独ローカルで従来通り)。
+const DEMO_PORT = Number(process.env.DEMO_PORT ?? 5180);
+const DEMO_BASE_URL = process.env.DEMO_BASE_URL ?? `http://localhost:${DEMO_PORT}`;
 const useDeployedTarget = DEMO_BASE_URL.startsWith('https://');
 
 export default defineConfig({
@@ -63,9 +68,9 @@ export default defineConfig({
 				// licenseStatus=ACTIVE スタブのため署名検証が走らない、src/hooks.server.ts §806 参照)。
 				command:
 					process.platform === 'win32'
-						? 'set AUTH_MODE=anonymous&& set DATA_SOURCE=demo&& set AWS_LICENSE_SECRET=e2e-test-secret-do-not-use-in-production&& npm run preview -- --port 5180'
-						: 'AUTH_MODE=anonymous DATA_SOURCE=demo AWS_LICENSE_SECRET=e2e-test-secret-do-not-use-in-production npm run preview -- --port 5180',
-				port: 5180,
+						? `set AUTH_MODE=anonymous&& set DATA_SOURCE=demo&& set AWS_LICENSE_SECRET=e2e-test-secret-do-not-use-in-production&& npm run preview -- --port ${DEMO_PORT}`
+						: `AUTH_MODE=anonymous DATA_SOURCE=demo AWS_LICENSE_SECRET=e2e-test-secret-do-not-use-in-production npm run preview -- --port ${DEMO_PORT}`,
+				port: DEMO_PORT,
 				reuseExistingServer: !process.env.CI,
 				timeout: 60_000,
 			},

--- a/src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte
@@ -37,6 +37,10 @@ const tabItems = [
 	{ value: 'privilege', label: CHILD_SHOP_LABELS.tabPrivilege },
 ] satisfies Array<{ value: TabValue; label: string }>;
 
+// #4417 (CSS 側の意図。lint がスタイルブロック内の日本語コメントを許さないためここに置く):
+// `.reward-list` の grid track 下限は `minmax(min(var(--reward-grid-min), 100%), 1fr)` で指定する。
+// 年齢別の最小カラム幅 (下記 gridMin、baby / preschool = 320px) が viewport 幅を上回る端末では
+// トラックが必ずあふれるため、min() で「器の幅」を上限にして頭打ちにする。
 // #2156: 年齢別 Grid カラム数 (uiMode に基づき min カラム幅を切替)
 const uiMode = $derived((page.params.uiMode ?? 'elementary') as UiMode);
 const gridMin = $derived.by(() => {
@@ -367,8 +371,6 @@ const pageTitle = $derived(`${CHILD_SHOP_LABELS.pageTitle}${APP_LABELS.pageTitle
 	.reward-list {
 		list-style: none; padding: 0; margin: 0;
 		display: grid;
-		/* #4417: 年齢別の最小カラム幅 (#2156、baby / preschool = 320px) が viewport 幅を
-		   上回る端末ではトラックが必ずあふれるため、min() で「器の幅」を上限にする。 */
 		grid-template-columns: repeat(auto-fill, minmax(min(var(--reward-grid-min, 280px), 100%), 1fr));
 		gap: var(--sp-md);
 	}

--- a/src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte
@@ -367,7 +367,9 @@ const pageTitle = $derived(`${CHILD_SHOP_LABELS.pageTitle}${APP_LABELS.pageTitle
 	.reward-list {
 		list-style: none; padding: 0; margin: 0;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(var(--reward-grid-min, 280px), 1fr));
+		/* #4417: 年齢別の最小カラム幅 (#2156、baby / preschool = 320px) が viewport 幅を
+		   上回る端末ではトラックが必ずあふれるため、min() で「器の幅」を上限にする。 */
+		grid-template-columns: repeat(auto-fill, minmax(min(var(--reward-grid-min, 280px), 100%), 1fr));
 		gap: var(--sp-md);
 	}
 	.reward-card { display: flex; align-items: center; gap: var(--sp-sm); }

--- a/src/routes/setup/+layout.svelte
+++ b/src/routes/setup/+layout.svelte
@@ -41,7 +41,9 @@ const currentStep = $derived(steps[currentStepIndex] ?? steps[0]);
 		<!-- Step indicator (#4417)
 		     step 名を全 step 分並べると nowrap のラベルが必ず画面幅を超えるため、
 		     並べるのは丸だけにして「現在どの step か」は下の 1 行に集約する。
-		     丸は縮み可 / 線は伸縮させるので、step が増減しても横幅は器に収まる。 -->
+		     CSS 側は丸を `flex: 0 1 32px; min-width: 20px` (32px を上限に縮む)、線を
+		     `flex: 1 1 4px; max-width: 24px` (余りを分け合う) にしてあるので、
+		     step が増減しても横幅は器に収まる。 -->
 		<div class="steps">
 			{#each steps as step, i (step.path)}
 				<div
@@ -90,7 +92,6 @@ const currentStep = $derived(steps[currentStepIndex] ?? steps[0]);
 		margin-bottom: 8px;
 	}
 
-	/* 丸は 32px を上限に縮み、線は余りを分け合う。step 数が増えても器の幅に収まる。 */
 	.step {
 		flex: 0 1 32px;
 		min-width: 20px;

--- a/src/routes/setup/+layout.svelte
+++ b/src/routes/setup/+layout.svelte
@@ -36,24 +36,34 @@ const currentStepIndex = $derived(
 			<p class="text-sm text-[var(--color-text-muted)] mt-1">{SETUP_LABELS.layoutTitle}</p>
 		</div>
 
-		<!-- Step indicator -->
-		<div class="flex items-center justify-center mb-6">
+		<!-- Step indicator (#4417)
+		     step 名を全 step 分並べると nowrap のラベルが必ず画面幅を超えるため、
+		     並べるのは丸だけにして「現在どの step か」は下の 1 行に集約する。
+		     丸は縮み可 / 線は伸縮させるので、step が増減しても横幅は器に収まる。 -->
+		<div class="steps">
 			{#each steps as step, i (step.path)}
-				<div class="step" class:step--active={i === currentStepIndex} class:step--done={i < currentStepIndex}>
-					<div class="step-circle">
-						{#if i < currentStepIndex}
-							<span>&#10003;</span>
-						{:else}
-							{i + 1}
-						{/if}
-					</div>
-					<span class="step-label">{step.label}</span>
+				<div
+					class="step"
+					class:step--active={i === currentStepIndex}
+					class:step--done={i < currentStepIndex}
+					aria-label={step.label}
+					aria-current={i === currentStepIndex ? 'step' : undefined}
+				>
+					{#if i < currentStepIndex}
+						<span aria-hidden="true">&#10003;</span>
+					{:else}
+						{i + 1}
+					{/if}
 				</div>
 				{#if i < steps.length - 1}
 					<div class="step-line" class:step-line--done={i < currentStepIndex}></div>
 				{/if}
 			{/each}
 		</div>
+		<p class="step-caption mb-6">
+			<span class="step-caption__count">{currentStepIndex + 1} / {steps.length}</span>
+			<span class="step-caption__label">{steps[currentStepIndex].label}</span>
+		</p>
 
 		<Card padding="lg">
 			{@render children()}
@@ -71,34 +81,41 @@ const currentStepIndex = $derived(
 		padding: 16px;
 	}
 
-	.step {
+	.steps {
 		display: flex;
-		flex-direction: column;
 		align-items: center;
-		gap: 4px;
+		justify-content: center;
+		margin-bottom: 8px;
 	}
 
-	.step-circle {
-		width: 32px;
-		height: 32px;
+	/* 丸は 32px を上限に縮み、線は余りを分け合う。step 数が増えても器の幅に収まる。 */
+	.step {
+		flex: 0 1 32px;
+		min-width: 20px;
+		aspect-ratio: 1;
 		border-radius: 50%;
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		font-size: 0.875rem;
+		font-size: 0.8125rem;
 		font-weight: 700;
 		background: var(--color-neutral-200);
 		color: var(--color-neutral-400);
-		transition: all 0.2s;
+		transition: background-color 0.2s, color 0.2s;
 	}
 
-	.step--active .step-circle { background: var(--color-brand-600); color: white; }
-	.step--done .step-circle { background: var(--color-success); color: white; }
+	.step--active { background: var(--color-brand-600); color: var(--color-text-inverse); }
+	.step--done { background: var(--color-success); color: var(--color-text-inverse); }
 
-	.step-label { font-size: 0.75rem; color: var(--color-neutral-400); white-space: nowrap; }
-	.step--active .step-label { color: var(--color-brand-600); font-weight: 600; }
-	.step--done .step-label { color: var(--color-success); }
-
-	.step-line { width: 24px; height: 2px; background: var(--color-neutral-200); margin-bottom: 20px; }
+	.step-line { flex: 1 1 4px; min-width: 4px; max-width: 24px; height: 2px; background: var(--color-neutral-200); }
 	.step-line--done { background: var(--color-success); }
+
+	.step-caption {
+		display: flex;
+		justify-content: center;
+		gap: 6px;
+		font-size: 0.75rem;
+	}
+	.step-caption__count { color: var(--color-text-muted); font-variant-numeric: tabular-nums; }
+	.step-caption__label { color: var(--color-brand-600); font-weight: 600; }
 </style>

--- a/src/routes/setup/+layout.svelte
+++ b/src/routes/setup/+layout.svelte
@@ -27,6 +27,8 @@ const currentStepIndex = $derived(
 		0,
 	),
 );
+// steps は空にならないが、index アクセスの型を確定させるため fallback を明示する
+const currentStep = $derived(steps[currentStepIndex] ?? steps[0]);
 </script>
 
 <div class="setup-page">
@@ -62,7 +64,7 @@ const currentStepIndex = $derived(
 		</div>
 		<p class="step-caption mb-6">
 			<span class="step-caption__count">{currentStepIndex + 1} / {steps.length}</span>
-			<span class="step-caption__label">{steps[currentStepIndex].label}</span>
+			<span class="step-caption__label">{currentStep?.label}</span>
 		</p>
 
 		<Card padding="lg">

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -81,6 +81,12 @@ const isScreenshotAll = $derived(getScreenshotModeKind() === 'all');
 // この overlay はアプリ内で唯一 primitive を使わない全画面 modal のため、Ark UI Dialog が
 // 内包するスクロールロックが抜けており、「読み込み中です」と出しながら背後が動いていた
 // (`body.overflow = visible` / overlay 越しに scrollY=266 まで動くことを実測、#4417)。
+// #4417 AC3' (CSS 側の意図。lint がスタイルブロック内の日本語コメントを許さないためここに置く):
+// `.login-overlay` の下端は `inset: 0` で決めず `height: 100lvh` (`100vh` は fallback) で決める。
+// iOS はソフトウェアキーボード表示中に layout viewport を縮めるため、PIN 入力直後に出るこの
+// overlay は `inset: 0` だと「viewport − キーボード」の高さ (実測 495 / 792 CSS px) で確定し、
+// キーボードが閉じても再レイアウトされない。lvh はキーボード / 動的 UI で縮まない基準。
+// スクロールロックは :global(body.parent-gate-scroll-lock) の overflow:hidden で行う。
 const overlayVisible = $derived(navigatingToAdmin || navigatingError || isScreenshotAll);
 $effect(() => {
 	if (!overlayVisible) return;
@@ -418,16 +424,12 @@ async function handlePinComplete(details: { valueAsString: string }) {
 	.portal-page {
 		background: linear-gradient(135deg, var(--color-brand-100) 0%, var(--color-brand-50) 50%, var(--color-gold-100) 100%);
 	}
-	/* #4417 AC3': 下端は inset で決めない。iOS はソフトウェアキーボード表示中に layout viewport を
-	   縮めるため、PIN 入力直後に表示されるこの overlay は `inset: 0` だと「viewport − キーボード」
-	   の高さ (実測 495 / 792 CSS px) で確定し、キーボードが閉じても再レイアウトされない。
-	   lvh (large viewport height) はキーボード / 動的 UI で縮まない基準なので下端まで覆える。 */
 	.login-overlay {
 		position: fixed;
 		top: 0;
 		left: 0;
 		right: 0;
-		height: 100vh; /* lvh 非対応ブラウザ向け fallback */
+		height: 100vh;
 		height: 100lvh;
 		overscroll-behavior: contain;
 		z-index: var(--z-modal);
@@ -439,7 +441,6 @@ async function handlePinComplete(details: { valueAsString: string }) {
 		background: var(--color-surface-overlay);
 		backdrop-filter: blur(2px);
 	}
-	/* overlay 表示中の背後スクロール抑止 (#4417 AC5)。class の付け外しは上記 $effect が担う。 */
 	:global(body.parent-gate-scroll-lock) {
 		overflow: hidden;
 	}

--- a/src/routes/switch/+page.svelte
+++ b/src/routes/switch/+page.svelte
@@ -77,6 +77,16 @@ function retryAdminNavigation() {
 // (MilestoneBanner の bypassSeenCheck と同型の既存パターン、src/routes/CLAUDE.md §?screenshot)。
 // 本番ユーザは screenshot mode に入らないため通常表示には影響しない。
 const isScreenshotAll = $derived(getScreenshotModeKind() === 'all');
+// #4417 AC5: overlay 表示中は背後のページをスクロールさせない。
+// この overlay はアプリ内で唯一 primitive を使わない全画面 modal のため、Ark UI Dialog が
+// 内包するスクロールロックが抜けており、「読み込み中です」と出しながら背後が動いていた
+// (`body.overflow = visible` / overlay 越しに scrollY=266 まで動くことを実測、#4417)。
+const overlayVisible = $derived(navigatingToAdmin || navigatingError || isScreenshotAll);
+$effect(() => {
+	if (!overlayVisible) return;
+	document.body.classList.add('parent-gate-scroll-lock');
+	return () => document.body.classList.remove('parent-gate-scroll-lock');
+});
 // PinInput remount 用 key (失敗時に入力欄を確実にリセット)
 let pinInputKey = $state<number>(0);
 
@@ -408,9 +418,18 @@ async function handlePinComplete(details: { valueAsString: string }) {
 	.portal-page {
 		background: linear-gradient(135deg, var(--color-brand-100) 0%, var(--color-brand-50) 50%, var(--color-gold-100) 100%);
 	}
+	/* #4417 AC3': 下端は inset で決めない。iOS はソフトウェアキーボード表示中に layout viewport を
+	   縮めるため、PIN 入力直後に表示されるこの overlay は `inset: 0` だと「viewport − キーボード」
+	   の高さ (実測 495 / 792 CSS px) で確定し、キーボードが閉じても再レイアウトされない。
+	   lvh (large viewport height) はキーボード / 動的 UI で縮まない基準なので下端まで覆える。 */
 	.login-overlay {
 		position: fixed;
-		inset: 0;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 100vh; /* lvh 非対応ブラウザ向け fallback */
+		height: 100lvh;
+		overscroll-behavior: contain;
 		z-index: var(--z-modal);
 		display: flex;
 		flex-direction: column;
@@ -419,6 +438,10 @@ async function handlePinComplete(details: { valueAsString: string }) {
 		gap: 1rem;
 		background: var(--color-surface-overlay);
 		backdrop-filter: blur(2px);
+	}
+	/* overlay 表示中の背後スクロール抑止 (#4417 AC5)。class の付け外しは上記 $effect が担う。 */
+	:global(body.parent-gate-scroll-lock) {
+		overflow: hidden;
 	}
 	.login-overlay__spinner {
 		width: 2.5rem;

--- a/tests/e2e/demo-lambda/visual-equality.spec.ts
+++ b/tests/e2e/demo-lambda/visual-equality.spec.ts
@@ -173,3 +173,90 @@ test.describe('#2097 AC12: 5 年齢モード home の構造等価 (demo Lambda)'
 		expect(failed).toEqual([]);
 	});
 });
+
+// #4417: モバイル幅 (320px) で横スクロールが発生しないこと。
+//
+// セットアップウィザードの step インジケータは step が 3 → 8 と増える過程 (#2140 → #2298 → #2322)
+// でモバイル幅が再検証されず、320px で 114px / 390px で 79px はみ出していた (全 10 ページ)。
+// ごほうびショップも年齢別カラム下限 (#2156、baby / preschool = 320px) が viewport 幅を
+// 上回るため 320px で 16px はみ出していた。
+//
+// いずれも「はみ出し量が減った」ではなく「0 である」ことを assert する。判定は
+// `documentElement.scrollWidth - clientWidth === 0` (横スクロール bar が出る条件そのもの)。
+//
+// 本 spec (demo Lambda config) に足す理由: /setup 配下は AUTH_MODE=local の E2E では
+// seed 済 tenant が setup 完了状態のため hooks.server.ts に redirect され描画できない。
+// AUTH_MODE=anonymous + DATA_SOURCE=demo では全 10 ページが 200 で描画されるため、
+// 既存の demo Lambda spec に判定を足す形にする (新しい CI 装置は増やさない、#4417 AC4)。
+test.describe('#4417: 320px 幅で横スクロールが発生しない', () => {
+	test.use({ viewport: { width: 320, height: 720 } });
+
+	const SETUP_PATHS = [
+		'/setup',
+		'/setup/children',
+		'/setup/questionnaire',
+		'/setup/packs',
+		'/setup/activities-defaults',
+		'/setup/rewards',
+		'/setup/rules',
+		'/setup/challenges',
+		'/setup/first-adventure',
+		'/setup/complete',
+	] as const;
+
+	/**
+	 * 横方向のはみ出し量 (px) が 0 になるまで待って assert する。
+	 *
+	 * hydration の途中では Svelte が一時的にノードを付け替えるため、その瞬間だけ数十 px の
+	 * はみ出しが観測される (実測: hydration 完了後は 0)。定常状態を見たいので `expect.poll` で
+	 * auto-retry する (`networkidle` は Playwright / 本 repo で禁止のため使わない)。
+	 */
+	async function expectNoHorizontalOverflow(
+		page: import('@playwright/test').Page,
+		label: string,
+	): Promise<void> {
+		await expect
+			.poll(
+				() =>
+					page.evaluate(
+						() => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+					),
+				{ message: `${label}: 320px でのはみ出し量は 0px であること` },
+			)
+			.toBe(0);
+	}
+
+	test('セットアップウィザード 10 ページすべてで横スクロールが発生しない (AC1)', async ({
+		page,
+	}) => {
+		for (const path of SETUP_PATHS) {
+			const res = await page.goto(path, { waitUntil: 'domcontentloaded' });
+			expect(res?.status() ?? 0, `${path} が描画できること`).toBeLessThan(400);
+			// step インジケータは全ページ共通の器。描画を待ってから測る
+			await expect(page.locator('.steps')).toBeVisible();
+			await expectNoHorizontalOverflow(page, path);
+		}
+	});
+
+	// baby / preschool は #2156 で reward card の最小幅を 320px に広げている (低年齢ほど大きく)。
+	// 320px 画面では左右 padding を引いた実効幅がそれを下回るため、min() で頭打ちにする必要がある。
+	for (const { childId, uiMode } of [
+		{ childId: '901', uiMode: 'baby' },
+		{ childId: '902', uiMode: 'preschool' },
+	] as const) {
+		test(`${uiMode}/shop で横スクロールが発生しない (AC2)`, async ({ context, page }) => {
+			await context.clearCookies();
+			await context.addCookies([
+				{ name: 'selectedChildId', value: childId, domain: 'localhost', path: '/' },
+			]);
+			const res = await page.goto(`/${uiMode}/shop`, { waitUntil: 'domcontentloaded' });
+			expect(res?.status() ?? 0).toBeLessThan(400);
+			await expect(page).toHaveURL(new RegExp(`/${uiMode}/shop`));
+			// demo fixture では baby (901) の ごほうびが 0 件のため、カード有無で待ち方を分ける。
+			// grid track のはみ出しはカードが 1 枚以上ある時だけ現れるので、preschool 側が本命の回帰検証。
+			const cards = page.locator('.reward-list > *');
+			if ((await cards.count()) > 0) await expect(cards.first()).toBeVisible();
+			await expectNoHorizontalOverflow(page, `/${uiMode}/shop`);
+		});
+	}
+});


### PR DESCRIPTION
## 顧客価値・目的

サインアップ直後の新規顧客が最初に通るセットアップウィザードが、モバイル幅（320px）で横にはみ出して画面が壊れていた。全 10 ページで横スクロールが消え、最初の体験が「壊れた画面」から始まらなくなる。

## 関連 Issue

Closes #4417

## 変更内容

はみ出しの原因は**共通の器 1 箇所**（`src/routes/setup/+layout.svelte` の step インジケータ）。step 名を全 step 分 `white-space: nowrap` で 1 行に並べており、step が 3 → 8 と増える過程（#2140 → #2298 → #2322）でモバイル幅が再検証されていなかった。10 ページ全部が同じ量（320px で 114px / 390px で 79px）はみ出していたのはこのため。

- **AC1（器の修正、1 箇所）**: 並べるのは丸だけにして、step 名は「N / 9 ルール」の 1 行キャプションに集約した。丸は `flex: 0 1 32px; min-width: 20px` で縮み、線は `flex: 1 1 4px; max-width: 24px` で余りを分け合うため、**step が増減しても器の幅に収まる**（12 step に増やした状態で 320px = 0px を実測、下記「検証」）。step 名は `aria-label` + `aria-current="step"` で読み上げに残した
- **AC2**: `minmax(var(--reward-grid-min), 1fr)` → `minmax(min(var(--reward-grid-min), 100%), 1fr)`。年齢別カラム下限（#2156、baby / preschool = 320px）の意図は維持したまま、器の幅を上限にして頭打ちにする
- **AC3'**: `.login-overlay` の高さを `inset: 0` ではなく `height: 100lvh`（`100vh` fallback）で決めるようにした。iOS はソフトウェアキーボード表示中にレイアウトビューポートを縮めるため、PIN 入力直後に出るこの overlay は `inset: 0` だと縮んだ高さで確定し、キーボードが閉じても戻らない（Issue コメントの実測: 覆われない帯 297 CSS px = キーボード高）。`lvh` はキーボードで縮まない基準
- **AC5**: overlay 表示中に `body` へ `parent-gate-scroll-lock` を付けて背後のスクロールを止めた（`overscroll-behavior: contain` 併用）。この overlay はアプリ内で唯一 primitive を使わない全画面 modal のため、Ark UI Dialog が内包するスクロールロックが抜けていた。**Dialog primitive への置換は行っていない** — Issue コメントで PO が撤回した通り `Dialog.svelte` の Positioner も `fixed inset-0` で同じ形であり、置き換えても AC3' は直らないため
- **AC4**: 新しい CI 装置は追加せず、既存 spec `tests/e2e/demo-lambda/visual-equality.spec.ts` に 320px の横スクロール判定を追加（`documentElement.scrollWidth - clientWidth === 0`。「減った」ではなく「0」を assert）
- `playwright.demo.config.ts` に `DEMO_PORT` env を追加（既定 5180 は不変）。並行 worktree で固定 port 5180 の preview server を掴み合う事故を避けるため、`playwright.config.ts` の `E2E_BASE_PORT`（#2832）と同じ形にした

**/setup 配下は `AUTH_MODE=local` の E2E では seed 済 tenant が setup 完了状態で hooks に redirect され描画できない**ため、回帰テストは demo Lambda config（`AUTH_MODE=anonymous` + `DATA_SOURCE=demo`、全 10 ページが 200）側の既存 spec に足している。

## 検証

### failing-test-first（先に落ちることを確認 → 修正 → green）

```
# 修正前
3 failed
  セットアップウィザード 10 ページすべてで横スクロールが発生しない (AC1)
    Received: ["/setup: 114px", "/setup/children: 114px", ... 全 10 ページ]
  baby/shop で横スクロールが発生しない (AC2)        Expected: 0  Received: 16
  preschool/shop で横スクロールが発生しない (AC2)   Expected: 0  Received: 16

# 修正後
3 passed
```

### 320px 実測（`AUTH_MODE=anonymous DATA_SOURCE=demo` の production preview、`scrollWidth - clientWidth`）

| ページ | Before | After |
|---|---|---|
| /setup 〜 /setup/complete（10 ページすべて） | 114px | **0px** |
| /preschool/shop・/baby/shop | 16px | **0px** |

### 他ブレークポイントを壊していないこと

10 setup ページ + 5 年齢モードの shop を 320 / 390 / 412 / 768 / 1280px で全数計測し、**全て 0px**（`ALL 0`）。修正前は 320px=114 / 390px=79 / 412px=68 だった。

### step 数非依存（AC1「8 個決め打ちで詰めるのは不可」）

step を 9 → 12 に増やした状態で AC1 テストを実行し **green**（320px で 0px）。1 箇所の器で吸収できていることの確認。

### mutation 検証（3 箇所を壊して落ちることを確認、実装は先に commit 済 b5beab2）

| # | 壊した箇所 | 結果 |
|---|---|---|
| M1 | `.step` / `.step-line` を固定幅（`flex: 0 0`）に戻す | **落ちた**（AC1 fail） |
| M2 | step ごとの `white-space: nowrap` ラベルを復活（元の実装） | **落ちた**（AC1 fail） |
| M3 | shop の `min(..., 100%)` を外す | **落ちた**（AC2 preschool fail） |
| M4（正の確認） | step を 12 個に増やす | **green のまま**（step 数に依存しない） |

生存 mutation: `.step` の `flex-shrink` だけを 0 にした変種（M1 の前半のみ）は **落ちなかった**。実測すると `.steps` の内容が 288px の器を 16px 超えるが、`justify-content: center` で左右 8px ずつページ padding に食い込むだけで**横スクロールは発生しない**（= AC の観点では実害なし）ため、テストの穴ではなく判定条件どおりの挙動と判断した。線も固定に戻すと落ちる（M1）。

### スクリーンショット（320 × 800、`AUTH_MODE=anonymous DATA_SOURCE=demo` の production preview）

Before = `origin/develop` を同条件でビルドして撮影 / After = 本 PR HEAD。全 10 枚とも Blob SHA は不一致（同一画像の使い回しなし）。

| 画面 | Before（develop） | After（本 PR） |
|---|---|---|
| /setup/children | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-children.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-children.png) |
| /setup/questionnaire | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-questionnaire.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-questionnaire.png) |
| /setup/packs | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-packs.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-packs.png) |
| /setup/rewards | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-rewards.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-rewards.png) |
| /setup/rules | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-rules.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-rules.png) |
| /setup/activities-defaults | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-activities-defaults.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-activities-defaults.png) |
| /setup/challenges | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-challenges.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-challenges.png) |
| /setup/first-adventure | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-first-adventure.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-first-adventure.png) |
| /setup/complete | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-setup-complete.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-setup-complete.png) |
| /preschool/shop（全画面） | ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/before-preschool-shop.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4439/after-preschool-shop.png) |

`/setup` は `/setup/children` へ 302 するため画面としては上表の 9 + shop の 10 枚（Issue の「10 ページ」= /setup を含む URL 数）。Before では step ラベルが画面の左右にはみ出して切れており、After では 9 個の丸が 320px に収まり「5 / 9 ルール」の 1 行に集約されている。

### そのほか

- `npx playwright test --config playwright.demo.config.ts`（demo Lambda 全 44 件）→ **44 passed**
- `npx playwright test tests/e2e/parent-gate.spec.ts tests/e2e/parent-gate-modal-dead-end.spec.ts tests/e2e/portal-pin-gate.spec.ts`（overlay 変更の影響先）→ **6 passed**
- `npx vitest run tests/unit/architecture/ src/routes/` → **409 passed**（Base トークン ratchet 含む。本 PR は setup layout の Base トークン参照を 8 → 7 に減らしている）
- `npx biome check .` / `npx svelte-check --threshold error` → **0 errors**
- **AC3' は実機確認が必要**（iOS のキーボードによるレイアウトビューポート縮小は headless で再現できないことを Issue コメントで PO が実測済）。ここに自動検査は足していない。iOS Brave / Safari で PIN 入力直後の overlay が下端まで覆うことの確認をお願いします

## 影響範囲

- **顧客に見える変化**: セットアップウィザードの step インジケータの見た目が変わる（各 step 名の常時表示 → 丸 + 現在地 1 行）。全ブレークポイント共通。ごほうびショップは 320px でのカード幅のみ変化（390px 以上は不変）
- **並行実装ペア**: shop は `src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte` の 1 ファイルで 5 年齢モード共通（`--reward-grid-min` の年齢別値は不変）。本番ルート = デモ Lambda（`AUTH_MODE=anonymous`）で同一ファイル
- **破壊的変更**: なし。`DEMO_PORT` は未指定時 5180 で従来どおり

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし（`DEMO_PORT` はローカル E2E 用の任意 override で、CI / 本番は既定値のまま）

## QM レビュー結果

<!-- QM が記入 -->
