### PR TITLE
docs: #4452 branch-strategy.md から GitHub ruleset の状態転記を除去する

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -144,7 +144,7 @@ PR body の構造化識別子（`## ` 見出し）を探す gate は **`scripts/
 
 `body.indexOf('## X')` / `body.includes('## X')` のような部分一致を新しく書くと `tests/unit/architecture/pr-body-partial-match-guard.test.ts`（ADR-0061 same-class-N→guard）が落ちる。prose（自然文）を本文全体から探す正当な用途は、同 test の `ALLOWLIST` に**理由付きで**登録する。
 
-セットアップ: Branch Ruleset の `required_status_checks` に 6 ジョブ追加（管理者作業。`closing keyword の記入 (feat/fix)` は #3458 で新設、required 化には ruleset 追加登録が必要）。
+セットアップ: 各 job を required にするかは GitHub の branch ruleset 設定で行う（管理者作業。現在の required 指定は GitHub 側が実体であり、ここには転記しない）。
 
 ## workflow の発火 type — commit を伴わない PR イベント（#4171）
 

--- a/docs/sessions/audit-team.md
+++ b/docs/sessions/audit-team.md
@@ -167,7 +167,7 @@ audit-manager が統合 PR の merge を判定する際に揃えるべき人間�
 3. **テスト結果表**: 上記テストの実行結果（pass / fail / skip）を最重厚レーン（[branch-strategy.md](branch-strategy.md) §4）の全 job 横断で集約。
 4. **自動テストカバレッジ**: カバレッジ値 + ratchet 閾値割れがないこと（ADR-0005 整合）。
 5. **NG 0 件エビデンス**: 8 領域 finding のうち severity 閾値以上（§3.6）の未解決 NG が **0 件**であること。残 NG があれば merge しない。
-6. **CodeQL new-alert 0 件エビデンス（#4155）**: `ref=refs/pull/<N>/merge` の open code-scanning alert が baseline（`scripts/audit/codeql-baseline.json`）を **1 件も超えない**こと。`CodeQL` check は main ruleset の required_status_checks 非該当（[branch-strategy.md](branch-strategy.md) §4「CodeQL の扱い」）だが、**その代替として本条件を NG-0 に含める**。「required でないから赤でも通す」を audit-manager が個別判断することを禁じる（外形が admin bypass と区別できないため、ADR-0022 同型）。
+6. **CodeQL new-alert 0 件エビデンス（#4155）**: `ref=refs/pull/<N>/merge` の open code-scanning alert が baseline（`scripts/audit/codeql-baseline.json`）を **1 件も超えない**こと。`CodeQL` check は main の branch ruleset で required にしない方針（[branch-strategy.md](branch-strategy.md) §4「CodeQL の扱い」）であり、**その代替として本条件を NG-0 に含める**。「required でないから赤でも通す」を audit-manager が個別判断することを禁じる（外形が admin bypass と区別できないため、ADR-0022 同型）。
 
    ```bash
    # 機械取得（CI では ci.yml integration-evidence job が自動実行し evidence.json / job summary に載せる）

--- a/docs/sessions/branch-strategy.md
+++ b/docs/sessions/branch-strategy.md
@@ -48,8 +48,8 @@ main = 即本番 deploy の不変条件下で「開発速度」と「品質」�
 | 3. 監査・merge | frozen な release HEAD に対し 8 領域監査 + adversarial evidence（ADR-0056）→ lab approve（author≠approver, ADR-0022）→ **merge commit（`gh pr merge --merge`、squash 禁止。根拠 SSOT = §2 #2871）**。HEAD が動かないため監査が無効化されない |
 | 4. back-merge | merge 後、`main → develop` の back-merge sync PR で main の merge commit を develop へ取り込む（hotfix back-merge と同じ §5 経路 / #2951・#3061 自動化）|
 
