### PR TITLE
fix(ci): #4550 gate が検査したつもりで検査していない残懸念 3 件を塞ぐ

### DIFF
--- a/actions/pr-lane/action.yml
+++ b/actions/pr-lane/action.yml
@@ -82,6 +82,7 @@ runs:
         GH_TOKEN: ${{ github.token }}
         REPO: ${{ github.repository }}
         PR_NUMBER: ${{ inputs.pr-number }}
+        ACTOR: ${{ inputs.actor }}
       run: |
         set -uo pipefail
         if [ -z "${PR_NUMBER}" ]; then
@@ -101,8 +102,19 @@ runs:
           --jq '[.[] | select((.parents | length) == 1) | (.author.login // "")] | join(",")' 2>/dev/null)"; then
           echo "authors=${authors}" >> "${GITHUB_OUTPUT}"
         else
+          # fail-open が常態化していないか後から追える必要がある (#4348 と同じ「gate が生きている
+          # つもりで死んでいる」class)。`::warning::` は annotation UI に残るが、実行中ログに埋もれて
+          # 発動回数が誰にも観測されない。job summary にも同じ内容を出し、Actions の Summary タブで
+          # 「この PR / この run で bot exemption 判定が実質 actor のみに縮退した」ことを見える化する。
           echo "::warning::[actions/pr-lane] commit author 取得に失敗しました。actor のみで判定します (fail-open)。"
           echo "authors=" >> "${GITHUB_OUTPUT}"
+          {
+            echo "### ⚠️ actions/pr-lane fail-open"
+            echo ""
+            echo "commit author 取得 (\`pulls/${PR_NUMBER}/commits\`) に失敗したため、bot exemption 判定を actor (\`${ACTOR}\`) のみで行いました。"
+            echo "権限不足 / API error / rate limit の可能性があります。頻発する場合は放置せず原因を調査してください。"
+            echo ""
+          } >> "${GITHUB_STEP_SUMMARY}"
         fi
 
     - name: Classify PR lane (scripts/pr-lane.mjs SSOT)

