### PR TITLE
fix(a11y): #4545 不可逆操作の最重要警告を「色文字だけ」「スクロール末尾」から救出する

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -87,7 +87,7 @@
   },
   "src/lib/features/admin/components/DowngradeResourceSelector.svelte": {
     "svelte/no-useless-children-snippet": {
-      "count": 9
+      "count": 8
     },
     "svelte/prefer-svelte-reactivity": {
       "count": 3
@@ -410,27 +410,6 @@
       "count": 1
     }
   },
-  "src/routes/(parent)/admin/subscription/cancel/+page.svelte": {
-    "local/max-style-lines": {
-      "count": 1
-    },
-    "svelte/no-useless-children-snippet": {
-      "count": 3
-    }
-  },
-  "src/routes/(parent)/admin/subscription/cancel/graduation/+page.svelte": {
-    "local/max-style-lines": {
-      "count": 1
-    },
-    "svelte/no-useless-children-snippet": {
-      "count": 5
-    }
-  },
-  "src/routes/(parent)/admin/subscription/cancel/thanks/+page.svelte": {
-    "svelte/no-useless-children-snippet": {
-      "count": 2
-    }
-  },
   "src/routes/(parent)/admin/certificates/+page.svelte": {
     "svelte/no-navigation-without-resolve": {
       "count": 2
@@ -621,6 +600,27 @@
     },
     "svelte/no-useless-children-snippet": {
       "count": 3
+    }
+  },
+  "src/routes/(parent)/admin/subscription/cancel/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 3
+    }
+  },
+  "src/routes/(parent)/admin/subscription/cancel/graduation/+page.svelte": {
+    "local/max-style-lines": {
+      "count": 1
+    },
+    "svelte/no-useless-children-snippet": {
+      "count": 5
+    }
+  },
+  "src/routes/(parent)/admin/subscription/cancel/thanks/+page.svelte": {
+    "svelte/no-useless-children-snippet": {
+      "count": 2
     }
   },
   "src/routes/(parent)/login/+page.svelte": {

--- a/scripts/capture-specs/flows/irreversible-warning-alert-4545.mjs
+++ b/scripts/capture-specs/flows/irreversible-warning-alert-4545.mjs
@@ -1,0 +1,148 @@
+/**
+ * scripts/capture-specs/flows/irreversible-warning-alert-4545.mjs (#4545)
+ *
+ * 不可逆操作の直前に出る最重要警告の **提示形式と縦位置** を撮る。
+ * 文言 (#4517 / #4529 / #4531) は既に正しく、本 PR が変えるのは「届き方」なので、
+ * 撮るべきは「素の viewport で読めるか」「色文字か枠付き Alert か」である。
+ *
+ * `CAPTURE_TARGET` で 2 つの対象を切り替える (1 起動 = 1 対象):
+ *
+ *   account   … /admin/settings/account の退会 Danger Zone。
+ *               AUTH_MODE=cognito (npm run dev:cognito、#1026) が必要。
+ *               `CAPTURE_PLAN` (free | standard | family) でログインする DEV_USER を変え、
+ *               猶予 0 日 (無料 = 取り消し不可) と猶予ありの見た目の差を撮り分ける。
+ *
+ *   downgrade … ダウングレード確認ダイアログの保持期間短縮警告。
+ *               **アプリ route では撮れない** — local backend (sqlite) は `tenants` を持たず
+ *               `getLicenseInfo()` が必ず null を返すため、ダイアログを開く条件
+ *               (`stripeSubscriptionId` を持つ契約) を作れない (docs/CLAUDE.md
+ *               §「local 検証不可」と同型)。よって Storybook の story を実ブラウザで描画する。
+ *               既存の downgrade-retention-warning-4528.mjs は警告を viewport 内へ
+ *               **スクロールしてから**撮るが、本フローは **スクロールせずに**撮る。
+ *               「素の viewport で読めるか」が本 PR の争点だからである。
+ *
+ * 使用例:
+ *   # 退会 Danger Zone (無料プラン = 猶予 0 日)
+ *   CAPTURE_PLAN=free node scripts/capture.mjs --pr <N> \
+ *     --flow irreversible-warning-alert-4545 --url /admin/settings/account \
+ *     --actions scripts/capture-specs/flows/irreversible-warning-alert-4545.mjs \
+ *     --server-mode cognito --presets desktop,mobile
+ *
+ *   # ダウングレードダイアログ (Storybook。port は他クローンとの衝突を避けて明示指定)
+ *   npx storybook dev -p 6031 --no-open
+ *   CAPTURE_TARGET=downgrade CAPTURE_NAME=after-downgrade-viewport node scripts/capture.mjs \
+ *     --base-url http://localhost:6031 --flow irreversible-warning-alert-4545 \
+ *     --url "/iframe.html?id=<story id>&viewMode=story" \
+ *     --actions scripts/capture-specs/flows/irreversible-warning-alert-4545.mjs --presets desktop
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+const TARGET = process.env.CAPTURE_TARGET ?? 'account';
+const PLAN = process.env.CAPTURE_PLAN ?? 'free';
+const CAPTURE_NAME = process.env.CAPTURE_NAME ?? `irreversible-warning-${TARGET}`;
+
+/** DEV_USERS (src/lib/server/auth/providers/cognito-dev.ts) の owner 3 プラン。 */
+const DEV_OWNERS = {
+	free: { email: 'free@example.com', password: 'Gq!Dev#Free2026xy' },
+	standard: { email: 'standard@example.com', password: 'Gq!Dev#Std2026xyz' },
+	family: { email: 'family@example.com', password: 'Gq!Dev#Fam2026xyz' },
+};
+
+/** cognito-dev のログインフォームを通す (cancel-vs-deletion-4496.mjs と同型) */
+async function loginAs(page, { email, password }) {
+	await page.goto(`${BASE_URL}/auth/login`);
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.waitForFunction(
+		() => document.querySelector('input[name="email"]')?.getAttribute('type') === 'email',
+		{ timeout: 15_000 },
+	);
+
+	await page.getByLabel('メールアドレス').click();
+	await page.keyboard.type(email, { delay: 20 });
+	await page.getByLabel('パスワード', { exact: true }).click();
+	await page.keyboard.type(password, { delay: 20 });
+
+	await page
+		.locator('button[type="submit"]:not([disabled])')
+		.first()
+		.waitFor({ state: 'visible', timeout: 30_000 });
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/(admin|ops|setup|billing|switch|child)/, { timeout: 30_000 });
+}
+
+/** 初回訪問で前面に出るチュートリアル / 販促オーバーレイを閉じる (出ていなければ no-op)。 */
+async function dismissOverlays(page) {
+	for (const label of ['終了する', 'あとで']) {
+		const btn = page.getByRole('button', { name: label }).first();
+		if (await btn.isVisible().catch(() => false)) {
+			await btn.click().catch(() => {});
+			await btn.waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
+		}
+	}
+}
+
+async function settle(page) {
+	await page.evaluate(
+		() =>
+			new Promise((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+			),
+	);
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	if (TARGET === 'downgrade') {
+		// capture recorder が --url (story の iframe) へ navigate 済のため二重 goto しない。
+		await page
+			.getByTestId('downgrade-preview-content')
+			.waitFor({ state: 'visible', timeout: 20_000 });
+		// **スクロールしない**。素の viewport で警告が読めるかどうかが本 PR の争点。
+		await settle(page);
+		await capture(CAPTURE_NAME);
+		return;
+	}
+
+	const owner = DEV_OWNERS[PLAN] ?? DEV_OWNERS.free;
+	await loginAs(page, owner);
+
+	if (TARGET === 'child-delete') {
+		// 子供カードの削除確認 (ChildProfileCard)。編集モード → 「この子供を削除」で確認文が出る。
+		await page.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' });
+		// ChildProfileCard は「選択中の子供」でのみ描画される (`?id=<childId>`)。
+		// 一覧カード (ChildListCard) の link が出るまで待ち、チュートリアル /
+		// 販促オーバーレイ (初回訪問で前面に出て click を横取りする) を閉じてから操作する。
+		const listLink = page.locator('a[href^="/admin/children?id="]').first();
+		await listLink.waitFor({ state: 'visible', timeout: 30_000 });
+		await dismissOverlays(page);
+		await listLink.click();
+
+		// 各 click は「押した結果 (次の状態) が見えるまで」待ってから次へ進む。
+		// 待たずに押すと hydrate 前 / オーバーレイ下の node を押して状態が変わらない。
+		const editBtn = page.getByRole('button', { name: '✏️ 編集' }).first();
+		await editBtn.waitFor({ state: 'visible', timeout: 30_000 });
+		await dismissOverlays(page);
+		await editBtn.click();
+		await dismissOverlays(page);
+		const deleteBtn = page.getByRole('button', { name: '🗑 この子供を削除' }).first();
+		await deleteBtn.waitFor({ state: 'visible', timeout: 30_000 });
+		await deleteBtn.click();
+		await page
+			.getByRole('button', { name: '本当に削除' })
+			.first()
+			.waitFor({ state: 'visible', timeout: 20_000 });
+		await settle(page);
+		await capture(CAPTURE_NAME);
+		return;
+	}
+
+	await page.goto(`${BASE_URL}/admin/settings/account`, { waitUntil: 'domcontentloaded' });
+	const dangerZone = page.getByTestId('account-danger-zone');
+	await dangerZone.waitFor({ state: 'visible', timeout: 30_000 }).catch(() => {});
+	await dangerZone.scrollIntoViewIfNeeded().catch(() => {});
+	await settle(page);
+	await capture(CAPTURE_NAME);
+};

--- a/src/lib/features/admin/components/ChildProfileCard.svelte
+++ b/src/lib/features/admin/components/ChildProfileCard.svelte
@@ -11,6 +11,7 @@ import {
 	getUnitLabel,
 } from '$lib/domain/point-display';
 import type { CategoryDef } from '$lib/domain/validation/activity';
+import Alert from '$lib/ui/primitives/Alert.svelte';
 import BirthdayInput from '$lib/ui/primitives/BirthdayInput.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
@@ -376,7 +377,13 @@ $effect(() => {
 			<!-- Delete section -->
 			<div class="profile-edit__danger-zone">
 				{#if confirmDelete}
-					<p class="profile-edit__danger-text">{CHILD_PROFILE_CARD_LABELS.deleteConfirmText}</p>
+					<!-- #4545: 子供の削除も不可逆。色文字 (独自 .profile-edit__danger-text) ではなく
+				     Alert primitive (枠線 + 背景 + アイコン + role="alert") で出す。 -->
+				<Alert
+					variant="danger"
+					message={CHILD_PROFILE_CARD_LABELS.deleteConfirmText}
+					data-testid="child-delete-confirm-warning"
+				/>
 					<div class="profile-edit__danger-actions">
 						<form
 							method="POST"
@@ -859,11 +866,6 @@ $effect(() => {
 		display: flex;
 		flex-direction: column;
 		gap: 0.5rem;
-	}
-	.profile-edit__danger-text {
-		font-size: 0.85rem;
-		font-weight: 700;
-		color: var(--color-danger, #ef4444);
 	}
 	.profile-edit__danger-actions {
 		display: flex;

--- a/src/lib/features/admin/components/DowngradeResourceSelector.stories.svelte
+++ b/src/lib/features/admin/components/DowngradeResourceSelector.stories.svelte
@@ -25,6 +25,7 @@ import { PLAN_HISTORY_RETENTION_DAYS } from '$lib/domain/constants/plan-retentio
 import type { DowngradePreview } from '$lib/domain/downgrade-types';
 import type { ActivityId, ChildId } from '$lib/domain/ids';
 import { DOWNGRADE_RESOURCE_SELECTOR_LABELS, STORYBOOK_LABELS } from '$lib/domain/labels';
+import { assertPrecedes } from '$lib/ui/primitives/story-play-helpers';
 import DowngradeResourceSelector from './DowngradeResourceSelector.svelte';
 
 const L = STORYBOOK_LABELS.downgradeResourceSelector;
@@ -135,6 +136,16 @@ const { Story } = defineMeta({
 		const warning = await waitFor(() => screen.getByText(expected));
 		await expect(warning).toBeVisible();
 		await expect(warning).toHaveTextContent('削除され、復元できません（再契約でも戻りません）');
+
+		// #4545: 文言が正しいだけでは届かない。提示形式と縦位置まで固定する。
+		const alertBox = await waitFor(() => screen.getByTestId('downgrade-retention-warning'));
+		// (a) 不可逆なので role="alert" (Alert の danger variant)。warning/status に弱めない
+		await expect(alertBox).toHaveAttribute('role', 'alert');
+		// (b) 超過リソースの選択 UI と確定ボタンより **前** に置く。
+		//     旧実装はチェックボックス一覧の後 = ダイアログ末尾にあり、素の viewport では
+		//     読まれないまま確定できた。警告を下へ戻すと本 assert が落ちる。
+		assertPrecedes(alertBox, screen.getByTestId('downgrade-child-list'));
+		assertPrecedes(alertBox, screen.getByTestId('downgrade-confirm-button'));
 	}}
 />
 
@@ -157,6 +168,11 @@ const { Story } = defineMeta({
 		const warning = await waitFor(() => screen.getByText(expected));
 		await expect(warning).toBeVisible();
 		await expect(warning).toHaveTextContent('削除され、復元できません（再契約でも戻りません）');
+
+		// #4545: 無制限側の分岐でも提示形式・縦位置は同じ
+		const alertBox = await waitFor(() => screen.getByTestId('downgrade-retention-warning'));
+		await expect(alertBox).toHaveAttribute('role', 'alert');
+		assertPrecedes(alertBox, screen.getByTestId('downgrade-confirm-button'));
 	}}
 />
 
@@ -183,6 +199,11 @@ const { Story } = defineMeta({
 		const warning = await waitFor(() => screen.getByText(expected));
 		await expect(warning).toBeVisible();
 		await expect(warning).toHaveTextContent('削除され、復元できません（再契約でも戻りません）');
+
+		// #4545: 超過の有無で警告の提示形式・縦位置が変わらないこと (1 箇所に統合済)
+		const alertBox = await waitFor(() => screen.getByTestId('downgrade-retention-warning'));
+		await expect(alertBox).toHaveAttribute('role', 'alert');
+		assertPrecedes(alertBox, screen.getByTestId('downgrade-confirm-button'));
 
 		// 超過が無いので選択 UI は出ない (無用な操作を増やさない)
 		await expect(screen.queryByTestId('downgrade-child-list')).toBeNull();

--- a/src/lib/features/admin/components/DowngradeResourceSelector.svelte
+++ b/src/lib/features/admin/components/DowngradeResourceSelector.svelte
@@ -125,9 +125,21 @@ function handleConfirm() {
 				</p>
 			</div>
 
-			<!-- 超過がない場合の履歴警告のみ表示 (#4530: caller がこの状態でも開く) -->
-			{#if !preview.hasExcess && preview.retentionChange.willLoseHistory}
-				<Alert variant="warning">
+			<!--
+			  履歴保持期間の短縮警告 (#4530: caller は超過が無くてもこの状態でダイアログを開く)。
+
+			  #4545: 本ダイアログで唯一**不可逆**な告知 (保持期間を超えた記録は物理削除され、
+			  再契約でも戻らない) なので、
+			    - 超過リソースの選択 UI と確定ボタンより**前** = ダイアログ上部に置き、
+			      スクロールせずに読める位置を保つ (旧実装は超過ありの分岐でチェックボックス
+			      一覧をすべて挟んだ後に置いており、素の viewport では見えなかった)
+			    - `hasExcess` の有無で位置が変わらないよう 1 箇所に統合する (旧実装は 2 箇所重複)
+			    - `variant="danger"` (role="alert") で出す。アーカイブ (復元可能) 側の警告は
+			      warning のままにして、可逆 / 不可逆を視覚的にも支援技術的にも区別する
+			  縦順は stories の play 関数が assert する (警告を下へ戻すと落ちる)。
+			-->
+			{#if preview.retentionChange.willLoseHistory}
+				<Alert variant="danger" data-testid="downgrade-retention-warning">
 					{#snippet children()}
 					<p>
 						{L.retentionWarning(
@@ -274,20 +286,6 @@ function handleConfirm() {
 						{/each}
 						{/snippet}
 					</Card>
-				{/if}
-
-				<!-- 履歴保持期間の警告 -->
-				{#if preview.retentionChange.willLoseHistory}
-					<Alert variant="warning">
-						{#snippet children()}
-						<p>
-							{L.retentionWarning(
-							preview.retentionChange.currentDays,
-							preview.retentionChange.targetDays,
-						)}
-						</p>
-						{/snippet}
-					</Alert>
 				{/if}
 
 				<!-- アップグレードで復元可能の説明 -->

--- a/src/lib/ui/primitives/story-play-helpers.ts
+++ b/src/lib/ui/primitives/story-play-helpers.ts
@@ -27,3 +27,22 @@ export function assertPointerInteractive(element: Element): void {
 		throw new Error('element is still in open transition (pointer-events: none)');
 	}
 }
+
+/**
+ * `earlier` が DOM 順で `later` より前にあることを assert する (#4545)。
+ *
+ * 「不可逆操作の最重要警告を、選択 UI や確定ボタンより前に置く」といった **縦位置の契約** を
+ * play 関数から固定するために使う。jsdom / Storybook vitest 環境ではレイアウト計算
+ * (`getBoundingClientRect`) が常に 0 を返すため「スクロールせずに見えるか」を pixel では
+ * 判定できない。DOM 順序は決定的に判定でき、かつ「警告を下へ押し下げる」改修を確実に捕捉する。
+ *
+ * @throws {Error} `earlier` が `later` より後、または比較不能な場合
+ */
+export function assertPrecedes(earlier: Element, later: Element): void {
+	const position = earlier.compareDocumentPosition(later);
+	if ((position & Node.DOCUMENT_POSITION_FOLLOWING) === 0) {
+		throw new Error(
+			'expected the first element to precede the second in DOM order, but it does not',
+		);
+	}
+}

--- a/src/routes/(parent)/admin/settings/account/+page.svelte
+++ b/src/routes/(parent)/admin/settings/account/+page.svelte
@@ -13,6 +13,7 @@ import { getErrorMessage } from '$lib/domain/errors';
 import { APP_LABELS, OYAKAGI_LABELS, PAGE_TITLES, SETTINGS_LABELS } from '$lib/domain/labels';
 import AccountDeletionExportPanel from '$lib/features/admin/components/AccountDeletionExportPanel.svelte';
 import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
+import Alert from '$lib/ui/primitives/Alert.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 import FormField from '$lib/ui/primitives/FormField.svelte';
@@ -359,37 +360,50 @@ const canConfirmDelete = $derived(
 							<li>{SETTINGS_LABELS.accountDeleteOwnerItem3}</li>
 							<li>{SETTINGS_LABELS.accountDeleteOwnerItem4}</li>
 						</ul>
-						<p class="text-[var(--color-feedback-error-text)] font-medium">
-							{SETTINGS_LABELS.accountDeleteOwnerWarning}
-						</p>
+						<!-- #4545: 不可逆 (復旧不能) の告知は色文字ではなく Alert primitive で出す。
+						     danger variant が枠線 + 背景 + アイコン + role="alert" を担保する。 -->
+						<Alert
+							variant="danger"
+							message={SETTINGS_LABELS.accountDeleteOwnerWarning}
+							data-testid="account-delete-owner-warning"
+						/>
 					</div>
 				{:else if $page.data.userRole === 'child'}
 					<div class="text-sm text-[var(--color-text-secondary)] space-y-2 mb-4">
 						<p>{SETTINGS_LABELS.accountDeleteChildDesc}</p>
 						<p>{SETTINGS_LABELS.accountDeleteChildDesc2}</p>
-						<p class="text-[var(--color-feedback-error-text)] font-medium">
-							{SETTINGS_LABELS.accountDeleteChildWarning}
-						</p>
+						<!-- #4545: 同上 (子供アカウント自身の削除も復旧不能) -->
+						<Alert
+							variant="danger"
+							message={SETTINGS_LABELS.accountDeleteChildWarning}
+							data-testid="account-delete-child-warning"
+						/>
 					</div>
 				{:else}
 					<div class="text-sm text-[var(--color-text-secondary)] space-y-2 mb-4">
 						<p>{SETTINGS_LABELS.accountDeleteMemberDesc}</p>
 						<p>{SETTINGS_LABELS.accountDeleteMemberDesc2}</p>
-						<p class="text-[var(--color-feedback-error-text)] font-medium">
-							{SETTINGS_LABELS.accountDeleteMemberWarning}
-						</p>
+						<!-- #4545: 同上 (メンバー離脱もログイン情報は復旧不能) -->
+						<Alert
+							variant="danger"
+							message={SETTINGS_LABELS.accountDeleteMemberWarning}
+							data-testid="account-delete-member-warning"
+						/>
 					</div>
 				{/if}
 
 				{#if $page.data.userRole === 'owner'}
 					<!-- #4496: プラン別の猶予期間を手続き **前** に述べる (無料プランは猶予なし) -->
 					{#if deletionGraceDays !== null}
-						<p
-							class="text-sm text-[var(--color-feedback-error-text)] font-medium mb-4"
+						<!-- #4545: 猶予 0 日 (無料プラン) は申込と同時に物理削除され取り消せないため
+						     danger (role="alert") で出す。猶予がある有料プランは期間内なら取り消せる
+						     ので warning (role="status") に留め、不可逆でないものを同じ強さで叫ばない。 -->
+						<Alert
+							variant={deletionGraceDays === 0 ? 'danger' : 'warning'}
+							message={SETTINGS_LABELS.accountDeleteGraceNotice(deletionGraceDays)}
+							class="mb-4"
 							data-testid="account-delete-grace-notice"
-						>
-							{SETTINGS_LABELS.accountDeleteGraceNotice(deletionGraceDays)}
-						</p>
+						/>
 					{/if}
 
 					<!-- #4472: 退会を実行する前にデータを持ち出せるようにする (無料プランを含む全プラン) -->

--- a/tests/e2e/admin-settings-danger-zone.spec.ts
+++ b/tests/e2e/admin-settings-danger-zone.spec.ts
@@ -56,6 +56,25 @@ test.describe('#2319 Danger Zone — accountDelete (/admin/settings/account)', (
 
 		await expect(dangerZone).toBeVisible();
 
+		// #4545: 復旧不能の告知は色文字ではなく Alert primitive (role="alert") で出す。
+		// 色だけを手がかりにすると色覚多様性のある方に届かない (WCAG 1.4.1)。
+		// role は Alert の danger variant が担保する。
+		const ownerWarning = page.getByTestId('account-delete-owner-warning');
+		if ((await ownerWarning.count()) > 0) {
+			await expect(ownerWarning).toBeVisible();
+			await expect(ownerWarning).toHaveAttribute('role', 'alert');
+		}
+
+		// 猶予期間の告知: 猶予 0 日 (無料プラン) は取り消せないので alert、
+		// 猶予がある有料プランは期間内に取り消せるので status に留める。
+		const graceNotice = page.getByTestId('account-delete-grace-notice');
+		if ((await graceNotice.count()) > 0) {
+			await expect(graceNotice).toBeVisible();
+			// どちらの場合も「枠線付きの Alert」であること = role 属性を持つこと自体を要求する
+			// (旧実装の裸の <p> は role を持たない)。
+			await expect(graceNotice).toHaveAttribute('role', /^(alert|status)$/);
+		}
+
 		const executeBtn = page.getByTestId('account-danger-execute-button');
 		await expect(executeBtn).toBeVisible();
 		await expect(executeBtn).toBeDisabled();

--- a/tests/unit/architecture/irreversible-warning-alert-fitness.test.ts
+++ b/tests/unit/architecture/irreversible-warning-alert-fitness.test.ts
@@ -1,0 +1,108 @@
+// tests/unit/architecture/irreversible-warning-alert-fitness.test.ts
+//
+// #4545: 不可逆操作 (物理削除 / 猶予なし退会 / 保持期間短縮) の直前に出す最重要警告が、
+// **色文字だけ**で表現されて顧客に届かなくなる class を lock する fitness function。
+//
+// 背景 (root class): 文言 (labels.ts) の正しさは #4517 / #4529 / #4531 で直ったが、
+// 提示形式 (primitive / role / 縦位置) には規約も検査も無く、
+//   - `<p class="text-[var(--color-feedback-error-text)]">` の色文字だけ (枠線 / 背景 / アイコン無し)
+//   - `role="alert"` 無し (支援技術に「警告」として伝わらない)
+// のまま放置されていた。色だけを手がかりにする表現は色覚多様性のある方に届かない
+// (WCAG 1.4.1 Use of Color)。
+//
+// 本 test は「登録された不可逆警告のラベルは Alert primitive の内側で描画されること」を assert する。
+// Alert (`variant="danger"`) が枠線 + 背景 + アイコン + `role="alert"` をまとめて担保するため、
+// 個別 file で色文字に戻す改修は必ずここで落ちる。
+//
+// 縦位置 (スクロールせずに読める位置にあること) は DOM 順序の話なので本 test では見ない。
+// `DowngradeResourceSelector.stories.svelte` の play 関数が assert する (両輪)。
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(__dirname, '../../..');
+
+/**
+ * 不可逆警告の registry (SSOT)。
+ *
+ * 新しく「取り消せない操作の直前に出す警告」を追加したら、ここに 1 行足す。
+ * 足さないと検査対象にならないが、足したうえで色文字に戻すと本 test が落ちる。
+ */
+const IRREVERSIBLE_WARNINGS: Array<{ file: string; labelRef: string; why: string }> = [
+	{
+		file: 'src/routes/(parent)/admin/settings/account/+page.svelte',
+		labelRef: 'SETTINGS_LABELS.accountDeleteOwnerWarning',
+		why: 'オーナー退会 = 家族グループ全データの物理削除 (復旧不能)',
+	},
+	{
+		file: 'src/routes/(parent)/admin/settings/account/+page.svelte',
+		labelRef: 'SETTINGS_LABELS.accountDeleteChildWarning',
+		why: '子供アカウント削除 = ログイン情報の削除 (復旧不能)',
+	},
+	{
+		file: 'src/routes/(parent)/admin/settings/account/+page.svelte',
+		labelRef: 'SETTINGS_LABELS.accountDeleteMemberWarning',
+		why: 'メンバー退会 = ログイン情報の削除 (復旧不能)',
+	},
+	{
+		file: 'src/routes/(parent)/admin/settings/account/+page.svelte',
+		labelRef: 'SETTINGS_LABELS.accountDeleteGraceNotice',
+		why: '無料プランは猶予 0 日 = 申込と同時に物理削除され取り消せない (DELETION_GRACE_PERIOD_DAYS.free = 0)',
+	},
+	{
+		file: 'src/lib/features/admin/components/DowngradeResourceSelector.svelte',
+		labelRef: 'L.retentionWarning',
+		why: '保持期間を超えた記録は物理削除され、再契約でも戻らない',
+	},
+	{
+		file: 'src/lib/features/admin/components/ChildProfileCard.svelte',
+		labelRef: 'CHILD_PROFILE_CARD_LABELS.deleteConfirmText',
+		why: '子供の削除 (プロフィール + 紐づく記録の消失)',
+	},
+];
+
+/** `index` の位置が `<Alert ...>` 〜 `</Alert>` の内側かを判定する。 */
+function isInsideAlert(source: string, index: number): boolean {
+	const lastOpen = source.lastIndexOf('<Alert', index);
+	if (lastOpen === -1) return false;
+	const lastClose = source.lastIndexOf('</Alert>', index);
+	// 直近の <Alert が 直近の </Alert> より後 = まだ閉じていない Alert の内側
+	return lastOpen > lastClose;
+}
+
+describe('#4545 不可逆警告は Alert primitive で出す (色文字だけにしない)', () => {
+	for (const { file, labelRef, why } of IRREVERSIBLE_WARNINGS) {
+		it(`${file} の ${labelRef} は Alert の内側で描画される (${why})`, () => {
+			const source = readFileSync(join(REPO_ROOT, file), 'utf8');
+
+			const occurrences: number[] = [];
+			let from = 0;
+			for (;;) {
+				const index = source.indexOf(labelRef, from);
+				if (index === -1) break;
+				occurrences.push(index);
+				from = index + labelRef.length;
+			}
+
+			// registry が腐って対象が消えていたら silent pass させない
+			expect(
+				occurrences.length,
+				`${labelRef} が ${file} に見つからない。ラベルを rename / 削除したなら registry も更新すること`,
+			).toBeGreaterThan(0);
+
+			const outside = occurrences.filter((index) => !isInsideAlert(source, index));
+			expect(
+				outside,
+				`${labelRef} が Alert の外で描画されている (色文字だけの警告は色覚多様性のある方に届かない)。` +
+					'$lib/ui/primitives/Alert.svelte の variant="danger" を使うこと',
+			).toEqual([]);
+		});
+	}
+
+	it('Alert primitive は danger variant に role="alert" を割り当てる (上の検査が意味を持つ前提)', () => {
+		const alertSource = readFileSync(join(REPO_ROOT, 'src/lib/ui/primitives/Alert.svelte'), 'utf8');
+		// role={variant === 'danger' ? 'alert' : 'status'} の形を要求する
+		expect(alertSource).toMatch(/role=\{variant === 'danger' \? 'alert' :/);
+	});
+});

--- a/tests/unit/ui/story-play-helpers.test.ts
+++ b/tests/unit/ui/story-play-helpers.test.ts
@@ -9,7 +9,10 @@
 
 import { waitFor } from '@testing-library/svelte';
 import { describe, expect, it } from 'vitest';
-import { assertPointerInteractive } from '../../../src/lib/ui/primitives/story-play-helpers';
+import {
+	assertPointerInteractive,
+	assertPrecedes,
+} from '../../../src/lib/ui/primitives/story-play-helpers';
 
 function createElement(pointerEvents: string): HTMLElement {
 	const el = document.createElement('div');
@@ -41,5 +44,38 @@ describe('assertPointerInteractive (#3687 Menu play flake 根治)', () => {
 		await waitFor(() => assertPointerInteractive(el));
 		expect(getComputedStyle(el).pointerEvents).not.toBe('none');
 		el.remove();
+	});
+});
+
+describe('assertPrecedes (#4545 不可逆警告の縦位置契約)', () => {
+	function createSiblings(): { first: HTMLElement; second: HTMLElement; parent: HTMLElement } {
+		const parent = document.createElement('div');
+		const first = document.createElement('p');
+		const second = document.createElement('button');
+		parent.append(first, second);
+		document.body.appendChild(parent);
+		return { first, second, parent };
+	}
+
+	it('DOM 順で前にある要素は throw しない (警告 → 確定ボタンの正しい並び)', () => {
+		const { first, second, parent } = createSiblings();
+		expect(() => assertPrecedes(first, second)).not.toThrow();
+		parent.remove();
+	});
+
+	it('DOM 順で後ろにある要素は throw する (警告を確定ボタンより下へ押し下げたら落ちる)', () => {
+		const { first, second, parent } = createSiblings();
+		expect(() => assertPrecedes(second, first)).toThrowError(/precede/);
+		parent.remove();
+	});
+
+	it('入れ子 (祖先 → 子孫) も「前」として扱う', () => {
+		const parent = document.createElement('div');
+		const child = document.createElement('span');
+		parent.appendChild(child);
+		document.body.appendChild(parent);
+		expect(() => assertPrecedes(parent, child)).not.toThrow();
+		expect(() => assertPrecedes(child, parent)).toThrowError(/precede/);
+		parent.remove();
 	});
 });


### PR DESCRIPTION
## 顧客価値・目的

取り返しのつかない操作（無料プランの即時退会 / 保持期間を超えた記録の物理削除 / 子供の削除）の直前に出る警告が、保護者に**実際に届く**ようになります。文言は #4517 / #4529 / #4531 で正しくなっていましたが、**色文字だけ**で表現されていたり、ダイアログの**スクロール末尾**に置かれていたため、読まないまま確定できていました。

## 関連 Issue

Closes #4545

## 変更内容

### (1) 退会 Danger Zone の 4 警告を `Alert` primitive 化（`/admin/settings/account`）

`<p class="text-[var(--color-feedback-error-text)]">` の色文字だけだった 4 箇所（owner / child / member の削除警告 + プラン別猶予の告知）を `$lib/ui/primitives/Alert.svelte` に載せ替えました（docs/DESIGN.md §5「アラートは `Alert.svelte` を使用」）。枠線 + 背景 + アイコン + `role` が primitive 側で担保されます。

**猶予の告知は可逆性で variant を分けています**:

| プラン | 猶予 | variant | role | 意味 |
|---|---|---|---|---|
| 無料 | 0 日（`DELETION_GRACE_PERIOD_DAYS.free = 0`） | `danger` ❌ | `alert` | 申込と同時に物理削除、**取り消せない** |
| スタンダード / プレミアム | 7 / 30 日 | `warning` ⚠️ | `status` | 期間内なら「復元」で取り消せる |

不可逆でないものを同じ強さで叫ばないための区別です（叫び続けると警告が無視されるようになるため）。

### (2) ダウングレード確認ダイアログの保持期間短縮警告を上部へ（`DowngradeResourceSelector`）

保持期間短縮の警告（「削除され、復元できません（再契約でも戻りません）」）は、`hasExcess` 分岐では**子供 / 活動 / チェックリストのチェックボックス一覧をすべて挟んだ後**にあり、素の viewport では見えませんでした。チェックボックスを埋めれば確定ボタンは有効になるため、**最も重要な不可逆警告を一度も読まずに操作を完了できる**導線でした。

- **超過リソースの選択 UI と確定ボタンより前**（ダイアログ上部）へ移動
- `hasExcess` の有無で位置が変わらないよう**重複 2 箇所を 1 箇所に統合**
- 不可逆なので `variant="danger"`（`role="alert"`）。アーカイブ（アップグレードで復元可能）側の警告は `warning` のまま据え置き、可逆 / 不可逆を視覚的にも支援技術的にも区別

### (3) 同 class sweep

「不可逆操作の直前の警告が色文字だけ / 見えない位置」を横断 grep しました。結果:

| 箇所 | 判定 | 対応 |
|---|---|---|
| `ChildProfileCard` の削除確認（`deleteConfirmText`） | **同 class** — 独自 `.profile-edit__danger-text`（色のみ、しかも `var(--color-danger, #ef4444)` の hex fallback 直書き = DESIGN.md §2 違反） | 本 PR で `Alert` 化 + 不要になった CSS 規則を削除 |
| `ActivityListItem` の削除確認 Dialog（`deleteConfirmBody`） | 同 class ではない — 警告文が**小さな確認ダイアログの本文そのもの**で、スクロールなしに読め、色に依存していない | 変更なし |
| `settings/data` の clear-all / import エラー、`ChurnPreventionModal` の失うもの一覧 | 同 class ではない — いずれも `--color-feedback-error-bg` の枠付きブロック内で、色単独の手がかりではない | 変更なし |
| メール文面（`DELETION_*_EMAIL_LABELS.irreversibleNote` 等） | 対象外 — UI のアラート提示形式の話ではない | 変更なし |

**`ChildProfileCard` の文言不足は本 PR の scope 外**です。「この子供を本当に削除しますか？」は不可逆であることを述べていません（本 PR は提示形式の是正であり、文言追加は別の変更）。#4545 に記録済みです。

### (4) 再発防止（同 class を機械で lock）

個別 instance のパッチで終わらせないため（ADR-0061 same-class-N→guard）、2 つの guard を追加しました。

- `tests/unit/architecture/irreversible-warning-alert-fitness.test.ts` — 不可逆警告のラベル 6 件を registry 化し、**すべて `Alert` の内側で描画されていること**を assert。ラベルが registry から消えていたら（rename / 削除の取りこぼし）silent pass せず fail します。`Alert` が danger variant に `role="alert"` を割り当てていること自体も検査し、上の検査が意味を持つ前提を固定します
- `DowngradeResourceSelector.stories.svelte` の play 関数 — `role="alert"` と **DOM 順序**（警告が選択 UI・確定ボタンより前）を 3 story すべてで assert。順序判定は `story-play-helpers.ts` に追加した `assertPrecedes` を使います（jsdom はレイアウトを計算しないため pixel では「スクロールなしで見えるか」を判定できず、DOM 順序で代替）

## 検証

### 実行コマンドと結果

| 検査 | コマンド | 結果 |
|---|---|---|
| Biome | `npx biome check .` | PASS（2317 files） |
| svelte-check | `npx svelte-check` | **0 errors / 0 warnings** |
| 新規 unit | `npx vitest run tests/unit/architecture/irreversible-warning-alert-fitness.test.ts tests/unit/ui/story-play-helpers.test.ts` | **13 passed** |
| Storybook | `npm run test:storybook` | **238 passed / 47 files** |
| 広域 unit | `npx vitest run tests/unit/architecture/ src/routes/ src/lib/ui/ tests/unit/ui/` | 612 passed / 1 failed（`svelte-lint-glob-covers-rune-modules` — **単独実行では PASS**。tests/CLAUDE.md §「全体実行だと落ち単独だと通る」の負荷起因。本変更は eslint glob に触れていない） |
| repo 走査 test 宣言 gate | `node scripts/check-repo-scan-test-declaration.mjs` | OK（57 件宣言済） |

### 変異試験（guard に歯があることの確認）

追加した guard を「壊す方向」に変異させ、実際に落ちることを確認しました。いずれも逆変換で復元し、復元後の状態を `git diff` で確認済みです（`git checkout --` は hook でブロックされるため未使用）。

| 変異 | 手段 | 結果 |
|---|---|---|
| 退会警告を `Alert` から色文字 `<p>` へ戻す | `perl -0pi -e` で置換 | **FAIL** — `SETTINGS_LABELS.accountDeleteOwnerWarning が Alert の外で描画されている` / 1 failed + 6 passed |
| 保持期間警告を旧位置（チェックボックス一覧の後）へ戻す | node script で block 移動 | **FAIL** — `expected the first element to precede the second in DOM order, but it does not` / 2 failed + 236 passed（`RetentionShortenedFromStandard` / `RetentionShortenedWithoutExcess`） |

復元後に再実行し、それぞれ 13 passed / 238 passed に戻ることを確認しています。

### 実機確認（`npm run dev:cognito`、#1026）

`AUTH_MODE=cognito COGNITO_DEV_MODE=true` の dev server を**自クローン専用ポートで起動**し、`netstat` + `Get-CimInstance` で listening PID の実行パスが本 worktree であることを確認してから撮影しています（初回撮影時、別クローンが保持していたポートのサーバーに当たり旧コードの SS を撮っていたため。DOM スナップショットの `role="alert"` 件数で検知しました）。

DOM スナップショットによる実測:

| 画面 | `role="alert"` | `role="status"` |
|---|---|---|
| 退会 Danger Zone（無料） | 2（owner 警告 + 猶予なし告知） | 0 |
| 退会 Danger Zone（スタンダード） | 1（owner 警告） | 1（猶予 7 日の告知） |
| 修正前（develop、両プラン） | **0** | 0 |

## スクリーンショット

<!-- ss-pair-prefix: before=before- after=after- -->

### (1) 退会 Danger Zone — 無料プラン（猶予 0 日 = 取り消し不可）

desktop:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/before-account-free-desktop.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/after-account-free-desktop.png) |

mobile:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/before-account-free-mobile.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/after-account-free-mobile.png) |

Before は「削除後のデータ復旧はできません」も猶予なしの告知も赤い文字だけで、周囲の本文と同じ視覚重みで並んでいます。After は ❌ 付きの枠線ブロック 2 つになります。

### (2) 退会 Danger Zone — スタンダードプラン（猶予 7 日 = 取り消し可）

desktop:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/before-account-standard-desktop.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/after-account-standard-desktop.png) |

mobile:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/before-account-standard-mobile.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/after-account-standard-mobile.png) |

猶予がある側は ⚠️（`role="status"`）で、無料プランの ❌ と区別されます。

### (3) ダウングレード確認ダイアログ — 素の viewport（スクロールしていない状態）

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/before-downgrade-viewport.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/after-downgrade-viewport.png) |

Before は不可逆警告が画面外で、見えているのは「アップグレード時に復元できます」と述べる**可逆**側の警告だけです。After は不可逆警告が最上部に出ます。

このダイアログは `SaasLicensePanel.requestPortal()` が有効な Stripe 契約（`stripeSubscriptionId`）を要求するため、`tenants` を持たない local backend では開けません（docs/CLAUDE.md §「local 検証不可」と同型）。よって Storybook の `Admin/DowngradeResourceSelector` → `RetentionShortenedFromStandard` を実ブラウザで描画して撮影しています（story: `src/lib/features/admin/components/DowngradeResourceSelector.stories.svelte`）。既存の `downgrade-retention-warning-4528.mjs` は警告まで**スクロールしてから**撮りますが、本 PR の争点は「スクロールせずに読めるか」なので**スクロールせずに**撮っています。

### (4) 子供カードの削除確認（sweep で見つかった同 class）

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/before-child-delete-desktop.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4552/after-child-delete-desktop.png) |

## 影響範囲

**顧客に見える変化**: 退会 Danger Zone の 4 警告 / ダウングレード確認ダイアログの保持期間警告 / 子供カードの削除確認 が、色文字から枠線 + 背景 + アイコン付きのブロックになります。**文言の変更はありません**（labels.ts は未変更）。

**ダウングレードダイアログの縦位置が変わります**: 保持期間短縮の警告がダイアログ上部へ移動し、末尾の重複が 1 箇所に統合されます。既存の `downgrade-retention-warning-4528.mjs`（警告までスクロールしてから撮る flow）は、スクロールが no-op になるだけで引き続き動作します。

**破壊的変更なし**。API / DB / env の変更なし。既存 testid（`account-delete-grace-notice` / `downgrade-preview-content` / `downgrade-confirm-button`）は維持しています。

**並行実装ペア**（docs/design/parallel-implementations.md）: UI ラベルは未変更のため LP 側（`site/shared-labels.js`）への波及なし。デモ Lambda は本番ルートを共有するため同一変更が反映されます。

**追加ファイル**: 撮影用 flow `scripts/capture-specs/flows/irreversible-warning-alert-4545.mjs`（既存 flow 群と同じ運用。`CAPTURE_TARGET` で account / downgrade / child-delete を切替）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
