### PR TITLE
test(switch): #4460 スクロールロック (parent-gate-scroll-lock) の解除漏れに回帰テストを足す

### DIFF
--- a/tests/e2e/demo-lambda/visual-equality.spec.ts
+++ b/tests/e2e/demo-lambda/visual-equality.spec.ts
@@ -260,3 +260,67 @@ test.describe('#4417: 320px 幅で横スクロールが発生しない', () => {
 		});
 	}
 });
+
+// #4417 AC3 の後追い回帰: /switch の全画面 overlay (`.login-overlay`) 表示中は背面をスクロールさせない。
+//
+// 実装は body に `parent-gate-scroll-lock` を付け、`:global(body.parent-gate-scroll-lock){overflow:hidden}`
+// で止める。class の付け外し (閉じたとき / component 破棄時) は component 層
+// (tests/unit/routes/switch-parent-gate-scroll-lock.test.ts) が担うが、**scoped style が実際に効いて
+// スクロールが止まるか**は jsdom では評価できないため、実ブラウザ側で assert する。
+//
+// 本 spec (demo Lambda config) に足す理由: overlay の本来の発火点は PIN 認証成功 → /admin ハードナビで、
+// これを回せる tests/e2e/parent-gate.spec.ts は PARENT_GATE_FORCE_ACTIVE=true でしか spec を登録せず
+// CI では 1 件も走らない。`?screenshot=all` は認証なしで overlay を決定的に描画できる既存経路 (#3089)
+// なので、#4417 の 320px 判定と同じ器に相乗りさせる (新しい CI 装置は増やさない)。
+test.describe('#4417 AC3: /switch の overlay 表示中は背面がスクロールしない', () => {
+	// 背面にスクロール可能な高さを作るため、意図的に低い viewport を使う
+	test.use({ viewport: { width: 320, height: 400 } });
+
+	/**
+	 * ユーザー操作 (ホイール) でスクロールを試し、実際に動いた量 (px) を返す。
+	 *
+	 * `window.scrollTo()` は使わない。`overflow: hidden` はユーザー操作によるスクロールだけを止め、
+	 * プログラムからの scroll は通す仕様のため、`scrollTo` では常に動いてしまい判定にならない
+	 * (実測: lock 中でも scrollY=400 になる)。顧客が体験するのはホイール / タッチ操作なのでそちらを使う。
+	 */
+	async function tryScroll(page: import('@playwright/test').Page): Promise<number> {
+		await page.mouse.move(160, 200);
+		await page.mouse.wheel(0, 400);
+		// スクロールは非同期に反映されるため 2 frame 待ってから読む (固定時間 sleep は使わない)
+		await page.evaluate(
+			() =>
+				new Promise((resolve) =>
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve(null))),
+				),
+		);
+		return page.evaluate(() => window.scrollY);
+	}
+
+	test('overlay 非表示時は背面がスクロールできる (対照条件 = 判定が空振りでないことの担保)', async ({
+		page,
+	}) => {
+		const res = await page.goto('/switch', { waitUntil: 'domcontentloaded' });
+		expect(res?.status() ?? 0).toBeLessThan(400);
+		await expect(page.getByTestId('parent-gate-navigating')).toHaveCount(0);
+		await expect(page.locator('body')).not.toHaveClass(/parent-gate-scroll-lock/);
+		// ここが 0 だと下の本命 assert が「そもそも動かない画面」で緑になる (空振り) ため先に潰す
+		expect(
+			await tryScroll(page),
+			'対照条件: overlay が無ければ背面はスクロールできる',
+		).toBeGreaterThan(0);
+	});
+
+	test('overlay 表示中は body が overflow:hidden になり背面が動かない', async ({ page }) => {
+		const res = await page.goto('/switch?screenshot=all', { waitUntil: 'domcontentloaded' });
+		expect(res?.status() ?? 0).toBeLessThan(400);
+		await expect(page.getByTestId('parent-gate-navigating')).toBeVisible();
+
+		await expect(page.locator('body')).toHaveClass(/parent-gate-scroll-lock/);
+		await expect
+			.poll(() => page.evaluate(() => getComputedStyle(document.body).overflowY), {
+				message: 'overlay 表示中は body が overflow:hidden であること',
+			})
+			.toBe('hidden');
+		expect(await tryScroll(page), 'overlay 表示中は背面が動かない').toBe(0);
+	});
+});

