### PR TITLE
fix(security): #4566 送信メールのユーザー入力を型でエスケープ強制する (HtmlSafe)

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -20,3 +20,213 @@ if command -v graphify >/dev/null 2>&1; then
     echo "Updating Graphify knowledge graph..."
     graphify update . || true
 fi
+
+# graphify-hook-start
+# Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
+# Installed by: graphify hook install
+
+# Deterministic clustering: networkx louvain iterates string-keyed sets whose
+# order is randomized per-process by PYTHONHASHSEED, so community assignments
+# churn run-to-run. Pinning it makes graphify-out reproducible.
+export PYTHONHASHSEED=0
+
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+# Skip during rebase/merge/cherry-pick to avoid blocking --continue with unstaged changes
+# git exports GIT_DIR to hooks; the rev-parse fallback only runs when invoked by
+# hand (each git exec costs 1s+ on AV-scanned Windows machines).
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+[ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
+
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+    exit 0
+fi
+
+CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+# Skip when only graphify-out/ artifacts changed (avoids rebuild loop when graph outputs are tracked in git)
+_NON_GRAPH=$(echo "$CHANGED" | grep -v '^graphify-out/' || true)
+if [ -z "$_NON_GRAPH" ]; then
+    exit 0
+fi
+
+# Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs).
+# _PINNED was recorded at hook-install time; tried first so the hook works even
+# when the graphify launcher is not on PATH (common in GUI clients and CI).
+#
+# Probes check availability with importlib.util.find_spec instead of importing
+# the package: a probe that imports graphify wholesale executes the full package
+# import (10s+ cold on machines with AV-scanned or large site-packages) and used
+# to run up to FOUR times synchronously, stalling every commit before the
+# detached launch even started. find_spec locates the package without executing
+# it, so each probe costs interpreter startup only. The detached rebuild still
+# fails loudly in the log if the package is broken under that interpreter.
+_GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+GRAPHIFY_PYTHON=""
+_PINNED='C:\Users\kokor\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe'
+if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then
+    GRAPHIFY_PYTHON="$_PINNED"
+fi
+# Second probe: read graphify-out/.graphify_python (written by the skill and
+# CLI; survives uv-tool reinstalls and is the same source the README documents).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    if [ -f "$_GFY_PYTHON_FILE" ]; then
+        _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
+        case "$_FROM_FILE" in
+            *[!a-zA-Z0-9/_.@:\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+        esac
+        if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_FROM_FILE"
+        fi
+    fi
+fi
+# Third probe: resolve via the graphify launcher on PATH.
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+    if [ -n "$GRAPHIFY_BIN" ]; then
+        # Windows pip layout: Scripts/graphify(.exe) sits beside ..\python.exe
+        # (or .\python.exe inside a venv's Scripts dir). NOTE: command -v may
+        # return the launcher path WITHOUT the .exe suffix, so this cannot key
+        # on the extension.
+        _GFY_BINDIR=$(dirname "$GRAPHIFY_BIN")
+        if [ -x "$_GFY_BINDIR/../python.exe" ] && "$_GFY_BINDIR/../python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/../python.exe"
+        elif [ -x "$_GFY_BINDIR/python.exe" ] && "$_GFY_BINDIR/python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/python.exe"
+        fi
+    fi
+    if [ -z "$GRAPHIFY_PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
+        # POSIX launcher: parse the shebang. head -c + tr strip NUL bytes first —
+        # when the launcher is a Windows binary reached without its .exe suffix,
+        # a raw `head -1` reads binary into the command substitution and the
+        # shell warns about ignored null bytes on every commit.
+        case "$GRAPHIFY_BIN" in
+            *.exe) _SHEBANG="" ;;
+            *)     _SHEBANG=$(head -c 256 "$GRAPHIFY_BIN" 2>/dev/null | tr -d '\000' | head -n 1 | sed 's/^#![[:space:]]*//') ;;
+        esac
+        case "$_SHEBANG" in
+            */env\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
+            *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
+        esac
+        # Allowlist: only keep characters valid in a filesystem path to prevent
+        # injection if the shebang contains shell metacharacters.
+        case "$GRAPHIFY_PYTHON" in
+            *[!a-zA-Z0-9/_.@:\\-]*) GRAPHIFY_PYTHON="" ;;
+        esac
+        if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON=""
+        fi
+    fi
+fi
+# Last resort: try python3 / python (works for system/venv installs on PATH).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    elif command -v python >/dev/null 2>&1 && python -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python"
+    else
+        echo "[graphify hook] could not locate a Python with graphify installed. Add the graphify bin dir to PATH or re-run 'graphify hook install' from the env where graphify lives." >&2
+        exit 0
+    fi
+fi
+
+export GRAPHIFY_CHANGED="$CHANGED"
+
+# Run the rebuild detached so git commit returns immediately. Full-repo rebuilds
+# can take hours; blocking the post-commit hook stalls the shell. The Python
+# launcher below detaches the child cross-platform, so it works on Git for
+# Windows' shell too (which lacks the coreutils backgrounding tools) (#1161).
+_GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
+echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
+"$GRAPHIFY_PYTHON" -c "import os, subprocess, sys
+_src = '''
+import os, signal, sys, threading
+from pathlib import Path
+
+changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
+changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
+
+if not changed:
+    sys.exit(0)
+
+print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
+
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0:
+        if hasattr(signal, 'SIGALRM'):
+            signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+            signal.alarm(_timeout)
+        else:
+            def _bail():
+                print(f'[graphify hook] graphify rebuild exceeded {_timeout}s', flush=True)
+                os._exit(1)
+            _watchdog = threading.Timer(_timeout, _bail)
+            _watchdog.daemon = True
+            _watchdog.start()
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _root = Path('.')
+    _out = os.environ.get('GRAPHIFY_OUT', 'graphify-out')
+    _saved = Path(_out) / '.graphify_root'
+    if _saved.exists():
+        _txt = _saved.read_text(encoding='utf-8').strip()
+        if _txt:
+            _root = Path(_txt)
+    _rebuild_code(_root, changed_paths=changed, force=_force)
+    # Refresh the work-memory lessons doc when saved Q&A outcomes exist
+    # (best-effort; never fails the hook).
+    try:
+        _md = (_root / _out) / 'memory'
+        if _md.is_dir() and any(_md.glob('*.md')):
+            from graphify.reflect import reflect as _reflect
+            _gj = (_root / _out) / 'graph.json'
+            _reflect(memory_dir=_md, out_path=(_root / _out) / 'reflections' / 'LESSONS.md',
+                     graph_path=_gj if _gj.exists() else None)
+    except Exception:
+        pass
+except TimeoutError as exc:
+    print(f'[graphify hook] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify hook] Rebuild failed: {exc}')
+    sys.exit(1)
+
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or os.path.join(os.path.expanduser('~'), '.cache', 'graphify-rebuild.log')
+try:
+    os.makedirs(os.path.dirname(_log), exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    _flags = 0x08000000 | 0x00000200  # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+    try:
+        subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
+    except OSError:
+        subprocess.Popen(_cmd, creationflags=_flags, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"
+# graphify-hook-end

--- a/src/lib/server/services/email-html.ts
+++ b/src/lib/server/services/email-html.ts
@@ -1,0 +1,97 @@
+// src/lib/server/services/email-html.ts (#4566)
+//
+// 送信 HTML メールの組み立てを「素の string を本文へ入れられない」形に閉じる。
+//
+// ## なぜ型で閉じるか
+// 元の実装は `wrapTemplate(`... ${tenantName} ...`)` のように、顧客が自由入力する値
+// (テナント名 / 表示名) を無エスケープで HTML に埋めていた。escape ヘルパを 1 つ足して
+// 「呼ぶ側が忘れないようにする」だけでは、同じ欠陥が次のメールで再発する
+// (実際 #4507 が同じ形でメール文面を 3 通追加し、class として拡大した)。
+//
+// そこで **エスケープ済みであることを型で表す** (`HtmlSafe`)。`wrapTemplate` 等の本文
+// 組み立て関数は `HtmlSafe` しか受け取らないため、素の string を渡すと **tsc / svelte-check
+// が落ちる**。エスケープの有無を人の注意ではなく型検査に委ねる (ADR-0061 原則 2)。
+//
+// `HtmlSafe` は branded string ではなく **class** にしてある。branded type は実行時に消えるため
+// `html` タグ側が「この値はエスケープ済みか」を判別できず、断片の合成 (行の組み立て → 表への
+// 埋め込み) で二重エスケープするしかなくなるためである。
+//
+// **constructor は private**。生成経路は本 module の `escapeHtml` / `html` / `joinHtml` の
+// 3 つだけで、「生の string を `HtmlSafe` に見せかけて本文へ入れる」逃げ道を持たない
+// (逃げ道を 1 つ用意すると、急ぐ日にそこが使われて lock が形骸化する)。
+
+const ESCAPE_PATTERN = /[&<>"']/g;
+const ESCAPE_MAP: Record<string, string> = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&#39;',
+};
+
+/** エスケープ済み、またはコード側が組み立てた安全な HTML 断片。 */
+export class HtmlSafe {
+	private constructor(private readonly value: string) {}
+
+	/** 埋め込み時の生文字列。テンプレートリテラル内では toString() 経由でこちらが使われる。 */
+	get raw(): string {
+		return this.value;
+	}
+
+	toString(): string {
+		return this.value;
+	}
+
+	/**
+	 * 任意の値を HTML エスケープする。`null` / `undefined` は空文字にする
+	 * (メール本文に "undefined" が出る事故を防ぐ)。
+	 */
+	static escape(value: unknown): HtmlSafe {
+		if (value === null || value === undefined) return new HtmlSafe('');
+		return new HtmlSafe(String(value).replace(ESCAPE_PATTERN, (c) => ESCAPE_MAP[c] ?? c));
+	}
+
+	/**
+	 * HTML 組み立て用のタグ付きテンプレート。
+	 * 埋め込み値は **既に `HtmlSafe` のものを除き全てエスケープ**される。
+	 */
+	static template(strings: TemplateStringsArray, ...values: unknown[]): HtmlSafe {
+		let out = strings[0] ?? '';
+		for (let i = 0; i < values.length; i++) {
+			const value = values[i];
+			out +=
+				(value instanceof HtmlSafe ? value.raw : HtmlSafe.escape(value).raw) +
+				(strings[i + 1] ?? '');
+		}
+		return new HtmlSafe(out);
+	}
+
+	/** `HtmlSafe` の配列を連結する (行の組み立て → 表への埋め込み)。 */
+	static joinAll(parts: HtmlSafe[], separator: string): HtmlSafe {
+		return new HtmlSafe(parts.map((p) => p.raw).join(separator));
+	}
+}
+
+/** 任意の値を HTML エスケープする。 */
+export function escapeHtml(value: unknown): HtmlSafe {
+	return HtmlSafe.escape(value);
+}
+
+/**
+ * HTML 組み立て用のタグ付きテンプレート。埋め込み値は自動でエスケープされる。
+ *
+ * ```ts
+ * html`<p>家族グループ「${tenantName}」</p>`   // tenantName は自動でエスケープされる
+ * ```
+ */
+export function html(strings: TemplateStringsArray, ...values: unknown[]): HtmlSafe {
+	return HtmlSafe.template(strings, ...values);
+}
+
+/** `HtmlSafe` の配列を連結する。 */
+export function joinHtml(parts: HtmlSafe[], separator = ''): HtmlSafe {
+	return HtmlSafe.joinAll(parts, separator);
+}
+
+/** 本文なしを表す `HtmlSafe` (条件付きブロックの else 側)。 */
+export const EMPTY_HTML: HtmlSafe = escapeHtml('');

--- a/src/lib/server/services/email-service.ts
+++ b/src/lib/server/services/email-service.ts
@@ -17,6 +17,7 @@ import {
 // #2057: 「管理画面」 → 「ご家族の見守り画面」 rename atom 参照
 import { ADMIN_VIEW_TERMS, CANCEL_TERMS, PLAN_FULL_TERMS } from '$lib/domain/terms';
 import { logger } from '$lib/server/logger';
+import { EMPTY_HTML, type HtmlSafe, html, joinHtml } from './email-html';
 import { generateUnsubscribeToken, type UnsubscribeKind } from './unsubscribe-token';
 
 // ============================================================
@@ -229,7 +230,7 @@ async function writeLocalEmailPreview(params: {
 // テンプレート: 共通レイアウト
 // ============================================================
 
-function wrapTemplate(content: string): string {
+function wrapTemplate(content: HtmlSafe): string {
 	return `<!DOCTYPE html>
 <html lang="ja">
 <head>
@@ -273,7 +274,7 @@ export async function sendWelcomeEmail(email: string, familyName?: string): Prom
 	return sendEmail({
 		to: email,
 		subject: 'がんばりクエストへようこそ！',
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>${greeting}ようこそ！</h2>
       <p>がんばりクエストへのご登録ありがとうございます。</p>
       <p>お子さまの毎日のがんばりを記録して、成長を見守りましょう！</p>
@@ -294,7 +295,7 @@ export async function sendInquiryConfirmationEmail(
 	return sendEmail({
 		to: email,
 		subject: `【がんばりクエスト】お問い合わせを受け付けました（${inquiryId}）`,
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>お問い合わせを受け付けました</h2>
       <p>お問い合わせ番号: <strong>${inquiryId}</strong></p>
       <p>いただいた内容を確認し、必要に応じてご返信いたします。</p>
@@ -323,7 +324,7 @@ export async function sendCancellationEmail(
 	return sendEmail({
 		to: email,
 		subject: '【がんばりクエスト】解約手続きを受け付けました',
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>解約手続きを受け付けました</h2>
       <p><strong>${untilPhrase}</strong>、現在の有料プランをそのままご利用いただけます。</p>
       <p>その後は${PLAN_FULL_TERMS.free}に切り替わります。お子さまの記録は残りますので、引き続き${PLAN_FULL_TERMS.free}の範囲でご利用いただけます。</p>
@@ -368,7 +369,7 @@ export async function sendDeletionWarningEmail(params: DeletionWarningParams): P
 	return sendEmail({
 		to: email,
 		subject: `【がんばりクエスト】${labels.subject(daysRemaining)}`,
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>${labels.heading}</h2>
       <p>${labels.greeting(ownerName)}</p>
       <p>${labels.intro}</p>
@@ -426,7 +427,7 @@ export async function sendDeletionReservedEmail(params: DeletionReservedParams):
 	return sendEmail({
 		to: email,
 		subject: `【がんばりクエスト】${labels.subject}`,
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>${labels.heading}</h2>
       <p>${labels.greeting(ownerName)}</p>
       <p>${labels.intro}</p>
@@ -466,7 +467,7 @@ export async function sendDeletionCompleteEmail(email: string): Promise<boolean>
 	return sendEmail({
 		to: email,
 		subject: `【がんばりクエスト】${labels.subject}`,
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>${labels.heading}</h2>
       <p>${labels.intro}</p>
       <p>${labels.irreversibleNote}</p>
@@ -489,7 +490,7 @@ export async function sendMemberRemovedEmail(email: string, tenantName: string):
 	return sendEmail({
 		to: email,
 		subject: '【がんばりクエスト】家族グループからの除外通知',
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>家族グループからの除外通知</h2>
       <p>家族グループ「${tenantName}」のオーナーにより、メンバーから除外されました。</p>
       <p>新しい招待リンクがあれば、別のグループに参加できます。</p>
@@ -507,7 +508,7 @@ export async function sendMemberJoinedEmail(
 	return sendEmail({
 		to: ownerEmail,
 		subject: '【がんばりクエスト】新しいメンバーが参加しました',
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>新しいメンバーが参加しました</h2>
       <p><strong>${memberName}</strong> さんが「${role}」として家族グループに参加しました。</p>
       <p style="text-align: center; margin: 24px 0;">
@@ -538,7 +539,7 @@ export async function sendOwnershipTransferredEmail(
 	return sendEmail({
 		to: newOwnerEmail,
 		subject: `【がんばりクエスト】${labels.subject}`,
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>${labels.heading}</h2>
       <p>${labels.greeting(memberName)}</p>
       <p>${labels.body(roleLabel)}</p>
@@ -585,7 +586,7 @@ export async function sendPaymentFailedNoticeEmail(
 	return sendEmail({
 		to: email,
 		subject: `【がんばりクエスト】${labels.subject(daysRemaining)}`,
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>${labels.heading}</h2>
       <p>${labels.greeting(ownerName)}</p>
       <p>${labels.intro}</p>
@@ -629,7 +630,7 @@ export async function sendPinResetCodeEmail(email: string, code: string): Promis
 	return sendEmail({
 		to: email,
 		subject: labels.subject,
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>${labels.heading}</h2>
       <p>${labels.intro}</p>
       <p style="text-align:center;margin:24px 0">
@@ -661,22 +662,23 @@ export async function sendWeeklyReportEmail(
 	email: string,
 	report: WeeklyReportData,
 ): Promise<boolean> {
-	const catRows = report.categories
-		.map((c) => {
+	const catRows = joinHtml(
+		report.categories.map((c) => {
 			const diff = c.diff > 0 ? `+${c.diff}` : c.diff === 0 ? '±0' : String(c.diff);
-			return `<tr><td style="padding:8px 12px;border-bottom:1px solid #eee">${c.name}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;text-align:center;font-weight:bold">${c.count}回</td><td style="padding:8px 12px;border-bottom:1px solid #eee;text-align:center;color:${c.diff >= 0 ? '#22c55e' : '#ef4444'}">${diff}</td></tr>`;
-		})
-		.join('');
+			const diffColor = c.diff >= 0 ? '#22c55e' : '#ef4444';
+			return html`<tr><td style="padding:8px 12px;border-bottom:1px solid #eee">${c.name}</td><td style="padding:8px 12px;border-bottom:1px solid #eee;text-align:center;font-weight:bold">${c.count}回</td><td style="padding:8px 12px;border-bottom:1px solid #eee;text-align:center;color:${diffColor}">${diff}</td></tr>`;
+		}),
+	);
 
 	const achievementHtml =
 		report.newAchievements.length > 0
-			? `<p style="margin-top:16px">🏆 <strong>新しい実績:</strong> ${report.newAchievements.join('、')}</p>`
-			: '';
+			? html`<p style="margin-top:16px">🏆 <strong>新しい実績:</strong> ${report.newAchievements.join('、')}</p>`
+			: EMPTY_HTML;
 
 	return sendEmail({
 		to: email,
 		subject: `🌟 ${report.childName}の今週のがんばり（${report.dateRange}）`,
-		htmlBody: wrapTemplate(`
+		htmlBody: wrapTemplate(html`
       <h2>${report.childName}の今週のがんばり</h2>
       <p style="color:#666">${report.dateRange}</p>
       <table style="width:100%;border-collapse:collapse;margin:16px 0">
@@ -727,7 +729,7 @@ function buildUnsubscribeUrl(tenantId: string, kind: UnsubscribeKind): string {
  * `wrapTemplate` (purple ヘッダ) や `wrapTrialEmailTemplate` (orange ヘッダ) と
  * 区別するため、Anti-engagement 整合の落ち着いたグレー基調にする。
  */
-function wrapLifecycleTemplate(content: string, unsubscribeUrl: string): string {
+function wrapLifecycleTemplate(content: HtmlSafe, unsubscribeUrl: string): string {
 	const labels = LIFECYCLE_EMAIL_LABELS;
 	return `<!DOCTYPE html>
 <html lang="ja">
@@ -791,7 +793,7 @@ export async function sendLicenseRenewalReminderEmail(
 	const subject = labels.renewalSubject(daysRemaining);
 	const ctaUrl = `${getAppBaseUrl()}/admin/subscription`;
 
-	const htmlContent = `
+	const htmlContent = html`
       <h2>${labels.renewalHeading}</h2>
       <p>${labels.renewalGreeting(ownerName)}</p>
       <p>${labels.renewalIntro}</p>
@@ -851,7 +853,7 @@ export async function sendDormantReactivationEmail(
 	const unsubscribeUrl = buildUnsubscribeUrl(tenantId, 'marketing');
 	const ctaUrl = `${getAppBaseUrl()}/auth/login`;
 
-	const htmlContent = `
+	const htmlContent = html`
       <h2>${labels.dormantHeading}</h2>
       <p>${labels.dormantGreeting(ownerName)}</p>
       <p>${labels.dormantIntro}</p>
@@ -911,7 +913,7 @@ export async function sendPmfSurveyEmail(params: PmfSurveyEmailParams): Promise<
 	const { email, tenantId, ownerName, round, surveyUrl } = params;
 	const unsubscribeUrl = buildUnsubscribeUrl(tenantId, 'marketing');
 
-	const htmlContent = `
+	const htmlContent = html`
       <h2>${labels.emailHeading}</h2>
       <p>${labels.emailGreeting(ownerName)}</p>
       <p>${labels.emailIntro}</p>

--- a/src/lib/server/services/trial-notification-service.ts
+++ b/src/lib/server/services/trial-notification-service.ts
@@ -8,6 +8,7 @@ import { PLAN_FULL_TERMS } from '$lib/domain/terms';
 import { getRepos } from '$lib/server/db/factory';
 import { logger } from '$lib/server/logger';
 import { getPlanLimits } from '$lib/server/services/plan-limit-service';
+import { type HtmlSafe, html } from './email-html';
 import { sendEmail } from './email-service';
 import type { TrialTier } from './trial-service';
 import { getTrialStatus } from './trial-service';
@@ -103,7 +104,7 @@ export async function sendTrialEnding3DaysEmail(
 	return sendEmail({
 		to: email,
 		subject: '【がんばりクエスト】トライアル期間が残り3日です',
-		htmlBody: wrapTrialEmailTemplate(`
+		htmlBody: wrapTrialEmailTemplate(html`
       <h2>トライアル期間が残り3日です</h2>
       <p>現在ご利用中の<strong>${tierLabel}</strong>のトライアル期間は <strong>${trialEndDate}</strong> に終了します。</p>
       <p>トライアル終了後は、${PLAN_FULL_TERMS.free}に切り替わります。${PLAN_FULL_TERMS.free}では以下の制限があります:</p>
@@ -135,7 +136,7 @@ export async function sendTrialEnding1DayEmail(
 	return sendEmail({
 		to: email,
 		subject: '【がんばりクエスト】トライアルが明日終了します',
-		htmlBody: wrapTrialEmailTemplate(`
+		htmlBody: wrapTrialEmailTemplate(html`
       <h2>トライアルが明日終了します</h2>
       <p><strong>${tierLabel}</strong>のトライアル期間は <strong>明日（${trialEndDate}）</strong> に終了します。終了後は${PLAN_FULL_TERMS.free}に切り替わります。</p>
       <p>${TRIAL_EMAIL_LABELS.archiveRestorableLine(PLAN_FULL_TERMS.free)}</p>
@@ -160,7 +161,7 @@ export async function sendTrialEndedTodayEmail(
 	return sendEmail({
 		to: email,
 		subject: '【がんばりクエスト】トライアル期間が終了しました',
-		htmlBody: wrapTrialEmailTemplate(`
+		htmlBody: wrapTrialEmailTemplate(html`
       <h2>トライアル期間が終了しました</h2>
       <p><strong>${tierLabel}</strong>のトライアル期間が終了しました。現在は${PLAN_FULL_TERMS.free}でご利用いただいています。</p>
       <p>${TRIAL_EMAIL_LABELS.archiveRestorableLine(PLAN_FULL_TERMS.free)}</p>
@@ -320,7 +321,7 @@ export async function processTrialNotifications(
 // Email template helper
 // ============================================================
 
-function wrapTrialEmailTemplate(content: string): string {
+function wrapTrialEmailTemplate(content: HtmlSafe): string {
 	return `<!DOCTYPE html>
 <html lang="ja">
 <head>

--- a/tests/unit/services/email-html-escaping.test.ts
+++ b/tests/unit/services/email-html-escaping.test.ts
@@ -1,0 +1,220 @@
+// tests/unit/services/email-html-escaping.test.ts (#4566)
+//
+// 送信 HTML メールにユーザー入力が無エスケープで埋まらないことを固定する。
+//
+// # 何を守るか
+// テナント名 / 表示名は顧客が自由入力する値で、`<a href="...">` を注入すると
+// **がんばりクエスト名義のメール本文に任意リンクを差し込める**。受信者には
+// 「除外されたメンバー」= もはや信頼関係にない相手が含まれるため、cross-user の
+// フィッシング経路になる (第 21 回統合監査 セキュリティ領域で検出)。
+//
+// # 3 層で見る
+//   1. `escapeHtml` / `html` タグ単体の振る舞い
+//   2. 実送信経路の pin (注入文字列を入れて SES に渡る HTML を検査する)
+//   3. class lock (fitness function) — 本文組み立てに素の template literal が現れたら fail
+//      instance 修正の繰り返しをやめて class を閉じる (ADR-0061 原則 2)。既に 2 instance 目
+//      (既存 sendMemberRemovedEmail + #4507 が追加した 3 通) であり、次に同じ形が書かれても
+//      **型検査 (HtmlSafe) と本 test の両方**が落ちる
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sesCommands: Array<{ type: 'simple' | 'raw'; params: Record<string, unknown> }> = [];
+
+vi.mock('@aws-sdk/client-ses', () => ({
+	SESClient: class {
+		send = vi.fn().mockResolvedValue({});
+	},
+	SendEmailCommand: class {
+		constructor(params: Record<string, unknown>) {
+			sesCommands.push({ type: 'simple', params });
+		}
+	},
+	SendRawEmailCommand: class {
+		constructor(params: Record<string, unknown>) {
+			sesCommands.push({ type: 'raw', params });
+		}
+	},
+}));
+
+vi.mock('$env/dynamic/private', () => ({
+	env: {
+		SES_SENDER_EMAIL: 'noreply@ganbari-quest.com',
+		APP_BASE_URL: 'https://ganbari-quest.com',
+	},
+}));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('$lib/runtime/env', () => ({
+	getEnv: () => ({ OPS_SECRET_KEY: 'test-fixed-secret', AUTH_MODE: 'cognito' }),
+	env: { OPS_SECRET_KEY: 'test-fixed-secret', AUTH_MODE: 'cognito' },
+}));
+
+import { escapeHtml, html, joinHtml } from '$lib/server/services/email-html';
+import {
+	sendMemberJoinedEmail,
+	sendMemberRemovedEmail,
+	sendWeeklyReportEmail,
+	sendWelcomeEmail,
+} from '$lib/server/services/email-service';
+
+/** 注入を試みる文字列。リンク・script・属性抜けの 3 系統を 1 本に混ぜてある。 */
+const INJECTION = `<a href="https://evil.example/steal">今すぐ確認</a><script>alert(1)</script>" onmouseover="x`;
+
+/** 直前に送られた 1 通の HTML 本文を取り出す。 */
+function takeSentHtml(): string {
+	expect(sesCommands).toHaveLength(1);
+	const sent = sesCommands[0];
+	if (!sent) throw new Error('メールが 1 通も送られていません');
+	if (sent.type === 'simple') {
+		const message = sent.params.Message as { Body: { Html?: { Data: string } } };
+		return message.Body.Html?.Data ?? '';
+	}
+	const raw = Buffer.from((sent.params.RawMessage as { Data: Uint8Array }).Data).toString('utf-8');
+	const marker = 'Content-Type: text/html; charset="UTF-8"\r\nContent-Transfer-Encoding: base64';
+	const start = raw.indexOf(marker);
+	if (start === -1) return '';
+	const bodyStart = raw.indexOf('\r\n\r\n', start) + 4;
+	const bodyEnd = raw.indexOf('\r\n--', bodyStart);
+	return Buffer.from(raw.slice(bodyStart, bodyEnd), 'base64').toString('utf-8');
+}
+
+beforeEach(() => {
+	sesCommands.length = 0;
+	// sendEmail は process.env.AUTH_MODE を直接見る。local だと SES に出さず tmp/ へ書くだけ
+	// なので、実送信経路 (SES に渡る HTML) を検査するために cognito にする。
+	process.env.AUTH_MODE = 'cognito';
+});
+
+describe('escapeHtml / html タグ', () => {
+	it('HTML 特殊文字 5 種をエスケープする', () => {
+		expect(escapeHtml(`<&>"'`).raw).toBe('&lt;&amp;&gt;&quot;&#39;');
+	});
+
+	it('null / undefined は空文字にする (本文に "undefined" を出さない)', () => {
+		expect(escapeHtml(null).raw).toBe('');
+		expect(escapeHtml(undefined).raw).toBe('');
+	});
+
+	it('html タグは埋め込み値だけをエスケープし、テンプレート側のタグは保つ', () => {
+		expect(html`<p>${'<b>x</b>'}</p>`.raw).toBe('<p>&lt;b&gt;x&lt;/b&gt;</p>');
+	});
+
+	it('HtmlSafe を埋め込んでも二重エスケープしない (断片の合成)', () => {
+		const row = html`<td>${'a&b'}</td>`;
+		expect(html`<tr>${row}</tr>`.raw).toBe('<tr><td>a&amp;b</td></tr>');
+	});
+
+	it('joinHtml は各要素の生 HTML を保ったまま連結する', () => {
+		expect(joinHtml([html`<i>${'<x>'}</i>`, html`<i>b</i>`]).raw).toBe('<i>&lt;x&gt;</i><i>b</i>');
+	});
+});
+
+describe('#4566 実送信経路 — ユーザー入力は生 HTML として出ない', () => {
+	it('除外通知メール (cross-user 経路) のテナント名', async () => {
+		await sendMemberRemovedEmail('member@example.com', INJECTION);
+		const body = takeSentHtml();
+
+		expect(body).not.toContain('<a href="https://evil.example/steal">');
+		expect(body).not.toContain('<script>');
+		expect(body).toContain('&lt;a href=&quot;https://evil.example/steal&quot;&gt;');
+	});
+
+	it('参加通知メールの表示名とロール', async () => {
+		await sendMemberJoinedEmail('owner@example.com', INJECTION, INJECTION);
+		const body = takeSentHtml();
+
+		expect(body).not.toContain('<script>');
+		expect(body).toContain('&lt;script&gt;');
+	});
+
+	it('ウェルカムメールの家族名', async () => {
+		await sendWelcomeEmail('owner@example.com', INJECTION);
+		const body = takeSentHtml();
+
+		expect(body).not.toContain('<script>');
+		expect(body).toContain('&lt;script&gt;');
+	});
+
+	it('週次レポートの子供名・カテゴリ名・実績名 (表の行組み立て経路)', async () => {
+		await sendWeeklyReportEmail('owner@example.com', {
+			childName: INJECTION,
+			dateRange: '2026-08-01 〜 2026-08-07',
+			categories: [{ name: INJECTION, count: 3, diff: 1 }],
+			streak: 5,
+			pointsEarned: 120,
+			totalPoints: 900,
+			newAchievements: [INJECTION],
+		});
+		const body = takeSentHtml();
+
+		expect(body).not.toContain('<script>');
+		expect(body).toContain('&lt;script&gt;');
+		// 表の枠組み (テンプレート側の tag) は壊れていない
+		expect(body).toContain('<tr><td style="padding:8px 12px;border-bottom:1px solid #eee">');
+	});
+});
+
+// ============================================================
+// class lock (fitness function)
+// ============================================================
+
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+/** 本文組み立て関数 → それを持つ file。HTML メールを組み立てる経路はこの 2 file が全て。 */
+const TEMPLATE_WRAPPERS: { file: string; wrappers: string[] }[] = [
+	{
+		file: 'src/lib/server/services/email-service.ts',
+		wrappers: ['wrapTemplate', 'wrapLifecycleTemplate'],
+	},
+	{
+		file: 'src/lib/server/services/trial-notification-service.ts',
+		wrappers: ['wrapTrialEmailTemplate'],
+	},
+];
+
+describe('#4566 class lock — 本文組み立てに素の string を渡せない', () => {
+	it.each(
+		TEMPLATE_WRAPPERS.flatMap(({ file, wrappers }) => wrappers.map((w) => [file, w] as const)),
+	)('%s: %s は HtmlSafe しか受け取らない', (file, wrapper) => {
+		const source = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+		expect(
+			source,
+			`${wrapper} の引数型が HtmlSafe でないと、素の string を本文に入れられてしまう`,
+		).toMatch(new RegExp(`function ${wrapper}\\(content: HtmlSafe`));
+	});
+
+	it.each(
+		TEMPLATE_WRAPPERS.flatMap(({ file, wrappers }) => wrappers.map((w) => [file, w] as const)),
+	)('%s: %s の呼び出しに素の template literal が無い', (file, wrapper) => {
+		const source = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+		const rawCalls = [...source.matchAll(new RegExp(`${wrapper}\\(\``, 'g'))];
+		expect(
+			rawCalls.length,
+			`${wrapper}(\`...\`) は無エスケープ経路。html\`...\` に置き換えること (#4566)`,
+		).toBe(0);
+	});
+
+	it('HtmlSafe の生成は email-html.ts の中だけで行われる (逃げ道を作らない)', () => {
+		for (const { file } of TEMPLATE_WRAPPERS) {
+			const source = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+			expect(source, `${file}: as HtmlSafe による cast は lock の迂回`).not.toMatch(
+				/as HtmlSafe\b/,
+			);
+			expect(source, `${file}: new HtmlSafe() は lock の迂回`).not.toMatch(/new HtmlSafe\(/);
+		}
+	});
+
+	it('検査対象の file が実在する (rename されたら空検査にならない)', () => {
+		for (const { file, wrappers } of TEMPLATE_WRAPPERS) {
+			const source = readFileSync(resolve(REPO_ROOT, file), 'utf8');
+			for (const wrapper of wrappers) {
+				expect(source, `${file} に ${wrapper} が無い`).toContain(`function ${wrapper}(`);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

家族グループのオーナーが、**「がんばりクエスト」名義のメール本文に任意のリンクや装飾を差し込めなくなる**。受信者には「グループから除外されたメンバー」= もはや信頼関係にない相手が含まれるため、これは cross-user のフィッシング経路だった。

## 関連 Issue

Closes #4566

第 21 回統合監査（`release/2026-08-13`）のセキュリティ領域監査で検出。#4507 が同じ形でメール文面を 3 通追加しており、class として拡大していた。

## 変更内容

**escape ヘルパを 1 つ足して「呼ぶ側が忘れないようにする」対処は採らなかった。** それは今ある 15 本文を直すだけで、次に書かれるメールには効かない（現に #4507 で 3 通増えた = 2 instance 目）。**型で閉じる**。

### 1. `src/lib/server/services/email-html.ts`（新規）

| export | 役割 |
|---|---|
| `HtmlSafe` | エスケープ済み HTML 断片を表す **class**。**constructor は private** |
| `escapeHtml(value)` | `& < > " '` の 5 種をエスケープ。`null` / `undefined` は空文字（本文に `undefined` を出さない） |
| `html\`...\`` | タグ付きテンプレート。**埋め込み値は `HtmlSafe` を除き全て自動エスケープ** |
| `joinHtml(parts)` | `HtmlSafe` の配列を連結（表の行 → 表） |

- **生成経路は上記 3 関数だけ**。`new HtmlSafe()` も `as HtmlSafe` も外から使えないため、「生の string を `HtmlSafe` に見せかけて本文へ入れる」逃げ道が無い。逃げ道を 1 つ用意すると、急ぐ日にそこが使われて lock が形骸化する
- **branded string ではなく class にした理由**: branded type は実行時に消えるため `html` タグが「この値はエスケープ済みか」を判別できず、断片の合成（行の組み立て → 表への埋め込み）で必ず二重エスケープになる

### 2. 本文組み立て関数の引数型を `HtmlSafe` に

`wrapTemplate` / `wrapLifecycleTemplate` / `wrapTrialEmailTemplate` の 3 本。**素の string を渡すと `tsc` / `svelte-check` が落ちる。** エスケープの有無を人の注意ではなく型検査に委ねる（ADR-0061 原則 2）。

### 3. 全 15 本文を `html\`...\`` に置換

`email-service.ts` 12 本 + `trial-notification-service.ts` 3 本。後者は Issue の列挙外だが、root class =「outbound HTML メールにユーザー入力を無エスケープで埋め込む」なので**同じ class の残りとして同時に閉じた**（今は定数しか埋めていないが、型が閉じていないと次に自由入力が入ったとき無防備になる）。

週次レポートの表は行ごとに `html\`` で組み立て `joinHtml` で合成する（行の中のカテゴリ名もエスケープされる）。

## 検証

```console
$ npx vitest run tests/unit/services/email-html-escaping.test.ts
 Test Files  1 passed (1)
      Tests  17 passed (17)

$ npx vitest run tests/unit/services/          # 既存メール test の巻き添え確認
 Test Files  176 passed (176)
      Tests  2946 passed (2946)

$ npx svelte-check --threshold error
svelte-check found 0 errors and 0 warnings

$ node scripts/check-repo-scan-test-declaration.mjs
[repo-scan-test-declaration] OK — repo 走査 test 58 件すべて区分宣言済
```

### 追加した test（3 層）

| 層 | 内容 |
|---|---|
| 単体 | `escapeHtml` / `html` / `joinHtml`。**`HtmlSafe` を埋めても二重エスケープしない**ことを含む |
| 実送信経路の pin | 注入文字列（`<a href>` + `<script>` + 属性抜け）を入れて **SES に渡る HTML** を検査。除外通知（cross-user）/ 参加通知 / ウェルカム / 週次レポート |
| class lock（fitness） | 引数型が `HtmlSafe` である / 素の template literal 呼び出しが 0 件 / `as HtmlSafe`・`new HtmlSafe` による迂回が無い / 検査対象 file が実在する（rename で空検査にならない） |

### mutation 検証（commit 後に実施 → `git stash` で戻す）

除外通知メールを素の template literal に戻すと、**実送信 pin と class lock の両方**が落ちる。

```console
× 除外通知メール (cross-user 経路) のテナント名
× src/lib/server/services/email-service.ts: wrapTemplate の呼び出しに素の template literal が無い
      Tests  2 failed | 15 passed (17)
```

**未実行**: 実際の SES 送信での目視確認（本番相当の送信は行っていない）。HTML の内容は上記 pin と既存の `email-content-snapshot.test.ts` で見ている。

## 影響範囲

**顧客に見える変化**: 通常の名前（HTML 特殊文字を含まない）では**メール表示は変わらない**。`&` を含む家族名などは `&amp;` として送られるようになり、**メールクライアント上の表示は正しくなる**（従来は `&amp;` の解釈次第で崩れうる）。

**触った並行実装ペア**: なし（メール本文は labels.ts SSOT のまま。文言は 1 文字も変えていない）。

**破壊的変更**: なし。`sendEmail` の公開シグネチャ（`htmlBody: string`）は不変で、変えたのは module 内部の組み立て関数 3 本の引数型のみ。

UI 変更なし（サーバ側のメール組み立てのみ。画面描画に一切触れていない）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
