### PR TITLE
fix(ui): #4538 内部 childId 露出の guard を親画面まで広げ、残っていた 7 箇所を是正する

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -9018,6 +9018,13 @@ export const STORYBOOK_LABELS = {
 	avatarDisplay: {
 		nickname: 'たろう',
 	},
+	// #4538: SiblingChallengeComparison の見た目確認用。children 一覧から引けない childId が
+	// あるときに内部 ID ではなく汎用語へ落ちることを目視できるようにする。
+	siblingChallengeComparison: {
+		challengeTitle: '今週は毎日おてつだい',
+		firstChildNickname: 'はると',
+		secondChildNickname: 'ひなた',
+	},
 	button: {
 		primary: 'プライマリ',
 		secondary: 'セカンダリ',
@@ -10196,6 +10203,27 @@ export const UNIFIED_EMPTY_STATE_LABELS = {
 	// Reward / Checklist 等で childId 必須な場合の補助文言
 	pickChildHint: '対象の子供を選んでから取り込みできます。',
 	disabledReason: '権限が不足しています',
+} as const;
+
+/**
+ * 参照先のレコードを解決できなかったときの表示名 (#4538)。
+ *
+ * 内部 ID (`#${childId}` 等) を表示名のフォールバックにしない (DESIGN.md §6「内部コード露出禁止」、
+ * 過去事例 #498 / #573)。UUID が画面に出ても顧客には意味が無く、誰のことか分からないうえ、
+ * 内部識別子を不必要に露出する。**画面 (子供 / 親) を問わず本ラベルを使う**。
+ *
+ * 出る条件は「一覧に載っていない子供 / 定義が無いカテゴリを参照している」= データ不整合であり、
+ * 通常運用では出ない。出たときに「不明である」と正直に述べるのが正しい (存在しない名前を作らない)。
+ *
+ * 子供画面側の同種フォールバックは `CHILD_HOME_LABELS.siblingUnknownName` (「きょうだい」)。
+ * 読み手が違う (子供 = ひらがな / 親 = 敬称) ため値は分けるが、**内部 ID を出さない**点は共通で、
+ * `tests/unit/architecture/child-ui-display-integrity.test.ts` が両 scope をまとめて guard する。
+ */
+export const UNRESOLVED_ENTITY_LABELS = {
+	/** children 一覧から引けなかった子供の表示名 */
+	child: `不明な${CHILD_TERMS.honorific}`,
+	/** カテゴリ定義から引けなかったカテゴリの表示名 */
+	category: '不明なカテゴリ',
 } as const;
 
 // #3593 ④: system 生成 ポイント台帳 (point_ledger) description の SSOT。

--- a/src/lib/features/value-preview/MonthlyValuePreview.svelte
+++ b/src/lib/features/value-preview/MonthlyValuePreview.svelte
@@ -11,7 +11,11 @@
 -->
 <script lang="ts">
 import type { CategoryId } from '$lib/domain/ids';
-import { getMilestoneLabel, VALUE_PREVIEW_LABELS } from '$lib/domain/labels';
+import {
+	getMilestoneLabel,
+	UNRESOLVED_ENTITY_LABELS,
+	VALUE_PREVIEW_LABELS,
+} from '$lib/domain/labels';
 import { getCategoryById } from '$lib/domain/validation/activity';
 import type {
 	ChildValuePreview,
@@ -44,7 +48,7 @@ function getMilestoneTitle(id: MilestoneId): string {
 }
 
 function getCategoryName(categoryId: CategoryId): string {
-	return getCategoryById(categoryId)?.name ?? `#${categoryId}`;
+	return getCategoryById(categoryId)?.name ?? UNRESOLVED_ENTITY_LABELS.category;
 }
 
 function maxCategoryCount(child: ChildValuePreview): number {

--- a/src/lib/ui/features/admin/SiblingChallengeComparison.stories.svelte
+++ b/src/lib/ui/features/admin/SiblingChallengeComparison.stories.svelte
@@ -13,12 +13,6 @@ import SiblingChallengeComparison from './SiblingChallengeComparison.svelte';
 // 表示テキストは labels SSOT 経由 (DESIGN.md §6 Storybook ラベル言語ポリシー)。
 const L = STORYBOOK_LABELS.siblingChallengeComparison;
 
-const { Story } = defineMeta({
-	title: 'Features/Admin/SiblingChallengeComparison',
-	component: SiblingChallengeComparison,
-	tags: ['autodocs'],
-});
-
 /** ChildChallenge の必須項目を埋める最小 fixture。表示に効くのは childId / 進捗 / completed のみ。 */
 function instance(
 	id: string,
@@ -90,29 +84,30 @@ const children = [child('child-1', L.firstChildNickname), child('child-2', L.sec
 
 /** child-2 が children 一覧に無い = 名前を解決できない状態 (データ不整合)。 */
 const childrenMissingOne = [child('child-1', L.firstChildNickname)];
+
+// `component` 指定時は Storybook が args でも component を描画するため、meta 既定 args を必ず与える
+// (与えないと group が undefined で render error になる)。
+const { Story } = defineMeta({
+	title: 'Features/Admin/SiblingChallengeComparison',
+	component: SiblingChallengeComparison,
+	tags: ['autodocs'],
+	args: { group, children },
+});
 </script>
 
-<Story name="Default">
-	<div style="width: 360px;">
-		<SiblingChallengeComparison {group} {children} />
-	</div>
-</Story>
+<Story name="Default" />
 
-<Story name="Unresolved Child Name">
-	<div style="width: 360px;">
-		<SiblingChallengeComparison {group} children={childrenMissingOne} />
-	</div>
-</Story>
+<!-- child-2 が children 一覧に無い = 名前を解決できない状態。内部 ID ではなく汎用語が出る。 -->
+<Story name="Unresolved Child Name" args={{ group, children: childrenMissingOne }} />
 
-<Story name="All Completed">
-	<div style="width: 360px;">
-		<SiblingChallengeComparison
-			group={{
-				...group,
-				instances: [instance('c1', 'child-1', 7, 7, 1), instance('c2', 'child-2', 7, 7, 1)],
-				allCompleted: true,
-			}}
-			{children}
-		/>
-	</div>
-</Story>
+<Story
+	name="All Completed"
+	args={{
+		group: {
+			...group,
+			instances: [instance('c1', 'child-1', 7, 7, 1), instance('c2', 'child-2', 7, 7, 1)],
+			allCompleted: true,
+		},
+		children,
+	}}
+/>

--- a/src/lib/ui/features/admin/SiblingChallengeComparison.stories.svelte
+++ b/src/lib/ui/features/admin/SiblingChallengeComparison.stories.svelte
@@ -1,0 +1,118 @@
+<script module lang="ts">
+// #4538: 内部 ID を表示名のフォールバックにしない (DESIGN.md §6) — その見た目を確認できる場所。
+//
+// フォールバックが出る条件は「children 一覧から引けない childId を参照している」= データ不整合で、
+// 通常運用でも demo 環境 (DATA_SOURCE=demo) でも発生しない。実画面での撮影が原理的にできないため、
+// **見た目の確認はこの story で行う** (SS gate の `ss-render-impossible` 宣言が指す先)。
+import { defineMeta } from '@storybook/addon-svelte-csf';
+import type { ChildId } from '$lib/domain/ids';
+import { STORYBOOK_LABELS } from '$lib/domain/labels';
+import type { Child, ChildChallenge } from '$lib/server/db/types';
+import SiblingChallengeComparison from './SiblingChallengeComparison.svelte';
+
+// 表示テキストは labels SSOT 経由 (DESIGN.md §6 Storybook ラベル言語ポリシー)。
+const L = STORYBOOK_LABELS.siblingChallengeComparison;
+
+const { Story } = defineMeta({
+	title: 'Features/Admin/SiblingChallengeComparison',
+	component: SiblingChallengeComparison,
+	tags: ['autodocs'],
+});
+
+/** ChildChallenge の必須項目を埋める最小 fixture。表示に効くのは childId / 進捗 / completed のみ。 */
+function instance(
+	id: string,
+	childId: string,
+	currentValue: number,
+	targetValue: number,
+	completed: number,
+): ChildChallenge {
+	return {
+		id,
+		childId: childId as ChildId,
+		title: L.challengeTitle,
+		description: null,
+		challengeType: 'count',
+		periodType: 'weekly',
+		startDate: '2026-08-10',
+		endDate: '2026-08-16',
+		targetConfig: '{}',
+		rewardConfig: '{}',
+		status: 'active',
+		isActive: 1,
+		sourceTemplateId: 'auto:weekly',
+		currentValue,
+		targetValue,
+		completed,
+		completedAt: null,
+		rewardClaimed: 0,
+		rewardClaimedAt: null,
+		celebrationShownAt: null,
+		createdAt: '2026-08-10T00:00:00.000Z',
+		updatedAt: '2026-08-10T00:00:00.000Z',
+	};
+}
+
+function child(id: string, nickname: string): Child {
+	return {
+		id: id as ChildId,
+		nickname,
+		age: 8,
+		birthDate: null,
+		theme: 'default',
+		uiMode: 'elementary',
+		uiModeManuallySet: 0,
+		avatarUrl: null,
+		displayConfig: null,
+		userId: null,
+		birthdayBonusMultiplier: 1,
+		lastBirthdayBonusYear: null,
+		isArchived: 0,
+		archivedReason: null,
+		createdAt: '2026-08-01T00:00:00.000Z',
+		updatedAt: '2026-08-01T00:00:00.000Z',
+	};
+}
+
+const group = {
+	groupKey: 'auto:weekly',
+	title: L.challengeTitle,
+	description: null,
+	startDate: '2026-08-10',
+	endDate: '2026-08-16',
+	periodType: 'weekly',
+	sourceTemplateId: 'auto:weekly',
+	instances: [instance('c1', 'child-1', 5, 7, 0), instance('c2', 'child-2', 7, 7, 1)],
+	allCompleted: false,
+};
+
+const children = [child('child-1', L.firstChildNickname), child('child-2', L.secondChildNickname)];
+
+/** child-2 が children 一覧に無い = 名前を解決できない状態 (データ不整合)。 */
+const childrenMissingOne = [child('child-1', L.firstChildNickname)];
+</script>
+
+<Story name="Default">
+	<div style="width: 360px;">
+		<SiblingChallengeComparison {group} {children} />
+	</div>
+</Story>
+
+<Story name="Unresolved Child Name">
+	<div style="width: 360px;">
+		<SiblingChallengeComparison {group} children={childrenMissingOne} />
+	</div>
+</Story>
+
+<Story name="All Completed">
+	<div style="width: 360px;">
+		<SiblingChallengeComparison
+			group={{
+				...group,
+				instances: [instance('c1', 'child-1', 7, 7, 1), instance('c2', 'child-2', 7, 7, 1)],
+				allCompleted: true,
+			}}
+			{children}
+		/>
+	</div>
+</Story>

--- a/src/lib/ui/features/admin/SiblingChallengeComparison.svelte
+++ b/src/lib/ui/features/admin/SiblingChallengeComparison.svelte
@@ -9,7 +9,7 @@
 // - 同じ sourceTemplateId / (title + 期間) を共有する instance を比較
 
 import type { ChildId } from '$lib/domain/ids';
-import { ADMIN_CHALLENGES_PAGE_LABELS } from '$lib/domain/labels';
+import { ADMIN_CHALLENGES_PAGE_LABELS, UNRESOLVED_ENTITY_LABELS } from '$lib/domain/labels';
 import type { Child, ChildChallengeGroup } from '$lib/server/db/types';
 import ProgressFill from '$lib/ui/components/ProgressFill.svelte';
 
@@ -22,7 +22,7 @@ const { group, children }: Props = $props();
 
 function childLabel(childId: ChildId): string {
 	const c = children.find((x) => x.id === childId);
-	return c?.nickname ?? `#${childId}`;
+	return c?.nickname ?? UNRESOLVED_ENTITY_LABELS.child;
 }
 
 // 進捗率 (0-100)

--- a/src/routes/(parent)/admin/challenges/+page.svelte
+++ b/src/routes/(parent)/admin/challenges/+page.svelte
@@ -8,6 +8,7 @@ import {
 	CHALLENGES_LABELS,
 	PAGE_TITLES,
 	UI_LABELS,
+	UNRESOLVED_ENTITY_LABELS,
 } from '$lib/domain/labels';
 // CX-DoR #9・#11: empty state を共通 SSOT に統一 (NN/G #4 consistency)
 import UnifiedEmptyState from '$lib/marketplace/ui/UnifiedEmptyState.svelte';
@@ -231,7 +232,7 @@ function tabHref(childId: ChildId | 'all'): string {
 						{@const pct = Math.min(100, Math.round((firstInstance.currentValue / firstInstance.targetValue) * 100))}
 						<div class="flex items-center gap-2" data-testid="admin-challenges-single-progress">
 							<span class="text-xs font-medium text-[var(--color-text-primary)] w-20 truncate">
-								{child?.nickname ?? `#${firstInstance.childId}`}
+								{child?.nickname ?? UNRESOLVED_ENTITY_LABELS.child}
 							</span>
 							<div class="flex-1 h-2 bg-[var(--color-surface-secondary)] rounded-full overflow-hidden">
 								<div
@@ -261,7 +262,7 @@ function tabHref(childId: ChildId | 'all'): string {
 											ADMIN_CHALLENGES_PAGE_LABELS.deleteConfirmTitle,
 											ADMIN_CHALLENGES_PAGE_LABELS.deleteConfirmBody(
 												group.title,
-												child?.nickname ?? `#${instance.childId}`,
+												child?.nickname ?? UNRESOLVED_ENTITY_LABELS.child,
 											),
 										)
 									) {
@@ -276,7 +277,7 @@ function tabHref(childId: ChildId | 'all'): string {
 									size="sm"
 									data-testid="admin-challenge-delete-{instance.id}"
 								>
-									{group.instances.length >= 2 ? `${child?.nickname ?? '#' + instance.childId} を削除` : CHALLENGES_LABELS.deleteButton}
+									{group.instances.length >= 2 ? `${child?.nickname ?? UNRESOLVED_ENTITY_LABELS.child} を削除` : CHALLENGES_LABELS.deleteButton}
 								</Button>
 							</form>
 						{/each}

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -6,7 +6,7 @@ import { todayDateJST } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asChildId, type ChildId } from '$lib/domain/ids';
-import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import { PLAN_GATE_LABELS, UNRESOLVED_ENTITY_LABELS } from '$lib/domain/labels';
 import type { ChecklistPayload } from '$lib/domain/marketplace-item';
 // #3151 slice3 (ADR-0066): item label / icon の値域 SSOT。admin authoring 経路と wire schema が
 // 同一境界を共有し、authoring 可能な item ⊆ export/import 往復可能な item を成立させる。
@@ -76,7 +76,7 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 					const child = children.find((c) => c.id === a.childId);
 					return {
 						childId: a.childId,
-						childName: child?.nickname ?? `#${a.childId}`,
+						childName: child?.nickname ?? UNRESOLVED_ENTITY_LABELS.child,
 						checkedCount: checkedIds.length,
 						totalCount: items.length,
 						completedAll: log?.completedAll === 1,

--- a/src/routes/(parent)/admin/checklists/+page.svelte
+++ b/src/routes/(parent)/admin/checklists/+page.svelte
@@ -12,6 +12,7 @@ import {
 	PAGE_TITLES,
 	PLAN_GATE_LABELS,
 	UI_LABELS,
+	UNRESOLVED_ENTITY_LABELS,
 } from '$lib/domain/labels';
 import { CONCEPT_ICONS } from '$lib/domain/terms';
 import AdminResourceHeader from '$lib/features/admin/components/AdminResourceHeader.svelte';
@@ -770,7 +771,7 @@ async function saveDistribution() {
 }
 
 function getChildName(childId: ChildId): string {
-	return data.children.find((c) => c.id === childId)?.nickname ?? `#${childId}`;
+	return data.children.find((c) => c.id === childId)?.nickname ?? UNRESOLVED_ENTITY_LABELS.child;
 }
 </script>
 

--- a/tests/unit/architecture/child-ui-display-integrity.test.ts
+++ b/tests/unit/architecture/child-ui-display-integrity.test.ts
@@ -20,6 +20,19 @@ const CHILD_SCOPE = [
 	join(ROOT, 'src', 'lib', 'features', 'child-home'),
 ];
 
+// #4538: 内部 ID 露出禁止 (DESIGN.md §6) は**画面を限定していない**。
+// 子供画面だけを走査していたため、親画面に同型が 7 箇所残ったまま「子供画面は直したから完了」と
+// 誤認する構造になっていた (実測: admin/challenges 3 / admin/checklists 2 / 共有 UI 2)。
+// 子供に見せるより実害は小さいが、guard が見ていない限り永久に先送りされる。
+// `src/lib/features` は `child-home` を含むため CHILD_SCOPE を足すと二重走査になる。
+// 子供画面 (`(child)`) だけを明示的に足し、残りは親画面 + 共有 UI で覆う。
+const UI_SCOPE = [
+	join(ROOT, 'src', 'routes', '(child)'),
+	join(ROOT, 'src', 'routes', '(parent)'),
+	join(ROOT, 'src', 'lib', 'features'),
+	join(ROOT, 'src', 'lib', 'ui'),
+];
+
 function collectFiles(dir: string): string[] {
 	const out: string[] = [];
 	for (const entry of readdirSync(dir)) {
@@ -31,10 +44,11 @@ function collectFiles(dir: string): string[] {
 }
 
 const FILES = CHILD_SCOPE.flatMap(collectFiles);
+const UI_FILES = UI_SCOPE.flatMap(collectFiles);
 
-function findViolations(pattern: RegExp): string[] {
+function findViolations(pattern: RegExp, files: string[] = FILES): string[] {
 	const hits: string[] = [];
-	for (const file of FILES) {
+	for (const file of files) {
 		const lines = readFileSync(file, 'utf-8').split(/\r?\n/);
 		lines.forEach((line, i) => {
 			// 実装ではなく経緯を書いたコメント行は対象外
@@ -56,8 +70,16 @@ describe('#4509 子供画面の表示整合 — 再発 guard', () => {
 	});
 
 	it('⑤ 内部 ID を表示名のフォールバックにしない (DESIGN.md §6、#498 / #573)', () => {
-		// 例: `nickname ?? \`#${s.childId}\`
-		expect(findViolations(/`#\$\{[^}]*[Ii]d\b[^}]*\}/u)).toEqual([]);
+		// #4538: 走査対象は子供画面に限らない。DESIGN.md §6 は画面を限定しておらず、
+		// 子供画面だけを見る guard は「子供画面は直したから完了」の誤認を作る。
+		//
+		// 2 つの書き方を両方見る。テンプレートリテラルだけを見ていた旧実装は、同一ファイル内の
+		// 文字列連結形 (admin/challenges の `'#' + instance.childId`) をそもそも検出できなかった。
+		const templateForm = /`#\$\{[^}]*[Ii]d\b[^}]*\}/u; // `#${childId}`
+		const concatForm = /['"]#['"]\s*\+\s*[A-Za-z0-9_.?[\]]*[Ii]d\b/u; // '#' + childId
+
+		expect(findViolations(templateForm, UI_FILES)).toEqual([]);
+		expect(findViolations(concatForm, UI_FILES)).toEqual([]);
 	});
 
 	it('① 経験値の増分を固定リテラルで描画しない (実データから導出する)', () => {
@@ -66,5 +88,17 @@ describe('#4509 子供画面の表示整合 — 再発 guard', () => {
 
 	it('guard の走査対象がゼロ件になっていない (scope 消失の検知)', () => {
 		expect(FILES.length).toBeGreaterThan(20);
+	});
+
+	it('⑤ の走査対象が親画面まで届いている (#4538、scope 縮退の検知)', () => {
+		// 0 件アンカー: dir を rename / 移動して UI_SCOPE が空振りしても guard が緑のままにならない。
+		// 「子供画面のぶんだけ」に戻る退行も、件数が FILES を上回ることで検知する。
+		expect(UI_FILES.length).toBeGreaterThan(FILES.length);
+		for (const dir of UI_SCOPE) {
+			expect(
+				UI_FILES.filter((f) => f.startsWith(dir)).length,
+				`${dir} の走査結果が 0 件 (dir 消失 / rename で guard が空振りしている)`,
+			).toBeGreaterThan(0);
+		}
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

親が管理画面で内部 ID (`#01J...`) を見せられなくなる。より重要なのは、同じ壊れ方が親画面で再発したら CI が落ちるようになること — guard が見ていない範囲は永久に先送りされる。

## 関連 Issue

Closes #4538

## 変更内容

### 本体: guard の走査範囲を親画面まで広げた

#4527 が追加した `tests/unit/architecture/child-ui-display-integrity.test.ts` の ⑤「内部 ID を表示名のフォールバックにしない」は `(child)` route と `child-home` しか走査していなかった。`docs/DESIGN.md` §6「内部コード露出禁止」は画面を限定していないため、親画面・共有 UI に同型が残ったまま CI は緑だった。

- 走査範囲に `src/routes/(parent)` / `src/lib/features` / `src/lib/ui` を追加（⑤ のみ。⑥ ① は子供画面固有のため scope 据え置き）
- **文字列連結形 (`'#' + childId`) の検出を追加**。テンプレートリテラルしか見ていなかったため、`admin/challenges/+page.svelte:279` は旧 regex ではそもそも検出できなかった（同一ファイル内に検出できる形と検出できない形が同居していた）
- 0 件アンカーを追加: `UI_FILES.length > FILES.length` + 走査 dir ごとに 0 件でないこと。dir の rename / 移動で guard が空振りしても緑にならない

### 文言: 7 箇所を labels SSOT 経由の汎用語に置換

`UNRESOLVED_ENTITY_LABELS`（labels.ts）を追加し、内部 ID を出さない表現へ置換した（ADR-0045、日本語直書きなし）。

| ファイル | 箇所 |
|---|---|
| `src/routes/(parent)/admin/challenges/+page.svelte` | 3 (テンプレート 2 + 連結 1) |
| `src/routes/(parent)/admin/checklists/+page.svelte` | 1 |
| `src/routes/(parent)/admin/checklists/+page.server.ts` | 1 |
| `src/lib/ui/features/admin/SiblingChallengeComparison.svelte` | 1 |
| `src/lib/features/value-preview/MonthlyValuePreview.svelte` | 1 (categoryId) |

`MonthlyValuePreview` の `#${categoryId}` は Issue 本文の 6 箇所リストに含まれるもので、childId ではないが**同じ class**（内部 ID を表示名のフォールバックにする）であり、広げた guard の走査対象に入るため同時に是正した。

子供画面側の同種フォールバックは既存の `CHILD_HOME_LABELS.siblingUnknownName`（「きょうだい」）。読み手が違う（子供 = ひらがな / 親 = 敬称）ため値は分けるが、内部 ID を出さない点は共通で、guard が両 scope をまとめて見る。

### Storybook story を追加

フォールバックが出る条件は「children 一覧から引けない childId を参照している」= データ不整合で、通常運用でも demo 環境でも発生しない。見た目を確認できる場所として `SiblingChallengeComparison.stories.svelte` を追加した（`Unresolved Child Name` story）。表示テキストは `STORYBOOK_LABELS` 経由（DESIGN.md §6 Storybook ラベル言語ポリシー）。

## 検証

| 検証 | コマンド | 結果 |
|---|---|---|
| guard 単体 | `npx vitest run tests/unit/architecture/child-ui-display-integrity.test.ts` | 1 file / 5 tests passed |
| architecture + 関連 unit | `npx vitest run tests/unit/architecture/ tests/unit/routes/admin-checklists-copy-distribution.test.ts tests/unit/routes/admin-checklists-create-template.test.ts tests/unit/domain/` | 126 files / 1623 tests passed |
| Storybook | `npm run test:storybook` | 48 files / 241 tests passed (Errors 4 = develop と同数の既知 leak) |
| 型 | `npx svelte-check --threshold error` | 8141 FILES 0 ERRORS 0 WARNINGS |
| lint | `npx biome check <変更 7 file>` | No fixes applied |
| cspell | `npm run cspell` | 1965 files, Issues found: 0 |
| repo 走査 test 宣言 | `node scripts/check-repo-scan-test-declaration.mjs` | OK — 55 件すべて区分宣言済 |

残存 0 件の物理確認（コメント行を除く実装行は 0 件）:

```console
$ grep -rnE '`#\$\{[^}]*[Ii]d\b[^}]*\}' src/
src/lib/domain/labels.ts:10070: * 内部 ID (`#${childId}` 等) を…          ← コメント
src/lib/features/child-home/sibling-display-name.ts:4: * #4509 ⑤: …        ← コメント
$ grep -rnE "['\"]#['\"]\s*\+\s*[A-Za-z0-9_.?\[\]]*[Ii]d\b" src/
(0 件)
```

### 変異試験（guard に歯があることの実測）

| 変異 | 内容 | 落ちたテスト |
|---|---|---|
| B1 | `SiblingChallengeComparison.svelte` の fallback を `` `#${childId}` `` に戻す | **1 failed / 4 passed** — ⑤「内部 ID を表示名のフォールバックにしない」 |
| B2 | `admin/challenges/+page.svelte` の fallback を `'#' + instance.childId` に戻す | **1 failed / 4 passed** — 同上（連結形も検出できている） |
| B3 | guard の scope を子供画面のみに縮退 (`UI_FILES = CHILD_SCOPE.flatMap(...)`) | **1 failed / 4 passed** — 「⑤ の走査対象が親画面まで届いている」 |
| 復元後 | — | **5 passed** |

B1 実測ログ:

```
× ⑤ 内部 ID を表示名のフォールバックにしない (DESIGN.md §6、#498 / #573)
AssertionError: expected [ Array(1) ] to deeply equal []
Tests  1 failed | 4 passed (5)
```

B2 実測ログ（検出行そのもの）:

```
× ⑤ 内部 ID を表示名のフォールバックにしない (DESIGN.md §6、#498 / #573)
+   "src\routes\(parent)\admin\challenges\+page.svelte:280: {group.instances.length >= 2 ? `${child?.nickname ?? '#' + instance.childId} を削除` … }",
Tests  1 failed | 4 passed (5)
```

B3 実測ログ:

```
× ⑤ の走査対象が親画面まで届いている (#4538、scope 縮退の検知)
AssertionError: expected 32 to be greater than 32
Tests  1 failed | 4 passed (5)
```

変異はすべて逆 sed で復元し、復元後に全 PASS を再確認した（`git diff` に残っていない）。

### 見た目の確認

<!-- ss-render-impossible: フォールバックの発生条件が「children 一覧から引けない childId を参照している」= データ不整合であり、撮影に使う demo 環境 (DATA_SOURCE=demo) では正常な seed しか入らないため実画面に描画させられない -->

story: `src/lib/ui/features/admin/SiblingChallengeComparison.stories.svelte` の `Unresolved Child Name`。

Storybook (`npx storybook dev -p 6017`) で実際に描画して目視確認した。Playwright で抽出した実テキスト:

```
=== unresolved-child-name ===       === default ===
きょうだいの進捗                      きょうだいの進捗
はると                              はると
5/7                                5/7
不明なお子さま                        ひなた
7/7 ✅                             7/7 ✅
```

**残課題 (本 PR では直さない)**: この列は既存の `w-20 truncate` のため、実描画では「不明なお子…」と切れる。旧実装の `#<内部ID>` も同じく切れており、**6 文字を超える実ニックネームも同様に切れる**既存のレイアウト制約であるため、本 PR の scope (内部 ID を出さない) とは別問題として扱う。ラベルを列幅に合わせて短くすると、同じラベルを使う他 4 箰所 (列幅制約なし) の表現が悪くなる。

### Storybook の unhandled error について

`npm run test:storybook` の `Errors 4` は既知の zag-js focus-visible leak (`tests/CLAUDE.md` #3687) で、本 PR 前後で変わらない (develop でも 4)。`--dangerouslyIgnoreUnhandledErrors` 下で全 test は PASS している。

## 影響範囲

- **顧客に見える変化**: 親管理画面（チャレンジ / チェックリスト）と月次サマリで、**参照先が解決できないときだけ**表示が `#<内部ID>` から「不明なお子さま」「不明なカテゴリ」に変わる。解決できる通常時の表示は不変
- 触った並行実装ペア: UI ラベル → `labels.ts` に追加（LP 側 `shared-labels.js` は本ラベルを配信しないため `generate-lp-labels` の再生成不要。アプリ内部のフォールバック文言のみ）
- 破壊的変更: なし。DB / API / route に変更なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
