### PR TITLE
build(deps): #4553 security 更新を develop に入れる（#4532 が塞げていない GHSA-frvp-7c67-39w9 を実際に閉じる）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3528,9 +3528,9 @@
 			}
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.14",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+			"version": "1.19.17",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+			"integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4289,13 +4289,13 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.29.0",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+			"integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@hono/node-server": "^1.19.9",
+				"@hono/node-server": "^1.19.9 || ^2.0.5",
 				"ajv": "^8.17.1",
 				"ajv-formats": "^3.0.1",
 				"content-type": "^1.0.5",


### PR DESCRIPTION
## 顧客価値・目的

security 更新が `main` にだけ入って `develop` で巻き戻る経路を塞ぐ。あわせて、その更新（PR #4532）が**実際には advisory を 1 件も塞いでいない**ことが調査で判明したため、対象の advisory を実際に閉じる。顧客に見える変化は無い（dev 依存のみ、本番 Lambda 非搭載）が、「塞いだつもりで塞げていない」状態を解消する。

UI 変更なし。

## 関連 Issue

Closes #4553
Refs #4532 — 本 PR と同一の sdk lockfile 変更を持つ dependabot PR（base=`main`）。**本 PR は #4532 を置き換えるものではなく、同じ内容を develop 側にも入れるもの**。#4532 自体の処遇（close / retarget）は QM / PO 判断であり、本 PR では触れていない
Refs #4544 — main 直行を止める guard 側の fail-open 修正（相補）

## 変更内容

`package-lock.json` のみ、2 ブロック 14 行。`package.json` は変更していない（**直接依存を追加せず transitive のまま**）。

**(1) `@modelcontextprotocol/sdk` 1.29.0 → 1.30.0** — PR #4532 と**同一の変更**。hunk 本体は #4532 の diff と byte 一致する（行番号ヘッダのみ 4279 → 4289 で相違、develop 側の先行 bump による位置ずれ）。

```console
$ diff <(gh pr diff 4532 | tail -n +5) <(git diff origin/develop HEAD -- package-lock.json | tail -n +5)
1c1
< @@ -4279,13 +4279,13 @@
---
> @@ -4289,13 +4289,13 @@
（以降 差分なし）
```

**(2) `@hono/node-server` 1.19.14 → 1.19.17** — #4532 に**含まれていない**追加分。理由は下記。

### なぜ (2) を足したか — #4532 は advisory を 1 件も塞いでいない

#4532 のタイトルは `Bump @hono/node-server ... from 1.19.14 to 2.1.0` と述べるが、**head の lockfile では 1.19.14 のまま**である。実際に変わったのは sdk が宣言する range だけ（`^1.19.9` → `^1.19.9 || ^2.0.5`）で、range が広がっても既存の 1.19.14 が引き続き満たすため解決結果は動かない。

```console
$ git show refs/pull/4532/head:package-lock.json | node -e "...['node_modules/@hono/node-server'].version"
1.19.14
```

さらに、引用されている 2 件の advisory のうち **当リポジトリに当たるのは 1 件だけ**である。

| advisory | 影響 range | 1.19.14 | 1.19.17 |
|---|---|---|---|
| GHSA-9mqv-5hh9-4cgg（WebSocket handshake の memory-leak DoS） | `>= 2.0.0, <= 2.0.9` | 非該当 | 非該当 |
| GHSA-frvp-7c67-39w9（`serve-static` Windows path traversal `%5C`） | `< 1.19.15` ／ `>= 2.0.0, < 2.0.5` | **該当** | 解消 |

2.x 系ではなく **1.19.17（1.19.x の最新）** を選んだのは、`>= 1.19.15` で GHSA-frvp が解消し、かつ 2.0.0–2.0.9 にのみ影響する GHSA-9mqv の範囲を踏まないため。dev 依存の major bump を避ける最小の選択。

## 検証

**lockfile 整合性（`npm ci` が成功 = integrity / 解決結果が正当）**

```console
$ npm ci --no-audit --no-fund
added 1409 packages in 8m          # exit 0
$ node -e "...require('./node_modules/@modelcontextprotocol/sdk/package.json').version"
@modelcontextprotocol/sdk 1.30.0
@hono/node-server 1.19.17
```

**`npm audit` — #4532 では減らず、本 PR で減る（実測 3 点比較）**

| 対象 | `@hono/node-server` | moderate | total |
|---|---|---|---|
| `origin/develop`（現状） | **FLAGGED** GHSA-frvp-7c67-39w9 `<1.19.15` | 3 | 26 |
| PR #4532 head | **STILL FLAGGED** 同上 | 3 | 26 |
| 本 PR | 検出なし | **2** | **25** |

```console
# PR #4532 head
$ npm audit --package-lock-only --json | ...
STILL FLAGGED: https://github.com/advisories/GHSA-frvp-7c67-39w9 range=<1.19.15
total: {"low":21,"moderate":3,"high":2,"critical":0,"total":26}

# 本 PR
$ npm audit --json | ...
（@hono/node-server の行なし）
total: {"low":21,"moderate":2,"high":2,"critical":0,"total":25}
```

**consumer の動作確認（`@browserbasehq/stagehand` / `@google/genai`）** — 更新後の sdk / node-server で 4 パッケージすべて実 import が成功する。

```console
$ node -e "await import('@browserbasehq/stagehand') ..."
stagehand ok, exports: AISdkClient,AVAILABLE_CUA_MODELS,ActTimeoutError,AgentAbortError,AgentProvider,AgentScreenshotProviderError
@google/genai ok, exports: ActivityHandling,AdapterSize,AggregationMetric,ApiError,ApiSpec,AspectRatio
mcp sdk ok, exports: McpServer,ResourceTemplate
hono/node-server ok, exports: RequestError,createAdaptorServer,getRequestListener,serve
```

**未実行**: `npm run test:storybook` / `npx playwright test` は本変更が dev 依存の transitive lockfile 更新のみでアプリコードに触れないため実行していない。CI の `unit-test` / `lint-and-test` レーンに委ねる。

## 影響範囲

**顧客に見える変化: なし。** 両パッケージとも dev 依存のみで、本番 Lambda bundle に載らない。

```console
$ npm ls @modelcontextprotocol/sdk @hono/node-server --omit=dev
ganbari-quest@1.0.0
`-- (empty)                # 本番依存ツリーに存在しない

$ npm ls @modelcontextprotocol/sdk --all
+-- @browserbasehq/stagehand@3.7.1        (dev)
| +-- @google/genai@1.52.0
| | `-- @modelcontextprotocol/sdk@1.30.0 deduped
| `-- @modelcontextprotocol/sdk@1.30.0
`-- @google/genai@2.16.0                  (dev)
  `-- @modelcontextprotocol/sdk@1.30.0 deduped
```

触った並行実装ペアなし。破壊的変更なし。`package.json` 無変更のため依存宣言の意味は変わらない。

**残る既知の脆弱性（本 PR の scope 外）**: `hono` 本体 4.12.31 に 4 件（GHSA-8j4g-w8fx-2239 ほか、いずれも `<4.12.34`）が develop 時点から残存する。これは `@hono/node-server` とは別パッケージで、本 PR の対象ではない。同じく dev 依存のみ。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
