### PR TITLE
fix(export): #4473 退会エクスポートの保存期間を SSOT から引いた日数で述べる

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -826,11 +826,25 @@ export const DELETION_EXPORT_NOTE_LABELS = {
 	/** null の意味 (記録 0 件のみ) */
 	nullMeansNoRecord: '記録が 1 件もない場合、firstRecordDate / lastRecordDate は null になります。',
 	/**
-	 * retention 削除済みデータは開示対象外であること + 登録日の在り処。
+	 * retention 削除済みデータは開示対象外であること + 保存期間の実日数 (#4473)。
+	 *
+	 * 「上限を過ぎた記録は含まれない」だけでは、読み手は「いつまで遡って含まれているか」を
+	 * 確定できない。日数は `PlanLimits.historyRetentionDays` が SSOT のため、
+	 * ここでは **値を持たず引数で受ける** (labels 側に 90 / 365 を複製しない)。
+	 */
+	retentionLimited: (days: number) =>
+		`記録の保存期間は${days}日間です。それより古い記録は削除済みのため、この期間には含まれません。`,
+	/**
+	 * `historyRetentionDays: null` (保存期間の上限なし) のプラン向け。
+	 * 「null日間」のような値の穴埋めにせず、上限がないという事実を別文で述べる。
+	 */
+	retentionUnlimited: '記録の保存期間に上限はないため、期間の上限による削除は行っていません。',
+	/**
+	 * 登録日の在り処。
 	 * `children[].createdAt` は JST 暦日ではなく ISO 8601 の UTC 日時をそのまま出しているため、
 	 * 形式を併記する (併記しないと上の JST 暦日と混同され、JST 00:00〜09:00 登録が前日に見える)。
 	 */
-	retentionExcluded: `保存期間の上限を過ぎた古い記録は削除済みのため、この期間には含まれません。${CHILD_TERMS.honorific}の登録日は children[].createdAt（協定世界時 UTC の日時）をご覧ください。`,
+	createdAtPointer: `${CHILD_TERMS.honorific}の登録日は children[].createdAt（協定世界時 UTC の日時）をご覧ください。`,
 } as const;
 
 // ============================================================

--- a/src/lib/server/services/deletion-export-service.ts
+++ b/src/lib/server/services/deletion-export-service.ts
@@ -13,7 +13,7 @@ import { getCategoryById } from '$lib/domain/validation/activity';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import type { PlanTier } from './plan-limit-service';
-import { resolveFullPlanTier } from './plan-limit-service';
+import { getPlanLimits, resolveFullPlanTier } from './plan-limit-service';
 
 // ============================================================
 // Types
