### PR TITLE
fix(billing): #4537 subscription が無いと解約フローが無言で portal ホームへ落ちるのを塞ぐ

### DIFF
--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -345,12 +345,19 @@ proration / 期末切替の表示責務がアプリに移り、Stripe を課金�
 外部 SaaS の設定を常時監視する機構は持たず（Pre-PMF、ADR-0010）、以下の 3 点で塞ぐ。
 
 1. **フォールバック**: `createPortalSession()` は flow 付き session の作成が失敗したら、**flow 無しで作り直す**。
-   作り直しも失敗した場合は握り潰さず throw する（portal に入れない事実を成功として返さない）
+   作り直しも失敗した場合は握り潰さず型付きの失敗（`PORTAL_CREATE_FAILED`）を返す
+   （portal に入れない事実を成功として返さない）
 2. **倒れたことを顧客に伝える**: 戻り値 `flowFallback: true` を呼び出し元へ返す。
+   立つ条件は 2 つで、**顧客から見た結果（要求した flow に入れず portal ホームに着く）が同一**なので
+   同じシグナルに集約する — (a) Stripe が `flow_data` を拒否した / (b) `stripeSubscriptionId` を持たず
+   `flow_data` を組み立てられなかった。(b) は解約済みで Customer だけ残る場合のほか、
+   **Stripe 側にサブスクが生きているのに DB 側が null というドリフト**でも起き、黙って通すと
+   「解約を押したのに課金が続く」になる。`home` を要求した場合はホーム着地が期待どおりなので立てない
    - プラン変更（`POST /api/stripe/portal`）: 応答 `{ url, flowFallback }`。画面は自動遷移せず
      `portal-fallback-notice` を出し、作成済み session への「請求管理ページへ進む」で進ませる（PIN 再入力なし）
-   - 解約（`cancel/+page.server.ts`）: portal へ飛ばさず `/admin/subscription?portalFallback=cancel` へ戻し、
-     同じ通知を出す。**解約理由を書き終えた直後に予期しない画面へ落とさない**
+   - 解約（`cancel/+page.server.ts`）/ 卒業（`cancel/graduation/+page.server.ts`）: portal へ飛ばさず
+     `/admin/subscription?portalFallback=cancel` へ戻し、同じ通知を出す。
+     **解約理由を書き終えた直後に予期しない画面へ落とさない**
    - 文言は `SUBSCRIPTION_PAGE_LABELS.portalFallback*`（labels SSOT）。**原因は顧客に説明しない**（ADR-0062）
 3. **`intent` の検証**: `POST /api/stripe/portal` の `intent` は allowlist
    （`plan-change` / `plan-upgrade` / `billing-history`）で検証し、外れたら安全側（`home`）に倒して

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -190,11 +190,21 @@ export type CreatePortalResult =
 	| {
 			url: string;
 			/**
-			 * 要求された flow を Stripe が受け付けず、portal ホームで session を作り直したか (#4270)。
+			 * 要求された flow へ直行できず、portal ホームに着地したか (#4270 / #4537)。
 			 *
 			 * true のとき、顧客は「プラン変更画面 / 解約画面へ直行する」と期待した操作の結果として
 			 * portal ホームに着く。**黙って落とすと、解約理由を書き終えた直後に予期しない画面へ
 			 * 落ちる**ので、呼び出し元は次の操作を示すメッセージを出す責務を負う。
+			 *
+			 * 立つ条件は 2 つある。**どちらも顧客から見た結果は同一**（解約フローに入れていない）なので
+			 * 同じシグナルに集約する:
+			 *
+			 * 1. Stripe が `flow_data` を拒否し、flow 無しで作り直した (#4270)
+			 * 2. `stripeSubscriptionId` を持たず、そもそも `flow_data` を組み立てられなかった (#4537)
+			 *
+			 * 2 は「解約済みで Customer だけ残っている」ほか、**Stripe 側にサブスクが生きているのに
+			 * DB 側が null というドリフト**でも起きる。後者を黙って通すと「解約を押したのに課金が続く」
+			 * (#4498 と同じ実害) になるため、成功として返してはならない。
 			 */
 			flowFallback?: true;
 	  }
@@ -230,6 +240,8 @@ export type PortalFlow =
  *
  * **subscription を持たないときは flow を付けない。** 付けたまま投げると Stripe が 400 を返し、
  * 顧客は何を押しても portal に入れなくなる (導線ごと死ぬ)。home に落とすのが安全側。
