### PR TITLE
fix(ci): graphify-refresh の push を bot 著者判定に変える（force-with-lease は追跡参照が無く常に stale info になる）

### DIFF
--- a/.github/workflows/graphify-refresh.yml
+++ b/.github/workflows/graphify-refresh.yml
@@ -138,10 +138,15 @@ jobs:
           git switch -C "$BRANCH"
           git add graphify-out
           git commit -m "chore(graphify): regenerate knowledge graph (develop ${DEVELOP_SHA:0:7}, #4536)"
-          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" \
-            "$BRANCH" --force-with-lease || \
-          git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" \
-            "$BRANCH" --force
+          # `--force-with-lease` が失敗するのは「他の誰かが同 branch を進めた」という信号そのもの
+          # なので、無条件 `--force` へ fallback すると lease の意味が消える (#4536 レビュー漏れ)。
+          # graphify-refresh PR に人が手を入れた直後の run が、その修正を警告なく消してしまう。
+          # 失敗したら push せず job を落とす (graphify-out は次の push 契機で再生成できる)。
+          if ! git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" \
+            "$BRANCH" --force-with-lease; then
+            echo "::error::${BRANCH} が他から進んでいるため push を中止しました。bot PR に人手の修正が入っている可能性があります。"
+            exit 1
+          fi
 
       - name: Upsert graphify-refresh PR
         if: steps.diff.outputs.changed == 'true' && steps.appcreds.outputs.present == 'true'

--- a/.github/workflows/graphify-refresh.yml
+++ b/.github/workflows/graphify-refresh.yml
@@ -138,15 +138,25 @@ jobs:
           git switch -C "$BRANCH"
           git add graphify-out
           git commit -m "chore(graphify): regenerate knowledge graph (develop ${DEVELOP_SHA:0:7}, #4536)"
-          # `--force-with-lease` が失敗するのは「他の誰かが同 branch を進めた」という信号そのもの
-          # なので、無条件 `--force` へ fallback すると lease の意味が消える (#4536 レビュー漏れ)。
-          # graphify-refresh PR に人が手を入れた直後の run が、その修正を警告なく消してしまう。
-          # 失敗したら push せず job を落とす (graphify-out は次の push 契機で再生成できる)。
-          if ! git push "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git" \
-            "$BRANCH" --force-with-lease; then
-            echo "::error::${BRANCH} が他から進んでいるため push を中止しました。bot PR に人手の修正が入っている可能性があります。"
-            exit 1
+          # push 先 branch を fetch していないため `--force-with-lease` は使えない (#4563)。
+          # 追跡参照が無いと lease は「人が進めた」ではなく「過去の値を知らない」で常に
+          # stale info になり、2 回目以降の run が永久に失敗する (bare repo で再現確認済み)。
+          #
+          # 代わりに「remote の tip を bot 自身が書いたか」で判定する。人手の commit が
+          # 載っていれば force しない — bot PR に入れた修正を警告なく消さないための唯一の砦。
+          REMOTE_URL="https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
+          REMOTE_SHA=$(git ls-remote "$REMOTE_URL" "refs/heads/${BRANCH}" | cut -f1)
+          if [ -n "${REMOTE_SHA}" ]; then
+            git fetch --depth=1 "$REMOTE_URL" "${BRANCH}"
+            TIP_EMAIL=$(git log -1 --format=%ae FETCH_HEAD)
+            if [ "${TIP_EMAIL}" != "${GIT_AUTHOR_EMAIL}" ]; then
+              echo "::error::${BRANCH} の先頭 commit が bot 以外 (${TIP_EMAIL}) です。\
+                push を中止しました。bot PR に入れた人手の修正を消さないためです。\
+                内容を取り込むか、不要なら ${BRANCH} を削除してから再実行してください。"
+              exit 1
+            fi
           fi
+          git push "$REMOTE_URL" "${BRANCH}" --force
 
       - name: Upsert graphify-refresh PR
         if: steps.diff.outputs.changed == 'true' && steps.appcreds.outputs.present == 'true'

--- a/.github/workflows/graphify-refresh.yml
+++ b/.github/workflows/graphify-refresh.yml
@@ -138,25 +138,32 @@ jobs:
           git switch -C "$BRANCH"
           git add graphify-out
           git commit -m "chore(graphify): regenerate knowledge graph (develop ${DEVELOP_SHA:0:7}, #4536)"
-          # push 先 branch を fetch していないため `--force-with-lease` は使えない (#4563)。
+          # push 先 branch を fetch していないため素の `--force-with-lease` は使えない (#4563)。
           # 追跡参照が無いと lease は「人が進めた」ではなく「過去の値を知らない」で常に
           # stale info になり、2 回目以降の run が永久に失敗する (bare repo で再現確認済み)。
           #
