### PR TITLE
fix(export): #4450 退会エクスポートの記録日を実データから出す（登録日流用 / lastRecordDate null 固定の是正）

### DIFF
--- a/src/lib/server/services/deletion-export-service.ts
+++ b/src/lib/server/services/deletion-export-service.ts
@@ -53,7 +53,12 @@ export interface ActivitySummaryExport {
 	totalActivities: number;
 	totalPoints: number;
 	categories: { name: string; count: number }[];
+	/**
+	 * 活動ログの **最初の記録日** (JST 暦日 `YYYY-MM-DD`)。記録が 1 件も無ければ null (#4450)。
+	 * 子供の登録日ではない (登録日は `MinimalChildExport.createdAt`)。
+	 */
 	firstRecordDate: string | null;
+	/** 活動ログの **最後の記録日** (JST 暦日 `YYYY-MM-DD`)。記録が 1 件も無ければ null (#4450)。 */
 	lastRecordDate: string | null;
 }
 
@@ -129,13 +134,23 @@ export async function generateMinimalExport(tenantId: string): Promise<MinimalEx
 
 		const totalPoints = statuses.reduce((sum, s) => sum + s.totalXp, 0);
 
+		// 記録期間は活動ログの実データから出す (#4450)。repo の返却順に依存しないよう
+		// min/max を取る (sqlite / dsql は recordedAt DESC、demo repo は無順序)。
+		// 暦日は JST 固定 — ISO 文字列の slice は UTC 暦日になり JST 00:00〜09:00 の記録が
+		// 前日へ落ちる (#4120 / ADR-0049 retention 監査との突き合わせが 1 日ずれる)。
+		const recordedDates = childLogs
+			.map((log) => log.recordedAt)
+			.filter((recordedAt): recordedAt is string => typeof recordedAt === 'string' && !!recordedAt)
+			.map(jstDateOfIso)
+			.sort();
+
 		activitySummary.push({
 			childNickname: child.nickname,
 			totalActivities: childLogs.length,
 			totalPoints,
 			categories,
-			firstRecordDate: child.createdAt ? jstDateOfIso(child.createdAt) : null,
-			lastRecordDate: null, // サマリレベルでは最終記録日は省略
+			firstRecordDate: recordedDates[0] ?? null,
+			lastRecordDate: recordedDates[recordedDates.length - 1] ?? null,
 		});
 	}
 

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -166,24 +166,73 @@ describe('deletion-export-service', () => {
 			expect(result.activitySummary[0]?.categories[1]?.name).toBe('べんきょう');
 		});
 
