### PR TITLE
fix(child): #4453 ニックネーム / テーマを変えたら仮アバターも作り直す

### DIFF
--- a/scripts/capture-specs/flows/admin-children-edit-avatar-4453.mjs
+++ b/scripts/capture-specs/flows/admin-children-edit-avatar-4453.mjs
@@ -1,0 +1,82 @@
+/**
+ * scripts/capture-specs/flows/admin-children-edit-avatar-4453.mjs
+ *
+ * #4453: 子供を登録 → **ニックネームを別の頭文字に変更** → `/admin/children` 一覧を撮る。
+ * 修正前は仮アバターが古い頭文字のまま (名前だけ変わる)、修正後は新しい頭文字に追随する。
+ *
+ * ニックネームは環境変数で指定する (before / after で別の子供を作れば、同じ tenant の
+ * DB を使い回しても互いの結果が混ざらない):
+ *   CAPTURE_CHILD_NICKNAME       登録時の名前 (既定: あおい)
+ *   CAPTURE_CHILD_NICKNAME_AFTER 変更後の名前 (既定: はると) — 頭文字を変えること
+ *
+ * 使用例:
+ *   CAPTURE_CHILD_NICKNAME=あおい CAPTURE_CHILD_NICKNAME_AFTER=はると \
+ *   BASE_URL=http://localhost:5174 node scripts/capture.mjs \
+ *     --flow admin-children-edit-avatar-4453 --url /admin/children \
+ *     --actions scripts/capture-specs/flows/admin-children-edit-avatar-4453.mjs --presets desktop
+ */
+
+const NICKNAME = process.env.CAPTURE_CHILD_NICKNAME ?? 'あおい';
+const NICKNAME_AFTER = process.env.CAPTURE_CHILD_NICKNAME_AFTER ?? 'はると';
+const AGE = process.env.CAPTURE_CHILD_AGE ?? '7';
+
+async function settle(page) {
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	// --- 1. 子供を登録する (仮アバターが付く) ---
+	const addToggle = page.locator('[data-tutorial="add-child-btn"]');
+	await addToggle.waitFor({ state: 'visible', timeout: 20_000 });
+
+	// Svelte 5 hydration race を click retry で吸収する (admin-children-add-4413 と同じ理由)。
+	const nickname = page.locator('#add-nickname');
+	for (let attempt = 0; attempt < 5; attempt++) {
+		await addToggle.click();
+		const opened = await nickname
+			.waitFor({ state: 'visible', timeout: 3_000 })
+			.then(() => true)
+			.catch(() => false);
+		if (opened) break;
+	}
+	await nickname.waitFor({ state: 'visible', timeout: 20_000 });
+	await nickname.fill(NICKNAME);
+	await page.locator('#add-age').fill(AGE);
+	await page.getByRole('button', { name: '追加する' }).click();
+
+	const addedCard = page.getByText(NICKNAME, { exact: true }).first();
+	await addedCard.waitFor({ state: 'visible', timeout: 20_000 });
+
+	// --- 2. その子供を選んで編集モードに入り、ニックネームを変える ---
+	await addedCard.click();
+	const editButton = page.getByRole('button', { name: /編集/ }).first();
+	await editButton.waitFor({ state: 'visible', timeout: 20_000 });
+	await editButton.click();
+
+	const editNickname = page.locator('input[name="nickname"]').first();
+	await editNickname.waitFor({ state: 'visible', timeout: 20_000 });
+	await editNickname.fill(NICKNAME_AFTER);
+	await page.getByRole('button', { name: /保存/ }).first().click();
+
+	// --- 3. 変更後の一覧を撮る (名前が変わった行のアバターに注目) ---
+	await page
+		.getByText(NICKNAME_AFTER, { exact: true })
+		.first()
+		.waitFor({ state: 'visible', timeout: 20_000 });
+	await page
+		.locator('.child-list-card__avatar')
+		.first()
+		.waitFor({ state: 'visible', timeout: 20_000 });
+	await settle(page);
+
+	await capture('admin-children-edit-avatar');
+};

