### PR TITLE
fix(avatar): #4468 旧アバター削除で `?v=` 付き URL を storage key に戻す

### DIFF
--- a/src/lib/server/services/child-service.ts
+++ b/src/lib/server/services/child-service.ts
@@ -23,6 +23,7 @@ import {
 	assertTenantScopedStorageKey,
 	childPrefix,
 	placeholderAvatarKey,
+	publicUrlToStorageKey,
 	storageKeyToPublicUrl,
 } from '$lib/server/storage-keys';
 
@@ -205,11 +206,11 @@ function shouldRegeneratePlaceholderAvatar(
 	if (!nicknameChanged && !themeChanged) return false;
 
 	if (!existing.avatarUrl) return true;
-	const placeholderUrl = storageKeyToPublicUrl(
-		placeholderAvatarKey(tenantId, id, PLACEHOLDER_AVATAR_EXTENSION),
+	// `?v=<版>` が付いている (#4453) ので、key に戻して (query を落として) 比べる。
+	return (
+		publicUrlToStorageKey(existing.avatarUrl) ===
+		placeholderAvatarKey(tenantId, id, PLACEHOLDER_AVATAR_EXTENSION)
 	);
-	// `?v=<版>` が付いている (#4453) ので path 部分で比べる。
-	return existing.avatarUrl.split('?')[0] === placeholderUrl;
 }
 
 export async function removeChild(id: ChildId, tenantId: string) {

--- a/src/lib/server/storage-keys.ts
+++ b/src/lib/server/storage-keys.ts
@@ -64,6 +64,18 @@ export function storageKeyToPublicUrl(key: string): string {
 }
 
 /**
+ * 公開URL から storage key を復元（`storageKeyToPublicUrl` の逆変換）。
+ *
+ * 仮アバターの公開URL には中身の版を表す `?v=<版>` が付く (#4461)。query / fragment は
+ * 配信経路のキャッシュ制御であって key の一部ではないので落とす。付いたまま key として扱うと
+ * 実ファイルと一致せず、削除・存在判定が黙って空振りする (#4468)。
+ */
+export function publicUrlToStorageKey(publicUrl: string): string {
+	const path = publicUrl.split('?')[0].split('#')[0];
+	return path.startsWith('/') ? path.slice(1) : path;
+}
+
+/**
  * #3566 ③ (§9.4): DB に永続化する storage key が tenant プレフィックス配下であることを保証する。
  *
  * `character_images.file_path` / `child_custom_voices.file_path` など、要保護メディア (子供の顔写真 /

--- a/src/lib/server/storage-keys.ts
+++ b/src/lib/server/storage-keys.ts
@@ -71,7 +71,7 @@ export function storageKeyToPublicUrl(key: string): string {
  * 実ファイルと一致せず、削除・存在判定が黙って空振りする (#4468)。
  */
 export function publicUrlToStorageKey(publicUrl: string): string {
-	const path = publicUrl.split('?')[0].split('#')[0];
+	const path = publicUrl.replace(/[?#].*$/s, '');
 	return path.startsWith('/') ? path.slice(1) : path;
 }
 

--- a/src/routes/api/v1/children/[id]/avatar/+server.ts
+++ b/src/routes/api/v1/children/[id]/avatar/+server.ts
@@ -6,7 +6,12 @@ import { logger } from '$lib/server/logger';
 import { sanitizeImage } from '$lib/server/security/file-sanitizer';
 import { validateImageMagicBytes } from '$lib/server/security/magic-bytes';
 import { deleteFile, saveFile } from '$lib/server/storage';
-import { avatarKey, storageKeyToPublicUrl } from '$lib/server/storage-keys';
+import {
+	assertTenantScopedStorageKey,
+	avatarKey,
+	publicUrlToStorageKey,
+	storageKeyToPublicUrl,
+} from '$lib/server/storage-keys';
 import type { RequestHandler } from './$types';
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
@@ -61,11 +66,18 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
 		const { buffer } = await sanitizeImage(rawBuffer, file.type);
 		await saveFile(storageKey, buffer, file.type);
 
-		// 旧アバターファイルを削除（パスがあり、新パスと異なる場合）
-		if (child.avatarUrl && child.avatarUrl !== publicUrl) {
-			const oldKey = child.avatarUrl.startsWith('/') ? child.avatarUrl.slice(1) : child.avatarUrl;
+		// 旧アバターファイルを削除（実 key が取れ、今保存した新 key と異なる場合）
+		if (child.avatarUrl) {
+			// 仮アバターの URL には `?v=<版>` が付く (#4461)。落とさないと実 key と一致せず
+			// 削除が空振りし placeholder.svg が孤児として残る (#4468)。
+			const oldKey = publicUrlToStorageKey(child.avatarUrl);
 			try {
-				await deleteFile(oldKey);
+				// 削除対象が本当にこの tenant のものかを確認してから消す
+				// (cross-tenant / traversal を指す avatar_url で他人のファイルを消さない)
+				assertTenantScopedStorageKey(oldKey, tenantId);
+				if (oldKey !== storageKey) {
+					await deleteFile(oldKey);
+				}
 			} catch {
 				// 旧ファイル削除失敗は無視（孤立ファイルは定期クリーンアップで対応）
 			}

--- a/tests/unit/routes/avatar-upload-old-file-deletion.test.ts
+++ b/tests/unit/routes/avatar-upload-old-file-deletion.test.ts
@@ -98,7 +98,8 @@ describe('POST /api/v1/children/[id]/avatar — 旧アバターファイルの�
 		const res = await postAvatar(
 			`/tenants/${TENANT_ID}/avatars/${CHILD_ID}/placeholder.svg?v=163ry6f`,
 		);
-		const newKey = mockUpdateChildAvatarUrl.mock.calls[0][1] as string;
+		expect(mockUpdateChildAvatarUrl).toHaveBeenCalledTimes(1);
+		const newKey = String(mockUpdateChildAvatarUrl.mock.calls[0]?.[1]);
 
 		expect(res.status).toBe(200);
 		expect(mockSaveFile).toHaveBeenCalledWith(

--- a/tests/unit/routes/avatar-upload-old-file-deletion.test.ts
+++ b/tests/unit/routes/avatar-upload-old-file-deletion.test.ts
@@ -1,0 +1,118 @@
+// tests/unit/routes/avatar-upload-old-file-deletion.test.ts
+// #4468: 写真アップロード時に旧アバターの実ファイルを確実に削除する
+//
+// 仮アバターの avatar_url には `?v=<中身の版>` が付く (#4461)。avatar_url をそのまま
+// storage key 扱いすると `placeholder.svg?v=163ry6f` という存在しない key を削除しようとして
+// 空振りし、`placeholder.svg` が孤児として残り続ける。
+//
+// 期待動作:
+//   - `?v=` 付き avatar_url でも query を落とした実 key (`.../placeholder.svg`) を削除する
+//   - 今まさに保存した新ファイル (uuid key) は削除しない
+//   - tenant プレフィックス外を指す avatar_url では削除しない (誤削除経路の遮断)
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFindChildById = vi.fn();
+const mockUpdateChildAvatarUrl = vi.fn();
+const mockSaveFile = vi.fn();
+const mockDeleteFile = vi.fn();
+
+vi.mock('$lib/server/db/activity-repo', () => ({
+	findChildById: mockFindChildById,
+}));
+
+vi.mock('$lib/server/db/image-repo', () => ({
+	updateChildAvatarUrl: mockUpdateChildAvatarUrl,
+}));
+
+vi.mock('$lib/server/storage', () => ({
+	saveFile: mockSaveFile,
+	deleteFile: mockDeleteFile,
+}));
+
+vi.mock('$lib/server/security/file-sanitizer', () => ({
+	sanitizeImage: vi.fn(async (buffer: Buffer) => ({ buffer })),
+}));
+
+vi.mock('$lib/server/security/magic-bytes', () => ({
+	validateImageMagicBytes: () => ({ valid: true }),
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const { POST } = await import('../../../src/routes/api/v1/children/[id]/avatar/+server');
+
+const TENANT_ID = 'tenant-abc123';
+const CHILD_ID = 42;
+
+/** PNG マジックバイト付きのダミー画像 (magic-bytes は mock 済みだが実データに近づける) */
+function makePngFile(): File {
+	const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0, 0, 0, 0, 0]);
+	return new File([png], 'photo.png', { type: 'image/png' });
+}
+
+async function postAvatar(avatarUrl: string | null) {
+	mockFindChildById.mockResolvedValue({ id: CHILD_ID, nickname: 'たろう', avatarUrl });
+
+	const formData = new FormData();
+	formData.append('avatar', makePngFile());
+	// multipart を実際にシリアライズすると File の実体クラスが undici 側に入れ替わり
+	// route の `instanceof File` 判定が環境依存になるため、formData() だけを備えた stub を渡す
+	const request = { formData: async () => formData } as unknown as Request;
+
+	return (await POST({
+		params: { id: String(CHILD_ID) },
+		request,
+		locals: { context: { tenantId: TENANT_ID } },
+		// biome-ignore lint/suspicious/noExplicitAny: route handler の RequestEvent を最小限で組み立てる
+	} as any)) as Response;
+}
+
+describe('POST /api/v1/children/[id]/avatar — 旧アバターファイルの削除', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('仮アバター (`?v=` 付き URL) の実ファイルを削除する', async () => {
+		const res = await postAvatar(
+			`/tenants/${TENANT_ID}/avatars/${CHILD_ID}/placeholder.svg?v=163ry6f`,
+		);
+
+		expect(res.status).toBe(200);
+		expect(mockDeleteFile).toHaveBeenCalledWith(
+			`tenants/${TENANT_ID}/avatars/${CHILD_ID}/placeholder.svg`,
+		);
+	});
+
+	it('query 無しの旧アバター (写真の差し替え) も従来どおり削除する', async () => {
+		const oldKey = `tenants/${TENANT_ID}/avatars/${CHILD_ID}/11111111-1111-4111-8111-111111111111.png`;
+		const res = await postAvatar(`/${oldKey}`);
+
+		expect(res.status).toBe(200);
+		expect(mockDeleteFile).toHaveBeenCalledWith(oldKey);
+	});
+
+	it('今保存した新ファイルは削除しない (query を落としても自己削除に化けない)', async () => {
+		const res = await postAvatar(
+			`/tenants/${TENANT_ID}/avatars/${CHILD_ID}/placeholder.svg?v=163ry6f`,
+		);
+		const newKey = mockUpdateChildAvatarUrl.mock.calls[0][1] as string;
+
+		expect(res.status).toBe(200);
+		expect(mockSaveFile).toHaveBeenCalledWith(
+			newKey.replace(/^\//, ''),
+			expect.anything(),
+			'image/png',
+		);
+		expect(mockDeleteFile).not.toHaveBeenCalledWith(newKey.replace(/^\//, ''));
+	});
+
+	it('tenant プレフィックス外を指す avatar_url では削除しない (誤削除経路の遮断)', async () => {
+		const res = await postAvatar('/tenants/other-tenant/avatars/999/secret.png');
+
+		expect(res.status).toBe(200);
+		expect(mockDeleteFile).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/child-service.test.ts
+++ b/tests/unit/services/child-service.test.ts
@@ -43,7 +43,10 @@ vi.mock('$lib/server/db/image-repo', () => ({
 	updateChildAvatarUrlIfMatches: vi.fn(),
 }));
 
-vi.mock('$lib/server/storage-keys', () => ({
+// 純粋関数なので実装を土台にし、必要な分だけ上書きする
+// (個別列挙だと export 追加のたびに undefined になり、実装ではなく mock が落ちる)
+vi.mock('$lib/server/storage-keys', async (importOriginal) => ({
+	...((await importOriginal()) as Record<string, unknown>),
 	childPrefix: vi.fn(
 		(tenantId: string, childId: number, type: string) => `tenants/${tenantId}/${type}/${childId}/`,
 	),

--- a/tests/unit/services/storage-keys.test.ts
+++ b/tests/unit/services/storage-keys.test.ts
@@ -5,6 +5,7 @@ import {
 	avatarKey,
 	childPrefix,
 	generatedImageKey,
+	publicUrlToStorageKey,
 	storageKeyToPublicUrl,
 	tenantPrefix,
 	voiceKey,
@@ -80,6 +81,31 @@ describe('storage-keys', () => {
 		it('キーの先頭にスラッシュを付与する', () => {
 			expect(storageKeyToPublicUrl('tenants/t1/avatars/1/abc.png')).toBe(
 				'/tenants/t1/avatars/1/abc.png',
+			);
+		});
+	});
+
+	describe('publicUrlToStorageKey (#4468)', () => {
+		it('先頭スラッシュを落として key に戻す (storageKeyToPublicUrl の逆変換)', () => {
+			const key = 'tenants/t1/avatars/1/abc.png';
+			expect(publicUrlToStorageKey(storageKeyToPublicUrl(key))).toBe(key);
+		});
+
+		it('仮アバターの `?v=<版>` (#4461) を落とす — 付いたままだと削除が空振りする', () => {
+			expect(publicUrlToStorageKey('/tenants/t1/avatars/1/placeholder.svg?v=163ry6f')).toBe(
+				'tenants/t1/avatars/1/placeholder.svg',
+			);
+		});
+
+		it('fragment も落とす', () => {
+			expect(publicUrlToStorageKey('/tenants/t1/avatars/1/abc.png#frag')).toBe(
+				'tenants/t1/avatars/1/abc.png',
+			);
+		});
+
+		it('スラッシュ無し (既に key 形) はそのまま返す', () => {
+			expect(publicUrlToStorageKey('tenants/t1/avatars/1/abc.png')).toBe(
+				'tenants/t1/avatars/1/abc.png',
 			);
 		});
 	});


### PR DESCRIPTION
## 顧客価値・目的

子供の写真をアップロードするたびに、置き換えられた仮アバターのファイルがストレージに残り続けていた。旧ファイルを確実に消し、家族のデータが使った分だけで収まるようにする。

## 関連 Issue

Closes #4468

## 変更内容

`src/routes/api/v1/children/[id]/avatar/+server.ts` は旧アバターの公開 URL をそのまま storage key として `deleteFile` に渡していた。#4461 で仮アバターの `avatar_url` に `?v=<中身の版>` が付いたため、`placeholder.svg?v=163ry6f` という存在しない key を消そうとして空振りし、`placeholder.svg` が孤児として残っていた（失敗は `catch {}` で握り潰されるため誰も気づけない）。

- **`storage-keys.ts` に `publicUrlToStorageKey()` を追加**（`storageKeyToPublicUrl` の逆変換。query / fragment を落として先頭スラッシュを外す）。同じ変換が `child-service.ts` の `shouldRegeneratePlaceholderAvatar` にも `.split('?')[0]` として存在していたため、その場しのぎを散らかさず 1 本に集約した
- avatar route / `child-service.ts` の両方を同関数経由に統一
- 削除前に `assertTenantScopedStorageKey(oldKey, tenantId)` を通し、query を落とした結果が別 tenant / traversal を指す場合は削除しない
- 自己削除の判定を URL 比較（`child.avatarUrl !== publicUrl`）から key 比較（`oldKey !== storageKey`）に変更。query の有無で判定が揺れないようにした

## 検証

| コマンド | 結果 |
|---|---|
| `npx vitest run tests/unit/routes/avatar-upload-old-file-deletion.test.ts` | PASS（4 件。実装前は `?v=` ケースと cross-tenant ケースの 2 件が FAIL することを確認済み = failing-test-first / ADR-0061） |
| `npx vitest run tests/unit/services/storage-keys.test.ts tests/unit/services/child-service.test.ts` | PASS（49 件） |
| `npm run pre-ready -- --pr 4469` | 全 step PASS |

### AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `?v=` 付き仮アバター URL でも旧 `placeholder.svg` が実際に削除される | unit test（route POST を mock storage で実行） | PASS: `avatar-upload-old-file-deletion.test.ts` 「仮アバター (`?v=` 付き URL) の実ファイルを削除する」が `deleteFile('tenants/<t>/avatars/42/placeholder.svg')` を assert |
| AC2 | query 無しの旧アバター（写真 → 写真の差し替え）も従来どおり削除される | 同上 | PASS: 同 spec 「query 無しの旧アバターも従来どおり削除する」で uuid key の削除を assert（回帰なし） |
| AC3 | 今保存した新ファイル（uuid key）は削除されない | 同上 | PASS: 同 spec 「今保存した新ファイルは削除しない」で `saveFile` した key が `deleteFile` に渡らないことを assert |
| AC4 | tenant プレフィックス外 / traversal を指す `avatar_url` では削除しない | 同上 | PASS: 同 spec 「tenant プレフィックス外を指す avatar_url では削除しない」で `deleteFile` 未呼出を assert（実装前は削除されていた） |
| AC5 | 「公開 URL → storage key」変換が SSOT 関数 1 本に集約されている | `grep -rn "split('?')\[0\]" src/` + `grep -rn "startsWith('/') ? .*slice(1)" src/` | PASS: storage key 変換の実装は `storage-keys.ts:73-76` の 1 箇所のみ。route / child-service は呼び出しのみ。残る `split('?')[0]` は `page-guide-registry.ts:185`（ルートパス正規化、storage key と無関係） |

## 影響範囲

- 顧客に見える変化: なし（サーバ側のファイル削除挙動のみ。UI・レスポンス body は不変）
- 触った並行実装ペア: なし
- 破壊的変更: なし。`publicUrlToStorageKey` は新規 export で既存呼出に影響しない
- 誤削除の経路: 新 key は `avatarKey()` の `randomUUID().<ext>` で、仮アバターの固定名 `placeholder.svg` と衝突しない。加えて key 比較で自己削除を弾き、`assertTenantScopedStorageKey` で tenant 外・`..` を弾くため、query を落としたことで別ファイルに当たる経路は無い（AC3 / AC4 の test で固定）

<!-- UI 変更なし（サーバ側のファイル削除挙動のみ。描画される DOM に差分が無いため SS 比較の対象が存在しない） -->
UI 変更なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
