### PR TITLE
fix: #4445 dependabot lane 判定を「全 commit が bot」で判定する

### DIFF
--- a/.github/workflows/integration-attest.yml
+++ b/.github/workflows/integration-attest.yml
@@ -40,10 +40,12 @@ concurrency:
   cancel-in-progress: false
 
 # actions/attest の必須権限 (id-token: Sigstore OIDC / attestations: GH attestations API write)。
+# pull-requests: read は actions/pr-lane が commit author 精査 (#4445) に使う `pulls/{n}/commits` 取得用。
 permissions:
   contents: read
   id-token: write
   attestations: write
+  pull-requests: read
 
 jobs:
   attest:

--- a/.github/workflows/pr-lane-smoke.yml
+++ b/.github/workflows/pr-lane-smoke.yml
@@ -37,6 +37,8 @@ on:
 
 permissions:
   contents: read
+  # actions/pr-lane が commit author 精査 (#4445) に使う `pulls/{n}/commits` 取得用
+  pull-requests: read
 
 jobs:
   lane-smoke:

--- a/actions/pr-lane/action.yml
+++ b/actions/pr-lane/action.yml
@@ -27,11 +27,24 @@
 #
 # resolve-base-branch.mjs (#2959、クライアント tooling 用) との責務分担は
 # scripts/pr-lane.mjs の冒頭コメントを参照 (CI gate 用 vs local tooling 用で別 SSOT)。
+#
+# 【bot 判定の commit 精査 (#4445)】
+#   旧実装は actor (PR 作成者) だけを見ていたため、dependabot PR に人が commit を積んでも
+#   `dependabot` lane のままになり PR テンプレート系 gate が丸ごと skip されていた (実測 PR #4422)。
+#   actor が bot のときだけ `pulls/{n}/commits` を 1 回 fetch し、**非マージ commit** (parents=1)
+#   の author login を `scripts/pr-lane.mjs --commit-authors` に渡して「全 commit が bot か」を
+#   追加検証する。マージ commit (branch 同期、`git merge origin/develop` 等) は対象から除外する —
+#   実測で複数の bot-only PR に `git config` 由来の human email を持つ「中身が空の branch 同期
+#   マージ commit」が混在しており (#4272 / #4271 / #4251)、これを人間 commit として数えると
+#   実際にはコードを書いていない bot-only PR まで gate 対象になってしまうため。
+#   commit 取得に失敗した場合 (権限不足 / API error) は `--commit-authors` を渡さず、
+#   scripts/pr-lane.mjs 側の fail-open (actor のみ判定) にフォールバックする。
 
 name: 'PR Lane Classifier'
 description: >-
   Classify a pull request into one of 4 lanes (feature / integration / hotfix / dependabot)
-  from base/head/actor using scripts/pr-lane.mjs (SSOT). Lightweight wiring only — no logic.
+  from base/head/actor (+ non-merge commit authors for bot exemption, #4445) using
+  scripts/pr-lane.mjs (SSOT). Lightweight wiring only — no logic.
 
 inputs:
   base-ref:
@@ -46,6 +59,12 @@ inputs:
     description: 'PR author login (default: github.actor). bot 判定に使用。'
     required: false
     default: ${{ github.actor }}
+  pr-number:
+    description: >-
+      PR number (default: github.event.pull_request.number)。actor が bot のときのみ、
+      非マージ commit の author 一覧を取得するために使用 (#4445)。空なら commit 精査を skip する。
+    required: false
+    default: ${{ github.event.pull_request.number }}
 
 outputs:
   lane:
@@ -55,6 +74,31 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    - name: Resolve non-merge commit authors for bot exemption check (#4445)
+      id: commits
+      if: inputs.actor == 'dependabot[bot]' || inputs.actor == 'renovate[bot]'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ inputs.pr-number }}
+      run: |
+        set -uo pipefail
+        if [ -z "${PR_NUMBER}" ]; then
+          echo "authors=" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+        # 非マージ commit (parents=1) のみ対象。login 未解決 (bot 判定に使えない) は空文字として残し
+        # scripts/pr-lane.mjs 側で「人間扱い (fail-closed)」させる。
+        authors="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits" --paginate \
+          --jq '[.[] | select((.parents | length) == 1) | (.author.login // "")] | join(",")' 2>/dev/null)"
+        if [ $? -ne 0 ]; then
+          echo "::warning::[actions/pr-lane] commit author 取得に失敗しました。actor のみで判定します (fail-open)。"
+          echo "authors=" >> "${GITHUB_OUTPUT}"
+        else
+          echo "authors=${authors}" >> "${GITHUB_OUTPUT}"
+        fi
+
     - name: Classify PR lane (scripts/pr-lane.mjs SSOT)
       id: classify
       shell: bash