--- a/tests/unit/routes/harness/SwitchPageScreenshotHarness.svelte
+++ b/tests/unit/routes/harness/SwitchPageScreenshotHarness.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+// /switch のスクロールロック回帰テスト用ハーネス (#4417 AC3 / #4439 の後追い)。
+//
+// 本番では root `+layout.svelte` が `setScreenshotModeContext()` で screenshot mode を配る。
+// component 層テストは layout を経由しないため、同じ公開 API で context を張り、
+// `?screenshot=all` 相当の overlay 表示 / 非表示を prop から駆動できるようにする。
+// 検証対象の `+page.svelte` 自体には一切手を入れない (テスト用の複製を作らない)。
+import type { Component } from 'svelte';
+import { type ScreenshotMode, setScreenshotModeContext } from '$lib/features/demo/screenshot-mode';
+import SwitchPageRaw from '../../../../src/routes/switch/+page.svelte';
+
+let { mode, data }: { mode: ScreenshotMode; data: unknown } = $props();
+
+setScreenshotModeContext(
+	() => mode !== 'off',
+	() => mode,
+);
+
+// `+page.svelte` の props は SvelteKit 生成型 (PageData) に紐づくため、テスト用の
+// 最小 data を渡せるよう unknown 受けの Component 型へ寄せる (既存 switch-parent-gate-reopen.test.ts と同型)。
+const SwitchPage = SwitchPageRaw as unknown as Component<{ data: unknown }>;
+</script>
+
+<SwitchPage {data} />

