### PR TITLE
feat(infra): #4367 AWS の Bedrock を最小権限 + in-Region で有効化する (AC2/AC3/AC4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,9 +39,13 @@ PORT=3000
 # GEMINI_MODEL=gemini-2.0-flash
 
 # Bedrock (Lambda 環境向け)
-# IAM ロール認証で自動利用。明示的に無効化する場合のみ設定。
+# 認証は IAM ロール。ただし **BEDROCK_MODEL_ID を配らない限り AI は無効** (#4366) —
+# 既定値の存在は「配線した」を意味しないため、isAvailable() は明示配布を要求する。
+# AWS 本番 / staging へは CDK (infra/lib/compute-stack.ts) が配る (#4367)。
+# model ID は base model (geo inference profile の `us.` 接頭辞を付けない) —
+# profile は us-east-2 / us-west-2 でも推論されうるため、in-Region に固定する。
 # BEDROCK_DISABLED=true
-# BEDROCK_MODEL_ID=us.anthropic.claude-haiku-4-5-20251001-v1:0
+# BEDROCK_MODEL_ID=anthropic.claude-haiku-4-5-20251001-v1:0
 # BEDROCK_REGION=us-east-1
 
 # ---------------------------------------------------------------

--- a/docs/design/07-API設計書.md
+++ b/docs/design/07-API設計書.md
@@ -1325,7 +1325,7 @@ Stripe からの Webhook イベントを受信する。Stripe 署名ヘッダ（
 
 テキスト入力から活動名・カテゴリを AI で推定する。
 