@@ -63,9 +107,13 @@ runs:
         PR_LANE_BASE: ${{ inputs.base-ref }}
         PR_LANE_HEAD: ${{ inputs.head-ref }}
         PR_LANE_ACTOR: ${{ inputs.actor }}
+        PR_LANE_COMMIT_AUTHORS: ${{ steps.commits.outputs.authors }}
       run: |
         set -euo pipefail
-        lane="$(node "${GITHUB_ACTION_PATH}/../../scripts/pr-lane.mjs" \
-          --base "${PR_LANE_BASE}" --head "${PR_LANE_HEAD}" --actor "${PR_LANE_ACTOR}")"
-        echo "Classified lane: ${lane} (base=${PR_LANE_BASE} head=${PR_LANE_HEAD} actor=${PR_LANE_ACTOR})"
+        args=(--base "${PR_LANE_BASE}" --head "${PR_LANE_HEAD}" --actor "${PR_LANE_ACTOR}")
+        if [ -n "${PR_LANE_COMMIT_AUTHORS}" ]; then
+          args+=(--commit-authors "${PR_LANE_COMMIT_AUTHORS}")
+        fi
+        lane="$(node "${GITHUB_ACTION_PATH}/../../scripts/pr-lane.mjs" "${args[@]}")"
+        echo "Classified lane: ${lane} (base=${PR_LANE_BASE} head=${PR_LANE_HEAD} actor=${PR_LANE_ACTOR} commit-authors=${PR_LANE_COMMIT_AUTHORS})"
         echo "lane=${lane}" >> "${GITHUB_OUTPUT}"

--- a/scripts/pr-lane.mjs
+++ b/scripts/pr-lane.mjs
@@ -22,22 +22,51 @@ export const BOT_ACTORS = Object.freeze(['dependabot[bot]', 'renovate[bot]']);
 const BOT_ACTOR_SET = new Set(BOT_ACTORS);
 
 /**
+ * `commitAuthors` が「全 commit が bot」であることを保証しているかを判定する (#4445)。
+ *
+ * `scripts/pr-lane.mjs` の lane 判定は従来 PR 作成者 (actor) だけを見ていたため、dependabot PR に
+ * 人が commit を積んでも `dependabot` lane のまま緩和が続いてしまっていた (実測: PR #4422)。
+ * `commitAuthors` (PR 上の非マージ commit の author login 一覧) を渡すことで「actor が bot でも
+ * commit の中に人間が混ざっていれば dependabot exempt を打ち切る」判定を追加する。
+ *
+ * - `undefined` (未指定): 呼び出し側が commit 情報を持たない旧来呼び出し。**後方互換のため
+ *   actor のみで判定する** (常に bot-only とみなす)。
+ * - 空配列: commit 取得に失敗した等で情報が欠落しているケース。fail-open で bot-only とみなし、
+ *   既存の bot-only PR の緩和を壊さない (可用性優先。actor 判定単独の従来挙動と同じ安全域)。
+ * - 非空配列: 各要素が `BOT_ACTORS` に含まれるかを厳密判定する。login が解決できない commit
+ *   (`author.login` が null → 呼び出し側で `''` に変換) は **人間扱い** とし fail-closed にする
+ *   (bot を誤って見逃さない方を優先)。
+ *
+ * @param {readonly string[] | undefined} commitAuthors
+ * @returns {boolean}
+ */
+function isBotOnlyCommits(commitAuthors) {
+	if (commitAuthors === undefined) return true;
+	if (!Array.isArray(commitAuthors) || commitAuthors.length === 0) return true;
+	return commitAuthors.every((a) => BOT_ACTOR_SET.has((a ?? '').trim()));
+}
+
+/**
  * PR lane 判定の純粋関数 (unit test 対象、AC1)。副作用なし (AC6)。
  *
  * @param {{
  *   baseRef: string;   // PR の base branch 名 (例: 'main' / 'develop')。GitHub Actions では `github.base_ref`
  *   headRef: string;   // PR の head branch 名 (例: 'develop' / 'feat/123-x' / 'fix/999')。`github.head_ref`
  *   actor: string;     // PR を作成した actor (例: 'Takenori-Kusaka' / 'dependabot[bot]')。`github.actor`
+ *   commitAuthors?: readonly string[]; // PR 上の非マージ commit の author login 一覧 (#4445、任意)。
+ *     未指定なら actor のみで判定 (後方互換)。マージ commit (branch 同期等) は呼び出し側で除外して渡すこと。
  * }} input
  * @returns {'feature' | 'integration' | 'hotfix' | 'dependabot'}
  */
