### PR TITLE
fix(docs): #4451 DPIA を現行構成に合わせる（DynamoDB 記述の是正 + Bedrock の委託先・越境移転への追記）

### DIFF
--- a/docs/design/17a-データ保護影響評価書.md
+++ b/docs/design/17a-データ保護影響評価書.md
@@ -28,13 +28,15 @@ GDPR Article 35 に基づくデータ保護影響評価。
 
 | カテゴリ | データ | 感度 | 保存先 |
 |---------|--------|------|--------|
-| 子供プロフィール | ニックネーム、年齢、UIモード | 低〜中 | DynamoDB |
-| 活動記録 | 活動名、記録日時、獲得ポイント | 中 | DynamoDB |
-| ステータス | レベル、経験値、連続日数 | 低 | DynamoDB |
-| 実績 | 獲得実績・称号 | 低 | DynamoDB |
-| アバター画像 | アップロード画像（AI 生成は #4397 で廃止。過去に保存された画像は保持） | 中 | S3 |
+| 子供プロフィール | ニックネーム、年齢、UIモード | 低〜中 | Aurora DSQL |
+| 活動記録 | 活動名、記録日時、獲得ポイント | 中 | Aurora DSQL |
+| ステータス | レベル、経験値、連続日数 | 低 | Aurora DSQL |
+| 実績 | 獲得実績・称号 | 低 | Aurora DSQL |
+| アバター画像 | アップロード画像（過去に保存された画像を含む） | 中 | S3 |
 | 保護者メールアドレス | 認証用 | 高 | Cognito User Pool |
 | 決済情報 | クレジットカード情報 | 極高 | Stripe（外部、自社保存なし） |
+
+保存先は運営者が提供する SaaS の構成を示す。セルフホスト構成（NUC）では同じデータが利用者宅内の SQLite ファイルに保存され、運営者は保持しない。
 
 ### 2.4 収集しないデータ
 
@@ -80,7 +82,7 @@ GDPR Article 35 に基づくデータ保護影響評価。
 
 - ユーザーによるアカウント削除: **30 日猶予期間**後に認証・テナント・全レコードを物理削除（ADR-0022）
 - 違反アカウント強制削除: OPS 画面から即時削除
-- 削除対象: DynamoDB 全レコード + S3 アセット + Cognito ユーザー
+- 削除対象: DB 全レコード + S3 アセット + Cognito ユーザー
 
 ---
 
@@ -91,7 +93,7 @@ GDPR Article 35 に基づくデータ保護影響評価。
 | リスク | 影響度 | 発生可能性 | 対策後リスク | 緩和策 |
 |--------|--------|-----------|------------|--------|
 | 不正アクセスによるデータ漏洩 | 高 | 低 | **低** | Cognito JWT認証、テナント分離、TLS 1.2+、IAM最小権限 |
-| クロステナントデータ混入 | 高 | 極低 | **極低** | DynamoDB PK にテナントプレフィックス、全層でtenantId必須 |
+| クロステナントデータ混入 | 高 | 極低 | **極低** | 複合 PK `(tenant_id, id)`、tenant-scoped repository を単一強制点として全層で tenantId 必須、CI fitness function で述語欠落を検出（ADR-0063） |
 | 子供データの目的外利用 | 高 | 極低 | **極低** | データ最小化方針、広告/トラッキング非使用、第三者提供なし |
 | アバター画像経由の攻撃 | 中 | 低 | **極低** | Sharp re-encode、マジックバイト検証、CSP、Content-Type ホワイトリスト |
 | ブルートフォース攻撃 | 中 | 中 | **低** | IP ベースレートリミッター、Cognito パスワードポリシー |
@@ -116,7 +118,7 @@ GDPR Article 35 に基づくデータ保護影響評価。
 | 措置 | 実装 | 参照 |
 |------|------|------|
 | 通信暗号化 | TLS 1.2+（CloudFront）、HSTS | セキュリティ設計書 §2 |