--- a/scripts/lib/ci/pr-input.mjs
+++ b/scripts/lib/ci/pr-input.mjs
@@ -191,11 +191,19 @@ export function parseGhPrView(raw) {
 /**
  * gh を実行して PR の body / labels / files を取る (既定の IO 実装、test では DI で差し替える)。
  *
+ * `expectedRepo` (`owner/repo`) が分かっているときは `gh pr view` に `--repo` を明示する。
+ * `gh` は `--repo` 未指定だと **cwd から推測したリポジトリ**に対して PR 番号を解決するため、
+ * CI の checkout 構成やローカルの cwd がずれると「意図と違うリポジトリの同番号 PR」を
+ * 静かに引いてしまう余地が残る (#4519 と同じ「検査対象の真正性」の軸)。`--repo` を渡せば
+ * gh 自身がその時点で pin する。事後の owner/repo 突合は `resolvePrInput` 側が担う。
+ *
  * @param {string} prNumber - 数字のみであることを呼び出し前に検証済み
+ * @param {string} [expectedRepo] - `owner/repo`。空なら従来通り cwd 推測に委ねる
  * @returns {string} 生 JSON
  */
-function defaultGhView(prNumber) {
-	return execSync(`gh pr view ${prNumber} --json body,labels,files,url`, {
+function defaultGhView(prNumber, expectedRepo = '') {
+	const repoArg = expectedRepo ? ` --repo ${expectedRepo}` : '';
+	return execSync(`gh pr view ${prNumber}${repoArg} --json body,labels,files,url`, {
 		encoding: 'utf-8',
 		stdio: ['ignore', 'pipe', 'pipe'],
 		timeout: 30_000,
@@ -209,7 +217,7 @@ function defaultGhView(prNumber) {
  * 解決できない場合は **必ず `PrInputError`**。空入力で先に進めない (skip / pass に倒さない)。
  *
  * @param {{ argv?: string[]; env?: Record<string, string | undefined>; need?: 'body' | 'prNumber';
- *   scriptName?: string; ghView?: (prNumber: string) => string }} input
+ *   scriptName?: string; ghView?: (prNumber: string, expectedRepo?: string) => string }} input
  * @returns {{ source: 'gh' | 'env'; prNumber: string | null; body: string; labels: string[];
  *   files: string[]; repo: string }}
  */
@@ -224,9 +232,11 @@ export function resolvePrInput({
 	if (plan.source === 'error') throw new PrInputError(plan.message);
 
 	if (plan.source === 'gh') {
+		// CI では常に定義される (GitHub Actions 既定 env)。ローカル実行で未設定なら突合を skip する。
+		const expectedRepo = (env.GITHUB_REPOSITORY ?? '').trim();
 		let raw;
 		try {
-			raw = ghView(plan.prNumber);
+			raw = ghView(plan.prNumber, expectedRepo);
 		} catch (err) {
 			throw new PrInputError(
 				`gh pr view ${plan.prNumber} に失敗しました: ${err instanceof Error ? err.message : String(err)}\n` +
@@ -239,13 +249,20 @@ export function resolvePrInput({
 				`PR #${plan.prNumber} の body が空です。検査対象が無い状態で成功終了させません (#4348 / #4084)。`,
 			);
 		}
+		const actualRepo = `${parsed.owner}/${parsed.repo}`;
+		if (expectedRepo && actualRepo !== expectedRepo) {
+			throw new PrInputError(
+				`PR #${plan.prNumber} は ${expectedRepo} ではなく ${actualRepo} の PR でした。` +
+					`意図しないリポジトリの PR を検査対象にしません (実在確認だけでは足りず、検査対象の真正性を突合する必要がある)。`,
+			);
+		}
 		return {
 			source: 'gh',
 			prNumber: plan.prNumber,
 			body: parsed.body,
 			labels: parsed.labels,
 			files: parsed.files,
-			repo: `${parsed.owner}/${parsed.repo}`,
+			repo: actualRepo,
 		};
 	}
 

--- a/tests/unit/scripts/pr-input.test.ts
+++ b/tests/unit/scripts/pr-input.test.ts
@@ -227,6 +227,42 @@ describe('resolvePrInput', () => {
 		).toThrow(PrInputError);
 	});
 
+	it('GITHUB_REPOSITORY があれば ghView に --repo pin 用の expectedRepo を渡す', () => {
+		const seen: Array<string | undefined> = [];
+		resolvePrInput({
+			argv: ['--pr', '4513'],
+			env: { GITHUB_REPOSITORY: 'Takenori-Kusaka/ganbari-quest' },
+			ghView: (_prNumber, expectedRepo) => {
+				seen.push(expectedRepo);
+				return ghView();
+			},
+		});
+		expect(seen).toEqual(['Takenori-Kusaka/ganbari-quest']);
+	});
+
+	it('gh が別リポジトリの PR url を返したら throw する (検査対象の真正性突合、#4519 と同軸)', () => {
+		// cwd ずれ / checkout 構成ミスで意図と違うリポジトリの同番号 PR を引いてしまうケースの再現。
+		// url 自体は妥当な形なので #4519 前の実装 (url 形式チェックのみ) は通してしまっていた。
+		expect(() =>
+			resolvePrInput({
+				argv: ['--pr', '4513'],
+				env: { GITHUB_REPOSITORY: 'Takenori-Kusaka/ganbari-quest' },
+				ghView: () =>
+					JSON.stringify({
+						body: '## 概要\n本文',
+						labels: [],
+						files: [],
+						url: 'https://github.com/some-other-org/some-other-repo/pull/4513',
+					}),
+			}),
+		).toThrow(PrInputError);
+	});
+
+	it('GITHUB_REPOSITORY 未設定ならリポジトリ突合を skip する (ローカル実行の既存経路は不変)', () => {
+		const input = resolvePrInput({ argv: ['--pr', '4513'], env: {}, ghView });
+		expect(input.repo).toBe('Takenori-Kusaka/ganbari-quest');
+	});
+
 	it('env 経路は従来どおり labels / files を分解する', () => {
 		const input = resolvePrInput({
 			argv: [],

--- a/tests/unit/services/email-content-snapshot.test.ts
+++ b/tests/unit/services/email-content-snapshot.test.ts
@@ -57,6 +57,7 @@ vi.mock('$lib/runtime/env', () => ({
 
 import { PLAN_FULL_TERMS, PLAN_RETENTION_TERMS } from '$lib/domain/terms';
 import * as emailService from '$lib/server/services/email-service';
+import * as trialNotificationService from '$lib/server/services/trial-notification-service';
 import {
 	sendTrialEndedTodayEmail,
 	sendTrialEnding1DayEmail,
@@ -254,16 +255,29 @@ describe('顧客向けメールの件名・本文 snapshot (#4507)', () => {
 // ============================================================
 
 describe('メール網羅性 (#4507)', () => {
-	it('email-service の send*Email export が全て snapshot 対象になっている', () => {
-		const exported = Object.keys(emailService)
-			.filter((key) => /^send[A-Z].*Email$/.test(key))
-			// sendEmail 相当の低レベル API は個別メールではないため対象外
-			.filter((key) => key !== 'sendEmail');
+	/** `send*Email` export を反射で数える。個別メール名のハードコード列挙は追加漏れを検出できない。 */
+	function sendEmailExportNames(mod: Record<string, unknown>): string[] {
+		return (
+			Object.keys(mod)
+				.filter((key) => /^send[A-Z].*Email$/.test(key))
+				// sendEmail 相当の低レベル API は個別メールではないため対象外
+				.filter((key) => key !== 'sendEmail')
+		);
+	}
+
+	it('email-service + trial-notification-service の send*Email export が全て snapshot 対象になっている', () => {
+		// email-service 側だけを数えると trial-notification-service 側の 3 通が分母から漏れ、
+		// そちらに新規メールを足しても検出されずに素通りしていた (#4507 監査後の残懸念)。
+		// 2 module を反射で数えて合算することで、どちらに足しても検出できるようにする。
+		const exported = [
+			...sendEmailExportNames(emailService as unknown as Record<string, unknown>),
+			...sendEmailExportNames(trialNotificationService as unknown as Record<string, unknown>),
+		];
 
 		// snapshot 側の網羅数と export 数が一致していれば、新規メールの追加漏れは無い。
-		// (email-service の 15 通 + trial-notification の 3 通)
-		expect(exported).toHaveLength(EMAILS.length - 3);
-		expect(EMAILS).toHaveLength(18);
+		// (手動アンカー `toHaveLength(18)` には依存しない — それ自体が「足し忘れても気づけない」
+		// 固定値だったため、比較先を反射由来の exported.length に置き換える)
+		expect(exported).toHaveLength(EMAILS.length);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

顧客への直接価値は無い CI 基盤 fix。QM / Dev が「gate が緑 = 実際に検査されている」を信頼できる状態を保つことで、間接的に顧客に届く前の品質劣化を防ぐ。

## 関連 Issue

Closes #4550

## 変更内容

#4519 / #4520 merge 後の QM レビューで見つかった、同一 class (「gate が検査したつもりで検査していない / 発動が観測できない」) の残懸念 3 件を同一 PR で修正。

1. **`scripts/lib/ci/pr-input.mjs`**: `resolvePrInput` が `gh pr view` で取得した PR の owner/repo を `GITHUB_REPOSITORY` と突合し、不一致なら `PrInputError` を投げるようにした。`defaultGhView` は `expectedRepo` があれば `gh pr view --repo <repo>` で pin する。旧実装は url 正規表現で「有効な PR url であること」しか見ておらず、cwd / checkout 構成のずれで意図と違うリポジトリの PR を検査対象にしてしまう余地が理論上残っていた
2. **`actions/pr-lane/action.yml`**: commit author 取得失敗時の fail-open (bot exemption 判定が actor のみに縮退する分岐) で、`::warning::` に加えて `GITHUB_STEP_SUMMARY` にも同内容を出力するようにした。annotation だけだとログに埋もれ、発動が常態化していても誰も気づけない
3. **`tests/unit/services/email-content-snapshot.test.ts`**: メール網羅性チェックが `email-service` の export しか反射で数えておらず、`trial-notification-service` の 3 通 (`sendTrialEnding3DaysEmail` 等) が手動アンカー `toHaveLength(18)` 頼みで分母から漏れていた。両 module の `send*Email` export を反射で合算するよう修正し、手動アンカーを撤去した

新しい CI check は追加していない。既存の script / action / test の中で穴を塞いだ (Platform 原則: 装置の本数を増やさない)。

## 検証

```
npx vitest run tests/unit/scripts/pr-input.test.ts tests/unit/services/email-content-snapshot.test.ts
# Test Files  2 passed (2) / Tests  53 passed (53)
```

**変異試験 (3 件とも歯があることを確認済み)**:

- (1) `resolvePrInput` に別リポジトリの PR url を返す `ghView` を注入すると `PrInputError` で throw する新規 test (`GITHUB_REPOSITORY があれば ghView に --repo pin 用の expectedRepo を渡す` / `gh が別リポジトリの PR url を返したら throw する`) で固定。既存の「GITHUB_REPOSITORY 未設定ならローカル実行は不変」も回帰確認済み
- (2) `actions/pr-lane/action.yml` の fail-open 分岐相当のシェルを `gh` を fail するようモックして単独実行し、`GITHUB_STEP_SUMMARY` に `### ⚠️ actions/pr-lane fail-open` が出力されることをローカルで実測確認 (composite action 自体は CI 上でしか完全実行できないため、bash ロジックの単独再現で確認)
- (3) `trial-notification-service.ts` に `sendMutationTestEmail` をローカルで一時追加し、網羅性 test が `expected ... to have a length of 18 but got 19` で fail することを確認 → 追加を revert し再度 53 test 全 PASS を確認

`biome check` / `eslint` は pre-push hook で該当変更ファイルに対して自動実行され PASS 済み。

## 影響範囲

- 顧客に見える変化: なし (CI / test 基盤のみ)
- 触った並行実装ペア: なし
- 破壊的変更: なし。`resolvePrInput` の repo 突合は `GITHUB_REPOSITORY` 未設定時 (ローカル実行) は従来どおり skip されるため、既存呼び出し元 3 script (`check-pr-screenshot.mjs` / `check-ss-blob-sha-uniqueness.mjs` / `check-ss-render-health.mjs`、いずれも default `ghView` 使用) の挙動は CI 上でのみ強化される

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
