### PR TITLE
fix(ci): #4348 SS 系 gate が --pr を黙殺して空入力を検査し成功終了するのを止める (7 箇所目)

### DIFF
--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -36,6 +36,7 @@ jobs:
             scripts/pr-lane.mjs
             scripts/check-pr-screenshot.mjs
             scripts/lib/is-main.mjs
+            scripts/lib/ci/pr-input.mjs
             scripts/lib/ci/reason-declaration.mjs
             # #4285 の story 実在確認 (storyFileExists) は src/ を走査する。
             # sparse-checkout に src が無いと **実在する story を書いても必ず false** になり、
@@ -195,6 +196,7 @@ jobs:
             scripts/pr-lane.mjs
             scripts/check-pr-screenshot.mjs
             scripts/lib/is-main.mjs
+            scripts/lib/ci/pr-input.mjs
             scripts/lib/ci/reason-declaration.mjs
           sparse-checkout-cone-mode: false
 
@@ -249,6 +251,7 @@ jobs:
             actions/pr-lane
             scripts/pr-lane.mjs
             scripts/check-ss-blob-sha-uniqueness.mjs
+            scripts/lib/ci/pr-input.mjs
             scripts/lib/ci/reason-declaration.mjs
             scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false
@@ -300,6 +303,7 @@ jobs:
         with:
           sparse-checkout: |
             scripts/check-ss-render-health.mjs
+            scripts/lib/ci/pr-input.mjs
             scripts/lib/ci/screenshot-helpers.mjs
             scripts/lib/is-main.mjs
           sparse-checkout-cone-mode: false

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -58,20 +58,27 @@
  *   2 = internal error
  */
 
+import {
+	formatPrInputUsage,
+	isHelpRequested,
+	PrInputError,
+	resolvePrInput,
+} from './lib/ci/pr-input.mjs';
+
+/**
+ * #4348 (対象 #7 の兄弟): 本 script も PR body / files / labels を env からしか読まず、
+ * `--pr <N>` を黙殺していた。`--pr` 付きで呼ぶと PR_FILES が空 → `isUiPr()` false →
+ * 「UI 関連ファイル変更なし — スキップ」と**安心感のある成功終了**をしていた
+ * (実測 2026-08-12、PR #4515 は env を正しく渡すと dom-snapshot-missing を検出する)。
+ * 入力解決は `scripts/lib/ci/pr-input.mjs` (SSOT) に委譲する。
+ */
+const SCRIPT_NAME = 'scripts/check-pr-screenshot.mjs';
+
 const MODE = (process.env.SCREENSHOT_CHECK_MODE || 'warn').toLowerCase();
 // #2946 (Phase A/A-4): lane 判定は SSOT (scripts/pr-lane.mjs + actions/pr-lane) が出した
 // 値を env PR_LANE で受け取るだけ。本 script 内で base/head/actor から lane を再判定しない
 // (no-go: lane 判定ロジックの inline 重複禁止)。未設定時は 'feature' (軽量レーン、後方互換)。
 const PR_LANE = (process.env.PR_LANE || 'feature').trim().toLowerCase();
-const PR_BODY = process.env.PR_BODY || '';
-const PR_FILES = (process.env.PR_FILES || '')
-	.split('\n')
-	.map((s) => s.trim())
-	.filter(Boolean);
-const PR_LABELS = (process.env.PR_LABELS || '')
-	.split(',')
-	.map((s) => s.trim())
-	.filter(Boolean);
 
 // ---------------------------------------------------------------------------
 // 検証関数（pure functions, named exports for unit testing）
@@ -739,7 +746,11 @@ function buildIntegrationEvidenceMissingViolation() {
 	};
 }
 