-| 保存データ暗号化 | DynamoDB AWS managed key、S3 SSE-S3 | セキュリティ設計書 §3 |
+| 保存データ暗号化 | S3 は SSE-S3（`BucketEncryption.S3_MANAGED`）。Aurora DSQL は顧客管理キー（CMK）を指定せず AWS 側の既定設定に従う | `infra/lib/storage-stack.ts` / `infra/lib/dsql-stack.ts` |
 | 認証 | Cognito JWT + HMAC Context Token | セキュリティ設計書 §4 |
 | 認可 | ロールベースアクセス制御、テナント分離 | セキュリティ設計書 §5 |
 | レートリミッター | IP ベース、認証/API 別制限 | セキュリティ設計書 §6 |
@@ -132,7 +134,7 @@ GDPR Article 35 に基づくデータ保護影響評価。
 |------|------|
 | 同意管理 | サインアップ時の利用規約・プライバシーポリシー同意（バージョン管理付き） |
 | 同意再取得 | ポリシーバージョン更新時の再同意フロー |
-| 同意記録 | IP、UA、タイムスタンプ、バージョンを DynamoDB に記録 |
+| 同意記録 | IP、UA、タイムスタンプ、バージョンを DB に記録 |
 | データ主体の権利 | アクセス権（UI閲覧）、ポータビリティ（JSON/ZIPエクスポート）、削除権（アカウント削除） |
 | データ最小化 | 本名・住所・位置情報等を収集しない方針 |
 | アカウント削除 | 30日猶予期間付き完全削除（DB + S3 + Cognito） |
@@ -155,11 +157,12 @@ GDPR Article 35 に基づくデータ保護影響評価。
 
 | サービス | 処理内容 | GDPR 対応 | DPA |
 |---------|---------|----------|-----|