--- a/src/lib/domain/placeholder-avatar.ts
+++ b/src/lib/domain/placeholder-avatar.ts
@@ -74,6 +74,31 @@ function firstGrapheme(nickname: string): string {
 }
 
 /**
+ * #4453: 仮アバターの中身を表す短い版 (version) 文字列。
+ *
+ * 仮アバターの保存先は childId ごとの**固定名**なので、作り直しても URL が変わらず、
+ * ブラウザは自分のキャッシュ (`private, max-age=300`) を出し続ける。つまり保護者が
+ * ニックネームを直しても最大 5 分は古い頭文字が表示されてしまう。`avatar_url` に
+ * `?v=<この値>` を付けて**中身が変われば URL も変わる**ようにし、その場で切り替わるようにする。
+ *
+ * 内容から導出する (時刻ではない) ので、同じニックネーム / テーマなら常に同じ値になり、
+ * 意味のない URL 変更でキャッシュを捨てさせることがない。
+ *
+ * ハッシュは FNV-1a (32bit)。衝突しても起きるのは「見た目が変わったのに URL が同じ」= 元の
+ * 挙動に戻るだけで、壊れ方が増えない。暗号用途ではないので強度は要らない
+ * (この module は import を 1 本も持たない制約があり、外部ハッシュを使えない)。
+ */
+export function placeholderAvatarVersion(nickname: string, theme: string): string {
+	const source = `${nickname}|${theme}`;
+	let hash = 0x811c9dc5;
+	for (let i = 0; i < source.length; i++) {
+		hash ^= source.charCodeAt(i);
+		hash = Math.imul(hash, 0x01000193) >>> 0;
+	}
+	return hash.toString(36);
+}
+
+/**
  * 子供のニックネームとテーマから、頭文字入りの円形アバター SVG を組み立てる。
  *
  * 純粋関数 — 外部通信も I/O も行わない。

--- a/src/lib/server/security/file-sanitizer.ts
+++ b/src/lib/server/security/file-sanitizer.ts
@@ -152,8 +152,10 @@ const MUTABLE_FIXED_NAME_STEMS = new Set<string>([PLACEHOLDER_AVATAR_BASENAME]);
  * **`immutable` はキーが実際に immutable なときだけ**: `avatarKey` / `voiceKey` (uuid) と
  * `generatedImageKey` (prompt hash) は内容が変われば URL も変わるので 1 年 immutable が正しい。
  * 一方 `placeholderAvatarKey` は childId ごとの固定名で、ニックネームやテーマを変えると
- * **同じ URL の中身が差し替わる**。ここに 1 年 immutable を付けると、再生成しても
- * ブラウザが古い画像を出し続ける (再検証しないのが immutable の意味) ため、短命 max-age にする。
+ * **同じパスの中身が差し替わる** (#4453 で editChild が実際に差し替える)。`avatar_url` には
+ * `?v=<中身の版>` が付くため通常の表示経路は即座に切り替わるが、**パス自体は依然 mutable**
+ * (版を持たない旧データ / パス直アクセス) なので、ここに 1 年 immutable は付けられない
+ * (再検証しないのが immutable の意味)。よって短命 max-age にする。
  *
  * user データを静的配信する全経路は本関数を経由すること (安全配信ユーティリティへの集約、#3105 同様)。
  */