-export function classifyLane({ baseRef, headRef, actor }) {
+export function classifyLane({ baseRef, headRef, actor, commitAuthors }) {
 	const base = (baseRef ?? '').trim();
 	const head = (headRef ?? '').trim();
 	const who = (actor ?? '').trim();
 
-	// 1. bot は base/head より優先 (Dependabot exempt を lane の 1 種として吸収、BOT_ACTORS SSOT)
-	if (BOT_ACTOR_SET.has(who)) return 'dependabot';
+	// 1. bot は base/head より優先 (Dependabot exempt を lane の 1 種として吸収、BOT_ACTORS SSOT)。
+	//    ただし commitAuthors が渡され、かつ人間の commit が混ざっている場合は exempt を打ち切り
+	//    通常の base/head 判定にフォールスルーする (#4445)。
+	if (BOT_ACTOR_SET.has(who) && isBotOnlyCommits(commitAuthors)) return 'dependabot';
 	// 2. develop → main または release/* → main = 統合 PR (重量レーン)
 	//    release/* は develop の凍結コミットから cut した統合標的 (branch-strategy.md §3)。
 	if (base === 'main' && (head === 'develop' || head.startsWith('release/'))) return 'integration';
@@ -50,15 +79,18 @@ export function classifyLane({ baseRef, headRef, actor }) {
 }
 
 /**
- * 簡易 argv パーサ (--base / --head / --actor)。pure 関数ではないが
+ * 簡易 argv パーサ (--base / --head / --actor / --commit-authors)。pure 関数ではないが
  * classifyLane の入力収集に限定し、判定 logic は持たない。
  *
+ * `--commit-authors` はカンマ区切りの login 一覧 (#4445)。未指定 or 空文字なら `commitAuthors`
+ * は `undefined` のまま返し、classifyLane の後方互換フォールバック (actor のみ判定) に委ねる。
+ *
  * @param {string[]} argv process.argv.slice(2)
- * @returns {{ baseRef: string; headRef: string; actor: string }}
+ * @returns {{ baseRef: string; headRef: string; actor: string; commitAuthors: string[] | undefined }}
  */
 export function parseArgs(argv) {
 	/** @type {Record<string, string>} */
-	const out = { base: '', head: '', actor: '' };
+	const out = { base: '', head: '', actor: '', 'commit-authors': '' };
 	for (let i = 0; i < argv.length; i += 1) {
 		const arg = argv[i];
 		if (arg === undefined || !arg.startsWith('--')) continue;
@@ -72,19 +104,25 @@ export function parseArgs(argv) {
 			i += 1;
 		}
 	}
-	return { baseRef: out.base ?? '', headRef: out.head ?? '', actor: out.actor ?? '' };
+	const rawCommitAuthors = out['commit-authors'] ?? '';
+	return {
+		baseRef: out.base ?? '',
+		headRef: out.head ?? '',
+		actor: out.actor ?? '',
+		commitAuthors: rawCommitAuthors === '' ? undefined : rawCommitAuthors.split(',').map((s) => s.trim()),
+	};
 }
 
 const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
-	const { baseRef, headRef, actor } = parseArgs(process.argv.slice(2));
+	const { baseRef, headRef, actor, commitAuthors } = parseArgs(process.argv.slice(2));
 	if (!baseRef && !headRef && !actor) {
 		console.error(
-			'[pr-lane] Usage: node scripts/pr-lane.mjs --base <baseRef> --head <headRef> --actor <actor>',
+			'[pr-lane] Usage: node scripts/pr-lane.mjs --base <baseRef> --head <headRef> --actor <actor> [--commit-authors <a,b,...>]',
 		);
 		process.exit(2);
 	}
-	process.stdout.write(`${classifyLane({ baseRef, headRef, actor })}\n`);
+	process.stdout.write(`${classifyLane({ baseRef, headRef, actor, commitAuthors })}\n`);
 	process.exit(0);
 }

--- a/scripts/pr-lane.mjs
+++ b/scripts/pr-lane.mjs
@@ -53,8 +53,7 @@ function isBotOnlyCommits(commitAuthors) {
  *   baseRef: string;   // PR の base branch 名 (例: 'main' / 'develop')。GitHub Actions では `github.base_ref`
  *   headRef: string;   // PR の head branch 名 (例: 'develop' / 'feat/123-x' / 'fix/999')。`github.head_ref`
  *   actor: string;     // PR を作成した actor (例: 'Takenori-Kusaka' / 'dependabot[bot]')。`github.actor`
- *   commitAuthors?: readonly string[]; // PR 上の非マージ commit の author login 一覧 (#4445、任意)。
- *     未指定なら actor のみで判定 (後方互換)。マージ commit (branch 同期等) は呼び出し側で除外して渡すこと。
+ *   commitAuthors?: readonly string[]; // PR 上の非マージ commit の author login 一覧 (#4445、任意)。未指定なら actor のみで判定 (後方互換)。マージ commit (branch 同期等) は呼び出し側で除外して渡すこと。
  * }} input
  * @returns {'feature' | 'integration' | 'hotfix' | 'dependabot'}
  */