-**AIモデル:** AWS Bedrock Claude Haiku (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) — tool_use（構造化出力）で確実にJSONスキーマ準拠のレスポンスを返す。Bedrock 未利用時はキーワードベースのフォールバック。
+**AIモデル:** AWS Bedrock Claude Haiku (`anthropic.claude-haiku-4-5-20251001-v1:0`) — tool_use（構造化出力）で確実にJSONスキーマ準拠のレスポンスを返す。Bedrock 未利用時はキーワードベースのフォールバック。
 
 **リクエストボディ:**
 ```json

--- a/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
+++ b/docs/design/13-AWSサーバレスアーキテクチャ設計書.md
@@ -672,10 +672,10 @@ Dockerfile.lambda        # Lambda Web Adapter用
 | 項目 | 内容 |
 |------|------|
 | サービス | Amazon Bedrock (Converse API) |
-| モデル | Claude Haiku 4.5 (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) |
-| 推論方式 | Cross-region inference profile |
+| モデル | Claude Haiku 4.5 (`anthropic.claude-haiku-4-5-20251001-v1:0`) |
+| 推論方式 | in-Region on-demand（base model ID）。cross-region inference profile (`us.` 接頭辞) は使わない — us-east-2 / us-west-2 でも推論されうるため、子供の活動テキストの所在を `site/privacy.html` 第 10 条の開示（us-east-1）と一致させる |
 | 構造化出力 | tool_use (function calling) でJSONスキーマ準拠の出力を保証 |
-| 認証 | Lambda 実行ロールの IAM ポリシーで `bedrock:InvokeModel` を許可 |
+| 認証 | Lambda 実行ロールの IAM ポリシーで `bedrock:InvokeModel` を許可。Resource は当該 base model の ARN 1 本 (`arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0`) に絞り `*` にしない。`bedrock:Converse` という IAM アクションは存在せず、Converse API は `bedrock:InvokeModel` で認可される |
 
 ### モデル選定理由
 
@@ -696,8 +696,8 @@ Dockerfile.lambda        # Lambda Web Adapter用
 
 | 変数 | デフォルト | 説明 |
 |------|----------|------|
-| `BEDROCK_MODEL_ID` | `us.anthropic.claude-haiku-4-5-20251001-v1:0` | 使用モデルID |
-| `BEDROCK_REGION` | `AWS_REGION` or `us-east-1` | Bedrock リージョン |
+| `BEDROCK_MODEL_ID` | `anthropic.claude-haiku-4-5-20251001-v1:0` | 使用モデル ID。**配布が可用性条件** — 未配布だと `isAvailable()` が false を返し AI はキーワード提案に縮退する (#4366)。AWS 本番 / staging へは `infra/lib/compute-stack.ts` が配る |
+| `BEDROCK_REGION` | `AWS_REGION` or `us-east-1` | Bedrock リージョン。AWS 本番 / staging へは `us-east-1` を明示配布する (既定値に委ねると実行環境の `AWS_REGION` 次第でずれる) |
 | `BEDROCK_DISABLED` | (未設定) | `true` でBedrock無効化（フォールバック使用） |
 
 ---

--- a/docs/design/14-セキュリティ設計書.md
+++ b/docs/design/14-セキュリティ設計書.md
@@ -891,6 +891,7 @@ user-content（avatar / ZIP import 由来ファイル等、attacker が content-
 **実装上の遵守事項**:
 - 子供データ（活動記録 / プロフィール / アバター画像）は外部第三者へ送信しない（§8.7 と整合）
 - 生成 AI リクエストには家族内一意 ID を含めない。SaaS (AWS) 側の生成 AI は Bedrock のみで、運営者の環境の外にある生成 AI へ子供データを出す経路は持たない（#4397 でアバター AI 生成を廃止。境界は `tests/unit/architecture/external-ai-client-boundary.test.ts` が固定）
+- Bedrock は **base model ID を us-east-1 に固定して呼ぶ**（cross-region inference profile を使わない）。profile 経由だと同じ AWS 内でも us-east-2 / us-west-2 で推論されうるため、`site/privacy.html` 第 10 条の移転先開示（米国 / us-east-1）と処理実体が一致しなくなる。IAM も当該 base model の ARN 1 本に限定する（`bedrock:InvokeModel`、Resource に `*` を使わない）。固定は `infra/lib/compute-stack.ts` と `src/lib/server/ai/bedrock-claude-provider.ts` の 2 箇所で、`tests/unit/infra/multi-lambda-cdk.test.ts` / `tests/unit/server/ai/bedrock-claude-provider.test.ts` が geo prefix の混入を検出する（#4367）
 - 文言ドリフト防止: `LEGAL_LABELS` (`src/lib/domain/labels.ts`) のキー用語が `site/privacy.html` に出現することを `scripts/check-lp-ssot.mjs` で CI 検証
 
 ### 8.6 個人情報保護法 §28 対応（域外移転 + 本人同意取得）

--- a/infra/lib/compute-stack.ts
+++ b/infra/lib/compute-stack.ts
@@ -44,6 +44,21 @@ const CRON_JOBS = [
 	{ name: 'stripe-webhook-delivery-check', utcCronExpression: 'cron(5 * * * ? *)' },
 ] as const;
 
+// --- Bedrock (#4367) ---
+// SSOT は src/lib/server/ai/bedrock-claude-provider.ts の DEFAULT_MODEL_ID。CDK tsconfig の
+// rootDir は infra/ 固定で src/ を import できないため、CRON_JOBS と同じくインライン定義する。
+//
+// **base model ID を使い、`us.` 等の geo inference profile は使わない**。profile は
+// us-east-1 に投げても us-east-2 / us-west-2 で推論されうる = 子供の活動テキストが
+// 開示リージョン (privacy.html 第 10 条: us-east-1) の外に出る。Pre-PMF で throughput
+// 冗長性は不要なので in-Region に固定する。
+const BEDROCK_REGION = 'us-east-1';
+const BEDROCK_MODEL_ID = 'anthropic.claude-haiku-4-5-20251001-v1:0';
+// foundation-model ARN は account 部が空 (AWS 管理リソース)。
+// profile を使う場合は profile ARN + 対象 3 リージョンの FM ARN を並べる必要があるが、
+// base model 固定なのでこの 1 本だけで足りる。
+const BEDROCK_MODEL_ARN = `arn:aws:bedrock:${BEDROCK_REGION}::foundation-model/${BEDROCK_MODEL_ID}`;
+
 export interface ComputeStackProps extends cdk.StackProps {
 	assetsBucket: s3.Bucket;
 	repository: ecr.Repository;
@@ -362,6 +377,10 @@ export class ComputeStack extends cdk.Stack {
 			...(stagingStripeSecretKey ? { STRIPE_SECRET_KEY: stagingStripeSecretKey } : {}),
 			...(stagingStripeWebhookSecret ? { STRIPE_WEBHOOK_SECRET: stagingStripeWebhookSecret } : {}),
 			...(stagingStripeSecretKey ? { USE_LOOKUP_KEY: 'true' } : {}),
+			// #4367 AC4 / AC5: staging は AI 提案の実機確認先。env が無いと isAvailable() が
+			// false のまま (#4366) で確認自体が成立しないため、本番と同じ値を配る。
+			BEDROCK_MODEL_ID: BEDROCK_MODEL_ID,
+			BEDROCK_REGION: BEDROCK_REGION,
 		};
 
 		// --- Lambda: SvelteKit via Lambda Web Adapter ---
@@ -444,6 +463,13 @@ export class ComputeStack extends cdk.Stack {
 						// kill switch: Lambda env を 'false' に変更すると約 30 秒で env var 直読経路に巻き戻し。
 						USE_LOOKUP_KEY: useLookupKey,
 						COGNITO_LOGOUT_URL: 'https://ganbari-quest.com/auth/login',
+						// #4367 AC4: BedrockClaudeProvider.isAvailable() は BEDROCK_MODEL_ID の
+						// **明示配布**を可用性条件にする (#4366)。既定値を持っていても配らない限り
+						// AI 提案 / レシート OCR は無効のままなので、ここで配ることが「AWS で
+						// Bedrock を使うと決めた」の唯一の表明になる。IAM (下の bedrock:InvokeModel)
+						// と対で初めて動く。
+						BEDROCK_MODEL_ID: BEDROCK_MODEL_ID,
+						BEDROCK_REGION: BEDROCK_REGION,
 						SES_SENDER_EMAIL: 'noreply@ganbari-quest.com',
 						SES_CONFIG_SET_NAME: 'ganbari-quest-config',
 						// #3438 Phase 2A: DATA_SOURCE=dsql は base env に無条件で含む (旧 dsqlEnabled 上書き撤去)。
@@ -478,6 +504,20 @@ export class ComputeStack extends cdk.Stack {
 				}),
 			);
 		}
+
+		// #4367 AC2: Bedrock 推論権限。prod / staging 共通で付与する (staging は AC5 の実機確認先で、
+		// SES / Cost Explorer と違い外部サービスへの副作用を持たない = 推論のみで保存なし)。
+		//
+		// `bedrock:Converse` という IAM アクションは存在しない — Converse API は
+		// `bedrock:InvokeModel` で認可される (AWS 公式)。Resource は使う 1 モデルの ARN に絞り、
+		// `*` にしない (`*` だと将来 model を増やしたとき権限だけ先に広がり、何が呼べるかが
+		// コードから読めなくなる)。geo inference profile を使わないので ARN は 1 本で足りる。
+		this.fn.addToRolePolicy(
+			new iam.PolicyStatement({
+				actions: ['bedrock:InvokeModel'],
+				resources: [BEDROCK_MODEL_ARN],
+			}),
+		);
 
 		// staging (#2873): SES / Cost Explorer grant は付与しない (本番外部サービスへの
 		// 副作用ゼロ + blast radius 最小化。SES env も非注入のためアプリは送信経路を持たない)。

--- a/src/lib/server/ai/bedrock-claude-provider.ts
+++ b/src/lib/server/ai/bedrock-claude-provider.ts
@@ -21,8 +21,18 @@ import type { AiProvider, ToolDefinition, ToolUseResult } from './provider';
  *
  * **可用性判定には使わない** (#4366)。既定値があること自体は「設定が配られている」ことを意味せず、
  * 既定値を根拠に `isAvailable()` を true にしたのが本欠陥の原因だった。
+ *
+ * **geo inference profile (`us.` 接頭辞) を既定にしない** (#4367 AC3)。`us.` は cross-region
+ * inference profile で、us-east-1 に投げても us-east-2 / us-west-2 で推論されうる。子供の活動
+ * テキストを「運営者が管理する AWS 環境」で処理すると開示している以上 (site/privacy.html 第 3 条 /
+ * 第 10 条、移転先は us-east-1 と明記)、既定は 1 リージョンに閉じる base model ID にする。
+ * Pre-PMF で throughput 冗長性 (profile の利点) は要らない。
+ *
+ * モデル選定 (Haiku 系 latest = 最安最適) は変えない。変えたのは profile → base model の形式のみ。
+ * IAM 側の Resource ARN (`infra/lib/compute-stack.ts` の `BEDROCK_MODEL_ARN`) と対で動くため、
+ * 片方だけ変えると権限が外れて `AccessDeniedException` になる。
  */
-const DEFAULT_MODEL_ID = 'us.anthropic.claude-haiku-4-5-20251001-v1:0';
+const DEFAULT_MODEL_ID = 'anthropic.claude-haiku-4-5-20251001-v1:0';
 
 /**
  * 呼び出しごとに env を読む。module 読込時に固定すると、テストからも運用からも

--- a/tests/unit/architecture/env-distribution-closure.test.ts
+++ b/tests/unit/architecture/env-distribution-closure.test.ts
@@ -381,7 +381,10 @@ const NOT_DISTRIBUTED: Array<{
 			'SCHEMA_VALIDATION_MODE',
 			'LOG_LEVEL',
 			'GEMINI_MODEL',
-			'BEDROCK_REGION',
+			// #4367 AC4: BEDROCK_REGION / BEDROCK_MODEL_ID は「既定値のまま動く上書き用」から
+			// **配る側** に移った (infra/lib/compute-stack.ts)。既定値に委ねると in-Region 固定
+			// (privacy.html 第 10 条の us-east-1) が実行環境の AWS_REGION 次第でずれるため、
+			// リージョンを配布側で明示する。免除宣言はここから外す。
 			'BEDROCK_DISABLED',
 			'VAPID_SUBJECT',
 			'OPS_DOMAIN_COST_JPY',
@@ -397,12 +400,11 @@ const NOT_DISTRIBUTED: Array<{
 		keys: ['PRICING_TRIGGER_MIN_PAID_USERS', 'SKIP_LOCAL_EMAIL_PREVIEW'],
 		why: '既定値のまま動く上書き用の env。未設定が正常系で、開発時にだけ設定する',
 	},
-	{
-		readers: ['app-env-schema'],
-		keys: ['BEDROCK_MODEL_ID'],
-		why: '配ることが「この環境で Bedrock を使う」の意思表示 (#4366)。未配布は異常ではなく "AI 提案を持たない環境" で、BedrockClaudeProvider.isAvailable() が false を返し全 service がキーワード提案に縮退する。既定値で暗黙に有効化すると、未配線と設定済みが区別できず AI が無言で不作動になる (#4366 の欠陥そのもの)。AWS で Bedrock を有効化するか Gemini に寄せるかはオーナー判断',
-		followUp: '#4367',
-	},
+	// #4367: BEDROCK_MODEL_ID の「配らない」宣言はここにあったが、AWS 本番 / staging で
+	// 配ることを決めた (compute-stack.ts) ため削除した。配ることが「この環境で Bedrock を使う」
+	// の意思表示である (#4366) 構造は変わらず、NUC 側は AI_PROVIDER=gemini なので配らない
+	// (reader は channel 集合の OR 判定なので、AWS で配っていれば closure は満たす — 本 file 冒頭
+	// §既知の残課題)。
 	{
 		readers: ['app-env-schema'],
 		keys: ['GITHUB_TOKEN', 'GH_TOKEN'],

--- a/tests/unit/infra/multi-lambda-cdk.test.ts
+++ b/tests/unit/infra/multi-lambda-cdk.test.ts
@@ -549,6 +549,96 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 		}, 60_000);
 	});
 
+	describe('#4367 Bedrock 有効化 (最小権限 + in-Region)', () => {
+		/** 指定 FunctionName の Lambda env Variables を取り出す。 */
+		function envOf(fnName: string): Record<string, unknown> {
+			const functions = computeTemplate.findResources('AWS::Lambda::Function', {
+				Properties: { FunctionName: fnName },
+			});
+			expect(Object.keys(functions).length).toBe(1);
+			const fnDef = Object.values(functions)[0] as {
+				Properties: { Environment?: { Variables?: Record<string, unknown> } };
+			};
+			return fnDef.Properties.Environment?.Variables ?? {};
+		}
+
+		/** IAM Policy の Statement を平坦化する (Action / Resource をそのまま持つ)。 */
+		function allStatements(): Array<Record<string, unknown>> {
+			const policies = computeTemplate.findResources('AWS::IAM::Policy');
+			const out: Array<Record<string, unknown>> = [];
+			for (const policyDef of Object.values(policies)) {
+				const props = (policyDef as { Properties?: Record<string, unknown> }).Properties ?? {};
+				const doc = props.PolicyDocument as
+					| { Statement?: Array<Record<string, unknown>> }
+					| undefined;
+				for (const stmt of doc?.Statement ?? []) out.push(stmt);
+			}
+			return out;
+		}
+
+		function bedrockStatements(): Array<Record<string, unknown>> {
+			return allStatements().filter((stmt) => {
+				const a = stmt.Action;
+				const actions = Array.isArray(a) ? a : typeof a === 'string' ? [a] : [];
+				return actions.some((v) => typeof v === 'string' && v.startsWith('bedrock:'));
+			});
+		}
+
+		// AC2: Lambda 実行ロールに bedrock:InvokeModel を最小権限で付与する。
+		it('AC2: 本番 Lambda role に bedrock:InvokeModel が付き、Resource は base model ARN 1 個 (`*` にしない)', () => {
+			const stmts = bedrockStatements();
+			expect(stmts.length).toBe(1);
+			const stmt = stmts[0];
+
+			const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+			expect(actions).toEqual(['bedrock:InvokeModel']);
+
+			// Resource は wildcard 禁止 (ses / ce の `*` grant と違い、Bedrock は対象モデルを特定できる)
+			const resources = Array.isArray(stmt.Resource) ? stmt.Resource : [stmt.Resource];
+			expect(resources.length).toBe(1);
+			expect(resources[0]).toBe(
+				'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0',
+			);
+			expect(JSON.stringify(resources)).not.toContain('*');
+		});
+
+		// AC4: #4366 で isAvailable() が env の明示配布を要求するため、配らない限り AI は無効のまま。
+		it('AC4: 本番 Fn の env に BEDROCK_MODEL_ID / BEDROCK_REGION が配られる', () => {
+			const envVars = envOf('ganbari-quest-app');
+			expect(envVars.BEDROCK_MODEL_ID).toBe('anthropic.claude-haiku-4-5-20251001-v1:0');
+			expect(envVars.BEDROCK_REGION).toBe('us-east-1');
+			// 対照: 同じ env block の既存値が生きている (検査が空振りしていない)
+			expect(envVars.DATA_SOURCE).toBe('dsql');
+		});
+
+		it('AC3+AC4: 配る model ID は cross-region inference profile ではない (in-Region 固定)', () => {
+			const modelId = envOf('ganbari-quest-app').BEDROCK_MODEL_ID as string;
+			expect(modelId).not.toMatch(/^(us|eu|apac|global)\./);
+			// IAM Resource の ARN と env の model ID が一致する (片方だけ変えると権限が外れる)
+			const stmt = bedrockStatements()[0];
+			const resources = Array.isArray(stmt.Resource) ? stmt.Resource : [stmt.Resource];
+			expect(String(resources[0])).toContain(`/${modelId}`);
+		});
+
+		it('demo Lambda は Bedrock を持たない (env / IAM とも、ADR-0048 role 分離)', () => {
+			const demoEnv = envOf('ganbari-quest-app-demo');
+			expect(demoEnv.BEDROCK_MODEL_ID).toBeUndefined();
+			expect(demoEnv.BEDROCK_REGION).toBeUndefined();
+
+			const policies = computeTemplate.findResources('AWS::IAM::Policy');
+			for (const [policyLogicalId, policyDef] of Object.entries(policies)) {
+				const props = (policyDef as { Properties?: Record<string, unknown> }).Properties ?? {};
+				if (!isPolicyAttachedToDemoRole(props)) continue;
+				for (const action of extractActions(props)) {
+					expect(
+						action.startsWith('bedrock:'),
+						`demo IAM role (policy ${policyLogicalId}) MUST NOT grant ${action}`,
+					).toBe(false);
+				}
+			}
+		});
+	});
+
 	describe('production Lambda preservation (zero regression on prod Fn)', () => {
 		it('production Fn は DATA_SOURCE=dsql + AUTH_MODE=cognito を維持する (#3438 Phase 2A)', () => {
 			const template = computeTemplate;

--- a/tests/unit/infra/multi-lambda-cdk.test.ts
+++ b/tests/unit/infra/multi-lambda-cdk.test.ts
@@ -576,6 +576,15 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 			return out;
 		}
 
+		/** bedrock statement をちょうど 1 本取り出す (0 本 / 2 本以上はここで落とす)。 */
+		function theBedrockStatement(): Record<string, unknown> {
+			const stmts = bedrockStatements();
+			expect(stmts.length, 'bedrock statement はちょうど 1 本であること').toBe(1);
+			const stmt = stmts[0];
+			if (stmt === undefined) throw new Error('bedrock statement が見つかりません');
+			return stmt;
+		}
+
 		function bedrockStatements(): Array<Record<string, unknown>> {
 			return allStatements().filter((stmt) => {
 				const a = stmt.Action;
@@ -586,9 +595,7 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 
 		// AC2: Lambda 実行ロールに bedrock:InvokeModel を最小権限で付与する。
 		it('AC2: 本番 Lambda role に bedrock:InvokeModel が付き、Resource は base model ARN 1 個 (`*` にしない)', () => {
-			const stmts = bedrockStatements();
-			expect(stmts.length).toBe(1);
-			const stmt = stmts[0];
+			const stmt = theBedrockStatement();
 
 			const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
 			expect(actions).toEqual(['bedrock:InvokeModel']);
@@ -615,7 +622,7 @@ describe('ADR-0048 Multi-Lambda Demo Deployment (#2097 week 4)', () => {
 			const modelId = envOf('ganbari-quest-app').BEDROCK_MODEL_ID as string;
 			expect(modelId).not.toMatch(/^(us|eu|apac|global)\./);
 			// IAM Resource の ARN と env の model ID が一致する (片方だけ変えると権限が外れる)
-			const stmt = bedrockStatements()[0];
+			const stmt = theBedrockStatement();
 			const resources = Array.isArray(stmt.Resource) ? stmt.Resource : [stmt.Resource];
 			expect(String(resources[0])).toContain(`/${modelId}`);
 		});

--- a/tests/unit/infra/staging-cdk.test.ts
+++ b/tests/unit/infra/staging-cdk.test.ts
@@ -484,6 +484,28 @@ describe('#2873 AWS staging stack (prod 不変 guard + staging template assert)'
 			});
 		});
 
+		it('Bedrock は staging にも配る (env + 最小権限 IAM、#4367 AC5 の実機確認先)', () => {
+			// AC5 は「staging で AI 提案が実際に動くことを実機確認する」。staging Lambda に env と
+			// 権限が無ければ isAvailable() === false (#4366) のままで、確認自体が成立しない。
+			// SES / Cost Explorer と違い Bedrock は本番外部サービスへの副作用を持たない (推論のみ、
+			// 保存なし) ため、blast radius 最小化の例外にはならない。
+			const functions = stagingCompute.findResources('AWS::Lambda::Function', {
+				Properties: { FunctionName: 'ganbari-quest-staging-app' },
+			});
+			const fnDef = Object.values(functions)[0] as {
+				Properties: { Environment?: { Variables?: Record<string, unknown> } };
+			};
+			const envVars = fnDef.Properties.Environment?.Variables ?? {};
+			expect(envVars.BEDROCK_MODEL_ID).toBe('anthropic.claude-haiku-4-5-20251001-v1:0');
+			expect(envVars.BEDROCK_REGION).toBe('us-east-1');
+
+			const serialized = JSON.stringify(stagingCompute.findResources('AWS::IAM::Policy'));
+			expect(serialized).toContain('bedrock:InvokeModel');
+			expect(serialized).toContain(
+				'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0',
+			);
+		});
+
 		it('staging synth は cronSecret / opsSecretKey 無しで throw しない (#1586 guard の分岐内移動)', () => {
 			// buildStagingStacks() が context に cronSecret / opsSecretKey を渡していないのに
 			// beforeAll で synth が成功していること自体が実証。ここでは明示再構築で assert する。

--- a/tests/unit/server/ai/bedrock-claude-provider.test.ts
+++ b/tests/unit/server/ai/bedrock-claude-provider.test.ts
@@ -130,6 +130,26 @@ describe('BedrockClaudeProvider.converseWithTool()', () => {
 		expect(command.input.modelId).toBe('custom.model-id');
 	});
 
+	it('既定モデルは in-Region の base model ID (cross-region inference profile を既定にしない、#4367 AC3)', async () => {
+		// #4367 AC3: 旧既定 `us.anthropic.claude-haiku-4-5-20251001-v1:0` は cross-region inference
+		// profile で、us-east-1 に投げても us-east-2 / us-west-2 で推論されうる。子供の活動テキストを
+		// 「運営者が管理する AWS 環境」に留める開示 (site/privacy.html 第 3 条 / 第 10 条) の趣旨に
+		// 照らし、既定は 1 リージョンに閉じる base model ID にする。Pre-PMF で throughput 冗長性は不要。
+		//
+		// env 未配布時は isAvailable() === false (#4366) だが、converseWithTool は可用性判定と
+		// 独立に既定値を使うため、ここで既定値そのものを固定できる。
+		delete process.env.BEDROCK_MODEL_ID;
+		const { provider } = await load();
+		mockSend.mockResolvedValueOnce(toolUseResponse({ ok: true }));
+
+		await provider.converseWithTool({ system: 's', userMessage: 'u', tool: TOOL });
+
+		const command = mockSend.mock.calls[0]?.[0] as { input: { modelId: string } };
+		expect(command.input.modelId).toBe('anthropic.claude-haiku-4-5-20251001-v1:0');
+		// geo prefix (us. / eu. / apac. / global.) が付いた瞬間に落ちる
+		expect(command.input.modelId).not.toMatch(/^(us|eu|apac|global)\./);
+	});
+
 	it('tool_use ブロックが無い応答は例外にする (握り潰さない)', async () => {
 		const { provider } = await load();
 		mockSend.mockResolvedValueOnce({ output: { message: { content: [{ text: 'hello' }] } } });


### PR DESCRIPTION
## 顧客価値・目的

AI 提案（活動名からのカテゴリ・アイコン推定 / レシート OCR）が AWS 本番で恒常的に不作動で、顧客にはキーワード規則の結果が「AI の提案」として出ている。その 3 つのブロッカーのうち Dev で塞げる 2 つ（IAM 権限 0 件 / env 未配布）を塞ぎ、あわせて推論を us-east-1 に閉じて、子供の活動テキストの所在を `site/privacy.html` 第 10 条の開示（米国 / us-east-1）と一致させる。

## 関連 Issue

<!-- no-issue-close: #4367 は AC1 / AC5 / AC6（オーナー手番 + staging 実機確認 + 初月コスト実測）が残るため close しない。本 PR は AC2 / AC3 / AC4 のみ -->
Refs #4367 / #4366（`isAvailable()` の明示配布要求 — 本 PR の前提）

## 変更内容

3 つとも**単独で AI を止める**ため、揃って初めて動く。

| AC | 変更 | 場所 |
|---|---|---|
| **AC2** | Lambda 実行ロールに `bedrock:InvokeModel` を付与。Resource は base model ARN **1 本**で `*` にしない | `infra/lib/compute-stack.ts` |
| **AC3** | 既定 model ID を geo inference profile → base model ID | `src/lib/server/ai/bedrock-claude-provider.ts` |
| **AC4** | `BEDROCK_MODEL_ID` / `BEDROCK_REGION` を prod / staging の Lambda env に配布 | `infra/lib/compute-stack.ts` |

- **AC3 で閉じるリージョン**: 旧既定 `us.anthropic.claude-haiku-4-5-20251001-v1:0` の `us.` は cross-region inference profile で、us-east-1 に投げても **us-east-2 / us-west-2 で推論されうる**。base model `anthropic.claude-haiku-4-5-20251001-v1:0` + `BEDROCK_REGION=us-east-1` の明示配布で **us-east-1 の 1 リージョンに閉じる**。**モデル選定は変えていない**（Haiku 系 latest のまま。変えたのは profile → base model の形式だけ）
- **IAM が 1 本で済む理由**: profile を使うなら profile ARN + 対象 3 リージョンの foundation-model ARN を並べる必要がある（AWS 公式の Important）。base model 固定なので 1 本で足りる。`bedrock:Converse` という IAM アクションは存在せず、Converse API は `bedrock:InvokeModel` で認可される
- **staging にも配る理由**: AC5（staging で実機確認）は env と権限が無ければ `isAvailable()` が false のままで成立しない。SES / Cost Explorer と違い Bedrock は外部サービスへの副作用を持たない（推論のみ・保存なし）ので、staging の blast radius 最小化方針の例外にはならない
- **demo Lambda には配らない**（env / IAM とも。ADR-0048 role 分離を維持し、テストで固定した）
- `tests/unit/architecture/env-distribution-closure.test.ts` の「`BEDROCK_MODEL_ID` は配らない」宣言を削除。**gate 自身が stale として検出した**（配り始めたのに免除宣言が残っている、という [EC2] の fail）
- 設計書 `13`（§7.1 モデル / 推論方式 / 認証 / env 表）・`14`（§8.5 実装上の遵守事項）・`07`（活動提案の AI モデル）・`.env.example` を実態に同期（ADR-0001）

## 検証

**failing-test-first**: 3 AC とも先にテストを書き、**5 件が落ちることを確認してから**実装した。

```
# 実装前
npx vitest run tests/unit/server/ai/bedrock-claude-provider.test.ts tests/unit/infra/multi-lambda-cdk.test.ts tests/unit/infra/staging-cdk.test.ts
  → Tests  5 failed | 80 passed (85)     # 追加した 5 件がすべて fail

