### PR TITLE
fix(marketplace): #4511 死に導線「デモを体験」の修正と説明不整合 3 件

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -20,3 +20,213 @@ if command -v graphify >/dev/null 2>&1; then
     echo "Updating Graphify knowledge graph..."
     graphify update . || true
 fi
+
+# graphify-hook-start
+# Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
+# Installed by: graphify hook install
+
+# Deterministic clustering: networkx louvain iterates string-keyed sets whose
+# order is randomized per-process by PYTHONHASHSEED, so community assignments
+# churn run-to-run. Pinning it makes graphify-out reproducible.
+export PYTHONHASHSEED=0
+
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+# Skip during rebase/merge/cherry-pick to avoid blocking --continue with unstaged changes
+# git exports GIT_DIR to hooks; the rev-parse fallback only runs when invoked by
+# hand (each git exec costs 1s+ on AV-scanned Windows machines).
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+[ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
+
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+    exit 0
+fi
+
+CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+# Skip when only graphify-out/ artifacts changed (avoids rebuild loop when graph outputs are tracked in git)
+_NON_GRAPH=$(echo "$CHANGED" | grep -v '^graphify-out/' || true)
+if [ -z "$_NON_GRAPH" ]; then
+    exit 0
+fi
+
+# Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs).
+# _PINNED was recorded at hook-install time; tried first so the hook works even
+# when the graphify launcher is not on PATH (common in GUI clients and CI).
+#
+# Probes check availability with importlib.util.find_spec instead of importing
+# the package: a probe that imports graphify wholesale executes the full package
+# import (10s+ cold on machines with AV-scanned or large site-packages) and used
+# to run up to FOUR times synchronously, stalling every commit before the
+# detached launch even started. find_spec locates the package without executing
+# it, so each probe costs interpreter startup only. The detached rebuild still
+# fails loudly in the log if the package is broken under that interpreter.
+_GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+GRAPHIFY_PYTHON=""
+_PINNED='C:\Users\kokor\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe'
+if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then
+    GRAPHIFY_PYTHON="$_PINNED"
+fi
+# Second probe: read graphify-out/.graphify_python (written by the skill and
+# CLI; survives uv-tool reinstalls and is the same source the README documents).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    if [ -f "$_GFY_PYTHON_FILE" ]; then
+        _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
+        case "$_FROM_FILE" in
+            *[!a-zA-Z0-9/_.@:\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+        esac
+        if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_FROM_FILE"
+        fi
+    fi
+fi
+# Third probe: resolve via the graphify launcher on PATH.
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+    if [ -n "$GRAPHIFY_BIN" ]; then
+        # Windows pip layout: Scripts/graphify(.exe) sits beside ..\python.exe
+        # (or .\python.exe inside a venv's Scripts dir). NOTE: command -v may
+        # return the launcher path WITHOUT the .exe suffix, so this cannot key
+        # on the extension.
+        _GFY_BINDIR=$(dirname "$GRAPHIFY_BIN")
+        if [ -x "$_GFY_BINDIR/../python.exe" ] && "$_GFY_BINDIR/../python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/../python.exe"
+        elif [ -x "$_GFY_BINDIR/python.exe" ] && "$_GFY_BINDIR/python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/python.exe"
+        fi
+    fi
+    if [ -z "$GRAPHIFY_PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
+        # POSIX launcher: parse the shebang. head -c + tr strip NUL bytes first —
+        # when the launcher is a Windows binary reached without its .exe suffix,
+        # a raw `head -1` reads binary into the command substitution and the
+        # shell warns about ignored null bytes on every commit.
+        case "$GRAPHIFY_BIN" in
+            *.exe) _SHEBANG="" ;;
+            *)     _SHEBANG=$(head -c 256 "$GRAPHIFY_BIN" 2>/dev/null | tr -d '\000' | head -n 1 | sed 's/^#![[:space:]]*//') ;;
+        esac
+        case "$_SHEBANG" in
+            */env\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
+            *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
+        esac
+        # Allowlist: only keep characters valid in a filesystem path to prevent
+        # injection if the shebang contains shell metacharacters.
+        case "$GRAPHIFY_PYTHON" in
+            *[!a-zA-Z0-9/_.@:\\-]*) GRAPHIFY_PYTHON="" ;;
+        esac
+        if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON=""
+        fi
+    fi
+fi
+# Last resort: try python3 / python (works for system/venv installs on PATH).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    elif command -v python >/dev/null 2>&1 && python -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python"
+    else
+        echo "[graphify hook] could not locate a Python with graphify installed. Add the graphify bin dir to PATH or re-run 'graphify hook install' from the env where graphify lives." >&2
+        exit 0
+    fi
+fi
+
+export GRAPHIFY_CHANGED="$CHANGED"
+
+# Run the rebuild detached so git commit returns immediately. Full-repo rebuilds
+# can take hours; blocking the post-commit hook stalls the shell. The Python
+# launcher below detaches the child cross-platform, so it works on Git for
+# Windows' shell too (which lacks the coreutils backgrounding tools) (#1161).
+_GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
+echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
+"$GRAPHIFY_PYTHON" -c "import os, subprocess, sys
+_src = '''
+import os, signal, sys, threading
+from pathlib import Path
+
+changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
+changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
+
+if not changed:
+    sys.exit(0)
+
+print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
+
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0:
+        if hasattr(signal, 'SIGALRM'):
+            signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+            signal.alarm(_timeout)
+        else:
+            def _bail():
+                print(f'[graphify hook] graphify rebuild exceeded {_timeout}s', flush=True)
+                os._exit(1)
+            _watchdog = threading.Timer(_timeout, _bail)
+            _watchdog.daemon = True
+            _watchdog.start()
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _root = Path('.')
+    _out = os.environ.get('GRAPHIFY_OUT', 'graphify-out')
+    _saved = Path(_out) / '.graphify_root'
+    if _saved.exists():
+        _txt = _saved.read_text(encoding='utf-8').strip()
+        if _txt:
+            _root = Path(_txt)
+    _rebuild_code(_root, changed_paths=changed, force=_force)
+    # Refresh the work-memory lessons doc when saved Q&A outcomes exist
+    # (best-effort; never fails the hook).
+    try:
+        _md = (_root / _out) / 'memory'
+        if _md.is_dir() and any(_md.glob('*.md')):
+            from graphify.reflect import reflect as _reflect
+            _gj = (_root / _out) / 'graph.json'
+            _reflect(memory_dir=_md, out_path=(_root / _out) / 'reflections' / 'LESSONS.md',
+                     graph_path=_gj if _gj.exists() else None)
+    except Exception:
+        pass
+except TimeoutError as exc:
+    print(f'[graphify hook] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify hook] Rebuild failed: {exc}')
+    sys.exit(1)
+
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or os.path.join(os.path.expanduser('~'), '.cache', 'graphify-rebuild.log')
+try:
+    os.makedirs(os.path.dirname(_log), exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    _flags = 0x08000000 | 0x00000200  # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+    try:
+        subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
+    except OSError:
+        subprocess.Popen(_cmd, creationflags=_flags, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"
+# graphify-hook-end

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -55,6 +55,8 @@ import {
 	LIFESTAGE_TERMS,
 	LOGIN_TERMS,
 	LP_FAQ_TERMS,
+	// #4511: marketplace 5 type 名 atom (tabs の別表記複製を廃止)
+	MARKETPLACE_TYPE_TERMS,
 	MECHANISM_TERMS,
 	NUC_EDITION_TERMS,
 	OSS_LICENSE_TERMS,
@@ -1177,14 +1179,17 @@ export const MARKETPLACE_LABELS = {
 	recommendedSection: `おすすめ${TEMPLATE_TERMS.short}`,
 	importCta: '使ってみる',
 	questsBadge: 'クエスト集',
+	// #4511: 同じ 5 type の名前が MARKETPLACE_TYPE_LABELS / registry displayLabel /
+	//   ここ の 3 箇所に別表記で併存していた (前者 2 つは一致、tabs だけ 4 つ全部ズレ)。
+	//   MARKETPLACE_TYPE_TERMS atom を参照し、文字列の複製を作らない (ADR-0045)。
+	//   旧「持ち物リスト」は実在しない画面名の引用でもあった (子供画面名は icons.ts SSOT)
+	//   が、DESIGN.md §10 の「リソース名に限定語を付けない」に従い type 名は
+	//   「チェックリスト」に揃える (チェックリストは持ち物専用ではない)。
 	tabs: {
-		activities: 'アクティビティ集',
-		rewards: 'ごほうび集',
-		// #4511: 「持ち物リスト」という画面は存在しない (子供画面は年齢帯ごとに
-		//   もちもの / もちものチェック / 持ち物チェック、icons.ts が SSOT)。
-		//   marketplace の type 名としては年齢帯に依らない中立名を使う
-		checklists: 'もちものチェック集',
-		rules: 'ルール集',
+		activities: MARKETPLACE_TYPE_TERMS.activityPack,
+		rewards: MARKETPLACE_TYPE_TERMS.rewardSet,
+		checklists: MARKETPLACE_TYPE_TERMS.checklist,
+		rules: MARKETPLACE_TYPE_TERMS.rulePreset,
 	},
 	detailIncludedActivities: 'ふくまれる活動',
 	detailIncludedRewards: 'ふくまれるごほうび',

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -48,6 +48,7 @@ import {
 	CTA_TERMS,
 	CURRENCY_TERMS,
 	DELETION_GRACE_TERMS,
+	DEMO_SITE_TERMS,
 	FREE_PLAN_TERMS,
 	FREE_TERMS,
 	GRADUATION_TERMS,
@@ -1156,7 +1157,8 @@ export const MARKETPLACE_LABELS = {
 	navShort: TEMPLATE_TERMS.short,
 	pageDescription: 'お子さまの年齢にぴったりの活動・ごほうび・チェックリストを見つけよう',
 	// Round 18 Cluster A (ADR-0045): 活動パック → TEMPLATE_TERMS atom 経由
-	metaDescription: `${TEMPLATE_TERMS.userFacing} — 活動・ごほうび・チェックリスト・特別ルールを探そう。がんばりクエストの公式${TEMPLATE_TERMS.short}集です。`,
+	// #4511: 陳列は #2896 で 3 type (rule-preset はブラウズ不可)。検索流入者に 4 type を訴求しない
+	metaDescription: `${TEMPLATE_TERMS.userFacing} — 活動・ごほうび・チェックリストを探そう。がんばりクエストの公式${TEMPLATE_TERMS.short}集です。`,
 	filterClear: 'フィルタをクリア',
 	emptyState: '条件に合うコンテンツがありません',
 	ctaHeading: `${TEMPLATE_TERMS.short}を使うには`,
@@ -1164,6 +1166,9 @@ export const MARKETPLACE_LABELS = {
 	ctaStart: '無料で はじめる',
 	backToHome: 'トップページへ',
 	backToDemo: 'デモを体験',
+	// #4511: 旧 href="/demo" は legacy redirect → 「/」→ 未認証は /auth/login に落ちる
+	// 死に導線だった (デモは #2181 で demo.ganbari-quest.com へ移設済み)。URL は atom 参照
+	backToDemoHref: DEMO_SITE_TERMS.url,
 	// #2900: 認証済みの親が marketplace を開いた際の header 戻り導線
 	// (AdminLayout の「← 子供画面へ」と同型。ADR-0045 atom 経由で SSOT 統一)
 	backToAdmin: `← ${ADMIN_VIEW_TERMS.short}へ`,
@@ -1175,7 +1180,10 @@ export const MARKETPLACE_LABELS = {
 	tabs: {
 		activities: 'アクティビティ集',
 		rewards: 'ごほうび集',
-		checklists: '持ち物リスト',
+		// #4511: 「持ち物リスト」という画面は存在しない (子供画面は年齢帯ごとに
+		//   もちもの / もちものチェック / 持ち物チェック、icons.ts が SSOT)。
+		//   marketplace の type 名としては年齢帯に依らない中立名を使う
+		checklists: 'もちものチェック集',
 		rules: 'ルール集',
 	},
 	detailIncludedActivities: 'ふくまれる活動',
@@ -1250,7 +1258,7 @@ export const MARKETPLACE_LABELS = {
 	// #2137 (MP-2): event-checklist 一括追加 CTA
 	detailCtaImportChecklist: '一括追加',
 	detailCtaImportChecklistDesc:
-		'お子さまの「持ち物リスト」へまとめて追加します（重複時はスキップ）',
+		'お子さまの「もちものチェック」へまとめて追加します（重複時はスキップ）',
 	detailCtaSignupToImport: 'がんばりクエストに登録して 一括追加',
 	detailChildSelectLabel: 'どのお子さまに追加しますか？',
 	detailImportSuccess: (n: number) => `${n}件のチェック項目を追加しました`,
@@ -1265,9 +1273,11 @@ export const MARKETPLACE_LABELS = {
 		'ご家族の見守り画面の「ルール」セクションに追加されます（取込後 ON/OFF できます）',
 	detailCtaImportRuleDescExchange:
 		'お子さまの「ごほうび」一覧にポイント交換アイテムとして追加されます',
+	// #4511: ADR 番号や no-op は社内語彙。顧客には「今は使えない」という事実だけを伝える
 	detailCtaImportRuleDescPenalty:
-		'⚠️ penalty タイプは ADR-0012 anti-engagement 細則により慎重審査中です。取込試行は警告として記録されます。',
-	detailCtaImportRuleDescSpecial: '⚠️ special タイプは将来枠です。本取込は記録のみで no-op です。',
+		'⚠️ このタイプのルールは現在ご利用いただけません（お子さまへの罰を伴う仕組みは提供しない方針のため）。',
+	detailCtaImportRuleDescSpecial:
+		'⚠️ このタイプのルールは準備中です。追加しても、今はまだ画面には反映されません。',
 	detailRuleImportSuccessBonus: (presetName: string) =>
 		`✨ 「${presetName}」を追加しました。ご家族の見守り画面の「ルール」で ON/OFF できます。`,
 	detailRuleImportSuccessExchange: (presetName: string, count: number) =>

--- a/src/lib/domain/marketplace-item.ts
+++ b/src/lib/domain/marketplace-item.ts
@@ -8,7 +8,7 @@
 import type { CategoryNumericId } from './categories.js';
 import { AGE_TIER_LABELS } from './labels.js';
 import type { ShopCategory } from './shop-category.js';
-import { CONCEPT_ICONS } from './terms.js';
+import { CONCEPT_ICONS, MARKETPLACE_TYPE_TERMS } from './terms.js';
 import type { CategoryCode, GradeLevel } from './validation/activity.js';
 import type { UiMode } from './validation/age-tier-types.js';
 import type { RewardCategory } from './validation/special-reward.js';
@@ -206,12 +206,14 @@ export interface MarketplaceItemMeta {
 // する。「みんなのテンプレート（活動）」(旧) は page title と重複し命名規則も不一致
 // だったため「活動セット」(= 活動の束、ごほうびセットと同型) に是正した。
 // 命名規則は DESIGN.md §6「marketplace type 命名規則」を参照。
+// #4511: 値は MARKETPLACE_TYPE_TERMS atom (terms.ts) を SSOT とする。同じ 5 type 名が
+// MARKETPLACE_LABELS.tabs に別表記で複製されていたため、複製を作れない形に集約した。
 export const MARKETPLACE_TYPE_LABELS: Record<MarketplaceItemType, string> = {
-	'activity-pack': '活動セット',
-	'reward-set': 'ごほうびセット',
-	checklist: 'チェックリスト',
-	'rule-preset': 'とくべつルール',
-	'challenge-set': 'チャレンジ集',
+	'activity-pack': MARKETPLACE_TYPE_TERMS.activityPack,
+	'reward-set': MARKETPLACE_TYPE_TERMS.rewardSet,
+	checklist: MARKETPLACE_TYPE_TERMS.checklist,
+	'rule-preset': MARKETPLACE_TYPE_TERMS.rulePreset,
+	'challenge-set': MARKETPLACE_TYPE_TERMS.challengeSet,
 };
 
 // #2899: 概念アイコンは CONCEPT_ICONS atom (terms.ts) を SSOT とする。

--- a/src/lib/domain/terms.ts
+++ b/src/lib/domain/terms.ts
@@ -1238,3 +1238,22 @@ export const DELETION_GRACE_TERMS = {
 	/** 同上・LP 本文の組版に合わせた半角スペース入り (例: 「30 日」) */
 	premiumSpaced: formatDeletionGracePeriod(DELETION_GRACE_PERIOD_DAYS.family, { spaced: true }),
 } as const;
+
+// ============================================================
+// DEMO_SITE_TERMS — デモ環境の URL atom (#4511)
+// ============================================================
+//
+// デモは #2181 で demo.ganbari-quest.com へ移設した。LP 側の CTA は切り替わったが
+// **marketplace だけ旧 `/demo` のまま**残り、legacy redirect → `/` → 未認証は
+// `/auth/login` という死に導線になっていた (「デモを体験」と表示してログイン画面へ誘導)。
+//
+// URL が複数箇所に literal で散っていると、移設のたびに同じ取りこぼしが起きる。
+// 表示側は必ず本 atom を参照する。
+//
+// **www. canonical を使う理由** (#2261): LP は www. で配信されており、apex 経由だと
+// 301 が挟まって UX が劣化する。デモは demo. サブドメインなのでそのまま。
+
+export const DEMO_SITE_TERMS = {
+	/** デモ環境のトップ (末尾スラッシュ込み) */
+	url: 'https://demo.ganbari-quest.com/',
+} as const;

--- a/src/lib/domain/terms.ts
+++ b/src/lib/domain/terms.ts
@@ -1100,6 +1100,40 @@ export const CONCEPT_ICONS = {
 } as const;
 
 // ============================================================
+// MARKETPLACE_TYPE_TERMS — marketplace 5 type の表示名 atom (#4511)
+// ============================================================
+//
+// 同じ 5 type の名前が 3 箇所に別々の文字列で書かれていた (origin/main 実測):
+//   - MARKETPLACE_TYPE_LABELS (marketplace top の type カード): 活動セット / …
+//   - registry displayLabel   (UnifiedImportHub タブ):          活動セット / …
+//   - MARKETPLACE_LABELS.tabs (marketplace 一覧タブ):           アクティビティ集 /
+//     ごほうび集 / 持ち物リスト / ルール集
+// DESIGN.md §6「marketplace type 命名規則」は上 2 つの一致だけを定めていたため、
+// 3 つ目 (tabs) がその外側でズレ続けていた。値を atom に集約し、複製を作らせない。
+//
+// 値は既存の一致している 2 SSOT (MARKETPLACE_TYPE_LABELS / registry displayLabel) を
+// 採る。DESIGN.md §10「リソース名は単独名詞 (「持ち物」等の限定語を付けない)」に整合
+// する側であり、checklist は持ち物専用ではない (朝の準備 / 帰宅後の手順など) ため、
+// 限定語付きの「持ち物リスト」「もちものチェック集」は採らない。
+//
+// ※ 子供画面の実名称 (もちもの / もちものチェック / 持ち物チェック、icons.ts が SSOT)
+//    とは別物。取込説明文が子供画面名を引用するのは正しく、本 atom の管轄外。
+//
+// ※ 配置が terms.ts である理由: labels.ts ← marketplace-item.ts の import が既にあり
+//    (AGE_TIER_LABELS)、labels.ts から MARKETPLACE_TYPE_LABELS を直接 import すると
+//    循環参照になる (marketplace-item.ts 側は top-level で AGE_TIER_LABELS を評価する
+//    ため、読み込み順によっては TDZ で落ちる)。両者が既に依存している terms.ts に
+//    atom を置き、双方が参照する形にする (ADR-0045 の atom / compound 責務分離)。
+
+export const MARKETPLACE_TYPE_TERMS = {
+	activityPack: '活動セット',
+	rewardSet: 'ごほうびセット',
+	checklist: 'チェックリスト',
+	rulePreset: 'とくべつルール',
+	challengeSet: 'チャレンジ集',
+} as const;
+
+// ============================================================
 // OVERFLOW_MENU_TERMS — admin route 共通 ⋮ menu atom (EPIC #2362 PR-2)
 // ============================================================
 //

--- a/src/routes/marketplace/+page.svelte
+++ b/src/routes/marketplace/+page.svelte
@@ -411,7 +411,10 @@ const hiddenTagsCount = $derived(Math.max(0, totalTags - DEFAULT_TAG_LIMIT));
 					<a href="/" class="text-sm text-[var(--color-action-primary)] hover:underline">
 						{MARKETPLACE_LABELS.backToHome}
 					</a>
-					<a href="/demo" class="text-sm text-[var(--color-action-primary)] hover:underline">
+					<a
+						href={MARKETPLACE_LABELS.backToDemoHref}
+						class="text-sm text-[var(--color-action-primary)] hover:underline"
+					>
 						{MARKETPLACE_LABELS.backToDemo}
 					</a>
 				</div>

--- a/tests/unit/domain/marketplace-claims-4511.test.ts
+++ b/tests/unit/domain/marketplace-claims-4511.test.ts
@@ -18,7 +18,9 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { getModeLabels } from '../../../src/lib/domain/icons';
 import { MARKETPLACE_LABELS } from '../../../src/lib/domain/labels';
+import { MARKETPLACE_TYPE_LABELS } from '../../../src/lib/domain/marketplace-item';
 import { DEMO_SITE_TERMS } from '../../../src/lib/domain/terms';
+import { MARKETPLACE_TYPE_METAS_CLIENT } from '../../../src/lib/marketplace/client-types';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoFile = (p: string) => readFileSync(resolve(__dirname, '../../../', p), 'utf-8');
@@ -68,6 +70,53 @@ describe('#4511 marketplace の導線と説明', () => {
 		it('「使えない / 準備中」という事実は伝えている (説明を消すだけにしない)', () => {
 			expect(MARKETPLACE_LABELS.detailCtaImportRuleDescPenalty).toContain('ご利用いただけません');
 			expect(MARKETPLACE_LABELS.detailCtaImportRuleDescSpecial).toContain('準備中');
+		});
+	});
+
+	describe('type 名の SSOT (finding 4 / PO 決裁)', () => {
+		// 同じ 5 type の名前が 3 箇所に別表記で併存していた:
+		//   MARKETPLACE_TYPE_LABELS / registry displayLabel は一致、MARKETPLACE_LABELS.tabs
+		//   だけが 4 つ全部ズレていた (アクティビティ集 / ごほうび集 / 持ち物リスト / ルール集)。
+		// DESIGN.md §6 は前 2 者の一致しか定めていなかったため、3 つ目が外側でズレ続けた。
+		it('tabs の 4 つが MARKETPLACE_TYPE_LABELS と一致する', () => {
+			expect(MARKETPLACE_LABELS.tabs.activities).toBe(MARKETPLACE_TYPE_LABELS['activity-pack']);
+			expect(MARKETPLACE_LABELS.tabs.rewards).toBe(MARKETPLACE_TYPE_LABELS['reward-set']);
+			expect(MARKETPLACE_LABELS.tabs.checklists).toBe(MARKETPLACE_TYPE_LABELS.checklist);
+			expect(MARKETPLACE_LABELS.tabs.rules).toBe(MARKETPLACE_TYPE_LABELS['rule-preset']);
+		});
+
+		it('tabs / MARKETPLACE_TYPE_LABELS が同じ atom を参照し、文字列を複製しない', () => {
+			// 値の一致だけでは「同じ literal を 2 箇所に書く」状態を許してしまい、片方だけ
+			// 変更されたときにまたズレる。参照そのものを assert して複製の復活を落とす。
+			const labelsSrc = repoFile('src/lib/domain/labels.ts');
+			const tabsBlock = labelsSrc.match(/\ttabs: \{[\s\S]*?\n\t\},/)?.[0] ?? '';
+			expect(tabsBlock, 'tabs ブロックが見つかる').not.toBe('');
+			for (const key of ['activityPack', 'rewardSet', 'checklist', 'rulePreset'] as const) {
+				expect(tabsBlock).toContain(`MARKETPLACE_TYPE_TERMS.${key}`);
+			}
+			expect(tabsBlock, '文字列 literal を書かない').not.toMatch(/: '/);
+
+			const itemSrc = repoFile('src/lib/domain/marketplace-item.ts');
+			const typeLabelsBlock =
+				itemSrc.match(
+					/export const MARKETPLACE_TYPE_LABELS: Record<MarketplaceItemType, string> = \{[\s\S]*?\n\};/,
+				)?.[0] ?? '';
+			expect(typeLabelsBlock, 'MARKETPLACE_TYPE_LABELS ブロックが見つかる').not.toBe('');
+			expect(typeLabelsBlock).toContain('MARKETPLACE_TYPE_TERMS.');
+			expect(typeLabelsBlock, '文字列 literal を書かない').not.toMatch(/: '/);
+		});
+
+		it('registry displayLabel と MARKETPLACE_TYPE_LABELS が一致する (DESIGN.md §6)', () => {
+			for (const meta of MARKETPLACE_TYPE_METAS_CLIENT) {
+				expect(meta.displayLabel).toBe(MARKETPLACE_TYPE_LABELS[meta.typeCode]);
+			}
+		});
+
+		it('type 名に限定語を付けない (DESIGN.md §10 / チェックリストは持ち物専用ではない)', () => {
+			const typeNames = Object.values(MARKETPLACE_TYPE_LABELS).join('\n');
+			for (const narrowing of ['持ち物', 'もちもの']) {
+				expect(typeNames).not.toContain(narrowing);
+			}
 		});
 	});
 

--- a/tests/unit/domain/marketplace-claims-4511.test.ts
+++ b/tests/unit/domain/marketplace-claims-4511.test.ts
@@ -1,0 +1,95 @@
+// tests/unit/domain/marketplace-claims-4511.test.ts (#4511)
+//
+// marketplace（みんなのテンプレート）面の死に導線・説明不整合を機械検出する。
+//
+// # 何が壊れていたか（GAMMA 監査 第2ラウンド）
+//   1. 「デモを体験」CTA が `href="/demo"` — legacy redirect → `/` → 未認証は `/auth/login`。
+//      デモは #2181 で demo.ganbari-quest.com へ移設済みで、LP 側 CTA は切替済みだった。
+//      **marketplace だけ取り残され、「デモを体験」と表示してログイン画面へ誘導**していた
+//   2. meta description が 4 type 訴求 — 陳列は #2896 で 3 type（rule-preset はブラウズ不可）
+//   3. rule-preset 詳細に内部語彙が露出 —「ADR-0012 anti-engagement 細則」「no-op」
+//      （現データでは非到達の休眠分岐だが live コード）
+//   4. checklist 取込説明が実在しない画面名「持ち物リスト」を引用
+//      （実際の子供画面名は icons.ts SSOT の もちもの / もちものチェック / 持ち物チェック）
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { getModeLabels } from '../../../src/lib/domain/icons';
+import { MARKETPLACE_LABELS } from '../../../src/lib/domain/labels';
+import { DEMO_SITE_TERMS } from '../../../src/lib/domain/terms';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoFile = (p: string) => readFileSync(resolve(__dirname, '../../../', p), 'utf-8');
+
+describe('#4511 marketplace の導線と説明', () => {
+	describe('デモ CTA (finding 1)', () => {
+		it('CTA の href が実在するデモ環境を指す (旧 /demo は死に導線)', () => {
+			expect(MARKETPLACE_LABELS.backToDemoHref).toBe(DEMO_SITE_TERMS.url);
+			expect(MARKETPLACE_LABELS.backToDemoHref).toContain('demo.ganbari-quest.com');
+		});
+
+		it('page が href を直書きせず label 経由で参照する (移設のたびの取りこぼしを防ぐ)', () => {
+			const page = repoFile('src/routes/marketplace/+page.svelte');
+			expect(page).toContain('MARKETPLACE_LABELS.backToDemoHref');
+			expect(page, '旧 /demo の直書きが残っていない').not.toMatch(/href="\/demo"/);
+		});
+
+		it('LP 側の CTA と同じ遷移先である (LP だけ切替済みの状態に戻らない)', () => {
+			const lpLabels = repoFile('src/lib/domain/labels.ts');
+			// LP は https://demo.ganbari-quest.com/ を使っている (#2181)
+			expect(lpLabels).toContain(`midHref: '${DEMO_SITE_TERMS.url}'`);
+		});
+	});
+
+	describe('meta description (finding 2)', () => {
+		it('陳列していない type (特別ルール) を訴求しない', () => {
+			expect(MARKETPLACE_LABELS.metaDescription).not.toContain('特別ルール');
+		});
+
+		it('陳列 3 type を訴求している', () => {
+			for (const t of ['活動', 'ごほうび', 'チェックリスト']) {
+				expect(MARKETPLACE_LABELS.metaDescription).toContain(t);
+			}
+		});
+	});
+
+	describe('内部語彙の露出 (finding 3)', () => {
+		it('顧客向けテキストに ADR 番号が出ない', () => {
+			expect(MARKETPLACE_LABELS.detailCtaImportRuleDescPenalty).not.toContain('ADR-');
+			expect(MARKETPLACE_LABELS.detailCtaImportRuleDescPenalty).not.toContain('anti-engagement');
+		});
+
+		it('顧客向けテキストに no-op が出ない', () => {
+			expect(MARKETPLACE_LABELS.detailCtaImportRuleDescSpecial).not.toContain('no-op');
+		});
+
+		it('「使えない / 準備中」という事実は伝えている (説明を消すだけにしない)', () => {
+			expect(MARKETPLACE_LABELS.detailCtaImportRuleDescPenalty).toContain('ご利用いただけません');
+			expect(MARKETPLACE_LABELS.detailCtaImportRuleDescSpecial).toContain('準備中');
+		});
+	});
+
+	describe('画面名の引用 (finding 4)', () => {
+		it('実在しない画面名「持ち物リスト」を引用しない', () => {
+			// namespace は `as const` で値型が literal union になるため、素朴な flatMap では
+			// 型が合わない。文字列化してから 1 本にする。
+			const values: unknown[] = Object.values(MARKETPLACE_LABELS);
+			const all = values
+				.flatMap((v) => (typeof v === 'object' && v !== null ? Object.values(v) : [v]))
+				.filter((v): v is string => typeof v === 'string')
+				.join('\n');
+			expect(all).not.toContain('持ち物リスト');
+		});
+
+		it('引用する画面名が icons.ts の実名称に含まれる', () => {
+			// 子供画面の checklist 名は年齢帯ごとに もちもの / もちものチェック / 持ち物チェック
+			const actualNames = ['baby', 'preschool', 'elementary', 'junior', 'senior'].map(
+				(mode) => getModeLabels(mode).checklist,
+			);
+			expect(actualNames).toContain('もちものチェック');
+			expect(MARKETPLACE_LABELS.detailCtaImportChecklistDesc).toContain('もちものチェック');
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**「デモを体験」を押した人がログイン画面に落ちる状態を止める。** デモは #2181 で `demo.ganbari-quest.com` へ移設済みで LP 側の CTA は切り替わっていましたが、**marketplace だけ旧 `/demo` のまま**残っていました。legacy redirect で `/` に飛び、未認証なら `/auth/login`。**体験したい人にログインを要求する**、最も損な形の死に導線です。

## 関連 Issue

Closes #4511

親 EPIC: #4495（第2ラウンド）/ 関連: #2181（デモ移設）/ #2896（陳列 3 type 化）

## 変更内容

### 1. 死に導線の修正（trust/medium）

```diff
- <a href="/demo" …>デモを体験</a>
+ <a href={MARKETPLACE_LABELS.backToDemoHref} …>デモを体験</a>
```

**URL を atom にしました。** `demo.ganbari-quest.com` は repo 内に **20 箇所** literal で散っており、移設のたびに同じ取りこぼしが起きます（今回まさに marketplace が取り残された）。`terms.ts` に `DEMO_SITE_TERMS.url` を新設し、表示側は必ずそれを参照します。

### 2〜4. 説明不整合

| # | Before | After |
|---|---|---|
| 2 | meta description が**4 type 訴求**（「…チェックリスト・**特別ルール**を探そう」）。陳列は #2896 で 3 type（rule-preset はブラウズ不可）で、検索流入者への訴求と実挙動が食い違い | 「活動・ごほうび・チェックリストを探そう」 |
| 3 | rule-preset 詳細に**内部語彙が露出**: 「**ADR-0012 anti-engagement 細則**により慎重審査中」「本取込は記録のみで **no-op** です」 | 「このタイプのルールは現在ご利用いただけません（お子さまへの罰を伴う仕組みは提供しない方針のため）」/「準備中です。追加しても、今はまだ画面には反映されません」 |
| 4 | checklist 取込説明が**実在しない画面名**「持ち物リスト」を引用 | 子供画面の実名称に統一（`icons.ts` SSOT: もちもの / もちものチェック / 持ち物チェック）。type 名は年齢帯に依らない中立名「もちものチェック集」 |

**#3 は現データ（bonus5 / exchange4）では非到達の休眠分岐ですが、live コードです。** 到達条件が変わった瞬間に顧客へ ADR 番号が出ます。「使えない / 準備中」という事実は残し、社内語彙だけを外しました。

### 4. PO 決裁 Q1 反映 — type 名の 3 通り併存を atom に集約

Q1 は「もちものチェック集 / 持ち物チェック集」の 2 択で出しましたが、**PO 決裁はどちらでもありませんでした**。どちらも DESIGN.md §10 の「リソース名に**限定語を付けない**」に反します（チェックリストは持ち物専用ではない）。

PO 調査で **同じ 5 type に 3 通りの名前が併存**していたことが判明しました。ズレていたのは `MARKETPLACE_LABELS.tabs` の **4 つ全部**で、checklist だけが目立ったのは、他 3 つが「別名だが意味は通る」のに対し**これだけが実在しない画面名を引用していた**ためです。

| key | 変更前 | 変更後 |
|---|---|---|
| activities | アクティビティ集 | **活動セット** |
| rewards | ごほうび集 | **ごほうびセット** |
| checklists | 持ち物リスト | **チェックリスト** |
| rules | ルール集 | **とくべつルール** |

**文字列は複製していません。** ただし `labels.ts` から `MARKETPLACE_TYPE_LABELS` を直接 import すると**循環参照**になります（`marketplace-item.ts` が top-level で `AGE_TIER_LABELS` を評価しており、逆向きの import を足すと読み込み順によって TDZ で `ReferenceError`）。そこで**双方が既に依存している `terms.ts` に atom を置き、両者が参照する**形にしました（ADR-0045 の atom / compound 分離そのもの）。

**取込説明文の「もちものチェック」は変えていません。** あれは子供画面の実名称（`icons.ts` SSOT）の引用で、**type 名とは別物**です（PO 明示）。

test を 4 件追加しました。**値の一致**だけでなく、**両ブロックが atom を参照し文字列 literal を含まないこと**、**registry `displayLabel` との一致**（DESIGN.md §6「2 つの SSOT を一致させる」の機械化）、**type 名に限定語が入ったら落ちる**ことまで assert します。3 つ目のズレが再発しません。

> `src/lib/marketplace/types/*.ts` の `displayLabel` は今も文字列 literal です。**値の一致は上記 test で pin 済**ですが、atom 参照化は本 PR の scope 外（PO 指示は tabs）。#4512 で拾える class として申し送ります。

## 検証

```console
$ npx vitest run tests/unit/domain/marketplace-claims-4511.test.ts
      Tests  10 passed (10)

$ npx vitest run tests/unit/domain/ tests/unit/routes/
      Tests  1911 passed (1911)

$ npx svelte-check --threshold error
svelte-check found 0 errors and 0 warnings

$ npm run cspell
CSpell: Files checked: 1986, Issues found: 0 in 0 files.
```

**実際にサーブして CTA の href を確認**（死に導線の実証と修正の実証）:

```console
$ curl -s <before>/marketplace | grep -o 'href="/demo"'
href="/demo"                          # ← legacy redirect → / → /auth/login

$ curl -s <after>/marketplace | grep -o 'demo.ganbari-quest.com'
demo.ganbari-quest.com                # ← LP と同じ遷移先
```

### 追加した test

| 観点 | 内容 |
|---|---|
| CTA | href が実在するデモを指す / **page が href を直書きせず label 経由**（移設のたびの取りこぼしを防ぐ）/ **LP 側 CTA と同じ遷移先**（LP だけ切替済みの状態に戻らない） |
| meta | 陳列していない type を訴求しない / 陳列 3 type を訴求している |
| 内部語彙 | ADR 番号が出ない / `no-op` が出ない / **「使えない・準備中」の事実は伝えている**（説明を消すだけにしない） |
| 画面名 | 「持ち物リスト」を引用しない / 引用名が `icons.ts` の実名称に含まれる |

### 未実行

- **デモ環境への実遷移は未確認**（`demo.ganbari-quest.com` を実際に開いてはいません）。href が LP と同一の値であることまでを test で担保しています
- E2E は未実行（CI の重量レーンで確認）

## 影響範囲

**顧客に見える変化**

- `/marketplace` の「デモを体験」が**実際にデモへ遷移する**
- 検索結果のスニペット（meta description）から「特別ルール」が消える
- rule-preset 詳細の注意書きから ADR 番号・`no-op` が消える
- checklist の type 名 / 取込説明が子供画面の実名称に揃う

<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4593/before-marketplace.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4593/after-marketplace.png -->

| Before | After |
|---|---|
| ![before-marketplace](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4593/before-marketplace.png) | ![after-marketplace](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4593/after-marketplace.png) |

**画面の見た目はほぼ変わりません**（CTA の文言は同じで、変わるのは href と type タブ名）。**変化の本体は上の `curl` による href の実証**で、DOM でも確認しています:
[after-marketplace.dom.html](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4593/after-marketplace.dom.html)

**触った並行実装ペア**: `terms.ts`（`DEMO_SITE_TERMS` 新設）→ `labels.ts` → `site/shared-labels.js` 再生成（LP fallback に差分なし = LP 側は既に正しい遷移先だったことの裏付け）。

**破壊的変更**: なし。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🟢可逆: 文言と href のみ"]
    R2["顧客面: デモ導線が<br/>実際に機能するようになる"]
    R3["revert で戻る"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 死に導線の解消<br/>URL の 1 箇所化"]
    T2["捨てる: 未認証訪問者を<br/>外部ドメインへ送る"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer)"]
    O1["business: marketplace 訪問者を<br/>登録導線から離脱させうる"]
    O2["UX: タブ名にひらがなが<br/>1 つだけ混ざる"]
    O3["security: URL が本番固定<br/>(環境切替なし)"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["デモを押すとデモが開く<br/>(今はログイン画面)"]
    C2["内部語彙 / 実在しない<br/>画面名が消える"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: タブ名は<br/>もちものチェック集 でよいか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R2,T2,O1,O2,O3 warn
  class R1,R3,T1,C1,C2 ok
  class Q1 ask
```

### ⑤ の 1 問（Yes/No で回答できる形）

- **Q1**: checklist の type タブ名を「持ち物リスト」→「**もちものチェック集**」にしました。子供画面の実名称（`icons.ts` SSOT）に合わせた結果ですが、**兄弟タブは「アクティビティ集 / ごほうび集 / ルール集」で、ひらがな主体が 1 つだけ混ざります**（③ UX の指摘）。marketplace のタブは保護者が読む場所なので「**持ち物チェック集**」（漢字、elementary 以上の実名称）のほうが揃うかもしれません。**どちらでよいか？**

<details>
<summary>補足 (PO は原則読まなくてよい — ③ の全文と対応)</summary>

`tmp/adversarial-evidence/4593.json`（`scripts/verify-adversarial-output.mjs --pr 4593` で schema 検証 PASS）からの転記。

**business（未対応 → 判断材料として提示）**

> marketplace は未認証でも閲覧できるページであり、そこから外部ドメインのデモへ送ると、テンプレートを見に来た訪問者を登録導線から離脱させる可能性がある。（中略）marketplace を見た人を登録に繋げる設計としては最適化されていない。

→ 指摘は成立するが、**現状は「デモを体験」を押すとログイン画面に落ちる**ので、離脱以前に体験自体が不可能。本 PR は「壊れている導線を直す」ところまでで、marketplace → 登録の導線最適化は別の話（同ページには `ctaStart`「無料で はじめる」が既にある）。

**UX（→ Q1 で判断依頼）**

> type タブ名を「持ち物リスト」から「もちものチェック集」に変えたが、兄弟タブは「アクティビティ集」「ごほうび集」「ルール集」であり、ひらがな主体の名称が 1 つだけ混ざる形になった。

→ 妥当。**「実在しない画面名を引用しない」ことが Issue の要求**なので、実名称のどれを選ぶかは残る自由度。Q1 で確認する。

**security（未対応 → 前例として明示）**

> DEMO_SITE_TERMS.url を新設したが、値はハードコードされた本番ドメインであり、環境ごとの切り替え機構を持たない。（中略）他の URL atom を追加するときの前例になる。

→ 事実。ただし**既存の LP 側 CTA（`midHref` 等）も同じく本番 URL 固定**で、本 PR はその値を 1 箇所に集約しただけ（分散した固定値 → 集約された固定値）。環境切替が必要になったときに、atom 1 箇所を関数化すれば済む形になったので、**前例としてはむしろ改善方向**と考える。

</details>


