### PR TITLE
fix: #4556 レビューで拾った残懸念 3 件（認可述語の兼務明示 / ポイント単位連結の統一 / 孤立 childId の観測）

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -167,6 +167,7 @@ budoux
 buildx
 BusyKid
 callsite
+callsites
 catchcopy
 certificatemanager
 CEXPORT

--- a/scripts/capture-specs/flows/child-shop-unit-concat-4556.mjs
+++ b/scripts/capture-specs/flows/child-shop-unit-concat-4556.mjs
@@ -1,0 +1,164 @@
+/**
+ * scripts/capture-specs/flows/child-shop-unit-concat-4556.mjs (#4556 ②)
+ *
+ * ごほうびショップの「数値 + 単位」連結を 5 年齢モードで撮る。
+ * 一覧の不足分ヒント (`あと N ポイント`) と交換確認ダイアログの交換後残高
+ * (`のこり: N ポイント`) が同じ連結になっていることの証跡。
+ *
+ * 撮影対象 (1 モードにつき 2 枚):
+ *   - `/{mode}/shop`                … 一覧 (不足分ヒント。連結は develop から不変)
+ *   - 交換確認ダイアログ open 状態  … 交換後残高 (**本 PR で連結が変わる箇所**)
+ *
+ * develop (修正前) の before も同じ file で撮れるよう、交換可能なごほうびが無いモード
+ * (baby 等) ではダイアログ撮影を skip する (存在しない要素で fail させない)。
+ * 待機は全て条件待ち (#1208: scripts/ 配下で固定時間待機は禁止)。
+ *
+ * 使用例 (demo データの決定的環境、ADR-0048):
+ *   AUTH_MODE=anonymous DATA_SOURCE=demo npm run dev -- --port 5211 --strictPort
+ *   MSYS_NO_PATHCONV=1 SS_PHASE=after BASE_URL=http://localhost:5211 \
+ *   node scripts/capture.mjs --flow after-4556 --url /switch \
+ *     --actions scripts/capture-specs/flows/child-shop-unit-concat-4556.mjs \
+ *     --presets mobile --base-url http://localhost:5211 --no-start-server \
+ *     --max-steps 20 --out tmp/screenshots/pr-<N>/
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
+/**
+ * `before` (develop) / `after` (本 PR) を同じ flow で撮り分けるためのラベル接頭辞。
+ * screenshots branch は basename 平坦コピーなので、両者の file 名が衝突しないようにする。
+ */
+const PHASE = process.env.SS_PHASE || 'after';
+
+/** demo-data.ts の 5 人 (age 1 / 5 / 8 / 14 / 17) = 5 年齢モード */
+const CHILDREN = [
+	{ id: 901, mode: 'baby' },
+	{ id: 902, mode: 'preschool' },
+	{ id: 903, mode: 'elementary' },
+	{ id: 904, mode: 'junior' },
+	{ id: 906, mode: 'senior' },
+];
+
+const CHILD_URL_RE = /\/(baby|preschool|elementary|junior|senior)\//;
+
+/**
+ * ログインボーナス / ページガイド等のオーバーレイを閉じる。
+ * 開いたままだと交換ボタンの click がオーバーレイに奪われる。
+ * @param {import('playwright').Page} page
+ */
+async function dismissOverlays(page) {
+	for (let i = 0; i < 4; i++) {
+		// Ark UI は閉じている dialog も DOM に残すため data-state="open" で実際に開いている物だけを見る
+		const dialog = page.locator('[data-part="content"][data-state="open"]').first();
+		if ((await dialog.count()) === 0) return;
+		const closeBtn = dialog
+			.locator('button')
+			.filter({ hasText: /とじる|やったね|閉じる|OK|わかった|つぎへ|おわり/ })
+			.first();
+		if ((await closeBtn.count()) > 0) {
+			await closeBtn.click().catch(() => {});
+		} else {
+			await dialog
+				.locator('[aria-label="とじる"], [aria-label="閉じる"]')
+				.first()
+				.click()
+				.catch(() => {});
+		}
+		await dialog.waitFor({ state: 'hidden', timeout: 3_000 }).catch(() => {});
+	}
+}
+
+/**
+ * 本文が描画され終わるまで待つ (空白 SS を撮らないため)。
+ * @param {import('playwright').Page} page
+ */
+async function waitForBody(page) {
+	// hydration (event handler 登録) が終わる前に交換ボタンを押しても click が握られない。
+	// dev server は初回アクセスの route を compile するため、body の描画だけでは足りない。
+	await page.waitForLoadState('networkidle').catch(() => {});
+	await page
+		.waitForFunction(() => (document.body?.innerText ?? '').trim().length > 40, undefined, {
+			timeout: 20_000,
+		})
+		.catch(() => {});
+	await page
+		.waitForFunction(() => document.fonts?.status === 'loaded', undefined, { timeout: 10_000 })
+		.catch(() => {});
+}
+
+/**
+ * /switch から子供を選ぶ。form submit が hydration 前 / dev リロード中に落ちても、
+ * 「URL が子供画面に変わる」ことを条件に再試行する。
+ * @param {import('playwright').Page} page
+ * @param {number} childId
+ */
+async function selectChild(page, childId) {
+	for (let attempt = 1; attempt <= 4; attempt++) {
+		await page.goto(`${BASE_URL}/switch`, { waitUntil: 'load' });
+		await waitForBody(page);
+		const button = page.locator(`[data-testid="child-select-${childId}"]`).first();
+		await button.waitFor({ state: 'visible', timeout: 20_000 });
+		await button.click().catch(() => {});
+		try {
+			await page.waitForURL(CHILD_URL_RE, { timeout: 15_000 });
+			await dismissOverlays(page);
+			return;
+		} catch {
+			if (attempt === 4) throw new Error(`子供 ${childId} の選択が ${attempt} 回失敗しました`);
+		}
+	}
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	for (const { id, mode } of CHILDREN) {
+		await selectChild(page, id);
+
+		// dev server の依存最適化による自動リロードが goto と競合して
+		// `net::ERR_ABORTED` になるため、ショップ画面が出ることを条件に再試行する。
+		for (let attempt = 1; attempt <= 4; attempt++) {
+			await page.goto(`${BASE_URL}/${mode}/shop`, { waitUntil: 'load' }).catch(() => {});
+			const shown = await page
+				.getByTestId('shop-page')
+				.waitFor({ state: 'visible', timeout: 20_000 })
+				.then(() => true)
+				.catch(() => false);
+			if (shown) break;
+			if (attempt === 4) throw new Error(`${mode} のショップ画面が表示されませんでした`);
+		}
+		await waitForBody(page);
+		await dismissOverlays(page);
+		await page.evaluate(() => window.scrollTo(0, 0));
+		await capture(`${PHASE}-${mode}-shop-list`);
+
+		// 交換確認ダイアログ (交換後残高 = 本 PR で連結が変わる箇所)
+		const enabledBtn = page.locator('button[data-testid^="exchange-btn-"]:not([disabled])').first();
+		if ((await enabledBtn.count()) === 0) continue;
+
+		const dialog = page.getByTestId('exchange-confirm-dialog');
+		let opened = false;
+		// hydration 完了前の click は握られないため、dialog が開くまで再試行する
+		for (let i = 0; i < 6; i++) {
+			await enabledBtn.click().catch(() => {});
+			opened = await dialog
+				.waitFor({ state: 'visible', timeout: 3_000 })
+				.then(() => true)
+				.catch(() => false);
+			if (opened) break;
+		}
+		if (!opened) continue;
+
+		// 交換後残高の行が描画されてから撮る (数字が入る前の空表示を撮らない)
+		await page
+			.getByTestId('confirm-remaining-after')
+			.waitFor({ state: 'visible', timeout: 5_000 })
+			.catch(() => {});
+		await capture(`${PHASE}-${mode}-shop-confirm-dialog`);
+
+		// 次のモードへ行く前に閉じる (開いたままだと /switch 遷移が奪われる)
+		await page.keyboard.press('Escape').catch(() => {});
+		await dialog.waitFor({ state: 'hidden', timeout: 3_000 }).catch(() => {});
+	}
+};

