### PR TITLE
fix(child): #4466 子供の編集が保護者のアップロード写真を踏み潰さないようにする

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -313,7 +313,7 @@ tenant 横断 listing (`findRedemptionRequestsByTenant` / `expireOldRedemptions`
 | theme | TEXT | NO | 'pink' | テーマ名 |
 | ui_mode | TEXT | NO | 'preschool' | UIモード（baby/preschool/elementary/junior/senior）。`getDefaultUiMode(age)` で導出 |
 | ui_mode_manually_set | INTEGER | NO | 0 | 手動設定フラグ（0=自動, 1=保護者が明示指定。age 変更時の自動再計算をスキップ） |
-| avatar_url | TEXT | YES | NULL | アバター画像URL。子供の登録時 (`addChild`) に仮アバター (ニックネームの頭文字 + テーマ色の SVG、`tenants/<tenantId>/avatars/<childId>/placeholder.svg`) が自動で入る。写真アップロードで上書きされる。仮アバターの保存に失敗した場合と、本機構より前に登録された子供は NULL のまま |
+| avatar_url | TEXT | YES | NULL | アバター画像URL。子供の登録時 (`addChild`) に仮アバター (ニックネームの頭文字 + テーマ色の SVG、`tenants/<tenantId>/avatars/<childId>/placeholder.svg`) が自動で入る。写真アップロードで上書きされる。仮アバターの保存に失敗した場合と、本機構より前に登録された子供は NULL のまま。**仮アバターの書き込みは `updateChildAvatarUrlIfMatches` (compare-and-set) を使う** — 読んだ時点の値を `WHERE` に載せ、判定から書き込みまでの間に写真がアップロードされていたら 0 行更新で負ける (保護者の写真を踏み潰さない)。無条件の `updateChildAvatarUrl` は写真アップロード / バックアップ復元のように「その値で確定させる」経路だけが使う |
 | active_title_id | INTEGER | YES | NULL | 装備中の称号ID |
 | display_config | TEXT | YES | NULL | 表示設定（JSON: cardSize, itemsPerCategory, collapsible） |
 | user_id | TEXT | YES | NULL | Cognito ユーザーID（SaaS モード） |

--- a/src/lib/server/db/demo/image-repo.ts
+++ b/src/lib/server/db/demo/image-repo.ts
@@ -29,6 +29,25 @@ export async function updateChildAvatarUrl(
 	// Stub: no-op
 }
 
+/**
+ * #4466: 条件付き更新 (compare-and-set) の demo Stub。
+ *
+ * demo backend は書き込みを一切永続しない (`updateChildAvatarUrl` も no-op)。**永続しない以上、
+ * 踏み潰される写真も存在しない**ので、ここでの条件検査は空回りになる。呼び出し元 (`child-service`)
+ * が false を「レースで負けた」と解釈して毎回 warn を出すのは誤報になるため、無条件版の no-op が
+ * 成功扱いなのと揃えて true を返す。**demo では TOCTOU 防御は検証できない** (実効するのは
+ * sqlite / dsql=PGlite の 2 backend)。
+ */
+export async function updateChildAvatarUrlIfMatches(
+	_childId: ChildId,
+	_expectedAvatarUrl: string | null,
+	_avatarUrl: string | null,
+	_tenantId: string,
+): Promise<boolean> {
+	// Stub: no-op
+	return true;
+}
+
 export async function findChildForImage(
 	childId: ChildId,
 	_tenantId: string,

--- a/src/lib/server/db/dsql/image-repo.ts
+++ b/src/lib/server/db/dsql/image-repo.ts
@@ -75,6 +75,21 @@ export function createDsqlImageRepo(db: SqlExecutor): IImageRepo {
 			`);
 		},
 
+		async updateChildAvatarUrlIfMatches(childId, expectedAvatarUrl, avatarUrl, tenantId) {
+			// #4466: 期待値を WHERE に載せ、一致しなければ 0 行更新で負ける (lost update 防止)。
+			// SqlExecutor は rowCount を公開しないため RETURNING の行数で判定する
+			// (cloud-export-repo の updateStatus / daily-mission-complete と同 convention)。
+			// NULL 同士も「一致」と見なす必要があるので `IS NOT DISTINCT FROM` を使う
+			// (`= NULL` は常に UNKNOWN で、avatar_url 未設定の子供が永久に更新できなくなる)。
+			const result = await db.execute(sql`
+				UPDATE children SET avatar_url = ${avatarUrl}, updated_at = now()
+				WHERE family_id = ${tenantId} AND child_id = ${childId}
+					AND avatar_url IS NOT DISTINCT FROM ${expectedAvatarUrl}::text
+				RETURNING child_id
+			`);
+			return result.rows.length > 0;
+		},
+
 		async findChildForImage(childId, tenantId) {
 			const result = await db.execute(sql`
 				SELECT ${CHILD_COLUMNS} FROM children

--- a/src/lib/server/db/image-repo.ts
+++ b/src/lib/server/db/image-repo.ts
@@ -22,6 +22,23 @@ export async function updateChildAvatarUrl(
 ) {
 	return getRepos().image.updateChildAvatarUrl(childId, avatarUrl, tenantId);
 }
+/**
+ * #4466: `avatar_url` を期待した値のままのときだけ更新する (compare-and-set)。
+ * 書けたら true、レースに負けて 0 行更新なら false。契約は `IImageRepo` を参照。
+ */
+export async function updateChildAvatarUrlIfMatches(
+	childId: ChildId,
+	expectedAvatarUrl: string | null,
+	avatarUrl: string | null,
+	tenantId: string,
+) {
+	return getRepos().image.updateChildAvatarUrlIfMatches(
+		childId,
+		expectedAvatarUrl,
+		avatarUrl,
+		tenantId,
+	);
+}
 export async function findChildForImage(childId: ChildId, tenantId: string) {
 	return getRepos().image.findChildForImage(childId, tenantId);
 }

--- a/src/lib/server/db/interfaces/image-repo.interface.ts
+++ b/src/lib/server/db/interfaces/image-repo.interface.ts
@@ -10,6 +10,23 @@ export interface IImageRepo {
 	): Promise<CharacterImage | undefined>;
 	insertCharacterImage(input: InsertCharacterImageInput, tenantId: string): Promise<void>;
 	updateChildAvatarUrl(childId: ChildId, avatarUrl: string | null, tenantId: string): Promise<void>;
+	/**
+	 * #4466: `avatar_url` を **読んだ時点の値と一致するときだけ** 書き換える (compare-and-set)。
+	 * 書けたら true、一致せず 0 行更新なら false。
+	 *
+	 * 仮アバターの作り直し (`child-service`) は「いま仮アバターのままか」を先に読んで判断するが、
+	 * 判断から書き込みまでの間に保護者の写真アップロードが完了しうる (await が 3 つ挟まる)。
+	 * 無条件 UPDATE だと**読んだ時点の古い前提で写真の URL を踏み潰す** (lost update)。
+	 * 期待値を WHERE に載せることで、レースに負けた側は 0 行更新になり写真が残る。
+	 *
+	 * `expectedAvatarUrl` に null を渡した場合は「まだ avatar_url が無い」ことを期待する。
+	 */
+	updateChildAvatarUrlIfMatches(
+		childId: ChildId,
+		expectedAvatarUrl: string | null,
+		avatarUrl: string | null,
+		tenantId: string,
+	): Promise<boolean>;
 	findChildForImage(childId: ChildId, tenantId: string): Promise<Child | undefined>;
 	deleteByTenantId(tenantId: string, childIds?: readonly ChildId[]): Promise<void>;
 }

--- a/src/lib/server/db/sqlite/image-repo.ts
+++ b/src/lib/server/db/sqlite/image-repo.ts
@@ -1,7 +1,7 @@
 // src/lib/server/db/image-repo.ts
 // キャラクター画像関連のリポジトリ層
 
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { asChildId, type ChildId } from '$lib/domain/ids';
 import { assertTenantScopedStorageKey } from '$lib/server/storage-keys';
 import { db } from '../client';
@@ -49,6 +49,35 @@ export async function updateChildAvatarUrl(
 		.set({ avatarUrl, updatedAt: new Date().toISOString() })
 		.where(eq(children.id, Number(childId)))
 		.run();
+}
+
+/**
+ * 子供のアバターURLを、期待した値のままのときだけ更新する (#4466)。
+ *
+ * 仮アバターの作り直しは「いま仮アバターのままか」を先に読んで判断するが、判断から書き込みまでの
+ * 間に保護者の写真アップロードが完了しうる。無条件 UPDATE だと写真の URL を踏み潰す (lost update)
+ * ため、期待値を WHERE に載せて負けた側を 0 行更新にする。DSQL 側と同契約。
+ *
+ * SQLite はシングルテナント前提なので tenantId は使わない (同ファイルの他メソッドと同じ)。
+ */
+export async function updateChildAvatarUrlIfMatches(
+	childId: ChildId,
+	expectedAvatarUrl: string | null,
+	avatarUrl: string | null,
+	_tenantId: string,
+): Promise<boolean> {
+	// `= NULL` は常に UNKNOWN なので、期待値が null のときは IS NULL で比べる
+	// (avatar_url 未設定の子供が永久に更新できなくなるのを防ぐ)。
+	const expectedMatches =
+		expectedAvatarUrl === null
+			? isNull(children.avatarUrl)
+			: eq(children.avatarUrl, expectedAvatarUrl);
+	const result = db
+		.update(children)
+		.set({ avatarUrl, updatedAt: new Date().toISOString() })
+		.where(and(eq(children.id, Number(childId)), expectedMatches))
+		.run();
+	return result.changes > 0;
 }
 
 /** 子供情報を取得 */

--- a/src/lib/server/services/child-service.ts
+++ b/src/lib/server/services/child-service.ts
@@ -16,7 +16,7 @@ import {
 	insertChild,
 	updateChild,
 } from '$lib/server/db/child-repo';
-import { updateChildAvatarUrl } from '$lib/server/db/image-repo';
+import { updateChildAvatarUrlIfMatches } from '$lib/server/db/image-repo';
 import { logger } from '$lib/server/logger';
 import { deleteByPrefix, deleteFile, listFiles, saveFile } from '$lib/server/storage';
 import {
@@ -80,11 +80,16 @@ export async function addChild(
  * 導出元が変わったら追随させないと「名前を直したのに古い頭文字のまま」になる。
  * ただし**保護者がアップロードした写真は上書きしない** — 呼ぶ前に
  * `shouldRegeneratePlaceholderAvatar` で `avatar_url` が仮アバター自身か未設定かを確認すること。
+ *
+ * #4466: その事前確認は「読んだ時点」の判断でしかない。ここに来るまでに DB write + SVG 生成 +
+ * storage write の await が挟まるので、その窓で保護者の写真アップロードが完了しうる。
+ * **書き込みは `child.avatarUrl` (読んだ時点の値) を期待値にした条件付き更新**で行い、
+ * レースに負けたら 0 行更新で写真を残す (`updateChildAvatarUrlIfMatches`)。
+ * 呼び出し元は `child.avatarUrl` に**判定に使った値そのもの**を渡すこと。
  */
-async function attachPlaceholderAvatar<T extends { id: ChildId; nickname: string; theme: string }>(
-	child: T,
-	tenantId: string,
-): Promise<T> {
+async function attachPlaceholderAvatar<
+	T extends { id: ChildId; nickname: string; theme: string; avatarUrl?: string | null },
+>(child: T, tenantId: string): Promise<T> {
 	try {
 		const key = placeholderAvatarKey(tenantId, child.id, PLACEHOLDER_AVATAR_EXTENSION);
 		assertTenantScopedStorageKey(key, tenantId);
@@ -96,7 +101,22 @@ async function attachPlaceholderAvatar<T extends { id: ChildId; nickname: string
 		// ブラウザが古い画像を出し続ける」(max-age=300) を防ぐ。配信側は path でルーティング
 		// するため query は無視される。
 		const publicUrl = `${storageKeyToPublicUrl(key)}?v=${placeholderAvatarVersion(child.nickname, child.theme)}`;
-		await updateChildAvatarUrl(child.id, publicUrl, tenantId);
+		const written = await updateChildAvatarUrlIfMatches(
+			child.id,
+			child.avatarUrl ?? null,
+			publicUrl,
+			tenantId,
+		);
+		if (!written) {
+			// レースで負けた = この間に avatar_url が別の値になった (写真アップロードが典型)。
+			// 仮アバターは付加価値なので操作自体は成功させるが、黙って諦めると運営が気づけない。
+			// 書いた SVG (固定名キー) は誰からも参照されないだけで、写真の実体には触れていない。
+			logger.warn(
+				'[child-service] 仮アバターの反映を見送りました（この間に avatar_url が変わったため。写真は保持されます）',
+				{ context: { childId: child.id, tenantId } },
+			);
+			return child;
+		}
 
 		return { ...child, avatarUrl: publicUrl };
 	} catch (err) {
@@ -154,6 +174,9 @@ export async function editChild(
 				id,
 				nickname: input.nickname ?? existing.nickname,
 				theme: input.theme ?? existing.theme,
+				// #4466: 判定に使った値をそのまま期待値として渡す。書き込みまでの間に
+				// 写真がアップロードされていたら 0 行更新になり、写真を踏み潰さない。
+				avatarUrl: existing.avatarUrl ?? null,
 			},
 			tenantId,
 		);

--- a/tests/unit/db/dsql-family-satellite-repos.test.ts
+++ b/tests/unit/db/dsql-family-satellite-repos.test.ts
@@ -46,6 +46,7 @@
 //   [IM1] insertCharacterImage + findCachedImage (type+hash 一致のみ) + §P9
 //   [IM2] updateChildAvatarUrl (tenant no-op) + findChildForImage (§P9)
 //   [IM3] deleteByTenantId は §P9 tenant 限定
+//   [IM5] #4466 updateChildAvatarUrlIfMatches (compare-and-set: null 一致 / 不一致は 0 行 / §P9)
 //   [IM4] #3566 ③ (§9.4): file_path が tenant プレフィックス外 / cross-tenant / traversal なら insert 拒否 (孤児バイト防止)
 
 import { sql } from 'drizzle-orm';
@@ -645,6 +646,41 @@ describe('DSQL 衛星系 family repos (M4-E PR8c、実 schema PGlite)', () => {
 		expect((await imageRepo.findChildForImage(childId, FAMILY))?.avatarUrl).toBe(null);
 		// §P9
 		expect(await imageRepo.findChildForImage(childId, OTHER_FAMILY)).toBe(undefined);
+	});
+
+	// #4466: 仮アバターの作り直しは「いま仮アバターのままか」を読んでから書くまでに await が
+	// 挟まる。無条件 UPDATE だと、その窓で完了した写真アップロードの URL を踏み潰す (lost update)。
+	// 期待値を WHERE に載せ、負けた側が 0 行更新になることを実 Postgres (PGlite) で固定する。
+	it('[IM5] #4466 updateChildAvatarUrlIfMatches は期待値一致時のみ書く (lost update 防止)', async () => {
+		const childId = await newChild('画像三郎');
+		const placeholder = '/tenants/x/avatars/placeholder.svg?v=1';
+		const photo = '/tenants/x/avatars/9f1c2d3e.webp';
+
+		// avatar_url 未設定 (null) を期待 → 書ける。`= NULL` は常に UNKNOWN なので
+		// null 一致が効かないと未設定の子供が永久に更新できなくなる。
+		expect(await imageRepo.updateChildAvatarUrlIfMatches(childId, null, placeholder, FAMILY)).toBe(
+			true,
+		);
+		expect((await imageRepo.findChildForImage(childId, FAMILY))?.avatarUrl).toBe(placeholder);
+
+		// 割り込み: 保護者が写真をアップロードした (無条件 UPDATE 経路)
+		await imageRepo.updateChildAvatarUrl(childId, photo, FAMILY);
+
+		// 読んだ時点の値 (placeholder) を期待した書き込みは負ける = 写真が残る
+		expect(
+			await imageRepo.updateChildAvatarUrlIfMatches(childId, placeholder, '/new.svg', FAMILY),
+		).toBe(false);
+		expect((await imageRepo.findChildForImage(childId, FAMILY))?.avatarUrl).toBe(photo);
+
+		// §P9: 他 tenant を名乗った条件付き更新も no-op (false)
+		expect(
+			await imageRepo.updateChildAvatarUrlIfMatches(childId, photo, '/evil.png', OTHER_FAMILY),
+		).toBe(false);
+		expect((await imageRepo.findChildForImage(childId, FAMILY))?.avatarUrl).toBe(photo);
+
+		// null 戻しも条件付きで可能
+		expect(await imageRepo.updateChildAvatarUrlIfMatches(childId, photo, null, FAMILY)).toBe(true);
+		expect((await imageRepo.findChildForImage(childId, FAMILY))?.avatarUrl).toBe(null);
 	});
 
 	it('[IM4] #3566 ③ (§9.4): filePath が tenant プレフィックス配下でなければ insert 拒否 (孤児バイト防止)', async () => {

--- a/tests/unit/db/sqlite/image-repo-avatar-cas-4466.test.ts
+++ b/tests/unit/db/sqlite/image-repo-avatar-cas-4466.test.ts
@@ -1,0 +1,91 @@
+// tests/unit/db/sqlite/image-repo-avatar-cas-4466.test.ts
+//
+// #4466: SQLite backend (NUC セルフホスト) 側の `updateChildAvatarUrlIfMatches`。
+//
+// 仮アバターの作り直しは「いま仮アバターのままか」を読んでから書くまでに await が挟まる。
+// 無条件 UPDATE だと、その窓で完了した写真アップロードの URL を踏み潰す (lost update)。
+// **この防御は両 backend に要る** — 片方だけだと NUC か cloud のどちらかで写真が消え続ける。
+// DSQL / PGlite 側の同等検証は `tests/unit/db/dsql-family-satellite-repos.test.ts` [IM5]。
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { asChildId } from '$lib/domain/ids';
+import { closeDb, createTestDb, type TestSqlite } from '../../helpers/test-db';
+
+const dbHolder: { sqlite: TestSqlite | null; db: ReturnType<typeof createTestDb>['db'] | null } = {
+	sqlite: null,
+	db: null,
+};
+
+vi.mock('$lib/server/db/client', () => ({
+	get db() {
+		if (!dbHolder.db) throw new Error('test db not initialized');
+		return dbHolder.db;
+	},
+}));
+
+const TENANT = 't-4466-sqlite';
+
+// import after mock
+import {
+	findChildForImage,
+	updateChildAvatarUrl,
+	updateChildAvatarUrlIfMatches,
+} from '$lib/server/db/sqlite/image-repo';
+
+const PLACEHOLDER = '/tenants/x/avatars/1/placeholder.svg?v=abc';
+const PHOTO = '/tenants/x/avatars/1/9f1c2d3e.webp';
+
+describe('#4466 sqlite image-repo: avatar_url は期待値一致時だけ書き換える', () => {
+	let childId: ReturnType<typeof asChildId>;
+
+	beforeEach(() => {
+		const created = createTestDb();
+		dbHolder.sqlite = created.sqlite;
+		dbHolder.db = created.db;
+		const info = created.sqlite
+			.prepare("INSERT INTO children (nickname, age, theme, ui_mode) VALUES ('たろう', 7, ?, ?)")
+			.run('blue', 'elementary');
+		childId = asChildId(Number(info.lastInsertRowid));
+	});
+
+	afterEach(() => {
+		if (dbHolder.sqlite) closeDb(dbHolder.sqlite);
+		dbHolder.sqlite = null;
+		dbHolder.db = null;
+	});
+
+	// `= NULL` は常に UNKNOWN なので、null 一致が効かないと「まだアバターが無い子供」が
+	// 永久に更新できなくなる (#4413 以前に登録された子供が該当する)。
+	it('avatar_url 未設定 (null) を期待した書き込みは通る', async () => {
+		expect(await updateChildAvatarUrlIfMatches(childId, null, PLACEHOLDER, TENANT)).toBe(true);
+		expect((await findChildForImage(childId, TENANT))?.avatarUrl).toBe(PLACEHOLDER);
+	});
+
+	it('読んだ時点の値と一致すれば書き換わる', async () => {
+		await updateChildAvatarUrl(childId, PLACEHOLDER, TENANT);
+
+		expect(await updateChildAvatarUrlIfMatches(childId, PLACEHOLDER, '/new.svg', TENANT)).toBe(
+			true,
+		);
+		expect((await findChildForImage(childId, TENANT))?.avatarUrl).toBe('/new.svg');
+	});
+
+	it('間に写真アップロードが入ったら 0 行更新になり写真が残る', async () => {
+		await updateChildAvatarUrl(childId, PLACEHOLDER, TENANT);
+		// 割り込み: 保護者が写真をアップロードした
+		await updateChildAvatarUrl(childId, PHOTO, TENANT);
+
+		// 読んだ時点の値 (PLACEHOLDER) を期待した書き込みは負ける
+		expect(await updateChildAvatarUrlIfMatches(childId, PLACEHOLDER, '/new.svg', TENANT)).toBe(
+			false,
+		);
+		expect((await findChildForImage(childId, TENANT))?.avatarUrl).toBe(PHOTO);
+	});
+
+	it('null 戻しも条件付きで可能', async () => {
+		await updateChildAvatarUrl(childId, PHOTO, TENANT);
+
+		expect(await updateChildAvatarUrlIfMatches(childId, PHOTO, null, TENANT)).toBe(true);
+		expect((await findChildForImage(childId, TENANT))?.avatarUrl).toBe(null);
+	});
+});

--- a/tests/unit/routes/child-registration-placeholder-avatar.test.ts
+++ b/tests/unit/routes/child-registration-placeholder-avatar.test.ts
@@ -12,7 +12,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { placeholderAvatarVersion } from '$lib/domain/placeholder-avatar';
 
 const mockInsertChild = vi.fn();
-const mockUpdateChildAvatarUrl = vi.fn();
+// #4466: 仮アバターの書き込みは条件付き (compare-and-set)。登録直後は avatar_url が無いので
+// 期待値は null になる。
+const mockUpdateChildAvatarUrlIfMatches = vi.fn();
 const mockSaveFile = vi.fn();
 
 vi.mock('$lib/server/db/child-repo', () => ({
@@ -29,7 +31,8 @@ vi.mock('$lib/server/db/image-repo', () => ({
 	findCachedImage: vi.fn(),
 	findChildForImage: vi.fn(),
 	insertCharacterImage: vi.fn(),
-	updateChildAvatarUrl: (...args: unknown[]) => mockUpdateChildAvatarUrl(...args),
+	updateChildAvatarUrl: vi.fn(),
+	updateChildAvatarUrlIfMatches: (...args: unknown[]) => mockUpdateChildAvatarUrlIfMatches(...args),
 }));
 
 vi.mock('$lib/server/storage', () => ({
@@ -97,6 +100,8 @@ function createEvent(formValues: Record<string, string>) {
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	// 既定は「競合なし = 書けた」(clearAllMocks で実装ごと消えるのでここで戻す)
+	mockUpdateChildAvatarUrlIfMatches.mockResolvedValue(true);
 	mockInsertChild.mockResolvedValue({
 		id: 'c-1',
 		nickname: 'まさと',
@@ -121,8 +126,12 @@ function expectPlaceholderAvatarAttached() {
 	expect(svg, 'ニックネームの頭文字が入っていない').toContain('>ま<');
 
 	// #4453: 保存先は固定名なので、中身の版 (`?v=`) を URL に付けて作り直しを即反映させる
-	expect(mockUpdateChildAvatarUrl, 'children.avatar_url が更新されていない').toHaveBeenCalledWith(
+	expect(
+		mockUpdateChildAvatarUrlIfMatches,
+		'children.avatar_url が更新されていない',
+	).toHaveBeenCalledWith(
 		'c-1',
+		null,
 		`/${key}?v=${placeholderAvatarVersion('まさと', 'blue')}`,
 		't-test',
 	);
@@ -160,6 +169,6 @@ describe('子供の登録で仮アバターが自動で付く (#4413)', () => {
 
 		expect(result).toEqual({ success: true });
 		expect(mockInsertChild).toHaveBeenCalledTimes(1);
-		expect(mockUpdateChildAvatarUrl).not.toHaveBeenCalled();
+		expect(mockUpdateChildAvatarUrlIfMatches).not.toHaveBeenCalled();
 	});
 });

--- a/tests/unit/server/db/demo/stub-repos.test.ts
+++ b/tests/unit/server/db/demo/stub-repos.test.ts
@@ -139,6 +139,21 @@ describe('demo/image-repo', () => {
 		const child = await imageRepo.findChildForImage(asChildId(902), 'demo');
 		expect(child?.id).toBe('902');
 	});
+	// #4466: 条件付き更新 (compare-and-set) も no-op。demo は書き込みを永続しないので
+	// 踏み潰される写真自体が存在せず、条件検査は空回りになる。呼び出し元が false を
+	// 「レースで負けた」と誤読して毎回 warn を出さないよう、無条件版と揃えて成功扱い。
+	it('updateChildAvatarUrl / updateChildAvatarUrlIfMatches は no-op (後者は成功扱い)', async () => {
+		await expect(
+			imageRepo.updateChildAvatarUrl(asChildId(902), '/a.png', 'demo'),
+		).resolves.toBeUndefined();
+		expect(
+			await imageRepo.updateChildAvatarUrlIfMatches(asChildId(902), null, '/a.png', 'demo'),
+		).toBe(true);
+		// 期待値が実データと合わない場合でも stub は分岐しない (永続しないので判定材料が無い)
+		expect(
+			await imageRepo.updateChildAvatarUrlIfMatches(asChildId(902), '/other.png', '/a.png', 'demo'),
+		).toBe(true);
+	});
 });
 
 describe('demo/inquiry-repo', () => {

--- a/tests/unit/services/child-service.test.ts
+++ b/tests/unit/services/child-service.test.ts
@@ -36,9 +36,11 @@ vi.mock('$lib/server/storage', () => ({
 	saveFile: vi.fn(),
 }));
 
-// #4413: 仮アバターの avatar_url 反映先
+// #4413: 仮アバターの avatar_url 反映先。
+// #4466: 仮アバターの書き込みは条件付き (compare-and-set)。無条件版は写真アップロード経路が使う。
 vi.mock('$lib/server/db/image-repo', () => ({
 	updateChildAvatarUrl: vi.fn(),
+	updateChildAvatarUrlIfMatches: vi.fn(),
 }));
 
 vi.mock('$lib/server/storage-keys', () => ({
@@ -68,7 +70,7 @@ import {
 	insertChild,
 	updateChild,
 } from '$lib/server/db/child-repo';
-import { updateChildAvatarUrl } from '$lib/server/db/image-repo';
+import { updateChildAvatarUrl, updateChildAvatarUrlIfMatches } from '$lib/server/db/image-repo';
 import { logger } from '$lib/server/logger';
 import {
 	addChild,
@@ -86,6 +88,8 @@ const TENANT = 'tenant-abc';
 describe('child-service', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		// #4466: 既定は「競合なし = 書けた」。競合を再現する test だけが実装を差し替える。
+		vi.mocked(updateChildAvatarUrlIfMatches).mockResolvedValue(true);
 	});
 
 	// --- Delegation tests ---
@@ -160,7 +164,8 @@ describe('child-service', () => {
 			expect(contentType).toBe('image/svg+xml');
 			expect(data.toString('utf-8')).toContain('>ま<');
 
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', expectedUrl, TENANT);
+			// #4466: 登録直後は avatar_url がまだ無い状態を期待値にした条件付き更新で書く
+			expect(updateChildAvatarUrlIfMatches).toHaveBeenCalledWith('10', null, expectedUrl, TENANT);
 			expect(result).toEqual({ ...inserted, avatarUrl: expectedUrl });
 		});
 
@@ -172,7 +177,7 @@ describe('child-service', () => {
 			const result = await addChild(input, TENANT);
 
 			expect(result).toEqual(inserted);
-			expect(updateChildAvatarUrl).not.toHaveBeenCalled();
+			expect(updateChildAvatarUrlIfMatches).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalled();
 		});
 	});
@@ -272,7 +277,12 @@ describe('child-service', () => {
 			expect(key).toBe(`tenants/${TENANT}/avatars/10/placeholder.svg`);
 			expect(data.toString('utf-8')).toContain('>は<');
 			// 保存先は固定名なので、URL の版が変わらないとブラウザが古い画像を出し続ける
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('はなこ', 'blue'), TENANT);
+			expect(updateChildAvatarUrlIfMatches).toHaveBeenCalledWith(
+				'10',
+				PLACEHOLDER_URL,
+				url('はなこ', 'blue'),
+				TENANT,
+			);
 			expect(url('はなこ', 'blue')).not.toBe(PLACEHOLDER_URL);
 		});
 
@@ -287,7 +297,12 @@ describe('child-service', () => {
 			// 期待値は実物の builder から作るので、配色を test に写し取らない。
 			expect(savedSvg.toString('utf-8')).toBe(buildPlaceholderAvatarSvg('たろう', 'pink'));
 			expect(savedSvg.toString('utf-8')).not.toBe(buildPlaceholderAvatarSvg('たろう', 'blue'));
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('たろう', 'pink'), TENANT);
+			expect(updateChildAvatarUrlIfMatches).toHaveBeenCalledWith(
+				'10',
+				PLACEHOLDER_URL,
+				url('たろう', 'pink'),
+				TENANT,
+			);
 		});
 
 		it('AC3: 保護者がアップロードした写真は上書きしない (ニックネームを変えても再生成しない)', async () => {
@@ -296,7 +311,7 @@ describe('child-service', () => {
 			await editChild(asChildId(10), { nickname: 'はなこ', theme: 'pink' }, TENANT);
 
 			expect(saveFile).not.toHaveBeenCalled();
-			expect(updateChildAvatarUrl).not.toHaveBeenCalled();
+			expect(updateChildAvatarUrlIfMatches).not.toHaveBeenCalled();
 		});
 
 		it('AC3 系: avatar_url 未設定なら (消せる写真が無いので) 仮アバターを作る', async () => {
@@ -305,7 +320,12 @@ describe('child-service', () => {
 			await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
 
 			expect(saveFile).toHaveBeenCalledTimes(1);
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('はなこ', 'blue'), TENANT);
+			expect(updateChildAvatarUrlIfMatches).toHaveBeenCalledWith(
+				'10',
+				null,
+				url('はなこ', 'blue'),
+				TENANT,
+			);
 		});
 
 		it('AC3 系: 版付き URL でない旧データ (?v= 無し) も仮アバターとして扱い作り直す', async () => {
@@ -314,7 +334,12 @@ describe('child-service', () => {
 			await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
 
 			expect(saveFile).toHaveBeenCalledTimes(1);
-			expect(updateChildAvatarUrl).toHaveBeenCalledWith('10', url('はなこ', 'blue'), TENANT);
+			expect(updateChildAvatarUrlIfMatches).toHaveBeenCalledWith(
+				'10',
+				PLACEHOLDER_PATH,
+				url('はなこ', 'blue'),
+				TENANT,
+			);
 		});
 
 		it('AC4: 同じ値で送り直しただけなら再生成しない (無駄な書き込みをしない)', async () => {
@@ -323,7 +348,7 @@ describe('child-service', () => {
 			await editChild(asChildId(10), { nickname: 'たろう', theme: 'blue', age: 9 }, TENANT);
 
 			expect(saveFile).not.toHaveBeenCalled();
-			expect(updateChildAvatarUrl).not.toHaveBeenCalled();
+			expect(updateChildAvatarUrlIfMatches).not.toHaveBeenCalled();
 		});
 
 		it('AC4 系: 年齢だけの変更では再生成しない', async () => {
@@ -334,6 +359,99 @@ describe('child-service', () => {
 			expect(saveFile).not.toHaveBeenCalled();
 		});
 
+		// #4466: 判定 (existing.avatarUrl を読む) と書き込み (avatar_url を上書き) の間に
+		// DB write + SVG 生成 + storage write の await が挟まる。この窓で写真アップロードが
+		// 完了すると「読んだ時点では仮アバターだった」を根拠に写真の URL を踏み潰す。
+		//
+		// 逐次 1 本の呼び出し (上の AC3) では再現しないので、**判定後・書き込み前に別の書き込みを
+		// 割り込ませて**再現する。fake DB (avatarUrlInDb) を置き、
+		//   - updateChildAvatarUrl        = 無条件 UPDATE (実 backend と同じ)
+		//   - updateChildAvatarUrlIfMatches = 期待値一致時だけ書く条件付き UPDATE
+		// の両方を繋いだうえで **最終的な DB の値**を assert するので、service がどちらを呼ぶかに
+		// 依存せず「写真が残るか」だけを判定できる (無条件で書けば必ず落ちる)。
+		describe('#4466: 写真アップロードとの競合 (TOCTOU)', () => {
+			/** 判定後・書き込み前に写真アップロードが割り込む状況を組み立てる。 */
+			function seedRace() {
+				const db: { avatarUrl: string | null } = { avatarUrl: PLACEHOLDER_URL };
+
+				vi.mocked(findChildById).mockImplementation(
+					async () =>
+						({
+							id: '10',
+							nickname: 'たろう',
+							theme: 'blue',
+							avatarUrl: db.avatarUrl,
+							uiMode: 'elementary',
+							uiModeManuallySet: 0,
+						}) as never,
+				);
+				vi.mocked(updateChild).mockResolvedValue({ id: '10' } as never);
+
+				// 割り込み: SVG を storage に書いている最中に、別リクエストの写真アップロードが完了する。
+				vi.mocked(saveFile).mockImplementation(async () => {
+					db.avatarUrl = UPLOADED_PHOTO_URL;
+				});
+
+				vi.mocked(updateChildAvatarUrl).mockImplementation(async (_id, next) => {
+					db.avatarUrl = next;
+				});
+				vi.mocked(updateChildAvatarUrlIfMatches).mockImplementation(async (_id, expected, next) => {
+					if (db.avatarUrl !== expected) return false;
+					db.avatarUrl = next;
+					return true;
+				});
+
+				return db;
+			}
+
+			it('AC2: 割り込みで写真が入ったら、仮アバターで踏み潰さない', async () => {
+				const db = seedRace();
+
+				await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
+
+				expect(db.avatarUrl).toBe(UPLOADED_PHOTO_URL);
+			});
+
+			it('AC3: 踏み潰しを避けた場合でも編集自体は成功し、warn で検知できる', async () => {
+				seedRace();
+
+				const result = await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
+
+				expect(result).toEqual({ id: '10' });
+				expect(updateChild).toHaveBeenCalled();
+				expect(logger.warn).toHaveBeenCalled();
+			});
+
+			it('競合がなければこれまで通り仮アバターを差し替える (条件付きにしても素通りしない)', async () => {
+				const db: { avatarUrl: string | null } = { avatarUrl: PLACEHOLDER_URL };
+				vi.mocked(findChildById).mockImplementation(
+					async () =>
+						({
+							id: '10',
+							nickname: 'たろう',
+							theme: 'blue',
+							avatarUrl: db.avatarUrl,
+							uiMode: 'elementary',
+							uiModeManuallySet: 0,
+						}) as never,
+				);
+				vi.mocked(updateChild).mockResolvedValue({ id: '10' } as never);
+				vi.mocked(updateChildAvatarUrl).mockImplementation(async (_id, next) => {
+					db.avatarUrl = next;
+				});
+				vi.mocked(updateChildAvatarUrlIfMatches).mockImplementation(async (_id, expected, next) => {
+					if (db.avatarUrl !== expected) return false;
+					db.avatarUrl = next;
+					return true;
+				});
+
+				await editChild(asChildId(10), { nickname: 'はなこ' }, TENANT);
+
+				expect(db.avatarUrl).toBe(url('はなこ', 'blue'));
+				expect(logger.warn).not.toHaveBeenCalled();
+			});
+		});
+
 		it('AC5: 仮アバターの保存に失敗しても編集自体は成功する', async () => {
 			seedExisting();
 			vi.mocked(saveFile).mockRejectedValueOnce(new Error('storage down'));
@@ -342,7 +460,7 @@ describe('child-service', () => {
 
 			expect(result).toEqual({ id: '10' });
 			expect(updateChild).toHaveBeenCalled();
-			expect(updateChildAvatarUrl).not.toHaveBeenCalled();
+			expect(updateChildAvatarUrlIfMatches).not.toHaveBeenCalled();
 			expect(logger.warn).toHaveBeenCalled();
 		});
 	});


### PR DESCRIPTION
## 顧客価値・目的

保護者がアップロードした子供の顔写真が、ニックネーム / テーマの編集で**無言で消えなくなる**。写真アップロード直後にニックネームを変える / 編集画面を複数タブで開く、といった操作で一覧が仮アバターに戻る事故を止める。

## 関連 Issue

Closes #4466

## 変更内容

PR #4461（#4453）が `editChild` に仮アバターの作り直しを足した際、TOCTOU（lost update）を持ち込んでいた:

```ts
const existing = await findChildById(id, tenantId);   // (T) 判定材料を読む
...
await updateChild(id, patched, tenantId);             // await
if (shouldRegeneratePlaceholderAvatar(existing, ...)) {
    await attachPlaceholderAvatar(...)                // (U) avatar_url を無条件 UPDATE
}
```

T と U の間に **DB write + SVG 生成 + storage write** の await が 3 つ挟まる。この窓で写真アップロード（`api/v1/children/[id]/avatar` → `updateChildAvatarUrl`）が完了すると、「読んだ時点ではまだ仮アバターだった」を根拠に写真の URL を踏み潰す。

**採った直し方 — 条件付き更新（compare-and-set）**:

- `IImageRepo` に `updateChildAvatarUrlIfMatches(childId, expectedAvatarUrl, avatarUrl, tenantId): Promise<boolean>` を追加し、**読んだ時点の値を `WHERE` に載せる**。レースに負けた側は 0 行更新になり `false` を返す
  - dsql/PGlite: `... AND avatar_url IS NOT DISTINCT FROM ${expected}::text RETURNING child_id` → `rows.length > 0`（`SqlExecutor` は rowCount 非公開のため `RETURNING` 行数で判定。`cloud-export-repo.updateStatus` / `daily-mission-complete` と同 convention）
  - sqlite: `and(eq(id), expected === null ? isNull(avatarUrl) : eq(avatarUrl, expected))` → `result.changes > 0`
  - **期待値 null の扱い**: `= NULL` は常に UNKNOWN なので、`IS NOT DISTINCT FROM` / `isNull` で比べる。ここを素直に `=` にすると **`avatar_url` 未設定の子供（#4413 以前に登録された子供）が永久に更新できなくなる**
- `attachPlaceholderAvatar` は `child.avatarUrl`（判定に使った値）を期待値として渡す。`addChild` は挿入直後の行（`avatar_url` = null）、`editChild` は `existing.avatarUrl` を渡す
- **0 行更新でも編集自体は成功させる**（#4461 の「アバターは付加価値であって前提条件ではない」に整合）。ただし `logger.warn` を出す — 現状は上書きが起きてもログが無く運営側が検知できなかった

**再読み込みで窓を狭める対症は採っていない**（TOCTOU は消えず、「直った気になる」ぶん危険なため）。

**踏み潰しを避けた場合に書いた SVG は残る**が、これは `placeholder.svg`（固定名キー）で、写真は `<uuid>.webp` の別キー。誰からも参照されないだけで写真の実体には触れていない。

無条件の `updateChildAvatarUrl` は残す — 写真アップロード / バックアップ復元のように「その値で確定させる」経路が使う。

## 検証

### AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `avatar_url` の書き込みが compare-and-set になっている | `IImageRepo.updateChildAvatarUrlIfMatches` を追加し 3 backend で実装。`child-service` の書き込み経路を差し替え | 実装済（`src/lib/server/db/interfaces/image-repo.interface.ts` / `child-service.ts`）。`npx svelte-check` 0 errors |
| AC2 | 判定後・書き込み前に写真が入ったら写真の URL が保たれる | 割り込みを注入する unit test（`child-service.test.ts` #4466 AC2）+ repo 層 test（sqlite / PGlite） | 修正前 FAIL（photo → placeholder に上書きされた実出力を PR 本文に記載）→ 修正後 PASS。29 passed |
| AC3 | 0 行更新でも編集は成功し `logger.warn` が出る | `child-service.test.ts` #4466 AC3（`result` と `updateChild` 呼び出し + `logger.warn`） | 修正前 FAIL（warn 0 回）→ 修正後 PASS |
| AC4 | 3 backend すべてで条件付き更新が効く（demo が stub なら明記） | sqlite: `image-repo-avatar-cas-4466.test.ts` / dsql=PGlite: `dsql-family-satellite-repos.test.ts` [IM5] / demo: `stub-repos.test.ts` | sqlite・PGlite は**実効**（実 DB で 0 行更新を確認）。demo は**空回りの stub**（下表に理由を明記）。45 + 23 passed |
| AC5 | failing-test-first（レース再現 test が先に落ちる） | `npx vitest run tests/unit/services/child-service.test.ts` を修正前に実行 | `Tests 2 failed | 27 passed` の実出力を下に貼付 |

**failing-test-first（ADR-0061）**: レース再現 test を先に書き、修正前に落ちることを確認した。逐次呼び出し 1 本（#4461 の AC3 test）では再現しないため、**判定後・書き込み前に別の書き込みを割り込ませる**形にした（fake DB を置き、`saveFile` の中で写真アップロードを完了させる）。

修正前（`npx vitest run tests/unit/services/child-service.test.ts`）:

```
× AC2: 割り込みで写真が入ったら、仮アバターで踏み潰さない
  AssertionError: expected '/tenants/tenant-abc/avatars/10/placeh…' to be '/tenants/tenant-abc/avatars/10/9f1c2d…'
  Expected: "/tenants/tenant-abc/avatars/10/9f1c2d3e-4b5a.webp"
  Received: "/tenants/tenant-abc/avatars/10/placeholder.svg?v=163ry6f"
× AC3: 踏み潰しを避けた場合でも編集自体は成功し、warn で検知できる
  AssertionError: expected "vi.fn()" to be called at least once   ← logger.warn
Tests  2 failed | 27 passed (29)
```

修正後:

| コマンド | 結果 |
|---|---|
| `npx vitest run tests/unit/services/child-service.test.ts` | 29 passed |
| `npx vitest run tests/unit/db/sqlite/image-repo-avatar-cas-4466.test.ts tests/unit/server/db/demo/stub-repos.test.ts` | 45 passed |
| `npx vitest run tests/unit/db/dsql-family-satellite-repos.test.ts` | 23 passed（PGlite = 実 Postgres で `IS NOT DISTINCT FROM` を実行） |
| `npx vitest run tests/unit/routes/... tests/unit/services/` | 174 files / 2866 passed |
| `npx vitest run tests/unit/architecture tests/unit/arch` | 58 files / 1006 passed（repo interface 追加で fitness function が落ちないこと） |
| `npx biome check src tests` | 1945 files, no fixes applied |
| `npm run pre-ready -- --pr <本 PR>` | 下記「pre-ready」参照 |

test の assert は「service がどちらのメソッドを呼ぶか」ではなく **fake DB の最終値**を見るので、無条件 UPDATE に戻せば必ず落ちる。「競合がなければこれまで通り差し替える」test も併置し、条件付きにしたことで素通りするようになっていないことを固定した。

**3 backend の対応状況（AC4）**:

| backend | 条件付き更新 | 備考 |
|---|---|---|
| sqlite（NUC セルフホスト） | **実効** | `isNull` / `eq` + `result.changes`。`tests/unit/db/sqlite/image-repo-avatar-cas-4466.test.ts` |
| dsql / PGlite（cloud / NUC） | **実効** | `IS NOT DISTINCT FROM` + `RETURNING`。`dsql-family-satellite-repos.test.ts` [IM5]（PGlite = 実 Postgres で検証） |
| demo | **空回り（stub）** | demo backend は書き込みを一切永続しない（`updateChildAvatarUrl` も no-op）。**永続しない以上、踏み潰される写真も存在しない**ため条件検査は空回りになる。呼び出し元が `false` を「レースで負けた」と誤読して毎回 warn を出すのは誤報なので、無条件版の no-op が成功扱いなのと揃えて `true` を返す。**demo では本防御を検証できない** |

**実 DSQL では未実行**: `IS NOT DISTINCT FROM` は PGlite（実 Postgres）で検証しており、DSQL の SQL 層は PostgreSQL 互換で本構文は標準の比較述語だが、**staging の実 DSQL クラスタでは走らせていない**。既存の repo 層 test が全て PGlite 前提であるのと同じ範囲（`docs/decisions/README.md` §OSS 採用記録 の PGlite 採用根拠に整合）。

**未実行**: E2E / Storybook（サーバ側の並行性のみで UI 変更なし）。本レースは 2 リクエストの時間差に依存するため、実ブラウザでの再現は不安定で回帰検証に使えない — 代わりに割り込みを決定的に注入する unit test で固定した。

## 影響範囲

- **顧客に見える変化**: 写真アップロードと子供の編集が競合したとき、写真が保たれる。競合が無い通常の編集は従来通り仮アバターが作り直される（動作不変）
- **触った並行実装ペア**: `IImageRepo` の 3 backend 実装（sqlite / dsql=PGlite / demo）。既定値・戻り値の契約を 3 実装で揃え、それぞれ repo 層の test で固定した
- **破壊的変更**: なし。`updateChildAvatarUrl`（無条件）は残しており、写真アップロード / バックアップ復元経路は不変
- 設計書同期: `docs/design/08-データベース設計書.md` の `children.avatar_url` 行に「仮アバターの書き込みは compare-and-set を使う / 無条件版は確定させる経路だけ」を追記

**UI 変更なし** — サーバ側（service / repo 層）だけの変更で `.svelte` は 1 file も触っていない。描画される DOM / スタイル / 文言に差分が生じないため SS 検証を skip する（顧客に見える挙動としては「写真が保たれる」= 保存された URL の違いであり、画面の見た目そのものは同一）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
