### PR TITLE
fix(labels): #4476 履歴保持日数の二重管理を解消し LP 料金表を実装の値から導出する

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -2165,7 +2165,7 @@ git push origin main
 | standard | `365` | 1 年より前のレコードは非表示 + 日次バッチで削除 | **あり（365 日）** |
 | family | `null` | 制限なし（全期間表示） | なし |
 
-値の正は `src/lib/server/services/plan-limit-service.ts` の `PLAN_LIMITS[tier].historyRetentionDays`。設計書とコードが乖離した場合はコードを正として設計書側を修正すること。
+値の正は `src/lib/domain/constants/plan-retention.ts` の `PLAN_HISTORY_RETENTION_DAYS`。`plan-limit-service.ts` の `PLAN_LIMITS[tier].historyRetentionDays` も、LP / アプリの表示文字列 (`terms.ts` の `PLAN_RETENTION_TERMS` 経由) も、すべてこの 1 箇所から引く。設計書とコードが乖離した場合はコードを正として設計書側を修正すること。
 
 ### 6.5.2 retention の実装：表示フィルタ + 物理削除（二層構造）
 

--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -326,7 +326,7 @@ function parseTermsTs() {
  *   整形結果が TS 側 `PLAN_RETENTION_TERMS` と一致することは
  *   tests/unit/domain/plan-retention-ssot.test.ts が機械検証する (drift 不可)。
  *
- * @returns {Record<string, string>} `{ free, freeSpaced, standard }`
+ * @returns {Record<string, string>} `{ free, freeSpaced, standard, standardSpaced }`
  */
 function buildPlanRetentionTerms() {
 	const src = fs.readFileSync(PLAN_RETENTION_TS, 'utf-8');
@@ -359,6 +359,7 @@ function buildPlanRetentionTerms() {
 		free: format(free),
 		freeSpaced: format(free, true),
 		standard: format(standard),
+		standardSpaced: format(standard, true),
 	};
 }
 

--- a/scripts/generate-lp-labels.mjs
+++ b/scripts/generate-lp-labels.mjs
@@ -29,6 +29,7 @@ const REPO_ROOT = path.resolve(__dirname, '..');
 
 const LABELS_TS = path.join(REPO_ROOT, 'src/lib/domain/labels.ts');
 const TERMS_TS = path.join(REPO_ROOT, 'src/lib/domain/terms.ts');
+const PLAN_RETENTION_TS = path.join(REPO_ROOT, 'src/lib/domain/constants/plan-retention.ts');
 const AGE_TIER_TS = path.join(REPO_ROOT, 'src/lib/domain/validation/age-tier.ts');
 const OUTPUT_JS = path.join(REPO_ROOT, 'site/shared-labels.js');
 
@@ -314,6 +315,54 @@ function parseTermsTs() {
 }
 
 /**
+ * 履歴保持日数の値 SSOT (`src/lib/domain/constants/plan-retention.ts`) を読み、
+ * terms.ts の `PLAN_RETENTION_TERMS` と同じ内容の namespace を組み立てる (#4477)。
+ *
+ * なぜ必要か:
+ *   本 script は TS を実行せず text parse するため、`formatRetentionPeriod(...)` で
+ *   計算された `PLAN_RETENTION_TERMS` を terms.ts から読み取れない (値が literal でない)。
+ *   一方、値の SSOT (`PLAN_HISTORY_RETENTION_DAYS`) は数値 literal なので読める。
+ *   そこで「数値は SSOT から読み、整形だけをここで再現する」形にする。
+ *   整形結果が TS 側 `PLAN_RETENTION_TERMS` と一致することは
+ *   tests/unit/domain/plan-retention-ssot.test.ts が機械検証する (drift 不可)。
+ *
+ * @returns {Record<string, string>} `{ free, freeSpaced, standard }`
+ */
+function buildPlanRetentionTerms() {
+	const src = fs.readFileSync(PLAN_RETENTION_TS, 'utf-8');
+	const block = extractBraceBlock(src, src.indexOf('export const PLAN_HISTORY_RETENTION_DAYS'));
+	if (block === null) {
+		throw new Error('PLAN_HISTORY_RETENTION_DAYS not found in plan-retention.ts');
+	}
+	/** @param {string} tier */
+	const readDays = (tier) => {
+		const m = block.match(new RegExp(`${tier}:\\s*(\\d+|null)`));
+		if (!m || m[1] === undefined) {
+			throw new Error(`PLAN_HISTORY_RETENTION_DAYS.${tier} not parseable in plan-retention.ts`);
+		}
+		return m[1] === 'null' ? null : Number(m[1]);
+	};
+	// formatRetentionPeriod (plan-retention.ts) と同じ整形規則。差異は上記 test が検出する。
+	/**
+	 * @param {number | null} days
+	 * @param {boolean} [spaced]
+	 */
+	const format = (days, spaced = false) => {
+		if (days === null) return '無期限';
+		const sep = spaced ? ' ' : '';
+		if (days % 365 === 0) return `${days / 365}${sep}年`;
+		return `${days}${sep}日`;
+	};
+	const free = readDays('free');
+	const standard = readDays('standard');
+	return {
+		free: format(free),
+		freeSpaced: format(free, true),
+		standard: format(standard),
+	};
+}
+
+/**
  * LP 用 namespace 名 ↔ 戻り値 key の対応表。
  *
  * #1917 のリファクタで parseLabelsTs() の cognitive complexity を 27 → 安全圏に下げるため、
@@ -394,6 +443,9 @@ function parseAllNamespacesResolved() {
 	/** @type {Record<string, Record<string, string | TemplateLiteralValue>>} */
 	const allNamespaces = {
 		...termsNamespaces,
+		// #4477: 値 SSOT (plan-retention.ts) 由来。terms.ts 側は関数呼び出しで組み立てるため
+		// text parse では読めない → ここで同じ値から組み立て直して上書きする。
+		PLAN_RETENTION_TERMS: buildPlanRetentionTerms(),
 		AGE_TIER_LABELS: ageTierLabels,
 		AGE_TIER_SHORT_LABELS: ageTierShort,
 		PLAN_LABELS: planLabels,
@@ -818,6 +870,7 @@ if (invokedAsCli) {
 // parseAllNamespacesResolved も公開する。個々の parser だけを検査すると「実データでは解決できない」
 // 状態を通してしまう。
 export {
+	buildPlanRetentionTerms,
 	isTemplateLiteral,
 	parseAllNamespacesResolved,
 	parseBlock,

--- a/src/lib/domain/constants/plan-retention.ts
+++ b/src/lib/domain/constants/plan-retention.ts
@@ -1,0 +1,48 @@
+// src/lib/domain/constants/plan-retention.ts
+// プラン別「履歴保持日数」の値 SSOT (#4477)。
+//
+// 背景:
+//   保持日数は長らく `plan-limit-service.ts` の PLAN_LIMITS[tier].historyRetentionDays と
+//   labels.ts / plan-features.ts の表示文字列 (「90日間の履歴保持」等) で二重管理されていた。
+//   前者を変えても LP 料金表・アプリの機能リストは古い日数のまま残り、顧客に見える価格表が
+//   実装と食い違う (ADR-0013 LP truth 違反)。本ファイルを値の唯一の定義とし、
+//   実装 (plan-limit-service) と表示 (terms.ts → labels.ts → LP) の両方がここから引く。
+//
+// 置き場所の判断:
+//   labels.ts / terms.ts は domain 層であり `$lib/server/**` を import できない。
+//   一方 plan-limit-service.ts は server 専用 module。したがって値を domain leaf に降ろし、
+//   plan-limit-service 側がここから import する (型 SSOT を domain leaf に降ろした #3963 と同型)。
+//
+// 関連: ADR-0013 (LP 文言は実装の事実を SSOT とする) / ADR-0045 (terms.ts atom / labels.ts compound)
+//       ADR-0049 (プラン別履歴保持期間ポリシー) / 08-データベース設計書 §6.5
+
+import type { PlanTier } from './plan-tier';
+
+/**
+ * プラン別の履歴保持日数。`null` = 無期限 (物理削除しない)。
+ *
+ * **この 3 つの数値がプロダクト全体の SSOT**。表示文字列側に数値を複製しないこと
+ * (複製は `scripts/check-hardcoded-strings.mjs` / 本 SSOT の unit test で検出する)。
+ */
+export const PLAN_HISTORY_RETENTION_DAYS: Record<PlanTier, number | null> = {
+	free: 90,
+	standard: 365,
+	family: null,
+};
+
+/**
+ * 保持日数を表示用の期間文字列にする。
+ *
+ * - `null` → `無期限`
+ * - 365 の倍数 → `N年` (365 → `1年`)
+ * - それ以外 → `N日`
+ *
+ * @param days 保持日数 (null = 無期限)
+ * @param options.spaced 数値と単位の間に半角スペースを入れる (LP 本文の組版に合わせる)
+ */
+export function formatRetentionPeriod(days: number | null, options?: { spaced?: boolean }): string {
+	if (days === null) return '無期限';
+	const sep = options?.spaced ? ' ' : '';
+	if (days % 365 === 0) return `${days / 365}${sep}年`;
+	return `${days}${sep}日`;
+}

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -6510,8 +6510,7 @@ export const LP_PRICING_LABELS = {
 	// #1912 (F-6): 「ログインボーナス履歴」→「毎日のごほうび履歴」へ日本語化
 	trialDataReassureLine2Strong: '活動履歴・ポイント獲得履歴・毎日のごほうび履歴',
 	trialDataReassureLine2Suffix: `は無料プランの保持期間（${PLAN_RETENTION_TERMS.freeSpaced}）を超えたものから順次削除されます。`,
-	trialDataReassureLine3:
-		'有料プランにアップグレードすれば、より長期間（スタンダード: 1 年 / ファミリー: 無制限）の履歴をご利用いただけます。',
+	trialDataReassureLine3: `有料プランにアップグレードすれば、より長期間（スタンダード: ${PLAN_RETENTION_TERMS.standardSpaced} / ファミリー: 無制限）の履歴をご利用いただけます。`,
 
 	// Family pattern section
 	familyPatternsTitle: '家族での使い方',

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -58,6 +58,7 @@ import {
 	PIN_DEFAULT_TERMS,
 	PLAN_CHANGE_TERMS,
 	PLAN_FULL_TERMS,
+	PLAN_RETENTION_TERMS,
 	PLAN_TERMS,
 	POINT_TERMS,
 	PRICE_TERMS,
@@ -2878,7 +2879,7 @@ export const SUBSCRIPTION_PAGE_LABELS = {
 	// スタンダードプラン
 	// #1963: atom (PLAN_TERMS / PRICE_TERMS) を terms.ts から参照
 	standardPlanName: `${PLAN_TERMS.standard}`,
-	standardPlanDesc: '子供無制限・活動無制限・1年保持',
+	standardPlanDesc: `子供無制限・活動無制限・${PLAN_RETENTION_TERMS.standard}保持`,
 	standardPriceMonthly: `${PRICE_TERMS.standard}`,
 	standardPerMonth: '/月',
 	// #3208: standardPriceYearly / standardPerYear / standardYearlyMonthlyEquiv は
@@ -6508,7 +6509,7 @@ export const LP_PRICING_LABELS = {
 	trialDataReassureLine1Suffix: 'は、無料プランに移行した後もそのまま保持されます。',
 	// #1912 (F-6): 「ログインボーナス履歴」→「毎日のごほうび履歴」へ日本語化
 	trialDataReassureLine2Strong: '活動履歴・ポイント獲得履歴・毎日のごほうび履歴',
-	trialDataReassureLine2Suffix: 'は無料プランの保持期間（90 日）を超えたものから順次削除されます。',
+	trialDataReassureLine2Suffix: `は無料プランの保持期間（${PLAN_RETENTION_TERMS.freeSpaced}）を超えたものから順次削除されます。`,
 	trialDataReassureLine3:
 		'有料プランにアップグレードすれば、より長期間（スタンダード: 1 年 / ファミリー: 無制限）の履歴をご利用いただけます。',
 
@@ -6537,7 +6538,7 @@ export const LP_PRICING_LABELS = {
 	// #1641 R36 整合: 並列構造で「保持」と「90 日で削除」を両方明記
 	// #1912 (F-6): LP FAQ の「ログインボーナス履歴」→「毎日のごほうび履歴」へ日本語化
 	// #2057 (UIUX-F-13): 「管理画面」→ ${ADMIN_VIEW_TERMS.canonical} 経由化
-	faqAfterTrialA: `7日間の無料体験終了後は無料プランに移行します。有料プランをご希望の場合は、${ADMIN_VIEW_TERMS.canonical}からアップグレードしてください。クレジットカードの事前登録は不要です。無料体験中に作成したオリジナル活動・ごほうび・チェックリスト・シール・レベルは保持されますが、活動履歴・ポイント獲得履歴・毎日のごほうび履歴は無料プランの保持期間（90 日）を超えたものから順次削除されます。`,
+	faqAfterTrialA: `7日間の無料体験終了後は無料プランに移行します。有料プランをご希望の場合は、${ADMIN_VIEW_TERMS.canonical}からアップグレードしてください。クレジットカードの事前登録は不要です。無料体験中に作成したオリジナル活動・ごほうび・チェックリスト・シール・レベルは保持されますが、活動履歴・ポイント獲得履歴・毎日のごほうび履歴は無料プランの保持期間（${PLAN_RETENTION_TERMS.freeSpaced}）を超えたものから順次削除されます。`,
 	// #1643 R38 + #1647 R42: プラン別猶予期間（実装 grace-period-service.ts 準拠）
 	faqCancelQ: '解約したらデータはすぐに削除されますか？',
 	// #1912 (F-9): 「読み取り専用猶予期間」を顧客語彙化（SaaS 業界用語のため）。
@@ -6584,7 +6585,7 @@ export const LP_PRICING_LABELS = {
 	// CTA-bottom 直下に既存有料ユーザー向け small リンクで /admin/billing へ誘導。
 	faqCancelPathNote: `解約経路: ログイン後 [プラン・お支払い] → [請求管理ページを開く] (${STRIPE_PORTAL_TERMS.canonical}) でいつでもお手続きいただけます。`,
 	faqCancelVsDeleteQ: `${CANCEL_TERMS.canonical}とアカウント${CANCEL_TERMS.account}は何が違いますか？`,
-	faqCancelVsDeleteA: `${CANCEL_TERMS.canonical}は有料プランの自動更新を停止し、猶予期間後に無料プランへ自動移行します。データは無料プランの保持期間（90 日）を超えたものから順次削除されます。アカウント${CANCEL_TERMS.account}は、ログイン後にご自身で実施いただくことで全データを猶予期間後に完全削除します。`,
+	faqCancelVsDeleteA: `${CANCEL_TERMS.canonical}は有料プランの自動更新を停止し、猶予期間後に無料プランへ自動移行します。データは無料プランの保持期間（${PLAN_RETENTION_TERMS.freeSpaced}）を超えたものから順次削除されます。アカウント${CANCEL_TERMS.account}は、ログイン後にご自身で実施いただくことで全データを猶予期間後に完全削除します。`,
 	existingCustomerCancelLinkPrefix: 'すでに有料プランをご利用中の方の',
 	existingCustomerCancelLinkLabel: `${CANCEL_TERMS.canonical}はこちら`,
 	existingCustomerCancelLinkSuffix: `（${ADMIN_VIEW_TERMS.canonical}に移動します）`,
@@ -8059,7 +8060,7 @@ export const LP_FAQ_LABELS = {
 	text32: `${PLAN_FULL_TERMS.free}でもすべてご利用いただけます`,
 	text33: '有料プランで解放される主な機能:',
 	text34: 'お子さま・活動の人数制限解除（無料: お子さま 2 人 / 活動 3 個まで）',
-	text35: '長期の履歴保持（無料: 過去 90 日まで → 有料: 無期限）',
+	text35: `長期の履歴保持（無料: 過去 ${PLAN_RETENTION_TERMS.freeSpaced}まで → 有料: 無期限）`,
 	text36: 'AI 自動提案（活動案・ごほうび案）',
 	text37: 'きょうだいランキング・家族メンバー招待',
 	text38: 'データのバックアップ',
@@ -8505,7 +8506,7 @@ export const LP_PAMPHLET_LABELS = {
 	k37: '毎日のごほうび・続けるごほうび',
 	// #1710 R3-C: 旧「持ち物／毎日習慣」統合表現を「持ち物チェックリスト」に純化（責務分離: 持ち物 = event-* / 毎日 must = 活動 priority 属性）
 	k38: '持ち物チェックリスト 3個/子まで',
-	k39: '90日間の履歴保持',
+	k39: `${PLAN_RETENTION_TERMS.free}間の履歴保持`,
 	k40: '&#x2B50; おすすめ',
 	// #1956 (Phase 3 D11): 'スタンダード' = PLAN_TERMS.standard、
 	//   '7日間無料体験' = TRIAL_TERMS.duration + CTA_TERMS.freeTrialNoun
@@ -8517,7 +8518,7 @@ export const LP_PAMPHLET_LABELS = {
 	k46: '家族メンバー招待：4人まで',
 	k47: '特別なごほうび設定',
 	k48: 'データのダウンロード',
-	k49: '1年間の履歴保持',
+	k49: `${PLAN_RETENTION_TERMS.standard}間の履歴保持`,
 	k50: 'メールサポート',
 	// #1956 (Phase 3 D11): 'ファミリー' = PLAN_TERMS.premium、
 	//   '7日間無料体験' = TRIAL_TERMS.duration + CTA_TERMS.freeTrialNoun、
@@ -8583,7 +8584,7 @@ export const LP_PRICING_EXTRA_LABELS = {
 	k6: '毎日のごほうび・続けるごほうび',
 	// #1710 R3-C: 旧「持ち物／毎日習慣」統合表現を「持ち物チェックリスト」に純化
 	k7: '持ち物チェックリスト 3個/子まで',
-	k8: '90日間の履歴保持',
+	k8: `${PLAN_RETENTION_TERMS.free}間の履歴保持`,
 	k9: 'メールサポート（標準）',
 	k10: 'お子さまの登録人数：無制限',
 	k11: 'オリジナル活動の作成：無制限',
@@ -8592,7 +8593,7 @@ export const LP_PRICING_EXTRA_LABELS = {
 	k14: '特別なごほうび設定（即時付与）',
 	k15: '家族のデータ預かり枠（同時保管 3 件・自分でダウンロード可）',
 	k16: 'データのダウンロード',
-	k17: '1年間の履歴保持',
+	k17: `${PLAN_RETENTION_TERMS.standard}間の履歴保持`,
 	k18: 'メールサポート',
 	// #1947: k19 「スタンダードの全機能」のプラン名 atom を terms.ts 参照化
 	k19: `${PLAN_TERMS.standard}の全機能`,
@@ -8622,8 +8623,8 @@ export const LP_PRICING_EXTRA_LABELS = {
 	k39: '無制限',
 	k40: '無制限',
 	k41: '活動履歴の保持',
-	k42: '90日',
-	k43: '1年',
+	k42: `${PLAN_RETENTION_TERMS.free}`,
+	k43: `${PLAN_RETENTION_TERMS.standard}`,
 	k44: '無制限',
 	k45: 'カスタマイズ',
 	// #1708 R3-A / #1710 R3-C: k47 (旧 朝夜習慣リスト / 旧ルーチン-CL) は廃止語彙、k48 を「持ち物チェックリスト自由作成」に純化
@@ -9265,7 +9266,7 @@ export const LP_PRICING_PHASEB_LABELS = {
 	k5: '毎日のごほうび・続けるごほうび',
 	// #1710 R3-C: 旧「持ち物／毎日習慣」統合表現を「持ち物チェックリスト」に純化
 	k6: '持ち物チェックリスト 3個/子まで',
-	k7: '90日間の履歴保持',
+	k7: `${PLAN_RETENTION_TERMS.free}間の履歴保持`,
 	k8: 'メールサポート（標準）',
 	k9: 'お子さまの登録人数：無制限',
 	k10: 'オリジナル活動の作成：無制限',
@@ -9274,7 +9275,7 @@ export const LP_PRICING_PHASEB_LABELS = {
 	k13: '特別なごほうび設定（即時付与）',
 	k14: '家族のデータ預かり枠（同時保管 3 件・自分でダウンロード可）',
 	k15: 'データのダウンロード',
-	k16: '1年間の履歴保持',
+	k16: `${PLAN_RETENTION_TERMS.standard}間の履歴保持`,
 	k17: 'メールサポート',
 	// #1947: k18 「スタンダードの全機能」のプラン名 atom (スタンダード) を terms.ts 参照化
 	k18: `${PLAN_TERMS.standard}の全機能`,
@@ -9297,7 +9298,7 @@ export const LP_PRICING_PHASEB_LABELS = {
 	k31: '<td>お子さまの登録人数</td><td>2人まで</td><td class="check">無制限</td><td class="check">無制限</td>',
 	k32: '<td>プリセット活動の利用</td><td class="check">&#10003;</td><td class="check">&#10003;</td><td class="check">&#10003;</td>',
 	k33: '<td>オリジナル活動の作成</td><td>3個まで</td><td class="check">無制限</td><td class="check">無制限</td>',
-	k34: '<td>活動履歴の保持</td><td>90日</td><td>1年</td><td class="check">無制限</td>',
+	k34: `<td>活動履歴の保持</td><td>${PLAN_RETENTION_TERMS.free}</td><td>${PLAN_RETENTION_TERMS.standard}</td><td class="check">無制限</td>`,
 	k35: '<td colspan="4">カスタマイズ</td>',
 	// #1708 R3-A: k37 (朝夜の習慣リスト / 旧ルーチン-CL) は削除（kind=routine 廃止に伴い）
 	// #1710 R3-C: k38 を「持ち物チェックリスト自由作成」に純化（持ち物 = event-* プリセット 3 件 / 毎日 must = 活動マスタ priority 属性 への責務分離）
@@ -9360,7 +9361,7 @@ export const LP_FAQ_PHASEB_LABELS = {
 	k32: `お子さまの冒険体験（活動記録・ポイント・レベル・スタンプ・チャレンジ・続けるごほうび）は、<strong>${PLAN_FULL_TERMS.free}でもすべてご利用いただけます</strong>。`,
 	k33: '有料プランで解放される主な機能:',
 	k34: `お子さま・活動の人数制限解除（${PLAN_TERMS.free}: お子さま 2 人 / 活動 3 個まで）`,
-	k35: `長期の履歴保持（${PLAN_TERMS.free}: 過去 90 日まで → 有料: 無期限）`,
+	k35: `長期の履歴保持（${PLAN_TERMS.free}: 過去 ${PLAN_RETENTION_TERMS.freeSpaced}まで → 有料: 無期限）`,
 	k36: 'AI 自動提案（活動案・ごほうび案）',
 	k37: 'きょうだいランキング・家族メンバー招待',
 	k38: 'データのバックアップ',
@@ -9507,7 +9508,7 @@ export const LP_PAMPHLET_PHASEB_LABELS = {
 	k33: '<span class="check">&#x2713;</span>毎日のごほうび・続けるごほうび',
 	// #1710 R3-C: 旧「持ち物／毎日習慣」統合表現を「持ち物チェックリスト」に純化
 	k34: '<span class="check">&#x2713;</span>持ち物チェックリスト 3個/子まで',
-	k35: '<span class="check">&#x2713;</span>90日間の履歴保持',
+	k35: `<span class="check">&#x2713;</span>${PLAN_RETENTION_TERMS.free}間の履歴保持`,
 	k36: '&#x2B50; おすすめ',
 	// #1956 (Phase 3 D11): 'スタンダード' = PLAN_TERMS.standard 参照化。
 	// #1913 (UIUX-E-5): k38 を「&#xA5;500」HTML エンティティから「¥500」(PRICE_TERMS.standard) に統一。
@@ -9521,7 +9522,7 @@ export const LP_PAMPHLET_PHASEB_LABELS = {
 	k42: '<span class="check">&#x2713;</span>家族メンバー招待：4人まで',
 	k43: '<span class="check">&#x2713;</span>特別なごほうび設定',
 	k44: '<span class="check">&#x2713;</span>データのダウンロード',
-	k45: '<span class="check">&#x2713;</span>1年間の履歴保持',
+	k45: `<span class="check">&#x2713;</span>${PLAN_RETENTION_TERMS.standard}間の履歴保持`,
 	k46: '<span class="check">&#x2713;</span>メールサポート',
 	// #1956 (Phase 3 D11): 'ファミリー' = PLAN_TERMS.premium、
 	//   'スタンダードの全機能' = PLAN_TERMS.standard + 'の全機能' 部分参照化。

--- a/src/lib/domain/plan-features.ts
+++ b/src/lib/domain/plan-features.ts
@@ -21,7 +21,7 @@
 
 import type { PlanKey } from './labels';
 import { ACTION_LABELS, TRIAL_LABELS } from './labels';
-import { PLAN_TERMS } from './terms';
+import { PLAN_RETENTION_TERMS, PLAN_TERMS } from './terms';
 
 /**
  * プラン料金カードに表示する機能リスト（/pricing/+page.svelte 用）
@@ -40,7 +40,7 @@ export const PRICING_PAGE_FEATURES: Record<PlanKey, readonly string[]> = {
 		'毎日のごほうび・続けるごほうび',
 		// #1710 R3-C: 持ち物純化（毎日 must は活動 priority 属性へ移管）
 		'持ち物チェックリスト 3個/子まで',
-		'90日間の履歴保持',
+		`${PLAN_RETENTION_TERMS.free}間の履歴保持`,
 		// #1654 R48: footer / tokushoho.html / sla.html がサポートメールを全プラン提示しているため SSOT 補完
 		'メールサポート（標準）',
 	],
@@ -54,7 +54,7 @@ export const PRICING_PAGE_FEATURES: Record<PlanKey, readonly string[]> = {
 		// #1912 (F-8): 「クラウド保管枠」→「家族のデータ預かり枠（自分でダウンロード可）」へ日本語化
 		'家族のデータ預かり枠（同時保管 3 件・自分でダウンロード可）',
 		'データのダウンロード',
-		'1年間の履歴保持',
+		`${PLAN_RETENTION_TERMS.standard}間の履歴保持`,
 		'メールサポート',
 	],
 	family: [

--- a/src/lib/domain/terms.ts
+++ b/src/lib/domain/terms.ts
@@ -1167,4 +1167,6 @@ export const PLAN_RETENTION_TERMS = {
 	freeSpaced: formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.free, { spaced: true }),
 	/** スタンダードプランの保持期間 (例: 「1年」) */
 	standard: formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.standard),
+	/** 同上・LP 本文の組版に合わせた半角スペース入り (例: 「1 年」) */
+	standardSpaced: formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.standard, { spaced: true }),
 } as const;

--- a/src/lib/domain/terms.ts
+++ b/src/lib/domain/terms.ts
@@ -44,7 +44,11 @@
 //   TOKUSHOHO_TERMS  — 特商法第12条の6 6 項目見出し + 短い名詞 atom（Phase 3 #2573 + Phase 7 PR-2a、#2688 / Round 1 #2689 で 6 見出し + cancelButtonLabel に絞込、法令文 compound は labels.ts 側へ移動）
 //   CHECKOUT_SUCCESS_TERMS — Stripe Checkout 完了後 success ページ atom（Phase 3 #2572 + Phase 7 PR-2a、#2688 / Round 1 #2689 で 5 variant 見出し + ボタンラベルに絞込、本文 compound は labels.ts 側へ移動）
 //
-// 参照: docs/DESIGN.md §6 / Issue #1916 / Issue #1917 (template literal parser) / Issue #1958 / Issue #1896 / Issue #1898 / Issue #1913 / Issue #2058 / Issue #1914 / Issue #1915 / Issue #2266 / Issue #2276 / Issue #2345 / Issue #2346 / Issue #2688 (Phase 7 PR-2a)
+//   PLAN_RETENTION_TERMS — プラン別 履歴保持期間 atom（値は constants/plan-retention.ts が SSOT、#4477）
+//
+// 参照: docs/DESIGN.md §6 / Issue #1916 / Issue #1917 (template literal parser) / Issue #1958 / Issue #1896 / Issue #1898 / Issue #1913 / Issue #2058 / Issue #1914 / Issue #1915 / Issue #2266 / Issue #2276 / Issue #2345 / Issue #2346 / Issue #2688 (Phase 7 PR-2a) / Issue #4477
+
+import { formatRetentionPeriod, PLAN_HISTORY_RETENTION_DAYS } from './constants/plan-retention';
 
 // ============================================================
 // PLAN_TERMS — プラン名（短縮形、PLAN_SHORT_LABELS の atom）
@@ -1140,4 +1144,27 @@ export const VISIBILITY_CHIP_TERMS = {
 	allOnLabel: '全員 ON',
 	allOffLabel: '全員 OFF',
 	groupAriaLabel: '配信お子さま選択',
+} as const;
+
+// ============================================================
+// PLAN_RETENTION_TERMS — プラン別 履歴保持期間の atom (#4477)
+// ============================================================
+//
+// 値の SSOT は `constants/plan-retention.ts` の PLAN_HISTORY_RETENTION_DAYS
+// (plan-limit-service.ts の PLAN_LIMITS[tier].historyRetentionDays も同じ定数から引く)。
+// 本 atom は「表示用に整形しただけ」で、数値そのものは持たない。
+// labels.ts / plan-features.ts は必ず本 atom を template literal 参照し、
+// 「90日」「1年」などの数値入り文字列を直書きしないこと (ADR-0013 / ADR-0045)。
+//
+// LP 側 (site/shared-labels.js) は scripts/generate-lp-labels.mjs が同じ値 SSOT から
+// 同名 namespace を組み立てて template literal を解決する。両者が一致することは
+// tests/unit/domain/plan-retention-ssot.test.ts が機械検証する。
+
+export const PLAN_RETENTION_TERMS = {
+	/** 無料プランの保持期間 (例: 「90日」) */
+	free: formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.free),
+	/** 同上・LP 本文の組版に合わせた半角スペース入り (例: 「90 日」) */
+	freeSpaced: formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.free, { spaced: true }),
+	/** スタンダードプランの保持期間 (例: 「1年」) */
+	standard: formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.standard),
 } as const;

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -4,6 +4,7 @@ import type { ChildId } from '$lib/domain/ids';
 
 import { countsTowardActivityQuota } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { PLAN_HISTORY_RETENTION_DAYS } from '$lib/domain/constants/plan-retention';
 import type { PlanTier } from '$lib/domain/constants/plan-tier';
 import { addDaysJST, prevDateJST, todayDateJST } from '$lib/domain/date-utils';
 import { getAuthMode } from '$lib/server/auth/factory';
@@ -40,7 +41,8 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxChecklistTemplates: 3,
 		// #1111: フリープランは招待不可（owner のみ）
 		maxFamilyMembers: 1,
-		historyRetentionDays: 90,
+		// 値の SSOT は domain/constants/plan-retention.ts (LP / 機能リストの表示も同じ定数から引く、#4477)
+		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.free,
 		canExport: false,
 		canFreeTextMessage: false,
 		canCustomReward: false,
@@ -53,7 +55,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxChecklistTemplates: null,
 		// #1111: スタンダードは owner + 3人 = 計4人まで（核家族想定）
 		maxFamilyMembers: 4,
-		historyRetentionDays: 365,
+		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.standard,
 		canExport: true,
 		canFreeTextMessage: false,
 		canCustomReward: true,
@@ -66,7 +68,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxChecklistTemplates: null,
 		// #1111: PLAN_LABELS.family は無制限
 		maxFamilyMembers: null,
-		historyRetentionDays: null,
+		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.family,
 		canExport: true,
 		canFreeTextMessage: true,
 		canCustomReward: true,

--- a/tests/unit/domain/plan-retention-ssot.test.ts
+++ b/tests/unit/domain/plan-retention-ssot.test.ts
@@ -1,0 +1,133 @@
+// tests/unit/domain/plan-retention-ssot.test.ts (#4477)
+//
+// 履歴保持日数の SSOT (src/lib/domain/constants/plan-retention.ts) が
+// 実装 (plan-limit-service の PLAN_LIMITS) と 表示 (labels.ts / plan-features.ts / LP) の
+// 双方に伝播していることを機械検証する。
+//
+// これが無いと「historyRetentionDays を変えても LP 料金表は 90 日のまま」という
+// 二重管理 (顧客に見える価格表が実装と食い違う、ADR-0013 LP truth 違反) が再発する。
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+// LP 生成側の実処理 (.mjs script) をそのまま検査する
+import { buildPlanRetentionTerms } from '../../../scripts/generate-lp-labels.mjs';
+import {
+	formatRetentionPeriod,
+	PLAN_HISTORY_RETENTION_DAYS,
+} from '../../../src/lib/domain/constants/plan-retention';
+import {
+	LP_PAMPHLET_PHASEB_LABELS,
+	LP_PRICING_LABELS,
+	LP_PRICING_PHASEB_LABELS,
+} from '../../../src/lib/domain/labels';
+import { PRICING_PAGE_FEATURES } from '../../../src/lib/domain/plan-features';
+import { PLAN_RETENTION_TERMS } from '../../../src/lib/domain/terms';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe('plan retention days SSOT (#4477)', () => {
+	describe('formatRetentionPeriod', () => {
+		it('null は無期限', () => {
+			expect(formatRetentionPeriod(null)).toBe('無期限');
+		});
+
+		it('365 の倍数は年で表す', () => {
+			expect(formatRetentionPeriod(365)).toBe('1年');
+			expect(formatRetentionPeriod(730)).toBe('2年');
+		});
+
+		it('それ以外は日で表す', () => {
+			expect(formatRetentionPeriod(90)).toBe('90日');
+			expect(formatRetentionPeriod(180)).toBe('180日');
+		});
+
+		it('spaced で数値と単位の間に半角スペースを入れる', () => {
+			expect(formatRetentionPeriod(90, { spaced: true })).toBe('90 日');
+			expect(formatRetentionPeriod(365, { spaced: true })).toBe('1 年');
+		});
+	});
+
+	describe('atom は SSOT の値から導出される', () => {
+		it('PLAN_RETENTION_TERMS は PLAN_HISTORY_RETENTION_DAYS を整形したもの', () => {
+			expect(PLAN_RETENTION_TERMS.free).toBe(
+				formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.free),
+			);
+			expect(PLAN_RETENTION_TERMS.freeSpaced).toBe(
+				formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.free, { spaced: true }),
+			);
+			expect(PLAN_RETENTION_TERMS.standard).toBe(
+				formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.standard),
+			);
+		});
+	});
+
+	describe('表示文字列に日数が直書きされていない (変異試験の対象)', () => {
+		// SSOT の値を変えたら表示も追随することを、「現在値から組み立てた文字列と一致するか」で確かめる。
+		// 直書きに戻すと SSOT を変えた瞬間にこの assert が落ちる。
+		const free = PLAN_RETENTION_TERMS.free;
+		const standard = PLAN_RETENTION_TERMS.standard;
+
+		it('アプリの料金カード機能リスト (plan-features.ts)', () => {
+			expect(PRICING_PAGE_FEATURES.free).toContain(`${free}間の履歴保持`);
+			expect(PRICING_PAGE_FEATURES.standard).toContain(`${standard}間の履歴保持`);
+		});
+
+		it('LP pricing の機能リストと比較表', () => {
+			expect(LP_PRICING_PHASEB_LABELS.k7).toBe(`${free}間の履歴保持`);
+			expect(LP_PRICING_PHASEB_LABELS.k16).toBe(`${standard}間の履歴保持`);
+			expect(LP_PRICING_PHASEB_LABELS.k34).toContain(`<td>${free}</td><td>${standard}</td>`);
+		});
+
+		it('LP pamphlet の機能リスト', () => {
+			expect(LP_PAMPHLET_PHASEB_LABELS.k35).toContain(`${free}間の履歴保持`);
+			expect(LP_PAMPHLET_PHASEB_LABELS.k45).toContain(`${standard}間の履歴保持`);
+		});
+
+		it('pricing ページの体験終了後 / 解約 FAQ', () => {
+			const spaced = PLAN_RETENTION_TERMS.freeSpaced;
+			expect(LP_PRICING_LABELS.trialDataReassureLine2Suffix).toContain(`保持期間（${spaced}）`);
+			expect(LP_PRICING_LABELS.faqAfterTrialA).toContain(`保持期間（${spaced}）`);
+			expect(LP_PRICING_LABELS.faqCancelVsDeleteA).toContain(`保持期間（${spaced}）`);
+		});
+	});
+
+	describe('実装側 (plan-limit-service) も同じ SSOT を引く', () => {
+		it('PLAN_LIMITS の historyRetentionDays に数値 literal を書かない', () => {
+			const src = readFileSync(
+				resolve(__dirname, '../../../src/lib/server/services/plan-limit-service.ts'),
+				'utf-8',
+			);
+			const assignments = [...src.matchAll(/historyRetentionDays:\s*([^,\n]+)/g)]
+				.map((m) => (m[1] ?? '').trim())
+				// 型宣言 (`historyRetentionDays: number | null;`) は対象外
+				.filter((v) => !v.includes('number'));
+			expect(assignments.length).toBeGreaterThan(0);
+			for (const value of assignments) {
+				expect(value).toMatch(/^PLAN_HISTORY_RETENTION_DAYS\.(free|standard|family)$/);
+			}
+		});
+	});
+
+	describe('LP の静的 JSON-LD も SSOT と一致する', () => {
+		// site/index.html の構造化データ (schema.org Offer) は data-lp-key 注入の対象外
+		// (crawler 向けに静的である必要がある) ため、生成では同期できない。
+		// 代わりに「SSOT の値と食い違ったら CI が落ちる」形で drift を可視化する。
+		it('index.html の無料プラン Offer description が現在の保持日数を書いている', () => {
+			const html = readFileSync(resolve(__dirname, '../../../site/index.html'), 'utf-8');
+			const days = PLAN_HISTORY_RETENTION_DAYS.free;
+			expect(html).toContain(`履歴${days}日`);
+		});
+	});
+
+	describe('LP 生成 script が同じ値 SSOT から同じ atom を組み立てる', () => {
+		it('generate-lp-labels.mjs の PLAN_RETENTION_TERMS は terms.ts と一致する', () => {
+			expect(buildPlanRetentionTerms()).toEqual({
+				free: PLAN_RETENTION_TERMS.free,
+				freeSpaced: PLAN_RETENTION_TERMS.freeSpaced,
+				standard: PLAN_RETENTION_TERMS.standard,
+			});
+		});
+	});
+});

--- a/tests/unit/domain/plan-retention-ssot.test.ts
+++ b/tests/unit/domain/plan-retention-ssot.test.ts
@@ -60,6 +60,9 @@ describe('plan retention days SSOT (#4477)', () => {
 			expect(PLAN_RETENTION_TERMS.standard).toBe(
 				formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.standard),
 			);
+			expect(PLAN_RETENTION_TERMS.standardSpaced).toBe(
+				formatRetentionPeriod(PLAN_HISTORY_RETENTION_DAYS.standard, { spaced: true }),
+			);
 		});
 	});
 
@@ -87,6 +90,9 @@ describe('plan retention days SSOT (#4477)', () => {
 
 		it('pricing ページの体験終了後 / 解約 FAQ', () => {
 			const spaced = PLAN_RETENTION_TERMS.freeSpaced;
+			expect(LP_PRICING_LABELS.trialDataReassureLine3).toContain(
+				`スタンダード: ${PLAN_RETENTION_TERMS.standardSpaced}`,
+			);
 			expect(LP_PRICING_LABELS.trialDataReassureLine2Suffix).toContain(`保持期間（${spaced}）`);
 			expect(LP_PRICING_LABELS.faqAfterTrialA).toContain(`保持期間（${spaced}）`);
 			expect(LP_PRICING_LABELS.faqCancelVsDeleteA).toContain(`保持期間（${spaced}）`);
@@ -127,6 +133,7 @@ describe('plan retention days SSOT (#4477)', () => {
 				free: PLAN_RETENTION_TERMS.free,
 				freeSpaced: PLAN_RETENTION_TERMS.freeSpaced,
 				standard: PLAN_RETENTION_TERMS.standard,
+				standardSpaced: PLAN_RETENTION_TERMS.standardSpaced,
 			});
 		});
 	});


### PR DESCRIPTION
## 顧客価値・目的

保存期間（履歴保持日数）を運用側が変えたときに、**顧客が見る LP の料金表・比較表・FAQ・アプリの料金カードが自動で追随する**ようになる。これまでは実装値（`historyRetentionDays`）を変えても表示は「90日」のまま残り、価格表が実装と食い違ったまま配信される状態だった。

## 関連 Issue

Closes #4476

## 変更内容

日数の値 SSOT を domain leaf に一本化し、実装と表示の両方がそこから引く形にした。

- **`src/lib/domain/constants/plan-retention.ts`（新規）**: `PLAN_HISTORY_RETENTION_DAYS`（free: 90 / standard: 365 / family: null）と表示整形 `formatRetentionPeriod`。**値はここだけに存在する**
- **`plan-limit-service.ts`**: `PLAN_LIMITS[tier].historyRetentionDays` を上記定数から引くようにした（数値 literal 撤去）
- **`terms.ts`**: `PLAN_RETENTION_TERMS`（`free` = 「90日」/ `freeSpaced` = 「90 日」/ `standard` = 「1年」）を追加。**値は持たず、SSOT を整形するだけ**（ADR-0045 atom / compound）
- **`labels.ts` / `plan-features.ts`**: 保持期間を含む 17 箇所を template literal 参照に置換（LP 料金カード / 比較表 / パンフ / FAQ / アプリ機能リスト）
- **`scripts/generate-lp-labels.mjs`**: 同 script は TS を実行せず text parse するため、関数呼び出しで組み立てた `PLAN_RETENTION_TERMS` を terms.ts から読めない。**数値 SSOT（literal なので読める）から同じ atom を組み立てる `buildPlanRetentionTerms()` を追加**し、`${PLAN_RETENTION_TERMS.free}` を解決できるようにした

### 設計判断（レビュー観点）

1. **値を domain 層へ降ろした理由**: `labels.ts` は domain 層で `$lib/server/**` を import できない。逆に `plan-limit-service.ts`（server 専用）へ表示を寄せることもできない。よって値だけを domain leaf へ降ろし、server 側がそこから引く（型 SSOT を domain leaf に降ろした #3963 と同型）。**値が 2 箇所に存在する状態は作っていない**
2. **LP 生成 script に整形ロジックが再現される点**: 数値は SSOT から読むが、「365 → 1年」の整形だけは script 側にも書かれる。これは text parser の制約であり、**drift は `tests/unit/domain/plan-retention-ssot.test.ts` が `buildPlanRetentionTerms()` と `PLAN_RETENTION_TERMS` を直接突き合わせて機械検出する**（整形規則がずれた瞬間に落ちる）
3. **文言は変えていない**: 「1年間の履歴保持」を「365日間の履歴保持」に変える案もあったが、顧客に見えるコピー変更は PO 判断の領域なので採らず、`formatRetentionPeriod` が 365 の倍数を「N年」に整形することで**既存文言を 1 文字も変えずに**導出化した。結果として `site/shared-labels.js` の再生成差分は 0 バイト
4. **`site/index.html` の JSON-LD**: `data-lp-key` 注入の対象外（crawler 向けに静的である必要がある）ため生成では同期できない。代わりに **SSOT と食い違ったら unit test が落ちる**形にして drift を可視化した

## 検証

| AC | 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | 日数の数値が 1 箇所のみ / `PLAN_LIMITS` もそこから引く | `plan-retention-ssot.test.ts` の「PLAN_LIMITS の historyRetentionDays に数値 literal を書かない」 | PASS（3 代入すべて `PLAN_HISTORY_RETENTION_DAYS.*`） |
| AC2 | `labels.ts` / `plan-features.ts` に日数直書き 0 件 | `grep -n "90日\|365日\|90 日\|1年間の履歴\|1年</td>" src/lib/domain/labels.ts src/lib/domain/plan-features.ts` | 保持期間文脈の hit 0 件（残る「直近 90 日」は ops KPI、「アカウント削除後90日」はバックアップ消去で別概念） |
| AC3 | SSOT を変えると LP 文言が追随する | **変異試験**: `free: 90 → 120` に変更 → `generate-lp-labels.mjs --check` が exit 1、再生成で `site/shared-labels.js` が 12 行変化し `"k39": "120日間の履歴保持"` 等になることを確認 → 復元 | PASS |
| AC4 | 直書きに戻すと test が落ちる | **変異試験**: `free: 120` の状態で `LP_PRICING_PHASEB_LABELS.k7` を `'90日間の履歴保持'` に戻す → `AssertionError: expected '90日間の履歴保持' to be '120日間の履歴保持'` で 1 failed → 復元 | PASS |
| AC5 | 再生成後に `generate-lp-labels --check` PASS | `node scripts/generate-lp-labels.mjs && node scripts/generate-lp-labels.mjs --check` | `✓ site/shared-labels.js は最新です`（**再生成しても差分 0 バイト** = 出力文言不変） |
| AC6 | LP メトリクスに抵触しない | `site/**` の差分が 0 件（`git status` / `git diff --stat site/`） | 該当なし（LP 資産を 1 バイトも変更していないため寸法・禁止語ともに不変） |
| AC7 | JSON-LD の drift を CI が検出する | `plan-retention-ssot.test.ts` の「index.html の無料プラン Offer description が現在の保持日数を書いている」 | PASS |

その他:

- `npx vitest run tests/unit/domain/plan-retention-ssot.test.ts` → 12 passed
- `npx vitest run src/lib/domain/ tests/unit/domain/ tests/unit/scripts/` → 110 files / 2224 passed
- `npx vitest run tests/unit/domain/plan-features.test.ts tests/unit/services/plan-limit-service.test.ts` → 132 passed（既存の期待値「90日間の履歴保持」「`historyRetentionDays === 90`」は無改変で PASS）
- `npx biome check .` → No fixes applied
- `npx svelte-check --threshold error` → 0 ERRORS
- `node scripts/check-no-plan-literals.mjs` → OK
- `npm run cspell` → Issues found: 0
- pre-commit hook（labels/terms 変更時の SSOT companion 検査: biome / generate-lp-labels --check / sync-lp-fallback --check）→ すべて OK
- E2E（`tests/e2e/pricing-features.spec.ts` 等）は未実行。表示文字列が完全一致のまま（`shared-labels.js` 差分 0）のため挙動不変

<!-- ss-identical-ok: LP 出力文字列が完全一致で shared-labels.js の再生成差分が 0 バイトのため、描画は不変 -->

`site/**` を触りうる変更だが、**再生成後の `site/shared-labels.js` は 1 バイトも変わらない**（生成方法だけを変え、出力は現状維持）。したがって LP の見た目に差分は生じない。

## 影響範囲

- **顧客に見える変化**: なし（文言・レイアウトともに不変。以後は SSOT を変えたときに表示が追随するようになる）
- **触った並行実装ペア**: UI ラベル・用語（`labels.ts` + `terms.ts` + `site/shared-labels.js`）— 再生成済みで差分 0。`site/*.html` の fallback は `sync-lp-fallback --check` で同期確認済み
- **破壊的変更**: なし（`PlanLimits` の型・値・公開 API はいずれも不変）
- **後続 PR への影響**: #4474 で入った退会エクスポートの `getPlanLimits(planTier).historyRetentionDays` 参照は、本 PR 後も同じ値を返す（同一 SSOT に合流）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 (revert で完全復帰)"]
    R2["顧客面: LP 料金表の生成方法のみ。表示文字列は不変"]
    R3["ロールバック: revert のみで戻る。データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 保存期間を変えると LP が自動追随"]
    T2["捨てる: 整形規則が LP 生成 script にも再現 (test で突合)"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: 🟡 日数変更で '1年' 表記が自動で崩れうる"]
    O2["UX: 🟡 整形が 2 箇所。test 無効化なら表示が食い違う"]
    O3["security: 🟢 法務文書は保持日数を書いておらず不整合なし"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["変化なし: shared-labels.js 再生成差分 0 バイト"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 表示文言を変えず導出化のみ、で進めてよいか?"]
    Q2["Q2: 365 の倍数を '年' に畳む整形規則を採用してよいか?"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3 ok
  class T2,O1,O2 warn
  class T1,C1,O3 ok
  class Q1,Q2 ask
```

<details>
<summary>補足 (PO は原則読まなくてよい — 図の根拠・詳細)</summary>

- 本 PR は PO 決裁「**日数の二重管理は論外。SSOT の原則を守って、別 PR でもいいのできちんと対応せよ**」(PR #4471 / #4474 レビュー往復) の射程内。決裁済み方針の実装であり、Q1 / Q2 は実装上の派生確認
- label は `terms.ts` / `plan-features.ts` (価格・プラン atom SSOT) を触ったことで自動付与された
- ③ の反対理由は `tmp/adversarial-evidence/4477.json` (schema 検証 PASS) からの転記
- ③ security 軸の裏取り: `site/privacy.html` / `terms.html` に保持日数の記述は無い (「アカウント削除後90日以内にバックアップから消去」はバックアップ消去期限で別概念)。よって現時点で法務文書との不整合は生じない
- ③ UX 軸への対処: `buildPlanRetentionTerms()` と `PLAN_RETENTION_TERMS` を直接突き合わせる unit test を置き、整形規則の drift をその場で落とす

</details>

## QM レビュー結果

<!-- QM が記入 -->

