### PR TITLE
chore(deps): #4454 未使用の googleapis 依存を package.json から削除する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,6 @@
 				"eslint-plugin-storybook": "^10.5.6",
 				"eslint-plugin-svelte": "^3.22.0",
 				"fast-check": "^4.9.0",
-				"googleapis": "^174.0.0",
 				"husky": "^9.1.7",
 				"jscpd": "^5.0.14",
 				"jsdom": "^30.0.1",
@@ -12772,56 +12771,6 @@
 				"node": ">=14"
 			}
 		},
-		"node_modules/googleapis": {
-			"version": "174.0.0",
-			"resolved": "https://registry.npmjs.org/googleapis/-/googleapis-174.0.0.tgz",
-			"integrity": "sha512-RsoF0NOM+hIB+Ja60ymQZjTFQAkOUcQMakD3hd0FK6WOCVIxGXmnnK0ndHaEJUmzp+aQuaZleRTMX1DnowUfTQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"google-auth-library": "10.5.0",
-				"googleapis-common": "^8.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/googleapis-common": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-8.0.1.tgz",
-			"integrity": "sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"extend": "^3.0.2",
-				"gaxios": "^7.0.0-rc.4",
-				"google-auth-library": "^10.1.0",
-				"qs": "^6.7.0",
-				"url-template": "^2.0.8"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/googleapis/node_modules/google-auth-library": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
-			"integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"base64-js": "^1.3.0",
-				"ecdsa-sig-formatter": "^1.0.11",
-				"gaxios": "^7.0.0",
-				"gcp-metadata": "^8.0.0",
-				"google-logging-utils": "^1.0.0",
-				"gtoken": "^8.0.0",
-				"jws": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -12841,20 +12790,6 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/gtoken": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
-			"integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"gaxios": "^7.0.0",
-				"jws": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/has-bigints": {
 			"version": "1.1.0",
@@ -21401,13 +21336,6 @@
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"node_modules/url-template": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-			"integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
-			"dev": true,
-			"license": "BSD"
 		},
 		"node_modules/use-sync-external-store": {
 			"version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
 		"eslint-plugin-storybook": "^10.5.6",
 		"eslint-plugin-svelte": "^3.22.0",
 		"fast-check": "^4.9.0",
-		"googleapis": "^174.0.0",
 		"husky": "^9.1.7",
 		"jscpd": "^5.0.14",
 		"jsdom": "^30.0.1",


### PR DESCRIPTION
## 顧客価値・目的

開発者が `npm ci` を待つ時間と、QM が判断に使う帯域が減る。使っていない巨大パッケージ 1 本と推移依存を取り除くことで、CI のインストール時間・supply chain 攻撃面・dependabot の無意味な通知を同時に削る。

## 関連 Issue

Closes #4454

## 変更内容

- `package.json` の devDependencies から `googleapis` (`^174.0.0`) を削除
- `npm install` で `package-lock.json` を更新 (`googleapis` / `googleapis-common` を含む 72 行が消える)

コードからの import はゼロであることを自分で再確認した (下記「検証」)。`grep -rn "googleapis"` のヒットは全て `fcm.googleapis.com` / `android.googleapis.com` / `generativelanguage.googleapis.com` / `iam.googleapis.com` 等の**ホスト名文字列**で、npm パッケージ `googleapis` の利用ではない。

UI 変更なし — 依存関係の削除のみで、顧客に見える画面・挙動は一切変わらない。

### knip が報告した他の未使用候補 (本 PR では触らない)

Issue #4454 の scope 外。列挙のみ行う。husky / textlint 系のように「設定ファイル・hook 経由で使われており knip が追えないだけ」の false positive が混ざるため、個別に裏取りが要る。

| 分類 | パッケージ | 備考 |
|---|---|---|
| dependencies | `@aws-sdk/client-ssm` | 要確認 |
| devDependencies | `@axe-core/playwright` | ADR に採用記録あり (a11y E2E)、要確認 |
| devDependencies | `@cspell/dict-fonts` / `@cspell/dict-software-terms` | cspell 設定経由の可能性大 (false positive 疑い) |
| devDependencies | `@types/dompurify` | 型のみ、要確認 |
| devDependencies | `husky` | `.husky/*` hook 経由で現に稼働中 (false positive) |
| devDependencies | `textlint` / `textlint-rule-preset-ja-spacing` / `textlint-rule-preset-ja-technical-writing` / `textlint-rule-preset-jtf-style` / `textlint-rule-prh` | textlint 設定経由 (false positive 疑い) |

## 検証

### AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `package.json` の devDependencies から `googleapis` が削除されている | `grep -c googleapis package.json` | 0 件 ✓ |
| AC2 | `package-lock.json` から `googleapis` / `googleapis-common` の entry が消えている | `grep -c googleapis package-lock.json` | 0 件 (削除前は 6 件) ✓ |
| AC3 | `npm ci` が成功し `npm run pre-ready` が全 step PASS | `npm ci` → `npm run pre-ready -- --pr <本 PR>` | 全 step PASS ✓ |
| AC4 | knip の他候補は scope 外とし列挙のみ | 本 PR body 上表 | 11 件を列挙、コード変更なし ✓ |

### import ゼロの物理確認 (QM の前提を鵜呑みにせず自分で再実行)

| 検証項目 | 実行したコマンド | output 件数 | 判定 |
|---|---|---|---|
| npm パッケージ import が無いこと | `grep -rnE "(from\|require\(\|import\()\s*['\"]googleapis(/\|['\"])" . --include="*.ts" --include="*.js" --include="*.mjs" --include="*.cjs" --include="*.svelte" --exclude-dir=node_modules` | 0 件 | ✓ |
| lock からの除去 | `grep -c googleapis package-lock.json` | 0 件 | ✓ |
| package.json からの除去 | `grep -c googleapis package.json` | 0 件 | ✓ |
| 静的解析の裏取り | `npm run knip` | `Unused devDependencies` に `googleapis package.json:139:4` を検出 | ✓ |

`npm run knip` の結果は上表「knip が報告した他の未使用候補」に転記済み。

## 影響範囲

- **顧客に見える変化**: なし (UI 変更なし)
- **触った並行実装ペア**: なし
- **破壊的変更**: なし。削除対象はコードから一度も import されていない devDependency であり、実行時・ビルド時のいずれにも登場しない
- **CI**: `npm ci` のインストール対象が減るのみ

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