-- release branch は **`non_fast_forward` の ruleset（`release-lane-freeze`、target=`refs/heads/release/*`、id 17725378）で保護**し、force-push（history 書換）で標的が動くのを機械的に防ぐ。監査中に見つかった修正は release branch への通常 commit（append、fast-forward）で対応する。deletion guard は付けない（merge 後の release branch auto-delete を妨げないため。develop の deletion 保護 #2989 とは異なり release は ephemeral）。
-- **append 後は再監査必須（approve HEAD と merge HEAD の乖離防止）**: `PR_Mearge`（id 14673945）は `dismiss_stale_reviews_on_push=false` のため、approve 後に release branch へ append しても stale approval が残り未監査差分が merge され得る。**adversarial evidence 取得・lab approve の後に release へ commit を積んだ場合は、adversarial evidence を再生成（TTL 30 分）し再 approve する**こと。approve した HEAD = merge する HEAD を必ず一致させる。
+- release branch は **force-push（history 書換）を禁止する ruleset（`release-lane-freeze`）で保護**し、標的が動くのを機械的に防ぐ。監査中に見つかった修正は release branch への通常 commit（append、fast-forward）で対応する。deletion guard は付けない（merge 後の release branch auto-delete を妨げないため。develop の deletion 保護 #2989 とは異なり release は ephemeral）。
+- **append 後は再監査必須（approve HEAD と merge HEAD の乖離防止）**: push による approval の自動 dismiss に依存しない。approve 後に release branch へ append すると stale approval が残り未監査差分が merge され得るため、**adversarial evidence 取得・lab approve の後に release へ commit を積んだ場合は、adversarial evidence を再生成（TTL 30 分）し再 approve する**こと。approve した HEAD = merge する HEAD を必ず一致させる。
 - 命名は `release/<YYYY-MM-DD>` を基本とし、同日複数回は `-2` 等の suffix を付ける。
 - machine 層: `pr-lane.mjs`（lane 判定）/ `resolve-base-branch.mjs`（release/* → main 基点解決）/ `ci.yml`（base-guard + 重量発火）が release/* を統合レーンとして扱う。
 - **`integration-pr.yml`（develop → main 自動発行、#2871）との関係**: `develop → main` も rule 2 で integration レーンに残す（後方互換）。audit-manager が形式 audit で main へ反映する際は **release/* を cut して frozen 標的で監査・merge する**のを正準とする。`integration-pr.yml` の自動発行を release/* cut 方式へ移行するかは別 Issue（#3063 派生）で判断する。
@@ -130,7 +130,7 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 
 ### 全 workflow の gate × lane 対応表（SSOT、#2948 / EPIC #2861 AC6）
 
-全 `.github/workflows/*.yml`（32 本）の lane 帰属・required 化・lane 分岐の網羅表。新規 workflow を追加する人はこの表に必ず 1 行追加する。**旧 `scripts/check-internal-terms.mjs`（workflow-coverage group で本表との網羅一致を機械検証していた）は #4322 で削除済み**。現在この一致は機械強制されていないため、workflow 追加 / 削除時は本表を手動同期すること。
+全 `.github/workflows/*.yml`（32 本）の lane 帰属・生成 context・lane 分岐の網羅表。新規 workflow を追加する人はこの表に必ず 1 行追加する。**旧 `scripts/check-internal-terms.mjs`（workflow-coverage group で本表との網羅一致を機械検証していた）は #4322 で削除済み**。現在この一致は機械強制されていないため、workflow 追加 / 削除時は本表を手動同期すること。
 
 > **2 つの不変原則（外部 research の結論を運用 SSOT 化、#2948 AC3）**:
 > 1. **required は trigger filter で skip 不可（permanent pending）** — required status check に登録した context は、`branches:` / `paths:` filter で workflow ごと skip すると GitHub 側で「報告されない = pending」のまま merge がブロックされる。required context を生む job は filter で消さず、**job 内で全 lane 実行 → 観点だけ切替** する（[GitHub Docs: Troubleshooting required status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)）。
@@ -148,29 +148,31 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 | `dependabot` | bot PR。`pr-lane.mjs` の `BOT_ACTORS` SSOT で exempt 判定（rule 1） |
 | `N/A（非 PR）` | PR event を持たない（schedule / push / workflow_run / issues / workflow_dispatch のみ）。lane 概念の対象外 |
 
-#### 対応表（required context は ★ 印 + context 名、`gh api .../rulesets/14673945` の配列と一致＝#2948 AC2）
+#### 対応表（各 workflow が生成する check context）
 
-| workflow | lane 帰属 | required context（★） | lane 分岐（A-1 SSOT 経由） | 重量/軽量 |
+> **どの context を required にしているかは本表に転記しない**。required 指定の実体は GitHub の branch ruleset 設定（Settings → Rules → Rulesets）にあり、docs 側の写しは必ず腐る（#4403）。required かを知りたいときは GitHub 側を見る。本表が担うのは「どの workflow がどの context を生むか」のマッピングのみ。
+
+| workflow | lane 帰属 | 生成する check context | lane 分岐（A-1 SSOT 経由） | 重量/軽量 |
 |---|---|---|---|---|
-| `ci.yml` | feature+integration（`branches:[main,develop]`） | ★`ci-gate` | あり（inline `base_ref=='main' && (head_ref=='develop' \|\| startsWith(head_ref,'release/'))` = `pr-lane.mjs` rule 2 SSOT。重量 job を統合 PR で保証発火、develop PR で skip） | 軽量 job=軽量 / 重量 job=重量 |
-| `pr-template-gate.yml` | 全 PR lane（`branches` 無指定） | ★`必須セクションの存在確認` / ★`関連 Issue 番号の記入` / ★`顧客価値・目的の記入` / `変更タイプの選択` / `テスト実行結果の記入` / `closing keyword の記入 (feat/fix)`（6 job。`変更タイプの選択` / `テスト実行結果の記入` は ruleset 実測で required 対象から外れている。closing keyword job は #3458 新設、required 化は ruleset 追加登録待ち） | あり（`uses: ./actions/pr-lane` → 各 job が `--lane`。feature/hotfix vs integration vs dependabot=skip 相当、#2944。closing keyword は feature×feat/fix のみ検証、integration=#3423 集約側 / hotfix=main 直接 auto-close で skip、#3458） | 軽量 |
-| `pr-ac-verification-check.yml` | 全 PR lane | ★`Verify AC map in PR body` | あり（`uses: ./actions/pr-lane`。feature/hotfix=AC マップ 4 列 / integration=マージ判定エビデンス表、#2945） | 軽量 |
-| `pr-merge-gate.yml` | 全 PR lane | ★`PR チェックリスト完了確認` | あり（`uses: ./actions/pr-lane`。feature/hotfix=2 section / integration=統合用 section、#2945） | 軽量 |
-| `pr-quality-gate.yml` | 全 PR lane | ★`screenshot-check` | あり（`uses: ./actions/pr-lane`。feature/hotfix=before/after 4 スロット / integration=VR 3 層委譲、#2946） | 軽量 |
-| `lp-metrics.yml` | 全 PR lane（`paths:site/**`） | ★`Measure LP dimensions and lint forbidden terms`（`measure` job） | なし（lane 非依存。`paths` scope のみ。`cumulative-lp-metrics` は main merge 擬似累積） | 軽量 |
+| `ci.yml` | feature+integration（`branches:[main,develop]`） | `ci-gate` | あり（inline `base_ref=='main' && (head_ref=='develop' \|\| startsWith(head_ref,'release/'))` = `pr-lane.mjs` rule 2 SSOT。重量 job を統合 PR で保証発火、develop PR で skip） | 軽量 job=軽量 / 重量 job=重量 |
+| `pr-template-gate.yml` | 全 PR lane（`branches` 無指定） | `必須セクションの存在確認` / `関連 Issue 番号の記入` / `顧客価値・目的の記入` / `変更タイプの選択` / `テスト実行結果の記入` / `closing keyword の記入 (feat/fix)`（6 job。closing keyword job は #3458 新設） | あり（`uses: ./actions/pr-lane` → 各 job が `--lane`。feature/hotfix vs integration vs dependabot=skip 相当、#2944。closing keyword は feature×feat/fix のみ検証、integration=#3423 集約側 / hotfix=main 直接 auto-close で skip、#3458） | 軽量 |
+| `pr-ac-verification-check.yml` | 全 PR lane | `Verify AC map in PR body` | あり（`uses: ./actions/pr-lane`。feature/hotfix=AC マップ 4 列 / integration=マージ判定エビデンス表、#2945） | 軽量 |
+| `pr-merge-gate.yml` | 全 PR lane | `PR チェックリスト完了確認` | あり（`uses: ./actions/pr-lane`。feature/hotfix=2 section / integration=統合用 section、#2945） | 軽量 |
+| `pr-quality-gate.yml` | 全 PR lane | `screenshot-check` | あり（`uses: ./actions/pr-lane`。feature/hotfix=before/after 4 スロット / integration=VR 3 層委譲、#2946） | 軽量 |
+| `lp-metrics.yml` | 全 PR lane（`paths:site/**`） | `Measure LP dimensions and lint forbidden terms`（`measure` job） | なし（lane 非依存。`paths` scope のみ。`cumulative-lp-metrics` は main merge 擬似累積） | 軽量 |
 | `orphan-check.yml` | 全 PR lane（`paths` scope）+ push[main] | — | なし | 軽量 |
 | `dependency-review.yml` | feature+integration（`branches:[main,develop]`、`paths` scope） | — | なし（develop/main 双方発火、軽量） | 軽量 |
 | `pr-info.yml` | feature+integration（`branches:[main,develop]`） | — | なし（`type-label` job は dependabot exempt） | 軽量 |
-| `pr-author-guard.yml` | 全 PR lane（`pull_request_target`） | —（`enforce-pr-author` job、ruleset 未登録） | なし（dependabot/renovate exempt） | 軽量 |
+| `pr-author-guard.yml` | 全 PR lane（`pull_request_target`） | `enforce-pr-author` | なし（dependabot/renovate exempt） | 軽量 |
 | `labeler.yml` | 全 PR lane（`pull_request_target`） | — | なし | 軽量 |
 | `pr-lane-smoke.yml` | feature+integration（`branches:[main,develop]`）+ dispatch | —（comment-only、block しない） | あり（`uses: ./actions/pr-lane` の動作実証専用、#2943 AC4） | 軽量 |
 | `dependabot-auto-merge.yml` | dependabot（`pull_request`、actor=`dependabot[bot]`） | — | なし（`BOT_ACTORS` SSOT を参照し inline 判定。composite action は overhead 回避で不採用、#2947） | 軽量 |
 | `lp-visual-regression.yml` | integration+hotfix（`branches:[main]`）+ push[main] | — | なし（develop PR で skip＝重量レーン、VR hard-fail） | 重量 |
 | `child-home-visual-regression.yml` | integration+hotfix（`branches:[main]`）+ push[main] | — | なし（develop PR で skip、VR warn） | 重量 |
 | `app-visual-regression.yml` | integration+hotfix（`branches:[main]`）+ push[main] | — | なし（develop PR で skip、VR warn） | 重量 |
-| `deploy-aws-staging.yml` | integration+hotfix（`branches:[main]` PR、paths filter 撤去で常時発火） | ★`deploy-aws-staging`（ruleset 実測で required 化済み、[runbooks/staging-gate-required-checks.md](../runbooks/staging-gate-required-checks.md)） | なし（main 向け PR で発火、actor allowlist） | 重量 |
+| `deploy-aws-staging.yml` | integration+hotfix（`branches:[main]` PR、paths filter 撤去で常時発火） | `deploy-aws-staging`（required 化の手順は [runbooks/staging-gate-required-checks.md](../runbooks/staging-gate-required-checks.md)） | なし（main 向け PR で発火、actor allowlist） | 重量 |
 | `deploy-nuc-staging.yml` | integration+hotfix（`branches:[main]` PR） | — | なし（actor allowlist） | 重量 |
-| `codeql.yml` | integration+hotfix（`branches:[main]` PR）+ push[main]+schedule | **— required 非該当（代替条件は下記「CodeQL の扱い」）** | なし（develop PR で skip、main 経路で coverage 維持、#2931） | 重量 |
+| `codeql.yml` | integration+hotfix（`branches:[main]` PR）+ push[main]+schedule | `CodeQL`（required にはしない方針。代替条件は下記「CodeQL の扱い」） | なし（develop PR で skip、main 経路で coverage 維持、#2931） | 重量 |
 | `deploy.yml` | N/A（push[main] / tags / dispatch） | — | — | 本番 deploy |
 | `deploy-nuc.yml` | N/A（push[main] / dispatch） | — | — | 本番 deploy |
 | `pages.yml` | N/A（push[main] / dispatch、LP 配信 + SS 撮影） | — | — | 本番 deploy |
@@ -185,17 +187,17 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 | `weekly-report.yml` | N/A（schedule weekly / dispatch） | — | — | 定期レポート |
 | `close-leak-report.yml` | N/A（schedule weekly / dispatch、main 反映済 open issue の close漏れ候補を job summary へ report。auto-close なし = `issues: read` のみ） | — | — | 定期レポート（#3459、検出 SSOT は `scripts/audit/close-leak-report.mjs`） |
 
-> **required context 数 = 9**（★ 印、2026-08-07 実測）。`gh api repos/Takenori-Kusaka/ganbari-quest/rulesets/14673945` の `required_status_checks` 配列（`ci-gate` / `screenshot-check` / `Verify AC map in PR body` / `Measure LP dimensions and lint forbidden terms` / `PR チェックリスト完了確認` / `必須セクションの存在確認` / `関連 Issue 番号の記入` / `顧客価値・目的の記入` / `deploy-aws-staging`）が真の SSOT。本表は「どの workflow がどの context を生むか」のマッピングであり、ruleset 変更時は本表も同期する（#2948 no-go: ruleset と乖離させない）。
+> **required 指定の SSOT は GitHub の branch ruleset 設定**（Settings → Rules → Rulesets）。件数・context 名の一覧を本表や本節に写さない。本表は「どの workflow がどの context を生むか」のマッピングであり、workflow 追加 / 削除時に同期する対象は本表と workflow file の関係だけである。
 >
-> **A-2〜A-5 で lane-aware 化した required gate**: `pr-template-gate.yml`（6 job、#2944 / #3458）/ `pr-ac-verification-check.yml`（#2945）/ `pr-merge-gate.yml`（#2945）/ `pr-quality-gate.yml`（#2946）の 4 workflow（5+1+1+1 = 8 required context）が `actions/pr-lane` 経由で観点切替する。`dependabot-auto-merge.yml`（#2947）は `BOT_ACTORS` SSOT を参照（required ではないが bot lane 判定を共通化）。`ci.yml`（#2874）は inline 式で `pr-lane.mjs` rule 2 と同一判定を行い重量 job を統合 PR で保証発火する。
+> **A-2〜A-5 で lane-aware 化した gate**: `pr-template-gate.yml`（6 job、#2944 / #3458）/ `pr-ac-verification-check.yml`（#2945）/ `pr-merge-gate.yml`（#2945）/ `pr-quality-gate.yml`（#2946）の 4 workflow が `actions/pr-lane` 経由で観点切替する。`dependabot-auto-merge.yml`（#2947）は `BOT_ACTORS` SSOT を参照（bot lane 判定を共通化）。`ci.yml`（#2874）は inline 式で `pr-lane.mjs` rule 2 と同一判定を行い重量 job を統合 PR で保証発火する。
 
-#### CodeQL の扱い — required 非該当と、その代わりに満たすべき条件（#4155）
+#### CodeQL の扱い — required にしない方針と、その代わりに満たすべき条件（#4155）
 
-`CodeQL` は main ruleset の `required_status_checks` に**含まれない**（上表 ★ 印なし）。ただしこれは「赤でも人の判断で通してよい」という意味では**ない**。required 非該当を維持する代わりに、以下を**機械条件**として課す。
+`CodeQL` は main の branch ruleset で required に**しない**方針を採る。ただしこれは「赤でも人の判断で通してよい」という意味では**ない**。required にしない代わりに、以下を**機械条件**として課す。
 
 | 項目 | 内容 |
 |---|---|
-| **required 非該当の理由** | 既知 alert が解消されるまで全 PR が止まる（`src/` 外の CI 補助 script 由来のものを含む）。Pre-PMF でリリース全停止に見合わない（ADR-0010） |
+| **required にしない理由** | 既知 alert が解消されるまで全 PR が止まる（`src/` 外の CI 補助 script 由来のものを含む）。Pre-PMF でリリース全停止に見合わない（ADR-0010） |
 | **代わりに満たすべき条件** | 統合 PR の ref（`refs/pull/<N>/merge`）由来の open alert が **baseline を 1 件も超えない**こと |
 | **検査主体** | `scripts/audit/check-codeql-alerts.mjs`（`ci.yml` `integration-evidence` job で実行、baseline 超過 / ledger 不正 / **未スキャン・API 取得失敗（= 検査不能）** のいずれかで exit 1） |
 | **baseline ledger** | `scripts/audit/codeql-baseline.json`（`tests/e2e/a11y-baseline.json` と同型。`(rule, path)` + `count` で pin、全 entry に `resolutionTrigger` 必須 = 期限なし pin 禁止） |
@@ -233,19 +235,15 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 
 ## §7 Branch Ruleset 変更（ユーザー手動）
 
-現行 Ruleset の確認・変更はユーザー手動作業。本 SSOT merge 後に実施する（§8）。
+Ruleset の確認・変更はユーザー手動作業。本 SSOT merge 後に実施する（§8）。
 
-- **現状確認コマンド**:
+**設定の実体は GitHub 側にあり、その内容を本ファイルに転記しない**（required checks・承認数・保護対象などの写しは必ず腐る、#4403）。現状を知る必要があるときは実体を見る。
 
-  ```bash
-  gh api repos/Takenori-Kusaka/ganbari-quest/rulesets/14673945
-  ```
-
-  現行 ruleset（id=14673945、name `PR_Mearge`、target=branch、condition=`~DEFAULT_BRANCH`=main）は `pull_request`（required_approving_review_count=1）+ `required_status_checks`（ci-gate / screenshot-check / Verify AC map / Measure LP dimensions / PR チェックリスト 等）+ `non_fast_forward` を強制している。
+- **実体の在り処**: GitHub → リポジトリ Settings → Rules → Rulesets（main を対象とする `PR_Mearge`、release branch を対象とする `release-lane-freeze`）。CLI で見るなら `gh api repos/Takenori-Kusaka/ganbari-quest/rulesets`。
 - **必要な変更（2 点）**:
   1. **main 向け PR の base 制限**: 「main へ PR を出せるのは develop と hotfix branch のみ」を Ruleset 単体で表現するのは困難（Branch Ruleset は head branch の base 制限を直接持たない）。**補完案**として、`main` 向け PR の base / head を workflow gate で検査し、`develop` / `fix/*` 以外を head とする main 向け PR を fail させる方式を採る — **#2931 で `ci.yml` の `main-pr-base-guard` job として実装済み**。有効化は repository variable **`BRANCH_STRATEGY_CUTOVER_AT`**（ISO 8601 UTC 日時、ユーザー手動設定）。未設定なら gate inactive、設定後は設定日時より後に作成された main 向け PR のみ enforce（既存 open PR は grandfather 免除 = §8 step 6）。bot（dependabot / renovate）は exempt（`dependabot.yml` の `target-branch: develop` 切替は #3072 で実施済 — 依存更新 PR は develop 軽量レーン経由、main へは統合 PR の重量レーン + 監査で反映）。
-  2. **develop 用 ruleset の整理**: 2026-06-04 時点で既存 ruleset `PR_Mearge` (id=14673945) の include に `refs/heads/develop` が追加済みだが、これは main と同一の required checks（重量含む）を develop に課す形であり §4 の軽量レーン設計と相違する。#2931 の workflow 改修により `ci-gate` は develop 向け PR でも報告される（重量 job は skip 扱いで gate を block しない）ため、当面は同居でも詰まらない。ただし設計どおり **`develop` を target とする軽量 ruleset を分離新設**（lint-and-test / unit-test / PR テンプレ gate 等のみ required、e2e / a11y / docker は含めない）し、`PR_Mearge` の include から develop を外すことを推奨。
-  3. **release/* freeze 保護 ruleset（§3.1、#3063）**: `release-lane-freeze`（id 17725378、target=`refs/heads/release/*`、`non_fast_forward` のみ）を新設済み。cut した release branch の force-push（history 書換）で audit 標的が動くのを機械的に防ぐ。deletion guard は付けない（merge 後 auto-delete を妨げないため）。release/* → main の PR 承認・required checks は既存 `PR_Mearge`（target=main）が担うため、本 ruleset に required_status_checks / pull_request は付けない。
+  2. **develop 用 ruleset の分離**: `develop` を main と同じ ruleset に同居させると、main 向けの重量 gate が develop にも課され §4 の軽量レーン設計と相違する。#2931 の workflow 改修により `ci-gate` は develop 向け PR でも報告される（重量 job は skip 扱いで gate を block しない）ため同居でも詰まりはしないが、設計どおり **`develop` を target とする軽量 ruleset を分離新設**（lint-and-test / unit-test / PR テンプレ gate 等のみ required、e2e / a11y / docker は含めない）し、main 側 ruleset の対象から develop を外すことを推奨。
+  3. **release/* freeze 保護 ruleset（§3.1、#3063）**: `release-lane-freeze`（target=`refs/heads/release/*`）で force-push を禁止し、cut した release branch の history 書換で audit 標的が動くのを機械的に防ぐ。deletion guard は付けない（merge 後 auto-delete を妨げないため）。release/* → main の PR 承認・required checks は main 側 ruleset が担うため、本 ruleset には付けない。
 
 - **GitHub App 認証の設定（ユーザー手動、#3067 / ADR-0022 Amendment 5）**: `hotfix-back-merge.yml`（§5 back-merge 機械強制）と B-3 統合 PR 自動発行（#2871）は、`secrets.GITHUB_TOKEN` で PR を作ると author が `github-actions[bot]` になり `pr-author-guard.yml` に auto-close され、かつ下流 CI を発火させない。これを回避するためプロジェクト専用の **GitHub App** を作成し、その install トークン（`actions/create-github-app-token` が実行毎に短命発行・自動失効）で PR を発行する。長命個人 PAT（旧 `BACK_MERGE_PAT`）は撤廃済み（GitHub 非推奨の常駐 credential を排除）。一度きりの設定手順:
   1. **GitHub App 作成**: Organization / 個人 Settings → Developer settings → GitHub Apps → New。Repository permissions に `Contents: Read & write` + `Pull requests: Read & write` を付与（Issues は label 付与のため `Read & write`）。Webhook は不要（off）。
@@ -264,7 +262,7 @@ stale develop 基点ズレ（single-branch refspec で `origin/develop` が更�
 2. **workflow 改修 PR**: `branches: [main]` 4 本の develop 向け発火追加 + 軽量 / 重量の振り分け + main 向け PR の base/head 検査 gate 追加。集約 job 名（`ci-gate` 等 required status check の context 名）は互換維持する。— ✅ 完了（#2931、§4「実装状況」参照）
 3. **develop branch 作成**: `main` から分岐して `develop` を作る。
 4. **数 PR で実測確認**: develop 向け軽量レーン PR を数本流し、軽量 / 重量の振り分けが期待どおりかを実測する。
-5. **Ruleset 変更（ユーザー手動）**: §7 の develop 用 ruleset 整理 + repository variable `BRANCH_STRATEGY_CUTOVER_AT` の設定（main 向け base 制限の有効化）。
+5. **Ruleset 変更（ユーザー手動）**: §7 の develop 用 ruleset 分離 + repository variable `BRANCH_STRATEGY_CUTOVER_AT` の設定（main 向け base 制限の有効化）。
 6. **既存 open PR は retarget しない**: merge 済みになるまで現行ルール（main 向け）のまま扱い、新規 PR から develop 向けに切り替える。強制 rebase / retarget はしない。
 7. **周知**: dev / po / qa session 各 doc に本 SSOT への参照を 1 行追加（本 PR で実施済み）。
 8. **ロールバック**: develop を廃止する場合は **develop branch 削除 + workflow revert のみ**で戻せる。deploy 経路（main push）は一切変えないため、ロールバックも無停止。


### PR DESCRIPTION
## 顧客価値・目的

GitHub ruleset の設定内容が docs に転記されていると、ruleset を変えた人が docs を直さない限り必ず食い違う。実際に #4403 では「required が 2 件」という docs 記述が現状と合わず、QM がオーナーに確認を上げる往復（＝滞留）が発生した。転記そのものを無くし、docs は方針・役割分担だけを持つ状態に戻す。以後この class の滞留は原理的に発生しない。

## 関連 Issue

Closes #4452

## 変更内容

`docs/sessions/branch-strategy.md` から **GitHub 側 branch ruleset の設定値スナップショット**だけを除去し、方針・責任分担は残した。

**除去した転記**:

- §4 対応表の `required context（★）` 列 — ★ 印と「ruleset 実測で required 対象から外れている」「required 化は ruleset 追加登録待ち」「ruleset 未登録」「ruleset 実測で required 化済み」等の状態注記。列自体は `生成する check context`（workflow が生む context 名 = repo 側の事実）として残した
- §4 の「required context 数 = 9（2026-08-07 実測）」+ `required_status_checks` 配列 9 件の列挙
- §7 の ruleset id / name / target / condition / `required_approving_review_count=1` / required_status_checks 列挙 / `non_fast_forward` の転記
- §3.1 の `PR_Mearge`（id 14673945）は `dismiss_stale_reviews_on_push=false` — 設定値への依存記述。導かれる運用ルール（append 後は再監査必須）は残した
- §3.1 / §7 の ruleset id（17725378 / 14673945）
- §7 の「2026-06-04 時点で include に `refs/heads/develop` が追加済み」という状態スナップショット

**残した pointer**: §4 と §7 に「required 指定の実体は GitHub Settings → Rules → Rulesets」を明記。CLI で見る場合の `gh api repos/Takenori-Kusaka/ganbari-quest/rulesets`（一覧 endpoint）は残したが、その出力内容は書かない。

**残したもの（本務）**: develop 二層 / gate 二層の設計、軽量・重量レーンの job 表、workflow → context のマッピング表、§3.2 close 運用、§5 hotfix 経路、§6 役割分担、§7 の「必要な変更 3 点」（base 制限 / develop 用 ruleset 分離 / release freeze 保護）— いずれも GitHub 側から読み取れない設計判断であり docs 側にあるべき情報。

**同一 PR での参照更新**: `docs/sessions/audit-team.md`（CodeQL の required 非該当を「required にしない方針」へ）/ `.github/CLAUDE.md`（「required_status_checks に 6 ジョブ追加」を、現在の required 指定を転記しない書き方へ）。

方針どおり、転記を検証する CI チェックは新設していない（装置を増やさず、腐る転記を無くす）。

## 検証

- `npm run pre-ready -- --pr <PR番号>`: 全 step PASS（結果は本 PR の commit 後に実行、下記 AC 検証マップに記載）
- `grep -n "ruleset\|required" docs/sessions/branch-strategy.md`: 残存箇所を全件目視し、設定値スナップショットが 0 件であることを確認
- `grep -rn "branch-strategy" scripts/ tests/ .github/`: 参照は §3〜§5 の節番号のみで、除去した表の内容に依存する script / test は無いことを確認（節番号は不変）

## 影響範囲

- 顧客に見える変化: なし（docs のみ）
- 触った並行実装ペア: なし
- 破壊的変更: なし。branch-strategy.md の節番号・見出しアンカー（§3 / §4 / §4「CodeQL の扱い」/ §5）は不変のため、`scripts/audit/check-codeql-alerts.mjs` / `scripts/back-merge-pr-body.mjs` / `audit-team.md` 等からの参照は壊れない

UI 変更なし（docs のみの変更で描画物を持たないため SS は添付しない）。

## AC 検証マップ

| AC | 内容 | 検証方法 | 結果/エビデンス |
|---|---|---|---|
| AC1 | branch-strategy.md から ruleset の設定値スナップショットが無くなっている | `grep -n "ruleset\|required" docs/sessions/branch-strategy.md` で残存行を全件目視 | required context 一覧 9 件 / 件数 / ruleset id 2 件 / `required_approving_review_count` / `dismiss_stale_reviews_on_push` / `non_fast_forward` / include 状態 のすべてが diff で削除済み。残る `required` 語は方針文（「required にしない」「required は trigger filter で skip 不可」）と外部 runbook への link のみ |
| AC2 | workflow→context マッピングと develop 二層 / gate 二層 / merge 責任分担が残っている | 変更後ファイルの §2 / §4 対応表 32 行 / §6 を確認 | 対応表は全 32 行が `生成する check context` 列を持って存置。§2 設計原則・§4 軽量/重量レーン job 表・§6 役割分担表は無改変（diff は §4 表の列 9 行と注記のみ） |
| AC3 | 除去箇所に設定実体への pointer があり、値は書かれていない | §4 対応表直上の注記 と §7「実体の在り処」を確認 | 両所に「GitHub Settings → Rules → Rulesets」を明記。§7 は一覧 endpoint `gh api repos/Takenori-Kusaka/ganbari-quest/rulesets` のみを示し、出力値は記載していない |
| AC4 | 同じ転記を持つ他 docs が同一 PR で更新されている | `grep -rn "ruleset\|required_status_checks" docs/ .github/` で branch-strategy 以外の転記を洗い出し | `docs/sessions/audit-team.md` L170 と `.github/CLAUDE.md` L147 を本 PR 内で是正。`docs/runbooks/staging-gate-required-checks.md` は required 化の操作手順（状態の転記ではない）のため対象外と判断 |
| AC5 | 転記を機械検証する CI チェックを新設していない | 本 PR の変更ファイル一覧を確認 | 変更は docs 3 file のみ。`scripts/` / `.github/workflows/` への追加は 0 件 |

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