@@ -108,12 +108,41 @@ export function resolveExportScope(planTier: PlanTier): ExportScope {
 // ============================================================
 
 /**
+ * エクスポート JSON に載せる但し書きを組み立てる (#4470 / #4473)。
+ *
+ * 保存期間の日数は `PlanLimits.historyRetentionDays` が唯一の SSOT。
+ * ここで 90 / 365 を書くと保存期間ポリシー変更時に JSON だけ古い日数を語る二重管理になるため、
+ * 値は必ず `getPlanLimits(planTier)` から引く (labels 側も値を持たず引数で受ける)。
+ *
+ * `historyRetentionDays: null` = 保存期間の上限なし。「null日間」の穴埋めにせず別文を出す。
+ */
+export function buildDeletionExportNotes(planTier: PlanTier): string[] {
+	const retentionDays = getPlanLimits(planTier).historyRetentionDays;
+
+	return [
+		DELETION_EXPORT_NOTE_LABELS.jstCalendarDate,
+		DELETION_EXPORT_NOTE_LABELS.nullMeansNoRecord,
+		retentionDays === null
+			? DELETION_EXPORT_NOTE_LABELS.retentionUnlimited
+			: DELETION_EXPORT_NOTE_LABELS.retentionLimited(retentionDays),
+		DELETION_EXPORT_NOTE_LABELS.createdAtPointer,
+	];
+}
+
+/**
  * free プラン向けの最小限エクスポートを生成する。
  *
  * 子供名と活動サマリのみ含む。法的要件（個人情報保護法のデータポータビリティ権）に
  * 最低限対応するためのもの。
+ *
+ * `planTier` は但し書きの保存期間日数を決めるために受け取る (#4473)。
+ * 呼び出し側が握っているプランをそのまま渡すこと (ここで free 固定にすると、
+ * 将来 minimal scope の対象プランが増えたときに嘘の日数を配ることになる)。
  */
-export async function generateMinimalExport(tenantId: string): Promise<MinimalExportData> {
+export async function generateMinimalExport(
+	tenantId: string,
+	planTier: PlanTier,
+): Promise<MinimalExportData> {
 	const repos = getRepos();
 	const allChildren = await repos.child.findAllChildren(tenantId);
 
@@ -166,11 +195,7 @@ export async function generateMinimalExport(tenantId: string): Promise<MinimalEx
 		version: '1.0.0',
 		exportedAt: new Date().toISOString(),
 		scope: 'minimal',
-		notes: [
-			DELETION_EXPORT_NOTE_LABELS.jstCalendarDate,
-			DELETION_EXPORT_NOTE_LABELS.nullMeansNoRecord,
-			DELETION_EXPORT_NOTE_LABELS.retentionExcluded,
-		],
+		notes: buildDeletionExportNotes(planTier),
 		children,
 		activitySummary,
 	};
@@ -255,7 +280,7 @@ export async function generateDeletionExport(
 
 	switch (scope) {
 		case 'minimal': {
-			const data = await generateMinimalExport(tenantId);
+			const data = await generateMinimalExport(tenantId, planTier);
 			return { scope, data, generatedAt };
 		}
 		case 'full': {

--- a/tests/unit/services/deletion-export-service.test.ts
+++ b/tests/unit/services/deletion-export-service.test.ts
@@ -23,6 +23,25 @@ vi.mock('$lib/server/auth/factory', () => ({
 	getAuthMode: () => 'cognito',
 }));
 
+/**
+ * #4473: 保存期間の日数が `PlanLimits.historyRetentionDays` 由来であることを試験するための override。
+ * `undefined` の間は実 SSOT をそのまま使う (既定の挙動を変えない)。
+ */
+const retentionDaysOverride: { value: number | null | undefined } = { value: undefined };
+
+vi.mock('$lib/server/services/plan-limit-service', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('$lib/server/services/plan-limit-service')>();
+	return {
+		...actual,
+		getPlanLimits: (tier: Parameters<typeof actual.getPlanLimits>[0]) => {
+			const limits = actual.getPlanLimits(tier);
+			return retentionDaysOverride.value === undefined
+				? limits
+				: { ...limits, historyRetentionDays: retentionDaysOverride.value };
+		},
+	};
+});
+
 vi.mock('$lib/server/services/trial-service', () => ({
 	getTrialStatus: vi.fn().mockResolvedValue({
 		isTrialActive: false,
@@ -81,11 +100,13 @@ vi.mock('$lib/server/services/export-service', () => ({
 
 import { DELETION_EXPORT_NOTE_LABELS } from '$lib/domain/labels';
 import {
+	buildDeletionExportNotes,
 	generateDeletionExport,
 	generateMinimalExport,
 	generateSiblingComparison,
 	resolveExportScope,
 } from '$lib/server/services/deletion-export-service';
+import { getPlanLimits } from '$lib/server/services/plan-limit-service';
 
 describe('deletion-export-service', () => {
 	beforeEach(() => {
@@ -151,7 +172,7 @@ describe('deletion-export-service', () => {
 				.mockResolvedValueOnce([{ id: '1' }, { id: '2' }, { id: '3' }, { id: '4' }, { id: '5' }])
 				.mockResolvedValueOnce([{ id: '6' }, { id: '7' }, { id: '8' }]);
 
-			const result = await generateMinimalExport('tenant-1');
+			const result = await generateMinimalExport('tenant-1', 'free');
 
 			expect(result.format).toBe('ganbari-quest-deletion-export');
 			expect(result.scope).toBe('minimal');
@@ -191,7 +212,7 @@ describe('deletion-export-service', () => {
 				{ id: '1', recordedAt: '2026-07-31T15:10:00.000Z' }, // JST 2026-08-01 00:10
 			]);
 
-			const result = await generateMinimalExport('tenant-1');
+			const result = await generateMinimalExport('tenant-1', 'free');
 
 			expect(result.activitySummary[0]?.firstRecordDate).toBe('2026-08-01');
 			expect(result.activitySummary[0]?.lastRecordDate).toBe('2026-08-05');
@@ -220,7 +241,7 @@ describe('deletion-export-service', () => {
 				{ id: '2', recordedAt: '2026-08-05T13:00:00.000Z' },
 			]);
 
-			const result = await generateMinimalExport('tenant-1');
+			const result = await generateMinimalExport('tenant-1', 'free');
 
 			expect(result.activitySummary[0]?.firstRecordDate).toBe('2026-08-01');
 			expect(result.activitySummary[0]?.lastRecordDate).toBe('2026-08-05');
@@ -239,7 +260,7 @@ describe('deletion-export-service', () => {
 			mockFindStatuses.mockResolvedValue([]);
 			mockFindActivityLogs.mockResolvedValue([]);
 
-			const result = await generateMinimalExport('tenant-1');
+			const result = await generateMinimalExport('tenant-1', 'free');
 
 			expect(result.activitySummary[0]?.firstRecordDate).toBeNull();
 			expect(result.activitySummary[0]?.lastRecordDate).toBeNull();
@@ -248,7 +269,7 @@ describe('deletion-export-service', () => {
 		it('子供がいない場合も空の結果を返す', async () => {
 			mockFindAllChildren.mockResolvedValue([]);
 
-			const result = await generateMinimalExport('tenant-1');
+			const result = await generateMinimalExport('tenant-1', 'free');
 
 			expect(result.children).toHaveLength(0);
 			expect(result.activitySummary).toHaveLength(0);
@@ -258,17 +279,13 @@ describe('deletion-export-service', () => {
 		// 読み手が誤解する (JST か UTC か / null の意味 / retention 削除済みデータが期間に
 		// 含まれないこと)。但し書きは top-level `notes` に置き、文言は labels.ts SSOT
 		// (DELETION_EXPORT_NOTE_LABELS) から取る。
-		it('notes に日付の但し書き 3 件が SSOT の文言で入る', async () => {
+		it('notes に日付の但し書きが SSOT の文言で入る', async () => {
 			mockFindAllChildren.mockResolvedValue([]);
 
-			const result = await generateMinimalExport('tenant-1');
+			const result = await generateMinimalExport('tenant-1', 'free');
 
-			expect(result.notes).toEqual([
-				DELETION_EXPORT_NOTE_LABELS.jstCalendarDate,
-				DELETION_EXPORT_NOTE_LABELS.nullMeansNoRecord,
-				DELETION_EXPORT_NOTE_LABELS.retentionExcluded,
-			]);
-			// 但し書きは「日付の timezone」「null の意味」「保存期間外の記録」の 3 点を必ず触れる
+			expect(result.notes).toEqual(buildDeletionExportNotes('free'));
+			// 但し書きは「日付の timezone」「null の意味」「保存期間」の 3 点を必ず触れる
 			// (どれか 1 つでも消えたら顧客が値を誤読しうるため、文言 refactor 時の網を残す)
 			const joined = result.notes.join('\n');
 			expect(joined).toContain('firstRecordDate');
@@ -296,7 +313,7 @@ describe('deletion-export-service', () => {
 			mockFindActivityLogs.mockResolvedValue([]);
 
 			// 顧客が受け取るのは JSON 化された値。notes は文字列配列として往復できる必要がある
-			const result = JSON.parse(JSON.stringify(await generateMinimalExport('tenant-1')));
+			const result = JSON.parse(JSON.stringify(await generateMinimalExport('tenant-1', 'free')));
 
 			expect(result.format).toBe('ganbari-quest-deletion-export');
 			expect(result.version).toBe('1.0.0');
@@ -305,9 +322,91 @@ describe('deletion-export-service', () => {
 			expect(result.children[0]?.createdAt).toBe('2026-07-31T15:10:00.000Z');
 			expect(result.activitySummary).toHaveLength(1);
 			expect(result.activitySummary[0]?.childNickname).toBe('たろう');
-			expect(result.notes).toHaveLength(3);
+			expect(result.notes).toEqual(buildDeletionExportNotes('free'));
 			// 但し書きは top-level にだけ置く (子供の人数だけ重複させない)
 			expect(result.activitySummary[0]).not.toHaveProperty('notes');
+		});
+	});
+
+	// ============================================================
+	// buildDeletionExportNotes — 保存期間の日数 (#4473)
+	// ============================================================
+
+	// PO 決裁「日数の二重管理は論外。SSOT の原則を守って対応せよ」。
+	// 保存期間の実値 SSOT は PlanLimits.historyRetentionDays であり、
+	// 但し書きに 90 / 365 を直書きしたら本 describe が落ちる形にしてある。
+	describe('buildDeletionExportNotes (#4473)', () => {
+		it('保存期間の文言に getPlanLimits の日数がそのまま入る (free / standard)', () => {
+			for (const tier of ['free', 'standard'] as const) {
+				const days = getPlanLimits(tier).historyRetentionDays;
+				// 前提: 有限プランは日数を持つ (null なら本 case の検証対象外)
+				expect(days).not.toBeNull();
+
+				const joined = buildDeletionExportNotes(tier).join('\n');
+
+				// 文言は labels.ts SSOT の関数に日数を渡した結果と完全一致する
+				expect(joined).toContain(
+					DELETION_EXPORT_NOTE_LABELS.retentionLimited(days as unknown as number),
+				);
+				expect(joined).toContain(String(days));
+				// 無期限プラン向けの別文が紛れ込まない
+				expect(joined).not.toContain(DELETION_EXPORT_NOTE_LABELS.retentionUnlimited);
+			}
+		});
+
+		it('free と standard で文面が変わる (単一の日数を直書きしていたら落ちる)', () => {
+			const freeNote = buildDeletionExportNotes('free').join('\n');
+			const standardNote = buildDeletionExportNotes('standard').join('\n');
+
+			expect(freeNote).not.toBe(standardNote);
+			expect(freeNote).toContain(String(getPlanLimits('free').historyRetentionDays));
+			expect(standardNote).toContain(String(getPlanLimits('standard').historyRetentionDays));
+		});
+
+		it('historyRetentionDays が null のプランは日数ではなく「上限なし」の別文を出す', () => {
+			// family は保存期間の上限を持たない (= null)
+			expect(getPlanLimits('family').historyRetentionDays).toBeNull();
+
+			const joined = buildDeletionExportNotes('family').join('\n');
+
+			expect(joined).toContain(DELETION_EXPORT_NOTE_LABELS.retentionUnlimited);
+			// 「null日間」「undefined日間」のような値の穴埋めをしていない
+			expect(joined).not.toContain('null日間');
+			expect(joined).not.toContain('undefined日間');
+			// 有限プラン向けの日数入り文型も出さない
+			expect(joined).not.toContain('保存期間は');
+		});
+
+		it('日数は SSOT (getPlanLimits) 由来で、値を差し替えると文面も変わる', () => {
+			// 値を直書きしていたら override しても文面が変わらず落ちる。
+			// 実際の保存期間ポリシー変更 (90 → 別値) と同じ経路を試験する。
+			retentionDaysOverride.value = 7;
+			try {
+				expect(buildDeletionExportNotes('free').join('\n')).toContain(
+					DELETION_EXPORT_NOTE_LABELS.retentionLimited(7),
+				);
+			} finally {
+				retentionDaysOverride.value = undefined;
+			}
+		});
+
+		it('無期限は override でも別文に切り替わる (null 判定が日数側に漏れない)', () => {
+			retentionDaysOverride.value = null;
+			try {
+				const joined = buildDeletionExportNotes('free').join('\n');
+				expect(joined).toContain(DELETION_EXPORT_NOTE_LABELS.retentionUnlimited);
+			} finally {
+				retentionDaysOverride.value = undefined;
+			}
+		});
+
+		it('法的主張ではなく事実だけを述べる', () => {
+			for (const tier of ['free', 'standard', 'family'] as const) {
+				const joined = buildDeletionExportNotes(tier).join('\n');
+				for (const claim of ['GDPR', '準拠', '法令', '個人情報保護法']) {
+					expect(joined).not.toContain(claim);
+				}
+			}
 		});
 	});
 


### PR DESCRIPTION
## 顧客価値・目的

退会時に受け取るエクスポート JSON から、顧客が「**記録がいつまで遡って入っているのか**」を読み取れるようになる。これまでは「保存期間の上限を過ぎた記録は含まれない」としか書いておらず、上限が何日なのかはどこにも書かれていなかった。

## 関連 Issue

Closes #4473

前提: #4471（`notes` 配列を追加した PR）は develop に merge 済み。本 PR はその上に rebase 済みで、diff は本 PR の 1 commit だけ。

## 変更内容

PO 決裁「**日数の二重管理は論外。SSOT の原則を守って、別 PR でもいいのできちんと対応せよ**」（出典: PR #4471 のレビュー往復 — adversarial review の指摘 → #4471 の PO 判断エスカレーション）に沿い、**日数は出すが直書きはしない**形で実装した。

- `src/lib/server/services/deletion-export-service.ts`
  - `buildDeletionExportNotes(planTier)` を新設。保存期間の日数は `getPlanLimits(planTier).historyRetentionDays` から引く（`90` / `365` はこのファイルに存在しない）
  - `historyRetentionDays === null`（上限なし）は日数の文型に押し込まず、別文に分岐する
  - `generateMinimalExport(tenantId, planTier)` が `planTier` を**必須引数**で受け取るようにし、`generateDeletionExport` から渡す。free 固定にすると、minimal scope の対象プランが増えたときに嘘の日数を配ることになるため
- `src/lib/domain/labels.ts`（`DELETION_EXPORT_NOTE_LABELS`）
  - `retentionLimited: (days: number) => ...` — **値を持たず引数で受ける関数**。既存の `planStatusCard.retentionDays` と同じ形
  - `retentionUnlimited` — 上限なしプラン向けの別文
  - 登録日 pointer（`children[].createdAt` は UTC 日時）を独立した note に分離。保存期間の文と 1 文に混ぜると、上限なし分岐のたびに pointer まで書き分ける羽目になるため
- 文面は事実のみ。「GDPR に準拠しています」等の法的主張は書いていない（test で非混入を assert）

出力される文面:

| プラン | `historyRetentionDays` | 保存期間の note |
|---|---|---|
| free | 90 | 記録の保存期間は90日間です。それより古い記録は削除済みのため、この期間には含まれません。 |
| standard | 365 | 記録の保存期間は365日間です。それより古い記録は削除済みのため、この期間には含まれません。 |
| family | null | 記録の保存期間に上限はないため、期間の上限による削除は行っていません。 |

## 検証

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | `notes` の保存期間文言の日数が `getPlanLimits(tier).historyRetentionDays` 由来 | `npx vitest run tests/unit/services/deletion-export-service.test.ts`（`保存期間の文言に getPlanLimits の日数がそのまま入る (free / standard)`） | PASS（20 tests passed） |
| AC2 | `90` / `365` のリテラルが本 PR の実装経路に無い | `grep -nE "\b(90\|365)\b" src/lib/server/services/deletion-export-service.ts`（1 件 = 「ここで 90 / 365 を書くな」と書いた注意書きコメントのみ、コードは 0 件）/ `git diff origin/develop -- src/lib/domain/labels.ts \| grep -E "90\|365"`（0 件） | 実装経路に日数リテラル 0 件 |
| AC3 | `null` プランは日数ではなく「上限なし」の別文 | 同 test（`historyRetentionDays が null のプランは日数ではなく「上限なし」の別文を出す`）。`null日間` / `undefined日間` / 日数文型の非出現も assert | PASS |
| AC4 | 3 通りで文面が変わり、直書きなら test が落ちる | ① `free と standard で文面が変わる` ② `getPlanLimits` を override して `7` を注入し文面が追随することを assert ③ **変異試験**: 実装を `const retentionDays = 90;` に差し替えて実行 | ③ で **5 件 fail** を実測（差し替えは検証後に戻し、commit には含まれていない） |
| AC5 | 法的主張を含まない | 同 test（`法的主張ではなく事実だけを述べる`。`GDPR` / `準拠` / `法令` / `個人情報保護法` の非混入を 3 tier 分 assert） | PASS |

- `npx vitest run tests/unit/services/deletion-export-service.test.ts` → 20 passed
- `npx biome check <変更 3 ファイル>` → No fixes applied
- `npm run pre-ready -- --pr <本 PR 番号>` → 全 step PASS（下記コメント参照）

## 影響範囲

- 顧客に見える変化: `GET /api/v1/admin/account/export`（free プラン = minimal scope）が返す JSON の `notes` に保存期間の日数が載る。既存フィールドの構造・意味は不変（test で JSON 往復と既存フィールドを固定）
- `generateMinimalExport` の signature が 2 引数になる。呼び出しは `generateDeletionExport` と test のみで、同 PR 内で全件更新済み
- 並行実装ペア: 該当なし（UI ラベル / 年齢モード / ナビ / DB スキーマ / チュートリアルのいずれにも触れていない）
- 破壊的変更: なし（公開 API のレスポンス形状は追加のみ）
- 観測事実（本 PR では触っていない）: `labels.ts` の LP 料金表側に `'90日間の履歴保持'` が 4 箇所あり、`historyRetentionDays: 90` と値が二重化している（`grep -n "90日間" src/lib/domain/labels.ts` → 8498 / 8576 / 9258 / 9500 行）。LP 文言は本 PR の対象外（エクスポート JSON の但し書きのみ）なので手を入れていない

**UI 変更なし** — サーバ側の JSON 文言のみで、描画される画面は存在しない（`/api/v1/admin/account/export` は API エンドポイントで、呼び出す UI コンポーネントはリポジトリ内に無い）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->


## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert で完全に戻る"]
    R2["顧客面: 退会時に渡す JSON の文言のみ"]
    R3["🟢 データ破壊なし 読み取り専用の但し書き"]
  end
  subgraph TRADE["② trade-off"]
    T1["得る: 保存期間の日数を顧客が確定できる"]
    T2["捨てる: 引数 1 個増 呼び出し側が tier を持つ義務"]
  end
  subgraph OBJ["③ 反対理由"]
    O1["🟡 standard/family 分岐は本番到達なし"]
    O2["🟡 LP 料金表の 90日間 は依然直書き"]
    O3["🟡 有料プランの JSON には但し書き自体が無い"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["free の JSON に 保存期間は90日間です が載る"]
    C2["UI 変更なし API の JSON 文言のみ"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 但し書きは free 向け JSON だけで良いか"]
    Q2["Q2: LP 料金表の 90日間 二重化は本 PR 対象外で良いか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3 ok
  class R2 warn
  class T2,O1,O2,O3 warn
  class T1,C1,C2 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- ③ の 3 件は **本 PR の実装者による自己 adversarial review** で挙げたもの（`.claude/skills/adversarial-reviewer` の JSON evidence は QM レビュー時に QM 側が生成する。ここに QM の evidence を騙って書かない）。起点は PR #4471 のレビュー往復で adversarial review が挙げた「日数が無いと開示として確定しない」指摘。
- **O1**: `resolveExportScope` は free → minimal / standard → full / family → family に分かれるため、`buildDeletionExportNotes` の standard / family 分岐は現状の本番経路には現れない（test でのみ実行される）。それでも tier 固定にしなかったのは、free 固定にすると minimal scope の対象プランが増えた瞬間に**嘘の日数を配る**ため。分岐を消すより、値が tier から導出されている状態を保つほうが安全と判断した。
- **O2**: `labels.ts` の LP 料金表側 4 箇所（8498 / 8576 / 9258 / 9500 行）に `'90日間の履歴保持'` が残っており、`historyRetentionDays: 90` と値が二重化している。LP 文言は ADR-0013 の別系統で、本 PR のスコープ（エクスポート JSON の但し書き）と surface が違うため触っていない。Q2 はこの扱いの確認。
- **O3**: `notes` は `MinimalExportData`（free）にしか無く、standard / family の `ExportData` には但し書きフィールド自体が無い。有料プランの顧客は JSON から保存期間を読めない。#4471 が `notes` を minimal にだけ置いた設計をそのまま踏襲している。Q1 はこの扱いの確認。

</details>