-		// #4120: 退会時に顧客へ手渡す日付は JST 暦日。createdAt (ISO UTC) を素朴に
-		// slice(0, 10) すると JST 00:00〜09:00 に作られた子供が前日として書き出され、
-		// 削除受領証 / retention 監査との突き合わせで 1 日食い違う (ADR-0049 / GDPR 第 15 条)。
-		// **注意 (QM #4412 レビュー)**: `firstRecordDate` に入るのは `child.createdAt`
-		// (子供の登録日) であって「最初の記録日」ではない。`lastRecordDate` は常に null
-		// (`deletion-export-service.ts:137-138`)。本 test が固定するのは **暦日の timezone だけ**で、
-		// フィールドの意味が正しいことは固定していない。test 名で意味まで保証したことにすると、
-		// 顧客へ手渡す成果物 (ADR-0049 / GDPR 第 15 条) の誤った意味を回帰テストで追認してしまう。
-		// フィールド名と中身の不一致は本 PR の scope 外 — 別途是正が要る。
-		it('firstRecordDate (実体は登録日) が JST 暦日で書き出される (UTC 暦日と割れる 9 時間の窓)', async () => {
+		// #4450: `firstRecordDate` / `lastRecordDate` は「活動ログの最初 / 最後の記録日」であり、
+		// 子供の登録日 (`child.createdAt`) ではない。退会時に顧客へ手渡す成果物
+		// (ADR-0049 / GDPR 第 15 条) なので、フィールド名と中身が食い違ってはならない。
+		// #4120: 日付は JST 暦日。ISO UTC を素朴に slice(0, 10) すると JST 00:00〜09:00 の記録が
+		// 前日として書き出され、削除受領証 / retention 監査との突き合わせで 1 日食い違う。
+		// 本 test は **暦日の timezone と、値の意味 (登録日ではなく記録日である) の両方**を固定する。
+		it('firstRecordDate / lastRecordDate に活動ログの最初・最後の記録日が JST 暦日で入る', async () => {
 			mockFindAllChildren.mockResolvedValue([
 				{
 					id: '1',
 					nickname: 'たろう',
 					age: 6,
 					uiMode: 'elementary',
-					// UTC 2026-07-31 15:10 = JST 2026-08-01 00:10
-					createdAt: '2026-07-31T15:10:00.000Z',
+					// UTC 2026-06-30 15:10 = JST 2026-07-01 00:10 (登録日。記録日ではない)
+					createdAt: '2026-06-30T15:10:00.000Z',
+				},
+			]);
+			mockFindStatuses.mockResolvedValue([]);
+			// repo は recordedAt DESC で返す (sqlite / dsql)
+			mockFindActivityLogs.mockResolvedValue([
+				{ id: '2', recordedAt: '2026-08-05T13:00:00.000Z' }, // JST 2026-08-05 22:00
+				{ id: '1', recordedAt: '2026-07-31T15:10:00.000Z' }, // JST 2026-08-01 00:10
+			]);
+
+			const result = await generateMinimalExport('tenant-1');
+
+			expect(result.activitySummary[0]?.firstRecordDate).toBe('2026-08-01');
+			expect(result.activitySummary[0]?.lastRecordDate).toBe('2026-08-05');
+			// UTC 暦日 (素朴な slice) なら前日になる = 本 assert は UTC 実装で必ず落ちる
+			expect(result.activitySummary[0]?.firstRecordDate).not.toBe('2026-07-31');
+			// 登録日 (JST 2026-07-01) を「最初の記録日」として出さない
+			expect(result.activitySummary[0]?.firstRecordDate).not.toBe('2026-07-01');
+			// 登録日そのものは children[] 側で引き続き開示される
+			expect(result.children[0]?.createdAt).toBe('2026-06-30T15:10:00.000Z');
+		});
+
+		it('記録日は repo の返却順に依存しない (昇順で返しても同じ)', async () => {
+			mockFindAllChildren.mockResolvedValue([
+				{
+					id: '1',
+					nickname: 'たろう',
+					age: 6,
+					uiMode: 'elementary',
+					createdAt: '2026-06-30T15:10:00.000Z',
+				},
+			]);
+			mockFindStatuses.mockResolvedValue([]);
+			// demo repo は順序を保証しない
+			mockFindActivityLogs.mockResolvedValue([
+				{ id: '1', recordedAt: '2026-07-31T15:10:00.000Z' },
+				{ id: '2', recordedAt: '2026-08-05T13:00:00.000Z' },
+			]);
+
+			const result = await generateMinimalExport('tenant-1');
+
+			expect(result.activitySummary[0]?.firstRecordDate).toBe('2026-08-01');
+			expect(result.activitySummary[0]?.lastRecordDate).toBe('2026-08-05');
+		});
+
+		it('活動ログが 0 件なら firstRecordDate / lastRecordDate とも null (登録日で埋めない)', async () => {
+			mockFindAllChildren.mockResolvedValue([
+				{
+					id: '1',
+					nickname: 'たろう',
+					age: 6,
+					uiMode: 'elementary',
+					createdAt: '2026-06-30T15:10:00.000Z',
 				},
 			]);
 			mockFindStatuses.mockResolvedValue([]);
@@ -191,21 +240,8 @@ describe('deletion-export-service', () => {
 
 			const result = await generateMinimalExport('tenant-1');
 
-			expect(result.activitySummary[0]?.firstRecordDate).toBe('2026-08-01');
-			// UTC 暦日 (素朴な slice) なら前日になる = 本 assert は UTC 実装で必ず落ちる
-			expect(result.activitySummary[0]?.firstRecordDate).not.toBe('2026-07-31');
-		});
-
-		it('createdAt が無い子供の firstRecordDate は null', async () => {
-			mockFindAllChildren.mockResolvedValue([
-				{ id: '1', nickname: 'たろう', age: 6, uiMode: 'elementary', createdAt: null },
-			]);
-			mockFindStatuses.mockResolvedValue([]);
-			mockFindActivityLogs.mockResolvedValue([]);
-
-			const result = await generateMinimalExport('tenant-1');
-
 			expect(result.activitySummary[0]?.firstRecordDate).toBeNull();
+			expect(result.activitySummary[0]?.lastRecordDate).toBeNull();
 		});
 
 		it('子供がいない場合も空の結果を返す', async () => {


### PR DESCRIPTION
## 顧客価値・目的

退会時に顧客が受け取る開示データ（free プランの最小限エクスポート）で、「最初の記録日」として子供の**登録日**が出ていて「最後の記録日」が常に空だった。実際の活動ログの期間が入るようにし、顧客が自分のデータを正しい期間で持ち出せるようにする。

## 関連 Issue

Closes #4450

## 変更内容

`src/lib/server/services/deletion-export-service.ts` `generateMinimalExport()`:

- `firstRecordDate` の代入元を `child.createdAt`（登録日）から、同関数が既に呼んでいる `findActivityLogs()` の `recordedAt` **最小値**に変更
- `lastRecordDate` の `null` 固定（「サマリレベルでは省略」）を撤廃し、同ログの `recordedAt` **最大値**に変更
- 日付は `jstDateOfIso()` を通した **JST 暦日**（#4120 / #4127 の JST SSOT を維持。ISO 文字列の slice は UTC 暦日になり JST 00:00〜09:00 の記録が前日に落ちる）
- 値は repo の返却順に依存せず min/max で決まる（sqlite / dsql は `recordedAt DESC`、demo repo は無順序）
- `ActivitySummaryExport` の 2 フィールドに、実体を明示する doc コメントを追加

### 採った方針と根拠（(a) 改名 / (b) 中身を名前に合わせる / (c) 両方）

**(b) 中身を名前に合わせる**を採った。

- この JSON は `GET /api/v1/admin/account/export` が返し、**顧客がダウンロードする開示成果物**（#740）。GDPR 第 15 条は「保有している個人データ」の開示であり、活動ログの期間は**実際に保有しているデータ**なので、開示すべきは記録日である。(a) の改名（`registeredDate` 等）は名前と中身を一致させはするが、**顧客が本来受け取れるはずの記録期間を落としたまま**になる
- 実装コストは低い。`findActivityLogs()` は同じループで既に呼ばれており（`totalActivities` の算出元）、**追加クエリはゼロ**。差分は min/max 算出の数行のみ（ADR-0065 DPU 規約にも抵触しない）
- wire format 互換: **フィールド名・型（`string | null`）は不変**。値の意味だけが是正される。`firstRecordDate` / `lastRecordDate` の参照箇所は `grep` で本 service と本 test のみ（`src/` / `docs/` / `scripts/` に他の読み手なし = パーサ側の追随不要）
- (c) 両方を出す案（記録日 + `registeredDate` 追加）は不採用。登録日は同じ JSON の `children[].createdAt` に**既に入っており**、フィールドを増やすと同じ値が 2 箇所に出る（Pre-PMF、ADR-0010）

## 検証

failing-test-first（ADR-0061）。test を先に書いて 3 件 fail することを確認してから実装した。

```
# 修正前（test 先行）
npx vitest run tests/unit/services/deletion-export-service.test.ts
  → Tests  3 failed | 9 passed (12)
    AssertionError: expected '2026-07-01' to be '2026-08-01'   （登録日が出ている）
    AssertionError: expected undefined to be '2026-08-05'       （lastRecordDate が null 固定）
    AssertionError: expected '2026-07-01' to be null            （ログ 0 件でも登録日で埋まる）

# 修正後
npx vitest run tests/unit/services/deletion-export-service.test.ts
  → Tests  12 passed (12)

npx biome check <変更 2 file>   → Checked 2 files. No fixes applied.
node scripts/check-local-tz-date-getters.mjs → OK
npm run pre-ready -- --pr 4459  → 全 step PASS（下記 AC 検証マップ参照）
```

QM が #4412 レビューで入れた test 注記コメント（「本 test が固定するのは暦日の timezone だけで、フィールドの意味は固定していない」）は、是正後の状態に合わせて更新した（timezone と**値の意味の両方**を固定する旨に書き換え）。test 名も `firstRecordDate (実体は登録日) が JST 暦日で書き出される` → `firstRecordDate / lastRecordDate に活動ログの最初・最後の記録日が JST 暦日で入る` に是正。既存の JST 暦日 assert（UTC 暦日と割れる 9 時間の窓 = `2026-07-31T15:10Z` → `2026-08-01`）は壊さず維持している。

### AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `firstRecordDate` = ログ `recordedAt` 最小値の JST 暦日 | `npx vitest run tests/unit/services/deletion-export-service.test.ts` | PASS（`firstRecordDate === '2026-08-01'`、UTC `2026-07-31T15:10Z` 入力） |
| AC2 | `lastRecordDate` = ログ `recordedAt` 最大値の JST 暦日（null 固定撤廃） | 同上 | PASS（`lastRecordDate === '2026-08-05'`） |
| AC3 | ログ 0 件なら両方 `null` | 同上 | PASS（`活動ログが 0 件なら firstRecordDate / lastRecordDate とも null (登録日で埋めない)`） |
| AC4 | repo の返却順に依存しない | 同上 | PASS（降順 mock / 昇順 mock の 2 test が同一結果） |
| AC5 | JST 暦日である（UTC 暦日に落ちない） | 同上 + `node scripts/check-local-tz-date-getters.mjs` | PASS（`not.toBe('2026-07-31')` assert / gate OK） |
| AC6 | 登録日は `children[].createdAt` として引き続き開示 | 同上 | PASS（`result.children[0].createdAt === '2026-06-30T15:10:00.000Z'` を assert） |
| AC7 | wire format のフィールド名・型が不変 | `git diff` + `npx svelte-check` | PASS（`ActivitySummaryExport` は doc コメント追加のみ、フィールド 6 個・型 `string \| null` のまま） |
| AC8 | QM の test 注記コメントが是正後の状態に更新 | `git diff tests/unit/services/deletion-export-service.test.ts` | PASS（#4450 の意図に書き換え、#4120 の JST 根拠は保持） |

## 影響範囲

- **顧客に見える変化**: free プランの退会前エクスポート JSON で `activitySummary[].firstRecordDate` / `lastRecordDate` の値が変わる（登録日 → 実際の記録期間 / null → 最終記録日）。standard / family の full export（`export-service.ts`）は無変更
- **UI 変更なし**（サーバ側の JSON 値の是正のみ。画面・文言・レイアウトに差分なし）
- 並行実装ペア: 触っていない。`findActivityLogs` は 3 backend（sqlite / dsql / demo）とも `ActivityLogSummary.recordedAt` を返す既存 API で、**repo 側は無変更**。返却順の差（sqlite / dsql = DESC、demo = 無順序）は min/max で吸収し、その不変条件を test で固定した
- 破壊的変更: なし（フィールド名・型は不変）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — revert のみで元に戻る"]
    R2["顧客面: 退会時の開示 JSON の値のみ。画面・課金・DB 無変更"]
    R3["データ破壊: 🟢なし — 読み取り専用の集計"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 開示データの正確性。記録期間が実データと一致"]
    T2["捨てる: activitySummary から登録日が消える。children[].createdAt を見る必要"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["🟡business: retention で古いログが消えると期間が短く見える"]
    O2["🟡UX: 裸の日付で JST・除外条件の説明が JSON 内に無い"]
    O3["🟡security: 集計元 JOIN で過小開示の懸念 → 実測で否定"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 free 退会者の JSON: 登録日→実記録期間 / null→最終記録日"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 記録期間を実データにする方針で進めてよいか"]
    Q2["Q2: 期間の但し書き文言の追加は別 Issue でよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R2,T2 warn
  class R1,R3,T1,C1 ok
  class O1,O2,O3 warn
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

adversarial-reviewer evidence: `tmp/adversarial-evidence/4459.json`（`node scripts/verify-adversarial-output.mjs --pr 4459` PASS）。3 軸の反対理由に対する Dev の回答:

- **business（retention で切られた期間が出る）**: 開示すべきは「保有している個人データ」（GDPR 第 15 条）であり、既に物理削除されたログは保有していない。**登録日は同じ JSON の `children[].createdAt` に残る**ため期間の手がかりは失われない（AC6 で test 固定）。JSON 内に「retention で古い記録が削除されている場合がある」旨の但し書きを足すかは文言追加の話で、本 PR の値の是正とは別軸 → Q2 で PO に確認
- **UX（裸の日付で JST / 除外条件の説明が無い）**: `null` の曖昧さは本 PR で解消している（従来は「省略」と「記録なし」が同じ `null` に潰れていたが、以後 `null` は「記録 0 件」だけを意味する）。日付表記の但し書きは Q2 と同件
- **security（`child_activities` への INNER JOIN で過小開示）**: **実測で否定**。活動削除は `src/routes/(parent)/admin/activities/+page.server.ts:330` で `hasActivityLogs()` を見て分岐し、**ログがある活動は soft delete（非表示化）**、hard delete はログ 0 件のときだけ。よって JOIN で落ちるログは存在しない。また `totalActivities` も同じ `findActivityLogs()` を集計元にしているため、件数と期間の間に不整合は生じない
- **security（`recordedAt` 非文字列の silent drop）**: filter は既存 test（`mockFindActivityLogs` が `{id}` のみを返す）を含む防御であり、3 backend とも `ActivityLogSummary.recordedAt` を必ず string で返す（`src/lib/server/db/{sqlite,dsql,demo}/activity-repo.ts`）。実データ経路で drop は起きない
- **実機経路の未検証**: `GET /api/v1/admin/account/export` を実データで叩く検証は未実施（free プラン + 活動ログを持つ owner の再現が local backend では組めない）。unit test で 3 backend 共通の契約（`recordedAt` の min/max、順序非依存）を固定して代替している

</details>
