### PR TITLE
fix(admin): #4472 退会画面にデータ持ち出し導線を作る（無料プランの唯一の持ち出し手段）

### DIFF
--- a/docs/design/account-deletion-flow.md
+++ b/docs/design/account-deletion-flow.md
@@ -244,7 +244,24 @@ soft delete 状態のテナントに対し、物理削除の **残り 14 日 (fa
 - 入力値が一致しない限り削除実行ボタンは disabled
 - 実装: `src/routes/(parent)/admin/settings/+page.svelte` の `deleteConfirmText !== 'アカウントを削除します'` ガード
 
-### 5.2 パターンごとの追加 UX
+### 5.2 退会前のデータ持ち出し（プラン非依存）
+
+削除実行の手順より**前**に、owner はデータをファイルとして持ち出せる。
+
+- **導線**: `/admin/settings/account` の Danger Zone 内、削除の 3 手順の上に配置（`AccountDeletionExportPanel`）。owner のみ表示（API が owner 限定のため）
+- **プランで出し分けない**: 通常のエクスポート（`/api/v1/export`）は `canExport: false` の無料プランでは使えないため、本導線が無料プランにとって唯一のデータ持ち出し手段になる
+- **API**: `GET /api/v1/admin/account/export` → `generateDeletionExportForTenant`。`Content-Disposition: attachment` で JSON ファイルとして保存させる
+- **入る範囲はプランで変わる**（`resolveExportScope`、SSOT: `src/lib/domain/deletion-export-scope.ts`）。何が入るかは押す前に 1 行で表示する
+
+| プラン | scope | 内容 |
+|---|---|---|
+| free | `minimal` | 子供の名前 + 記録の件数・期間のまとめ |
+| standard | `full` | フルエクスポート |
+| family | `family` | フル + きょうだい比較 |
+
+- **失敗時**: エラー文言を画面に出す（ADR-0062。無言で失敗させない）。処理中は `Button` の `loading` で可視化する
+
+### 5.3 パターンごとの追加 UX
 
 | パターン | 追加表示 | 注記 |
 |---------|---------|------|
@@ -255,7 +272,7 @@ soft delete 状態のテナントに対し、物理削除の **残り 14 日 (fa
 | 3. child | 子供レコードは残る旨を明示 | parent からの操作ではなく **child 本人セッション** から実行 |
 | 4. member | 「テナントは残ります」「自分のログイン情報のみ削除」 | parent ロールのみ |
 
-### 5.3 削除完了後
+### 5.4 削除完了後
 
 - 全パターンで `window.location.href = '/auth/signout'` → サインアウト経由で `/` に戻す
 - セッションが切れているため admin 画面の再読込は不要

--- a/src/lib/domain/deletion-export-scope.ts
+++ b/src/lib/domain/deletion-export-scope.ts
@@ -1,0 +1,22 @@
+// src/lib/domain/deletion-export-scope.ts
+// 退会前エクスポートのプラン別スコープ (#740 / #4472)
+//
+// 実データ生成は server 側 (`$lib/server/services/deletion-export-service`) が担うが、
+// 退会画面は「何が入るか」を押す前に説明する必要があるため、スコープ判定だけを
+// client からも import できる domain leaf に置く (server 実装との二重定義を作らない)。
+
+import type { PlanTier } from './constants/plan-tier';
+
+export type ExportScope = 'minimal' | 'full' | 'family';
+
+/** プランティアからエクスポートスコープを判定する。 */
+export function resolveExportScope(planTier: PlanTier): ExportScope {
+	switch (planTier) {
+		case 'family':
+			return 'family';
+		case 'standard':
+			return 'full';
+		default:
+			return 'minimal';
+	}
+}

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2655,6 +2655,16 @@ export const SETTINGS_LABELS = {
 	dangerStep3Label: '手順 3: 実行ボタン',
 	clearDangerConsentLabel: 'すべてのデータを削除することに同意します',
 	accountDeleteDangerConsentLabel: 'このアカウントを削除することに同意します（元に戻せません）',
+	// 削除前のデータ持ち出し (#740 API / #4472 導線)。プランに関係なく提供する
+	accountDeleteExportTitle: `${CANCEL_TERMS.account}する前にデータを持ち出す`,
+	accountDeleteExportAction: 'データをダウンロード',
+	accountDeleteExportSubmitting: '準備しています…',
+	accountDeleteExportScopeMinimal:
+		'お子さまの名前と、記録した件数・期間のまとめを JSON ファイルで保存します。',
+	accountDeleteExportScopeFull:
+		'活動記録・スタンプ・ごほうびを含む全データを JSON ファイルで保存します。',
+	accountDeleteExportScopeFamily: '全データときょうだいの比較データを JSON ファイルで保存します。',
+	accountDeleteExportSuccess: (filename: string) => `${filename} を保存しました。`,
 } as const;
 
 /**

--- a/src/lib/features/admin/components/AccountDeletionExportPanel.svelte
+++ b/src/lib/features/admin/components/AccountDeletionExportPanel.svelte
@@ -1,0 +1,84 @@
+<script lang="ts">
+// #4472: 退会前のデータ持ち出し導線。
+// 無料プランは通常のエクスポート (`/api/v1/export`) を使えないため、退会画面のこの導線が
+// 唯一のデータ持ち出し手段になる。プランで出し分けず、退会を実行する前に押せる位置に置く。
+
+import type { PlanTier } from '$lib/domain/constants/plan-tier';
+import { resolveExportScope } from '$lib/domain/deletion-export-scope';
+import { SETTINGS_LABELS } from '$lib/domain/labels';
+import {
+	type DeletionExportDownloadResult,
+	downloadDeletionExport,
+} from '$lib/features/admin/deletion-export-download';
+import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
+import Button from '$lib/ui/primitives/Button.svelte';
+
+interface Props {
+	planTier: PlanTier;
+	/** test / Storybook からの差し替え用 */
+	download?: () => Promise<DeletionExportDownloadResult>;
+}
+
+let { planTier, download = downloadDeletionExport }: Props = $props();
+
+let busy = $state(false);
+let errorMessage = $state('');
+let savedFilename = $state('');
+
+const scopeDesc = $derived(
+	{
+		minimal: SETTINGS_LABELS.accountDeleteExportScopeMinimal,
+		full: SETTINGS_LABELS.accountDeleteExportScopeFull,
+		family: SETTINGS_LABELS.accountDeleteExportScopeFamily,
+	}[resolveExportScope(planTier)],
+);
+
+async function handleDownload() {
+	if (busy) return;
+	busy = true;
+	errorMessage = '';
+	savedFilename = '';
+	try {
+		const result = await download();
+		if (result.ok) savedFilename = result.filename;
+		else errorMessage = result.message;
+	} finally {
+		busy = false;
+	}
+}
+</script>
+
+<div
+	class="mb-4 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-surface-card)] p-4"
+	data-testid="account-deletion-export"
+>
+	<h4 class="mb-1 text-base font-bold text-[var(--color-text-primary)]">
+		{SETTINGS_LABELS.accountDeleteExportTitle}
+	</h4>
+	<p
+		class="mb-3 text-sm text-[var(--color-text-secondary)]"
+		data-testid="account-deletion-export-scope"
+	>
+		{scopeDesc}
+	</p>
+
+	{#if errorMessage}
+		<ErrorAlert message={errorMessage} severity="error" action="retry" />
+	{/if}
+	{#if savedFilename}
+		<SuccessAlert message={SETTINGS_LABELS.accountDeleteExportSuccess(savedFilename)} />
+	{/if}
+
+	<Button
+		type="button"
+		variant="secondary"
+		size="md"
+		loading={busy}
+		onclick={handleDownload}
+		data-testid="account-deletion-export-button"
+	>
+		{busy
+			? SETTINGS_LABELS.accountDeleteExportSubmitting
+			: SETTINGS_LABELS.accountDeleteExportAction}
+	</Button>
+</div>

--- a/src/lib/features/admin/deletion-export-download.ts
+++ b/src/lib/features/admin/deletion-export-download.ts
@@ -1,0 +1,90 @@
+// src/lib/features/admin/deletion-export-download.ts
+// #4472: 退会前データ持ち出しのクライアント側ダウンロード処理
+//
+// 退会確認画面から `GET /api/v1/admin/account/export` を呼び、応答をファイルとして保存する。
+// 無料プランは通常のエクスポート (`/api/v1/export`) を使えない (plan-limit-service の
+// `free.canExport: false`) ため、本経路が唯一のデータ持ち出し手段になる。
+//
+// 失敗は throw せずユーザ向け文言として返す (ADR-0062: 無言で失敗させない / 内部例外を露出しない)。
+
+import { todayDateJST } from '$lib/domain/date-utils';
+import { ERROR_NOTIFY_LABELS } from '$lib/domain/labels';
+import { resolveApiErrorMessage } from '$lib/ui/error-notify';
+
+export const DELETION_EXPORT_ENDPOINT = '/api/v1/admin/account/export';
+
+export type DeletionExportDownloadResult =
+	| { ok: true; filename: string }
+	| { ok: false; message: string };
+
+export interface DeletionExportDownloadDeps {
+	fetchFn?: typeof fetch;
+	/** Blob をファイルとして保存する (既定はアンカー経由。test では差し替える) */
+	saveBlob?: (blob: Blob, filename: string) => void;
+}
+
+/** Content-Disposition から filename を取り出す (無ければ null)。 */
+function parseFilename(disposition: string | null): string | null {
+	if (!disposition) return null;
+	const match = disposition.match(/filename="?([^";]+)"?/);
+	return match?.[1] ?? null;
+}
+
+function defaultFilename(): string {
+	return `ganbari-quest-deletion-export-${todayDateJST()}.json`;
+}
+
+function saveBlobViaAnchor(blob: Blob, filename: string): void {
+	const url = URL.createObjectURL(blob);
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = filename;
+	document.body.appendChild(anchor);
+	anchor.click();
+	anchor.remove();
+	URL.revokeObjectURL(url);
+}
+
+/** 非 2xx 応答から UI 向け文言を取り出す (内部例外は 500 系汎用文言に落ちる)。 */
+async function resolveErrorMessage(res: Response): Promise<string> {
+	let serverMessage = '';
+	try {
+		const body = (await res.clone().json()) as { message?: unknown; error?: unknown };
+		if (typeof body?.message === 'string') serverMessage = body.message;
+		else if (typeof body?.error === 'string') serverMessage = body.error;
+	} catch {
+		// 非 JSON / 空 body — ステータス別の汎用文言にフォールバックする
+	}
+	return resolveApiErrorMessage(res.status, serverMessage);
+}
+
+/**
+ * 退会前エクスポートをダウンロードする。
+ * 成功時は保存したファイル名、失敗時は表示可能なエラー文言を返す。
+ */
+export async function downloadDeletionExport(
+	deps: DeletionExportDownloadDeps = {},
+): Promise<DeletionExportDownloadResult> {
+	const fetchFn = deps.fetchFn ?? fetch;
+	const saveBlob = deps.saveBlob ?? saveBlobViaAnchor;
+
+	let res: Response;
+	try {
+		res = await fetchFn(DELETION_EXPORT_ENDPOINT);
+	} catch {
+		return { ok: false, message: ERROR_NOTIFY_LABELS.network };
+	}
+
+	if (!res.ok) {
+		return { ok: false, message: await resolveErrorMessage(res) };
+	}
+
+	try {
+		const blob = await res.blob();
+		const filename = parseFilename(res.headers.get('Content-Disposition')) ?? defaultFilename();
+		saveBlob(blob, filename);
+		return { ok: true, filename };
+	} catch {
+		return { ok: false, message: ERROR_NOTIFY_LABELS.generic };
+	}
+}

--- a/src/lib/server/services/deletion-export-service.ts
+++ b/src/lib/server/services/deletion-export-service.ts
@@ -7,6 +7,8 @@
 // - family:   上記 + きょうだい比較データ
 
 import { jstDateOfIso } from '$lib/domain/date-utils';
+import type { ExportScope } from '$lib/domain/deletion-export-scope';
+import { resolveExportScope } from '$lib/domain/deletion-export-scope';
 import type { ExportData } from '$lib/domain/export-format';
 import { DELETION_EXPORT_NOTE_LABELS } from '$lib/domain/labels';
 import { getCategoryById } from '$lib/domain/validation/activity';
@@ -19,7 +21,10 @@ import { resolveFullPlanTier } from './plan-limit-service';
 // Types
 // ============================================================
 
-export type ExportScope = 'minimal' | 'full' | 'family';
+// スコープ判定の SSOT は domain leaf (退会画面が押す前の説明に使うため client からも import する)。
+// 既存 import 元を壊さないためここから再 export する。
+export type { ExportScope };
+export { resolveExportScope };
 
 export interface DeletionExportOptions {
 	tenantId: string;
@@ -83,24 +88,6 @@ export interface SiblingComparisonExport {
 /** family プラン向けエクスポート（フルエクスポート + きょうだい比較） */
 export interface FamilyExportData extends ExportData {
 	siblingComparison: SiblingComparisonExport;
-}
-
-// ============================================================
-// Scope resolution
-// ============================================================
-
-/**
- * プランティアからエクスポートスコープを判定する。
- */
-export function resolveExportScope(planTier: PlanTier): ExportScope {
-	switch (planTier) {
-		case 'family':
-			return 'family';
-		case 'standard':
-			return 'full';
-		default:
-			return 'minimal';
-	}
 }
 
 // ============================================================

--- a/src/routes/(parent)/admin/settings/account/+page.svelte
+++ b/src/routes/(parent)/admin/settings/account/+page.svelte
@@ -6,9 +6,11 @@
 
 import { enhance } from '$app/forms';
 import { page } from '$app/stores';
+import type { PlanTier } from '$lib/domain/constants/plan-tier';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { getErrorMessage } from '$lib/domain/errors';
 import { APP_LABELS, OYAKAGI_LABELS, PAGE_TITLES, SETTINGS_LABELS } from '$lib/domain/labels';
+import AccountDeletionExportPanel from '$lib/features/admin/components/AccountDeletionExportPanel.svelte';
 import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
@@ -187,6 +189,9 @@ async function handleFullDelete() {
 	}
 }
 
+// #4472: 退会前エクスポートのスコープ表示に使う (未解決時は最小スコープ扱い)
+const exportPlanTier = $derived(($page.data.planTier as PlanTier | null) ?? 'free');
+
 const canConfirmDelete = $derived(
 	deleteConfirmText === 'アカウントを削除します' && deleteAgreeChecked,
 );
@@ -362,6 +367,11 @@ const canConfirmDelete = $derived(
 							{SETTINGS_LABELS.accountDeleteMemberWarning}
 						</p>
 					</div>
+				{/if}
+
+				{#if $page.data.userRole === 'owner'}
+					<!-- #4472: 退会を実行する前にデータを持ち出せるようにする (無料プランを含む全プラン) -->
+					<AccountDeletionExportPanel planTier={exportPlanTier} />
 				{/if}
 
 				{#if deleteError}

--- a/src/routes/api/v1/admin/account/export/+server.ts
+++ b/src/routes/api/v1/admin/account/export/+server.ts
@@ -22,9 +22,11 @@ export const GET: RequestHandler = async ({ locals }) => {
 	const result = await generateDeletionExportForTenant(tenantId, licenseStatus, planId);
 
 	// ブラウザに JSON を表示させず、ファイルとして保存させる (#4472)。
+	// 応答は子供の氏名を含む PII なので、戻る操作 / 中間キャッシュに残さない。
 	return json(result, {
 		headers: {
 			'Content-Disposition': `attachment; filename="ganbari-quest-deletion-export-${todayDateJST()}.json"`,
+			'Cache-Control': 'no-store',
 		},
 	});
 };

--- a/src/routes/api/v1/admin/account/export/+server.ts
+++ b/src/routes/api/v1/admin/account/export/+server.ts
@@ -7,6 +7,7 @@
 //   family:   フル + きょうだい比較
 
 import { json } from '@sveltejs/kit';
+import { todayDateJST } from '$lib/domain/date-utils';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { requireRole } from '$lib/server/auth/guards';
 import { generateDeletionExportForTenant } from '$lib/server/services/deletion-export-service';
@@ -20,5 +21,10 @@ export const GET: RequestHandler = async ({ locals }) => {
 
 	const result = await generateDeletionExportForTenant(tenantId, licenseStatus, planId);
 
-	return json(result);
+	// ブラウザに JSON を表示させず、ファイルとして保存させる (#4472)。
+	return json(result, {
+		headers: {
+			'Content-Disposition': `attachment; filename="ganbari-quest-deletion-export-${todayDateJST()}.json"`,
+		},
+	});
 };

--- a/tests/e2e/account-deletion.spec.ts
+++ b/tests/e2e/account-deletion.spec.ts
@@ -242,6 +242,36 @@ test.describe('#755 アカウント削除 — UI（cognito-dev モード）free'
 		// free プランでもアカウント削除は利用可能
 		await expect(deleteSection.first()).toBeVisible({ timeout: 15_000 });
 	});
+
+	// #4472: 無料プランは通常のエクスポート (canExport=false) を使えないため、
+	// 退会画面のこの導線が唯一のデータ持ち出し手段になる。退会を実行する前に押せること。
+	test('free プランでも退会前のデータ持ち出しボタンが押せて、エクスポート API に到達する', async ({
+		page,
+	}) => {
+		await page.goto('/admin/settings/account', { waitUntil: 'commit', timeout: 30_000 });
+
+		const exportButton = page.getByTestId('account-deletion-export-button');
+		if ((await exportButton.count()) === 0) {
+			test.info().annotations.push({
+				type: 'env-skip',
+				description: 'Danger Zone は cognito モードでのみ表示（ローカルモードでは非表示）',
+			});
+			return;
+		}
+
+		await expect(exportButton).toBeVisible({ timeout: 15_000 });
+		await expect(exportButton).toBeEnabled();
+
+		const [response] = await Promise.all([
+			page.waitForResponse((res) => res.url().includes('/api/v1/admin/account/export'), {
+				timeout: 30_000,
+			}),
+			exportButton.click(),
+		]);
+
+		expect(response.status()).toBe(200);
+		expect(response.headers()['content-disposition']).toContain('attachment');
+	});
 });
 
 // ============================================================

--- a/tests/e2e/account-deletion.spec.ts
+++ b/tests/e2e/account-deletion.spec.ts
@@ -262,6 +262,18 @@ test.describe('#755 アカウント削除 — UI（cognito-dev モード）free'
 		await expect(exportButton).toBeVisible({ timeout: 15_000 });
 		await expect(exportButton).toBeEnabled();
 
+		// hydration 待ち: SSR 直後の DOM は click しても handler が無く無反応になる。
+		// 3-step ガード (確認テキスト + 同意 checkbox → 実行ボタン enabled) は client state
+		// なので、これが成立することを hydration の probe に使う (削除は実行しない)。
+		await page.fill('#deleteConfirm', 'アカウントを削除します');
+		await page.getByTestId('account-danger-agree-checkbox').check();
+		await expect(page.getByTestId('account-danger-execute-button')).toBeEnabled({
+			timeout: 30_000,
+		});
+		await page.getByTestId('account-danger-agree-checkbox').uncheck();
+		await page.fill('#deleteConfirm', '');
+		await expect(page.getByTestId('account-danger-execute-button')).toBeDisabled();
+
 		const [response] = await Promise.all([
 			page.waitForResponse((res) => res.url().includes('/api/v1/admin/account/export'), {
 				timeout: 30_000,

--- a/tests/unit/components/account-deletion-export-panel.test.ts
+++ b/tests/unit/components/account-deletion-export-panel.test.ts
@@ -1,0 +1,71 @@
+// tests/unit/components/account-deletion-export-panel.test.ts
+// #4472: 退会画面のデータ持ち出し導線 (AccountDeletionExportPanel)
+//
+// 固定する挙動:
+//   - 無料プランでもボタンが押せる (プランで出し分けない = 本 Issue の主旨)
+//   - 押すとダウンロード処理が呼ばれる
+//   - 失敗するとエラー文言が画面に出る (ADR-0062 無言失敗の禁止)
+//   - プランごとに「何が入るか」の 1 行説明が変わる
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SETTINGS_LABELS } from '../../../src/lib/domain/labels';
+import AccountDeletionExportPanel from '../../../src/lib/features/admin/components/AccountDeletionExportPanel.svelte';
+
+describe('AccountDeletionExportPanel (#4472)', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('無料プランでもダウンロードボタンが enabled で表示される', () => {
+		render(AccountDeletionExportPanel, {
+			planTier: 'free',
+			download: async () => ({ ok: true as const, filename: 'x.json' }),
+		});
+		const btn = screen.getByTestId('account-deletion-export-button');
+		expect(btn).toBeTruthy();
+		expect((btn as HTMLButtonElement).disabled).toBe(false);
+	});
+
+	it('クリックするとダウンロード処理が呼ばれる', async () => {
+		const download = vi.fn(async () => ({ ok: true as const, filename: 'x.json' }));
+		render(AccountDeletionExportPanel, { planTier: 'free', download });
+
+		await fireEvent.click(screen.getByTestId('account-deletion-export-button'));
+
+		await waitFor(() => expect(download).toHaveBeenCalledTimes(1));
+	});
+
+	it('失敗するとエラー文言が画面に出る', async () => {
+		const download = vi.fn(async () => ({
+			ok: false as const,
+			message: 'ダウンロードできませんでした',
+		}));
+		render(AccountDeletionExportPanel, { planTier: 'free', download });
+
+		await fireEvent.click(screen.getByTestId('account-deletion-export-button'));
+
+		await waitFor(() => {
+			expect(screen.getByText('ダウンロードできませんでした')).toBeTruthy();
+		});
+	});
+
+	it('プランごとに「何が入るか」の説明が変わる', () => {
+		render(AccountDeletionExportPanel, {
+			planTier: 'free',
+			download: async () => ({ ok: true as const, filename: 'x.json' }),
+		});
+		expect(screen.getByTestId('account-deletion-export-scope').textContent).toContain(
+			SETTINGS_LABELS.accountDeleteExportScopeMinimal,
+		);
+		cleanup();
+
+		render(AccountDeletionExportPanel, {
+			planTier: 'standard',
+			download: async () => ({ ok: true as const, filename: 'x.json' }),
+		});
+		expect(screen.getByTestId('account-deletion-export-scope').textContent).toContain(
+			SETTINGS_LABELS.accountDeleteExportScopeFull,
+		);
+	});
+});

--- a/tests/unit/features/deletion-export-download.test.ts
+++ b/tests/unit/features/deletion-export-download.test.ts
@@ -1,0 +1,95 @@
+// tests/unit/features/deletion-export-download.test.ts
+// #4472: 退会前データ持ち出しのクライアント側ダウンロード処理
+//
+// 固定する挙動:
+//   - 押すと `GET /api/v1/admin/account/export` を呼ぶ (導線が API に到達している)
+//   - 成功時は Blob として保存する (JSON をブラウザに表示するだけにしない)
+//   - filename は Content-Disposition を尊重し、無ければ JST 日付の既定名にフォールバック
+//   - 失敗時は例外を投げずユーザ向け文言を返す (ADR-0062 無言失敗の禁止)
+
+import { describe, expect, it, vi } from 'vitest';
+import { ERROR_NOTIFY_LABELS } from '../../../src/lib/domain/labels';
+import {
+	DELETION_EXPORT_ENDPOINT,
+	downloadDeletionExport,
+} from '../../../src/lib/features/admin/deletion-export-download';
+
+function jsonResponse(
+	status: number,
+	body: unknown,
+	headers: Record<string, string> = {},
+): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json', ...headers },
+	});
+}
+
+describe('downloadDeletionExport (#4472)', () => {
+	it('エンドポイントを GET し、Blob を保存する', async () => {
+		let requestedUrl = '';
+		const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+			requestedUrl = String(input);
+			return jsonResponse(
+				200,
+				{ scope: 'minimal', data: {}, generatedAt: '2026-08-08T00:00:00.000Z' },
+				{ 'Content-Disposition': 'attachment; filename="deletion-export-2026-08-08.json"' },
+			);
+		});
+		const saveBlob = vi.fn((_blob: Blob, _filename: string) => {});
+
+		const result = await downloadDeletionExport({ fetchFn, saveBlob });
+
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+		expect(requestedUrl).toBe(DELETION_EXPORT_ENDPOINT);
+		expect(result.ok).toBe(true);
+		expect(saveBlob).toHaveBeenCalledTimes(1);
+		const [blob, filename] = saveBlob.mock.calls[0] as [Blob, string];
+		// jsdom / node の Blob は別 realm のため instanceof ではなく実体で検証する
+		expect(blob.type).toBe('application/json');
+		expect(await blob.text()).toContain('"scope":"minimal"');
+		expect(filename).toBe('deletion-export-2026-08-08.json');
+	});
+
+	it('Content-Disposition が無ければ既定のファイル名で保存する', async () => {
+		const fetchFn = vi.fn(async () => jsonResponse(200, { scope: 'minimal' }));
+		const saveBlob = vi.fn((_blob: Blob, _filename: string) => {});
+
+		const result = await downloadDeletionExport({ fetchFn, saveBlob });
+
+		expect(result.ok).toBe(true);
+		const filename = (saveBlob.mock.calls[0] as [Blob, string])[1];
+		expect(filename).toMatch(/^ganbari-quest-deletion-export-\d{4}-\d{2}-\d{2}\.json$/);
+	});
+
+	it('403 のときは保存せずユーザ向け文言を返す', async () => {
+		const fetchFn = vi.fn(async () => jsonResponse(403, { error: '権限がありません' }));
+		const saveBlob = vi.fn();
+
+		const result = await downloadDeletionExport({ fetchFn, saveBlob });
+
+		expect(result.ok).toBe(false);
+		expect(saveBlob).not.toHaveBeenCalled();
+		if (!result.ok) expect(result.message).toBe('権限がありません');
+	});
+
+	it('500 のときは内部例外を出さず汎用文言を返す (ADR-0062)', async () => {
+		const fetchFn = vi.fn(async () =>
+			jsonResponse(500, { error: 'TypeError: repos.child is undefined' }),
+		);
+		const result = await downloadDeletionExport({ fetchFn, saveBlob: vi.fn() });
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.message).toBe(ERROR_NOTIFY_LABELS.server);
+	});
+
+	it('通信例外のときは throw せず network 文言を返す', async () => {
+		const fetchFn = vi.fn(async () => {
+			throw new Error('network down');
+		});
+		const result = await downloadDeletionExport({ fetchFn, saveBlob: vi.fn() });
+
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.message).toBe(ERROR_NOTIFY_LABELS.network);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

無料プランの家族が退会するとき、これまでは自分たちのデータを一切持ち出せなかった（通常のエクスポートは `canExport: false`、退会用の最小エクスポート API は実装済みなのに呼ぶ画面が無かった）。退会確認画面から、**退会を実行する前に**データをファイルとしてダウンロードできるようにする。

## 関連 Issue

Closes #4472

## 変更内容

- 退会確認画面（`/admin/settings/account` の Danger Zone）の削除 3 手順の**上**に `AccountDeletionExportPanel` を追加。owner のみ表示（API が owner 限定のため）
- **プランで出し分けない**（本 Issue の主旨）。押す前に「何が入るか」を 1 行だけ表示する（free = 最小 / standard = フル / family = フル + きょうだい比較）
- `GET /api/v1/admin/account/export` に `Content-Disposition: attachment` を付与し、ブラウザに JSON を表示するのではなくファイルとして保存させる
- 処理中は `Button` の `loading`（DESIGN.md §5）、失敗時は `ErrorAlert` で画面に出す（ADR-0062 無言失敗の禁止。500 系は内部例外を出さず汎用文言）
- `resolveExportScope` を domain leaf（`src/lib/domain/deletion-export-scope.ts`）へ移し、client / server が同一定義を参照する（二重定義を作らない）
- 文言は `SETTINGS_LABELS` に追加（ADR-0045。日本語リテラル直書きなし）
- 設計書 `docs/design/account-deletion-flow.md` §5.2 に本導線を追記（ADR-0001）

## 検証

failing-test-first（ADR-0061）— 先に test を書き、モジュール未実装で 2 file が fail することを確認してから実装した。

| コマンド | 結果 |
|---|---|
| `npx vitest run tests/unit/features/deletion-export-download.test.ts tests/unit/components/account-deletion-export-panel.test.ts` | 9 passed |
| `npx vitest run tests/unit/services/deletion-export-service.test.ts` | 12 passed（`resolveExportScope` 移設後も既存 import 経路で緑） |
| `npx biome check .` | PASS |
| `npx svelte-check --threshold error` | 0 errors（`cd infra && npm ci` 実行後） |
| `npx vitest run tests/unit/services/ tests/unit/architecture/` | 全 PASS（exit 0） |
| `npx playwright test --config playwright.cognito-dev.config.ts --project account-deletion --grep "退会前のデータ持ち出し"` | 7 passed（実サーバー + free storageState） |
| `node scripts/check-no-plan-literals.mjs` | OK |
| `npm run pre-ready -- --pr 4475` | 全 step PASS |

### 無料プランで実際にダウンロードできることの確認（実機）

`npm run dev:cognito` (#1026) を起動し、**free プラン owner** (`free@example.com` / `dev-tenant-free`、license なし) のセッションで実測した。

```
$ curl -s -D - -H "Cookie: <free の identity_token / context_token>" \
    http://localhost:5174/api/v1/admin/account/export
HTTP/1.1 200 OK
content-disposition: attachment; filename="ganbari-quest-deletion-export-2026-08-08.json"
content-type: application/json
content-length: 1055

{"scope":"minimal","data":{...,"children":[{"nickname":"たろうくん","age":4,...},
{"nickname":"はなこちゃん","age":1,...}],"activitySummary":[...]}}
```

`scope: "minimal"` で子供名・活動サマリが実データで返り、`Content-Disposition: attachment` が付いている（= ブラウザ表示ではなくファイル保存になる）。画面側の導線は下の After SS のとおり free プランで enabled 表示される。

## スクリーンショット

`npm run dev:cognito` (#1026) + free プランの storageState で `/admin/settings/account` を撮影。Before は `origin/develop` を checkout して同じ手順で撮影した（DOM スナップショットで `account-deletion-export` が Before 0 件 / After 1 件であることを確認済み）。

### Desktop

| Before (develop) | After (本 PR) |
|---|---|
| ![before-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4475/before-admin-settings-account-desktop.png) | ![after-desktop](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4475/after-admin-settings-account-desktop.png) |

### Mobile

| Before (develop) | After (本 PR) |
|---|---|
| ![before-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4475/before-admin-settings-account-mobile.png) | ![after-mobile](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4475/after-admin-settings-account-mobile.png) |

[DOM HTML (after / desktop)](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4475/after-admin-settings-account-desktop.dom.html)

Before の画面には「削除後のデータ復旧はできません。事前にデータをエクスポートすることを強くお勧めします。」と書いてあるのに、その手段が画面上に無かった。After はその直下にダウンロードブロックが入る。

### AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 退会を実行する前に押せる導線がある | 実装 + SS | Danger Zone の削除 3 手順より上に配置。After SS |
| AC2 | 無料プランでも押せる | unit + E2E | `account-deletion-export-panel.test.ts`「無料プランでも…enabled」/ `account-deletion.spec.ts` free storageState |
| AC3 | ファイルとして保存される | 実装 + E2E | `Content-Disposition: attachment` を E2E で assert / unit で Blob 保存を assert |
| AC4 | 押したことが分かる feedback | 実装 | `Button` の `loading`（spinner + disabled + `aria-busy`） |
| AC5 | 失敗時にエラーが見える | unit | 「失敗するとエラー文言が画面に出る」/ 500 は汎用文言に落とす test |
| AC6 | 何が入るかが 1 行で分かる | unit | 「プランごとに『何が入るか』の説明が変わる」 |
| AC7 | primitives + labels SSOT | 実装 + lint | `Button.svelte` 使用 / 文言は `SETTINGS_LABELS` / `check-no-plan-literals` OK |
| AC8 | test で固定 | 上表 | unit 2 file + E2E 1 test |
| AC9 | 設計書追記 | diff | `account-deletion-flow.md` §5.2 |

## 影響範囲

- **顧客に見える変化**: 退会画面（owner）にデータ持ち出しブロックが増える。他の画面・他のロールに変化なし
- **既存 API の応答**: `GET /api/v1/admin/account/export` に `Content-Disposition` と `Cache-Control: no-store` ヘッダが増える（body は不変）。呼び出し元は本 PR で追加した画面のみ
- **並行実装ペア**: UI 文言 → `labels.ts` に追加（LP 側の露出なし）。デモ / 本番の分岐なし
- **破壊的変更**: なし

## 配布済み env / secret (ADR-0006)

- [ ] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

---

## PO 決裁ブリーフ (po-decision:required)

<!-- labeler が deletion-export-service.ts (retention / PII 経路) を検出して自動付与。
     本 PR 自体は PO 決裁済み（退会画面にダウンロード導線を作る）だが、
     下記 ⑤ の 2 点は決裁の外側に残った隣接論点であり、Yes/No の判断を仰ぐ。 -->

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 — UI 導線 1 箇所の追加"]
    R2["顧客面: 親画面 / 退会前のデータ持ち出し"]
    R3["ロールバック: revert で戻る。データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 無料プラン唯一の持ち出し手段"]
    T2["捨てる: PII を端末に落とす経路が 1 本増"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: 退会手続き中は導線ごと非表示"]
    O2["UX: full export は待ち時間の予告なし"]
    O3["security: 追加認証なしで子供の氏名を保存"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["削除警告の直下に持ち出しボタンが出る"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 猶予期間中も持ち出せるようにする?"]
    Q2["Q2: 持ち出し前におやカギコードを要求する?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R2 danger
  class T2,O1,O2,O3 warn
  class R1,R3,T1,C1 ok
  class Q1,Q2 ask
```

実機 SS は本文上部「スクリーンショット」節（free プラン / Before・After）。

<details>
<summary>補足 (PO は原則読まなくてよい)</summary>

- ③ の根拠は `tmp/adversarial-evidence/4475.json`（`scripts/verify-adversarial-output.mjs` PASS）。
- ③ security のうち「PII 応答が中間キャッシュ / 戻る操作に残る」は本 PR 内で対処済み（`Cache-Control: no-store` を付与）。残る Q1 / Q2 は仕様判断のため本 PR では変更していない。
- Q1: Danger Zone は `tenantStatus !== GRACE_PERIOD` で非表示になるため、退会手続き中（物理削除待ちの猶予期間）は持ち出しボタンも消える。猶予期間中こそ持ち出したい、という判断なら別 Issue で表示条件を分ける。
- Q2: 家庭内の共有端末では、親セッションが生きていれば誰でも 1 クリックで家族データを保存できる。Parent-Gate（おやカギコード）の再確認を挟むかは体験と安全のトレードオフ。

</details>