# 実装後
npx vitest run tests/unit/server/ai/ tests/unit/infra/
  → Test Files  31 passed (31) / Tests  351 passed (351)
npx vitest run tests/unit/architecture/
  → Test Files  55 passed (55) / Tests  409 passed (409)
```

**mutation 検証**（実装を commit した後に `git stash push -- <path>` で戻す方式。4 件すべて検出された）:

| # | 壊した内容 | 結果 |
|---|---|---|
| M1 | 既定 model ID を `us.` profile に戻す | `bedrock-claude-provider.test.ts` 1 fail |
| M2 | IAM Resource を `*` にする | `multi-lambda-cdk.test.ts` AC2 fail |
| M3 | prod env の 2 行を削除 | `multi-lambda-cdk.test.ts` AC4 / AC3+AC4 fail |
| M4 | staging env の 2 行を削除 | `staging-cdk.test.ts` staging fail |

対照 assert も置いた（AC4 は同 env block の `DATA_SOURCE=dsql` が生きていること、AC2 は bedrock statement が 1 本であること）。#4404 が入れた「context を渡しても `GEMINI_API_KEY` が付かない」テストと同じ形。

**CDK synth（本番 stack、exit 0）**:

```yaml
- Action: bedrock:InvokeModel
  Effect: Allow
  Resource: arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-haiku-4-5-20251001-v1:0
