### PR TITLE
fix(export): #4470 退会エクスポート JSON に記録期間の但し書きを載せる（JST 暦日 / null の意味 / 保存期間外）

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -810,6 +810,26 @@ export const DELETION_WARNING_EMAIL_LABELS = {
 } as const;
 
 // ============================================================
+// 削除前エクスポート JSON の但し書き（#4470 / #4450 follow-up）
+// ============================================================
+
+/**
+ * 退会時に顧客へ手渡す JSON (`generateMinimalExport`) の `notes` 文言 SSOT。
+ *
+ * トーン方針:
+ *   - 事実のみを書く。法務的主張 (「○○ 法に準拠しています」等) や弁明は書かない
+ *   - 読み手は開発者ではない保護者。フィールド名は識別のため原文のまま出す
+ */
+export const DELETION_EXPORT_NOTE_LABELS = {
+	/** 日付が JST 暦日であること (ISO の UTC 表記と 9 時間ずれるため明記する) */
+	jstCalendarDate: 'firstRecordDate / lastRecordDate は日本標準時（JST）の暦日です（YYYY-MM-DD）。',
+	/** null の意味 (記録 0 件のみ) */
+	nullMeansNoRecord: '記録が 1 件もない場合、firstRecordDate / lastRecordDate は null になります。',
+	/** retention 削除済みデータは開示対象外であること + 登録日の在り処 */
+	retentionExcluded: `保存期間の上限を過ぎた古い記録は削除済みのため、この期間には含まれません。${CHILD_TERMS.honorific}の登録日は children[].createdAt をご覧ください。`,
+} as const;
+
+// ============================================================
 // PMF 判定アンケート（#1598 / ADR-0023 §3.6 §5 I7）
 // ============================================================
 

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -825,8 +825,12 @@ export const DELETION_EXPORT_NOTE_LABELS = {
 	jstCalendarDate: 'firstRecordDate / lastRecordDate は日本標準時（JST）の暦日です（YYYY-MM-DD）。',
 	/** null の意味 (記録 0 件のみ) */
 	nullMeansNoRecord: '記録が 1 件もない場合、firstRecordDate / lastRecordDate は null になります。',
-	/** retention 削除済みデータは開示対象外であること + 登録日の在り処 */
-	retentionExcluded: `保存期間の上限を過ぎた古い記録は削除済みのため、この期間には含まれません。${CHILD_TERMS.honorific}の登録日は children[].createdAt をご覧ください。`,
+	/**
+	 * retention 削除済みデータは開示対象外であること + 登録日の在り処。
+	 * `children[].createdAt` は JST 暦日ではなく ISO 8601 の UTC 日時をそのまま出しているため、
+	 * 形式を併記する (併記しないと上の JST 暦日と混同され、JST 00:00〜09:00 登録が前日に見える)。
+	 */
+	retentionExcluded: `保存期間の上限を過ぎた古い記録は削除済みのため、この期間には含まれません。${CHILD_TERMS.honorific}の登録日は children[].createdAt（協定世界時 UTC の日時）をご覧ください。`,
 } as const;
 
 // ============================================================

--- a/src/lib/server/services/deletion-export-service.ts
+++ b/src/lib/server/services/deletion-export-service.ts
@@ -8,6 +8,7 @@
 
 import { jstDateOfIso } from '$lib/domain/date-utils';
 import type { ExportData } from '$lib/domain/export-format';
+import { DELETION_EXPORT_NOTE_LABELS } from '$lib/domain/labels';
 import { getCategoryById } from '$lib/domain/validation/activity';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
@@ -37,6 +38,12 @@ export interface MinimalExportData {
 	version: '1.0.0';
 	exportedAt: string;
 	scope: 'minimal';
+	/**
+	 * 顧客が JSON 単体を読んだときに値を誤解しないための但し書き (#4470)。
+	 * 日付の timezone / null の意味 / 保存期間外データの扱いを事実だけ記す。
+	 * `activitySummary` の各要素ではなく top-level に置く (子供の人数だけ重複させない)。
+	 */
+	notes: string[];
 	children: MinimalChildExport[];
 	activitySummary: ActivitySummaryExport[];
 }