+ * ただし**黙って落としてはいけない** — 呼び出し元は `flowRequestedButUnavailable()` で
+ * 「flow を要求したのに付けられなかった」を判定し、`flowFallback` として伝える (#4537)。
  *
  * `after_completion` は明示する。省略時の挙動は公式ドキュメントに明記が無く、
  * 「完了した更新の詳細を示す確認ページ」に留まると読めるため、アプリへ戻す指定を必ず置く。
@@ -266,6 +278,16 @@ function buildPortalFlowData(
 	};
 }
 
+/**
+ * 「flow を要求したのに `flow_data` を付けられなかった」= 顧客は portal ホームに着く、を判定する (#4537)。
+ *
+ * `home` を要求して home に着くのは**期待どおりの着地**なので false。区別せず一律に立てると
+ * 汎用導線 (請求書確認 / 支払い方法変更) にまで「手続きは完了していません」の案内が出てしまう。
+ */
+function flowRequestedButUnavailable(flow: PortalFlow, subscriptionId: string | null): boolean {
+	return flow.kind !== 'home' && !subscriptionId;
+}
+
 export async function createPortalSession(
 	tenantId: string,
 	returnUrl: string,
@@ -284,12 +306,18 @@ export async function createPortalSession(
 		// 途中でやめた顧客が戻れるリンク。flow の有無に関わらず常に渡す
 		return_url: returnUrl,
 	};
-	const flowData = buildPortalFlowData(flow, tenant.stripeSubscriptionId ?? null, returnUrl);
+	const subscriptionId = tenant.stripeSubscriptionId ?? null;
+	const flowData = buildPortalFlowData(flow, subscriptionId, returnUrl);
 
 	if (!flowData.flow_data) {
+		// #4537: subscription が無くて flow を組めなかった場合、session 作成自体は成功する。
+		// ここで `{ url }` だけを返すと呼び出し元は「直行できた」と解釈して素通しし、顧客は
+		// 「解約手続きへ進む」を押したのに portal ホームへ放り出される (説明が一切出ない)。
+		// 着地は #4270 の flow 拒否時と同一なので、同じ `flowFallback` で伝える。
+		const fallback = flowRequestedButUnavailable(flow, subscriptionId);
 		try {
 			const session = await stripe.billingPortal.sessions.create(baseParams);
-			return { url: session.url };
+			return fallback ? { url: session.url, flowFallback: true } : { url: session.url };
 		} catch (err) {
 			return reportPortalCreateFailure(tenantId, flow.kind, err);
 		}

--- a/tests/unit/routes/portal-flow-fallback-no-subscription.test.ts
+++ b/tests/unit/routes/portal-flow-fallback-no-subscription.test.ts
@@ -1,0 +1,239 @@
+// tests/unit/routes/portal-flow-fallback-no-subscription.test.ts
+// #4537 — subscription を持たない顧客が「解約手続きへ進む」で portal ホームに放り出されない。
+//
+// ## なぜ route ごとの単体テストでは足りないか
+//
+// `flowFallback` は **service が立て、route が読む** 2 層の契約である。既存の route テストは
+// `createPortalSession` をモックして `{ url, flowFallback: true }` を注入しているため、
+// **service がその値を実際に立てるか**は検証していない。逆に service テストは
+// **route が本当に自画面へ戻すか**を検証していない。
+//
+// 契約が切れるのは 2 層の継ぎ目なので、本 test は **stripe-service を実物のまま** 通し、
+// 「DB に stripeSubscriptionId が無い」という入力だけを与えて、離反経路と卒業経路の
+// **両方**が自画面へ戻すことを端から端まで固定する。
+//
+// ## 実害 (#4498 と同じ結果)
+//
+// stripeCustomerId はあるが stripeSubscriptionId が null の顧客 (解約済みで Customer だけ残る /
+// webhook 取りこぼしによるドリフト) は、flow_data 無しで session が作れてしまうため
+// Stripe API は成功する。旧実装はこれを「直行できた」として素通しし、顧客は解約フローに
+// 到達しないまま portal ホームに着いた。ドリフト側では **押したのに課金が続く**。
+
+// biome-ignore-all lint/suspicious/noExplicitAny: テスト用 action の型を最小化
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	PORTAL_FALLBACK_CONTEXT,
+	PORTAL_FALLBACK_PARAM,
+} from '$lib/domain/constants/stripe-portal';
+
+const mockFindTenantById = vi.fn();
+const mockPortalCreate = vi.fn();
+const mockGetLicenseInfo = vi.fn();
+const mockSubmitCancellationReason = vi.fn();
+const mockRecordGraduationConsent = vi.fn();
+
+// **stripe-service はモックしない** (本 test の主眼が service ↔ route の継ぎ目のため)。
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		auth: { findTenantById: mockFindTenantById },
+		child: { findAllChildren: async () => [] },
+		webhookEvent: {
+			findByEventId: async () => null,
+			claim: async () => true,
+			finalize: async () => {},
+			releaseClaim: async () => {},
+			incrementRetryCount: async () => {},
+			deleteOlderThan: async () => 0,
+		},
+	}),
+}));
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: () => true,
+	getStripeClient: () => ({ billingPortal: { sessions: { create: mockPortalCreate } } }),
+}));
+
+vi.mock('$lib/server/stripe/config', () => ({
+	getPlans: () => ({}),
+	planIdFromPriceId: () => null,
+	planIdFromLookupKey: () => null,
+	getWebhookSecret: () => 'whsec_test',
+	GRACE_PERIOD_DAYS: 7,
+	CURRENCY: 'jpy',
+}));
+vi.mock('$lib/server/stripe/alert', () => ({ notifyStripeAlert: vi.fn() }));
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyDiscord: vi.fn(),
+	notifyIncident: vi.fn(),
+}));
+
+vi.mock('$lib/server/services/license-service', () => ({
+	getLicenseInfo: (...args: unknown[]) => mockGetLicenseInfo(...args),
+}));
+vi.mock('$lib/server/services/cancellation-service', () => ({
+	submitCancellationReason: (...args: unknown[]) => mockSubmitCancellationReason(...args),
+}));
+vi.mock('$lib/server/services/graduation-service', async () => {
+	const actual = (await vi.importActual('$lib/server/services/graduation-service')) as Record<
+		string,
+		unknown
+	>;
+	return {
+		...actual,
+		recordGraduationConsent: (...args: unknown[]) => mockRecordGraduationConsent(...args),
+	};
+});
+vi.mock('$lib/server/db/point-repo', () => ({ getBalance: async () => 0 }));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+}));
+
+import { actions as cancelActionsRaw } from '../../../src/routes/(parent)/admin/subscription/cancel/+page.server';
+import { actions as graduationActionsRaw } from '../../../src/routes/(parent)/admin/subscription/cancel/graduation/+page.server';
+
+const cancelAction = (cancelActionsRaw as any).default as (...args: unknown[]) => any;
+const graduationAction = (graduationActionsRaw as any).default as (...args: unknown[]) => any;
+
+const LOCALS = { context: { tenantId: 'tenant-1' } };
+const EXPECTED_FALLBACK_LOCATION = `/admin/subscription?${PORTAL_FALLBACK_PARAM}=${PORTAL_FALLBACK_CONTEXT.CANCEL}`;
+
+/** Stripe Customer は持つが subscription を持たないテナント (本 test の入力そのもの)。 */
+function tenantWithoutSubscription() {
+	return {
+		tenantId: 'tenant-1',
+		stripeCustomerId: 'cus_123',
+		stripeSubscriptionId: null,
+		status: 'active',
+		plan: 'monthly',
+	};
+}
+
+async function catchThrown(run: () => Promise<unknown>): Promise<any> {
+	try {
+		return { returned: await run() };
+	} catch (e) {
+		return e;
+	}
+}
+
+function formRequest(form: Record<string, string>): Request {
+	return new Request('http://localhost/admin/subscription/cancel', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+		body: new URLSearchParams(form).toString(),
+	});
+}
+
+/** 離反 (churn) を選んで解約理由を送信する = 通常解約経路。 */
+function runCancelAction() {
+	return catchThrown(() =>
+		cancelAction({
+			request: formRequest({ category: 'churn', freeText: '' }),
+			locals: LOCALS,
+			url: new URL('https://app.example/admin/subscription/cancel'),
+		}),
+	);
+}
+
+/** 「卒業を完了する」を押す = 卒業経路 (#4498 で portal 到達を実装した側)。 */
+function runGraduationAction() {
+	return catchThrown(() =>
+		graduationAction({
+			request: formRequest({
+				consented: 'on',
+				nickname: 'たろう家',
+				message: '',
+				totalPoints: '100',
+				usagePeriodDays: '30',
+			}),
+			locals: LOCALS,
+			url: new URL('https://app.example/admin/subscription/cancel/graduation'),
+		}),
+	);
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockPortalCreate.mockResolvedValue({ url: 'https://billing.stripe.com/home_1' });
+	mockFindTenantById.mockResolvedValue(tenantWithoutSubscription());
+	mockSubmitCancellationReason.mockResolvedValue({ ok: true });
+	mockGetLicenseInfo.mockResolvedValue({
+		plan: 'standard_monthly',
+		createdAt: new Date().toISOString(),
+		stripeSubscriptionId: null,
+		stripeCustomerId: 'cus_123',
+	});
+	mockRecordGraduationConsent.mockResolvedValue({
+		ok: true,
+		record: {
+			id: '1',
+			tenantId: 'tenant-1',
+			nickname: 'たろう家',
+			consented: true,
+			userPoints: 100,
+			usagePeriodDays: 30,
+			message: null,
+			consentedAt: new Date().toISOString(),
+		},
+	});
+});
+
+describe('#4537 subscription が無い顧客を portal ホームへ無言で飛ばさない (service ↔ route 通し)', () => {
+	// 「両方の経路が同じ扱いになること」= AC3。片方だけ直しても気づけないよう 1 つの表で回す。
+	it.each([
+		['通常解約 (離反)', runCancelAction],
+		['卒業', runGraduationAction],
+	] as const)('%s: portal URL へ飛ばさず、手続きを続けられる自画面へ戻す', async (_name, run) => {
+		const thrown = await run();
+
+		expect(thrown.status).toBe(303);
+		expect(
+			thrown.location,
+			'ここで portal URL へ飛ばすと、顧客は説明のないまま portal ホームに着く',
+		).not.toBe('https://billing.stripe.com/home_1');
+		expect(thrown.location).toBe(EXPECTED_FALLBACK_LOCATION);
+	});
+
+	it.each([
+		['通常解約 (離反)', runCancelAction],
+		['卒業', runGraduationAction],
+	] as const)('%s: subscription があるときは従来どおり portal へ直行する (回帰防止)', async (_name, run) => {
+		mockFindTenantById.mockResolvedValue({
+			...tenantWithoutSubscription(),
+			stripeSubscriptionId: 'sub_123',
+		});
+		mockGetLicenseInfo.mockResolvedValue({
+			plan: 'standard_monthly',
+			createdAt: new Date().toISOString(),
+			stripeSubscriptionId: 'sub_123',
+			stripeCustomerId: 'cus_123',
+		});
+		mockPortalCreate.mockResolvedValue({ url: 'https://billing.stripe.com/session_1' });
+
+		const thrown = await run();
+
+		expect(thrown.status).toBe(303);
+		expect(thrown.location).toBe('https://billing.stripe.com/session_1');
+	});
+
+	it.each([
+		['通常解約 (離反)', runCancelAction],
+		['卒業', runGraduationAction],
+	] as const)('%s: 解約フローを要求したこと自体は変えない (flow_data は組めないので付かない)', async (_name, run) => {
+		await run();
+
+		expect(mockPortalCreate).toHaveBeenCalledTimes(1);
+		expect(
+			mockPortalCreate.mock.calls.at(0)?.[0]?.flow_data,
+			'subscription 無しで flow を付けると Stripe が 400 を返し導線ごと死ぬ',
+		).toBeUndefined();
+	});
+});