...
  BEDROCK_MODEL_ID: anthropic.claude-haiku-4-5-20251001-v1:0
  BEDROCK_REGION: us-east-1
```

**CDK diff（deploy 済み本番 stack との差分）**: `[+] "Action": "bedrock:InvokeModel"` / `[+] Added: .BEDROCK_MODEL_ID` / `[+] Added: .BEDROCK_REGION`。**replacement / destroy は 0 件**（IAM statement 追加 + env 追加のみ）。

**未実行**:

- **本番 / staging への deploy は行っていない**（synth / diff まで）。AC5（staging で AI 提案が実際に動くことの実機確認）は deploy 後に行う。Issue #4367 に AC5 として残っている
- **実 Bedrock への Converse は投げていない**。base model ID 直指定が実際に通るかは AC5 で確定させる（オーナーの実測 2026-08-07 は `us.` profile 経由で成功しており、base model ID での呼び出しは未検証。`get-foundation-model-availability` は base model ID で `AVAILABLE` / `AUTHORIZED` を返している）

## 影響範囲

- **顧客に見える変化**: deploy 後、AI 提案 4 経路と領収書 OCR がキーワード規則から実 AI に切り替わる（`activity-suggest-service.ts` の `suggestByKeywords()` フォールバックを抜ける）。#4391 の alarm `ganbari-quest-ai-provider-unavailable` が鳴り止むはず
- UI 変更なし — infra (CDK) と server 側の設定のみで、画面の描画に差分は出ない（AI 提案の**中身**は変わるが、それは deploy 後に実データで現れるもので、この diff の描画差分ではない）
- **触った並行実装ペア**: prod Lambda env / staging Lambda env（同じ値を両方に配布）。demo Lambda は意図的に非対象で、テストで固定
- **破壊的変更**: なし。既存 env / IAM の削除・変更は無く、追加のみ
- **法務文書の判断（ADR-0001 / ADR-0013）**: `site/privacy.html` は**変更不要**。第 3 条は Bedrock を「AWS 環境内で処理」、第 10 条は移転先を「米国 / AWS us-east-1」と既に開示しており、本 PR は**開示に実体を寄せる方向**（`us.` profile なら別リージョンで推論されうる状態を us-east-1 に固定する）。開示範囲は広がらないため新たな同意取得も不要。判断根拠は `docs/design/14-セキュリティ設計書.md` §8.5 に残した
- なお Issue 本文の補足にある `site/privacy.html` の「DynamoDB」記述は**現時点で 0 件**（`grep -c DynamoDB site/privacy.html` → 0）。既に是正済みで、本 PR で触るものはない

## 配布済み env / secret (ADR-0006)

新規 secret はなし（Bedrock の認証は IAM ロールで、API キーを増やさない）。**値がコードに固定された env を 2 本 Lambda に配布**する:

- 配布済み: BEDROCK_MODEL_ID（`infra/lib/compute-stack.ts` → prod / staging Lambda env。GitHub Secret 不要）
- 配布済み: BEDROCK_REGION（同上）

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

`infra/**` を触るため label が自動付与された。**本 PR に新規のオーナー判断事項は無い**（Bedrock 有効化は 2026-08-07 のオーナー決裁済み、AC3 の in-Region 化は「AWS の外に出さない」の徹底であって二択ではない）。⑤ は Yes/No を問う質問ではなく **決定事項の確認**である。

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🟢 可逆: IAM 1 文 + env 2 本の追加のみ"]
    R2["顧客面: 親が見る提案の中身が変わる"]
    R3["revert で戻る。データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: AI 提案が実 AI になる"]
    T2["捨てる: profile の throughput 冗長性"]
    T3["🟡 負う: Bedrock 従量課金 (単価未確認)"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: 単価未確認 + 予算 alarm 無し"]
    O2["UX: 全顧客同時切替、即時 kill-switch 無し"]
    O3["security: 送信先は絞ったが送信内容は未検査"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 UI 差分なし。提案の中身が deploy 後に変わる"]
  end
  subgraph ASK["⑤ 決定事項の確認 (新規の問いなし)"]
    Q1["決裁済: Bedrock 有効化 2026-08-07"]
    Q2["決定: 推論を us-east-1 に固定 (開示と一致)"]
    Q3["残: AC5 実機確認 / AC6 初月コスト実測"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R2 danger
  class T2,T3,O1,O2,O3 warn
  class R1,R3,T1,C1 ok
  class Q1,Q2,Q3 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠)</summary>

③ は `tmp/adversarial-evidence/4444.json`（`scripts/verify-adversarial-output.mjs` で schema PASS）からの転記。3 件とも本 PR の scope 外に着地する:

- **business（単価・予算）** → Issue #4367 の AC6（オーナー手番、初月の Cost Explorer 実測）で既に追跡されている
- **UX（切替の即時 kill-switch）** → `BEDROCK_DISABLED` を手で Lambda env に入れても次の deploy で消える（`infra/CLAUDE.md` §Lambda env の SSOT は CDK）。即時停止が要るなら CDK に kill-switch を足す形になるが、AI 提案は失敗しても `suggestByKeywords()` に縮退して顧客は操作を続けられるため、Pre-PMF では足していない
- **security（送信内容の検査）** → Bedrock へ送る payload に識別子が無いことを機械検査する仕組みは無い（`external-ai-client-boundary.test.ts` は SDK の import 先を固定するだけで payload は見ていない、実測）。Issue #4367 のオーナーコメントが「Bedrock へ送る payload の規律」を**本件と独立した論点**として切り出しているため、本 PR では混ぜない

② の「捨てる」= cross-region inference profile の throughput 冗長性。Pre-PMF の負荷では不要で、代わりに推論のリージョンが確定する。④ の根拠: 変更は `infra/lib/compute-stack.ts` と `bedrock-claude-provider.ts` の既定値のみで `.svelte` の変更は 0 件。

</details>