@@ -159,6 +166,11 @@ export async function generateMinimalExport(tenantId: string): Promise<MinimalEx
 		version: '1.0.0',
 		exportedAt: new Date().toISOString(),
 		scope: 'minimal',
+		notes: [
+			DELETION_EXPORT_NOTE_LABELS.jstCalendarDate,
+			DELETION_EXPORT_NOTE_LABELS.nullMeansNoRecord,
+			DELETION_EXPORT_NOTE_LABELS.retentionExcluded,
+		],
 		children,
 		activitySummary,
 	};

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -277,6 +277,9 @@ describe('deletion-export-service', () => {
 			expect(joined).toContain('null');
 			expect(joined).toContain('保存期間');
 			expect(joined).toContain('children[].createdAt');
+			// createdAt は JST 暦日ではなく ISO UTC 日時。形式を併記しないと上の JST 暦日と混同され、
+			// JST 00:00〜09:00 に登録した子供の登録日が前日に見える (#4120 と同型の誤読)
+			expect(joined).toContain('UTC');
 		});
 
 		it('notes を足しても既存フィールドの構造・意味は変わらない', async () => {

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -79,6 +79,7 @@ vi.mock('$lib/server/services/export-service', () => ({
 	exportFamilyData: (...args: unknown[]) => mockExportFamilyData(...args),
 }));
 
+import { DELETION_EXPORT_NOTE_LABELS } from '$lib/domain/labels';
 import {
 	generateDeletionExport,
 	generateMinimalExport,
@@ -251,6 +252,59 @@ describe('deletion-export-service', () => {
 
 			expect(result.children).toHaveLength(0);
 			expect(result.activitySummary).toHaveLength(0);
+		});
+
+		// #4470 (#4450 follow-up、PO 決裁 Q2=Yes): 顧客へ手渡す JSON の日付は裸の値だと
+		// 読み手が誤解する (JST か UTC か / null の意味 / retention 削除済みデータが期間に
+		// 含まれないこと)。但し書きは top-level `notes` に置き、文言は labels.ts SSOT
+		// (DELETION_EXPORT_NOTE_LABELS) から取る。
+		it('notes に日付の但し書き 3 件が SSOT の文言で入る', async () => {
+			mockFindAllChildren.mockResolvedValue([]);
+
+			const result = await generateMinimalExport('tenant-1');
+
+			expect(result.notes).toEqual([
+				DELETION_EXPORT_NOTE_LABELS.jstCalendarDate,
+				DELETION_EXPORT_NOTE_LABELS.nullMeansNoRecord,
+				DELETION_EXPORT_NOTE_LABELS.retentionExcluded,
+			]);
+			// 但し書きは「日付の timezone」「null の意味」「保存期間外の記録」の 3 点を必ず触れる
+			// (どれか 1 つでも消えたら顧客が値を誤読しうるため、文言 refactor 時の網を残す)
+			const joined = result.notes.join('\n');
+			expect(joined).toContain('firstRecordDate');
+			expect(joined).toContain('lastRecordDate');
+			expect(joined).toContain('日本標準時');
+			expect(joined).toContain('null');
+			expect(joined).toContain('保存期間');
+			expect(joined).toContain('children[].createdAt');
+		});
+
+		it('notes を足しても既存フィールドの構造・意味は変わらない', async () => {
+			mockFindAllChildren.mockResolvedValue([
+				{
+					id: '1',
+					nickname: 'たろう',
+					age: 6,
+					uiMode: 'elementary',
+					createdAt: '2026-07-31T15:10:00.000Z',
+				},
+			]);
+			mockFindStatuses.mockResolvedValue([]);
+			mockFindActivityLogs.mockResolvedValue([]);
+
+			// 顧客が受け取るのは JSON 化された値。notes は文字列配列として往復できる必要がある
+			const result = JSON.parse(JSON.stringify(await generateMinimalExport('tenant-1')));
+
+			expect(result.format).toBe('ganbari-quest-deletion-export');
+			expect(result.version).toBe('1.0.0');
+			expect(result.scope).toBe('minimal');
+			expect(result.children).toHaveLength(1);
+			expect(result.children[0]?.createdAt).toBe('2026-07-31T15:10:00.000Z');
+			expect(result.activitySummary).toHaveLength(1);
+			expect(result.activitySummary[0]?.childNickname).toBe('たろう');
+			expect(result.notes).toHaveLength(3);
+			// 但し書きは top-level にだけ置く (子供の人数だけ重複させない)
+			expect(result.activitySummary[0]).not.toHaveProperty('notes');
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

退会時に受け取る JSON で「記録期間がなぜこの範囲なのか」を顧客自身が読み解ける。日付が JST 暦日であること・`null` が「記録 0 件」を意味すること・保存期間を過ぎた古い記録が含まれないこと（登録日は別フィールドに残っていること）を JSON 自体に書いたので、「もっと前から使っていたのに期間が短い」という誤解が起きない。

## 関連 Issue

Closes #4470

- Related: #4459（#4450、記録期間を実データから出す修正）— develop に merge 済み（d51e46fab）。本 PR はその上に rebase 済み

## 変更内容

- `MinimalExportData` の **top-level に `notes: string[]` を追加**（free プラン = minimal scope の削除前エクスポート）。`generateMinimalExport` が但し書き 3 件を返す
  - 日付（`firstRecordDate` / `lastRecordDate`）は日本標準時（JST）の暦日である
  - 記録が 1 件もない場合は `null` になる
  - 保存期間の上限を過ぎた古い記録は削除済みで期間に含まれない。登録日は `children[].createdAt`（協定世界時 UTC の日時）にある
- **`activitySummary` の各要素ではなく top-level に置いた**。各要素に足すと子供の人数だけ同じ文が重複し、JSON が読みにくくなるため
- **既存フィールドの意味・構造は変えていない**（`format` / `version` / `scope` / `children` / `activitySummary` は不変、追加のみ）。wire format としては後方互換
- 文言は `src/lib/domain/labels.ts` の `DELETION_EXPORT_NOTE_LABELS`（compound、`CHILD_TERMS.honorific` atom を参照）に置き、service 側に日本語リテラルを直書きしていない（ADR-0045 / docs/DESIGN.md §6）
- 書いたのは事実だけ。法的主張（「GDPR に準拠しています」等）や弁明は書いていない
- 2 commit 目は adversarial-reviewer（UX 軸）の指摘対応。`children[].createdAt` は JST 暦日ではなく ISO UTC 日時をそのまま出しているため、形式を併記しないと同じ `notes` 内の「日付は JST 暦日」と混同され、**但し書きが指し示す先で #4120 と同型の誤読（JST 00:00〜09:00 登録が前日に見える）が再発する**。UTC である旨を併記して解消し、unit test で固定した

## 検証

| 検査 | コマンド | 結果 |
|---|---|---|
| unit test（対象 service） | `npx vitest run tests/unit/services/deletion-export-service.test.ts` | 14 passed（新規 2 件含む） |
| unit test（labels SSOT 波及） | `npx vitest run tests/unit/domain/` | 58 files / 1063 passed |
| Ready 化前 gate | `npm run pre-ready -- --pr 4471` | 6 step PASS（SS embed gate は UI 変更なしで対象外） |

### AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `MinimalExportData` に `notes: string[]` を追加し 3 件返す | unit test `notes に日付の但し書き 3 件が SSOT の文言で入る` | PASS（`toEqual` で 3 件固定） |
| AC2 | JST 暦日 / `null` の意味 / 保存期間外（+ 登録日の在り処）の 3 点を含む | 同 test の `joined` 検査（`日本標準時` / `null` / `保存期間` / `children[].createdAt` / `UTC` / `firstRecordDate` / `lastRecordDate`） | PASS |
| AC3 | 文言は `DELETION_EXPORT_NOTE_LABELS` に置き service に直書きしない | `src/lib/server/services/deletion-export-service.ts` は labels の参照のみ（日本語リテラル 0）／`npx biome check` | PASS |
| AC4 | 既存フィールドの意味・構造を変えない | unit test `notes を足しても既存フィールドの構造・意味は変わらない`（JSON 往復後に `format` / `version` / `scope` / `children` / `activitySummary` を assert）＋ 既存 12 test が無改変で PASS | PASS |
| AC5 | 「SSOT の文言で出る」「既存が壊れていない」「top-level のみで要素に重複しない」を test で固定 | 上記 2 test（`activitySummary[0]` に `notes` プロパティが無いことも assert） | PASS |

## 影響範囲

- 顧客に見える変化: free プランのアカウント削除前エクスポート（`GET /api/v1/admin/account/export`）の JSON に `notes` が増える。既存フィールドは不変
- 並行実装ペア: 用語 SSOT（`labels.ts`）に compound を 1 つ追加。`terms.ts` の atom（`CHILD_TERMS.honorific`）を参照するだけで新規 atom は追加していないため LP 側（`shared-labels.js`）への波及なし（pre-commit の `generate-lp-labels --check` / `sync-lp-fallback --check` とも OK）
- 破壊的変更: なし（フィールド追加のみ）
- 設計書同期: `docs/design/07-API設計書.md` / `docs/design/account-deletion-flow.md` を grep したところ本エンドポイント・本 JSON 構造の記述は **0 件**。同期すべき既存記述が無いため本 PR では docs 変更なし（エンドポイントを新規に文書化するのは本 PR の scope 外）

### 本 PR で対応しなかった点（adversarial-reviewer 指摘、silent に落とさないため明記）

| 指摘 | 本 PR での判断 |
|---|---|
| business: 但し書きが minimal scope（free）だけで、standard / family の full / family export には載らない | full / family export は `exportFamilyData` の別構造で `firstRecordDate` / `lastRecordDate` を持たない。同等の但し書きを載せるかは別の文面設計が要るため本 PR の scope 外。**PO 判断を仰ぐ（下記 Q1）** |
| security: GDPR 15(1)(d) の「保存期間または決定基準」を満たすには日数（free = 90 日、ADR-0049）が要る | 保存期間の日数は ADR-0049 / プランに依存する値で、JSON に直書きすると SSOT が二重化する。PO 指示は「事実 3 点を最小限」「断定的な法的主張は書かない」であり、日数追加は指示範囲外。**PO 判断を仰ぐ（下記 Q2）** |
| security: retention cron 失敗時に「削除済み」が事実でなくなりうる | 文面は PO が決裁時に指定した内容そのもの。cron の実行保証は本 PR の対象外 |

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — JSON にフィールド 1 個追加のみ"]
    R2["顧客面: 退会時の開示データ。UI 変更なし"]
    R3["ロールバック: 🟢 revert のみで戻る。データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 日付の誤読が消える。登録日の在り処も伝わる"]
    T2["捨てる: 🟡 有料プランの export には但し書きが無いまま"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: 🟡 free だけ説明され有料が未対応"]
    O2["UX: 🔴 createdAt が UTC で JST と混同 → 本 PR で修正済"]
    O3["security: 🟡 GDPR は保存期間の日数提示を求める"]
  end
  subgraph CUST["④ 顧客面の変化 (プロダクト実態)"]
    C1["画面変化なし。DL する JSON に notes 3 行が増える"]
  end
  subgraph ASK["⑤ PO 判断依頼 (Yes/No で回答可能に)"]
    Q1["Q1: 有料プランの export への但し書きは別 Issue でよい?"]
    Q2["Q2: 保存期間の日数(90日)は書かない、でよい?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3 ok
  class R2,C1 ok
  class T2,O1,O3 warn
  class O2 danger
  class T1 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- ③ の反対理由は `.claude/skills/adversarial-reviewer/SKILL.md` の手順で生成した `tmp/adversarial-evidence/4471.json`（`node scripts/verify-adversarial-output.mjs --pr 4471` exit 0）からの転記
- O2（UX 軸）は本 PR 内で修正済み。`children[].createdAt` が ISO UTC であることを但し書きに併記し、unit test で固定した
- O1 / O3 は「本 PR で対応しなかった点」の表に判断根拠を書いた。Q1 / Q2 が Yes なら本 PR は現状のまま merge 可、No ならそれぞれ追補する

</details>

## SS 検証

UI 変更なし — サーバ側（service の返却 JSON + labels SSOT + unit test）のみの変更で、描画される画面は一切変わらない。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