--- a/tests/unit/services/stripe-portal-flow.test.ts
+++ b/tests/unit/services/stripe-portal-flow.test.ts
@@ -239,7 +239,97 @@ describe('#4166 AC2 subscription を持たないなら home にフォールバ�
 			lastArgs().flow_data,
 			'subscription 無しで flow を付けると Stripe が 400 を返し導線ごと死ぬ',
 		).toBeUndefined();
-		// **落とさずに portal へは入れる**こと（fallback の意味）
+		// **落とさずに portal へは入れる**こと（fallback の意味）。
+		// #4537: 同時に「直行できていない」を呼び出し元へ伝える (下の describe が固定する)。
+		expect(result).toEqual({
+			url: 'https://billing.stripe.com/session_1',
+			flowFallback: true,
+		});
+	});
+});
+
+describe('#4537 subscription が無くて flow を組めなかったことを黙って通さない', () => {
+	// ## 実害
+	//
+	// `stripeCustomerId` はあるが `stripeSubscriptionId` が null の顧客は、flow_data 無しで
+	// session を作るので Stripe API は**成功する**。旧実装は `{ url }` だけを返し、呼び出し元は
+	// 「直行できた」と解釈して素通ししていた。顧客は「解約手続きへ進む」を押したのに
+	// portal ホームへ放り出され、**説明が一切出ない**。
+	//
+	// DB の stripeSubscriptionId が null なのに Stripe 側にサブスクが生きているドリフトがあれば、
+	// これは「押したのに課金が続く」(#4498) と同じ結果になる。
+	it.each([
+		'subscription_update',
+		'subscription_cancel',
+	] as const)('%s: subscription が無ければ flowFallback を立てる', async (kind) => {
+		mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: null }));
+
+		const result = await createPortalSession('t-test', RETURN_URL, { kind });
+
+		expect(
+			'flowFallback' in result && result.flowFallback,
+			'立てないと呼び出し元は素通しし、顧客は説明なく portal ホームへ落ちる',
+		).toBe(true);
+	});
+
+	it('undefined の subscription (列自体が無い) でも flowFallback を立てる', async () => {
+		// `?? null` の正規化を経由しない実データ形状でも判定が効くこと
+		mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: undefined }));
+
+		const result = await createPortalSession('t-test', RETURN_URL, {
+			kind: 'subscription_cancel',
+		});
+
+		expect('flowFallback' in result && result.flowFallback).toBe(true);
+	});
+
+	it('空文字の subscription でも flowFallback を立てる (flow_data を組めていない事実は同じ)', async () => {
+		mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: '' }));
+
+		const result = await createPortalSession('t-test', RETURN_URL, {
+			kind: 'subscription_cancel',
+		});
+
+		expect(lastArgs().flow_data).toBeUndefined();
+		expect('flowFallback' in result && result.flowFallback).toBe(true);
+	});
+
+	// AC2: home は「ホームに着く」のが期待どおりの着地。ここまで案内を出すと、請求書確認 /
+	// 支払い方法変更をしに来た顧客に「手続きは完了していません」が出てしまう。
+	it('home 要求時は subscription が無くても flowFallback を立てない', async () => {
+		mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: null }));
+
+		const result = await createPortalSession('t-test', RETURN_URL, { kind: 'home' });
+
 		expect(result).toEqual({ url: 'https://billing.stripe.com/session_1' });