--- a/scripts/pr-lane.mjs
+++ b/scripts/pr-lane.mjs
@@ -109,7 +109,8 @@ export function parseArgs(argv) {
 		baseRef: out.base ?? '',
 		headRef: out.head ?? '',
 		actor: out.actor ?? '',
-		commitAuthors: rawCommitAuthors === '' ? undefined : rawCommitAuthors.split(',').map((s) => s.trim()),
+		commitAuthors:
+			rawCommitAuthors === '' ? undefined : rawCommitAuthors.split(',').map((s) => s.trim()),
 	};
 }
 

--- a/tests/unit/github/pr-lane.test.ts
+++ b/tests/unit/github/pr-lane.test.ts
@@ -290,7 +290,16 @@ describe('parseArgs (#2943 AC5 CLI)', () => {
 
 	it('--commit-authors はカンマ区切りで配列にパースされる (#4445)', () => {
 		expect(
-			parseArgs(['--base', 'develop', '--head', 'x', '--actor', 'dependabot[bot]', '--commit-authors', 'dependabot[bot],Takenori-Kusaka']),
+			parseArgs([
+				'--base',
+				'develop',
+				'--head',
+				'x',
+				'--actor',
+				'dependabot[bot]',
+				'--commit-authors',
+				'dependabot[bot],Takenori-Kusaka',
+			]),
 		).toEqual({
 			baseRef: 'develop',
 			headRef: 'x',
@@ -300,12 +309,15 @@ describe('parseArgs (#2943 AC5 CLI)', () => {
 	});
 
 	it('--commit-authors 未指定時は commitAuthors が undefined のまま (後方互換)', () => {
-		expect(parseArgs(['--base', 'develop', '--head', 'x', '--actor', 'y']).commitAuthors).toBeUndefined();
+		expect(
+			parseArgs(['--base', 'develop', '--head', 'x', '--actor', 'y']).commitAuthors,
+		).toBeUndefined();
 	});
 
 	it('--commit-authors="" (空文字) は commitAuthors が undefined 扱い (fetch 失敗等の fail-open 経路)', () => {
 		expect(
-			parseArgs(['--base', 'develop', '--head', 'x', '--actor', 'y', '--commit-authors', '']).commitAuthors,
+			parseArgs(['--base', 'develop', '--head', 'x', '--actor', 'y', '--commit-authors', ''])
+				.commitAuthors,
 		).toBeUndefined();
 	});
 

--- a/tests/unit/github/pr-lane.test.ts
+++ b/tests/unit/github/pr-lane.test.ts
@@ -143,6 +143,102 @@ describe('classifyLane (#2943 AC1/AC2)', () => {
 	});
 });
 
+describe('commitAuthors — 全 commit が bot かどうかで dependabot exempt を判定 (#4445)', () => {
+	it('actor が bot で commitAuthors 未指定 (旧呼び出し) は従来どおり dependabot (後方互換)', () => {
+		expect(classifyLane({ baseRef: 'develop', headRef: 'fix/x', actor: 'dependabot[bot]' })).toBe(
+			'dependabot',
+		);
+	});
+
+	it('actor が bot で commitAuthors が全て bot なら dependabot lane を維持する (bot のみ PR の緩和は不変)', () => {
+		expect(
+			classifyLane({
+				baseRef: 'develop',
+				headRef: 'dependabot/npm_and_yarn/x',
+				actor: 'dependabot[bot]',
+				commitAuthors: ['dependabot[bot]'],
+			}),
+		).toBe('dependabot');
+	});
+
+	it('actor が bot でも commitAuthors に人間が 1 件でも混ざれば dependabot lane から外れる (#4445 実測 PR #4422 相当)', () => {
+		expect(
+			classifyLane({
+				baseRef: 'develop',
+				headRef: 'dependabot/npm_and_yarn/infra/x',
+				actor: 'dependabot[bot]',
+				commitAuthors: ['dependabot[bot]', 'Takenori-Kusaka', 'ganbariquestsupport-lab'],
+			}),
+		).not.toBe('dependabot');
+	});
+
+	it('人間混入時は通常の base/head 判定にフォールスルーする (base develop → feature)', () => {
+		expect(
+			classifyLane({
+				baseRef: 'develop',
+				headRef: 'dependabot/npm_and_yarn/infra/x',
+				actor: 'dependabot[bot]',
+				commitAuthors: ['dependabot[bot]', 'Takenori-Kusaka'],
+			}),
+		).toBe('feature');
+	});
+
+	it('人間混入時は base main / head fix/* なら hotfix にフォールスルーする', () => {
+		expect(
+			classifyLane({
+				baseRef: 'main',
+				headRef: 'fix/dependabot-manual-follow-up',
+				actor: 'dependabot[bot]',
+				commitAuthors: ['dependabot[bot]', 'Takenori-Kusaka'],
+			}),
+		).toBe('hotfix');
+	});
+
+	it('commitAuthors が空配列 (fetch 失敗等で不明) の場合は fail-open で従来どおり dependabot を維持する', () => {
+		expect(
+			classifyLane({
+				baseRef: 'develop',
+				headRef: 'fix/x',
+				actor: 'dependabot[bot]',
+				commitAuthors: [],
+			}),
+		).toBe('dependabot');
+	});
+
+	it('renovate[bot] actor でも同様に commitAuthors 混入で dependabot lane から外れる', () => {
+		expect(
+			classifyLane({
+				baseRef: 'develop',
+				headRef: 'renovate/x',
+				actor: 'renovate[bot]',
+				commitAuthors: ['renovate[bot]', 'someone'],
+			}),
+		).not.toBe('dependabot');
+	});
+
+	it('login 未解決 (null → 空文字) の commit author は人間扱いとして扱う (fail-closed、bot 誤認防止)', () => {
+		expect(
+			classifyLane({
+				baseRef: 'develop',
+				headRef: 'dependabot/npm_and_yarn/x',
+				actor: 'dependabot[bot]',
+				commitAuthors: ['dependabot[bot]', ''],
+			}),
+		).not.toBe('dependabot');
+	});
+
+	it('actor が human の PR は commitAuthors の影響を受けない (bot 判定の対象外)', () => {
+		expect(
+			classifyLane({
+				baseRef: 'develop',
+				headRef: 'feat/x',
+				actor: 'Takenori-Kusaka',
+				commitAuthors: ['dependabot[bot]'],
+			}),
+		).toBe('feature');
+	});
+});
+
 describe('BOT_ACTORS SSOT (#2947 AC1)', () => {
 	it('bot lane の actor 集合を named export する (dependabot[bot] / renovate[bot])', () => {
 		expect(BOT_ACTORS).toEqual(['dependabot[bot]', 'renovate[bot]']);
@@ -190,5 +286,40 @@ describe('parseArgs (#2943 AC5 CLI)', () => {
 			'x',
 		]);
 		expect(classifyLane({ baseRef, headRef, actor })).toBe('integration');
+	});
+
+	it('--commit-authors はカンマ区切りで配列にパースされる (#4445)', () => {
+		expect(
+			parseArgs(['--base', 'develop', '--head', 'x', '--actor', 'dependabot[bot]', '--commit-authors', 'dependabot[bot],Takenori-Kusaka']),
+		).toEqual({
+			baseRef: 'develop',
+			headRef: 'x',
+			actor: 'dependabot[bot]',
+			commitAuthors: ['dependabot[bot]', 'Takenori-Kusaka'],
+		});
+	});
+
+	it('--commit-authors 未指定時は commitAuthors が undefined のまま (後方互換)', () => {
+		expect(parseArgs(['--base', 'develop', '--head', 'x', '--actor', 'y']).commitAuthors).toBeUndefined();
+	});
+
+	it('--commit-authors="" (空文字) は commitAuthors が undefined 扱い (fetch 失敗等の fail-open 経路)', () => {
+		expect(
+			parseArgs(['--base', 'develop', '--head', 'x', '--actor', 'y', '--commit-authors', '']).commitAuthors,
+		).toBeUndefined();
+	});
+
+	it('parseArgs + classifyLane の結合: commit-authors 混入で dependabot lane から外れる (AC5 経路 #4445)', () => {
+		const { baseRef, headRef, actor, commitAuthors } = parseArgs([
+			'--base',
+			'develop',
+			'--head',
+			'dependabot/x',
+			'--actor',
+			'dependabot[bot]',
+			'--commit-authors',
+			'dependabot[bot],Takenori-Kusaka',
+		]);
+		expect(classifyLane({ baseRef, headRef, actor, commitAuthors })).toBe('feature');
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: システム全体（開発基盤 / CI ガバナンス）

**解決する課題**: `scripts/pr-lane.mjs` の lane 判定が PR 作成者 (`actor`) だけを見ていたため、dependabot PR に人が commit を積んでも `dependabot` lane のままになり、PR テンプレート系 gate（PR body 検証 / AC マップ / チェックリスト / title→label / main-pr-base-guard）が全て skip されていた（実測: PR #4422）。人が書いた CI workflow 変更が証跡検証を 1 つも通らずに merge できる状態だった。

**期待される効果**: dependabot PR に人間の commit が混ざった時点で通常の PR レーン（feature/hotfix/integration）に正しく分類され、証跡検証 gate が発火する。一方で bot のみで完結する PR の緩和は維持され、緩和の意味を壊さない。

## 関連 Issue

Closes #4445

## 変更内容

`scripts/pr-lane.mjs` の `classifyLane` に `commitAuthors`（PR 上の非マージ commit の author login 一覧、任意）を追加し、actor が bot（`dependabot[bot]` / `renovate[bot]`）でも commit に人間が混ざっていれば `dependabot` lane から外し、通常の base/head 判定にフォールスルーするようにした。`commitAuthors` 未指定時は従来どおり actor のみで判定する（後方互換）。

composite action `actions/pr-lane` は actor が bot のときだけ `pulls/{n}/commits` を fetch し、**非マージ commit**（`parents.length === 1`）の author login を `--commit-authors` に渡す。branch 同期のためのマージ commit（`git merge origin/develop` 等）は対象から除外する。fetch 失敗時は `--commit-authors` を渡さず fail-open（actor のみ判定）にフォールバックする。

呼び出し元のうち `pull-requests: read` 権限を持たなかった 2 workflow（`integration-attest.yml` / `pr-lane-smoke.yml`）に同権限を追加した。

## AC 検証マップ (ADR-0004)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | 人の commit を含む dependabot PR が `dependabot` lane に分類されない | `npx vitest run tests/unit/github/pr-lane.test.ts` + `node scripts/pr-lane.mjs --base develop --head dependabot/x --actor "dependabot[bot]" --commit-authors "dependabot[bot],Takenori-Kusaka"` | HEAD `2d3fdb56d` / 39 passed / CLI 出力 `feature`（`dependabot` から外れることを実行確認） |
| AC2 | bot のみの PR は従来どおり緩和される（意図的に bot のみ PR を作って挙動が変わらないことを実証） | `node scripts/pr-lane.mjs --base develop --head dependabot/x --actor "dependabot[bot]" --commit-authors "dependabot[bot]"` + `tests/unit/github/pr-lane.test.ts` の `commitAuthors 未指定` / `全て bot` テスト | HEAD `2d3fdb56d` / CLI 出力 `dependabot`（維持を実行確認）。既存 39 テストのうち旧 actor-only 挙動の回帰テスト（`BOT_ACTORS SSOT` describe ブロック等）も全 PASS |
| AC3 | 判定変更の影響（既存 PR が通せるか）を実測して記録した | `gh api repos/Takenori-Kusaka/ganbari-quest/pulls/<N>/commits` を直近 merge 済み dependabot PR 31 件（#4425〜#3310）に実行、各 commit の author / parents を確認 | 実測: 31 件中、人間 commit を含むのは **#4422**（実測起点）と **#3311**（better-sqlite3 除外の追加 commit）の 2 件のみ。#4272 / #4271 / #4251 には `git merge origin/develop` の branch 同期マージ commit が human email で残っていたが、これは非マージでない = parents=2 のため除外対象。新判定でも影響を受けない（詳細は「検証」節） |
| AC4 | 上記を機械検証するテストがある | `tests/unit/github/pr-lane.test.ts` の `describe('commitAuthors — 全 commit が bot かどうかで dependabot exempt を判定 (#4445)')` + `parseArgs` の `--commit-authors` テスト | HEAD `2d3fdb56d` / 39 passed（新規 16 テスト追加、failing-test-first で実装前に red を確認済み） |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## 影響範囲

UI 画面への影響なし。CI gate (`.github/workflows/pr-template-gate.yml` / `pr-ac-verification-check.yml` / `pr-merge-gate.yml` / `pr-quality-gate.yml` / `integration-attest.yml` / `pr-lane-smoke.yml`) が composite action `actions/pr-lane` 経由で参照する lane 判定ロジックのみ変更。破壊的変更なし（`commitAuthors` は optional 引数で追加、既存呼び出しは全て後方互換）。

### 横展開チェック

- [ ] **並行実装ペア**を同期した（labels SSOT / 5 年齢モード / ナビ 3 種 / E2E・unit seed / チュートリアル）
- [ ] **設計書同期** (ADR-0001): 影響する `docs/design/` を同 PR で更新
- [ ] **LP ↔ アプリ整合** (ADR-0013): LP 記載が実装と一致。Aspirational を LP に新規追加していない
- [ ] **重量 e2e 敏感領域**に触れる場合、該当 spec のローカル実行ログを本文に貼った
- [x] N/A — 上記いずれも影響範囲外（CI gate script のみ、UI / DB / LP 非関連）

## テスト・品質セルフチェック

| テスト種別 | コマンド | 結果 |
|---|---|---|
| pre-ready | `npm run pre-ready -- --pr 4446` | PASS（下記「検証」節に詳細） |
| 追加・変更テスト | `npx vitest run tests/unit/github/pr-lane.test.ts` | PASS（39 passed） |

- [x] **SOLID / DRY / YAGNI**: `isBotOnlyCommits` を単一責任関数として分離、`classifyLane` は既存の pure function 構造を維持。`commitAuthors` 未指定時は既存ロジックへの完全後方互換フォールバックとし重複実装なし
- [x] **Security（OSS 公開前提）**: 秘密情報・内部 URL の hardcode なし。`gh api` 呼び出しは `github.token`（既定 GITHUB_TOKEN）のみ使用、新規 secret 追加なし
- [x] **A11y・パフォーマンス**: UI 変更なし N/A。commit fetch は actor が bot のときのみ発火する条件付き step とし、全 PR に無条件でオーバーヘッドを追加しない
- [x] **Critical バグ修正**(ADR-0002): 該当なし（`priority:high`、critical ではない）N/A

## スクリーンショット / ビジュアルデモ

該当なし（UI 変更を含まない CI script / workflow の修正）

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**:

マージ commit（`parents.length === 2`）を「非マージ」判定から除外する設計判断についてレビューをお願いします。実測（#4272 / #4271 / #4251）で、branch 同期のためのマージ commit が human の git config（email/name）で記録されているケースが確認され、これを人間 commit としてカウントすると中身の無い bot-only PR まで gate 対象になってしまうため除外しました。一方、実際に人間が意味のあるコードを書いた commit（#4422 / #3311）は全て非マージ commit（parents=1）で構成されており、本設計判断による見逃しは実測範囲では確認されていません。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更時: SS が GitHub 上で表示確認 + DOM HTML 併記 + DESIGN.md §9 禁忌 6 点を目視確認（該当なし）
- [x] 認証画面変更時: `npm run dev:cognito` (#1026) で実ブラウザ操作した SS を添付（該当なし）

## QM レビュー結果

[QM 5 手順 approve body は `docs/sessions/qm-session.md` を参照](../docs/sessions/qm-session.md)

## 検証

### 影響実測（AC3 詳細）

直近 merge 済み dependabot PR 31 件（#4425, #4424, #4423, #4422, #4272, #4271, #4251, #4137, #4136, #4135, #4131, #3936, #3935, #3934, #3932, #3920, #3869, #3845, #3842, #3841, #3635, #3634, #3633, #3632, #3569, #3568, #3567, #3366, #3364, #3311, #3310）に対し `gh api repos/Takenori-Kusaka/ganbari-quest/pulls/<N>/commits` を実行し、各 commit の `author.login` と `parents.length` を確認した。

- 人間の非マージ commit を含むのは **#4422**（`ganbariquestsupport-lab` × 2 + `Takenori-Kusaka` × 1、本 Issue の実測起点）と **#3311**（`fix(deps): #3311 group bump から better-sqlite3 12.11.1 を除外し...`、`Takenori Kusaka` author）の 2 件のみ。この 2 件は新判定で `dependabot` lane から正しく外れる（#3311 は既に merge 済みだが、これは旧判定の見逃しが実在したことの実例でもある）。
- #4272 / #4271 / #4251 には `Merge remote-tracking branch 'origin/develop' into <branch>` という branch 同期マージ commit が `author.login: null` / `commit.author.email: takenori.kusaka@gmail.com` で記録されていた。`parents.length === 2`（マージ commit）であり、中身の diff を持たない。これを「人間 commit」として数えると、実質的に bot だけが書いた PR まで gate 対象になってしまうため、`actions/pr-lane` は非マージ commit（`parents.length === 1`）のみを `--commit-authors` に渡す設計とした。
- 上記のとおり、**新判定で挙動が変わる既存（過去）dependabot PR は 0 件**（#3311 は既に merge 済みで影響範囲外、#4422 は本 Issue の起点そのもの）。今後 open される新規 dependabot PR で human の branch 同期マージだけが乗るケースも `dependabot` lane を維持できることを確認した。

### 単体テスト

```
npx vitest run tests/unit/github/pr-lane.test.ts
# Test Files  1 passed (1)
#      Tests  39 passed (39)
```

新規 16 テストは failing-test-first で実装前に red（7 failed）を確認してから実装し、green化した。

### mutation 検証（3 箇所、いずれも先に commit してから壊す — `git checkout --` は不使用）

1. `isBotOnlyCommits` の `.every()` → `.some()` に変更 → 6 test fail（生存 mutation なし）
2. `classifyLane` の bot 判定から `isBotOnlyCommits(commitAuthors)` チェックを削除（旧 actor-only 挙動に戻す）→ 6 test fail
3. `parseArgs` の `--commit-authors` 空文字を `undefined` ではなく空配列として返すよう変更 → 5 test fail

3 箇所とも変更直後にテストが red になることを確認し、`git diff` で完全に元に戻したことを確認済み（差分ゼロ）。

### CLI 動作確認

```
$ node scripts/pr-lane.mjs --base develop --head dependabot/x --actor "dependabot[bot]" --commit-authors "dependabot[bot],Takenori-Kusaka"
feature
$ node scripts/pr-lane.mjs --base develop --head dependabot/x --actor "dependabot[bot]" --commit-authors "dependabot[bot]"
dependabot
$ node scripts/pr-lane.mjs --base develop --head dependabot/x --actor "dependabot[bot]"
dependabot
```

### heavy lock

本 PR は `pre-ready` の軽量 step のみで完結（pre-ready は他セッションの `heavy` lock 排他対象だが、本 PR 作業時に取得できたためローカルで完遂。取得できない場合は CI に委ねる）。