-          # 代わりに「remote の tip を bot 自身が書いたか」で判定する。人手の commit が
-          # 載っていれば force しない — bot PR に入れた修正を警告なく消さないための唯一の砦。
+          # 2 段で守る:
+          #   1. remote tip の作者が bot 自身か        … 判定時点で人手の commit が載っていないこと
+          #   2. --force-with-lease=<ref>:<expect>     … 判定から push までの間に誰も push していないこと
+          # 1 だけだと判定後の窓に入った push を黙って消す。2 は明示 lease 値なので追跡参照が無くても効く。
           REMOTE_URL="https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
-          REMOTE_SHA=$(git ls-remote "$REMOTE_URL" "refs/heads/${BRANCH}" | cut -f1)
+          # ls-remote の一過性失敗で set -e により生の非ゼロ終了になるのを避ける
+          # (裸の代入は条件部でないため -e の対象。#4520 で実測した class と同じ)。
+          if ! REMOTE_SHA=$(git ls-remote "$REMOTE_URL" "refs/heads/${BRANCH}" | cut -f1); then
+            echo "::error::${BRANCH} の現在値を取得できませんでした (GitHub API の一過性障害の可能性)。次の develop push で再試行されます。"
+            exit 1
+          fi
           if [ -n "${REMOTE_SHA}" ]; then
             git fetch --depth=1 "$REMOTE_URL" "${BRANCH}"
             TIP_EMAIL=$(git log -1 --format=%ae FETCH_HEAD)
             if [ "${TIP_EMAIL}" != "${GIT_AUTHOR_EMAIL}" ]; then
-              echo "::error::${BRANCH} の先頭 commit が bot 以外 (${TIP_EMAIL}) です。\
-                push を中止しました。bot PR に入れた人手の修正を消さないためです。\
-                内容を取り込むか、不要なら ${BRANCH} を削除してから再実行してください。"
+              echo "::error::${BRANCH} の先頭 commit が bot 以外 (${TIP_EMAIL}) です。push を中止しました。bot PR に入れた人手の修正を消さないためです。内容を取り込むか、不要なら ${BRANCH} を削除してください。"
               exit 1
             fi
+            git push "$REMOTE_URL" "${BRANCH}" --force-with-lease="refs/heads/${BRANCH}:${REMOTE_SHA}"
+          else
+            git push "$REMOTE_URL" "${BRANCH}"
           fi
-          git push "$REMOTE_URL" "${BRANCH}" --force
 
       - name: Upsert graphify-refresh PR
         if: steps.diff.outputs.changed == 'true' && steps.appcreds.outputs.present == 'true'


### PR DESCRIPTION
## 顧客価値・目的

**対象**: 開発チーム（顧客に見える変化なし）。

**解決する課題**: `graphify-refresh.yml` が `git push --force-with-lease` の失敗時に**無条件 `--force` へ fallback**していた。`--force-with-lease` が失敗するのは「他の誰かが同 branch を進めた」という信号そのものなので、そこで `--force` に落ちると **lease の意味が完全に消える**。

`chore/graphify-refresh` は bot が管理する branch だが、**bot PR に人が手を入れた直後の run が、その修正を警告なく上書きする**。上書きされた側には何も通知されない。

## 関連 Issue

なし。PR #4539（#4536、本日 merge）の QM レビューで**私が見落とした点**を、merge 後の adversarial 指摘で発見したもの。装置の Issue は起票しない（チーム憲章 §0 ルール 7）ため、その場で PR 化している。

<!-- no-issue-close: PR #4539 のレビュー漏れの是正。§0 ルール 7 により Issue を経由せず PR 化 -->

## 変更内容

```diff
-          git push ... "$BRANCH" --force-with-lease || \
-          git push ... "$BRANCH" --force
+          if ! git push ... "$BRANCH" --force-with-lease; then
+            echo "::error::${BRANCH} が他から進んでいるため push を中止しました。..."
+            exit 1
+          fi
```

**失敗したら push せず job を落とす。** `graphify-out` は次の develop push 契機で再生成できるため、1 回取りこぼしても実害が無い側に倒せる。逆に人手の修正を消すのは取り返しがつかない。

## 検証

- `python3 -c "import yaml; yaml.safe_load(...)"` で YAML 構文が有効であることを確認
- `set -euo pipefail` 下で `if ! cmd; then` は条件部なので `-e` の対象外。本日 #4520 で確認した挙動と同じ形（裸の実行だと即死するが、条件部なら else に落ちる）

**実発火の確認は merge 後**。`graphify-refresh.yml` 自体が #4539 で入ったばかりで、まだ 1 度も動いていない（#4536 の close 条件も「初回 push で bot PR が上がることの確認」としている）。

## 影響範囲

- **顧客に見える変化**: なし
- **破壊的変更**: なし。push が成功する通常系の挙動は不変
- **変わるのは失敗時のみ**: 従来は黙って上書き → 今後は job が赤くなって気づける

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret なし

## QM レビュー結果

（QM が記入）

UI 変更なし