--- a/tests/unit/routes/switch-parent-gate-scroll-lock.test.ts
+++ b/tests/unit/routes/switch-parent-gate-scroll-lock.test.ts
@@ -1,0 +1,113 @@
+// tests/unit/routes/switch-parent-gate-scroll-lock.test.ts
+// /switch の全画面 overlay (`.login-overlay`) が body に付けるスクロールロックの回帰。
+//
+// 背景: PR #4439 (#4417 AC3) が overlay 表示中の背面スクロールを止めるため、
+// `document.body` に `parent-gate-scroll-lock` (`overflow: hidden`) を `$effect` で付け外し
+// する実装を入れた。付ける側だけが壊れると「背面が動く」だけだが、**外す側が壊れると
+// ページ全体が二度とスクロールできなくなる** (子供はリロードでしか復帰できない)。
+// #4439 の回帰対象は AC1 / AC2 (320px 横スクロール) のみで、この付け外しには自動検証が
+// 無かったため、後追いで固定する。
+//
+// テスト層の選択 (component 層):
+//   docs/DESIGN.md §5 は「Esc / 外側クリックの close 挙動は Ark UI のグローバル listener 依存で
+//   jsdom では非決定のため Playwright 層で検証する」と定めるが、本件はその制約に当たらない。
+//   検証対象は `$effect` → `document.body.classList` の付け外しだけで、Ark UI の listener も
+//   実ブラウザ固有の合成イベントも介在しない。`+page.svelte` は既に jsdom で render 済
+//   (switch-parent-gate-reopen.test.ts) のため、**破棄 (unmount) 時の cleanup** という
+//   Playwright では作りにくい条件を含めて component 層で決定的に検証できる。
+//   一方「class が付いた結果、実際に CSS が効いて overflow:hidden になる」ことは jsdom では
+//   評価できない (Svelte の scoped style は当たらない) ため、その半分は
+//   tests/e2e/parent-gate.spec.ts の #3089 fail-safe test に相乗りして実ブラウザで assert する。
+
+import { cleanup, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$app/forms', () => ({
+	enhance: () => ({ destroy: () => {} }),
+}));
+vi.mock('$app/navigation', () => ({
+	invalidateAll: vi.fn(async () => {}),
+}));
+// jsdom に AudioContext が無いため sound service を no-op stub にする
+vi.mock('$lib/ui/sound/sound-service', () => ({
+	soundService: { ensureContext: () => {}, play: () => {} },
+}));
+
+import Harness from './harness/SwitchPageScreenshotHarness.svelte';
+
+/** 実装 (`+page.svelte`) が body に付けるクラス名 */
+const LOCK_CLASS = 'parent-gate-scroll-lock';
+
+function isLocked(): boolean {
+	return document.body.classList.contains(LOCK_CLASS);
+}
+
+/** overlay 以外の分岐 (modal / banner) を鳴らさない最小 data */
+function makeData() {
+	return {
+		children: [],
+		adminLink: '/admin',
+		parentGateInteractive: true,
+		showAdminLink: true,
+		reason: null,
+		timedOut: false,
+		pinRequired: false,
+		nextPath: '/admin',
+		onboarding: null,
+		pinConfigured: true,
+		pinResetAvailable: true,
+	};
+}
+
+afterEach(() => {
+	cleanup();
+	// 後続 test へ状態を持ち越さない (lock が残っていたら次の test が誤検知するため)
+	document.body.classList.remove(LOCK_CLASS);
+});
+
+describe('/switch 全画面 overlay のスクロールロック', () => {
+	it('overlay が出ていないときは body をロックしない', async () => {
+		const { queryByTestId } = render(Harness, {
+			props: { mode: 'off' as const, data: makeData() },
+		});
+
+		expect(queryByTestId('parent-gate-navigating')).toBeNull();
+		expect(isLocked()).toBe(false);
+	});
+
+	it('overlay が表示されると body がスクロールロックされる', async () => {
+		const { getByTestId } = render(Harness, {
+			props: { mode: 'all' as const, data: makeData() },
+		});
+
+		// vacuous PASS 防止: overlay が実際に描画されていることを先に確定させる
+		expect(getByTestId('parent-gate-navigating')).toBeTruthy();
+		await waitFor(() => expect(isLocked()).toBe(true));
+	});
+
+	it('overlay が閉じるとロックが解除される (画面がスクロール不能のまま残らない)', async () => {
+		const { rerender, queryByTestId } = render(Harness, {
+			props: { mode: 'all' as const, data: makeData() },
+		});
+		await waitFor(() => expect(isLocked()).toBe(true));
+
+		// overlay を閉じる (component は mount されたまま)
+		await rerender({ mode: 'off' as const, data: makeData() });
+
+		await waitFor(() => expect(queryByTestId('parent-gate-navigating')).toBeNull());
+		await waitFor(() => expect(isLocked()).toBe(false));
+	});
+
+	it('overlay 表示中に画面が破棄されてもロックが残らない ($effect cleanup)', async () => {
+		const { unmount } = render(Harness, {
+			props: { mode: 'all' as const, data: makeData() },
+		});
+		await waitFor(() => expect(isLocked()).toBe(true));
+
+		// ページ遷移などで component ごと破棄されるケース。ここで class が残ると
+		// 遷移先の画面が丸ごとスクロール不能になる。
+		unmount();
+
+		await waitFor(() => expect(isLocked()).toBe(false));
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

`/switch` の全画面オーバーレイが消えたのに `body` の `overflow: hidden` が残り、**ページが一切スクロールできなくなる**（子供はリロードするしかない）という壊れ方を、機械的に検出できるようにする。PR #4439 (#4417 AC3) が入れたスクロールロックには回帰テストが 1 件も無く、`$effect` の cleanup が走るかは静止画 SS では確認できなかった。

## 関連 Issue

Closes #4460

## 変更内容

`src/routes/switch/+page.svelte` の実装は変更していない（テスト追加のみ）。

- **component 層** `tests/unit/routes/switch-parent-gate-scroll-lock.test.ts`（新規）
  - overlay 非表示ではロックしない / 表示で `body` に `parent-gate-scroll-lock` が付く / **閉じると外れる** / **表示中に component が破棄されても外れる**（`$effect` cleanup）
  - `tests/unit/routes/harness/SwitchPageScreenshotHarness.svelte`（新規）は、本番で root `+layout.svelte` が担う `setScreenshotModeContext()` を同じ公開 API で張り、overlay の表示 / 非表示を prop から駆動するためのハーネス。**検証対象の `+page.svelte` は本物のまま**（テスト用の複製は作らない）
- **E2E 層** `tests/e2e/demo-lambda/visual-equality.spec.ts`（既存 spec に相乗り、新規ファイルなし）
  - scoped style が実際に効き、**ホイール操作で背面が動かない**ことを実ブラウザで検証。空振り防止に「overlay が無ければ動く」対照条件を同 describe 内に置いた

### 層の選択根拠（QM 指摘 3 への回答）

`docs/DESIGN.md` §5 の「Playwright 層で検証する」制約は **Ark UI のグローバル listener に依存する Esc / 外側クリックの close 挙動**に対するもので、本件は該当しない。検証対象は `$effect` → `document.body.classList` の付け外しだけで、Ark UI の listener も実ブラウザ固有の合成イベントも介在しない。`+page.svelte` は既に jsdom で render できている（既存 `switch-parent-gate-reopen.test.ts`）ため、**破棄時の cleanup という Playwright では作りにくい条件**を含めて component 層で決定的に書ける。

ただし「class が付いた結果 CSS が効いて実際にスクロールが止まる」ことは jsdom では評価できない（Svelte の scoped style は当たらない）。この半分だけを E2E に置いた（両輪）。

**E2E の置き場所を `tests/e2e/parent-gate.spec.ts` にしなかった理由**: 同 spec は `PARENT_GATE_FORCE_ACTIVE=true` のときしか spec を登録せず、**CI ではその env を設定していないため 1 件も走らない**（`grep -rn "PARENT_GATE_FORCE_ACTIVE" .github/` = 0 件）。そこに足しても検査は増えない（一度そちらに書いてから、この事実を確認して demo-lambda spec へ移した）。`?screenshot=all` は認証なしで overlay を決定的に描画できる既存経路（#3089）で、CI の `e2e-demo-lambda` job で実行される。

### E2E 側の実行 cadence（正直な限界）

`e2e-demo-lambda` job は **base=develop の PR では label の有無に依らず skip される**（`ci.yml` の重量レーン条件、branch-strategy.md §4）。実際に走るのは develop → main の統合 PR / main への push / `workflow_dispatch` のときだけで、本 PR（base=develop）では走らない。

そのため **`gh workflow run ci.yml --ref test/4460-scroll-lock-regression` で手動 dispatch し、この branch 上で e2e-demo-lambda を実際に実行して緑を確認した**（run URL は下記「検証」表）。以後は **component 層 4 件が per-PR の常時 gate、E2E 2 件は統合レーン / main push の後段 gate** という二段構えになる。

### `scrollTo` ではなくホイールで判定している理由

`overflow: hidden` は**ユーザー操作によるスクロールだけ**を止め、プログラムからの `window.scrollTo()` は通す。最初 `scrollTo` で書いたところ lock 中でも `scrollY=400` になり判定にならなかったため、顧客が実際に行う操作（`page.mouse.wheel`）で判定している。

## 検証

### failing-test-first の実証（ADR-0061 / QM 指摘 4）

追加したテストが空振りでないことを、**実装を壊して落ちることで**確認した。

| # | 壊した箇所 | 実行コマンド | 結果 |
|---|---|---|---|
| 1 | `$effect` の cleanup を削除（`return () => ...classList.remove(...)` の行を削除） | `npx vitest run tests/unit/routes/switch-parent-gate-scroll-lock.test.ts` | **2 failed / 2 passed** — 「閉じると解除」「破棄されても残らない」が `expected true to be false` で fail |
| 2 | class の付与を削除（`document.body.classList.add(...)` の行を削除 = #4439 以前の状態） | 同上 | **3 failed / 1 passed** — 付与・解除の 3 件が `expected false to be true` で fail |
| 3 | CSS セレクタを別名に改変（`:global(body.parent-gate-scroll-lock)` → `...-mutated`） | `npm run build && npx playwright test --config playwright.demo.config.ts -g "4417 AC3"` | **1 failed / 1 passed** — `body` の computed `overflow-y` が `hidden` にならず fail（class は付くので component 層は緑のまま = E2E 層が必要な理由の実証） |

いずれも実装を元に戻したうえで再実行し、`git diff src/` が空であることを確認済み。

### 通常実行

| コマンド | 結果 |
|---|---|
| `npx vitest run tests/unit/routes/switch-parent-gate-scroll-lock.test.ts` | 4 passed |
| `npx playwright test --config playwright.demo.config.ts -g "4417 AC3"` | 2 passed（対照条件 + 本命） |
| `npm run pre-ready -- --pr 4463` | 6 step すべて PASS (biome / svelte-check / check-no-plan-literals / check-local-tz-date-getters / check-pr-body / SS embed gate) |
| CI (PR run、base=develop 軽量レーン) | success — https://github.com/Takenori-Kusaka/ganbari-quest/actions/runs/31222386134 (unit-test 1/2 + lint-and-test ほか) |
| CI (`workflow_dispatch` run、`e2e-demo-lambda` を含む) | `e2e-demo-lambda` **success** — https://github.com/Takenori-Kusaka/ganbari-quest/actions/runs/31223207937 |

## AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | overlay 表示で `body` に class が付く | `switch-parent-gate-scroll-lock.test.ts`「overlay が表示されると body がスクロールロックされる」 | PASS（mutation 2 で fail することを確認） |
| AC2 | overlay が閉じると class が外れる | 同 spec「overlay が閉じるとロックが解除される」 | PASS（mutation 1 / 2 で fail） |
| AC3 | 表示中に component が破棄されても class が外れる | 同 spec「overlay 表示中に画面が破棄されてもロックが残らない ($effect cleanup)」 | PASS（mutation 1 / 2 で fail） |
| AC4 | 実ブラウザでホイール操作により背面が動かない + 対照条件 | `visual-equality.spec.ts` の `#4417 AC3` describe 2 件（CI `e2e-demo-lambda` job で実行） | PASS（mutation 3 で fail） |
| AC5 | 実装を壊すと落ちることを確認し手順と結果を記載 | 本 PR body §検証「failing-test-first の実証」表 | 3 パターン記載済み |
| AC6 | 新規 CI workflow / script を追加しない | `git show --stat HEAD` | 変更は `tests/` 配下 3 ファイルのみ |

## 影響範囲

- 顧客に見える変化: **なし**（テスト追加のみ、`src/` は無変更）
- 触った並行実装ペア: なし
- 破壊的変更: なし
- CI 実行時間: unit 4 件 + demo-lambda E2E 2 件の増加のみ（新規 job / workflow なし）

UI 変更なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