-function main() {
+/**
+ * CI screenshot-quality-check 本体。入力は entry で解決済のものを受け取る (#4348)。
+ * @param {{ body: string; files: string[]; labels: string[] }} input
+ */
+function main({ body: PR_BODY, files: PR_FILES, labels: PR_LABELS }) {
 	const violations = [];
 
 	// 検証 1: ローカルパス禁止 (#1741) — UI PR でなくても貼ったらアウト (lane 非依存)
@@ -836,11 +847,15 @@ function main() {
  *
  * @returns {number} exit code (0 = PASS / skip, 1 = 違反)
  */
-function mainEmbedGate() {
+/**
+ * pre-ready Step 11b の SS embed gate。入力は entry で解決済のものを受け取る (#4348)。
+ * @param {{ body: string; files: string[]; labels: string[] }} input
+ */
+function mainEmbedGate({ body, files, labels }) {
 	const { skipped, skipReason, violations } = checkScreenshotEmbedReadiness({
-		body: PR_BODY,
-		files: PR_FILES,
-		labels: PR_LABELS,
+		body,
+		files,
+		labels,
 	});
 
 	if (skipped && violations.length === 0) {
@@ -868,6 +883,33 @@ import { isMain as isMainModule } from './lib/is-main.mjs';
 const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
+	const argv = process.argv.slice(2);
+	if (isHelpRequested(argv)) {
+		console.log(
+			[
+				`${SCRIPT_NAME} — PR の SS 添付品質 / SS embed 完了を検証します (#1740 / #2918)。`,
+				'',
+				'入力 (いずれか。無指定は失敗します — #4348):',
+				formatPrInputUsage(SCRIPT_NAME, 'body'),
+				'',
+				'(help を表示しただけで、検査は実行していません)',
+			].join('\n'),
+		);
+		process.exit(0);
+	}
+
+	// #4348: 入力ゼロ (`--pr` 黙殺 / PR_BODY 未設定) を「UI 変更なし skip」で成功終了させない。
+	let input;
+	try {
+		input = resolvePrInput({ argv, env: process.env, need: 'body', scriptName: SCRIPT_NAME });
+	} catch (err) {
+		if (err instanceof PrInputError) {
+			console.error(`[screenshot-check] INPUT ERROR — ${err.message}`);
+			process.exit(2);
+		}
+		throw err;
+	}
+
 	try {
 		// #2918: SCREENSHOT_EMBED_GATE=1 で Ready 化前 SS embed ゲートを起動 (pre-ready Step 用)。
 		// 未設定時は従来の CI screenshot-check (before/after / DOM / ローカルパス) を実行する。
@@ -876,7 +918,7 @@ if (isMain) {
 			(process.env.SCREENSHOT_EMBED_GATE || '').toLowerCase() === 'true'
 				? mainEmbedGate
 				: main;
-		process.exit(runner());
+		process.exit(runner(input));
 	} catch (err) {
 		console.error('[screenshot-check] internal error:', err);
 		process.exit(2);

--- a/scripts/check-ss-blob-sha-uniqueness.mjs
+++ b/scripts/check-ss-blob-sha-uniqueness.mjs
@@ -1,6 +1,26 @@
 #!/usr/bin/env node
+/**
+ * scripts/check-ss-blob-sha-uniqueness.mjs
+ *
+ * Before/After SS の Blob SHA 一致 (= 完全同一画像 = 偽装) を検出する gate (#2063 / #4084)。
+ *
+ * 入力:
+ *   node scripts/check-ss-blob-sha-uniqueness.mjs --pr <N>              # gh で PR を引く
+ *   PR_BODY="$(gh pr view <N> --json body -q .body)" node scripts/...   # CI (workflow) 経路
+ *
+ * `--pr` を黙殺して空 body を検査し SKIP (exit 0) していたのを #4348 で是正した。
+ * 入力解決は `scripts/lib/ci/pr-input.mjs` (SSOT) に委譲する。
+ */
+import {
+	formatPrInputUsage,
+	isHelpRequested,
+	PrInputError,
+	resolvePrInput,
+} from './lib/ci/pr-input.mjs';
 import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
+
+const SCRIPT_NAME = 'scripts/check-ss-blob-sha-uniqueness.mjs';
 
 const MODE = (process.env.CHECK_MODE || 'warn').toLowerCase();
 // #2946 (Phase A/A-4): lane は SSOT (actions/pr-lane → scripts/pr-lane.mjs) 経由で渡される。
@@ -8,11 +28,6 @@ const MODE = (process.env.CHECK_MODE || 'warn').toLowerCase();
 // integration lane (統合 PR、複数機能バッチで before/after ペアを持たない) で false positive が
 // 出ないことを log で可視化するに留め、検証ロジック (checkSsBlobShaUniqueness) は lane 非依存に保つ。
 const PR_LANE = (process.env.PR_LANE || 'feature').trim().toLowerCase();
-const PR_BODY = process.env.PR_BODY || '';
-const PR_LABELS = (process.env.PR_LABELS || '')
-	.split(',')
-	.map((s) => s.trim())
-	.filter(Boolean);
 
 // ---------------------------------------------------------------------------
 // Pure functions (named exports for vitest)
@@ -398,10 +413,37 @@ export async function checkSsBlobShaUniqueness({ body, labels, fetcher = fetch }
 async function main() {
 	// CHECK_MODE は warn / error の二値運用 (将来の段階適用フラグ)
 	const isError = MODE === 'error';
+	const argv = process.argv.slice(2);
+
+	if (isHelpRequested(argv)) {
+		console.log(
+			[
+				`${SCRIPT_NAME} — Before/After SS の Blob SHA 一致 (偽装) を検出します (#2063 / #4084)。`,
+				'',
+				'入力 (いずれか。無指定は失敗します — #4348):',
+				formatPrInputUsage(SCRIPT_NAME, 'body'),
+				'',
+				'(help を表示しただけで、検査は実行していません)',
+			].join('\n'),
+		);
+		return 0;
+	}
+
+	// #4348: 入力ゼロ (`--pr` 黙殺 / PR_BODY 未設定) を SKIP=exit 0 にしない。
+	let input;
+	try {
+		input = resolvePrInput({ argv, env: process.env, need: 'body', scriptName: SCRIPT_NAME });
+	} catch (err) {
+		if (err instanceof PrInputError) {
+			console.error(`[ss-blob-sha-uniqueness] INPUT ERROR — ${err.message}`);
+			return 2;
+		}
+		throw err;
+	}
 
 	let result;
 	try {
-		result = await checkSsBlobShaUniqueness({ body: PR_BODY, labels: PR_LABELS });
+		result = await checkSsBlobShaUniqueness({ body: input.body, labels: input.labels });
 	} catch (err) {
 		console.error(
 			'[ss-blob-sha-uniqueness] internal error:',

--- a/scripts/check-ss-render-health.mjs
+++ b/scripts/check-ss-render-health.mjs
@@ -1,14 +1,28 @@
 #!/usr/bin/env node
+/**
+ * scripts/check-ss-render-health.mjs
+ *
+ * screenshots branch の `.dom.html` を text scan して error ページ混入を検出する gate (#3012)。
+ *
+ * 入力:
+ *   node scripts/check-ss-render-health.mjs --pr <N>                       # gh で PR を引く
+ *   PR_NUMBER=<N> GITHUB_REPOSITORY=<owner>/<repo> node scripts/...        # CI (workflow) 経路
+ *
+ * #4348 (対象 #7 の兄弟): 本 script も argv を読まず、`--pr <N>` で呼ぶと PR_NUMBER 未設定 →
+ * 「PR コンテキスト外」SKIP = exit 0 になっていた。入力解決は
+ * `scripts/lib/ci/pr-input.mjs` (SSOT) に委譲する。
+ */
+import {
+	formatPrInputUsage,
+	isHelpRequested,
+	PrInputError,
+	resolvePrInput,
+} from './lib/ci/pr-input.mjs';
 import { detectErrorMarkersInHtml } from './lib/ci/screenshot-helpers.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
+const SCRIPT_NAME = 'scripts/check-ss-render-health.mjs';
 const MODE = (process.env.CHECK_MODE || 'error').toLowerCase();
-const PR_NUMBER = process.env.PR_NUMBER || '';
-const REPO = process.env.GITHUB_REPOSITORY || '';
-const PR_LABELS = (process.env.PR_LABELS || '')
-	.split(',')
-	.map((s) => s.trim())
-	.filter(Boolean);
 
 // ---------------------------------------------------------------------------
 // Pure functions (named exports for vitest)
@@ -187,10 +201,46 @@ export async function checkSsRenderHealth({ repo, prNumber, labels, fetcher = fe
 async function main() {
 	const isError = MODE === 'error';
 	const prefix = '[ss-render-health]';
+	const argv = process.argv.slice(2);
+
+	if (isHelpRequested(argv)) {
+		console.log(
+			[
+				`${SCRIPT_NAME} — SS に error ページが混入していないかを検証します (#3012)。`,
+				'',
+				'入力 (いずれか。無指定は失敗します — #4348):',
+				formatPrInputUsage(SCRIPT_NAME, 'prNumber'),
+				'',
+				'(help を表示しただけで、検査は実行していません)',
+			].join('\n'),
+		);
+		return 0;
+	}
+
+	// #4348: 入力ゼロ (`--pr` 黙殺 / PR_NUMBER 未設定) を「PR コンテキスト外」SKIP で成功終了させない。
+	let input;
+	try {
+		input = resolvePrInput({ argv, env: process.env, need: 'prNumber', scriptName: SCRIPT_NAME });
+	} catch (err) {
+		if (err instanceof PrInputError) {
+			console.error(`${prefix} INPUT ERROR — ${err.message}`);
+			return 2;
+		}
+		throw err;
+	}
+	const PR_NUMBER = input.prNumber ?? '';
+	const repo = input.repo || process.env.GITHUB_REPOSITORY || '';
+	if (!repo) {
+		console.error(
+			`${prefix} INPUT ERROR — repository が解決できません (GITHUB_REPOSITORY 未設定)。` +
+				' 対象なしとして成功終了させません (#4348)。',
+		);
+		return 2;
+	}
 
 	let result;
 	try {
-		result = await checkSsRenderHealth({ repo: REPO, prNumber: PR_NUMBER, labels: PR_LABELS });
+		result = await checkSsRenderHealth({ repo, prNumber: PR_NUMBER, labels: input.labels });
 	} catch (err) {
 		console.error(`${prefix} internal error:`, err instanceof Error ? err.message : String(err));
 		return 2;

--- a/scripts/lib/ci/pr-input.mjs
+++ b/scripts/lib/ci/pr-input.mjs
@@ -1,0 +1,279 @@
+/**
+ * scripts/lib/ci/pr-input.mjs
+ *
+ * PR を入力に取る gate 群の **入力解決 SSOT** (#4348 対象 #7)。
+ *
+ * # なぜ共有するか
+ *
+ * SS 系 gate (`check-ss-blob-sha-uniqueness.mjs` / `check-pr-screenshot.mjs` /
+ * `check-ss-render-health.mjs`) は PR body / files / labels を **環境変数からしか読まず、
+ * argv を一切パースしていなかった**。兄弟 script (`check-pr-body.mjs` / `capture.mjs`) が
+ * 揃って `--pr <N>` を取り、しかも各 gate 自身の案内文が `--pr <N>` 形式を提示するため、
+ * 書き手が `--pr` を付けて呼ぶのは自然な誤用である。その結果:
+ *
+ *   $ node scripts/check-ss-blob-sha-uniqueness.mjs --pr 4513
+ *   [ss-blob-sha-uniqueness] SKIP — PR body に ... 参照が見つかりません   ← exit 0
+ *
+ * **空文字列を検査して成功終了**していた (実測 2026-08-12、PR #4513: body の SS URL が
+ * 404 していたのにローカルでは緑、CI で初めて hard error として露見)。
+ *
+ * # 本 module が固定する不変条件
+ *
+ * **「実行できて、何も検査せず、成功終了する」を不可能にする。**
+ *
+ *   - argv `--pr <N>` があれば gh で実 PR を引く (入力ゼロにならない)
+ *   - argv が無くても env が実体を持っていればそれを使う (CI の既存経路は不変)
+ *   - どちらも無い / `--pr` の値が PR 番号でない / gh 取得に失敗した →
+ *     **`PrInputError` を投げて呼び出し側で非 0 終了させる**。skip / pass に倒さない
+ *
+ * 「届いた入力をどう判定するか」の層 (#4348 の対象一覧 6 箇所) には触れない。
+ * 本 module は「**入力が届いているか**」の層だけを担う。
+ *
+ * # 関連
+ *   - #4348 (PR body gate の同 class 群) / #4084 (検査できなかったのに pass の初出)
+ *   - `scripts/lib/ci/reason-declaration.mjs` (例外宣言の理由判定 SSOT。宣言機構は増やさない)
+ */
+
+import { execSync } from 'node:child_process';
+
+/** 入力解決に失敗したことを表す例外 (呼び出し側は非 0 で終了する)。 */
+export class PrInputError extends Error {
+	/** @param {string} message */
+	constructor(message) {
+		super(message);
+		this.name = 'PrInputError';
+	}
+}
+
+/** `--pr` の別名 (兄弟 script `check-pr-body.mjs` と揃える)。 */
+const PR_ARG_ALIASES = ['--pr', '-p'];
+
+/**
+ * argv から `--pr <N>` / `--pr=<N>` を読む。
+ *
+ * `present` は「書き手が `--pr` を渡した」事実で、`value` は「PR 番号として妥当だった値」。
+ * この 2 つを分けるのが本 module の要点である。`present && !value` を env fallback に
+ * 落とすと、**誤用が黙って空入力の検査になる**（本 Issue の現象そのもの）。
+ *
+ * @param {string[]} argv - `process.argv.slice(2)` 相当
+ * @returns {{ present: boolean; value: string | null; raw: string }}
+ */
+export function parsePrNumberArg(argv) {
+	for (let i = 0; i < argv.length; i++) {
+		const a = argv[i] ?? '';
+		if (PR_ARG_ALIASES.includes(a)) {
+			const next = argv[i + 1];
+			if (next === undefined || next.startsWith('-'))
+				return { present: true, value: null, raw: '' };
+			return { present: true, value: /^\d+$/.test(next) ? next : null, raw: next };
+		}
+		const m = /^(?:--pr|-p)=(.*)$/.exec(a);
+		if (m) {
+			const raw = m[1] ?? '';
+			return { present: true, value: /^\d+$/.test(raw) ? raw : null, raw };
+		}
+	}
+	return { present: false, value: null, raw: '' };
+}
+
+/**
+ * 入力の渡し方を案内する文字列。
+ *
+ * @param {string} scriptName - 例: `scripts/check-ss-blob-sha-uniqueness.mjs`
+ * @param {'body' | 'prNumber'} need
+ * @returns {string}
+ */
+export function formatPrInputUsage(scriptName, need = 'body') {
+	const envLine =
+		need === 'body'
+			? `  PR_BODY="$(gh pr view <N> --json body -q .body)" node ${scriptName}`
+			: `  PR_NUMBER=<N> GITHUB_REPOSITORY=<owner>/<repo> node ${scriptName}`;
+	return [`  node ${scriptName} --pr <N>`, envLine].join('\n');
+}
+
+/**
+ * 入力の取得元を決める **純関数** (IO なし、test で全分岐を固定する)。
+ *
+ * @param {{ argv?: string[]; env?: Record<string, string | undefined>; need?: 'body' | 'prNumber';
+ *   scriptName?: string }} input
+ * @returns {{ source: 'gh'; prNumber: string } | { source: 'env'; prNumber: string | null }
+ *   | { source: 'error'; message: string }}
+ */
+export function planPrInput({ argv = [], env = {}, need = 'body', scriptName = 'this script' }) {
+	const arg = parsePrNumberArg(argv);
+
+	if (arg.present && arg.value) return { source: 'gh', prNumber: arg.value };
+
+	if (arg.present) {
+		return {
+			source: 'error',
+			message:
+				`--pr の値が PR 番号ではありません (受領: ${JSON.stringify(arg.raw)})。\n` +
+				`入力の渡し方:\n${formatPrInputUsage(scriptName, need)}`,
+		};
+	}
+
+	const envBody = (env.PR_BODY ?? '').trim();
+	const envNumber = (env.PR_NUMBER ?? '').trim();
+
+	if (need === 'body' && envBody !== '') {
+		return { source: 'env', prNumber: /^\d+$/.test(envNumber) ? envNumber : null };
+	}
+	if (need === 'prNumber' && /^\d+$/.test(envNumber)) {
+		return { source: 'env', prNumber: envNumber };
+	}
+
+	return {
+		source: 'error',
+		message:
+			`検査対象の PR 入力がありません (${need === 'body' ? 'PR_BODY' : 'PR_NUMBER'} 未設定 / 空、かつ --pr 未指定)。\n` +
+			`入力ゼロのまま SKIP すると「何も検査していないのに緑」になるため、実行を失敗させます (#4348 / #4084)。\n` +
+			`入力の渡し方:\n${formatPrInputUsage(scriptName, need)}`,
+	};
+}
+
+/**
+ * `gh pr view <N> --json body,labels,files,url` の生 JSON を解釈する **純関数**。
+ *
+ * `--jq` は使わない (#3962: Windows の cmd.exe が単一引用符を引用符として扱わず jq が落ち、
+ * その失敗を握り潰すと gate が黙って縮退する)。JSON を素で受けて JS 側で取り出す。
+ *
+ * 単一フィールドの `--json` は存在しない PR でも値を返すことがあるため、
+ * `url` から owner/repo を取り出せることを**実在確認**として使う。
+ *
+ * @param {string} raw
+ * @returns {{ body: string; labels: string[]; files: string[]; owner: string; repo: string }}
+ */
+export function parseGhPrView(raw) {
+	/** @type {unknown} */
+	let json;
+	try {
+		json = JSON.parse(raw);
+	} catch {
+		throw new PrInputError(`gh pr view の出力が JSON として解釈できません: ${raw.slice(0, 200)}`);
+	}
+	if (typeof json !== 'object' || json === null) {
+		throw new PrInputError('gh pr view の出力が object ではありません');
+	}
+	const obj = /** @type {Record<string, unknown>} */ (json);
+
+	const url = typeof obj.url === 'string' ? obj.url : '';
+	const m = /^https?:\/\/[^/]+\/([^/]+)\/([^/]+)\/pull\/\d+/.exec(url);
+	if (!m) {
+		throw new PrInputError(
+			`gh pr view の出力に妥当な PR url がありません (実在しない PR 番号の可能性): url=${JSON.stringify(url)}`,
+		);
+	}
+
+	const body = typeof obj.body === 'string' ? obj.body : '';
+	const labels = Array.isArray(obj.labels)
+		? obj.labels
+				.map((l) =>
+					typeof l === 'object' && l !== null && typeof (/** @type {any} */ (l).name) === 'string'
+						? /** @type {any} */ (l).name
+						: '',
+				)
+				.filter(Boolean)
+		: [];
+	const files = Array.isArray(obj.files)
+		? obj.files
+				.map((f) =>
+					typeof f === 'object' && f !== null && typeof (/** @type {any} */ (f).path) === 'string'
+						? /** @type {any} */ (f).path
+						: '',
+				)
+				.filter(Boolean)
+		: [];
+
+	return { body, labels, files, owner: m[1] ?? '', repo: m[2] ?? '' };
+}
+
+/**
+ * gh を実行して PR の body / labels / files を取る (既定の IO 実装、test では DI で差し替える)。
+ *
+ * @param {string} prNumber - 数字のみであることを呼び出し前に検証済み
+ * @returns {string} 生 JSON
+ */
+function defaultGhView(prNumber) {
+	return execSync(`gh pr view ${prNumber} --json body,labels,files,url`, {
+		encoding: 'utf-8',
+		stdio: ['ignore', 'pipe', 'pipe'],
+		timeout: 30_000,
+		maxBuffer: 20 * 1024 * 1024,
+	});
+}
+
+/**
+ * gate の入力 (body / labels / files / prNumber / repo) を解決する。
+ *
+ * 解決できない場合は **必ず `PrInputError`**。空入力で先に進めない (skip / pass に倒さない)。
+ *
+ * @param {{ argv?: string[]; env?: Record<string, string | undefined>; need?: 'body' | 'prNumber';
+ *   scriptName?: string; ghView?: (prNumber: string) => string }} input
+ * @returns {{ source: 'gh' | 'env'; prNumber: string | null; body: string; labels: string[];
+ *   files: string[]; repo: string }}
+ */
+export function resolvePrInput({
+	argv = process.argv.slice(2),
+	env = process.env,
+	need = 'body',
+	scriptName = 'this script',
+	ghView = defaultGhView,
+}) {
+	const plan = planPrInput({ argv, env, need, scriptName });
+	if (plan.source === 'error') throw new PrInputError(plan.message);
+
+	if (plan.source === 'gh') {
+		let raw;
+		try {
+			raw = ghView(plan.prNumber);
+		} catch (err) {
+			throw new PrInputError(
+				`gh pr view ${plan.prNumber} に失敗しました: ${err instanceof Error ? err.message : String(err)}\n` +
+					`gh 未認証 / オフライン / PR 番号違いの可能性があります。取得できない入力を「検査対象なし」に倒しません (#4348)。`,
+			);
+		}
+		const parsed = parseGhPrView(raw);
+		if (need === 'body' && parsed.body.trim() === '') {
+			throw new PrInputError(
+				`PR #${plan.prNumber} の body が空です。検査対象が無い状態で成功終了させません (#4348 / #4084)。`,
+			);
+		}
+		return {
+			source: 'gh',
+			prNumber: plan.prNumber,
+			body: parsed.body,
+			labels: parsed.labels,
+			files: parsed.files,
+			repo: `${parsed.owner}/${parsed.repo}`,
+		};
+	}
+
+	return {
+		source: 'env',
+		prNumber: plan.prNumber,
+		body: env.PR_BODY ?? '',
+		labels: (env.PR_LABELS ?? '')
+			.split(',')
+			.map((s) => s.trim())
+			.filter(Boolean),
+		files: (env.PR_FILES ?? '')
+			.split('\n')
+			.map((s) => s.trim())
+			.filter(Boolean),
+		repo: env.GITHUB_REPOSITORY ?? '',
+	};
+}
+
+/**
+ * `--help` 指定かどうか。
+ *
+ * help は「検査結果」ではなく使い方の要求なので exit 0 で返してよい。ただし
+ * OK / PASS の語を出さないこと (help を検査 pass と読み違えさせない)。
+ *
+ * @param {string[]} argv
+ * @returns {boolean}
+ */
+export function isHelpRequested(argv) {
+	return argv.includes('--help') || argv.includes('-h');
+}

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -294,6 +294,7 @@ export const PRE_READY_GATE_SSOT_PATHS = /** @type {const} */ ([
 	'scripts/pr-template-gate-checks.mjs',
 	'scripts/lib/is-main.mjs',
 	'scripts/lib/ci/pr-body-sections.mjs',
+	'scripts/lib/ci/pr-input.mjs',
 	'scripts/lib/ci/reason-declaration.mjs',
 	'scripts/lib/ci/resolve-base-branch.mjs',
 	'scripts/lib/ci/tz-invariance-cases.mjs',

--- a/tests/unit/architecture/pr-body-partial-match-guard.test.ts
+++ b/tests/unit/architecture/pr-body-partial-match-guard.test.ts
@@ -121,6 +121,97 @@ function collectOccurrences(): Occurrence[] {
 	return out;
 }
 
+// ---------------------------------------------------------------------------
+// #4348 対象 #7: 「入力ゼロのまま skip / pass に倒れる」形を止める guard
+//
+// 判定ロジック (上の guard) を厳しくしても、**入力が届いていない**まま実行されれば
+// gate は何も検査せず成功終了する。実測 (2026-08-12): SS 系 3 本が argv を読まず、
+// `--pr <N>` を付けた誤用が空入力の検査になって exit 0 していた (#4513 の 404 SS を見逃した)。
+// 入力解決は scripts/lib/ci/pr-input.mjs (SSOT) に集約し、env 直読みを増やさせない。
+// ---------------------------------------------------------------------------
+
+/** PR 入力を env から直読みしている形 (コメント行は除外して検出する)。 */
+const ENV_INPUT_RE = /process\.env\.(?:PR_BODY|PR_NUMBER)\b/;
+
+/** 入力解決 SSOT の import (これがあれば env 直読みでも解決経路を通っている)。 */
+const PR_INPUT_IMPORT_RE = /from\s+'\.(?:\/lib)?\/(?:lib\/)?ci\/pr-input\.mjs'/;
+
+/**
+ * env 直読みのまま残す script。値は **なぜ本 PR で是正しないか**。
+ *
+ * #4348 の「やらないこと」に従い、箇所ごとに実測してから移行する。本 PR の scope は
+ * SS 系 gate 3 本 (check-ss-blob-sha-uniqueness / check-pr-screenshot / check-ss-render-health)。
+ */
+const ENV_INPUT_ALLOWLIST: Record<string, string> = {
+	'scripts/check-ac-verification-map.mjs':
+		'#4348 scope 外: 本 PR は SS 系 gate 3 本の入力層のみ是正した。全 feature PR に波及するため箇所ごとに corpus 実測してから pr-input.mjs へ移行する',
+	'scripts/check-cdk-replacement.mjs':
+		'#4348 scope 外: deploy 経路の gate で PR body は補助入力。移行時に deploy lane の実測が要るため別 PR で扱う',
+	'scripts/check-merge-gate-checklist.mjs':
+		'#4348 scope 外: 統合 lane の gate。#4357 で判定側を是正済のため入力層は別 PR で続けて移行する',
+	'scripts/check-new-required-env.mjs':
+		'#4348 scope 外: env 配布証跡 gate。本 PR の SS 系 3 本と実行経路が異なるため別 PR で移行する',
+	'scripts/check-pr-file-overlap.mjs':
+		'#4348 scope 外: PR_NUMBER を使う並行 PR 検査。CI 専用経路で手元実行の誤用報告が無いため別 PR で移行する',
+	'scripts/check-schema-change-tests.mjs':
+		'#4348 scope 外: schema 変更 lane の gate。別 PR で移行する',
+	'scripts/check-schema-migration-completeness.mjs':
+		'#4348 scope 外: schema 変更 lane の gate。同上',
+};
+
+describe('#4348 fitness: PR 入力を env から直読みする gate を増やさない', () => {
+	const offenders = walkMjs(SCAN_DIR, [])
+		.map((file) => ({ file, rel: relative(REPO_ROOT, file).replace(/\\/g, '/') }))
+		.filter(({ file }) => {
+			const src = readFileSync(file, 'utf8');
+			const hit = src.split('\n').some((line) => !isCommentLine(line) && ENV_INPUT_RE.test(line));
+			return hit && !PR_INPUT_IMPORT_RE.test(src);
+		})
+		.map(({ rel }) => rel);
+
+	it('検出器が機能している (0 件なら regex が壊れている)', () => {
+		expect(offenders.length).toBeGreaterThan(0);
+	});
+
+	it('ALLOWLIST 外の env 直読みが存在しない', () => {
+		const unknown = offenders.filter((f) => !(f in ENV_INPUT_ALLOWLIST));
+		expect(
+			unknown,
+			[
+				'PR 入力を env から直読みする gate を検出しました (#4348 対象 #7)。',
+				'',
+				'argv を読まない gate は `--pr <N>` を黙殺し、空入力を検査して成功終了します。',
+				'scripts/lib/ci/pr-input.mjs の resolvePrInput() を使ってください',
+				'(入力ゼロ / 取得失敗は PrInputError で非 0 終了し、skip / pass に倒れません)。',
+				'',
+				...unknown,
+			].join('\n'),
+		).toEqual([]);
+	});
+
+	it('ALLOWLIST に stale なエントリがない', () => {
+		const stale = Object.keys(ENV_INPUT_ALLOWLIST).filter((f) => !offenders.includes(f));
+		expect(
+			stale,
+			`是正済みなのに許可が残っています。該当行を削除してください:\n${stale.join('\n')}`,
+		).toEqual([]);
+	});
+
+	it('SS 系 gate 3 本は入力解決 SSOT を経由している', () => {
+		for (const rel of [
+			'scripts/check-ss-blob-sha-uniqueness.mjs',
+			'scripts/check-pr-screenshot.mjs',
+			'scripts/check-ss-render-health.mjs',
+		]) {
+			const src = readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+			expect(PR_INPUT_IMPORT_RE.test(src), `${rel} が pr-input.mjs を import していません`).toBe(
+				true,
+			);
+			expect(ENV_INPUT_RE.test(src), `${rel} に env 直読みが残っています`).toBe(false);
+		}
+	});
+});
+
 describe('#4348 fitness: PR body を部分一致で判定する新規コードを増やさない', () => {
 	const occurrences = collectOccurrences();
 

--- a/tests/unit/scripts/pr-input.test.ts
+++ b/tests/unit/scripts/pr-input.test.ts
@@ -1,0 +1,247 @@
+/**
+ * tests/unit/scripts/pr-input.test.ts (#4348 対象 #7)
+ *
+ * 検証対象: PR を入力に取る gate が **入力ゼロのまま成功終了しない**こと。
+ *
+ * 実測 (2026-08-12、PR #4513 / #4515):
+ *   $ node scripts/check-ss-blob-sha-uniqueness.mjs --pr 4513
+ *   [ss-blob-sha-uniqueness] SKIP — PR body に ... 参照が見つかりません     ← exit 0
+ *   $ node scripts/check-pr-screenshot.mjs --pr 4515
+ *   [screenshot-check] UI 関連ファイル変更なし — スキップ                   ← exit 0
+ *   $ node scripts/check-ss-render-health.mjs --pr 4513
+ *   [ss-render-health] SKIP — PR_NUMBER 未指定 (PR コンテキスト外)          ← exit 0
+ *
+ * 3 本とも argv を一切パースせず env からしか入力を読まないため、`--pr` を付けた誤用が
+ * **空文字列を検査して成功終了**していた。PR #4513 は body の SS URL が 404 していたが、
+ * この偽 SKIP でローカルは緑になり、CI で初めて hard error として露見した。
+ *
+ * 本 test は「実行できて、何も検査せず、成功終了する」を不可能にする不変条件を固定する。
+ * 判定ロジック層 (#4348 の対象一覧 6 箇所) は本 test の対象ではない。
+ */
+
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+	formatPrInputUsage,
+	PrInputError,
+	parseGhPrView,
+	parsePrNumberArg,
+	planPrInput,
+	resolvePrInput,
+} from '../../../scripts/lib/ci/pr-input.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** 入力ゼロで実行しても成功終了してはいけない gate 群 (#4348 対象 #7 + 兄弟 2 本)。 */
+const INPUT_ZERO_GATES = [
+	'scripts/check-ss-blob-sha-uniqueness.mjs',
+	'scripts/check-pr-screenshot.mjs',
+	'scripts/check-ss-render-health.mjs',
+] as const;
+
+/** 子プロセスで gate を起動し exit code と出力を返す (throw しない)。 */
+function runGate(script: string, args: string[]): { status: number; output: string } {
+	// PR 由来 env を明示的に落とす (CI 上で PR_BODY 等が入っていても「入力ゼロ」を再現する)
+	const env = { ...process.env };
+	for (const k of ['PR_BODY', 'PR_NUMBER', 'PR_LABELS', 'PR_FILES', 'GITHUB_REPOSITORY']) {
+		delete env[k];
+	}
+	try {
+		const out = execFileSync(process.execPath, [resolve(REPO_ROOT, script), ...args], {
+			cwd: REPO_ROOT,
+			encoding: 'utf-8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+			timeout: 60_000,
+			env,
+		});
+		return { status: 0, output: out };
+	} catch (e) {
+		const err = e as { status?: number; stdout?: string; stderr?: string };
+		return { status: err.status ?? 1, output: `${err.stdout ?? ''}\n${err.stderr ?? ''}` };
+	}
+}
+
+describe('入力ゼロで成功終了しない (CLI 不変条件、#4348)', () => {
+	for (const script of INPUT_ZERO_GATES) {
+		it(`${script}: 引数も env も無ければ非 0 で終了する`, () => {
+			const { status, output } = runGate(script, []);
+			expect(status).not.toBe(0);
+			expect(output).toContain('INPUT ERROR');
+		});
+
+		it(`${script}: --pr の値が PR 番号でなければ非 0 で終了する`, () => {
+			const { status, output } = runGate(script, ['--pr', 'abc']);
+			expect(status).not.toBe(0);
+			expect(output).toContain('INPUT ERROR');
+		});
+
+		it(`${script}: --pr の値が欠落していれば非 0 で終了する (次の引数を食わない)`, () => {
+			const { status } = runGate(script, ['--pr']);
+			expect(status).not.toBe(0);
+		});
+	}
+});
+
+describe('parsePrNumberArg', () => {
+	it('--pr <N> / --pr=<N> / -p <N> を読む', () => {
+		expect(parsePrNumberArg(['--pr', '4513'])).toEqual({
+			present: true,
+			value: '4513',
+			raw: '4513',
+		});
+		expect(parsePrNumberArg(['--pr=4513']).value).toBe('4513');
+		expect(parsePrNumberArg(['-p', '4513']).value).toBe('4513');
+	});
+
+	it('「渡した事実」と「妥当な値」を分ける (誤用を env fallback に落とさない)', () => {
+		// 値が無い / 数字でない場合でも present=true。これが false になると
+		// 「--pr を書いたのに env の空 body を検査する」旧挙動に戻る。
+		expect(parsePrNumberArg(['--pr'])).toEqual({ present: true, value: null, raw: '' });
+		expect(parsePrNumberArg(['--pr', '--verbose'])).toEqual({
+			present: true,
+			value: null,
+			raw: '',
+		});
+		expect(parsePrNumberArg(['--pr', 'abc'])).toEqual({ present: true, value: null, raw: 'abc' });
+	});
+
+	it('--pr が無ければ present=false', () => {
+		expect(parsePrNumberArg([])).toEqual({ present: false, value: null, raw: '' });
+		expect(parsePrNumberArg(['--help']).present).toBe(false);
+	});
+});
+
+describe('planPrInput', () => {
+	it('--pr <N> があれば gh 経由で引く', () => {
+		expect(planPrInput({ argv: ['--pr', '4513'], env: {} })).toEqual({
+			source: 'gh',
+			prNumber: '4513',
+		});
+	});
+
+	it('--pr があっても env PR_BODY で代替しない (誤用を黙って通さない)', () => {
+		const plan = planPrInput({ argv: ['--pr', 'abc'], env: { PR_BODY: 'x'.repeat(50) } });
+		expect(plan.source).toBe('error');
+	});
+
+	it('argv 無し + env PR_BODY 実体あり = 既存 CI 経路は不変', () => {
+		expect(planPrInput({ argv: [], env: { PR_BODY: '## 概要\n本文' } })).toEqual({
+			source: 'env',
+			prNumber: null,
+		});
+	});
+
+	it('env PR_BODY が空 / 空白のみなら error (これが本 Issue の現象)', () => {
+		expect(planPrInput({ argv: [], env: {} }).source).toBe('error');
+		expect(planPrInput({ argv: [], env: { PR_BODY: '   \n' } }).source).toBe('error');
+	});
+
+	it('need=prNumber は PR_NUMBER を見る (check-ss-render-health)', () => {
+		expect(planPrInput({ argv: [], env: { PR_NUMBER: '4513' }, need: 'prNumber' })).toEqual({
+			source: 'env',
+			prNumber: '4513',
+		});
+		expect(planPrInput({ argv: [], env: { PR_BODY: 'x' }, need: 'prNumber' }).source).toBe('error');
+	});
+
+	it('error メッセージは入力の渡し方 2 通りを案内する', () => {
+		const plan = planPrInput({ argv: [], env: {}, scriptName: 'scripts/foo.mjs' });
+		expect(plan.source).toBe('error');
+		if (plan.source !== 'error') return;
+		expect(plan.message).toContain('--pr <N>');
+		expect(plan.message).toContain('PR_BODY=');
+	});
+});
+
+describe('parseGhPrView', () => {
+	const raw = JSON.stringify({
+		body: '## 概要\n本文',
+		labels: [{ name: 'type:fix' }, { name: 'priority:high' }],
+		files: [{ path: 'scripts/a.mjs' }, { path: 'src/b.svelte' }],
+		url: 'https://github.com/Takenori-Kusaka/ganbari-quest/pull/4513',
+	});
+
+	it('body / labels / files / owner / repo を取り出す', () => {
+		expect(parseGhPrView(raw)).toEqual({
+			body: '## 概要\n本文',
+			labels: ['type:fix', 'priority:high'],
+			files: ['scripts/a.mjs', 'src/b.svelte'],
+			owner: 'Takenori-Kusaka',
+			repo: 'ganbari-quest',
+		});
+	});
+
+	it('url が取れない出力は実在確認できないので throw する', () => {
+		// gh の単一フィールド --json は存在しない PR でも値を返すことがあるため、
+		// url を実在確認に使う (memory: gh-single-field-json-fabricates)。
+		expect(() => parseGhPrView(JSON.stringify({ body: 'x' }))).toThrow(PrInputError);
+		expect(() => parseGhPrView('not json')).toThrow(PrInputError);
+	});
+});
+
+describe('resolvePrInput', () => {
+	const ghView = () =>
+		JSON.stringify({
+			body: '## 概要\n本文',
+			labels: [{ name: 'type:fix' }],
+			files: [{ path: 'src/b.svelte' }],
+			url: 'https://github.com/Takenori-Kusaka/ganbari-quest/pull/4513',
+		});
+
+	it('--pr 指定で body / labels / files / repo が揃う', () => {
+		const input = resolvePrInput({ argv: ['--pr', '4513'], env: {}, ghView });
+		expect(input.source).toBe('gh');
+		expect(input.body).toContain('本文');
+		expect(input.labels).toEqual(['type:fix']);
+		expect(input.files).toEqual(['src/b.svelte']);
+		expect(input.repo).toBe('Takenori-Kusaka/ganbari-quest');
+	});
+
+	it('gh 取得に失敗しても「対象なし」に倒さず throw する', () => {
+		expect(() =>
+			resolvePrInput({
+				argv: ['--pr', '4513'],
+				env: {},
+				ghView: () => {
+					throw new Error('gh: not authenticated');
+				},
+			}),
+		).toThrow(PrInputError);
+	});
+
+	it('取得できた body が空なら throw する (検査対象ゼロで成功終了させない)', () => {
+		expect(() =>
+			resolvePrInput({
+				argv: ['--pr', '4513'],
+				env: {},
+				ghView: () =>
+					JSON.stringify({
+						body: '',
+						labels: [],
+						files: [],
+						url: 'https://github.com/Takenori-Kusaka/ganbari-quest/pull/4513',
+					}),
+			}),
+		).toThrow(PrInputError);
+	});
+
+	it('env 経路は従来どおり labels / files を分解する', () => {
+		const input = resolvePrInput({
+			argv: [],
+			env: { PR_BODY: '本文', PR_LABELS: 'a, b', PR_FILES: 'x.svelte\ny.ts' },
+			ghView,
+		});
+		expect(input.source).toBe('env');
+		expect(input.labels).toEqual(['a', 'b']);
+		expect(input.files).toEqual(['x.svelte', 'y.ts']);
+	});
+});
+
+describe('formatPrInputUsage', () => {
+	it('need に応じて env の渡し方を出し分ける', () => {
+		expect(formatPrInputUsage('scripts/foo.mjs', 'body')).toContain('PR_BODY=');
+		expect(formatPrInputUsage('scripts/foo.mjs', 'prNumber')).toContain('PR_NUMBER=');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

SS 系 gate を手元で回した開発者が「緑だった」と信じて Ready 化したのに CI で落ちる、という手戻りを無くす。実測 (PR #4513) では PR body の SS URL が 404 していたのに、手元の `--pr 4513` 実行は空入力を検査して `SKIP` = exit 0 を返し、CI で初めて hard error として露見した。gate が「検査できなかった」ことを黙るのをやめる。

## 関連 Issue

<!-- no-issue-close: #4348 は 6 箇所の残件を追跡する Issue で、本 PR はそのうち入力層 (7 箇所目) だけを是正するため閉じない -->
Refs #4348 (7 箇所目 — 入力層)

## 変更内容

`scripts/check-ss-blob-sha-uniqueness.mjs` は PR body を `process.env.PR_BODY` からしか読まず、**argv を一切パースしていなかった**。兄弟 script (`check-pr-body.mjs` / `capture.mjs`) が揃って `--pr <N>` を取り、しかも本 script 自身の案内文 (470 行目) が `--pr <N>` 形式を提示するため、`--pr` を付けて呼ぶのは自然な誤用である。結果、**空文字列を検査して成功終了**していた。

同じ入力欠陥を SS gate ファミリーの兄弟 2 本も持っていたので同 PR で是正した (同一の欠陥であり、1 本ずつ直す形は #4348 が「3 回失敗した」と記録している):

| script | 旧: `--pr <N>` で呼んだときの挙動 |
|---|---|
| `check-ss-blob-sha-uniqueness.mjs` | `SKIP — PR body に ... 参照が見つかりません` (exit 0) |
| `check-pr-screenshot.mjs` | `PR_FILES` 空 → `isUiPr()` false → `UI 関連ファイル変更なし — スキップ` (exit 0) |
| `check-ss-render-health.mjs` | `PR_NUMBER` 未設定 → `SKIP — PR コンテキスト外` (exit 0) |

**採った選択肢は (a) `--pr <N>` の実装** (報告するだけの (b) ではなく)。理由: ① 兄弟 script が全て `--pr` を取るので、誤用を「エラーで教える」より「そのまま動く」方が導線として正しい ② `--pr` があれば入力ゼロという状態自体が起こらず、footgun を報告ではなく除去できる ③ 再利用できる body 取得 helper は**存在しなかった** (`check-pr-body.mjs` 内の module-private な `fetchPrBody` / `fetchPrLabels` のみ) ため、共有 SSOT を新設して 3 本が同じ経路を通るようにした。

- **新規** `scripts/lib/ci/pr-input.mjs` (入力解決 SSOT。新規 `check-*.mjs` は増やしていない — #4348 の「やらないこと」準拠)
  - `--pr <N>` / `--pr=<N>` / `-p <N>` を解釈し `gh pr view <N> --json body,labels,files,url` で取得。`--jq` は使わない (#3962 Windows)。`url` から owner/repo を取れることを **PR 実在確認**に使う (単一フィールド `--json` は存在しない PR でも値を返すため)
  - 不変条件: **入力ゼロ / `--pr` の値が PR 番号でない / gh 取得失敗 / 取得できた body が空 → `PrInputError` → exit 2**。skip / pass に倒す経路を残していない
  - 例外宣言機構は増やしていない (`reason-declaration.mjs` の既存 SSOT に手を入れる必要が無かった)
- 3 script の entry を入力解決経由に変更 (判定関数の中身は不変)。`--help` を追加 (OK / PASS の語を出さず「検査は実行していません」と明示)
- `.github/workflows/pr-quality-gate.yml` の sparse-checkout 4 箇所に `scripts/lib/ci/pr-input.mjs` を追加 (無いと CI で import 解決に失敗する)
- `scripts/pre-ready.mjs` の `PRE_READY_GATE_SSOT_PATHS` に同 file を追加 (import 閉包の両方向照合 test [B13] に整合)
- fitness function 追加 (`tests/unit/architecture/pr-body-partial-match-guard.test.ts`、#4348 AC6 の同 class 拡張): `scripts/**` が `process.env.PR_BODY` / `PR_NUMBER` を直読みしていたら、`pr-input.mjs` を import しているか ALLOWLIST に理由付き登録されているかを要求する。ALLOWLIST の stale も落とす

### この PR の境界 (なぜ #4348 の表 6 箇所を直さないか)

本 PR が触るのは「**入力が届いているか**」の層であり、「**届いた入力をどう判定するか**」の層 (#4348 の対象一覧 #1〜#6) ではない。判定層は同 Issue の「やらないこと」が 1 箇所ずつの corpus 実測を要求しているため別 PR の領分で、`check-pr-screenshot.mjs` の `hasDomSnapshotReference` / `hasIntegrationVrEvidence` (表の #4) は**同じファイルにありながら意図的に未変更**である。

関連して、調査中に判明した事実を #4348 にコメントとして記録した (表 #4 の実装者が同じ調査を繰り返さないため): `check-pr-screenshot.mjs` の DOM スナップショット違反メッセージは回避手段があるかのように読めるが、`hasDomSnapshotReference` はリテラルな `.dom.html` URL しか受け付けず、案内されている逃げ道が実在しない。**別 PR 送り**。

## 検証

### 両方の経路を実際に動かした

```console
# 修正前 (実測、#4348 のコメントに記録済み)
$ node scripts/check-ss-blob-sha-uniqueness.mjs --pr 4513
[ss-blob-sha-uniqueness] SKIP — PR body に raw.githubusercontent.com/.../screenshots/... 参照が見つかりません   ← exit 0

# 修正後: --pr が実際に PR を引く
$ node scripts/check-ss-blob-sha-uniqueness.mjs --pr 4513
[ss-blob-sha-uniqueness] OK — 1 ペアすべて Blob SHA が異なる (偽装なし)                                        ← exit 0
$ node scripts/check-pr-screenshot.mjs --pr 4513
[screenshot-check] WARN (dom-snapshot-missing, #1766 / #1747 AC4): ...                                        ← 実際の違反を検出
$ node scripts/check-ss-render-health.mjs --pr 4513
[ss-render-health] WARN — 2 件の画像に対応する .dom.html がありません ...

# 修正後: 入力ゼロ / 不正入力は成功終了しない (3 本とも同じ)
$ node scripts/check-ss-blob-sha-uniqueness.mjs            ; echo $?
[ss-blob-sha-uniqueness] INPUT ERROR — 検査対象の PR 入力がありません (PR_BODY 未設定 / 空、かつ --pr 未指定)。
入力ゼロのまま SKIP すると「何も検査していないのに緑」になるため、実行を失敗させます (#4348 / #4084)。
2
$ node scripts/check-ss-blob-sha-uniqueness.mjs --pr abc   ; echo $?
[ss-blob-sha-uniqueness] INPUT ERROR — --pr の値が PR 番号ではありません (受領: "abc")。
2
```

### テスト

- `npx vitest run tests/unit/scripts/` → **52 files / 1174 passed | 1 skipped** (既存の SS 系 test 3 本を含めて回帰なし)
- 新規 `tests/unit/scripts/pr-input.test.ts` (25 件)。3 script を**子プロセスで実起動**して exit code を assert する (関数単体ではなく CLI の不変条件を固定する)
- `npx biome check .` → **エラー 0**

### mutation 実測 (実装 commit 79cd5ae1 を先に確定させてから破壊 → 復元)

| # | 壊した箇所 | 期待 | 実測 |
|---|---|---|---|
| 1 | `planPrInput` の入力ゼロ → `{ source: 'env' }` (旧挙動に戻す) | 赤 | **5 failed / 28 passed** (`引数も env も無ければ非 0 で終了する` ×2、`env PR_BODY が空 / 空白のみなら error` 他) |
| 2 | `parsePrNumberArg` の値欠落を `present: false` (誤用を env fallback に落とす) | 赤 | **1 failed / 24 passed** (`「渡した事実」と「妥当な値」を分ける`) |
| 3 | `check-ss-blob-sha-uniqueness.mjs` を `process.env.PR_BODY` 直読みに戻す | 赤 | **4 failed / 29 passed** (CLI 3 件 + fitness `SS 系 gate 3 本は入力解決 SSOT を経由している`) |

復元後: `git status --short` に実装 file の差分なし (`git diff --stat -- scripts tests .github` が空)、両 test file 33 passed。※ 破壊は commit 後にのみ行い、退避は `cp` バックアップからの復元で行った (`git checkout --` は使っていない)。

### corpus 実測 (#4348 AC4 — 一斉赤化しないことの確認)

直近 merged 15 PR (`gh pr list --state merged --limit 15 --json number,body,labels,files`) × gate 3 本 = **45 判定**を、**同一入力**で旧 (`HEAD~1` を `git archive` で取り出したもの) と新で比較:

- **判定が変化した組み合わせ: 0 / 45**。既存の CI 経路 (env で渡す) の挙動は完全に不変
- 同じ 15 PR を `--pr <N>` で回した結果も 45/45 で env 経路と同一 verdict。1 件だけ exit code が違うのは `CHECK_MODE` を env 実行側にだけ渡した計測ハーネスの差 (#4465 は `error` → exit 1 / 既定 `warn` → exit 0 で、**verdict 文言は同一**)
- 旧新ともに exit 2 になった 5 件は `GitHub API ... 403 rate limit exceeded` (ローカル無認証実行の制約)。**旧実装でも同じく 2** なので本変更に起因しない

「新たに落ちるようになった正当な PR」は 0 件のため、受容宣言の逃げ道は追加していない。

## 影響範囲

- **顧客に見える変化: なし** (CI / 開発者向け gate のみ)
- 破壊的変更: なし。CI の既存経路 (env 渡し) は corpus 45/45 で判定不変。**新たに非 0 になるのは「入力を渡さずに実行した」場合だけ**で、それは今まで嘘の緑を返していたケース
- 触った並行実装ペア: SS gate ファミリー 3 本 + `pr-quality-gate.yml` の sparse-checkout (import 閉包) + `pre-ready.mjs` の gate SSOT 一覧 (test [B13] が両方向照合)
- #4348 の残 6 箇所は未着手 (同 Issue の「やらないこと」に従い 1 箇所ずつ corpus 実測して別 PR で消化)

該当なし（refactor / docs / chore） — UI 変更なしのため SS 添付は対象外です。変更は `scripts/` / `tests/` / `.github/workflows/` のみで、顧客に見える描画は 1 px も変わりません。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