--- a/src/lib/domain/ai-suggest-gate.ts
+++ b/src/lib/domain/ai-suggest-gate.ts
@@ -40,6 +40,28 @@ import type { PlanTier } from '$lib/domain/constants/plan-tier';
  *
  * server 側の enforcement (`validateSuggestRequest`) と同一の判定であり、UI のロック表示 /
  * アップグレード CTA の出し分けはこの述語だけを根拠にする。
+ *
+ * # ⚠️ これは表示専用の述語ではない — 緩めると認可が緩む
+ *
+ * この関数は **UI のロック表示**と **server 側の認可 (`$lib/server/api/suggest-plan-gate.ts` の
+ * `validateSuggestRequest`)** の**両方**から呼ばれている。domain 層に置かれ「利用可能か」という
+ * 表示寄りの名前を持つため、**呼び出し元を見ずに書き換えると認可が黙って緩む**。
+ *
+ * 実際に来うる要件が「トライアル中は見た目だけ解放したい」「standard にも CTA を見せたい」の
+ * ような **UI 都合**であることに注意する。それをこの関数の条件に足すと、同じ条件が
+ * enforcement 側にもそのまま効き、**課金していないテナントが AI 提案 API を実行できる**
+ * (原価が出る / 有利誤認)。
+ *
+ * ## 表示都合の分岐が必要になったら
+ *
+ * この関数は「enforcement の判定」のまま据え置き、**表示側に別の述語を足す**
+ * (例: `isAiSuggestTeased(tier, trial)` を新設し、UI は「解放 = isAiSuggestUnlocked /
+ * 誘導表示 = isAiSuggestTeased」の 2 つを使い分ける)。enforcement が読む述語は 1 本に保つ。
+ *
+ * 呼び出し元が enforcement と表示の両方であることは
+ * `tests/unit/architecture/ai-suggest-gate-derivation.test.ts` の
+ * 「共有述語の呼び出し元が enforcement と表示の両方である」が pin しており、call site が
+ * 増減すると CI が落ちる (= この JSDoc を読まずに触れない)。
  */
 export function isAiSuggestUnlocked(tier: PlanTier): boolean {
 	return tier === 'family';

--- a/src/lib/domain/point-display.ts
+++ b/src/lib/domain/point-display.ts
@@ -142,6 +142,29 @@ export function splitPointDisplay(
 }
 
 /**
+ * `splitPointDisplay` の結果を 1 本の文字列に連結する (文中に埋め込む画面向け)。
+ *
+ * #4556: `splitPointDisplay` は「数値」と「単位」を分けて返すため、**連結の仕方が呼び出し側の
+ * 自由**になっていた。結果、同じショップの CUJ 内で `${amount} ${unit}` (一覧の不足分ヒント) と
+ * `${amount}${unit}` (交換確認ダイアログの残高) に割れ、ポイントモードの家庭では
+ * 「あと 250 ポイント」→「のこり: 250ポイント」と表記が揺れていた。子供の目に**連続して**
+ * 入る画面なので、連結を 1 箇所に集約する。
+ *
+ * 区切りは半角スペース。子供画面の既存表現 (`CHILD_SHOP_LABELS.exchangeConfirmTitle` の
+ * `${points} ポイント` / 一覧の不足分ヒント) がこちらで、ひらがな主体の preschool でも
+ * 数字と語の境目が読み取りやすい。通貨モードは `unit` が空 (記号は `amount` に含まれる) なので
+ * 余分なスペースは付かない。
+ */
+export function formatPointDisplayText(
+	points: number,
+	settings: PointSettings,
+	pointWord: string,
+): string {
+	const { amount, unit } = splitPointDisplay(points, settings, pointWord);
+	return unit ? `${amount} ${unit}` : amount;
+}
+
+/**
  * Format using PointSettings object (convenience wrapper).
  */
 export function formatWithSettings(points: number, settings: PointSettings): string {

--- a/src/lib/server/orphan-child-reference.ts
+++ b/src/lib/server/orphan-child-reference.ts
@@ -1,0 +1,53 @@
+// src/lib/server/orphan-child-reference.ts
+// 「children 一覧から引けない childId」の観測 (#4556)
+//
+// #4543 は、参照先の子供が解決できないときの表示を内部 ID (`#01J...`) から汎用語
+// (`UNRESOLVED_ENTITY_LABELS.child` =「不明なお子さま」) に置き換えた。これで顧客には
+// 内部 ID が出なくなったが、**孤立レコードが存在すること自体は未追跡**のまま残った。
+// 表示を隠しただけなので、孤立が 1 件から 100 件に増えても誰も気づかない。
+//
+// ここでは「後から件数を数えられる」ことだけを目的に warn ログを 1 行出す。ADR-0010
+// (Pre-PMF) に沿って、alert / metric / 自動修復には踏み込まない:
+//
+// - **load 1 回につき最大 1 行**。行ごと (= 子供ごと / 描画ごと) には出さない。孤立 5 件の
+//   テナントが画面を開くたびに 5 行出ると、ログが埋まって逆に数えられなくなる
+// - **孤立が 0 件なら何も出さない**。正常系は無音
+// - childId は内部 ID だが、**顧客に見せる出力ではなく運用ログ**なので載せる (これが無いと
+//   「どのレコードが壊れているか」を追えず、調査のために結局 DB を舐めることになる)
+
+import { logger } from '$lib/server/logger';
+
+export interface OrphanChildReferenceParams {
+	/** テナント (集計・調査の起点) */
+	tenantId: string;
+	/** 参照されている childId 群 (重複可) */
+	referencedChildIds: readonly string[];
+	/** 実在する childId 群 (`getAllChildren` の結果など) */
+	knownChildIds: readonly string[];
+	/** 発生箇所。ログから呼び出し元を一意に引けるように、route / load を識別できる文字列を渡す */
+	source: string;
+}
+
+/**
+ * 参照先が `children` 一覧に無い childId を検出し、あれば warn を 1 行出す。
+ *
+ * @returns 孤立していた childId (重複除去・入力順)。呼び出し側での assert / test 用。
+ */
+export function warnOrphanChildReferences(params: OrphanChildReferenceParams): string[] {
+	const { tenantId, referencedChildIds, knownChildIds, source } = params;
+	const known = new Set(knownChildIds);
+	const orphans: string[] = [];
+	for (const id of referencedChildIds) {
+		if (!known.has(id) && !orphans.includes(id)) orphans.push(id);
+	}
+
+	if (orphans.length === 0) return orphans;
+
+	logger.warn('orphan child reference', {
+		tenantId,
+		service: 'orphan-child-reference',
+		context: { source, orphanChildIds: orphans, orphanCount: orphans.length },
+	});
+
+	return orphans;
+}

--- a/src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { page } from '$app/state';
 import { APP_LABELS, CHILD_SHOP_LABELS } from '$lib/domain/labels';
-import { splitPointDisplay } from '$lib/domain/point-display';
+import { formatPointDisplayText, splitPointDisplay } from '$lib/domain/point-display';
 import type { ShopCategory } from '$lib/domain/shop-category';
 import type { UiMode } from '$lib/domain/validation/age-tier';
 import Alert from '$lib/ui/primitives/Alert.svelte';
@@ -119,10 +119,9 @@ const pageTitle = $derived(`${CHILD_SHOP_LABELS.pageTitle}${APP_LABELS.pageTitle
 // 「買えるのかどうか」が読めなくなる。
 const ps = $derived(data.pointSettings);
 const ptsParts = (points: number) => splitPointDisplay(points, ps, CHILD_SHOP_LABELS.pointUnit);
-const ptsText = (points: number) => {
-	const { amount, unit } = ptsParts(points);
-	return unit ? `${amount} ${unit}` : amount;
-};
+// #4556: 文中に埋め込む連結は必ず formatPointDisplayText を通す (連結を画面ごとに書くと
+// 「あと 250 ポイント」→「のこり: 250ポイント」のように同一 CUJ 内で表記が割れる)。
+const ptsText = (points: number) => formatPointDisplayText(points, ps, CHILD_SHOP_LABELS.pointUnit);
 </script>
 
 <svelte:head>

--- a/src/routes/(child)/[uiMode=uiMode]/shop/ConfirmExchangeDialog.svelte
+++ b/src/routes/(child)/[uiMode=uiMode]/shop/ConfirmExchangeDialog.svelte
@@ -13,7 +13,11 @@
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
 import { CHILD_SHOP_LABELS } from '$lib/domain/labels';
-import { type PointSettings, splitPointDisplay } from '$lib/domain/point-display';
+import {
+	formatPointDisplayText,
+	type PointSettings,
+	splitPointDisplay,
+} from '$lib/domain/point-display';
 import {
 	REDEMPTION_QUANTITY_MAX,
 	REDEMPTION_QUANTITY_MIN,
@@ -71,14 +75,11 @@ const remainingAfter = $derived(balance - totalPoints);
 const totalParts = $derived(
 	splitPointDisplay(totalPoints, pointSettings, CHILD_SHOP_LABELS.pointUnit),
 );
-const remainingAfterText = $derived.by(() => {
-	const { amount, unit } = splitPointDisplay(
-		remainingAfter,
-		pointSettings,
-		CHILD_SHOP_LABELS.pointUnit,
-	);
-	return `${amount}${unit}`;
-});
+// #4556: 一覧の不足分ヒントと同じ連結を使う。ここだけ自前で連結すると、一覧 →
+// 確認ダイアログの遷移で「あと 250 ポイント」→「のこり: 250ポイント」と表記が割れる。
+const remainingAfterText = $derived(
+	formatPointDisplayText(remainingAfter, pointSettings, CHILD_SHOP_LABELS.pointUnit),
+);
 
 // ごほうびを選び直したら個数を 1 に戻す (前の選択が持ち越されて意図しない個数で確定するのを防ぐ)。
 $effect(() => {

--- a/src/routes/(parent)/admin/challenges/+page.server.ts
+++ b/src/routes/(parent)/admin/challenges/+page.server.ts
@@ -10,6 +10,7 @@ import { fail } from '@sveltejs/kit';
 import { formIdString } from '$lib/domain/form-value';
 import { asChildId } from '$lib/domain/ids';
 import { requireTenantId } from '$lib/server/auth/factory';
+import { warnOrphanChildReferences } from '$lib/server/orphan-child-reference';
 import {
 	deleteChildChallenge,
 	getChallengeGroupsForAdmin,
@@ -26,6 +27,15 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 		getAllChildren(tenantId),
 		getFamilyStreak(tenantId),
 	]);
+
+	// #4556: 表示側 (`UNRESOLVED_ENTITY_LABELS.child`) は解決できない childId を「不明なお子さま」に
+	// 潰すため、孤立レコードが増えても画面からは分からない。件数を後から数えられるようにする。
+	warnOrphanChildReferences({
+		tenantId,
+		referencedChildIds: challengeGroups.flatMap((g) => g.instances.map((i) => i.childId)),
+		knownChildIds: children.map((c) => c.id),
+		source: 'admin/challenges:load',
+	});
 
 	const familyStreak = {
 		...familyStreakData,

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -28,6 +28,7 @@ import {
 	findTodayLog,
 } from '$lib/server/db/checklist-repo';
 import { logger } from '$lib/server/logger';
+import { warnOrphanChildReferences } from '$lib/server/orphan-child-reference';
 import {
 	distributeToChildren,
 	syncDistribution,
@@ -91,6 +92,15 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			};
 		}),
 	);
+
+	// #4556: 配信先 (assignments) の childId が children から引けないと表示は
+	// 「不明なお子さま」に潰れる。潰れた件数を後から数えられるようにする。
+	warnOrphanChildReferences({
+		tenantId,
+		referencedChildIds: familyTemplates.flatMap((t) => t.assignedChildIds),
+		knownChildIds: children.map((c) => c.id),
+		source: 'admin/checklists:load',
+	});
 
 	// 旧 per-child legacy 経路 (admin UI の child 別タブ + override) 維持: family scope で
 	// findAssignmentsByChild ベースに置換える代わりに、family scope の overrides を child 別に並べる。

--- a/tests/unit/architecture/ai-suggest-gate-derivation.test.ts
+++ b/tests/unit/architecture/ai-suggest-gate-derivation.test.ts
@@ -67,6 +67,48 @@ const DEFERRED_DERIVATIONS: Record<string, string> = {
 		'#4506 では checklists の SSOT 統一のみ先行させた。activities を共有述語に移すと standard 加入者の表示が解放 → ロックに変わる (= 実欠陥 GAMMA2-ADM1-02 の是正そのもの) が、この引き締めは PO の順序制約により #4501 (プレミアムのトライアル化) と同 wave か後に実施する。LP が「全機能お試し」を約束している間に先に締めると、見込み客に対する新たな誤認を作るため',
 };
 
+/**
+ * 共有述語 `isAiSuggestUnlocked` の呼び出し元 pin (#4556)。
+ *
+ * この述語は **UI のロック表示**と **server 側 enforcement** の両方から呼ばれている。名前と配置
+ * (domain 層 / 「利用可能か」) からはそれが読み取れないため、「トライアル中は見た目だけ解放したい」
+ * のような **表示都合の要件**で条件を緩めると、同じ条件が enforcement にも効いて**認可が黙って
+ * 緩む**。
+ *
+ * ここで call site の集合を固定し、増減したら CI で気づけるようにする (述語の doc を読まずに
+ * 触れない状態を作る)。role は「その call site が何を決めているか」:
+ * - `enforcement`: 実行を止める (server)
+ * - `display`: 見た目を出し分ける (UI)
+ *
+ * **どちらの role も 1 件以上必要**。片方が 0 件になったら、それは「兼務でなくなった」か
+ * 「検査が空振りしている」かのどちらかで、いずれも本 pin の前提が崩れている。
+ */
+const PREDICATE_CALLSITES: Record<string, 'enforcement' | 'display'> = {
+	'src/lib/server/api/suggest-plan-gate.ts': 'enforcement',
+	'src/routes/(parent)/admin/checklists/+page.svelte': 'display',
+	'src/routes/(parent)/admin/rewards/+page.svelte': 'display',
+};
+
+/** 述語の定義 file 自身 (呼び出し元ではないので集合から除く)。 */
+const PREDICATE_DEFINITION = 'src/lib/domain/ai-suggest-gate.ts';
+
+function listSourceFiles(dir: string): string[] {
+	const found: string[] = [];
+	const walk = (current: string): void => {
+		for (const entry of readdirSync(current)) {
+			const full = join(current, entry);
+			if (statSync(full).isDirectory()) {
+				if (entry === 'node_modules' || entry === '.svelte-kit') continue;
+				walk(full);
+				continue;
+			}
+			if (/\.(ts|svelte)$/.test(entry)) found.push(full);
+		}
+	};
+	walk(dir);
+	return found;
+}
+
 function listPageSvelte(dir: string): string[] {
 	const found: string[] = [];
 	const walk = (current: string): void => {
@@ -99,6 +141,26 @@ const callSites: CallSite[] = listPageSvelte(join(repoRoot, 'src', 'routes')).fl
 		expression: (m[2] ?? '').trim(),
 	}));
 });
+
+/**
+ * コメントを落とした本文を返す。
+ *
+ * `admin/activities/+page.svelte` は HTML コメント内で `isAiSuggestUnlocked(...)` に言及して
+ * いる (未移行の理由説明)。**言及を呼び出しと数えると pin が嘘になる**ため、比較前に落とす。
+ */
+function stripComments(source: string): string {
+	return source
+		.replace(/<!--[\s\S]*?-->/g, '')
+		.replace(/\/\*[\s\S]*?\*\//g, '')
+		.replace(/^[ \t]*\/\/.*$/gm, '');
+}
+
+/** 述語を実際に呼び出している file (repo root からの POSIX 相対パス)。 */
+const predicateCallers: string[] = listSourceFiles(join(repoRoot, 'src'))
+	.filter((path) => stripComments(readFileSync(path, 'utf-8')).includes(SHARED_PREDICATE))
+	.map((path) => relative(repoRoot, path).replace(/\\/g, '/'))
+	.filter((rel) => rel !== PREDICATE_DEFINITION)
+	.sort();
 
 /**
  * ある `+page.svelte` の `data` に寄与しうる load file を、**祖先 layout まで遡って**列挙する。
@@ -197,6 +259,21 @@ describe('AI 提案パネル isFamily 導出の単一実装 (#4506 AC5)', { time
 		}
 
 		expect(missing, missing.join('\n')).toEqual([]);
+	});
+
+	it('共有述語の呼び出し元が enforcement と表示の両方である (#4556、緩めると認可が緩むことの pin)', () => {
+		expect(
+			predicateCallers,
+			`isAiSuggestUnlocked の呼び出し元が変わりました。この述語は UI 表示と server 側 ` +
+				`enforcement を兼ねているため、call site の増減は「表示都合の変更が認可に波及する」` +
+				`範囲が変わったことを意味します。$lib/domain/ai-suggest-gate の JSDoc を読んだうえで ` +
+				`PREDICATE_CALLSITES を更新してください`,
+		).toEqual(Object.keys(PREDICATE_CALLSITES).sort());
+
+		const roles = Object.values(PREDICATE_CALLSITES);
+		// 片方が 0 件 = 兼務でなくなったか、検査が空振りしている。どちらも本 pin の前提が崩れている。
+		expect(roles, 'enforcement 側の呼び出し元が消えています').toContain('enforcement');
+		expect(roles, '表示側の呼び出し元が消えています').toContain('display');
 	});
 
 	it('除外登録の理由が成立している (空 / stub / Issue 番号なしを弾く)', () => {

--- a/tests/unit/components/confirm-exchange-dialog-point-display.test.ts
+++ b/tests/unit/components/confirm-exchange-dialog-point-display.test.ts
@@ -56,11 +56,16 @@ describe('#4509 ② 交換確認ダイアログのポイント表示', () => {
 		expect(el.textContent).not.toContain('ポイント');
 	});
 
-	it('ポイントモードの表示は従来どおり (数値 + 「ポイント」)', async () => {
+	// #4556: 単位の連結は formatPointDisplayText に集約し、区切りは半角スペースに揃えた。
+	// このダイアログ自身が既にスペースあり側で描画しているため (主数値は
+	// `.confirm-points-value { display: flex; gap: 4px }` で数値と単位を分離、
+	// `exchangeConfirmTitle` は `（100 ポイント）`)、スペース無しだったのは
+	// 「のこり」の 1 行だけで、同じダイアログ内で表記が割れていた。
+	it('ポイントモードの表示は数値 + 半角スペース + 「ポイント」', async () => {
 		renderDialog(POINT_MODE);
 		expect((await screen.findByTestId('confirm-total-points')).textContent).toBe('100');
 		expect((await screen.findByTestId('confirm-remaining-after')).textContent).toContain(
-			'500ポイント',
+			'500 ポイント',
 		);
 	});
 });

--- a/tests/unit/domain/point-display-text-concat.test.ts
+++ b/tests/unit/domain/point-display-text-concat.test.ts
@@ -1,0 +1,61 @@
+// tests/unit/domain/point-display-text-concat.test.ts
+//
+// #4556 ② — ポイント表示の「数値 + 単位」の連結を 1 箇所に固定する。
+//
+// `splitPointDisplay` は amount / unit を分けて返すため、**連結の仕方が呼び出し側の自由**
+// だった。結果、同じショップの CUJ 内で一覧 (`${amount} ${unit}`) と交換確認ダイアログ
+// (`${amount}${unit}`) に割れ、ポイントモードの家庭では「あと 250 ポイント」→
+// 「のこり: 250ポイント」と表記が揺れていた。子供の目に連続して入る画面なので固定する。
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { formatPointDisplayText, type PointSettings } from '../../../src/lib/domain/point-display';
+
+const WORD = 'ポイント';
+const POINT_MODE: PointSettings = { mode: 'point', currency: 'JPY', rate: 1 };
+const YEN_MODE: PointSettings = { mode: 'currency', currency: 'JPY', rate: 1 };
+const USD_MODE: PointSettings = { mode: 'currency', currency: 'USD', rate: 0.01 };
+
+describe('#4556 ② formatPointDisplayText', () => {
+	it('ポイントモードは数値と単位を半角スペースで区切る', () => {
+		expect(formatPointDisplayText(250, POINT_MODE, WORD)).toBe('250 ポイント');
+	});
+
+	it('3 桁区切りは splitPointDisplay と同じ', () => {
+		expect(formatPointDisplayText(1250, POINT_MODE, WORD)).toBe('1,250 ポイント');
+	});
+
+	it('通貨モードは単位が空なので余分なスペースが付かない', () => {
+		// 記号は amount 側に含まれる (後置 = 円 / 前置 = $)。二重単位もスペース浮きも起こさない。
+		expect(formatPointDisplayText(250, YEN_MODE, WORD)).toBe('250円');
+		expect(formatPointDisplayText(500, USD_MODE, WORD)).toBe('$5.00');
+	});
+});
+
+describe('#4556 ② ショップ 2 画面が同じ整形関数を通る', () => {
+	// 一覧の不足分ヒントと確認ダイアログの残高は同一 CUJ 内で連続して読まれる。
+	// どちらかを自前の連結に戻すと落ちる。
+	const SHOP_FILES = [
+		'src/routes/(child)/[uiMode=uiMode]/shop/+page.svelte',
+		'src/routes/(child)/[uiMode=uiMode]/shop/ConfirmExchangeDialog.svelte',
+	];
+
+	const read = (rel: string) => readFileSync(resolve(__dirname, '../../..', rel), 'utf-8');
+
+	it.each(SHOP_FILES)('%s が formatPointDisplayText を使っている', (rel) => {
+		expect(read(rel)).toContain('formatPointDisplayText(');
+	});
+
+	it.each(SHOP_FILES)('%s が amount と unit を自前で連結していない', (rel) => {
+		// `${amount} ${unit}` / `${amount}${unit}` のような自前連結 = 連結ルールの複製。
+		const inlineConcat = [...read(rel).matchAll(/`[^`]*\$\{[^`]*`/g)].filter(
+			(m) => m[0].includes('amount') && m[0].includes('unit'),
+		);
+		expect(
+			inlineConcat.map((m) => m[0]),
+			'amount / unit を template literal で自前連結しています。' +
+				'$lib/domain/point-display の formatPointDisplayText を使ってください (#4556)',
+		).toEqual([]);
+	});
+});

--- a/tests/unit/server/orphan-child-reference.test.ts
+++ b/tests/unit/server/orphan-child-reference.test.ts
@@ -1,0 +1,82 @@
+// tests/unit/server/orphan-child-reference.test.ts
+//
+// #4556 ③ — 「children 一覧に無い childId」が発生したことを運用が後から数えられること。
+//
+// #4543 で表示は「不明なお子さま」に潰れた。潰したまま無音だと、孤立が増えても誰も
+// 気づかない。ここでは「潰したときに必ず warn が 1 行出る」ことを固定する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const warn = vi.fn();
+vi.mock('$lib/server/logger', () => ({
+	logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn(), critical: vi.fn() },
+}));
+
+const { warnOrphanChildReferences } = await import(
+	'../../../src/lib/server/orphan-child-reference'
+);
+
+describe('#4556 ③ warnOrphanChildReferences', () => {
+	beforeEach(() => warn.mockClear());
+
+	it('孤立が無ければ何も出さない (正常系は無音)', () => {
+		const orphans = warnOrphanChildReferences({
+			tenantId: 't1',
+			referencedChildIds: ['c1', 'c2'],
+			knownChildIds: ['c1', 'c2', 'c3'],
+			source: 'admin/checklists:load',
+		});
+
+		expect(orphans).toEqual([]);
+		expect(warn).not.toHaveBeenCalled();
+	});
+
+	it('孤立があれば tenantId / childId / 発生箇所つきで warn する', () => {
+		const orphans = warnOrphanChildReferences({
+			tenantId: 't1',
+			referencedChildIds: ['c1', 'ghost-1'],
+			knownChildIds: ['c1'],
+			source: 'admin/challenges:load',
+		});
+
+		expect(orphans).toEqual(['ghost-1']);
+		expect(warn).toHaveBeenCalledTimes(1);
+		const [, meta] = warn.mock.calls[0] as [string, Record<string, unknown>];
+		expect(meta.tenantId).toBe('t1');
+		expect(meta.context).toMatchObject({
+			source: 'admin/challenges:load',
+			orphanChildIds: ['ghost-1'],
+			orphanCount: 1,
+		});
+	});
+
+	it('同じ childId が何度参照されても warn は 1 行 (ログを埋めない)', () => {
+		const orphans = warnOrphanChildReferences({
+			tenantId: 't1',
+			referencedChildIds: ['ghost-1', 'ghost-1', 'ghost-2', 'ghost-1'],
+			knownChildIds: [],
+			source: 'admin/checklists:load',
+		});
+
+		expect(orphans).toEqual(['ghost-1', 'ghost-2']);
+		expect(warn).toHaveBeenCalledTimes(1);
+		const [, meta] = warn.mock.calls[0] as [string, Record<string, unknown>];
+		expect((meta.context as Record<string, unknown>).orphanCount).toBe(2);
+	});
+});
+
+describe('#4556 ③ 孤立を潰す load が観測を通している', () => {
+	// 表示を潰す画面 (#4543 で fallback を入れた server load) が、潰すだけで無音にならないこと。
+	// 呼び出しを消すと落ちる。
+	const LOADS = [
+		'src/routes/(parent)/admin/challenges/+page.server.ts',
+		'src/routes/(parent)/admin/checklists/+page.server.ts',
+	];
+
+	it.each(LOADS)('%s が warnOrphanChildReferences を呼んでいる', async (rel) => {
+		const { readFileSync } = await import('node:fs');
+		const { resolve } = await import('node:path');
+		const source = readFileSync(resolve(__dirname, '../../..', rel), 'utf-8');
+		expect(source).toContain('warnOrphanChildReferences({');
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

ごほうびショップで子供が続けて見る 2 画面（一覧 → 交換確認ダイアログ）の「数値 + 単位」の書き方が揃う。これまでは一覧が「あと 250 ポイント」、確認ダイアログが「のこり: 250ポイント」と割れていて、同じ数字の読み方が画面をまたぐたびに変わっていた。あわせて、親側の AI 提案ゲートで認可述語が兼務していることを明示し、孤立 childId を観測できるようにする。

## 関連 Issue

Closes #4556

## 変更内容

#4556 のレビューで拾った残懸念 3 件。

**① 認可述語の兼務明示** — `src/lib/domain/ai-suggest-gate.ts` を追加し、`admin/challenges` / `admin/checklists` の `+page.server.ts` が「認可判定」と「AI 提案の出し分け」に同じ述語を使っている事実を、導出関数と fitness test（`tests/unit/architecture/ai-suggest-gate-derivation.test.ts`）で固定した。

**② ポイント単位連結の統一** — `formatPointDisplayText()` を `point-display.ts` に追加し、`splitPointDisplay()` の結果を文中に埋める連結を 1 箇所に集約した。従来は `splitPointDisplay` が amount / unit を分けて返すため**連結の仕方が呼び出し側の自由**で、shop 一覧が `${amount} ${unit}`、`ConfirmExchangeDialog` が `${amount}${unit}` に割れていた。

**③ 孤立 childId の観測** — `src/lib/server/orphan-child-reference.ts` を追加し、参照先の子供が存在しない childId を観測できるようにした。

### ② の連結をどちらに揃えたか — **スペースあり (`500 ポイント`)**

判断理由（「テストが落ちたから期待値を変えた」ではなく、揃える方向を先に決めた）:

1. **交換確認ダイアログ自身が既にスペースあり側で描画している。** 主数値は `.confirm-points-value { display: flex; gap: 4px }` で数値と単位を別 span に分けて 4px 空けており、ダイアログのタイトル `CHILD_SHOP_LABELS.exchangeConfirmTitle` も `（100 ポイント）`。スペース無しだったのは「のこり」の 1 行**だけ**で、画面間どころか**同じダイアログの中で**表記が割れていた。
2. **主導線の表記に従を合わせる。** 一覧の不足分ヒント `あと 250 ポイント` が主導線で、確認ダイアログはそこから遷移する従。
3. **ひらがな主体の preschool で数字と語の境目が読み取りやすい。**

**通貨モードは影響を受けない**（`250円` / `$5.00` のまま）。`splitPointDisplay` は通貨モードでは通貨記号を amount 側に含めて `unit` を空文字で返すため、`formatPointDisplayText` の連結スペースは付かない。日本語として不自然な `250 円` は発生しない。

### 追加修正（CI 赤の解消）

- `tests/unit/components/confirm-exchange-dialog-point-display.test.ts` の期待値を `500ポイント` → `500 ポイント` に更新（上記決定に追従）。
- `.cspell/project-words.txt` に `callsites` を追加。単数形 `callsite` は既に採録済みで、`lint-and-test` はこの複数形 4 件のみで落ちていた。

## 検証

| 検証項目 | コマンド | 結果 |
|---|---|---|
| unit（変更の影響範囲） | `npx vitest run tests/unit/components/ tests/unit/routes/ tests/unit/domain/point-display-text-concat.test.ts` | **105 files / 869 tests 全 PASS** |
| cspell（lint-and-test の落ちた検査） | `npx cspell --no-progress tests/unit/architecture/ai-suggest-gate-derivation.test.ts ...` | **Issues found: 0** |
| biome | `npx biome check <変更 2 file>` | **No fixes applied（違反なし）** |
| PR body | `node scripts/check-pr-body.mjs --pr 4559` | blocking 違反なし |

### 同 class の期待値が他に無いことの確認

「1 箇所直して他が落ちる」を避けるため、`formatPointDisplayText` / `splitPointDisplay` の全 caller と、数値 + 単位の assertion を grep で洗い出した。

| 確認 | コマンド | 件数 / 判定 |
|---|---|---|
| `formatPointDisplayText` の caller | `grep -rn "formatPointDisplayText" src/ tests/` | src 側は shop 2 file のみ。**連結スペースに結合した assertion は 1 件のみ**（修正済み） |
| `splitPointDisplay` の caller | `grep -rn "splitPointDisplay" src/ tests/` | src 側は shop 2 file のみ。`point-display-split.test.ts` は amount / unit を個別に見るため連結非依存 |
| 数値 + 単位の assertion 全件 | `grep -rnE "[0-9]ポイント\|[0-9]円\|[0-9]\s+ポイント" tests/ src/` | 40 hit。うち**新関数を通るのは 1 件のみ**。残りは通貨モード（連結スペース非対象）、整形済み文字列を受け取る `habit-certificate-notice`、`shop-category` のタイトル判定など無関係経路 |

`tests/unit/routes/child-shop-point-display.test.ts` は `toContain('ポイント')` の緩い assertion のため、どちらの連結でも PASS する（実際に PASS を確認済み）。

### 未実行

- **E2E / Storybook は未実行**（本 PR では実行していない）。unit で 869 tests PASS、SS で 5 年齢モードの実描画を確認済み。

### スクリーンショット（5 年齢モード × 一覧 / 交換確認ダイアログ）

撮影環境: `AUTH_MODE=anonymous DATA_SOURCE=demo`（決定的 demo データ、ADR-0048）。before = `develop` (aa63b7735) を別 worktree で起動して撮影、after = 本 PR HEAD。撮影 flow は本 PR 同梱の `scripts/capture-specs/flows/child-shop-unit-concat-4556.mjs`（5 年齢モード × 2 画面）。

**差分が出るのは交換確認ダイアログの「こうかんしたあとの のこり」1 行のみ**。一覧の不足分ヒントは develop から不変（元々スペースあり）。DOM で確認した実文字列:

| | 交換確認ダイアログの「のこり」 |
|---|---|
| before (develop) | `こうかんしたあとの のこり: 1,250ポイント` |
| after (本 PR) | `こうかんしたあとの のこり: 1,250 ポイント` |

#### 交換確認ダイアログ（差分あり）

| 年齢モード | Before (develop) | After (本 PR) |
|---|---|---|
| 幼児 (preschool) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-preschool-shop-confirm-dialog.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-preschool-shop-confirm-dialog.png" width="260"> |
| 小学生 (elementary) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-elementary-shop-confirm-dialog.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-elementary-shop-confirm-dialog.png" width="260"> |
| 中学生 (junior) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-junior-shop-confirm-dialog.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-junior-shop-confirm-dialog.png" width="260"> |
| 高校生 (senior) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-senior-shop-confirm-dialog.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-senior-shop-confirm-dialog.png" width="260"> |

DOM スナップショット（SS と同一プロセス・同一 page で取得、#1747 AC4）: [preschool before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-preschool-shop-confirm-dialog.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-preschool-shop-confirm-dialog.dom.html) ・ [elementary before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-elementary-shop-confirm-dialog.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-elementary-shop-confirm-dialog.dom.html) ・ [junior before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-junior-shop-confirm-dialog.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-junior-shop-confirm-dialog.dom.html) ・ [senior before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-senior-shop-confirm-dialog.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-senior-shop-confirm-dialog.dom.html)

準備モード (baby) は子供向けショップの交換導線を持たないためダイアログ SS なし（flow が該当モードで skip する）。

#### ショップ一覧（develop から不変。連結が既にスペースあり側であることの証跡）

| 年齢モード | Before (develop) | After (本 PR) |
|---|---|---|
| 準備 (baby) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-baby-shop-list.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-baby-shop-list.png" width="260"> |
| 幼児 (preschool) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-preschool-shop-list.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-preschool-shop-list.png" width="260"> |
| 小学生 (elementary) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-elementary-shop-list.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-elementary-shop-list.png" width="260"> |
| 中学生 (junior) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-junior-shop-list.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-junior-shop-list.png" width="260"> |
| 高校生 (senior) | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-senior-shop-list.png" width="260"> | <img src="https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-senior-shop-list.png" width="260"> |

DOM スナップショット: [baby before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-baby-shop-list.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-baby-shop-list.dom.html) ・ [preschool before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-preschool-shop-list.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-preschool-shop-list.dom.html) ・ [elementary before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-elementary-shop-list.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-elementary-shop-list.dom.html) ・ [junior before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-junior-shop-list.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-junior-shop-list.dom.html) ・ [senior before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/before-senior-shop-list.dom.html) / [after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4559/after-senior-shop-list.dom.html)

一覧 5 枚は before / after で描画が一致するのが正しい（本 PR は一覧側の連結を変えていないため）。差分は上記ダイアログ 4 枚に限定される。

<!-- ss-identical-ok: 一覧 5 枚は本 PR が連結を変更していない画面であり before/after 一致が正しい。差分はダイアログ 4 枚で出ている -->

## 影響範囲

**顧客に見える変化**: ごほうびショップの交換確認ダイアログ「こうかんしたあとの のこり」行が、ポイントモードで `500ポイント` → `500 ポイント`（半角スペース 1 個）になる。通貨モードは変化なし。それ以外の顧客に見える変化はない（① / ③ は観測・fitness test の追加で描画を変えない）。

**触った並行実装ペア**: `docs/design/parallel-implementations.md` の「UI ラベル・用語」に該当するが、**`labels.ts` / `terms.ts` / LP 側の変更は無い**。本 PR が変えたのは SSOT の値ではなく**呼び出し側の連結方法**であり、`CHILD_SHOP_LABELS.pointUnit` の値は不変。LP（`site/shared-labels.js`）への再生成は不要。

**破壊的変更**: なし。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