-| AWS（DynamoDB, S3, Lambda, Cognito） | データ保存・処理・認証 | [AWS GDPR Center](https://aws.amazon.com/compliance/gdpr-center/) | AWS DPA（オンラインで締結可能） |
+| AWS（Aurora DSQL, S3, Lambda, Cognito） | データ保存・処理・認証 | [AWS GDPR Center](https://aws.amazon.com/compliance/gdpr-center/) | AWS DPA（オンラインで締結可能） |
+| AWS Bedrock | 生成 AI によるテキスト補助（活動 / ごほうび / おうえん / チェックリストの提案、レシート画像からの金額読み取り） | 同上 | 同上 |
 | Stripe | 決済処理 | [Stripe Privacy](https://stripe.com/privacy) | Stripe DPA（利用規約に含まれる） |
 | GitHub | ソースコード管理・CI/CD | [GitHub DPA](https://github.com/customer-terms/github-data-protection-agreement) | GitHub DPA |
 
-**注意**: 子供の個人情報（ニックネーム等）を運営者の環境の外にある生成 AI へ送る経路は存在しない。SaaS 側の AI 画像生成は #4397 で廃止した。
+**生成 AI に渡す内容**: リクエストに載るのは、固定の指示文と、保護者が入力欄に自分で書いた自由記述テキスト、またはレシート画像だけである。子供のニックネーム・年齢・家族内一意 ID・活動履歴をアプリケーションが載せる経路は持たない。運営者が提供する SaaS 側の生成 AI は自社 AWS アカウント内の Bedrock のみで、運営者の環境の外にある生成 AI へ子供のデータを出す経路は無い（境界は `tests/unit/architecture/external-ai-client-boundary.test.ts` が固定する）。セルフホスト構成（NUC）では利用者の判断で外部の生成 AI を設定できるが、その場合の管理者は利用者自身であり運営者は経路を持たない。
 
 ---
 
@@ -167,12 +170,15 @@ GDPR Article 35 に基づくデータ保護影響評価。
 
 | データ | 移転先リージョン | 根拠 |
 |--------|----------------|------|
-| DynamoDB データ | us-east-1（米国） | AWS DPA + SCC（標準契約条項） |
+| Aurora DSQL データ | us-east-1（米国） | AWS DPA + SCC（標準契約条項） |
 | S3 アセット | us-east-1（米国） | AWS DPA + SCC |
 | Cognito ユーザー情報 | us-east-1（米国） | AWS DPA + SCC |
+| Bedrock への推論リクエスト | us-east-1（米国） | AWS DPA + SCC |
 | 決済情報 | Stripe のデータセンター | Stripe DPA + SCC |
 
 AWS は EU-US Data Privacy Framework 認証済みであり、SCC（Standard Contractual Clauses）もカバー。
+
+Bedrock は base model ID を us-east-1 に固定して呼び、cross-region inference profile を使わない（profile 経由では同じ AWS 内でも別リージョンで推論されうるため、本表の移転先と処理実体が一致しなくなる）。IAM も当該 base model の ARN 1 本に限定する（詳細な遵守事項は [14-セキュリティ設計書.md §8.5](14-セキュリティ設計書.md)）。
 
 ---
 
@@ -183,8 +189,8 @@ AWS は EU-US Data Privacy Framework 認証済みであり、SCC（Standard Cont
 本サービスは子供の個人情報を処理するため GDPR Art. 35 に基づく DPIA が必要であるが、以下の理由により**リスクは適切に緩和されている**と評価する:
 
 1. **データ最小化**: 子供の本名・住所・位置情報等の高感度データを収集しない
-2. **テナント分離**: DynamoDB PK プレフィックスにより家族間のデータ分離を保証
-3. **暗号化**: 通信（TLS 1.2+）および保存データ（DynamoDB/S3 暗号化）の両方で保護
+2. **テナント分離**: 複合 PK `(tenant_id, id)` + tenant-scoped repository の単一強制点 + CI fitness function により家族間のデータ分離を保証（ADR-0063）
+3. **暗号化**: 通信（TLS 1.2+）および保存データ（Aurora DSQL / S3 のサーバーサイド暗号化）の両方で保護
 4. **権利保障**: アクセス・訂正・削除・ポータビリティの全権利に対応済み
 5. **同意管理**: バージョン管理付きの同意取得・再同意フローを実装済み
 6. **削除の完全性**: 30日猶予期間後にDB・S3・Cognitoから完全削除
@@ -196,6 +202,7 @@ AWS は EU-US Data Privacy Framework 認証済みであり、SCC（Standard Cont
 | バックアップ内の残存データ（最大30日） | 低 | S3ライフサイクルで自動削除。30日は合理的な保持期間 |
 | Lambda インスタンス間のレートリミッター非共有 | 低 | 現在のトラフィック規模では実質的な影響なし |
 | us-east-1 リージョンでのデータ保存 | 低 | AWS DPA + SCC で法的根拠を確保。EU展開時に eu-west-1 への移行を検討 |
+| レシート画像に写り込む付随情報（店舗名・購入品目等）の Bedrock 送信 | 低 | 自社 AWS アカウント内・us-east-1 に閉じた処理で、画像は金額読み取り後に保存しない。IAM は 1 つの base model ARN に限定 |
 
 ### 7.3 今後のアクション
 


### PR DESCRIPTION
## 顧客価値・目的

GDPR Art. 35 に基づく法務文書（DPIA）に、実在しないデータストアが載り、実際に使っている生成 AI が委託先にも越境移転にも載っていない状態を解消する。規制当局・監査・顧客からの開示要求に対して、文書と処理実体が一致した状態で答えられるようにする。

## 関連 Issue

Closes #4451

## 変更内容

`docs/design/17a-データ保護影響評価書.md` のみを変更した（1 ファイル / +21 -14）。

1. **データストア名の是正（12 箇所）** — §2.3 保存先 / §2.6 削除対象 / §3.1 リスク緩和策 / §4.1 暗号化 / §4.2 同意記録 / §5 サブプロセッサー / §6 越境データ移転 / §7.1 総合評価。`DynamoDB` を `Aurora DSQL` または `DB` に置換した
2. **セルフホストの但し書きを §2.3 に追加** — 保存先表は SaaS 構成であり、NUC では同じデータが利用者宅内の SQLite に載り運営者は保持しない
3. **§3.1 / §7.1 のテナント分離を実装に合わせた** — 「PK プレフィックス」→ 複合 PK `(tenant_id, id)` + tenant-scoped repository 単一強制点 + CI fitness function（ADR-0063）
4. **§4.1 暗号化の参照先を実装ファイルに変更** — S3 は `BucketEncryption.S3_MANAGED`、Aurora DSQL は CMK を指定していない旨を書き、参照を `storage-stack.ts` / `dsql-stack.ts` にした
5. **§5 に AWS Bedrock 行を追加** — 処理内容（活動 / ごほうび / おうえん / チェックリストの提案、レシート画像からの金額読み取り）つき
6. **§5 の注記を書き直した** — 「生成 AI に渡す内容」として、載るのは固定の指示文 + 保護者が自分で書いた自由記述テキスト or レシート画像だけであること、子供のニックネーム / 年齢 / 家族内一意 ID / 活動履歴を載せる経路が無いこと、境界を `external-ai-client-boundary.test.ts` が固定していることを書いた
7. **§6 に Bedrock 推論リクエスト（us-east-1）行を追加**し、base model ID を us-east-1 に固定して cross-region inference profile を使わない / IAM を base model ARN 1 本に限定する旨をセキュリティ設計書 §8.5 への pointer つきで併記した
8. **§7.2 残留リスクに 1 行追加** — レシート画像に写り込む付随情報の Bedrock 送信（自社 AWS アカウント内 us-east-1 に閉じ、画像は読み取り後に保存しない）
9. **§2.3 アバター画像行から経緯注記を外した** — `docs/CLAUDE.md` §docs SSOT 原則（「旧 X は #NNNN で撤去済」型の inline 経緯注記の禁止）に合わせ、現状（アップロード画像。過去に保存された画像を含む）だけを書いた

推測で書いた記述は無い。下の「未確定として QM/PO に上げる項目」に挙げたものは、DPIA 本文に書いていない。

## 検証

UI 変更なし（docs 1 ファイルのみの変更で、顧客に見える画面の差分は無い）。

### AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | DPIA から DynamoDB 記述が 0 件 | `grep -n -i "dynamodb" docs/design/17a-データ保護影響評価書.md` | 0 件（exit 1）。変更前は 12 件 |
| AC2 | §5 サブプロセッサーに Bedrock | 本文目視 + diff | `AWS Bedrock \| 生成 AI によるテキスト補助（…）` 行を追加 |
| AC3 | §6 越境データ移転に Bedrock 行 | 本文目視 + diff | `Bedrock への推論リクエスト \| us-east-1（米国） \| AWS DPA + SCC` 行を追加 |
| AC4 | §3.1 / §7.1 が ADR-0063 / `storage-stack.ts` と一致 | `docs/decisions/0063-dsql-pool-multitenant-isolation.md` §決定 1〜5、`infra/lib/storage-stack.ts:84` を読んで突き合わせ | 複合 PK `(tenant_id, id)` / 単一強制点 / fitness function、SSE-S3 の記述が一致 |
| AC5 | セキュリティ設計書 §8.5 の Bedrock 遵守事項と矛盾しない | `docs/design/14-セキュリティ設計書.md:891,898,899` と本 PR の §5 注記 / §6 追記を照合 | us-east-1 固定・cross-region inference profile 不使用・IAM を base model ARN 1 本・家族内一意 ID を含めない、の 4 点すべて同趣旨。DPIA 側は pointer を張り記述を重複させていない |
| AC6 | 推測で書いていない | 下記「実測した根拠」に列挙。確認できなかったものは本文に書かず PR body へ | 未確定 3 件を本 PR body に列挙 |
| AC7 | 経緯の物語を本文に書かない | diff 目視（`docs/CLAUDE.md` §docs SSOT 原則） | 「#4397 で廃止した」型の inline 注記 2 箇所を撤去。Issue 番号の出典 pointer も新規には足していない |

### 実測した根拠

| 記述 | 実測元 |
|---|---|
| backend は sqlite / dsql / demo の 3 種、DynamoDB は無い | `src/lib/server/db/backend.ts`（`DbBackend` 型）/ `src/lib/server/db/factory.ts` |
| 全 stack が us-east-1 | `infra/bin/*.ts:19`（`region: 'us-east-1'`） |
| S3 は SSE-S3 | `infra/lib/storage-stack.ts:84` |
| Bedrock は us-east-1 明示注入 / IAM は base model ARN 1 本 | `infra/lib/compute-stack.ts:60,517`（`bedrock:InvokeModel` × `arn:aws:bedrock:us-east-1::foundation-model/...`、`*` 不使用）/ `src/lib/server/ai/bedrock-claude-provider.ts` |
| プロンプトに子供の DB レコードが載らない | `activity-suggest-service.ts:259` / `reward-suggest-service.ts:231` / `cheer-suggest-service.ts:291` / `checklist-suggest-service.ts:229` / `receipt-ocr-service.ts:70-74` の 5 箇所すべてで、`system` は静的文字列、`userMessage` は呼び出し元が受け取った自由記述テキストのみ |
| レシート画像を保存しない | `src/routes/api/v1/points/ocr-receipt/+server.ts`（検証 → `ocrReceipt()` に渡すのみ、S3 書き込み無し） |
| SaaS から Google の生成 AI へ到達しない | `infra/lib/compute-stack.ts:144`（`GEMINI_API_KEY` 注入なし、`AI_PROVIDER` 未設定 → factory 既定は bedrock）/ `tests/unit/architecture/external-ai-client-boundary.test.ts` |

### 未確定として QM/PO に上げる項目（本文には書いていない）

1. **Aurora DSQL の保存時暗号化そのもの** — リポジトリから確認できるのは「CMK を指定していない」ところまでで、AWS 側の既定暗号化が有効であることは repo からは検証できない。本文もその範囲でしか書いていない。AWS の公表資料 / DPA での裏取りが必要かどうかは QM/PO の判断を仰ぐ
2. **DPA の締結状況** — §5 の表は締結手段（AWS DPA / Stripe DPA）を書いているだけで、実際に締結済みかは repo から確認できない。§7.3 に「DPA 締結状況の定期確認（年1回）」があるので、その運用側の話として残す
3. **`site/privacy.html` 側の開示との突き合わせ** — 本 PR は DPIA のみを直した。顧客向けプライバシーポリシー第 3 条 / 第 10 条の記載が Bedrock / Aurora DSQL と一致しているかは未確認

### 本 PR で直していない観察（#4458 として起票済み）

`docs/design/14-セキュリティ設計書.md` にも同種の陳腐化が残っている。DPIA と切り離してレビュー可能にするため本 PR には含めず、#4458 に切り出した。

- §3.1 の見出しが `DynamoDB（本番DB）`、§3.5 の暗号化・保持期間方針も DynamoDB 前提（`storage-stack.ts:29 timeToLiveAttribute='ttl'` 参照つき）
- §8.7「データの域外送信 | ゼロ。自社 AWS アカウント内 DynamoDB のみで処理（生成 AI 等への送信なし）」が、同 §8.5 の「送信先 … AWS Bedrock」と正面から食い違っている
- §11 の環境差分表に `Stripe / SES / Discord / Gemini | 注入する（本番）` の行が残っているが、`GEMINI_API_KEY` の注入は Lambda から撤去済み（`compute-stack.ts:144`）
- §10 OWASP A02 の対策欄が `DynamoDB/S3 サーバーサイド暗号化`

## 影響範囲

顧客に見える変化: なし（設計書 1 ファイルのみ）。触った並行実装ペア: なし。破壊的変更: なし。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
