### PR TITLE
fix(plan): #4504 ひとことメッセージ（自由テキスト）に premium ゲートを実装する

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -20,3 +20,213 @@ if command -v graphify >/dev/null 2>&1; then
     echo "Updating Graphify knowledge graph..."
     graphify update . || true
 fi
+
+# graphify-hook-start
+# Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
+# Installed by: graphify hook install
+
+# Deterministic clustering: networkx louvain iterates string-keyed sets whose
+# order is randomized per-process by PYTHONHASHSEED, so community assignments
+# churn run-to-run. Pinning it makes graphify-out reproducible.
+export PYTHONHASHSEED=0
+
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+# Skip during rebase/merge/cherry-pick to avoid blocking --continue with unstaged changes
+# git exports GIT_DIR to hooks; the rev-parse fallback only runs when invoked by
+# hand (each git exec costs 1s+ on AV-scanned Windows machines).
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+[ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
+
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+    exit 0
+fi
+
+CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+# Skip when only graphify-out/ artifacts changed (avoids rebuild loop when graph outputs are tracked in git)
+_NON_GRAPH=$(echo "$CHANGED" | grep -v '^graphify-out/' || true)
+if [ -z "$_NON_GRAPH" ]; then
+    exit 0
+fi
+
+# Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs).
+# _PINNED was recorded at hook-install time; tried first so the hook works even
+# when the graphify launcher is not on PATH (common in GUI clients and CI).
+#
+# Probes check availability with importlib.util.find_spec instead of importing
+# the package: a probe that imports graphify wholesale executes the full package
+# import (10s+ cold on machines with AV-scanned or large site-packages) and used
+# to run up to FOUR times synchronously, stalling every commit before the
+# detached launch even started. find_spec locates the package without executing
+# it, so each probe costs interpreter startup only. The detached rebuild still
+# fails loudly in the log if the package is broken under that interpreter.
+_GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+GRAPHIFY_PYTHON=""
+_PINNED='C:\Users\kokor\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe'
+if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then
+    GRAPHIFY_PYTHON="$_PINNED"
+fi
+# Second probe: read graphify-out/.graphify_python (written by the skill and
+# CLI; survives uv-tool reinstalls and is the same source the README documents).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    if [ -f "$_GFY_PYTHON_FILE" ]; then
+        _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
+        case "$_FROM_FILE" in
+            *[!a-zA-Z0-9/_.@:\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+        esac
+        if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_FROM_FILE"
+        fi
+    fi
+fi
+# Third probe: resolve via the graphify launcher on PATH.
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+    if [ -n "$GRAPHIFY_BIN" ]; then
+        # Windows pip layout: Scripts/graphify(.exe) sits beside ..\python.exe
+        # (or .\python.exe inside a venv's Scripts dir). NOTE: command -v may
+        # return the launcher path WITHOUT the .exe suffix, so this cannot key
+        # on the extension.
+        _GFY_BINDIR=$(dirname "$GRAPHIFY_BIN")
+        if [ -x "$_GFY_BINDIR/../python.exe" ] && "$_GFY_BINDIR/../python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/../python.exe"
+        elif [ -x "$_GFY_BINDIR/python.exe" ] && "$_GFY_BINDIR/python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/python.exe"
+        fi
+    fi
+    if [ -z "$GRAPHIFY_PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
+        # POSIX launcher: parse the shebang. head -c + tr strip NUL bytes first —
+        # when the launcher is a Windows binary reached without its .exe suffix,
+        # a raw `head -1` reads binary into the command substitution and the
+        # shell warns about ignored null bytes on every commit.
+        case "$GRAPHIFY_BIN" in
+            *.exe) _SHEBANG="" ;;
+            *)     _SHEBANG=$(head -c 256 "$GRAPHIFY_BIN" 2>/dev/null | tr -d '\000' | head -n 1 | sed 's/^#![[:space:]]*//') ;;
+        esac
+        case "$_SHEBANG" in
+            */env\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
+            *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
+        esac
+        # Allowlist: only keep characters valid in a filesystem path to prevent
+        # injection if the shebang contains shell metacharacters.
+        case "$GRAPHIFY_PYTHON" in
+            *[!a-zA-Z0-9/_.@:\\-]*) GRAPHIFY_PYTHON="" ;;
+        esac
+        if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON=""
+        fi
+    fi
+fi
+# Last resort: try python3 / python (works for system/venv installs on PATH).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    elif command -v python >/dev/null 2>&1 && python -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python"
+    else
+        echo "[graphify hook] could not locate a Python with graphify installed. Add the graphify bin dir to PATH or re-run 'graphify hook install' from the env where graphify lives." >&2
+        exit 0
+    fi
+fi
+
+export GRAPHIFY_CHANGED="$CHANGED"
+
+# Run the rebuild detached so git commit returns immediately. Full-repo rebuilds
+# can take hours; blocking the post-commit hook stalls the shell. The Python
+# launcher below detaches the child cross-platform, so it works on Git for
+# Windows' shell too (which lacks the coreutils backgrounding tools) (#1161).
+_GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
+echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
+"$GRAPHIFY_PYTHON" -c "import os, subprocess, sys
+_src = '''
+import os, signal, sys, threading
+from pathlib import Path
+
+changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
+changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
+
+if not changed:
+    sys.exit(0)
+
+print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
+
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0:
+        if hasattr(signal, 'SIGALRM'):
+            signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+            signal.alarm(_timeout)
+        else:
+            def _bail():
+                print(f'[graphify hook] graphify rebuild exceeded {_timeout}s', flush=True)
+                os._exit(1)
+            _watchdog = threading.Timer(_timeout, _bail)
+            _watchdog.daemon = True
+            _watchdog.start()
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _root = Path('.')
+    _out = os.environ.get('GRAPHIFY_OUT', 'graphify-out')
+    _saved = Path(_out) / '.graphify_root'
+    if _saved.exists():
+        _txt = _saved.read_text(encoding='utf-8').strip()
+        if _txt:
+            _root = Path(_txt)
+    _rebuild_code(_root, changed_paths=changed, force=_force)
+    # Refresh the work-memory lessons doc when saved Q&A outcomes exist
+    # (best-effort; never fails the hook).
+    try:
+        _md = (_root / _out) / 'memory'
+        if _md.is_dir() and any(_md.glob('*.md')):
+            from graphify.reflect import reflect as _reflect
+            _gj = (_root / _out) / 'graph.json'
+            _reflect(memory_dir=_md, out_path=(_root / _out) / 'reflections' / 'LESSONS.md',
+                     graph_path=_gj if _gj.exists() else None)
+    except Exception:
+        pass
+except TimeoutError as exc:
+    print(f'[graphify hook] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify hook] Rebuild failed: {exc}')
+    sys.exit(1)
+
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or os.path.join(os.path.expanduser('~'), '.cache', 'graphify-rebuild.log')
+try:
+    os.makedirs(os.path.dirname(_log), exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    _flags = 0x08000000 | 0x00000200  # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+    try:
+        subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
+    except OSError:
+        subprocess.Popen(_cmd, creationflags=_flags, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"
+# graphify-hook-end

--- a/scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs
+++ b/scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs
@@ -48,10 +48,12 @@ async function loginAsOwner(page) {
 async function ensureChild(page) {
 	// login 直後は redirect が飛んでいる最中で goto が ERR_ABORTED になることがある
 	await page.waitForLoadState('networkidle').catch(() => {});
+	// 固定 sleep は使わない (#1208)。goto が redirect と競合したら、URL が落ち着くのを
+	// 待ってから 1 度だけやり直す。
 	await page
 		.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' })
 		.catch(async () => {
-			await page.waitForTimeout(1_000);
+			await page.waitForURL(/\/(admin|switch|child)/, { timeout: 15_000 }).catch(() => {});
 			await page.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' });
 		});
 	await page.waitForLoadState('networkidle').catch(() => {});

--- a/scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs
+++ b/scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs
@@ -48,10 +48,12 @@ async function loginAsOwner(page) {
 async function ensureChild(page) {
 	// login 直後は redirect が飛んでいる最中で goto が ERR_ABORTED になることがある
 	await page.waitForLoadState('networkidle').catch(() => {});
-	await page.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' }).catch(async () => {
-		await page.waitForTimeout(1_000);
-		await page.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' });
-	});
+	await page
+		.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' })
+		.catch(async () => {
+			await page.waitForTimeout(1_000);
+			await page.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' });
+		});
 	await page.waitForLoadState('networkidle').catch(() => {});
 	const existing = page.getByText('はなちゃん', { exact: false }).first();
 	if (await existing.isVisible().catch(() => false)) return;

--- a/scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs
+++ b/scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs
@@ -1,0 +1,102 @@
+/**
+ * scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs (#4504)
+ *
+ * `/admin/cheer` の Step 6「付随スタンプ / メッセージ」を撮る。
+ *
+ *   before … 全プランで自由テキスト入力欄が出ていた (ゲート無し)
+ *   after  … premium 以外は入力欄が消え、「スタンプは今のプランでも送れる」旨の説明に変わる
+ *
+ * `dev:cognito` の owner@example.com は **スタンダード** なので、この環境で
+ * 「ロックされた側」が撮れる (premium 側は plan を切り替えないと出ない)。
+ *
+ * AUTH_MODE=cognito (npm run dev:cognito、#1026) で動作させる。
+ *
+ * 使用例:
+ *   SS_PHASE=after BASE_URL=http://localhost:5187 node scripts/capture.mjs --pr <N> \
+ *     --flow cheer-free-text-gate \
+ *     --url /admin/cheer \
+ *     --actions scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs \
+ *     --presets desktop
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+const PHASE = process.env.SS_PHASE === 'before' ? 'before' : 'after';
+
+/** cognito-dev のログインフォームを通す (cancel-vs-deletion-4496.mjs と同型) */
+async function loginAsOwner(page) {
+	await page.goto(`${BASE_URL}/auth/login`);
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.waitForFunction(
+		() => document.querySelector('input[name="email"]')?.getAttribute('type') === 'email',
+		{ timeout: 15_000 },
+	);
+
+	await page.getByLabel('メールアドレス').click();
+	await page.keyboard.type('owner@example.com', { delay: 20 });
+	await page.getByLabel('パスワード', { exact: true }).click();
+	await page.keyboard.type('Gq!Dev#Owner2026x', { delay: 20 });
+
+	await page
+		.locator('button[type="submit"]:not([disabled])')
+		.first()
+		.waitFor({ state: 'visible', timeout: 30_000 });
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/(admin|ops|setup|billing|switch|child)/, { timeout: 30_000 });
+}
+
+/** 子供が 0 人なら 1 人だけ登録する (cheer フォームの描画条件を満たすため) */
+async function ensureChild(page) {
+	// login 直後は redirect が飛んでいる最中で goto が ERR_ABORTED になることがある
+	await page.waitForLoadState('networkidle').catch(() => {});
+	await page.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' }).catch(async () => {
+		await page.waitForTimeout(1_000);
+		await page.goto(`${BASE_URL}/admin/children`, { waitUntil: 'domcontentloaded' });
+	});
+	await page.waitForLoadState('networkidle').catch(() => {});
+	const existing = page.getByText('はなちゃん', { exact: false }).first();
+	if (await existing.isVisible().catch(() => false)) return;
+
+	const addToggle = page.locator('[data-tutorial="add-child-btn"]');
+	await addToggle.waitFor({ state: 'visible', timeout: 20_000 });
+	const nickname = page.locator('#add-nickname');
+	for (let attempt = 0; attempt < 5; attempt++) {
+		await addToggle.click();
+		const opened = await nickname
+			.waitFor({ state: 'visible', timeout: 3_000 })
+			.then(() => true)
+			.catch(() => false);
+		if (opened) break;
+	}
+	await nickname.fill('はなちゃん');
+	await page.locator('#add-age').fill('8');
+	await page.getByRole('button', { name: '追加する' }).click();
+	await page
+		.getByText('はなちゃん', { exact: false })
+		.first()
+		.waitFor({ state: 'visible', timeout: 20_000 });
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	await loginAsOwner(page);
+
+	// cheer の入力フォームは子供が 1 人も居ないと描画されない (empty state になる)。
+	// local sqlite は空なので、撮影前に 1 人だけ作る (admin-children-add-4413.mjs と同型)。
+	await ensureChild(page);
+
+	await page.goto(`${BASE_URL}/admin/cheer`, { waitUntil: 'domcontentloaded' });
+	await page
+		.getByText('付随スタンプ', { exact: false })
+		.first()
+		.waitFor({ state: 'visible', timeout: 30_000 })
+		.catch(() => {});
+	await page
+		.getByText('付随スタンプ', { exact: false })
+		.first()
+		.scrollIntoViewIfNeeded()
+		.catch(() => {});
+	await capture(`${PHASE}-cheer-extra-step`);
+};

--- a/src/lib/domain/free-text-message-gate.ts
+++ b/src/lib/domain/free-text-message-gate.ts
@@ -1,0 +1,40 @@
+// src/lib/domain/free-text-message-gate.ts
+// ひとことメッセージ (自由テキスト) のプランゲート述語 SSOT (#4504 / EPIC #4495)。
+//
+// # 何が壊れていたか
+//
+// LP は自由テキストを **プレミアム限定** と訴求している (pricing 比較表 / pamphlet) のに、
+// 実装にゲートが無く全プランで送信できた。`PLAN_LIMITS.canFreeTextMessage` は
+// **定義だけで参照ゼロのデッド設定**で、送信経路 2 本 (`/admin/cheer` の action と
+// `POST /api/v1/messages/[childId]`) はどちらも tier を見ていなかった。
+// 旧 `/admin/messages` の family 専用化 (#772) が cheer 統合 (#2266 / #2267) で失われたもの。
+//
+// # なぜ述語を 1 本にするか
+//
+// AI 提案 (`$lib/domain/ai-suggest-gate`) と同型。enforcement (server) と表示 (UI) が
+// 別々の式で導出されると、片側だけがずれて「表示の嘘」になる (#2902 → #4506 の実例)。
+// **同じ関数を両方が import する**ことで、ずれた状態を作れなくする。
+//
+// # ⚠️ これは表示専用の述語ではない — 緩めると認可が緩む
+//
+// UI のロック表示と server の認可の両方がこれを読む。「standard にも入力欄だけ見せたい」
+// のような表示都合をこの条件に足すと、同じ条件が enforcement 側にも効き、
+// **プレミアム以外が自由テキストを送信できる** (差別化機能の無償開放)。
+// 表示都合が必要になったら、この関数は enforcement のまま据え置き、表示側に別述語を足す。
+//
+// # 適用範囲 (定型応援は含まない)
+//
+// ゲートするのは **自由テキスト (`body`)** のみ。プリセットのスタンプ / 定型応援は
+// **全プランのまま**である (LP も定型応援は全プラン共通と訴求しており、そちらが正)。
+
+import type { PlanTier } from '$lib/domain/constants/plan-tier';
+
+/**
+ * 自由テキストのひとことメッセージが当該プランで送信可能か。
+ *
+ * トライアル中は `resolvePlanTier` が `TRIAL_TIER` (premium) を返すため、
+ * トライアル利用者もここで許可される (別分岐を書かない)。
+ */
+export function isFreeTextMessageUnlocked(tier: PlanTier): boolean {
+	return tier === 'family';
+}

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -5063,6 +5063,12 @@ export const CHEER_LABELS = {
 	iconHint: '絵文字を入れてください',
 	extraTitle: '6. 付随スタンプ / メッセージ（任意）',
 	extraDescription: 'いつものスタンプや、ひとことメッセージも一緒に届けられます',
+	// #4504: 自由テキストは premium 限定 (LP の訴求どおり)。定型スタンプは全プランで使える。
+	/** プランゲートのエラー文言 / ロック表示に使う機能名 */
+	freeTextFeatureName: 'ひとことメッセージ（自由テキスト）',
+	/** premium 以外に出す説明。スタンプは使えることを同時に伝える (全否定しない) */
+	freeTextLockedNote: `ひとことメッセージ（自由テキスト）は${PLAN_FULL_TERMS.premium}の機能です。スタンプは今のプランでも送れます。`,
+	freeTextPlaceholder: 'ひとことメッセージを足す（任意）',
 	confirmTitle: `7. 内容を確認して${CHEER_TERMS.action}`,
 	grantButton: CHEER_TERMS.action,
 	grantButtonDisabled: '理由とポイントを入力してください',

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -7,6 +7,7 @@ import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { PLAN_HISTORY_RETENTION_DAYS } from '$lib/domain/constants/plan-retention';
 import type { PlanTier } from '$lib/domain/constants/plan-tier';
 import { addDaysJST, prevDateJST, todayDateJST } from '$lib/domain/date-utils';
+import { isFreeTextMessageUnlocked } from '$lib/domain/free-text-message-gate';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { getDebugPlanTier } from '$lib/server/debug-plan';
@@ -44,7 +45,8 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		// 値の SSOT は domain/constants/plan-retention.ts (LP / 機能リストの表示も同じ定数から引く、#4477)
 		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.free,
 		canExport: false,
-		canFreeTextMessage: false,
+		// #4504: 値は述語 SSOT から導出する (定義だけで参照ゼロのデッド設定だった)
+		canFreeTextMessage: isFreeTextMessageUnlocked('free'),
 		canCustomReward: false,
 		canSiblingRanking: false,
 		maxCloudExports: 0,
@@ -57,7 +59,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxFamilyMembers: 4,
 		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.standard,
 		canExport: true,
-		canFreeTextMessage: false,
+		canFreeTextMessage: isFreeTextMessageUnlocked('standard'),
 		canCustomReward: true,
 		canSiblingRanking: false,
 		maxCloudExports: 3,
@@ -70,7 +72,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		maxFamilyMembers: null,
 		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.family,
 		canExport: true,
-		canFreeTextMessage: true,
+		canFreeTextMessage: isFreeTextMessageUnlocked('family'),
 		canCustomReward: true,
 		canSiblingRanking: true,
 		maxCloudExports: 10,

--- a/src/routes/(parent)/admin/cheer/+page.server.ts
+++ b/src/routes/(parent)/admin/cheer/+page.server.ts
@@ -6,9 +6,12 @@
 // 旧 /admin/messages はスタンプ/テキストのみ (P 付与なし) で存在意義なし → 本機能に統合。
 
 import { fail } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { getErrorMessage } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
+import { isFreeTextMessageUnlocked } from '$lib/domain/free-text-message-gate';
 import { asChildId } from '$lib/domain/ids';
+import { CHEER_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import {
 	CHEER_CATEGORIES,
@@ -20,11 +23,16 @@ import {
 } from '$lib/server/services/cheer-service';
 import { getAllChildren } from '$lib/server/services/child-service';
 import { getMessageHistory, STAMP_PRESETS } from '$lib/server/services/message-service';
+import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
 	const tenantId = requireTenantId(locals);
 	const children = await getAllChildren(tenantId);
+	// #4504: 自由テキストのロック表示に使う。UI と server が同じ述語 (isFreeTextMessageUnlocked)
+	// を読むようにして、表示と認可がずれた状態を作れなくする (ai-suggest-gate と同型)。
+	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+	const planTier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
 
 	const childrenWithMessages = await Promise.all(
 		children.map(async (child) => {
@@ -35,6 +43,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 
 	return {
 		children: childrenWithMessages,
+		planTier,
 		stamps: STAMP_PRESETS,
 		categories: CHEER_CATEGORIES,
 		reasonMaxLength: CHEER_REASON_MAX_LENGTH,
@@ -102,6 +111,16 @@ export const actions: Actions = {
 		const validation = parseAndValidateForm(formData);
 		if (!validation.ok) {
 			return fail(validation.status, { error: validation.error });
+		}
+
+		// #4504: 入力欄を隠すだけでは form を直接 POST されると素通しするため server で強制する。
+		// スタンプ (stampCode) とポイント付与は全プランのままで、落とすのは body だけ。
+		if (validation.data.body) {
+			const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+			const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
+			if (!isFreeTextMessageUnlocked(tier)) {
+				return fail(403, { error: CHEER_LABELS.freeTextLockedNote });
+			}
 		}
 
 		const result = await grantCheer(validation.data, tenantId);

--- a/src/routes/(parent)/admin/cheer/+page.svelte
+++ b/src/routes/(parent)/admin/cheer/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+import { isFreeTextMessageUnlocked } from '$lib/domain/free-text-message-gate';
 import type { ChildId } from '$lib/domain/ids';
 import { APP_LABELS, CHEER_LABELS, PAGE_TITLES } from '$lib/domain/labels';
 import { notifyActionError } from '$lib/ui/error-notify';
@@ -9,6 +10,10 @@ import FormField from '$lib/ui/primitives/FormField.svelte';
 import NativeSelect from '$lib/ui/primitives/NativeSelect.svelte';
 
 let { data, form } = $props();
+
+// #4504: enforcement (server action / API) と同じ述語を読む。別式で導出すると
+// 「表示は開いているのに送信は 403」がまた起きる (#2902 → #4506 の実例)。
+const freeTextUnlocked = $derived(isFreeTextMessageUnlocked(data.planTier));
 
 const errorMessage = $derived((form as { error?: string } | null)?.error);
 const granted = $derived(Boolean((form as { granted?: boolean } | null)?.granted));
@@ -230,15 +235,26 @@ $effect(() => {
 							</Button>
 						{/each}
 					</div>
-					<FormField
-						label=""
-						type="textarea"
-						rows={2}
-						name="body"
-						maxlength={120}
-						placeholder="ひとことメッセージを足す（任意）"
-						bind:value={body}
-					/>
+					{#if freeTextUnlocked}
+						<FormField
+							label=""
+							type="textarea"
+							rows={2}
+							name="body"
+							maxlength={120}
+							placeholder={CHEER_LABELS.freeTextPlaceholder}
+							bind:value={body}
+						/>
+					{:else}
+						<!-- #4504: 自由テキストは premium 限定 (LP の訴求どおり)。スタンプは上に残っており
+						     全プランで使えるので、「何が使えないか」だけでなく「何は使えるか」も伝える -->
+						<p
+							class="text-xs text-[var(--color-text-muted)] bg-[var(--color-surface-muted)] rounded-lg p-3"
+							data-testid="cheer-free-text-locked"
+						>
+							{CHEER_LABELS.freeTextLockedNote}
+						</p>
+					{/if}
 					<input type="hidden" name="stampCode" value={stampCode} />
 				</Card>
 			</section>

--- a/src/routes/api/v1/messages/[childId]/+server.ts
+++ b/src/routes/api/v1/messages/[childId]/+server.ts
@@ -1,12 +1,16 @@
 import { json } from '@sveltejs/kit';
+import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { isFreeTextMessageUnlocked } from '$lib/domain/free-text-message-gate';
+import { CHEER_LABELS, PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { messageQuerySchema, sendMessageSchema } from '$lib/domain/validation/message';
-import { validationError } from '$lib/server/errors';
+import { apiError, validationError } from '$lib/server/errors';
 import {
 	getMessageHistory,
 	getUnshownMessage,
 	getUnshownMessageCount,
 	sendMessage,
 } from '$lib/server/services/message-service';
+import { resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ params, url, locals }) => {
@@ -47,6 +51,20 @@ export const POST: RequestHandler = async ({ request, params, locals }) => {
 	});
 	if (!parsed.success) {
 		return validationError(parsed.error.issues[0]?.message ?? '入力が不正です');
+	}
+
+	// #4504: 自由テキストは premium 限定 (LP の訴求どおり)。UI を隠すだけでは直接 POST を
+	// 素通しするため server で強制する (AI 提案の validateSuggestRequest と同型)。
+	// 定型スタンプ (`messageType: 'stamp'`) は全プランのままにする。
+	if (parsed.data.messageType === 'text') {
+		const licenseStatus = context.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
+		const tier = await resolveFullPlanTier(tenantId, licenseStatus, context.plan);
+		if (!isFreeTextMessageUnlocked(tier)) {
+			return apiError(
+				'PLAN_LIMIT_EXCEEDED',
+				PLAN_GATE_LABELS.familyOnlyFor(CHEER_LABELS.freeTextFeatureName),
+			);
+		}
 	}
 
 	const message = await sendMessage(parsed.data, tenantId);

--- a/tests/unit/routes/admin-cheer-grant.test.ts
+++ b/tests/unit/routes/admin-cheer-grant.test.ts
@@ -18,6 +18,15 @@ vi.mock('$lib/server/auth/factory', () => ({
 		if (!locals.context?.tenantId) throw new Error('Unauthorized');
 		return locals.context.tenantId;
 	},
+	// #4504: 自由テキストの plan gate が tier 解決経由で getAuthMode を引く
+	getAuthMode: () => 'cognito',
+}));
+
+// #4504: 自由テキスト (body) は premium 限定になった。本 test の主題は
+// 「form の値が grantCheer に渡るか」なので、tier 解決は premium 固定で mock する
+// (gate 自体の検査は tests/unit/services/free-text-message-gate-4504.test.ts)。
+vi.mock('$lib/server/services/plan-limit-service', () => ({
+	resolveFullPlanTier: async () => 'family',
 }));
 
 const mockGrantCheer = vi.fn();

--- a/tests/unit/services/free-text-message-gate-4504.test.ts
+++ b/tests/unit/services/free-text-message-gate-4504.test.ts
@@ -1,0 +1,103 @@
+// tests/unit/services/free-text-message-gate-4504.test.ts (#4504)
+//
+// ひとことメッセージ (自由テキスト) の premium ゲートを固定する。
+//
+// # 何が壊れていたか
+// LP は自由テキストを premium 限定と訴求しているのに、送信経路 2 本 (cheer action /
+// messages API) はどちらも tier を見ておらず、**全プランが送信できた**。
+// `PLAN_LIMITS.canFreeTextMessage` は定義だけで参照ゼロのデッド設定だった。
+//
+// # 何を検査するか
+//   1. 述語そのもの (free / standard 拒否、premium 許可)
+//   2. `canFreeTextMessage` が述語から導出されている (デッド設定に戻らない)
+//   3. トライアル中 (premium tier 解決) は許可される
+//   4. 送信経路 2 本が **述語を実際に呼んでいる** (UI を隠すだけで終わっていない)
+//   5. 定型スタンプはゲートしない (全プランのまま)
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('$lib/server/debug-plan', () => ({
+	getDebugPlanTier: () => null,
+	getDebugTrialOverride: () => null,
+}));
+vi.mock('$lib/server/auth/factory', () => ({ getAuthMode: () => 'cognito' }));
+vi.mock('$lib/server/db/factory', () => ({ getRepos: () => ({}) }));
+vi.mock('$lib/server/request-context', () => ({
+	getRequestContext: () => null,
+	invalidateRequestCaches: vi.fn(),
+}));
+
+import { isFreeTextMessageUnlocked } from '$lib/domain/free-text-message-gate';
+import { getPlanLimits, resolvePlanTier } from '$lib/server/services/plan-limit-service';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoFile = (p: string) => readFileSync(resolve(__dirname, '../../../', p), 'utf-8');
+
+describe('#4504 自由テキストの premium ゲート', () => {
+	describe('述語', () => {
+		it('free / standard は拒否、premium (family) は許可', () => {
+			expect(isFreeTextMessageUnlocked('free')).toBe(false);
+			expect(isFreeTextMessageUnlocked('standard')).toBe(false);
+			expect(isFreeTextMessageUnlocked('family')).toBe(true);
+		});
+
+		it('canFreeTextMessage が述語から導出されている (デッド設定に戻らない)', () => {
+			for (const tier of ['free', 'standard', 'family'] as const) {
+				expect(getPlanLimits(tier).canFreeTextMessage).toBe(isFreeTextMessageUnlocked(tier));
+			}
+		});
+
+		it('premium トライアル中は許可される (別分岐を書かない)', () => {
+			const future = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+			// trial tier = 'family' (#4501 FR-2)。resolvePlanTier がそれを返し、述語が許可する
+			const tier = resolvePlanTier('none', undefined, future, 'family');
+			expect(tier).toBe('family');
+			expect(isFreeTextMessageUnlocked(tier)).toBe(true);
+		});
+
+		it('standard トライアル中は拒否される (tier がそのまま効く)', () => {
+			const future = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString();
+			const tier = resolvePlanTier('none', undefined, future, 'standard');
+			expect(isFreeTextMessageUnlocked(tier)).toBe(false);
+		});
+	});
+
+	// UI を隠すだけでは form / API を直接叩かれると素通しする。**server 側で落ちること**を
+	// 経路ごとに固定する (経路が増えたらここに足す)。
+	describe('送信経路が述語を実際に呼んでいる', () => {
+		const ENFORCEMENT_SITES = [
+			'src/routes/api/v1/messages/[childId]/+server.ts',
+			'src/routes/(parent)/admin/cheer/+page.server.ts',
+		];
+
+		it.each(ENFORCEMENT_SITES)('%s が isFreeTextMessageUnlocked を呼ぶ', (file) => {
+			const src = repoFile(file);
+			expect(src).toContain('isFreeTextMessageUnlocked');
+			expect(src, 'tier を解決せずに判定はできない').toContain('resolveFullPlanTier');
+		});
+
+		it('API は messageType=text のときだけゲートする (スタンプは全プラン)', () => {
+			const src = repoFile('src/routes/api/v1/messages/[childId]/+server.ts');
+			expect(src).toContain("parsed.data.messageType === 'text'");
+			expect(src).toContain('PLAN_LIMIT_EXCEEDED');
+		});
+
+		it('cheer action は body があるときだけゲートする (ポイント付与とスタンプは全プラン)', () => {
+			const src = repoFile('src/routes/(parent)/admin/cheer/+page.server.ts');
+			expect(src).toContain('if (validation.data.body)');
+		});
+
+		it('UI も同じ述語を読む (表示と認可が別式にならない)', () => {
+			const src = repoFile('src/routes/(parent)/admin/cheer/+page.svelte');
+			expect(src).toContain('isFreeTextMessageUnlocked(data.planTier)');
+			// page が読む field は load が返していること (silent undefined を防ぐ)
+			expect(repoFile('src/routes/(parent)/admin/cheer/+page.server.ts')).toContain('planTier,');
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**プレミアムの差別化機能が、書いてあるとおりプレミアムの機能になる。** LP は「ひとことメッセージ（自由テキスト）」をプレミアム限定と訴求している（pricing 比較表 / pamphlet）のに、実装にゲートが無く**全プランが送信できていた**。プレミアムを選ぶ理由の 1 つが無償で開いている状態を塞ぐ。

## 関連 Issue

Closes #4504

親 EPIC: #4495 / 関連: #772（旧 `/admin/messages` の family 専用化）/ #2266・#2267（cheer 統合で失われた）/ #4506（同型の述語 SSOT 化）

## 変更内容

`PLAN_LIMITS.canFreeTextMessage` は **定義だけで参照ゼロのデッド設定**で、送信経路 2 本（`/admin/cheer` の action / `POST /api/v1/messages/[childId]`）はどちらも tier を見ていなかった。PO 決裁「LP 訴求に合わせて gate を実装する」に従い、**AI 提案（#4506）と同じ形**で実装する。

### 1. 述語 SSOT を 1 本置く

`src/lib/domain/free-text-message-gate.ts`（新規）— `isFreeTextMessageUnlocked(tier)`

**enforcement（server）と表示（UI）が同じ関数を import する。** 別々の式で導出すると片側だけずれて「表示は開いているのに送信は 403」になる（#2902 → #4506 で実際に起きた）。

### 2. デッド設定を述語から導出する

```ts
canFreeTextMessage: isFreeTextMessageUnlocked('standard'),   // free / standard / family の 3 tier
```

値と述語が構造的に一致し、**片方だけ変えられない**（デッド設定に戻らない）。

### 3. 送信経路 2 本を server で塞ぐ

| 経路 | 変更 |
|---|---|
| `POST /api/v1/messages/[childId]` | `messageType === 'text'` のとき `PLAN_LIMIT_EXCEEDED`（`validateSuggestRequest` と同型） |
| `/admin/cheer` の `grant` action | `body` があるとき 403。**UI を隠すだけでは form を直接 POST されると素通し**するため |

### 4. UI（`/admin/cheer` Step 6）

premium 以外は入力欄を出さず、「ひとことメッセージ（自由テキスト）は**プレミアムプラン**の機能です。**スタンプは今のプランでも送れます。**」を出す。**何が使えないかだけでなく、何は使えるかを同時に伝える**。

### ゲートしないもの

**定型スタンプとポイント付与は全プランのまま。** LP も定型応援は全プラン共通と訴求しており、そちらが正しい。トライアル中は `resolvePlanTier` が premium を返すため、**別分岐を書かずに**許可される。

## 検証

```console
$ npx vitest run tests/unit/services/free-text-message-gate-4504.test.ts
      Tests  9 passed (9)

$ npx vitest run tests/unit/routes/admin-cheer-grant.test.ts tests/unit/services/free-text-message-gate-4504.test.ts tests/unit/services/plan-limit-service.test.ts
      Tests  99 passed (99)

$ npx vitest run tests/unit/services/ tests/unit/routes/
      Tests  3658 passed (3658)      # cheer route test の mock 追加を含む

$ npx svelte-check --threshold error
svelte-check found 0 errors and 0 warnings

$ npm run cspell
CSpell: Files checked: 1987, Issues found: 0 in 0 files.
```

### 追加した test（`free-text-message-gate-4504.test.ts`）

| 観点 | 内容 |
|---|---|
| 述語 | free / standard 拒否、premium 許可 |
| デッド設定の解消 | `canFreeTextMessage` が 3 tier とも述語と一致する |
| トライアル | premium トライアル中は許可 / standard トライアル中は拒否（tier がそのまま効く） |
| 経路の網羅 | **送信経路 2 本が述語を実際に呼んでいる**（UI を隠すだけで終わっていない） |
| 巻き添え防止 | API は `messageType==='text'` のときだけ / cheer は `body` があるときだけ |
| 表示と認可の一致 | UI が同じ述語を読み、page が読む `data.planTier` を load が返している |

### 既存 test を 1 件変えた（弱体化ではない）

`admin-cheer-grant.test.ts` に `getAuthMode` と `resolveFullPlanTier` の mock を追加した。**assert は 1 つも変えていない** — gate 追加により tier 解決が走るようになったため、mock が足りずに落ちていたもの。この test の主題（form の値が `grantCheer` に渡るか）は不変で、gate 自体の検査は新しい test が持つ。

### 未実行

- **premium 側の実機表示は未撮影**。`dev:cognito` の `owner@example.com` は**スタンダード**で、premium に切り替えるには `DEBUG_PLAN` 等の別 env 起動が要る。ロック側（本 PR で変わる側）は撮れており、premium 側で入力欄が残ることは unit test（述語 + UI が同一述語を読むこと）で担保している
- E2E は未実行（CI の重量レーンで確認する）

## 影響範囲

**顧客に見える変化**

- 無料 / スタンダードのご家庭では `/admin/cheer` の自由テキスト入力欄が**消える**（スタンプとポイント付与は従来どおり）
- 同プランで `POST /api/v1/messages/[childId]` に `messageType: 'text'` を送ると `PLAN_LIMIT_EXCEEDED` で拒否される
- プレミアム / トライアル中は**従来どおり**

<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4579/01-before-cheer-extra-step.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4579/01-after-cheer-extra-step.png -->

### `/admin/cheer` Step 6（スタンダードのご家庭）

| Before | After |
|---|---|
| ![01-before-cheer-extra-step](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4579/01-before-cheer-extra-step.png) | ![01-after-cheer-extra-step](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4579/01-after-cheer-extra-step.png) |

同一 page から取った DOM でも確認している（before = 入力欄あり・ロック説明なし / after = 入力欄なし・`cheer-free-text-locked` あり。**スタンプ選択は両方に残っている**）:
[01-after-cheer-extra-step.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4579/01-after-cheer-extra-step.dom.html)

撮影用に `scripts/capture-specs/flows/cheer-free-text-gate-4504.mjs` を追加した（cheer のフォームは子供が 0 人だと描画されないため、撮影前に 1 人だけ登録する）。

**触った並行実装ペア**: なし（メッセージ機能のみ。LP 文言は**変更なし** — 既存訴求が真になっただけ）。

**破壊的変更**: 無料 / スタンダードで自由テキストが送れなくなる = **機能の剥奪**にあたる。PO 決裁は「ゼロユーザー期のため機能剥奪の実害はなく、プレミアム差別化を維持する」。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