+	});
+
+	it('flow 未指定 (home 相当) も同様に立てない', async () => {
+		mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: null }));
+
+		const result = await createPortalSession('t-test', RETURN_URL);
+
+		expect(result).toEqual({ url: 'https://billing.stripe.com/session_1' });
+	});
+
+	it('subscription があって直行できたときは立てない (通常経路の回帰防止)', async () => {
+		mockFindTenantById.mockResolvedValue(tenant());
+
+		const result = await createPortalSession('t-test', RETURN_URL, {
+			kind: 'subscription_cancel',
+		});
+
+		expect(result).toEqual({ url: 'https://billing.stripe.com/session_1' });
+	});
+
+	it('subscription 無しで session 作成も失敗したら成功として返さない', async () => {
+		mockFindTenantById.mockResolvedValue(tenant({ stripeSubscriptionId: null }));
+		mockPortalCreate.mockRejectedValue(new Error('Stripe API down'));
+
+		const result = await createPortalSession('t-test', RETURN_URL, {
+			kind: 'subscription_cancel',
+		});
+
+		expect(result).toEqual({ error: 'PORTAL_CREATE_FAILED' });
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

「解約手続きへ進む」を押した顧客が、Stripe portal のホームに説明なく放り出されなくなる。手続きが完了していないことが画面で伝わり、続ける導線が出る。

## 関連 Issue

Closes #4537

## 変更内容

`stripeCustomerId` はあるが `stripeSubscriptionId` が null の顧客は、`flow_data` を組み立てられないまま `billingPortal.sessions.create` が**成功する**。旧実装は `{ url }` だけを返し、呼び出し元は「解約フローへ直行できた」と解釈して素通ししていた。

`flowRequestedButUnavailable()` を追加し、**home 以外の flow を要求 × subscription 無し**のとき `flowFallback: true` を立てる。顧客から見た結果 (要求した flow に入れず portal ホームに着く) は #4270 の flow 拒否時と同一なので、シグナルを分けず既存の `flowFallback` に集約した。`home` 要求時はホーム着地が期待どおりなので立てない (請求書確認 / 支払い方法変更の汎用導線に「手続きは完了していません」を出さない)。

呼び出し元 (`cancel/+page.server.ts` / `cancel/graduation/+page.server.ts`) は既に `flowFallback` で自画面へ戻す実装があり、本 PR で両経路が同じ扱いになる。

`docs/design/plan-change-flow.md` §3.2.2 の `flowFallback` 条件を 2 つに更新し、卒業経路を明記した。

### なぜ重要か

DB の `stripeSubscriptionId` が null なのに Stripe 側にサブスクが生きているドリフト (webhook 取りこぼし / ダッシュボード手動操作) があると、これは **#4498 と同じ「押したのに課金が続く」** になる。#4498 が塞いだのは「そもそも portal を呼んでいない」経路、本 PR は「呼んだが解約フローに入れていない」経路で、顧客から見た症状は同一。

## 検証

| 検証 | コマンド | 結果 |
|---|---|---|
| 対象 unit test | `npx vitest run tests/unit/services/stripe-portal-flow.test.ts tests/unit/routes/portal-flow-fallback-no-subscription.test.ts tests/unit/routes/subscription-cancel-graduation.test.ts tests/unit/routes/subscription-cancel-portal-dead-end.test.ts tests/unit/routes/stripe-portal-intent.test.ts` | 5 files / 64 tests passed |
| 型 | `npx svelte-check --threshold error` | 8141 FILES 0 ERRORS 0 WARNINGS |
| lint | `npx biome check src/lib/server/services/stripe-service.ts tests/unit/routes/portal-flow-fallback-no-subscription.test.ts tests/unit/services/stripe-portal-flow.test.ts docs/` | Checked 5 files, No fixes applied |

### 変異試験 (テストに歯があることの実測)

`flowRequestedButUnavailable()` の返り値を壊して、テストが落ちることを確認した。

| 変異 | 実装 | 落ちたテスト |
|---|---|---|
| M1: fallback を一切立てない (旧挙動へ退行) | `return false;` | **8 failed / 20 passed** — 通常解約・卒業の自画面戻し 2 件、`flowFallback` を立てる 4 件、既存の #4166 AC2 期待 2 件 |
| M2: home 除外を落とす | `return !subscriptionId;` | **2 failed / 26 passed** — 「home 要求時は立てない」「flow 未指定も立てない」 |
| 復元後 | `return flow.kind !== 'home' && !subscriptionId;` | **28 passed** |

M1 実測ログ (抜粋):

```
× 通常解約 (離反): portal URL へ飛ばさず、手続きを続けられる自画面へ戻す
× 卒業: portal URL へ飛ばさず、手続きを続けられる自画面へ戻す
× subscription_update: stripeSubscriptionId が無ければ flow を付けない
× subscription_cancel: stripeSubscriptionId が無ければ flow を付けない
× subscription_update: subscription が無ければ flowFallback を立てる
× subscription_cancel: subscription が無ければ flowFallback を立てる
× undefined の subscription (列自体が無い) でも flowFallback を立てる
× 空文字の subscription でも flowFallback を立てる
Tests  8 failed | 20 passed (28)
```

M2 実測ログ:

```
× home 要求時は subscription が無くても flowFallback を立てない
× flow 未指定 (home 相当) も同様に立てない
Tests  2 failed | 26 passed (28)
```

変異は逆 sed で復元し、復元後に全 PASS を再確認した (`git diff` に残っていない)。

## 影響範囲

- **顧客に見える変化**: `stripeSubscriptionId` を持たない顧客が解約 / 卒業を送信したとき、portal へ飛ばず `/admin/subscription?portalFallback=cancel` に戻り、既存の `portal-fallback-notice` (文言は `SUBSCRIPTION_PAGE_LABELS.portalFallback*`) が出る。**subscription を持つ通常の顧客の挙動は不変** (回帰テストで固定)
- `POST /api/stripe/portal` (プラン変更) も同じ経路を通るため、subscription 無しでの `intent=plan-change` は `flowFallback: true` を返し、`SaasLicensePanel` が既存の notice を出す (自動遷移しない)
- 触った並行実装ペア: なし。UI 文言の新規追加なし (既存の fallback 通知を再利用)
- 破壊的変更: なし

UI 変更なし — 描画するコンポーネント / 文言に差分は無く、既存の fallback 通知が出る条件が 1 つ増えるだけ。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