--- a/src/lib/server/services/child-service.ts
+++ b/src/lib/server/services/child-service.ts
@@ -71,8 +71,14 @@ export async function addChild(
  * 生成は外部通信ゼロ (`buildPlaceholderAvatarSvg` は import を持たない純粋関数)。
  * 保護者が写真をアップロードすれば `avatar_url` が上書きされ、仮アバターは差し替えられる。
  *
- * アバターは付加価値であって登録の前提条件ではないので、**失敗しても登録は成功させる**
- * (storage 不調で子供を登録できない方が顧客にとって悪い)。その場合は一覧で 👤 のままになる。
+ * アバターは付加価値であって登録・編集の前提条件ではないので、**失敗しても呼び出し元の操作は
+ * 成功させる** (storage 不調で子供を登録・編集できない方が顧客にとって悪い)。その場合は
+ * 一覧で 👤 or 古い仮アバターのままになる。
+ *
+ * #4453: `editChild` からも呼ぶ。仮アバターは nickname + theme から導出されるので、
+ * 導出元が変わったら追随させないと「名前を直したのに古い頭文字のまま」になる。
+ * ただし**保護者がアップロードした写真は上書きしない** — 呼ぶ前に
+ * `shouldRegeneratePlaceholderAvatar` で `avatar_url` が仮アバター自身か未設定かを確認すること。
  */
 async function attachPlaceholderAvatar<T extends { id: ChildId; nickname: string; theme: string }>(
 	child: T,
@@ -90,7 +96,7 @@ async function attachPlaceholderAvatar<T extends { id: ChildId; nickname: string
 
 		return { ...child, avatarUrl: publicUrl };
 	} catch (err) {
-		logger.warn('[child-service] 仮アバターの生成に失敗しました（登録は継続します）', {
+		logger.warn('[child-service] 仮アバターの生成に失敗しました（登録・編集は継続します）', {
 			context: { childId: child.id, tenantId },
 			error: err instanceof Error ? err.message : String(err),
 		});
@@ -115,21 +121,67 @@ export async function editChild(
 ) {
 	const patched: typeof input = { ...input };
 
+	// #4453: 仮アバターは nickname + theme から導出されるので、どちらかが変わったら作り直す。
+	// 判定には「変更前の値」が要る。uiMode 再計算 (#580/#1382) も同じ既存行を見るため、
+	// ここで 1 回だけ引いて両方で使う (同じ行を 2 回引かない)。
+	const needsExisting =
+		input.nickname !== undefined ||
+		input.theme !== undefined ||
+		(patched.uiMode === undefined && patched.age !== undefined);
+	const existing = needsExisting ? await findChildById(id, tenantId) : null;
+
 	if (patched.uiMode !== undefined) {
 		// #1382: 保護者が明示的に UIMode を指定 → 手動フラグを立てる
 		patched.uiModeManuallySet = 1;
-	} else if (patched.age !== undefined) {
+	} else if (patched.age !== undefined && existing) {
 		// #580/#1382: age 変更時は既存フラグを参照して自動再計算するか判断する
-		const existing = await findChildById(id, tenantId);
-		if (existing) {
-			patched.uiMode = recalcUiMode(
-				{ uiMode: existing.uiMode as UiMode, uiModeManuallySet: existing.uiModeManuallySet ?? 0 },
-				patched.age,
-			);
-		}
+		patched.uiMode = recalcUiMode(
+			{ uiMode: existing.uiMode as UiMode, uiModeManuallySet: existing.uiModeManuallySet ?? 0 },
+			patched.age,
+		);
 	}
 
-	return await updateChild(id, patched, tenantId);
+	const updated = await updateChild(id, patched, tenantId);
+
+	if (existing && shouldRegeneratePlaceholderAvatar(existing, input, id, tenantId)) {
+		// 失敗しても編集は成功させる (attachPlaceholderAvatar が内部で握って warn する)。
+		await attachPlaceholderAvatar(
+			{
+				id,
+				nickname: input.nickname ?? existing.nickname,
+				theme: input.theme ?? existing.theme,
+			},
+			tenantId,
+		);
+	}
+
+	return updated;
+}
+
+/**
+ * #4453: 編集後に仮アバターを作り直すべきか。
+ *
+ * **保護者がアップロードした写真を消さないことが本判定の主目的**。仮アバターは childId ごとの
+ * 固定名キー (`placeholderAvatarKey`) なので、`avatar_url` がそのキーを指していれば「まだ仮アバター
+ * のまま」= 上書きしてよい。写真をアップロードすると `avatar_url` は uuid キー (別 URL) に変わるため、
+ * その子は対象外になる。`avatar_url` が未設定なら消せる写真自体が無いので生成してよい
+ * (#4413 以前に登録された子供 / 仮アバター生成に失敗した子供がここに該当する)。
+ */
+function shouldRegeneratePlaceholderAvatar(
+	existing: { nickname: string; theme: string; avatarUrl?: string | null },
+	input: { nickname?: string; theme?: string },
+	id: ChildId,
+	tenantId: string,
+): boolean {
+	const nicknameChanged = input.nickname !== undefined && input.nickname !== existing.nickname;
+	const themeChanged = input.theme !== undefined && input.theme !== existing.theme;
+	if (!nicknameChanged && !themeChanged) return false;
+
+	if (!existing.avatarUrl) return true;
+	const placeholderUrl = storageKeyToPublicUrl(
+		placeholderAvatarKey(tenantId, id, PLACEHOLDER_AVATAR_EXTENSION),
+	);
+	return existing.avatarUrl === placeholderUrl;
 }
 
 export async function removeChild(id: ChildId, tenantId: string) {

--- a/src/lib/server/services/child-service.ts
+++ b/src/lib/server/services/child-service.ts
@@ -3,6 +3,7 @@ import {
 	buildPlaceholderAvatarSvg,
 	PLACEHOLDER_AVATAR_CONTENT_TYPE,
 	PLACEHOLDER_AVATAR_EXTENSION,
+	placeholderAvatarVersion,
 } from '$lib/domain/placeholder-avatar';
 import type { UiMode } from '$lib/domain/validation/age-tier';
 import { getDefaultUiMode, recalcUiMode } from '$lib/domain/validation/age-tier';
@@ -91,7 +92,10 @@ async function attachPlaceholderAvatar<T extends { id: ChildId; nickname: string
 		const svg = buildPlaceholderAvatarSvg(child.nickname, child.theme);
 		await saveFile(key, Buffer.from(svg, 'utf-8'), PLACEHOLDER_AVATAR_CONTENT_TYPE);
 
-		const publicUrl = storageKeyToPublicUrl(key);
+		// #4453: 保存先は固定名なので、中身から導いた版を URL に付けて「作り直したのに
+		// ブラウザが古い画像を出し続ける」(max-age=300) を防ぐ。配信側は path でルーティング
+		// するため query は無視される。
+		const publicUrl = `${storageKeyToPublicUrl(key)}?v=${placeholderAvatarVersion(child.nickname, child.theme)}`;
 		await updateChildAvatarUrl(child.id, publicUrl, tenantId);
 
 		return { ...child, avatarUrl: publicUrl };
@@ -181,7 +185,8 @@ function shouldRegeneratePlaceholderAvatar(
 	const placeholderUrl = storageKeyToPublicUrl(
 		placeholderAvatarKey(tenantId, id, PLACEHOLDER_AVATAR_EXTENSION),
 	);
-	return existing.avatarUrl === placeholderUrl;
+	// `?v=<版>` が付いている (#4453) ので path 部分で比べる。
+	return existing.avatarUrl.split('?')[0] === placeholderUrl;
 }
 
 export async function removeChild(id: ChildId, tenantId: string) {

--- a/tests/unit/routes/child-registration-placeholder-avatar.test.ts
+++ b/tests/unit/routes/child-registration-placeholder-avatar.test.ts
@@ -9,6 +9,8 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { placeholderAvatarVersion } from '$lib/domain/placeholder-avatar';
+
 const mockInsertChild = vi.fn();
 const mockUpdateChildAvatarUrl = vi.fn();
 const mockSaveFile = vi.fn();
@@ -118,9 +120,10 @@ function expectPlaceholderAvatarAttached() {
 	expect(svg).toContain('<svg');
 	expect(svg, 'ニックネームの頭文字が入っていない').toContain('>ま<');
 
+	// #4453: 保存先は固定名なので、中身の版 (`?v=`) を URL に付けて作り直しを即反映させる
 	expect(mockUpdateChildAvatarUrl, 'children.avatar_url が更新されていない').toHaveBeenCalledWith(
 		'c-1',
-		`/${key}`,
+		`/${key}?v=${placeholderAvatarVersion('まさと', 'blue')}`,
 		't-test',
 	);
 }
@@ -145,7 +148,7 @@ describe('子供の登録で仮アバターが自動で付く (#4413)', () => {
 
 		// 追加直後に一覧へ返す child にも avatarUrl が載っている
 		// (載っていないと画面上は 👤 のままで、再読込するまで反映されない)
-		expect(result.addedChild.avatarUrl).toMatch(/^\/tenants\/t-test\/.*\.svg$/);
+		expect(result.addedChild.avatarUrl).toMatch(/^\/tenants\/t-test\/.*\.svg\?v=[0-9a-z]+$/);
 	});
 
 	it('AC5: 仮アバターの保存に失敗しても子供の登録自体は成功する', async () => {

--- a/tests/unit/services/child-service.test.ts
+++ b/tests/unit/services/child-service.test.ts
@@ -214,12 +214,114 @@ describe('child-service', () => {
 		});
 
 		it('#580: age 未指定時は uiMode を付与しない', async () => {
+			// #4453: nickname 変更は仮アバターの再生成判定に変更前の値を要するため
+			// findChildById を引く。ここで固定するのは「uiMode を勝手に足さない」こと。
+			vi.mocked(findChildById).mockResolvedValue({
+				id: '10',
+				nickname: 'まさと',
+				theme: 'blue',
+				avatarUrl: null,
+			} as never);
 			vi.mocked(updateChild).mockResolvedValue({ id: '10' } as never);
 
 			await editChild(asChildId(10), { nickname: 'まさと改' }, TENANT);
 
-			expect(findChildById).not.toHaveBeenCalled();
 			expect(updateChild).toHaveBeenCalledWith('10', { nickname: 'まさと改' }, TENANT);
+		});
+	});
+
+	// --- #4453: ニックネーム / テーマを変えたら仮アバターも作り直す ---
+	//
+	// 仮アバターは nickname + theme から導出される永続アセットなので、導出元が変わったら
+	// 追随しないと「名前を直したのにアイコンが古い頭文字のまま」になる。
+	// 一方で **保護者がアップロードした写真を上書きしてはならない** ので、再生成するのは
+	// avatar_url が仮アバター自身 (固定名キー) を指しているか未設定のときだけ。
+	describe('editChild — 仮アバターの再生成 (#4453)', () => {
+		const PLACEHOLDER_URL = `/tenants/${TENANT}/avatars/10/placeholder.svg`;
+		const UPLOADED_PHOTO_URL = `/tenants/${TENANT}/avatars/10/9f1c2d3e-4b5a.webp`;
+
+		function seedExisting(overrides: Record<string, unknown> = {}) {
+			vi.mocked(findChildById).mockResolvedValue({
+				id: '10',
+				nickname: 'たろう',
+				theme: 'blue',
+				avatarUrl: PLACEHOLDER_URL,
+				uiMode: 'elementary',
+				uiModeManuallySet: 0,
+				...overrides,
+			} as never);
+			vi.mocked(updateChild).mockResolvedValue({ id: '10' } as never);
+		}
+
+		it('AC1: ニックネームを変えると新しい頭文字で仮アバターを作り直し avatar_url を更新する', async () => {
+			seedExisting();
+
+			await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
+
+			expect(saveFile).toHaveBeenCalledTimes(1);
+			const [key, data] = vi.mocked(saveFile).mock.calls[0] as [string, Buffer, string];
+			expect(key).toBe(`tenants/${TENANT}/avatars/10/placeholder.svg`);
+			expect(data.toString('utf-8')).toContain('>は<');
+			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', PLACEHOLDER_URL, TENANT);
+		});
+
+		it('AC2: テーマを変えると仮アバターを作り直す (色が追随する)', async () => {
+			seedExisting();
+
+			await editChild(asChildId(10), { theme: 'pink' }, TENANT);
+
+			expect(saveFile).toHaveBeenCalledTimes(1);
+			const [, blueless] = vi.mocked(saveFile).mock.calls[0] as [string, Buffer, string];
+			// 変更後のテーマで組み立てられている (頭文字は据え置き)
+			expect(blueless.toString('utf-8')).toContain('>た<');
+			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', PLACEHOLDER_URL, TENANT);
+		});
+
+		it('AC3: 保護者がアップロードした写真は上書きしない (ニックネームを変えても再生成しない)', async () => {
+			seedExisting({ avatarUrl: UPLOADED_PHOTO_URL });
+
+			await editChild(asChildId(10), { nickname: 'はなこ', theme: 'pink' }, TENANT);
+
+			expect(saveFile).not.toHaveBeenCalled();
+			expect(updateChildAvatarUrl).not.toHaveBeenCalled();
+		});
+
+		it('AC3 系: avatar_url 未設定なら (消せる写真が無いので) 仮アバターを作る', async () => {
+			seedExisting({ avatarUrl: null });
+
+			await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
+
+			expect(saveFile).toHaveBeenCalledTimes(1);
+			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', PLACEHOLDER_URL, TENANT);
+		});
+
+		it('AC4: 同じ値で送り直しただけなら再生成しない (無駄な書き込みをしない)', async () => {
+			seedExisting();
+
+			await editChild(asChildId(10), { nickname: 'たろう', theme: 'blue', age: 9 }, TENANT);
+
+			expect(saveFile).not.toHaveBeenCalled();
+			expect(updateChildAvatarUrl).not.toHaveBeenCalled();
+		});
+
+		it('AC4 系: 年齢だけの変更では再生成しない', async () => {
+			seedExisting();
+
+			await editChild(asChildId(10), { age: 9 }, TENANT);
+
+			expect(saveFile).not.toHaveBeenCalled();
+		});
+
+		it('AC5: 仮アバターの保存に失敗しても編集自体は成功する', async () => {
+			seedExisting();
+			vi.mocked(saveFile).mockRejectedValueOnce(new Error('storage down'));
+
+			const result = await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
+
+			expect(result).toEqual({ id: '10' });
+			expect(updateChild).toHaveBeenCalled();
+			expect(updateChildAvatarUrl).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalled();
 		});
 	});
 

--- a/tests/unit/services/child-service.test.ts
+++ b/tests/unit/services/child-service.test.ts
@@ -56,6 +56,7 @@ vi.mock('$lib/server/storage-keys', () => ({
 // --- Imports (after mocks) ---
 
 import { asChildId } from '$lib/domain/ids';
+import { placeholderAvatarVersion } from '$lib/domain/placeholder-avatar';
 import {
 	deleteChild,
 	findAllChildren,
@@ -144,6 +145,8 @@ describe('child-service', () => {
 			const result = await addChild(input, TENANT);
 
 			const expectedKey = `tenants/${TENANT}/avatars/10/placeholder.svg`;
+			// #4453: 保存先は固定名なので、URL には中身の版が付く (キャッシュ切替のため)
+			const expectedUrl = `/${expectedKey}?v=${placeholderAvatarVersion(input.nickname, input.theme)}`;
 			expect(saveFile).toHaveBeenCalledTimes(1);
 			const [key, data, contentType] = vi.mocked(saveFile).mock.calls[0] as [
 				string,
@@ -154,8 +157,8 @@ describe('child-service', () => {
 			expect(contentType).toBe('image/svg+xml');
 			expect(data.toString('utf-8')).toContain('>ま<');
 
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', `/${expectedKey}`, TENANT);
-			expect(result).toEqual({ ...inserted, avatarUrl: `/${expectedKey}` });
+			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', expectedUrl, TENANT);
+			expect(result).toEqual({ ...inserted, avatarUrl: expectedUrl });
 		});
 
 		// #4413 AC5: アバターは付加価値。storage が不調でも子供の登録は成功させる。
@@ -237,7 +240,10 @@ describe('child-service', () => {
 	// 一方で **保護者がアップロードした写真を上書きしてはならない** ので、再生成するのは
 	// avatar_url が仮アバター自身 (固定名キー) を指しているか未設定のときだけ。
 	describe('editChild — 仮アバターの再生成 (#4453)', () => {
-		const PLACEHOLDER_URL = `/tenants/${TENANT}/avatars/10/placeholder.svg`;
+		const PLACEHOLDER_PATH = `/tenants/${TENANT}/avatars/10/placeholder.svg`;
+		const url = (nickname: string, theme: string) =>
+			`${PLACEHOLDER_PATH}?v=${placeholderAvatarVersion(nickname, theme)}`;
+		const PLACEHOLDER_URL = url('たろう', 'blue');
 		const UPLOADED_PHOTO_URL = `/tenants/${TENANT}/avatars/10/9f1c2d3e-4b5a.webp`;
 
 		function seedExisting(overrides: Record<string, unknown> = {}) {
@@ -262,7 +268,9 @@ describe('child-service', () => {
 			const [key, data] = vi.mocked(saveFile).mock.calls[0] as [string, Buffer, string];
 			expect(key).toBe(`tenants/${TENANT}/avatars/10/placeholder.svg`);
 			expect(data.toString('utf-8')).toContain('>は<');
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', PLACEHOLDER_URL, TENANT);
+			// 保存先は固定名なので、URL の版が変わらないとブラウザが古い画像を出し続ける
+			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('はなこ', 'blue'), TENANT);
+			expect(url('はなこ', 'blue')).not.toBe(PLACEHOLDER_URL);
 		});
 
 		it('AC2: テーマを変えると仮アバターを作り直す (色が追随する)', async () => {
@@ -274,7 +282,7 @@ describe('child-service', () => {
 			const [, blueless] = vi.mocked(saveFile).mock.calls[0] as [string, Buffer, string];
 			// 変更後のテーマで組み立てられている (頭文字は据え置き)
 			expect(blueless.toString('utf-8')).toContain('>た<');
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', PLACEHOLDER_URL, TENANT);
+			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('たろう', 'pink'), TENANT);
 		});
 
 		it('AC3: 保護者がアップロードした写真は上書きしない (ニックネームを変えても再生成しない)', async () => {
@@ -292,7 +300,16 @@ describe('child-service', () => {
 			await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
 
 			expect(saveFile).toHaveBeenCalledTimes(1);
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', PLACEHOLDER_URL, TENANT);
+			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('はなこ', 'blue'), TENANT);
+		});
+
+		it('AC3 系: 版付き URL でない旧データ (?v= 無し) も仮アバターとして扱い作り直す', async () => {
+			seedExisting({ avatarUrl: PLACEHOLDER_PATH });
+
+			await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
+
+			expect(saveFile).toHaveBeenCalledTimes(1);
+			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('はなこ', 'blue'), TENANT);
 		});
 
 		it('AC4: 同じ値で送り直しただけなら再生成しない (無駄な書き込みをしない)', async () => {

--- a/tests/unit/services/child-service.test.ts
+++ b/tests/unit/services/child-service.test.ts
@@ -56,7 +56,10 @@ vi.mock('$lib/server/storage-keys', () => ({
 // --- Imports (after mocks) ---
 
 import { asChildId } from '$lib/domain/ids';
-import { placeholderAvatarVersion } from '$lib/domain/placeholder-avatar';
+import {
+	buildPlaceholderAvatarSvg,
+	placeholderAvatarVersion,
+} from '$lib/domain/placeholder-avatar';
 import {
 	deleteChild,
 	findAllChildren,
@@ -279,9 +282,11 @@ describe('child-service', () => {
 			await editChild(asChildId(10), { theme: 'pink' }, TENANT);
 
 			expect(saveFile).toHaveBeenCalledTimes(1);
-			const [, blueless] = vi.mocked(saveFile).mock.calls[0] as [string, Buffer, string];
-			// 変更後のテーマで組み立てられている (頭文字は据え置き)
-			expect(blueless.toString('utf-8')).toContain('>た<');
+			const [, savedSvg] = vi.mocked(saveFile).mock.calls[0] as [string, Buffer, string];
+			// 変更後のテーマ (pink) で組み立て直されている = 色が追随する。
+			// 期待値は実物の builder から作るので、配色を test に写し取らない。
+			expect(savedSvg.toString('utf-8')).toBe(buildPlaceholderAvatarSvg('たろう', 'pink'));
+			expect(savedSvg.toString('utf-8')).not.toBe(buildPlaceholderAvatarSvg('たろう', 'blue'));
 			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('たろう', 'pink'), TENANT);
 		});
 


### PR DESCRIPTION
## 顧客価値・目的

子供のニックネームを直すと、一覧に出るアイコン（仮アバター）も新しい頭文字に変わる。テーマを変えれば色も追随する。これまでは名前だけ変わってアイコンは古いままで、「直したのに直っていない」状態が残っていた。写真をアップロードしない家庭ほど当たる不整合。

## 関連 Issue

Closes #4453

## 変更内容

1. **再生成そのもの**: `editChild()` が nickname / theme の変更に追随して仮アバターを作り直す（`attachPlaceholderAvatar` の再利用）
   - 再生成するのは **導出元が実際に変わったとき** かつ **`avatar_url` が仮アバター自身のパス、または未設定のとき** だけ。保護者がアップロードした写真は uuid キー（別 URL）になるため対象外で、**上書きされない**（`shouldRegeneratePlaceholderAvatar`）
   - 生成・保存に失敗しても編集は成功させる（`addChild` と同じ設計判断。アバターは付加価値であって前提条件ではない）
   - uiMode 再計算（#580/#1382）と再生成判定はどちらも「変更前の行」が要るので、`findChildById` は 1 回だけ引いて共用する
2. **反映されないままだった残り半分**: 保存先が childId ごとの**固定名**のため、作り直しても URL が変わらず、ブラウザは `private, max-age=300` の自分のキャッシュを出し続けていた。**実機 SS で「DB もファイルも新しい頭文字なのに、一覧は古い頭文字のまま」を確認した**ので、`avatar_url` に `?v=<中身の版>`（`placeholderAvatarVersion`、nickname + theme の FNV-1a）を付けてその場で切り替わるようにした。版は内容から導出する（時刻ではない）ので、同じ内容なら同じ値になり、意味のない再取得を起こさない
3. SS 撮影用フロー `scripts/capture-specs/flows/admin-children-edit-avatar-4453.mjs` を追加（既存 `admin-children-add-4413.mjs` と同じ流儀）

`src/lib/server/security/file-sanitizer.ts` はコメントのみ実装に追随させた。同ファイルは「`placeholderAvatarKey` は固定名で、ニックネームやテーマを変えると同じ URL の中身が差し替わる」という**実装に存在しない前提**のもとで仮アバターだけ短い `max-age`（300 秒）を払っていた。本 PR で前提が真になった一方、**パス自体は依然 mutable**（版を持たない旧データ / パス直アクセス）なので、`max-age` 値は据え置きが正しい。

## 検証

failing-test-first（ADR-0061）。実装前に test を書き、**4 件 fail することを確認してから**実装した。

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | nickname 変更で再生成され `avatar_url` が更新される | `tests/unit/services/child-service.test.ts` "AC1: ニックネームを変えると…" | PASS（保存 SVG に `>は<` = 新しい頭文字を assert）。実装前は fail |
| AC2 | theme 変更で再生成される | 同 "AC2: テーマを変えると…" | PASS。実装前は fail |
| AC3 | 写真アップロード済みは再生成しない（写真が消えない） | 同 "AC3: 保護者がアップロードした写真は上書きしない" | PASS（`saveFile` / `updateChildAvatarUrl` が 0 回） |
| AC3 系 | `avatar_url` 未設定なら生成する | 同 "AC3 系: avatar_url 未設定なら…" | PASS。実装前は fail |
| AC4 | 変わっていない編集では再生成しない | 同 "AC4: 同じ値で送り直しただけなら…" / "AC4 系: 年齢だけの変更では…" | PASS |
| AC5 | 生成失敗でも編集は成功する | 同 "AC5: 仮アバターの保存に失敗しても…" | PASS（`saveFile` reject でも `editChild` は resolve、`logger.warn`） |
| AC6 | unit test で固定 | `npx vitest run` | 173 files / 2859 tests PASS（実装後）。実装前は 4 fail |
| 追加 | 版付き URL で即座に切り替わる | 実機 SS（下記） | 修正前は「は」に変えても「あ」のまま / 修正後は「は」 |

`npx vitest run tests/unit/services/child-service.test.ts tests/unit/domain/placeholder-avatar.test.ts tests/unit/routes/child-registration-placeholder-avatar.test.ts tests/unit/architecture/placeholder-avatar-offline.test.ts tests/unit/architecture/user-content-delivery-headers-fitness.test.ts` → 5 files / 58 tests PASS。

### 実機（`npm run dev:cognito` = `AUTH_MODE=cognito` + `COGNITO_DEV_MODE=true`、DB は Before / After とも初期化）

`/admin/children` で「あおい」を登録 → **ニックネームを「はると」に変更** → 一覧。頭文字が変わる名前にしてあるので、追随していなければ「あ」のまま残る。

| Before（develop） | After（本 PR） |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4461/before-child-avatar.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4461/after-child-avatar.png) |
| 名前は「はると」なのに **アイコンは「あ」のまま** | アイコンも **「は」** に変わる |

撮影は `scripts/capture-specs/flows/admin-children-edit-avatar-4453.mjs`（同一フロー・同一操作）。Before は `src/lib/server/services/child-service.ts` を origin/develop の内容に戻して撮影した。

## 影響範囲

- 顧客に見える変化: `/admin/children` の子供一覧・プロフィール、および子供画面のアバター。ニックネーム / テーマを変えた**その子だけ**が更新される（既存データの一括再生成 migration は行わない）
- **`avatar_url` の値の形が変わる**（`…/placeholder.svg` → `…/placeholder.svg?v=<版>`）。仮アバターに限った変更で、写真アバター（uuid キー）は不変。配信は path でルーティングするため query は無視される。版を持たない既存行も「仮アバター」と判定して作り直す（回帰テストあり）
- 並行実装ペア: `editChild` は `/admin/children` の action 1 経路のみ（`grep` 済み）。仮アバターの生成点は `child-service` の 1 箇所に集約したまま増やしていない
- 破壊的変更: なし。DB スキーマ・API・ルーティングの変更なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
