### PR TITLE
fix(admin): #4506 activities の AI 提案ゲートを共有述語に移す (standard への解放表示を止める)

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -20,3 +20,213 @@ if command -v graphify >/dev/null 2>&1; then
     echo "Updating Graphify knowledge graph..."
     graphify update . || true
 fi
+
+# graphify-hook-start
+# Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
+# Installed by: graphify hook install
+
+# Deterministic clustering: networkx louvain iterates string-keyed sets whose
+# order is randomized per-process by PYTHONHASHSEED, so community assignments
+# churn run-to-run. Pinning it makes graphify-out reproducible.
+export PYTHONHASHSEED=0
+
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+# Skip during rebase/merge/cherry-pick to avoid blocking --continue with unstaged changes
+# git exports GIT_DIR to hooks; the rev-parse fallback only runs when invoked by
+# hand (each git exec costs 1s+ on AV-scanned Windows machines).
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+[ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
+
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+    exit 0
+fi
+
+CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+# Skip when only graphify-out/ artifacts changed (avoids rebuild loop when graph outputs are tracked in git)
+_NON_GRAPH=$(echo "$CHANGED" | grep -v '^graphify-out/' || true)
+if [ -z "$_NON_GRAPH" ]; then
+    exit 0
+fi
+
+# Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs).
+# _PINNED was recorded at hook-install time; tried first so the hook works even
+# when the graphify launcher is not on PATH (common in GUI clients and CI).
+#
+# Probes check availability with importlib.util.find_spec instead of importing
+# the package: a probe that imports graphify wholesale executes the full package
+# import (10s+ cold on machines with AV-scanned or large site-packages) and used
+# to run up to FOUR times synchronously, stalling every commit before the
+# detached launch even started. find_spec locates the package without executing
+# it, so each probe costs interpreter startup only. The detached rebuild still
+# fails loudly in the log if the package is broken under that interpreter.
+_GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+GRAPHIFY_PYTHON=""
+_PINNED='C:\Users\kokor\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe'
+if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then
+    GRAPHIFY_PYTHON="$_PINNED"
+fi
+# Second probe: read graphify-out/.graphify_python (written by the skill and
+# CLI; survives uv-tool reinstalls and is the same source the README documents).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    if [ -f "$_GFY_PYTHON_FILE" ]; then
+        _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
+        case "$_FROM_FILE" in
+            *[!a-zA-Z0-9/_.@:\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+        esac
+        if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_FROM_FILE"
+        fi
+    fi
+fi
+# Third probe: resolve via the graphify launcher on PATH.
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+    if [ -n "$GRAPHIFY_BIN" ]; then
+        # Windows pip layout: Scripts/graphify(.exe) sits beside ..\python.exe
+        # (or .\python.exe inside a venv's Scripts dir). NOTE: command -v may
+        # return the launcher path WITHOUT the .exe suffix, so this cannot key
+        # on the extension.
+        _GFY_BINDIR=$(dirname "$GRAPHIFY_BIN")
+        if [ -x "$_GFY_BINDIR/../python.exe" ] && "$_GFY_BINDIR/../python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/../python.exe"
+        elif [ -x "$_GFY_BINDIR/python.exe" ] && "$_GFY_BINDIR/python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/python.exe"
+        fi
+    fi
+    if [ -z "$GRAPHIFY_PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
+        # POSIX launcher: parse the shebang. head -c + tr strip NUL bytes first —
+        # when the launcher is a Windows binary reached without its .exe suffix,
+        # a raw `head -1` reads binary into the command substitution and the
+        # shell warns about ignored null bytes on every commit.
+        case "$GRAPHIFY_BIN" in
+            *.exe) _SHEBANG="" ;;
+            *)     _SHEBANG=$(head -c 256 "$GRAPHIFY_BIN" 2>/dev/null | tr -d '\000' | head -n 1 | sed 's/^#![[:space:]]*//') ;;
+        esac
+        case "$_SHEBANG" in
+            */env\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
+            *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
+        esac
+        # Allowlist: only keep characters valid in a filesystem path to prevent
+        # injection if the shebang contains shell metacharacters.
+        case "$GRAPHIFY_PYTHON" in
+            *[!a-zA-Z0-9/_.@:\\-]*) GRAPHIFY_PYTHON="" ;;
+        esac
+        if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON=""
+        fi
+    fi
+fi
+# Last resort: try python3 / python (works for system/venv installs on PATH).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    elif command -v python >/dev/null 2>&1 && python -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python"
+    else
+        echo "[graphify hook] could not locate a Python with graphify installed. Add the graphify bin dir to PATH or re-run 'graphify hook install' from the env where graphify lives." >&2
+        exit 0
+    fi
+fi
+
+export GRAPHIFY_CHANGED="$CHANGED"
+
+# Run the rebuild detached so git commit returns immediately. Full-repo rebuilds
+# can take hours; blocking the post-commit hook stalls the shell. The Python
+# launcher below detaches the child cross-platform, so it works on Git for
+# Windows' shell too (which lacks the coreutils backgrounding tools) (#1161).
+_GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
+echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
+"$GRAPHIFY_PYTHON" -c "import os, subprocess, sys
+_src = '''
+import os, signal, sys, threading
+from pathlib import Path
+
+changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
+changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
+
+if not changed:
+    sys.exit(0)
+
+print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
+
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0:
+        if hasattr(signal, 'SIGALRM'):
+            signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+            signal.alarm(_timeout)
+        else:
+            def _bail():
+                print(f'[graphify hook] graphify rebuild exceeded {_timeout}s', flush=True)
+                os._exit(1)
+            _watchdog = threading.Timer(_timeout, _bail)
+            _watchdog.daemon = True
+            _watchdog.start()
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _root = Path('.')
+    _out = os.environ.get('GRAPHIFY_OUT', 'graphify-out')
+    _saved = Path(_out) / '.graphify_root'
+    if _saved.exists():
+        _txt = _saved.read_text(encoding='utf-8').strip()
+        if _txt:
+            _root = Path(_txt)
+    _rebuild_code(_root, changed_paths=changed, force=_force)
+    # Refresh the work-memory lessons doc when saved Q&A outcomes exist
+    # (best-effort; never fails the hook).
+    try:
+        _md = (_root / _out) / 'memory'
+        if _md.is_dir() and any(_md.glob('*.md')):
+            from graphify.reflect import reflect as _reflect
+            _gj = (_root / _out) / 'graph.json'
+            _reflect(memory_dir=_md, out_path=(_root / _out) / 'reflections' / 'LESSONS.md',
+                     graph_path=_gj if _gj.exists() else None)
+    except Exception:
+        pass
+except TimeoutError as exc:
+    print(f'[graphify hook] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify hook] Rebuild failed: {exc}')
+    sys.exit(1)
+
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or os.path.join(os.path.expanduser('~'), '.cache', 'graphify-rebuild.log')
+try:
+    os.makedirs(os.path.dirname(_log), exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    _flags = 0x08000000 | 0x00000200  # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+    try:
+        subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
+    except OSError:
+        subprocess.Popen(_cmd, creationflags=_flags, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"
+# graphify-hook-end

--- a/scripts/capture-specs/flows/activities-ai-gate-4506.mjs
+++ b/scripts/capture-specs/flows/activities-ai-gate-4506.mjs
@@ -1,0 +1,78 @@
+/**
+ * scripts/capture-specs/flows/activities-ai-gate-4506.mjs (#4506)
+ *
+ * `/admin/activities` の「+ 追加 → AI で提案」ダイアログを撮る。
+ *
+ *   before … スタンダード加入者にも AI 提案パネルが**解放状態**で出る (押すと 403)
+ *   after  … プレミアム限定のロック表示 + アップグレード CTA になる
+ *
+ * `dev:cognito` の owner@example.com は **スタンダード**なので、この環境で
+ * 「誤って解放されていた側 → ロック」の変化がそのまま撮れる。
+ *
+ * AUTH_MODE=cognito (npm run dev:cognito、#1026) で動作させる。
+ *
+ * 使用例:
+ *   SS_PHASE=after BASE_URL=http://localhost:5393 node scripts/capture.mjs --pr <N> \
+ *     --flow activities-ai-gate \
+ *     --url /admin/activities \
+ *     --actions scripts/capture-specs/flows/activities-ai-gate-4506.mjs \
+ *     --presets desktop
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+const PHASE = process.env.SS_PHASE === 'before' ? 'before' : 'after';
+
+/** cognito-dev のログインフォームを通す (cheer-free-text-gate-4504.mjs と同型) */
+async function loginAsOwner(page) {
+	await page.goto(`${BASE_URL}/auth/login`);
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.waitForFunction(
+		() => document.querySelector('input[name="email"]')?.getAttribute('type') === 'email',
+		{ timeout: 15_000 },
+	);
+
+	await page.getByLabel('メールアドレス').click();
+	await page.keyboard.type('owner@example.com', { delay: 20 });
+	await page.getByLabel('パスワード', { exact: true }).click();
+	await page.keyboard.type('Gq!Dev#Owner2026x', { delay: 20 });
+
+	await page
+		.locator('button[type="submit"]:not([disabled])')
+		.first()
+		.waitFor({ state: 'visible', timeout: 30_000 });
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/(admin|ops|setup|billing|switch|child)/, { timeout: 30_000 });
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	await loginAsOwner(page);
+
+	await page.waitForLoadState('networkidle').catch(() => {});
+	await page.goto(`${BASE_URL}/admin/activities`, { waitUntil: 'domcontentloaded' });
+	await page.waitForLoadState('networkidle').catch(() => {});
+
+	// header の「+ 追加」dropdown → 「AI で提案」(#2998 の正準構成)
+	await page
+		.getByRole('button', { name: /追加/ })
+		.first()
+		.click()
+		.catch(() => {});
+	const aiItem = page.getByRole('menuitem', { name: /AI/ }).first();
+	await aiItem.waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+	await aiItem.click().catch(() => {});
+
+	await page
+		.getByTestId('add-activity-dialog')
+		.waitFor({ state: 'visible', timeout: 20_000 })
+		.catch(() => {});
+	// パネル本体が描画されるまで待つ (dialog の枠だけ出た瞬間に撮ると全白になる)
+	await page
+		.getByTestId('ai-suggest-panel')
+		.waitFor({ state: 'visible', timeout: 20_000 })
+		.catch(() => {});
+	await capture(`${PHASE}-activities-ai-dialog`);
+};

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { deserialize } from '$app/forms';
 import { goto, invalidateAll } from '$app/navigation';
+import { isAiSuggestUnlocked } from '$lib/domain/ai-suggest-gate';
 import { CATEGORY_CODE_TO_ID } from '$lib/domain/categories';
 import { getActionErrorDisplay } from '$lib/domain/errors';
 import { splitIcon } from '$lib/domain/icon-utils';
@@ -614,22 +615,12 @@ function selectChild(childId: ChildId) {
 	<!-- #2558 段階2: 'import' (admin 内マーケットプレイス風ブラウズ UI) を撤去。manual / ai のみ。 -->
 	<Dialog bind:open={showAddDialog} title={addMode === 'ai' ? FEATURES_LABELS.activitiesHeader.addDialogTitleAi : FEATURES_LABELS.activitiesHeader.addDialogTitleManual} testid="add-activity-dialog">
 		{#if addMode === 'ai'}
-			<!-- ⚠ この式は **誤り** です (standard 加入者に解放表示 → 実行時 403 = 有利誤認 / legal)。
-			     isPremium は有料 tier 全体 (standard を含む) を指し、AI 提案は premium 限定のため。
-
-			     #2902 の経緯 (#4506 で訂正): 旧 `data.planTier === 'family'` を「load が planTier を
-			     返さないので常に undefined === 'family' = false」と読んで isPremium に置換えたが、
-			     **この読みが誤りだった**。`data` は祖先 layout の戻り値をマージしたものであり、
-			     (parent)/admin/+layout.server.ts が planTier を返しているため解決していた
-			     (#4506 で premium account の実機検証により確認)。つまり動いていた式を壊している。
-
-			     #4506: 是正 (isAiSuggestUnlocked(data.planTier) への置換え) は PO の順序制約により
-			     **#4501 (プレミアムのトライアル化) と同 wave か、その後**に実施する。standard の表示が
-			     解放 → ロックに変わるため、LP が「全機能お試し」を約束している間に先に締めると
-			     見込み客に対する新たな誤認を作る。
-			     この未移行は tests/unit/architecture/ai-suggest-gate-derivation.test.ts の
-			     DEFERRED_DERIVATIONS に理由付きで pin されており、除外を消さない限り再訪される。 -->
-			<AiSuggestPanel onaccept={acceptAiPreview} isFamily={data.isPremium} />
+			<!-- #4506 (GAMMA2-ADM1-02): 旧 `data.isPremium` は有料 tier 全体 (standard を含む) を指すため、
+			     standard 加入者に解放表示 → 実行時 403 という有利誤認になっていた。enforcement
+			     ($lib/server/api/suggest-plan-gate.ts) と同じ述語を読む。
+			     引き締めのタイミングは #4501 (トライアルの premium 化) と同 wave という制約があり、
+			     #4501 の実装 (PR #4578) と揃えて本 PR で解除した。 -->
+			<AiSuggestPanel onaccept={acceptAiPreview} isFamily={isAiSuggestUnlocked(data.planTier)} />
 		{:else if addMode === 'manual'}
 			<ActivityCreateForm
 				categoryDefs={data.categoryDefs}

--- a/tests/unit/architecture/ai-suggest-gate-derivation.test.ts
+++ b/tests/unit/architecture/ai-suggest-gate-derivation.test.ts
@@ -63,8 +63,8 @@ const CALLSITE_PATTERN = /<AiSuggest(\w*)Panel\b[^>]*?isFamily=\{([^}]*)\}/gs;
  * (`findReasonDefect` が空 / stub を弾き、本 file が `#\d+` を追加で要求する)。
  */
 const DEFERRED_DERIVATIONS: Record<string, string> = {
-	'src/routes/(parent)/admin/activities/+page.svelte':
-		'#4506 では checklists の SSOT 統一のみ先行させた。activities を共有述語に移すと standard 加入者の表示が解放 → ロックに変わる (= 実欠陥 GAMMA2-ADM1-02 の是正そのもの) が、この引き締めは PO の順序制約により #4501 (プレミアムのトライアル化) と同 wave か後に実施する。LP が「全機能お試し」を約束している間に先に締めると、見込み客に対する新たな誤認を作るため',
+	// #4506 で activities を共有述語へ移行済み (PR #4578 = #4501 と同 wave)。
+	// **空のまま維持すること** — ここに足すのは「あとで直す」の登録であって免除ではない。
 };
 
 /**
@@ -85,6 +85,9 @@ const DEFERRED_DERIVATIONS: Record<string, string> = {
  */
 const PREDICATE_CALLSITES: Record<string, 'enforcement' | 'display'> = {
 	'src/lib/server/api/suggest-plan-gate.ts': 'enforcement',
+	// #4506: activities も共有述語に移行した (旧 data.isPremium は standard を含むため
+	// 解放表示 → 実行時 403 の有利誤認だった)。これで AI 提案パネル 3 画面が同一述語になる
+	'src/routes/(parent)/admin/activities/+page.svelte': 'display',
 	'src/routes/(parent)/admin/checklists/+page.svelte': 'display',
 	'src/routes/(parent)/admin/rewards/+page.svelte': 'display',
 };

--- a/tests/unit/ui/ai-suggest-gate-matrix-4506.test.ts
+++ b/tests/unit/ui/ai-suggest-gate-matrix-4506.test.ts
@@ -1,0 +1,74 @@
+// tests/unit/ui/ai-suggest-gate-matrix-4506.test.ts (#4506 AC4)
+//
+// AI 提案パネルの表示状態を **プラン × 画面のマトリクス**で固定する。
+//
+// # 何が壊れていたか
+// 兄弟 3 画面が別々の式で `isFamily` を導出しており、2 画面が誤っていた。
+//   - checklists: `data.planTier === 'family'` (正) — ただし「load が返していない」と 2 度誤読された
+//   - activities: `data.isPremium` (= 有料 tier 全体) — **standard に解放表示 → 実行時 403**
+//   - rewards:    `data.planTier === 'family'` (正)
+//
+// 述語を 1 本 (`isAiSuggestUnlocked`) にした後も、**「どのプランで開くか」の答えは
+// test に書かれていなければ次の改修で静かに変わる**。プラン別の期待値をここに置く。
+//
+// 導出経路 (call site が述語を通っているか / load が field を返しているか) の検査は
+// tests/unit/architecture/ai-suggest-gate-derivation.test.ts が担う (本 test は値の側)。
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { isAiSuggestUnlocked } from '../../../src/lib/domain/ai-suggest-gate';
+import type { PlanTier } from '../../../src/lib/domain/constants/plan-tier';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoFile = (p: string) => readFileSync(resolve(__dirname, '../../../', p), 'utf-8');
+
+/** AI 提案パネルを持つ admin 3 画面。増えたらここに足す (足さないと網羅が黙って減る)。 */
+const AI_SUGGEST_SCREENS = [
+	'src/routes/(parent)/admin/activities/+page.svelte',
+	'src/routes/(parent)/admin/checklists/+page.svelte',
+	'src/routes/(parent)/admin/rewards/+page.svelte',
+];
+
+/** プラン × 期待表示。true = パネルが使える / false = ロック + アップグレード CTA。 */
+const EXPECTED: Array<{ tier: PlanTier; unlocked: boolean; note: string }> = [
+	{ tier: 'free', unlocked: false, note: '無料プランは対象外' },
+	{
+		tier: 'standard',
+		unlocked: false,
+		note: 'AI 提案は premium 限定。旧 activities はここで解放表示 → 実行時 403 だった (GAMMA2-ADM1-02)',
+	},
+	{
+		tier: 'family',
+		unlocked: true,
+		note: 'premium (内部コード family)。旧 checklists はここでロック表示だった (GAMMA2-ADM1-01)',
+	},
+];
+
+describe('#4506 AI 提案パネルの表示状態マトリクス', () => {
+	describe('プラン別の期待値', () => {
+		it.each(EXPECTED)('$tier → unlocked=$unlocked ($note)', ({ tier, unlocked }) => {
+			expect(isAiSuggestUnlocked(tier)).toBe(unlocked);
+		});
+
+		it('premium トライアル中も使える (resolvePlanTier が family を返すため別分岐が要らない)', () => {
+			// #4501 で TRIAL_TIER = 'family' に固定した。トライアル利用者は tier=family として解決される
+			expect(isAiSuggestUnlocked('family')).toBe(true);
+		});
+	});
+
+	describe('3 画面が同一の式で導出している (画面ごとの独自式に戻らない)', () => {
+		it.each(AI_SUGGEST_SCREENS)('%s が isAiSuggestUnlocked(data.planTier) を使う', (file) => {
+			const src = repoFile(file);
+			expect(src).toContain('isAiSuggestUnlocked(data.planTier)');
+		});
+
+		it.each(AI_SUGGEST_SCREENS)('%s に旧式 (data.isPremium での isFamily 導出) が無い', (file) => {
+			const src = repoFile(file);
+			// isPremium 自体は他用途 (上限バナー等) で使うため、AI パネルへの受け渡しだけを禁じる
+			expect(src).not.toMatch(/isFamily=\{data\.isPremium\}/);
+			expect(src).not.toMatch(/isFamily=\{data\.planTier === 'family'\}/);
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**スタンダードのご家庭に「使える」と見せてから 403 を返す状態を止める。** `/admin/activities` の AI 提案パネルは有料プラン全体に解放表示されていたが、AI 提案は**プレミアム限定**。押して初めて「プレミアムプランでご利用いただけます」と拒否される dead-end で、スタンダードに含まれない機能を含まれるかのように提示していた（有利誤認）。

## 関連 Issue

Closes #4506

親 EPIC: #4495（第2ラウンド）/ 関連: #2902（同 class の前例）/ #727（server gate）/ #4501（順序制約の相手、PR #4578）

## 変更内容

### 直したもの

```diff
- <AiSuggestPanel onaccept={acceptAiPreview} isFamily={data.isPremium} />
+ <AiSuggestPanel onaccept={acceptAiPreview} isFamily={isAiSuggestUnlocked(data.planTier)} />
```

`data.isPremium` は `isPaidTier(planTier)` = **standard を含む有料 tier 全体**。AI 提案の enforcement（`suggest-plan-gate.ts`）は premium 限定なので、表示と認可がずれていました。enforcement と同じ述語（`$lib/domain/ai-suggest-gate`）を読ませます。

### なぜ今なのか（順序制約の解除）

この引き締めは「**#4501（トライアルの premium 化）と同 wave かその後**」という PO の順序制約があり、`DEFERRED_DERIVATIONS` に理由付きで pin されていました（LP が「全機能お試し」を約束している間に standard の表示を先に締めると、見込み客に新たな誤認を作るため）。**#4501 の実装（PR #4578）が出たので解除**します。

- `DEFERRED_DERIVATIONS` は**空**になりました（「あとで直す」の登録が 0 件）
- `PREDICATE_CALLSITES` に activities を `display` として登録。**call site の増減は「表示都合の変更が認可に波及する範囲」の変更**なので pin します

これで AI 提案パネルを持つ 3 画面（activities / checklists / rewards）が**同一述語**になりました。

## 検証

```console
$ npx vitest run tests/unit/ui/ai-suggest-gate-matrix-4506.test.ts
      Tests  10 passed (10)

$ npx vitest run tests/unit/ui/ tests/unit/architecture/ tests/unit/routes/
 Test Files  161 passed (161)
      Tests  1353 passed (1353)

$ npx svelte-check --threshold error
svelte-check found 0 errors and 0 warnings

$ npm run cspell
CSpell: Files checked: 1986, Issues found: 0 in 0 files.

$ node scripts/check-repo-scan-test-declaration.mjs
[repo-scan-test-declaration] OK — repo 走査 test 58 件すべて区分宣言済
```

### 追加した test（AC4: 表示状態マトリクス）

導出経路の検査は既存の architecture test が持っていますが、**「どのプランで開くか」の答えが test に無いと次の改修で静かに変わる**ので、値の側を固定しました。

| プラン | 期待 | 根拠 |
|---|---|---|
| free | ロック | 対象外 |
| standard | **ロック** | 旧 activities はここで解放表示 → 実行時 403 だった（GAMMA2-ADM1-02） |
| premium (family) | 解放 | 旧 checklists はここでロック表示だった（GAMMA2-ADM1-01、修正済み） |
| premium トライアル中 | 解放 | #4501 で `TRIAL_TIER = 'family'` に固定したので別分岐が要らない |

あわせて **3 画面が同一式であること**と、**旧式 2 種（`isFamily={data.isPremium}` / `isFamily={data.planTier === 'family'}`）が復活しないこと**を pin しています。

### AC5（fitness function 化の可否）— 判断と根拠

**新規の fitness function は追加しません。既存の 2 本で足りているためです。**

| 既に効いている guard | 何を止めるか |
|---|---|
| `ai-suggest-gate-derivation.test.ts`（#4506 で導入済み） | call site が共有述語を経由していること / `data.<field>` を load 連鎖が実際に返していること（型では捕まらない silent undefined を機械で見る）/ 未移行を無言で置けないこと（`DEFERRED_DERIVATIONS` の理由必須） |
| 本 PR の matrix test | プラン別の期待値そのもの |

同 class 3 回目（#2902 → #4506 checklists → 本 PR）ですが、**3 回目の再発を許したのは guard の不在ではなく「順序制約による意図的な保留」**でした。保留は `DEFERRED_DERIVATIONS` に理由付きで登録されており、機械が「まだ残っている」と言い続ける状態は既に成立していました。ここにさらに guard を足すのは装置の重複になります（ADR-0061 原則 2 は instance 修正の反復を止めるためのもので、既に guard がある class への追加は目的外）。

### 未実行

- **premium 側の実機表示は未撮影**。`dev:cognito` の `owner@example.com` は standard で、premium 表示には別 env 起動が要ります。**本 PR で変わるのは standard 側**（解放 → ロック）で、そちらは撮れています
- E2E は未実行（CI の重量レーンで確認）

## 影響範囲

**顧客に見える変化**: スタンダードのご家庭で `/admin/activities` の AI 提案が**ロック表示（プレミアム限定バッジ + アップグレード CTA）**になります。**実行時 403 の dead-end が消えます。** プレミアム / トライアル中は従来どおり使えます。

<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4588/01-before-activities-ai-dialog.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4588/01-after-activities-ai-dialog.png -->

### `/admin/activities` → 「+ 追加 → AI で提案」（スタンダードのご家庭）

| Before | After |
|---|---|
| ![01-before-activities-ai-dialog](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4588/01-before-activities-ai-dialog.png) | ![01-after-activities-ai-dialog](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4588/01-after-activities-ai-dialog.png) |

同一 page から取った DOM でも確認しています:

| | `data-plan-locked` | ロックバッジ |
|---|---|---|
| Before | `false`（**誤って解放**） | なし |
| After | `true`（正しくロック） | あり |

[01-after-activities-ai-dialog.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4588/01-after-activities-ai-dialog.dom.html)

撮影用に `scripts/capture-specs/flows/activities-ai-gate-4506.mjs` を追加しました（`+ 追加` dropdown → AI で提案 → パネル描画待ち）。

**触った並行実装ペア**: AI 提案パネルの 3 画面（activities / checklists / rewards）。本 PR で 3 画面が同一述語に揃いました。

**破壊的変更**: なし（server 側の認可は元から premium 限定で、表示をそれに合わせただけ）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
