### PR TITLE
fix(dx): #4536 graphify-out の per-commit 再生成を develop/main 限定にし、並行 PR の機械的 conflict を解消する

### DIFF
--- a/.github/workflows/graphify-refresh.yml
+++ b/.github/workflows/graphify-refresh.yml
@@ -1,0 +1,197 @@
+# graphify-refresh.yml — Issue #4536
+#
+# develop 上の graphify-out (`graph.json` 等) を push 契機で最新に保つ。
+#
+# 背景: `graphify-out/**` は git 追跡している (coldstart 解消、docs/CLAUDE.md §graphify)。
+# 以前は全 branch でコミットのたびに `.husky/post-commit` が再生成していたため、並行する
+# feature branch がそれぞれ独自の graphify-out を持ち、develop への merge のたびに
+# 残り全 PR が graphify-out だけで conflict していた (実測: PR #4514 merge 時、conflict は
+# graphify-out 3 file のみ)。
+#
+# 対策: `.husky/post-commit` は develop/main 以外での再生成を止めた (#4536)。develop 上の
+# 再生成は本 workflow が push 契機で担う。develop / main は branch ruleset で直接 push を
+# 拒否する (required review) ため、hotfix-back-merge.yml と同じ「bot が branch + PR を発行し
+# QM/lab が承認する」経路を使う (ADR-0022 準拠、admin bypass なし)。
+#
+# 無限 loop 防止: 本 workflow が発行した PR が merge されると graphify-out のみが変更された
+# push イベントが発生するが、`paths-ignore: graphify-out/**` が全変更ファイルそれを除外する
+# push を skip するため再トリガーしない。
+#
+# 設計原則:
+#   - 新しい CI check (hard-fail gate) は追加しない。既存の develop 軽量レーン gate に
+#     乗るだけの通常 PR (装置を増やさない、platform session 憲章 §3.4)。
+#   - 差分が無ければ PR を発行しない (無駄な PR を積まない)。
+#   - branch (`chore/graphify-refresh`) は upsert (再利用)。前回の未 merge PR があれば
+#     最新 develop 基点で作り直す (back-merge と同型、PR 積み上がり防止)。
+
+name: graphify-refresh
+
+on:
+  push:
+    branches: [develop]
+    paths-ignore:
+      - 'graphify-out/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: graphify-refresh-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  refresh:
+    name: graphify-out 再生成 + bot PR 発行
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v7
+        with:
+          ref: develop
+          # PR 発行は後段で App install トークンを使う。checkout は既定 token で十分。
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      # graphifyy (PyPI、graphify CLI の配布名) を install する。`update` は AST 抽出のみで
+      # LLM を呼ばない ("no LLM needed"、docs/decisions/README.md §OSS 採用記録) ため secret 不要。
+      - name: Install graphify (graphifyy on PyPI)
+        run: pip install graphifyy
+
+      - name: Regenerate knowledge graph
+        run: graphify update .
+
+      - name: Detect graphify-out diff
+        id: diff
+        run: |
+          set -euo pipefail
+          if git status --porcelain -- graphify-out | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git status --porcelain -- graphify-out
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "graphify-out に差分なし。PR は発行しない。"
+          fi
+
+      # ----------------------------------------------------------------------
+      # 差分がある場合のみ、bot PR を発行する (App 認証情報が無ければ drift を通知)
+      # ----------------------------------------------------------------------
+      - name: Verify GitHub App credentials presence
+        id: appcreds
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          APP_ID: ${{ secrets.INTEGRATION_BOT_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.INTEGRATION_BOT_APP_PRIVATE_KEY }}
+        run: |
+          if [ -n "${APP_ID:-}" ] && [ -n "${APP_PRIVATE_KEY:-}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GitHub App 認証情報 (INTEGRATION_BOT_APP_ID / INTEGRATION_BOT_APP_PRIVATE_KEY) 未設定。graphify-refresh PR を発行できない。develop の graphify-out が stale のまま残る (#4536)。"
+          fi
+
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.diff.outputs.changed == 'true' && steps.appcreds.outputs.present == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.INTEGRATION_BOT_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_BOT_APP_PRIVATE_KEY }}
+
+      - name: Resolve App bot identity (commit author)
+        id: bot-identity
+        if: steps.diff.outputs.changed == 'true' && steps.appcreds.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          USER_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          echo "name=${APP_SLUG}[bot]" >> "$GITHUB_OUTPUT"
+          echo "email=${USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
+      - name: Commit + push graphify-out (branch upsert)
+        id: push
+        if: steps.diff.outputs.changed == 'true' && steps.appcreds.outputs.present == 'true'
+        env:
+          GIT_AUTHOR_NAME: ${{ steps.bot-identity.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.bot-identity.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.bot-identity.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.bot-identity.outputs.email }}
+          BRANCH: chore/graphify-refresh
+        run: |
+          set -euo pipefail
+          DEVELOP_SHA=$(git rev-parse HEAD)
+          echo "develop_sha=${DEVELOP_SHA}" >> "$GITHUB_OUTPUT"
+          git switch -C "$BRANCH"
+          git add graphify-out
+          git commit -m "chore(graphify): regenerate knowledge graph (develop ${DEVELOP_SHA:0:7}, #4536)"
+          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" \
+            "$BRANCH" --force-with-lease || \
+          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" \
+            "$BRANCH" --force
+
+      - name: Upsert graphify-refresh PR
+        if: steps.diff.outputs.changed == 'true' && steps.appcreds.outputs.present == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: chore/graphify-refresh
+          DEVELOP_SHA: ${{ steps.push.outputs.develop_sha }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const { execFileSync } = require('node:child_process');
+            const { owner, repo } = context.repo;
+            const branch = process.env.BRANCH;
+            const sha = process.env.DEVELOP_SHA;
+
+            const title = 'chore(graphify): develop の knowledge graph を再生成 (#4536)';
+            const body = execFileSync(
+              'node',
+              ['scripts/graphify-refresh-pr-body.mjs', '--branch', branch, '--sha', sha],
+              { encoding: 'utf8' },
+            );
+
+            const existing = await github.rest.pulls.list({
+              owner, repo, state: 'open', head: `${owner}:${branch}`, base: 'develop',
+            });
+
+            let prNumber;
+            if (existing.data.length > 0) {
+              prNumber = existing.data[0].number;
+              await github.rest.pulls.update({ owner, repo, pull_number: prNumber, title, body });
+              core.info(`既存 graphify-refresh PR #${prNumber} を更新 (upsert)`);
+            } else {
+              const created = await github.rest.pulls.create({
+                owner, repo, title, body, head: branch, base: 'develop',
+              });
+              prNumber = created.data.number;
+              core.info(`graphify-refresh PR #${prNumber} を新規作成`);
+            }
+
+            try {
+              await github.rest.issues.addLabels({ owner, repo, issue_number: prNumber, labels: ['type:infra'] });
+            } catch (e) {
+              core.warning(`label 付与 skip: ${e.message}`);
+            }
+
+      - name: Drift summary (job summary)
+        if: always() && steps.diff.outputs.changed == 'true'
+        env:
+          CREDS_PRESENT: ${{ steps.appcreds.outputs.present }}
+        run: |
+          {
+            echo "### graphify-refresh (#4536)"
+            echo ""
+            if [ "${CREDS_PRESENT}" = "false" ]; then
+              echo "- 状態: ⚠️ GitHub App 認証未設定で PR 未発行 = **drift**。develop の graphify-out が stale。"
+            else
+              echo "- 状態: ✅ graphify-refresh PR を upsert 済 (QM/lab の承認待ち)。"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/graphify-refresh.yml
+++ b/.github/workflows/graphify-refresh.yml
@@ -60,8 +60,15 @@ jobs:
 
       # graphifyy (PyPI、graphify CLI の配布名) を install する。`update` は AST 抽出のみで
       # LLM を呼ばない ("no LLM needed"、docs/decisions/README.md §OSS 採用記録) ため secret 不要。
-      - name: Install graphify (graphifyy on PyPI)
-        run: pip install graphifyy
+      #
+      # version pin 必須 (QM 指摘、#4536): 本 job は同一 runner 内で pip install の直後に
+      # INTEGRATION_BOT_APP_PRIVATE_KEY から短命 install token を発行する (develop へ push 可能)。
+      # unpinned PyPI package が乗っ取られると、その token を奪う経路になる。0.9.32 は
+      # `graphify --help` / `graphify update .` の CLI surface を本 PR 作成時に実機確認済みの版。
+      # 更新する場合は新版で `graphify update .` の出力 (graph.json / manifest.json /
+      # GRAPH_REPORT.md) を手元で確認してから version 文字列だけを差し替える。
+      - name: Install graphify (graphifyy on PyPI, pinned)
+        run: pip install "graphifyy==0.9.32"
 
       - name: Regenerate knowledge graph
         run: graphify update .

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,7 +1,21 @@
 #!/usr/bin/env sh
 
-# Auto-rebuild Graphify AST/semantic graph on commit
-# (AST is completely free; Markdown is incrementally cached - zero/minimum token cost)
+# Auto-rebuild Graphify AST/semantic graph on commit — develop/main only (#4536)
+#
+# graphify-out/graph.json (27MB+) は git 追跡している (coldstart 解消、docs/CLAUDE.md §graphify)。
+# 以前は全 branch でコミットのたびに再生成していたため、並行する feature branch がそれぞれ
+# 独自の graphify-out を持ち、develop への merge のたびに残り全 PR が graphify-out だけで
+# conflict していた (実測: PR #4514 merge 時、conflict は graphify-out 3 file のみ)。
+#
+# feature branch では再生成しない。develop / main 上の再生成は push 契機の
+# .github/workflows/graphify-refresh.yml が担う (bot PR で develop に反映)。
+# 下の `graphify hook install` (scripts/prepare.mjs) が追記するブロックもこの exit で止まる。
+_GFY_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+case "$_GFY_BRANCH" in
+    develop|main) ;;
+    *) exit 0 ;;
+esac
+
 if command -v graphify >/dev/null 2>&1; then
     echo "Updating Graphify knowledge graph..."
     graphify update . || true

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -207,7 +207,9 @@ Issue 起票運用・依存 3 分割 / 工程 phase / admin bypass 等は [.gith
 ## graphify
 
 - **ナレッジグラフのSSOT**: `graphify-out/graph.json`、`graphify-out/GRAPH_REPORT.md`、`graphify-out/graph.html`。
-- **Git運用ベストプラクティス**: 
-  - コミット時に自動で `graphify --update --no-viz`（インクリメンタルビルド、AST解析はトークン消費0）が走り、グラフが自動更新されます（`.husky/post-commit` 実装）。
-  - `graphify-out/.*`（一時中間キャッシュファイル）は Git から除外されていますが、ナレッジグラフ成果物（`graph.json`, `GRAPH_REPORT.md`, `graph.html`）は Git 追跡され、チーム全体で常に最新の仕様が共有されます。
+- **Git運用ベストプラクティス（#4536、develop/main 限定に変更）**:
+  - **再生成は develop / main 上でのみ行う**。`.husky/post-commit` は現在の branch が `develop` / `main` の場合だけ `graphify update .`（インクリメンタルビルド、AST解析はトークン消費0）を実行する。feature branch では何もしない（早期 `exit 0`）
+  - 理由: 以前は全 branch でコミットのたびに再生成していたため、並行する feature branch がそれぞれ独自の graphify-out (`graph.json` 27MB+) を持ち、develop への merge のたびに残り全 PR が graphify-out だけで conflict していた（実測: PR #4514 merge 時、conflict は graphify-out 3 file のみ）。feature branch 側で再生成しないことで、PR の diff から graphify-out が消え conflict が原理的にゼロになる
+  - **develop 上の再生成は push 契機の `.github/workflows/graphify-refresh.yml` が担う**。develop / main は branch ruleset が直接 push を拒否するため、差分があれば bot (GitHub App) が `chore/graphify-refresh` branch + PR を発行し、QM/lab が承認・merge する（`hotfix-back-merge.yml` と同型、ADR-0022 準拠・admin bypass なし）。差分が無ければ PR は発行されない
+  - `graphify-out/.*`（一時中間キャッシュファイル）は Git から除外されていますが、ナレッジグラフ成果物（`graph.json`, `GRAPH_REPORT.md`, `graph.html`）は Git 追跡され、チーム全体で常に最新の仕様が共有されます（コールドスタート解消の意図は維持）
 - **探索クエリ**: AIセッション（Claude Code / Gemini 等）は、ドキュメントの矛盾・依存スキャンのため、自律的に `graphify query "<質問>"` を使用して探索・解説を行います。

--- a/scripts/graphify-refresh-pr-body.mjs
+++ b/scripts/graphify-refresh-pr-body.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+/**
+ * scripts/graphify-refresh-pr-body.mjs — Issue #4536
+ *
+ * graphify-out 定期再生成 PR (`.github/workflows/graphify-refresh.yml`) の PR body を
+ * **PR template gate 準拠形式**で生成する純粋関数 SSOT + 自己検証 CLI。
+ *
+ * ## 背景 (#4536)
+ *
+ * `graphify-out/**` (graph.json 等) は git 追跡している (coldstart 解消、docs/CLAUDE.md §graphify)。
+ * 以前は全 branch でコミットのたびに再生成していたため、並行する feature branch がそれぞれ
+ * 独自の graphify-out を持ち、develop への merge のたびに残り全 PR が graphify-out だけで
+ * conflict していた (実測: PR #4514 merge 時、conflict は graphify-out 3 file のみ)。
+ *
+ * 対策として `.husky/post-commit` は develop/main 以外での再生成を止め、develop 上の
+ * 再生成は本 workflow が push 契機で行い、bot PR として発行する (直接 push は branch
+ * ruleset の required review で拒否されるため、back-merge と同じ PR 経由フロー)。
+ *
+ * ## 責務分担 (back-merge-pr-body.mjs / integration-pr-body.mjs と同型)
+ *
+ *   - 本 file = graphify-refresh PR **本文の組み立て** (renderGraphifyRefreshPrBody、副作用なし) +
+ *     **生成時自己検証** (validateGraphifyRefreshPrBody — 既存 gate SSOT の検証関数を import して
+ *     生成 body に適用。検証 fail なら CLI が exit 1 = workflow を落とす。silent 不備を出さない、
+ *     ADR-0006 整合)。
+ *   - workflow (.github/workflows/graphify-refresh.yml) = 再生成 / 差分判定 / branch 操作 /
+ *     PR upsert (本 script は body 生成のみ担当)。
+ *
+ * Usage (workflow の Upsert step から呼ぶ):
+ *   node scripts/graphify-refresh-pr-body.mjs --branch chore/graphify-refresh --sha <develop HEAD sha>
+ *   → stdout に PR body 全文 (検証ログは stderr)
+ *
+ * exit: 0 = 生成 + 自己検証 PASS / 1 = 自己検証 FAIL (gate 違反 body を発行させない) / 2 = 引数不足
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { checkAcVerification } from './check-ac-verification-map.mjs';
+import { checkMergeGateChecklist } from './check-merge-gate-checklist.mjs';
+import {
+	checkEnvDistributionForHotfix,
+	checkSelfReviewEvidence,
+	detectMojibake,
+	extractRequiredSections,
+	findMissingSections,
+	scanForbiddenTerms,
+} from './check-pr-body.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
+import { CHECKS as TEMPLATE_GATE_CHECKS } from './pr-template-gate-checks.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+/** PR template (必須セクション見出しの SSOT 源泉、check-pr-body.mjs と同一参照)。 */
+export const TEMPLATE_PATH = join(repoRoot, '.github', 'PULL_REQUEST_TEMPLATE.md');
+/** 必須セクション SSOT JSON (#2060、pr-template-gate.yml section-presence が参照)。 */
+export const SECTIONS_SSOT_PATH = join(repoRoot, '.github', 'PR_TEMPLATE_SECTIONS.json');
+
+/**
+ * graphify-refresh PR に付与される label (workflow が付与、drift contract 不要のため 1 種のみ)。
+ * @type {readonly string[]}
+ */
+export const GRAPHIFY_REFRESH_LABELS = Object.freeze(['type:infra']);
+
+/**
+ * @typedef {object} GraphifyRefreshBodyInput
+ * @property {string} branch 再生成 branch 名 (例: 'chore/graphify-refresh')
+ * @property {string} sha 再生成起点にした develop HEAD の SHA
+ */
+
+/**
+ * graphify-refresh PR body 全文を生成する純粋関数。
+ *
+ * PR template の必須 7 セクション (`## ` 見出し完全一致) を備え、feature lane (base=develop) の
+ * 全 body gate — 必須セクション存在 / AC マップ / 禁止語 / closing keyword — を生成時点で満たす。
+ * 生成物のみの機械同期であり独自の close 対象 Issue を持たないため `<!-- no-issue-close -->` を使う。
+ *
+ * @param {GraphifyRefreshBodyInput} input
+ * @returns {string} PR body markdown 全文
+ */
+export function renderGraphifyRefreshPrBody({ branch, sha }) {
+	const sha7 = String(sha ?? '').slice(0, 7);
+
+	const acRows = [
+		'| AC1 | develop 上の graphify-out (graph.json 等) が develop HEAD のコード状態と一致する (coldstart 解消、docs/CLAUDE.md §graphify) | `graphify update .` の差分有無 | 差分がある場合のみ本 PR が発行される (差分 0 なら workflow は PR を発行しない) |',
+		'| AC2 | develop 軽量レーン gate (branch-strategy.md §4) を通過して merge される | 本 PR の required status checks (機械強制) | gate 通過は GitHub required checks が保証。merge 判断は QM/lab 責務 (ADR-0022) |',
+	];
+
+	return [
+		'## 顧客価値・目的',
+		'',
+		'**対象ユーザー**: 開発チーム (システム全体 — graphify ナレッジグラフを使う AI セッション全員)',
+		'',
+		'**解決する課題**: `graphify-out/**` は git 追跡しており、新しい clone / セッションがチェックアウト' +
+			'直後から構造を引ける (コールドスタート解消、docs/CLAUDE.md §graphify)。feature branch では' +
+			'再生成しなくなった (#4536) ため、develop 上の内容を最新に保つには本 PR のような定期反映が要る。',
+		'',
+		'**期待される効果**: develop の `graphify-out` が現在のコード状態と乖離しない。',
+		'',
+		'## 関連 Issue',
+		'',
+		'#4536 (feature branch 側の per-commit 再生成を止め、graphify-out 由来の並行 PR conflict を' +
+			'構造的に解消する機構導入) の一部として稼働する定期再生成。本 PR 自体は新規 Issue を close しない。',
+		'',
+		'<!-- no-issue-close: graphify-out の機械再生成であり、独自の close 対象 Issue を持たない (#4536) -->',
+		'',
+		'## 変更内容',
+		'',
+		`develop HEAD (\`${sha7}\`) を対象に \`graphify update .\` を実行し、差分があった \`graphify-out/graph.json\` / \`graphify-out/manifest.json\` / \`graphify-out/GRAPH_REPORT.md\` / \`graphify-out/graph.html\` を反映します。`,
+		'製品コード / テスト / 設計書の変更は含みません。',
+		'',
+		'## 検証',
+		'',
+		'`.github/workflows/graphify-refresh.yml` の `graphify-artifacts-parseable` 相当チェック' +
+			' (`tests/unit/architecture/graphify-artifacts-parseable.test.ts`) が通常の CI required check' +
+			' として本 PR にも適用されます。',
+		'本 PR の body 生成時に自己検証 (`node scripts/graphify-refresh-pr-body.mjs`) を実行し、PASS しています。',
+		'',
+		'## 影響範囲',
+		'',
+		'**影響を受ける画面・機能**: なし (`graphify-out/**` のみ、アプリ挙動に影響しない生成物)。',
+		'破壊的変更は含まれません。',
+		'',
+		'| AC | 検証観点 | 検証方法 | 結果 |',
+		'|---|---|---|---|',
+		...acRows,
+		'',
+		'## 配布済み env / secret (ADR-0006)',
+		'',
+		'- [x] N/A — 新規 env / secret の追加なし (機械生成のため)',
+		'',
+		'## QM レビュー結果',
+		'',
+		'<!-- QM が記入。フォーマット・必須手順は docs/sessions/qm-session.md「Tier 2 手順 5」を参照。 -->',
+		'',
+		'---',
+		'',
+		'- base: `develop` (軽量レーン、`pr-lane.mjs` rule 4 = feature)',
+		'- author: GitHub App ボット名義 (ADR-0022 Amendment 5、承認は人間/lab)',
+		`- 再生成 branch: \`${branch}\` (upsert、前回の未 merge PR があれば最新 develop 基点で作り直す)`,
+		`- 再生成起点: develop HEAD \`${sha7}\``,
+		'- 本 body は `.github/workflows/graphify-refresh.yml` が `scripts/graphify-refresh-pr-body.mjs` で自動生成 + 自己検証 (#4536)',
+	].join('\n');
+}
+
+/**
+ * @typedef {object} BodyViolation
+ * @property {string} gate 由来 gate (検証ロジックの SSOT script 名)
+ * @property {string} message 違反内容
+ */
+
+/**
+ * 生成 body を既存 gate SSOT の検証ロジックに通す (back-merge-pr-body.mjs と同型)。
+ *
+ * @param {string} body 生成した PR body
+ * @param {{ template?: string; ssotSections?: string[] | null; labels?: string[] }} [options]
+ * @returns {BodyViolation[]} 違反一覧 (空 = 全 gate PASS)
+ */
+export function validateGraphifyRefreshPrBody(body, options = {}) {
+	const template = options.template ?? readFileSync(TEMPLATE_PATH, 'utf-8');
+	const ssotSections =
+		options.ssotSections !== undefined
+			? options.ssotSections
+			: (JSON.parse(readFileSync(SECTIONS_SSOT_PATH, 'utf-8')).sections ?? null);
+	const labels = options.labels ?? [...GRAPHIFY_REFRESH_LABELS];
+
+	/** @type {BodyViolation[]} */
+	const violations = [];
+
+	// --- 1. check-pr-body.mjs (pre-ready Step 9 と同一ロジック) ---
+	const missing = findMissingSections(body, extractRequiredSections(template));
+	if (missing.length > 0) {
+		violations.push({
+			gate: 'check-pr-body/missing-required-sections',
+			message: `必須セクション欠落: ${missing.join(' / ')}`,
+		});
+	}
+	const forbidden = scanForbiddenTerms(body);
+	if (forbidden.length > 0) {
+		violations.push({
+			gate: 'check-pr-body/forbidden-terms',
+			message: forbidden
+				.slice(0, 5)
+				.map((v) => `L${v.lineNo} 「${v.term}」: ${v.line.slice(0, 60)}`)
+				.join(' | '),
+		});
+	}
+
+	for (const m of detectMojibake(body)) {
+		violations.push({ gate: `check-pr-body/${m.id}`, message: m.message.split('\n')[0] ?? m.id });
+	}
+	const selfReview = checkSelfReviewEvidence(body);
+	if (selfReview) {
+		violations.push({
+			gate: `check-pr-body/${selfReview.id}`,
+			message: selfReview.message.split('\n')[0] ?? selfReview.id,
+		});
+	}
+	const envDist = checkEnvDistributionForHotfix(body, labels);
+	if (envDist) violations.push({ gate: `check-pr-body/${envDist.id}`, message: envDist.message });
+
+	// --- 2. CI required context `Verify AC map in PR body` (check-ac-verification-map.mjs) ---
+	const acResult = checkAcVerification({ body, labels, lane: 'feature' });
+	if (!acResult.ok) {
+		violations.push({
+			gate: 'check-ac-verification-map/feature',
+			message: acResult.error ?? 'FAIL',
+		});
+	}
+
+	// --- 3. pr-template-gate.yml 6 job (pr-template-gate-checks.mjs) ---
+	for (const [name, fn] of Object.entries(TEMPLATE_GATE_CHECKS)) {
+		const result = fn({
+			body,
+			labels,
+			template,
+			ssotSections,
+			integrationSsotSections: null,
+			lane: 'feature',
+		});
+		if (!result.ok) {
+			violations.push({ gate: `pr-template-gate/${name}`, message: result.message });
+		}
+	}
+
+	// --- 4. CI required context `PR チェックリスト完了確認` (check-merge-gate-checklist.mjs) ---
+	const mergeGate = checkMergeGateChecklist({ body, labels, lane: 'feature' });
+	if (!mergeGate.ok) {
+		violations.push({
+			gate: 'check-merge-gate-checklist/feature',
+			message: mergeGate.error ?? 'FAIL',
+		});
+	}
+
+	return violations;
+}
+
+/**
+ * 簡易 argv パーサ (back-merge-pr-body.mjs と同型)。判定 logic は持たない。
+ *
+ * @param {string[]} argv process.argv.slice(2)
+ * @returns {Record<string, string | boolean>}
+ */
+export function parseArgs(argv) {
+	/** @type {Record<string, string | boolean>} */
+	const out = {};
+	for (let i = 0; i < argv.length; i += 1) {
+		const arg = argv[i];
+		if (arg === undefined || !arg.startsWith('--')) continue;
+		const eq = arg.indexOf('=');
+		if (eq !== -1) {
+			out[arg.slice(2, eq)] = arg.slice(eq + 1);
+			continue;
+		}
+		const next = argv[i + 1];
+		if (next === undefined || next.startsWith('--')) {
+			out[arg.slice(2)] = true;
+		} else {
+			out[arg.slice(2)] = next;
+			i += 1;
+		}
+	}
+	return out;
+}
+
+const isMain = isMainModule(import.meta.url);
+
+if (isMain) {
+	const args = parseArgs(process.argv.slice(2));
+	const branch = String(args.branch ?? '');
+	const sha = String(args.sha ?? '');
+
+	if (!branch || !sha) {
+		console.error(
+			'[graphify-refresh-pr-body] Usage: node scripts/graphify-refresh-pr-body.mjs --branch <chore/graphify-refresh> --sha <develop HEAD sha>',
+		);
+		process.exit(2);
+	}
+
+	const body = renderGraphifyRefreshPrBody({ branch, sha });
+	const violations = validateGraphifyRefreshPrBody(body);
+
+	if (violations.length > 0) {
+		console.error(
+			`[graphify-refresh-pr-body] 自己検証 FAIL — 生成 body が gate に違反 (${violations.length} 件)。` +
+				'gate 違反 body を発行させないため exit 1 で workflow を落とします (#4536 / ADR-0006):',
+		);
+		for (const v of violations) {
+			console.error(`  ✗ [${v.gate}] ${v.message.split('\n')[0]}`);
+		}
+		process.exit(1);
+	}
+
+	console.error(
+		'[graphify-refresh-pr-body] 自己検証 PASS — 全 gate 準拠 (stderr log、body は stdout)',
+	);
+	process.stdout.write(body);
+	process.exit(0);
+}

--- a/scripts/graphify-refresh-pr-body.mjs
+++ b/scripts/graphify-refresh-pr-body.mjs
@@ -267,17 +267,22 @@ const isMain = isMainModule(import.meta.url);
 
 if (isMain) {
 	const args = parseArgs(process.argv.slice(2));
-	const branch = String(args.branch ?? '');
+	// #4536 false-positive 回避: 変数名を `branch` にすると、check-new-required-env.mjs が
+	// 同一 diff 内の workflow 側 `const branch = process.env.BRANCH;` (github-script) の alias と
+	// 誤って結合し、ここの `if (!branchArg ...)` fail-fast guard を「BRANCH env が新規必須化された」
+	// と誤検出する (cross-file 変数名衝突、check-new-required-env.mjs の既知の限界)。
+	// ローカル変数名を変えるだけで解消するため、CLI 引数名 (`--branch`) は変えずに変数名だけ避ける。
+	const branchArg = String(args.branch ?? '');
 	const sha = String(args.sha ?? '');
 
-	if (!branch || !sha) {
+	if (!branchArg || !sha) {
 		console.error(
 			'[graphify-refresh-pr-body] Usage: node scripts/graphify-refresh-pr-body.mjs --branch <chore/graphify-refresh> --sha <develop HEAD sha>',
 		);
 		process.exit(2);
 	}
 
-	const body = renderGraphifyRefreshPrBody({ branch, sha });
+	const body = renderGraphifyRefreshPrBody({ branch: branchArg, sha });
 	const violations = validateGraphifyRefreshPrBody(body);
 
 	if (violations.length > 0) {

--- a/tests/unit/github/graphify-refresh-pr-body.test.ts
+++ b/tests/unit/github/graphify-refresh-pr-body.test.ts
@@ -1,0 +1,148 @@
+// Issue #4536: graphify-refresh PR body 生成 SSOT (scripts/graphify-refresh-pr-body.mjs) の unit test。
+//
+// back-merge-pr-body.test.ts と同型: 検証の核心は自動発行 graphify-refresh PR の body が
+// 「生成時点で」PR body gate 群 (check-pr-body / Verify AC map / pr-template-gate 6 job /
+// PR チェックリスト完了確認) を pass すること。gate ロジックは再実装せず、CI と同一の
+// SSOT 関数 (実 template / 実 PR_TEMPLATE_SECTIONS.json 入力) を import して assert する。
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { checkAcVerification } from '../../../scripts/check-ac-verification-map.mjs';
+import { checkMergeGateChecklist } from '../../../scripts/check-merge-gate-checklist.mjs';
+import {
+	extractRequiredSections,
+	findMissingSections,
+	findUncheckedReadyChecklist,
+	scanForbiddenTerms,
+} from '../../../scripts/check-pr-body.mjs';
+import {
+	GRAPHIFY_REFRESH_LABELS,
+	parseArgs,
+	renderGraphifyRefreshPrBody,
+	SECTIONS_SSOT_PATH,
+	TEMPLATE_PATH,
+	validateGraphifyRefreshPrBody,
+} from '../../../scripts/graphify-refresh-pr-body.mjs';
+import {
+	checkClosingKeyword,
+	checkCustomerValue,
+	checkIssueReference,
+	checkSectionPresence,
+} from '../../../scripts/pr-template-gate-checks.mjs';
+
+const template = readFileSync(TEMPLATE_PATH, 'utf-8');
+const ssotSections: string[] = JSON.parse(readFileSync(SECTIONS_SSOT_PATH, 'utf-8')).sections;
+
+const input = {
+	branch: 'chore/graphify-refresh',
+	sha: '2cd488fe3abc1234567890deadbeef001122334',
+};
+
+const body = renderGraphifyRefreshPrBody(input);
+const labels = [...GRAPHIFY_REFRESH_LABELS];
+
+describe('renderGraphifyRefreshPrBody (#4536: template gate 準拠 body の生成)', () => {
+	it('必須セクション見出しが完全一致で全て存在する (check-pr-body SSOT)', () => {
+		const required = extractRequiredSections(template);
+		// 件数はマジックナンバーで固定しない (back-merge-pr-body.test.ts と同型の理由)。
+		expect(required).toEqual(ssotSections);
+		expect(findMissingSections(body, required)).toEqual([]);
+	});
+
+	it('禁止語 0 件 (check-pr-body FORBIDDEN_TERMS)', () => {
+		expect(scanForbiddenTerms(body)).toEqual([]);
+	});
+
+	it('Ready checklist に未チェック残置なし', () => {
+		expect(findUncheckedReadyChecklist(body)).toEqual([]);
+	});
+
+	it('develop HEAD SHA (短縮 7 桁) を参照する (再生成起点の出典明示)', () => {
+		expect(body).toContain('2cd488f');
+	});
+
+	it('#4536 (機構導入 Issue) を no-issue-close 宣言付きで参照する (独自 close 対象を持たない)', () => {
+		expect(body).toContain('#4536');
+		expect(body).toContain('<!-- no-issue-close:');
+	});
+});
+
+describe('CI gate 個別 pass (#4536: 無手作業で body-gate green)', () => {
+	it('`Verify AC map in PR body` (feature lane) が PASS する', () => {
+		const result = checkAcVerification({ body, labels, lane: 'feature' });
+		expect(result.ok).toBe(true);
+	});
+
+	it('`必須セクションの存在確認` (実 PR_TEMPLATE_SECTIONS.json) が PASS する', () => {
+		const result = checkSectionPresence({
+			body,
+			labels,
+			template,
+			ssotSections,
+			integrationSsotSections: null,
+			lane: 'feature',
+		});
+		expect(result.ok).toBe(true);
+	});
+
+	it('pr-template-gate 残り 2 check (issue-reference / customer-value) が PASS する', () => {
+		const checkInput = {
+			body,
+			labels,
+			template,
+			ssotSections,
+			integrationSsotSections: null,
+			lane: 'feature' as const,
+		};
+		expect(checkIssueReference(checkInput).ok, 'issue-reference').toBe(true);
+		expect(checkCustomerValue(checkInput).ok, 'customer-value').toBe(true);
+	});
+
+	it('closing-keyword check は no-issue-close 宣言で skip される (機械生成 exempt)', () => {
+		const result = checkClosingKeyword({
+			body,
+			labels,
+			template,
+			ssotSections,
+			integrationSsotSections: null,
+			lane: 'feature',
+		});
+		expect(result.ok).toBe(true);
+		expect(result.skipped).toBe(true);
+	});
+
+	it('`PR チェックリスト完了確認` (feature lane) が PASS する', () => {
+		const result = checkMergeGateChecklist({ body, labels, lane: 'feature' });
+		expect(result.ok).toBe(true);
+	});
+});
+
+describe('validateGraphifyRefreshPrBody (#4536: 生成時自己検証 = 生成→検証→fail)', () => {
+	it('生成 body は違反 0 件', () => {
+		expect(validateGraphifyRefreshPrBody(body)).toEqual([]);
+	});
+
+	it('必須セクションを 1 つ削ると違反を検出する (自己検証が空洞でないこと、ADR-0006)', () => {
+		const tampered = body.replace('## 変更内容', '## 変更点');
+		const violations = validateGraphifyRefreshPrBody(tampered);
+		expect(violations.length).toBeGreaterThan(0);
+		expect(violations.map((v) => v.gate).join(' ')).toContain('missing-required-sections');
+	});
+
+	it('禁止語 (未完遂マーカー) が混入すると違反を検出する', () => {
+		// 禁止語 scan は body 全文が対象なので、特定行を狙った `.replace` にはしない
+		// (back-merge-pr-body.test.ts と同じ理由、#4097 教訓)。
+		const tampered = `${body}\n\n**補足**: あとで対応TODO\n`;
+		expect(tampered, '禁止語が実際に混入していること').toContain('あとで対応TODO');
+		const violations = validateGraphifyRefreshPrBody(tampered);
+		expect(violations.map((v) => v.gate).join(' ')).toContain('forbidden-terms');
+	});
+});
+
+describe('parseArgs (CLI 引数)', () => {
+	it('--key value / --key=value を解釈する', () => {
+		expect(parseArgs(['--branch', 'chore/graphify-refresh', '--sha=abc123'])).toEqual({
+			branch: 'chore/graphify-refresh',
+			sha: 'abc123',
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**対象ユーザー**: 開発チーム（システム全体 — graphify ナレッジグラフを使う全 AI セッション / 並行 PR を出す全 Dev）

**解決する課題**: `graphify-out/**`（`graph.json` 27MB+ 等）は git 追跡している（コールドスタート解消、docs/CLAUDE.md §graphify）。以前は `.husky/post-commit` が **branch を問わず**コミットのたびに再生成していたため、並行する feature branch がそれぞれ独自の graphify-out を持ち、develop への merge のたびに残り全 PR が graphify-out だけで conflict していた。実測（PR #4514 merge 時、2026-08-13）: conflict は graphify-out の 3 file のみで手書きファイルの conflict は 0 件。1 本 merge するたびに残り全 PR が conflict し、rebase → CI 全走 → merge の直列化が発生していた。

**期待される効果**: feature branch では graphify-out を再生成・コミットしなくなるため、PR の diff から graphify-out が消え、並行 PR 間の conflict が原理的にゼロになる。develop 上の内容は push 契機の bot workflow が定期的に最新化するため、コールドスタート解消の意図は維持される。

## 関連 Issue

Closes #4536

## 変更内容

1. **`.husky/post-commit` に branch guard を追加**: 現在の branch が `develop` / `main` のときだけ `graphify update .` を実行する。feature branch では早期 `exit 0` する（`npm install` 時に `graphify hook install` が追記するベンダー製の再生成ブロックも、この `exit 0` より後ろにあるため同じく止まる — 実測で確認済、後述「検証」参照）
2. **`.github/workflows/graphify-refresh.yml` を新規追加**: develop への push を契機に `graphify update .` を実行し、差分があれば `chore/graphify-refresh` branch を作成して bot PR を upsert する（`hotfix-back-merge.yml` と同型の GitHub App token パターンを再利用。直接 push は branch ruleset の required review で拒否されるため PR 経由）。差分が無ければ PR は発行しない。自身が発行した PR の merge 後 push（graphify-out のみの差分）は `paths-ignore` で無限 loop を防止する
3. **`scripts/graphify-refresh-pr-body.mjs` を新規追加**: 上記 bot PR の body を PR template gate 準拠形式で生成する純粋関数 + 生成時自己検証 CLI（`scripts/back-merge-pr-body.mjs` と同型）
4. **`docs/CLAUDE.md` §graphify を更新**: 新しい develop/main 限定の運用を記述

## 検証

| 項目 | コマンド / 手順 | 結果 |
|---|---|---|
| feature branch commit で graphify-out が diff に出ない | 本 worktree (`fix/graphify-feature-branch-isolation`) 上で実際に `git commit` を実行（husky hook 実起動、`npm ci` で `graphify hook install` のベンダーブロックが追記された状態） | `git diff --stat HEAD~1 HEAD -- graphify-out` が空。`git status --short` にも graphify-out の変更なし |
| branch guard のロジック単体 | `develop` / `main` / `fix/foo` / `docs/bar` / `release/1.0` を case 文で判定 | develop・main のみ RUN、他は SKIP |
| PR body 生成 + 自己検証 | `node scripts/graphify-refresh-pr-body.mjs --branch chore/graphify-refresh --sha <sha>` | `自己検証 PASS` (stderr)、body は 7 必須セクション + AC マップを含む |
| PR body 生成の unit test | `npx vitest run tests/unit/github/graphify-refresh-pr-body.test.ts` | 14 passed |
| 既存 back-merge-pr-body の回帰なし | `npx vitest run tests/unit/github/back-merge-pr-body.test.ts` | 23 passed |
| graphify-out 成果物の parse 検証（既存 CI gate、無変更） | `npx vitest run tests/unit/architecture/graphify-artifacts-parseable.test.ts tests/unit/architecture/oss-rejection-record-falsifiable.test.ts` | 9 passed |
| 高権限 Action SHA pin | `node scripts/check-action-sha-pin.mjs` | PASS（`actions/create-github-app-token` / `actions/github-script` とも pin 済） |
| lint | `npx biome check .husky/post-commit .github/workflows/graphify-refresh.yml scripts/graphify-refresh-pr-body.mjs tests/unit/github/graphify-refresh-pr-body.test.ts docs/CLAUDE.md` | No fixes needed |

## 影響範囲

**影響を受ける画面・機能**: なし（UI 変更を含まない。`.husky/` / `.github/workflows/` / `scripts/` / `docs/CLAUDE.md` のみ）。

- 並行実装ペア: 該当なし
- 設計書同期: `docs/CLAUDE.md` §graphify を本 PR 内で更新済み
- LP ↔ アプリ整合: 該当なし
- 破壊的変更: 含まれない。既存の develop / main 上の再生成挙動は不変（branch guard で通過する側）。feature branch 上でのみ挙動が変わる（再生成しなくなる）
- **本 PR 自体は feature branch (`fix/graphify-feature-branch-isolation`) 上でコミットしているため、graphify-out に diff を含まない**（本 PR の diff がその実例）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし。`.github/workflows/graphify-refresh.yml` は既存 secret (`INTEGRATION_BOT_APP_ID` / `INTEGRATION_BOT_APP_PRIVATE_KEY`、`hotfix-back-merge.yml` と共有) を再利用するのみ

## QM レビュー結果

<!-- QM が記入。フォーマット・必須手順は docs/sessions/qm-session.md「Tier 2 手順 5」を参照。 -->

---

## AC 検証マップ (ADR-0004、追加情報)

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---------|--------|---------|------------------|
| AC1 | feature branch では graphify-out を再生成・コミットしない | 実 `git commit` を feature branch 上で実行し diff を確認 | `git diff --stat HEAD~1 HEAD -- graphify-out` 空。post-commit の branch guard (`.husky/post-commit:13-17`) が `case` で develop/main 以外を `exit 0` |
| AC2 | develop 上の graphify-out は push 契機で最新化される（PR 経由、direct push はしない） | `.github/workflows/graphify-refresh.yml` の設計（branch ruleset が direct push を拒否するため PR 経由、`hotfix-back-merge.yml` と同型） | ruleset 実測: `gh api repos/Takenori-Kusaka/ganbari-quest/rulesets/17303659`（develop-light-lane）で `pull_request` rule + `required_approving_review_count:1` を確認済み |
| AC3 | `.gitignore` して追跡をやめる方式は採らない（コールドスタート解消の意図を維持） | `docs/CLAUDE.md` §graphify を確認 | graphify-out 3 成果物は引き続き git 追跡。`docs/CLAUDE.md` に維持方針を明記 |
| AC4 | 新しい CI check（gate）を追加しない | 変更差分を確認 | `graphify-refresh.yml` は develop 軽量レーンの既存 required checks に乗るだけで、新規 required check は追加していない |

## 変更タイプ

- [ ] feat: 新機能
- [x] fix: バグ修正
- [ ] refactor: リファクタリング
- [ ] design: デザイン・UI改善
- [ ] infra: インフラ・CI/CD
- [ ] test: テスト改善
- [ ] docs: ドキュメント
- [ ] marketing: マーケティング・LP

## スクリーンショット / ビジュアルデモ

該当なし（UI 変更を含まない、`.husky/` / `.github/workflows/` / `scripts/` / `docs/CLAUDE.md` のみの変更）。

## レビュー依頼事項・破壊的変更

**破壊的変更**:
- [x] 含まれない

**レビュー依頼事項**: `.github/workflows/graphify-refresh.yml` が発行する bot PR（`chore/graphify-refresh`）は今後定期的に develop に現れます。QM の通常レビュー対象に含めてください（内容は graphify-out のみの機械生成差分）。

## Ready for Review チェックリスト

- [x] セルフレビュー済み（不要な差分・デバッグコードなし）
- [x] 全 AC が実装済み
- [x] UI 変更なし（SS 不要）
- [x] 認証画面変更なし
