### PR TITLE
docs(ai): #4367 agreementAvailability を稼働判定に使わせない注記を Bedrock provider に置く

### DIFF
--- a/src/lib/server/ai/bedrock-claude-provider.ts
+++ b/src/lib/server/ai/bedrock-claude-provider.ts
@@ -31,6 +31,13 @@ import type { AiProvider, ToolDefinition, ToolUseResult } from './provider';
  * モデル選定 (Haiku 系 latest = 最安最適) は変えない。変えたのは profile → base model の形式のみ。
  * IAM 側の Resource ARN (`infra/lib/compute-stack.ts` の `BEDROCK_MODEL_ARN`) と対で動くため、
  * 片方だけ変えると権限が外れて `AccessDeniedException` になる。
+ *
+ * **稼働判定は実呼び出しのみ。`agreementAvailability` は誤判定実績あり** (#4367)。
+ * `aws bedrock get-foundation-model-availability` の `agreementAvailability` は、同じ model ID /
+ * region で Converse が実際に成功する状態でも `NOT_AVAILABLE` を返した。モデルを呼べるかどうかを
+ * 表していない指標なので、これや infra の grep・env 一覧といった静的根拠だけで「Bedrock が未有効化 /
+ * 不作動」と結論づけてはならない (この形の診断は 7 回連続で誤検出だった)。稼働を主張・否定する側が
+ * 同日の実 Converse 呼び出しか本番ログを添えること。
  */
 const DEFAULT_MODEL_ID = 'anthropic.claude-haiku-4-5-20251001-v1:0';
 


### PR DESCRIPTION
## 顧客価値・目的

「Bedrock が有効化されていない / AI が動いていない」という誤診断が 7 回連続で発生し、そのたびにオーナーの手番として上げられ、実際には毎回 Bedrock は稼働していた。次の読み手が最初に開く provider 実装に「その根拠は使えない」と書いておくことで、8 回目の誤診断とそれに伴うオーナーの時間の空費を止める。

## 関連 Issue

Refs #4367

<!-- no-issue-close: #4367 は AC5 (本番 /admin での AI 提案 1 回成功の実機確認) が未達のため閉じられない。本 PR は同 Issue の PO 依頼 3 のうちコメント追記のみを担う -->

## 変更内容

`src/lib/server/ai/bedrock-claude-provider.ts` の `DEFAULT_MODEL_ID` の JSDoc に段落を 1 つ追加した。コメントのみで実行されるコードの変更はない。

内容は #4367 の PO 決裁 (2026-08-12) の 3 番目の依頼そのもので、次の 3 点を記す:

- `aws bedrock get-foundation-model-availability` の `agreementAvailability` は、同じ model ID / region で Converse が実際に成功する状態でも `NOT_AVAILABLE` を返した (#4367 thread の 2026-08-07 実測)
- したがってこの指標や infra の grep・env 一覧といった静的根拠**だけ**で「Bedrock が未有効化 / 不作動」と結論づけてはならない (この形の診断は 7 回連続で誤検出だった)
- 稼働を主張・否定する側が、同日の実 Converse 呼び出しか本番ログを添えること

「使うな」だけでなく**なぜ当てにならないか**を書いたのは、根拠を省くと次の読み手が同じ推論を再構成してしまうため。

## 検証

| 検査 | コマンド | 結果 |
|---|---|---|
| コメント位置 | `grep -n "agreementAvailability" src/lib/server/ai/bedrock-claude-provider.ts` | `DEFAULT_MODEL_ID` (L35) の直前 JSDoc 内 |
| 実行コードの差分 | `git diff origin/develop -- src/lib/server/ai/bedrock-claude-provider.ts` | 追加 6 行すべてが `*` 始まりの JSDoc 行 |

pre-ready の結果は本 body の下部に Ready 化時点で追記する。

**AC5 は本 PR では実施していない (未実行)**。理由は下記「影響範囲」に記す。

## 影響範囲

- 顧客に見える変化: **なし** (コメントのみ)
- 触った並行実装ペア: なし
- 破壊的変更: なし
- 該当なし（refactor / docs / chore）— UI ファイル (`*.svelte` / `*.css` / `site/`) を 1 つも触っていないため、スクリーンショットの対象になる画面が存在しない

### #4367 の AC5 は本 PR の範囲外 (Dev から実施できない)

AC5 =「本番 `/admin` で AI 提案が 1 回成功することの実機確認」は、本ワークスペースからは実行できない。判断の根拠:

- `aws sts get-caller-identity` → `Your session has expired.` (AWS 資格情報なし)。実 Converse 呼び出しも CloudWatch ログ確認もできない
- 本番の親アカウントの資格情報がこの環境に配備されていない。`DEV_USERS` (`src/lib/server/auth/providers/cognito-dev.ts`) は `COGNITO_DEV_MODE` 前提のローカル専用定義で、本番にも staging にも存在しない (`docs/runbooks/staging-live-verification.md` §5)
- AI 提案の起動は書き込み操作であり、`.claude/skills/live-ui-verification/SKILL.md` の絶対原則 1「本番で不可逆操作をしない」に抵触する

推測で「たぶん動いている」と書くことは、本 Issue が止めようとしている失敗そのもの (7 回の誤診断はいずれも本番を測らず本番について推論した結果) なので行わない。AC5 はオーナー (本番アクセスを持つ主体) の手番として #4367 に残す。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
