### PR TITLE
fix(ci): #4557 main-pr-base-guard に止められた bot PR の滞留を検知して通知する

### DIFF
--- a/.github/workflows/admin-bypass-evidence.yml
+++ b/.github/workflows/admin-bypass-evidence.yml
@@ -3,6 +3,9 @@ name: Admin Bypass Evidence Check
 # #1201 / ADR-0044: admin bypass merge された PR に Self-Review 証跡セクションが
 # 含まれているかを検証し、欠落 PR に追記要求コメントを投稿する。
 # block はしない（事後 merge を revert することは運用上困難なため、事後追記を促す）。
+#
+# #4557: 同じ日次 cron に「main 直行のまま滞留した bot PR」検知 job を相乗りさせている
+# (既存の定期実行 workflow に寄せ、新規 workflow / 新規 cron を増やさない判断)。
 
 on:
   schedule:
@@ -20,6 +23,10 @@ on:
         description: 'Skip comment posting (for testing)'
         required: false
         default: 'false'
+      stall_days:
+        description: 'main 直行 bot PR を滞留とみなす経過日数 (default 2)'
+        required: false
+        default: '2'
 
 permissions:
   contents: read
@@ -38,3 +45,22 @@ jobs:
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/check-admin-bypass-evidence.mjs
+
+  # #4557: main-pr-base-guard (ci.yml) に fail-close された bot PR (dependabot/renovate の
+  # security update 等) は、bot 自身が retarget しないため人が気づくまで滞留する。
+  # #4532 が実例 (GHSA-9mqv-5hh9-4cgg、認証前到達可能な WebSocket upgrade メモリ枯渇の修正が
+  # fail のまま放置されていた)。検知したら PR コメント (新規 secret 不要) を投稿し、
+  # DISCORD_WEBHOOK_INCIDENT が設定済みなら要約も通知する (既存 secret を再利用、新規追加なし)。
+  stalled-bot-pr-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run stalled bot PR check
+        env:
+          REPO: ${{ github.repository }}
+          STALL_DAYS: ${{ github.event.inputs.stall_days || '2' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_WEBHOOK_INCIDENT: ${{ secrets.DISCORD_WEBHOOK_INCIDENT }}
+        run: node scripts/check-stalled-bot-pr.mjs

--- a/scripts/check-stalled-bot-pr.mjs
+++ b/scripts/check-stalled-bot-pr.mjs
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+/**
+ * scripts/check-stalled-bot-pr.mjs
+ *
+ * #4557 (発端: #4532): `main-pr-base-guard` (ci.yml、#3922/#4273) は dependabot/renovate の
+ * main 直行 PR を正しく fail-close する。しかし GitHub 仕様上 security update PR は
+ * default branch (main) にしか作られず、`target-branch: develop` を無視する。
+ * bot は失敗した PR を自動で retarget しないため、**人が `gh pr edit --base develop` を
+ * 打つまで PR は赤いまま滞留する**。fail メッセージに対処コマンドは出るが、誰かが
+ * その PR を見に行かない限り気づけない。「guard が正しく止める」と「security 更新が
+ * 永久放置される」が両立してしまう構造的な穴を埋める。
+ *
+ * 本スクリプトは以下を満たす PR を「滞留した bot PR」として検出する:
+ *   - base = main
+ *   - author が bot (dependabot / renovate / その他 `is_bot: true`)
+ *   - open のまま STALL_DAYS 日以上経過
+ *   - `main-pr-base-guard` チェックが failure のまま
+ *
+ * 検出したら PR コメント (既存経路、新規 secret 不要) を投稿する。加えて
+ * DISCORD_WEBHOOK_INCIDENT (既存 secret、deploy-nuc.yml / deploy-aws-staging.yml と共用)
+ * が設定されていれば要約を通知する。**新規 secret は追加しない** (ADR-0024)。
+ *
+ * 自動 retarget (`gh pr edit --base develop`) は本スクリプトでは行わない。
+ * base 付け替えは PR の意味を変える不可逆に近い操作であり、dependabot 自身の
+ * PR 追跡状態 (rebase / auto-merge 判定) と衝突するリスクを排除しきれないため、
+ * 「検知して人に気づかせる」に留める判断とした (#4557 PR body に判断理由を記載)。
+ *
+ * 想定実行環境: GitHub Actions の schedule トリガ (admin-bypass-evidence.yml に相乗り、日次)
+ *   env:
+ *     REPO:                     owner/repo
+ *     GH_TOKEN:                 GITHUB_TOKEN (read PR + write PR comment 権限)
+ *     STALL_DAYS:               何日経過で「滞留」とみなすか (default: 2)
+ *     DRY_RUN:                  'true' でコメント投稿 / Discord 通知をスキップ
+ *     DISCORD_WEBHOOK_INCIDENT: 設定時のみ Discord 要約通知 (optional、新規 secret ではない)
+ *     OUTPUT_MODE:              'json' | 'text' (default: text)
+ *
+ * exit:
+ *   0 = OK (滞留 0 件、または検知 + 通知完了)
+ *   2 = API 失敗等の internal error
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { isMain } from './lib/is-main.mjs';
+
+/**
+ * @typedef {Object} PrAuthor
+ * @property {string} login
+ * @property {boolean} [is_bot]
+ */
+
+/**
+ * @typedef {Object} GhPr
+ * @property {number} number
+ * @property {string} title
+ * @property {PrAuthor | null} author
+ * @property {string} createdAt
+ * @property {string} url
+ * @property {string} [baseRefName]
+ */
+
+/**
+ * @typedef {Object} GhCheck
+ * @property {string} name
+ * @property {string} [bucket]
+ * @property {string} [state]
+ */
+
+const REPO = process.env.REPO;
+const STALL_DAYS = Number(process.env.STALL_DAYS || '2');
+const DRY_RUN = process.env.DRY_RUN === 'true';
+const OUTPUT_MODE = process.env.OUTPUT_MODE || 'text';
+const DISCORD_WEBHOOK_INCIDENT = process.env.DISCORD_WEBHOOK_INCIDENT || '';
+
+const GUARD_CHECK_NAME = 'main-pr-base-guard';
+const BOT_COMMENT_MARKER = '<!-- stalled-bot-pr-check -->';
+
+/**
+ * @param {string[]} args
+ * @returns {string}
+ */
+function gh(args) {
+	try {
+		return execFileSync('gh', args, {
+			stdio: ['ignore', 'pipe', 'inherit'],
+			encoding: 'utf-8',
+			maxBuffer: 20 * 1024 * 1024,
+		});
+	} catch (/** @type {unknown} */ err) {
+		console.error(`[stalled-bot-pr] gh command failed: ${args.join(' ')}`);
+		const msg = err instanceof Error ? err.message : String(err);
+		console.error(msg);
+		process.exit(2);
+	}
+}
+
+/**
+ * bot 判定。gh の JSON は `author.is_bot` を持つ (dependabot / integrator 等)。
+ * 念のため login 側の慣習 (`[bot]` サフィックス / `app/` prefix) もフォールバックで見る。
+ *
+ * @param {GhPr} pr
+ * @returns {boolean}
+ */
+export function isBotAuthor(pr) {
+	const author = pr.author;
+	if (!author) return false;
+	if (author.is_bot === true) return true;
+	const login = author.login || '';
+	return login.endsWith('[bot]') || login.startsWith('app/');
+}
+
+/**
+ * @param {string} createdAtIso
+ * @param {string} nowIso
+ * @returns {number}
+ */
+export function ageDays(createdAtIso, nowIso) {
+	const created = new Date(createdAtIso).getTime();
+	const now = new Date(nowIso).getTime();
+	return (now - created) / (24 * 60 * 60 * 1000);
+}
+
+/**
+ * base=main かつ bot 作成かつ STALL_DAYS 日以上経過した候補を抽出する (guard 状態は未考慮、
+ * ここまでは `gh pr checks` を呼ばずに絞り込める安価な条件)。
+ *
+ * @param {GhPr[]} prs
+ * @param {{ stallDays: number, nowIso: string }} opts
+ * @returns {GhPr[]}
+ */
+export function filterStaleBotMainPrs(prs, { stallDays, nowIso }) {
+	return prs.filter((pr) => {
+		if (pr.baseRefName !== 'main') return false;
+		if (!isBotAuthor(pr)) return false;
+		return ageDays(pr.createdAt, nowIso) >= stallDays;
+	});
+}
+
+/**
+ * `gh pr checks --json name,bucket,state` の結果から main-pr-base-guard が
+ * failure のままかを判定する。pending / pass / skipping は対象外。
+ *
+ * @param {GhCheck[]} checks
+ * @returns {boolean}
+ */
+export function isGuardFailing(checks) {
+	const guard = checks.find((c) => c.name === GUARD_CHECK_NAME);
+	if (!guard) return false;
+	return guard.bucket === 'fail' || guard.state === 'FAILURE' || guard.state === 'ERROR';
+}
+
+/**
+ * @param {{ comments?: string[] } | string[]} commentsInput
+ * @param {string} marker
+ * @returns {boolean}
+ */
+export function hasExistingMarkerComment(commentsInput, marker) {
+	const bodies = Array.isArray(commentsInput) ? commentsInput : commentsInput.comments || [];
+	return bodies.some((body) => typeof body === 'string' && body.includes(marker));
+}
+
+/**
+ * @param {GhPr} pr
+ * @param {number} days
+ * @returns {string}
+ */
+export function buildCommentBody(pr, days) {
+	return [
+		BOT_COMMENT_MARKER,
+		'## 🚧 main 直行のまま滞留している bot PR を検知しました',
+		'',
+		`本 PR は base=main のまま \`${GUARD_CHECK_NAME}\` に fail し続け、` +
+			`${Math.floor(days)} 日以上 open です。`,
+		'',
+		'security update の可能性があるため、内容を確認のうえ以下のいずれかで解消してください:',
+		'',
+		'```bash',
+		`gh pr edit ${pr.number} --base develop`,
+		'```',
+		'',
+		'（通常レーンに載せたくない理由がある場合は close して手動で対処してください）',
+		'',
+		'背景: #4557 / #3922 / #4273 / #4532',
+	].join('\n');
+}
+
+/**
+ * @param {GhPr[]} prs
+ * @returns {string}
+ */
+export function buildDiscordPayload(prs) {
+	const lines = prs.map(
+		(pr) =>
+			`- [#${pr.number}] ${pr.title} (${Math.floor(ageDays(pr.createdAt, new Date().toISOString()))}日 停滞) ${pr.url}`,
+	);
+	return JSON.stringify({
+		embeds: [
+			{
+				title: `⚠️ main 直行のまま滞留した bot PR: ${prs.length} 件`,
+				description: lines.join('\n'),
+				color: 15158332,
+				footer: { text: 'がんばりクエスト stalled-bot-pr-check (#4557)' },
+			},
+		],
+	});
+}
+
+/**
+ * @param {number} prNumber
+ * @returns {string[]}
+ */
+function listCommentBodies(prNumber) {
+	const out = gh(['api', `repos/${REPO}/issues/${prNumber}/comments`, '--jq', '.[].body']);
+	return out.split('\n').filter((l) => l.length > 0);
+}
+
+/**
+ * @param {GhPr} pr
+ */
+function fetchChecks(pr) {
+	const out = gh([
+		'pr',
+		'checks',
+		String(pr.number),
+		'--repo',
+		REPO,
+		'--json',
+		'name,bucket,state',
+	]);
+	try {
+		return /** @type {GhCheck[]} */ (JSON.parse(out));
+	} catch {
+		// checks がまだ 1 件も無い (「no checks reported」等) は空配列扱い
+		return [];
+	}
+}
+
+/**
+ * @param {string} nowIso
+ */
+async function main(nowIso = new Date().toISOString()) {
+	if (!REPO) {
+		console.error('[stalled-bot-pr] REPO env var is required (owner/repo)');
+		process.exit(2);
+	}
+	const prsOut = gh([
+		'pr',
+		'list',
+		'--repo',
+		REPO,
+		'--state',
+		'open',
+		'--base',
+		'main',
+		'--json',
+		'number,title,author,createdAt,url,baseRefName',
+	]);
+	const prs = /** @type {GhPr[]} */ (JSON.parse(prsOut));
+
+	const candidates = filterStaleBotMainPrs(prs, { stallDays: STALL_DAYS, nowIso });
+
+	const newlyFlagged = [];
+	const alreadyFlagged = [];
+	const notStalled = [];
+
+	for (const pr of candidates) {
+		const checks = fetchChecks(pr);
+		if (!isGuardFailing(checks)) {
+			notStalled.push(pr);
+			continue;
+		}
+		const existingComments = listCommentBodies(pr.number);
+		if (hasExistingMarkerComment(existingComments, BOT_COMMENT_MARKER)) {
+			alreadyFlagged.push(pr);
+			continue;
+		}
+		newlyFlagged.push(pr);
+		const days = ageDays(pr.createdAt, nowIso);
+		const body = buildCommentBody(pr, days);
+		if (DRY_RUN) {
+			console.log(`[stalled-bot-pr] [DRY_RUN] would post comment on PR #${pr.number}:`);
+			console.log(body);
+		} else {
+			gh(['pr', 'comment', String(pr.number), '--repo', REPO, '--body', body]);
+		}
+	}
+
+	if (newlyFlagged.length > 0 && DISCORD_WEBHOOK_INCIDENT) {
+		const payload = buildDiscordPayload(newlyFlagged);
+		if (DRY_RUN) {
+			console.log('[stalled-bot-pr] [DRY_RUN] would POST to DISCORD_WEBHOOK_INCIDENT:');
+			console.log(payload);
+		} else {
+			try {
+				execFileSync('curl', [
+					'-s',
+					'-X',
+					'POST',
+					'-H',
+					'Content-Type: application/json',
+					'-d',
+					payload,
+					DISCORD_WEBHOOK_INCIDENT,
+				]);
+			} catch (/** @type {unknown} */ err) {
+				const msg = err instanceof Error ? err.message : String(err);
+				console.error(`[stalled-bot-pr] Discord webhook post failed (non-fatal): ${msg}`);
+			}
+		}
+	}
+
+	const summary = {
+		nowIso,
+		stallDays: STALL_DAYS,
+		openMainPrCount: prs.length,
+		candidateCount: candidates.length,
+		newlyFlaggedCount: newlyFlagged.length,
+		alreadyFlaggedCount: alreadyFlagged.length,
+		notStalledCount: notStalled.length,
+	};
+
+	if (OUTPUT_MODE === 'json') {
+		console.log(
+			JSON.stringify(
+				{
+					summary,
+					newlyFlagged: newlyFlagged.map((pr) => ({
+						number: pr.number,
+						title: pr.title,
+						url: pr.url,
+					})),
+					alreadyFlagged: alreadyFlagged.map((pr) => pr.number),
+				},
+				null,
+				2,
+			),
+		);
+	} else {
+		console.log(
+			`[stalled-bot-pr] since ${nowIso} (stallDays=${STALL_DAYS}): candidates=${candidates.length} ` +
+				`newly_flagged=${newlyFlagged.length} already_flagged=${alreadyFlagged.length}`,
+		);
+		for (const pr of newlyFlagged) {
+			console.log(`  🚨 #${pr.number}: ${pr.title} (${pr.url})`);
+		}
+	}
+
+	process.exit(0);
+}
+
+if (isMain(import.meta.url)) {
+	main().catch((/** @type {unknown} */ err) => {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.error('[stalled-bot-pr] unexpected error', msg);
+		process.exit(2);
+	});
+}

--- a/tests/unit/scripts/check-stalled-bot-pr.test.ts
+++ b/tests/unit/scripts/check-stalled-bot-pr.test.ts
@@ -1,0 +1,210 @@
+/**
+ * tests/unit/scripts/check-stalled-bot-pr.test.ts (#4557)
+ *
+ * scripts/check-stalled-bot-pr.mjs の純粋関数を unit test する。
+ *
+ * 背景: `main-pr-base-guard` は dependabot/renovate の main 直行 PR を fail-close するが、
+ * bot は失敗した PR を自動で retarget しないため人が気づくまで滞留する (#4532 実例)。
+ * 本テストは「滞留の判定ロジックが壊れていることを検出できる」ことを保証する
+ * (= 変異試験の恒久版として、境界条件・除外条件を固定する)。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+	ageDays,
+	buildCommentBody,
+	buildDiscordPayload,
+	filterStaleBotMainPrs,
+	hasExistingMarkerComment,
+	isBotAuthor,
+	isGuardFailing,
+} from '../../../scripts/check-stalled-bot-pr.mjs';
+
+describe('isBotAuthor', () => {
+	it('is_bot: true の author を bot と判定する (dependabot 実例)', () => {
+		expect(isBotAuthor({ author: { login: 'app/dependabot', is_bot: true } })).toBe(true);
+	});
+
+	it('[bot] サフィックスの login を bot と判定する (is_bot 欠落フォールバック)', () => {
+		expect(isBotAuthor({ author: { login: 'dependabot[bot]' } })).toBe(true);
+	});
+
+	it('app/ prefix の login を bot と判定する (is_bot 欠落フォールバック)', () => {
+		expect(isBotAuthor({ author: { login: 'app/ganbari-quest-integrator' } })).toBe(true);
+	});
+
+	it('人間 author は bot と判定しない', () => {
+		expect(isBotAuthor({ author: { login: 'Takenori-Kusaka', is_bot: false } })).toBe(false);
+	});
+
+	it('author が null なら bot と判定しない (クラッシュしない)', () => {
+		expect(isBotAuthor({ author: null })).toBe(false);
+	});
+});
+
+describe('ageDays', () => {
+	it('経過日数を計算する', () => {
+		expect(ageDays('2026-08-10T00:00:00Z', '2026-08-13T00:00:00Z')).toBe(3);
+	});
+
+	it('端数日も計算する (24h 未満は 1 日未満)', () => {
+		expect(ageDays('2026-08-12T20:24:06Z', '2026-08-13T20:24:06Z')).toBe(1);
+	});
+});
+
+describe('filterStaleBotMainPrs (#4532 実例に基づく回帰防止)', () => {
+	const nowIso = '2026-08-15T00:00:00Z';
+
+	it('base=main + bot + STALL_DAYS 以上経過した PR を候補として抽出する', () => {
+		const prs = [
+			{
+				number: 4532,
+				title: 'dependabot bump',
+				author: { login: 'app/dependabot', is_bot: true },
+				createdAt: '2026-08-12T20:24:06Z',
+				url: 'https://example.com/4532',
+				baseRefName: 'main',
+			},
+		];
+		const result = filterStaleBotMainPrs(prs, { stallDays: 2, nowIso });
+		expect(result).toHaveLength(1);
+		expect(result[0]?.number).toBe(4532);
+	});
+
+	it('base=develop の PR は候補から除外する (通常レーンの PR を誤検知しない)', () => {
+		const prs = [
+			{
+				number: 1,
+				title: 'normal feature',
+				author: { login: 'app/dependabot', is_bot: true },
+				createdAt: '2026-08-01T00:00:00Z',
+				url: 'https://example.com/1',
+				baseRefName: 'develop',
+			},
+		];
+		expect(filterStaleBotMainPrs(prs, { stallDays: 2, nowIso })).toEqual([]);
+	});
+
+	it('人間作成の main PR は候補から除外する (release PR 手動対応等)', () => {
+		const prs = [
+			{
+				number: 2,
+				title: 'human main pr',
+				author: { login: 'Takenori-Kusaka', is_bot: false },
+				createdAt: '2026-08-01T00:00:00Z',
+				url: 'https://example.com/2',
+				baseRefName: 'main',
+			},
+		];
+		expect(filterStaleBotMainPrs(prs, { stallDays: 2, nowIso })).toEqual([]);
+	});
+
+	it('STALL_DAYS 未満の新規 PR は候補から除外する (即時 flag によるノイズ防止)', () => {
+		const prs = [
+			{
+				number: 3,
+				title: 'just opened',
+				author: { login: 'app/dependabot', is_bot: true },
+				createdAt: '2026-08-14T12:00:00Z', // now から 12h
+				url: 'https://example.com/3',
+				baseRefName: 'main',
+			},
+		];
+		expect(filterStaleBotMainPrs(prs, { stallDays: 2, nowIso })).toEqual([]);
+	});
+
+	it(
+		'統合 PR (release パターン、head=develop/release/* が正規に main へ向く) は' +
+			'author が bot でも base=main が正規状態なので候補には残るが、' +
+			'guard 自体は pass するため isGuardFailing 側で最終的に除外される',
+		() => {
+			// filterStaleBotMainPrs は guard 状態を見ないため、
+			// 統合 PR (app/ganbari-quest-integrator, base=main が正規) も候補には入る。
+			// 誤検知防止は isGuardFailing の責務であることを明示するテスト。
+			const prs = [
+				{
+					number: 4534,
+					title: '[統合] develop → main',
+					author: { login: 'app/ganbari-quest-integrator', is_bot: true },
+					createdAt: '2026-08-01T00:00:00Z',
+					url: 'https://example.com/4534',
+					baseRefName: 'main',
+				},
+			];
+			expect(filterStaleBotMainPrs(prs, { stallDays: 2, nowIso })).toHaveLength(1);
+		},
+	);
+});
+
+describe('isGuardFailing (#4532 実例)', () => {
+	it('main-pr-base-guard が bucket=fail なら滞留と判定する', () => {
+		expect(isGuardFailing([{ name: 'main-pr-base-guard', bucket: 'fail' }])).toBe(true);
+	});
+
+	it('main-pr-base-guard が state=FAILURE でも滞留と判定する (bucket 欠落フォールバック)', () => {
+		expect(isGuardFailing([{ name: 'main-pr-base-guard', state: 'FAILURE' }])).toBe(true);
+	});
+
+	it('main-pr-base-guard が pass (統合 PR の正規状態) なら滞留と判定しない', () => {
+		expect(isGuardFailing([{ name: 'main-pr-base-guard', bucket: 'pass' }])).toBe(false);
+	});
+
+	it('main-pr-base-guard が skipping なら滞留と判定しない (cutover 前 grandfather 等)', () => {
+		expect(isGuardFailing([{ name: 'main-pr-base-guard', bucket: 'skipping' }])).toBe(false);
+	});
+
+	it('checks 配列に main-pr-base-guard が無ければ滞留と判定しない (未実行を fail 扱いしない)', () => {
+		expect(isGuardFailing([{ name: 'lint-and-test', bucket: 'pass' }])).toBe(false);
+	});
+
+	it('checks 0 件でもクラッシュしない', () => {
+		expect(isGuardFailing([])).toBe(false);
+	});
+});
+
+describe('hasExistingMarkerComment (再通知スパム防止)', () => {
+	const marker = '<!-- stalled-bot-pr-check -->';
+
+	it('マーカー付きコメントが既にあれば true (一度通知したら repeat しない)', () => {
+		expect(hasExistingMarkerComment(['よろしく', `${marker}\n本文`], marker)).toBe(true);
+	});
+
+	it('マーカーが無ければ false', () => {
+		expect(hasExistingMarkerComment(['よろしく', '別のコメント'], marker)).toBe(false);
+	});
+
+	it('{ comments } 形式でも読める', () => {
+		expect(hasExistingMarkerComment({ comments: [`${marker}\n本文`] }, marker)).toBe(true);
+	});
+
+	it('空配列でも false (初回通知は必ず飛ぶ)', () => {
+		expect(hasExistingMarkerComment([], marker)).toBe(false);
+	});
+});
+
+describe('buildCommentBody / buildDiscordPayload (出力内容の健全性)', () => {
+	const pr = {
+		number: 4532,
+		title: 'build(deps): Bump @hono/node-server',
+		author: { login: 'app/dependabot', is_bot: true },
+		createdAt: '2026-08-12T20:24:06Z',
+		url: 'https://github.com/Takenori-Kusaka/ganbari-quest/pull/4532',
+		baseRefName: 'main',
+	};
+
+	it('コメント本文にマーカー・PR 番号・retarget コマンドを含む', () => {
+		const body = buildCommentBody(pr, 3);
+		expect(body).toContain('<!-- stalled-bot-pr-check -->');
+		expect(body).toContain('gh pr edit 4532 --base develop');
+		expect(body).toContain('3 日以上 open');
+	});
+
+	it('Discord payload は valid JSON で embeds を含む', () => {
+		const payload = buildDiscordPayload([pr]);
+		const parsed = JSON.parse(payload);
+		expect(parsed.embeds).toHaveLength(1);
+		expect(parsed.embeds[0].title).toContain('1 件');
+		expect(parsed.embeds[0].description).toContain('#4532');
+	});
+});


### PR DESCRIPTION
## 変更タイプ
- [x] fix

## 関連 Issue
Closes #4557

## 顧客価値・目的

`main-pr-base-guard` は dependabot/renovate の main 直行 PR を正しく fail-close するが（#3922 / #4273）、GitHub 仕様上 security update PR は `target-branch: develop` を無視して main にしか作られない。bot は失敗した PR を自動で retarget しないため、fail のまま誰にも気づかれず滞留し得る。実例（#4532）: GHSA-9mqv-5hh9-4cgg（`upgradeWebSocket` の認証前到達可能な WebSocket upgrade メモリ枯渇 DoS）の修正 PR が `main-pr-base-guard=FAILURE` のまま気づかれず放置されていた。

「guard が正しく main 直行を止める」ことと「security update が誰にも気づかれず放置される」が両立してしまう構造的な穴を、検知 + 通知で塞ぐ。

## 実装内容

- `scripts/check-stalled-bot-pr.mjs`: base=main かつ author が bot（`is_bot: true` / `[bot]` サフィックス / `app/` prefix）かつ `main-pr-base-guard` が failure のまま `STALL_DAYS`（既定 2 日）以上 open な PR を検知
  - 検知したら PR コメント（marker comment で idempotent、既存 GITHUB_TOKEN のみ、新規 secret 不要）を投稿
  - `DISCORD_WEBHOOK_INCIDENT`（既存 secret、deploy-nuc.yml / deploy-aws-staging.yml と共用）が設定済みなら要約通知（新規 secret は追加しない、ADR-0024）
- `.github/workflows/admin-bypass-evidence.yml`: 既存の日次 cron（15:10 UTC）に `stalled-bot-pr-check` job を相乗り。新規 workflow / 新規 cron エントリは追加していない（装置の本数を増やさない判断）
- `tests/unit/scripts/check-stalled-bot-pr.test.ts`: 純粋関数（`isBotAuthor` / `ageDays` / `filterStaleBotMainPrs` / `isGuardFailing` / `hasExistingMarkerComment` / `buildCommentBody` / `buildDiscordPayload`）の unit test 24 件

## 自動 retarget を採用しない判断（Issue #4557 で言及した判断理由）

`gh pr edit --base develop` を機械が自動実行する案は不採用とした。base 付け替えは PR の意味を変える不可逆に近い操作であり、dependabot 自身の内部状態（rebase 判定 / auto-merge 判定 / conflict 検知）と衝突するリスクを排除しきれないため。検知して人に気づかせるところまでに留め、対処（retarget するか close するか）は人が判断する。

## 変異試験（検出ロジックが壊れたら test が red になることの確認）

`isGuardFailing` / `filterStaleBotMainPrs` / `isBotAuthor` の 3 箇所で意図的に検出条件を逆転・削除する mutation を local で適用し、いずれも該当 test が fail することを確認（mutation 後 revert して push、diff には含まれない）:

1. `isGuardFailing`: `bucket === 'fail'` → `bucket === 'pass'` に反転 → 3 test fail
2. `filterStaleBotMainPrs`: `baseRefName !== 'main'` フィルタを削除 → 1 test fail（develop 向け PR を誤検知するケース）
3. `isBotAuthor`: `app/` prefix フォールバックを削除 → 1 test fail

## 実機検証（本番 repo に対する dry-run、副作用なし）

```
REPO=Takenori-Kusaka/ganbari-quest STALL_DAYS=0.1 DRY_RUN=true OUTPUT_MODE=json node scripts/check-stalled-bot-pr.mjs
```

結果: open な main 向け PR 2 件中、`main-pr-base-guard` が failure のままの #4532（dependabot security update）のみを `newlyFlagged` として正しく検知し、guard が pass の統合 PR #4534 は `notStalled` として正しく除外した（`candidateCount=2, newlyFlaggedCount=1, notStalledCount=1`）。

## テスト実行結果
<!-- PASS / FAIL -->
- `npx vitest run tests/unit/scripts/check-stalled-bot-pr.test.ts` → PASS（24/24）
- `npx biome check scripts/check-stalled-bot-pr.mjs tests/unit/scripts/check-stalled-bot-pr.test.ts` → PASS
- `npx cspell scripts/check-stalled-bot-pr.mjs tests/unit/scripts/check-stalled-bot-pr.test.ts` → PASS（0 issues）

## UI 変更なし
- [x] UI 変更なし

## 配布済み env / secret (ADR-0006)

新規 secret は追加していない。`DISCORD_WEBHOOK_INCIDENT` は既存 secret（deploy-nuc.yml / deploy-aws-staging.yml で既に配布済み）を workflow env として参照するのみ。未設定でも `if (DISCORD_WEBHOOK_INCIDENT)` の任意分岐のため fail-fast しない（`check-new-required-env.mjs` 非該当）。

## 注記: #4532 自体の処遇について

本 PR は検知の仕組みのみを追加する。#4532 の retarget / close 判断は QM / PO が別途行う（本 PR のスコープ外）。
