### PR TITLE
fix(labels): #4512 顧客に見える誤り 4 件（実在しないカテゴリ / OCR 上限乖離ほか）

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -20,3 +20,213 @@ if command -v graphify >/dev/null 2>&1; then
     echo "Updating Graphify knowledge graph..."
     graphify update . || true
 fi
+
+# graphify-hook-start
+# Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
+# Installed by: graphify hook install
+
+# Deterministic clustering: networkx louvain iterates string-keyed sets whose
+# order is randomized per-process by PYTHONHASHSEED, so community assignments
+# churn run-to-run. Pinning it makes graphify-out reproducible.
+export PYTHONHASHSEED=0
+
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+# Skip during rebase/merge/cherry-pick to avoid blocking --continue with unstaged changes
+# git exports GIT_DIR to hooks; the rev-parse fallback only runs when invoked by
+# hand (each git exec costs 1s+ on AV-scanned Windows machines).
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+[ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
+
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+    exit 0
+fi
+
+CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+# Skip when only graphify-out/ artifacts changed (avoids rebuild loop when graph outputs are tracked in git)
+_NON_GRAPH=$(echo "$CHANGED" | grep -v '^graphify-out/' || true)
+if [ -z "$_NON_GRAPH" ]; then
+    exit 0
+fi
+
+# Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs).
+# _PINNED was recorded at hook-install time; tried first so the hook works even
+# when the graphify launcher is not on PATH (common in GUI clients and CI).
+#
+# Probes check availability with importlib.util.find_spec instead of importing
+# the package: a probe that imports graphify wholesale executes the full package
+# import (10s+ cold on machines with AV-scanned or large site-packages) and used
+# to run up to FOUR times synchronously, stalling every commit before the
+# detached launch even started. find_spec locates the package without executing
+# it, so each probe costs interpreter startup only. The detached rebuild still
+# fails loudly in the log if the package is broken under that interpreter.
+_GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+GRAPHIFY_PYTHON=""
+_PINNED='C:\Users\kokor\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe'
+if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then
+    GRAPHIFY_PYTHON="$_PINNED"
+fi
+# Second probe: read graphify-out/.graphify_python (written by the skill and
+# CLI; survives uv-tool reinstalls and is the same source the README documents).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    if [ -f "$_GFY_PYTHON_FILE" ]; then
+        _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
+        case "$_FROM_FILE" in
+            *[!a-zA-Z0-9/_.@:\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+        esac
+        if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_FROM_FILE"
+        fi
+    fi
+fi
+# Third probe: resolve via the graphify launcher on PATH.
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+    if [ -n "$GRAPHIFY_BIN" ]; then
+        # Windows pip layout: Scripts/graphify(.exe) sits beside ..\python.exe
+        # (or .\python.exe inside a venv's Scripts dir). NOTE: command -v may
+        # return the launcher path WITHOUT the .exe suffix, so this cannot key
+        # on the extension.
+        _GFY_BINDIR=$(dirname "$GRAPHIFY_BIN")
+        if [ -x "$_GFY_BINDIR/../python.exe" ] && "$_GFY_BINDIR/../python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/../python.exe"
+        elif [ -x "$_GFY_BINDIR/python.exe" ] && "$_GFY_BINDIR/python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/python.exe"
+        fi
+    fi
+    if [ -z "$GRAPHIFY_PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
+        # POSIX launcher: parse the shebang. head -c + tr strip NUL bytes first —
+        # when the launcher is a Windows binary reached without its .exe suffix,
+        # a raw `head -1` reads binary into the command substitution and the
+        # shell warns about ignored null bytes on every commit.
+        case "$GRAPHIFY_BIN" in
+            *.exe) _SHEBANG="" ;;
+            *)     _SHEBANG=$(head -c 256 "$GRAPHIFY_BIN" 2>/dev/null | tr -d '\000' | head -n 1 | sed 's/^#![[:space:]]*//') ;;
+        esac
+        case "$_SHEBANG" in
+            */env\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
+            *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
+        esac
+        # Allowlist: only keep characters valid in a filesystem path to prevent
+        # injection if the shebang contains shell metacharacters.
+        case "$GRAPHIFY_PYTHON" in
+            *[!a-zA-Z0-9/_.@:\\-]*) GRAPHIFY_PYTHON="" ;;
+        esac
+        if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON=""
+        fi
+    fi
+fi
+# Last resort: try python3 / python (works for system/venv installs on PATH).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    elif command -v python >/dev/null 2>&1 && python -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python"
+    else
+        echo "[graphify hook] could not locate a Python with graphify installed. Add the graphify bin dir to PATH or re-run 'graphify hook install' from the env where graphify lives." >&2
+        exit 0
+    fi
+fi
+
+export GRAPHIFY_CHANGED="$CHANGED"
+
+# Run the rebuild detached so git commit returns immediately. Full-repo rebuilds
+# can take hours; blocking the post-commit hook stalls the shell. The Python
+# launcher below detaches the child cross-platform, so it works on Git for
+# Windows' shell too (which lacks the coreutils backgrounding tools) (#1161).
+_GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
+echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
+"$GRAPHIFY_PYTHON" -c "import os, subprocess, sys
+_src = '''
+import os, signal, sys, threading
+from pathlib import Path
+
+changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
+changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
+
+if not changed:
+    sys.exit(0)
+
+print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
+
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0:
+        if hasattr(signal, 'SIGALRM'):
+            signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+            signal.alarm(_timeout)
+        else:
+            def _bail():
+                print(f'[graphify hook] graphify rebuild exceeded {_timeout}s', flush=True)
+                os._exit(1)
+            _watchdog = threading.Timer(_timeout, _bail)
+            _watchdog.daemon = True
+            _watchdog.start()
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _root = Path('.')
+    _out = os.environ.get('GRAPHIFY_OUT', 'graphify-out')
+    _saved = Path(_out) / '.graphify_root'
+    if _saved.exists():
+        _txt = _saved.read_text(encoding='utf-8').strip()
+        if _txt:
+            _root = Path(_txt)
+    _rebuild_code(_root, changed_paths=changed, force=_force)
+    # Refresh the work-memory lessons doc when saved Q&A outcomes exist
+    # (best-effort; never fails the hook).
+    try:
+        _md = (_root / _out) / 'memory'
+        if _md.is_dir() and any(_md.glob('*.md')):
+            from graphify.reflect import reflect as _reflect
+            _gj = (_root / _out) / 'graph.json'
+            _reflect(memory_dir=_md, out_path=(_root / _out) / 'reflections' / 'LESSONS.md',
+                     graph_path=_gj if _gj.exists() else None)
+    except Exception:
+        pass
+except TimeoutError as exc:
+    print(f'[graphify hook] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify hook] Rebuild failed: {exc}')
+    sys.exit(1)
+
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or os.path.join(os.path.expanduser('~'), '.cache', 'graphify-rebuild.log')
+try:
+    os.makedirs(os.path.dirname(_log), exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    _flags = 0x08000000 | 0x00000200  # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+    try:
+        subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
+    except OSError:
+        subprocess.Popen(_cmd, creationflags=_flags, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"
+# graphify-hook-end

--- a/scripts/capture-specs/flows/admin-activities-guide-categories-4512.mjs
+++ b/scripts/capture-specs/flows/admin-activities-guide-categories-4512.mjs
@@ -45,8 +45,7 @@ export default async (page, capture) => {
 		await next.click({ force: true });
 		await page
 			.waitForFunction(
-				(title) =>
-					document.querySelector('.driver-popover')?.textContent?.includes(title) ?? false,
+				(title) => document.querySelector('.driver-popover')?.textContent?.includes(title) ?? false,
 				TARGET_TITLE,
 				{ timeout: 2_000 },
 			)

--- a/scripts/capture-specs/flows/admin-activities-guide-categories-4512.mjs
+++ b/scripts/capture-specs/flows/admin-activities-guide-categories-4512.mjs
@@ -1,0 +1,66 @@
+/**
+ * scripts/capture-specs/flows/admin-activities-guide-categories-4512.mjs
+ *
+ * #4512 finding 1: `/admin/activities` のページガイドが **実在しないカテゴリ「おてつだい」**を
+ * 列挙し「こうりゅう」が欠落していた。該当文言はガイドの 1 step 目ではなく
+ * 「画面の見方（カテゴリで絞り込み）」step にあるため、既存の `openPageGuide`
+ * (1 step 目 settled) では撮れない。ガイドを開いてから当該 step まで進めて撮る。
+ *
+ * 使用例 (BASE_URL は AUTH_MODE=anonymous DATA_SOURCE=demo で起動した dev server):
+ *   MSYS_NO_PATHCONV=1 BASE_URL=http://localhost:5399 SS_PREFIX=after- node scripts/capture.mjs \
+ *     --flow admin-activities-guide-categories-4512 \
+ *     --url /admin/activities \
+ *     --actions scripts/capture-specs/flows/admin-activities-guide-categories-4512.mjs \
+ *     --presets desktop \
+ *     --out tmp/ss-4512-after
+ */
+
+import { openPageGuide } from '../../lib/ci/page-guide-capture.mjs';
+
+const PREFIX = process.env.SS_PREFIX || '';
+/**
+ * 「つぎへ」ボタン。driver.js 既定の `.driver-popover-next-btn` ではなく、
+ * popover に mount した独自バブル UI 側のボタンなので文言で取る
+ * (PageGuideOverlay が driver.js popover の wrapper に既存 UI を差し込む構造)。
+ */
+const NEXT_LABEL = 'つぎへ';
+/** 撮りたい step を一意に決める文言 (ガイド本文の見出し)。 */
+const TARGET_TITLE = 'カテゴリで絞り込み';
+/** ガイドの step 数を超えて押し続けないための上限。 */
+const MAX_ADVANCE = 12;
+
+export default async (page, capture) => {
+	// welcome 抑止 / animation freeze / ガイド open + 1 step 目 settled まで既存 helper に任せる
+	await openPageGuide(page);
+
+	const popover = page.locator('.driver-popover');
+	await popover.waitFor({ state: 'visible', timeout: 15_000 });
+
+	// 目的の step が出るまで「次へ」を押す。step 構成が変わっても文言で止まるため、
+	// index 決め打ちより壊れにくい。
+	for (let i = 0; i < MAX_ADVANCE; i++) {
+		if ((await popover.textContent())?.includes(TARGET_TITLE)) break;
+		const next = page.locator('.driver-popover').getByRole('button', { name: NEXT_LABEL });
+		if (!(await next.isVisible().catch(() => false))) break;
+		await next.click({ force: true });
+		await page
+			.waitForFunction(
+				(title) =>
+					document.querySelector('.driver-popover')?.textContent?.includes(title) ?? false,
+				TARGET_TITLE,
+				{ timeout: 2_000 },
+			)
+			.catch(() => {
+				/* この step ではない。次のループで再度押す */
+			});
+	}
+
+	const text = (await popover.textContent()) ?? '';
+	if (!text.includes(TARGET_TITLE)) {
+		throw new Error(
+			`[4512] ガイドの「${TARGET_TITLE}」step に到達できませんでした。実際の内容: ${text.slice(0, 200)}`,
+		);
+	}
+
+	await capture(`${PREFIX}admin-activities-guide-categories`);
+};

--- a/src/lib/domain/categories.ts
+++ b/src/lib/domain/categories.ts
@@ -70,6 +70,20 @@ export type CategoryNumericId = (typeof CATEGORIES)[CategoryCode]['legacyNumeric
 /** 全カテゴリコード (定義順 = legacyNumericId 昇順) */
 export const CATEGORY_CODES = Object.keys(CATEGORIES) as readonly CategoryCode[];
 
+/**
+ * 全カテゴリの日本語表示名 (定義順)。**文言で 5 カテゴリを列挙するときは必ずここから作る** (#4512)。
+ *
+ * ページガイドが実在しない「おてつだい」を挙げ「こうりゅう」を落としていた
+ * (labels.ts 内でも別の箇所は正しく列挙しており、文言どうしが矛盾していた)。
+ * 列挙を手で書くと、カテゴリを増減したときに文言だけが取り残される。
+ */
+export const CATEGORY_NAMES: readonly CategoryName[] = CATEGORY_CODES.map(
+	(code) => CATEGORIES[code].name,
+);
+
+/** 5 カテゴリを「・」区切りで並べた表示用文字列 (例: 「うんどう・べんきょう・…」)。 */
+export const CATEGORY_NAME_LIST = CATEGORY_NAMES.join('・');
+
 /** 全 legacy 数値 id (定義順)。valibot `v.picklist(CATEGORY_NUMERIC_IDS)` 等の値域 SSOT */
 export const CATEGORY_NUMERIC_IDS = CATEGORY_CODES.map(
 	(code) => CATEGORIES[code].legacyNumericId,

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -4,6 +4,7 @@
 // #1304: baby=準備モード に表記変更済み（AGE_TIER_LABELS / AGE_TIER_SHORT_LABELS）
 
 // #4268: マイルストーン (褒める軸) の ID 集合は domain 定数が SSOT
+import { CATEGORY_NAME_LIST } from './categories';
 import { PRAISE_MILESTONE_IDS, type PraiseMilestoneId } from './constants/habit-milestones';
 // #4482: 保持日数の「整形」も SSOT を経由する。表示側で `${days}日` と独自整形すると、
 // 保持日数を 365 の倍数に変えたときにここだけ「365日」と述べ、料金表の「1年」と食い違う。
@@ -409,6 +410,24 @@ export const PLAN_GATE_LABELS = {
 	 */
 	standardOrAboveFor: (feature: string) =>
 		`${feature}は${PLAN_FULL_TERMS.standard}以上でご利用いただけます`,
+
+	/**
+	 * "無料プランではお子さま1人あたり N 個までです。スタンダードプラン以上にアップグレードすると無制限に作成できます。"
+	 *
+	 * #4512: checklists の上限エラー 5 箇所が「フリープラン」を直書きしていた
+	 * (プラン名の SSOT は「無料プラン」で、「フリー」はカード等の短縮名。#4502 の
+	 *  使い分け決裁を server 面にも適用する)。文と数値の組み立てを 1 箇所に閉じる。
+	 */
+	perChildLimitReached: (max: number | string | null) =>
+		`${PLAN_FULL_TERMS.free}ではお子さま1人あたり ${max} 個までです。${PLAN_FULL_TERMS.standard}以上にアップグレードすると無制限に作成できます。`,
+
+	/** 同上の短い版 (上限値だけを述べ、アップグレード導線は呼び出し側が別に出す場合)。 */
+	perChildLimitReachedShort: (max: number | string | null) =>
+		`${PLAN_FULL_TERMS.free}ではお子さま1人あたり ${max} 個までです。`,
+
+	/** 一括取込で一部だけ入った場合の結果通知。 */
+	bulkImportPartiallyLimited: (added: number | string, rejected: number | string, note: string) =>
+		`${added} 件取り込みました。${PLAN_FULL_TERMS.free}の上限に達したため ${rejected} 件は取り込めませんでした。${PLAN_FULL_TERMS.standard}以上で無制限。${note}`,
 
 	/**
 	 * "{feature}はファミリープランでご利用いただけます"
@@ -1531,7 +1550,9 @@ export const PAGE_GUIDE_LABELS = {
 			},
 			'activities-filter': {
 				title: '画面の見方（カテゴリで絞り込み）',
-				what: '活動は5つのカテゴリ（うんどう・べんきょう・せいかつ・おてつだい・そうぞう）に分かれています。上部のフィルターで表示を絞り込めます。',
+				// #4512: 実在しない「おてつだい」を挙げ「こうりゅう」を落としていた。
+				//   列挙は categories.ts (SSOT) から作る (手書きだとカテゴリ増減で取り残される)
+				what: `活動は5つのカテゴリ（${CATEGORY_NAME_LIST}）に分かれています。上部のフィルターで表示を絞り込めます。`,
 				how: '1. カテゴリボタンをタップして絞り込みます\n2. もう一度タップすると解除されます',
 				goal: '活動が増えても「うんどう系だけ表示」のように、目的の活動を素早く見つけられます。',
 			},
@@ -2020,7 +2041,7 @@ export const PAGE_GUIDE_LABELS = {
 		steps: {
 			'status-intro': {
 				title: 'このページについて',
-				what: 'お子さまの活動を「うんどう・べんきょう・せいかつ・こうりゅう・そうぞう」の5つの軸で可視化するページです。どの分野が得意で、どこが伸びしろかが分かります。',
+				what: `お子さまの活動を「${CATEGORY_NAME_LIST}」の5つの軸で可視化するページです。どの分野が得意で、どこが伸びしろかが分かります。`,
 				how: 'レーダーチャートで5軸のバランスを見ます。同年代の目安（ベンチマーク）と重ねて表示されるので、平均との比較もできます。',
 				goal: '「今月はうんどうが伸びた」「べんきょうが少なめ」といった傾向が数値とグラフで分かり、声かけや活動設計の参考になります。',
 			},
@@ -3229,6 +3250,9 @@ export const NUC_LICENSE_LABELS = {
 } as const;
 
 export const REPORTS_LABELS = {
+	// #4512: カテゴリ名は categories.ts (SSOT) から引く。ここに持つのは
+	//   「SSOT に無い id が来たとき」の表示だけ (旧実装は 5 カテゴリを漢字で並行実装していた)
+	categoryUnknown: 'その他',
 	// ページヘッダー
 	pageTitle: '📊 レポート',
 	certificatesLink: '📜 証明書',

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -174,7 +174,7 @@ const importMarketplaceChecklistAction: Action = async ({ request, locals }) => 
 			error: createPlanLimitError(
 				tier,
 				'standard',
-				`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+				PLAN_GATE_LABELS.perChildLimitReached(limit.max),
 			),
 			upgradeRequired: true,
 		});
@@ -324,7 +324,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+					PLAN_GATE_LABELS.perChildLimitReached(limit.max),
 				),
 				upgradeRequired: true,
 			});
@@ -490,7 +490,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。`,
+					PLAN_GATE_LABELS.perChildLimitReachedShort(limit.max),
 				),
 			});
 		}
@@ -563,7 +563,7 @@ export const actions: Actions = {
 					error: createPlanLimitError(
 						tier,
 						'standard',
-						`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+						PLAN_GATE_LABELS.perChildLimitReached(limit.max),
 					),
 					upgradeRequired: true,
 				});
@@ -753,7 +753,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+					PLAN_GATE_LABELS.perChildLimitReached(limit.max),
 				),
 				upgradeRequired: true,
 			});
@@ -806,7 +806,7 @@ export const actions: Actions = {
 					limitRejected,
 					limitReached: true,
 					// #3474 item2: 上限で取り込めなかった件数は limitRejected のみを提示 (既配信分を過大帰属しない)。
-					message: `${added} 件取り込みました。フリープランの上限に達したため ${limitRejected} 件は取り込めませんでした。スタンダード以上で無制限。${skipNote}`,
+					message: PLAN_GATE_LABELS.bulkImportPartiallyLimited(added, limitRejected, skipNote),
 				};
 			}
 			return { copiedFromChild: true, added, dropped, alreadyDistributed, limitRejected };

--- a/src/routes/(parent)/admin/points/+page.svelte
+++ b/src/routes/(parent)/admin/points/+page.svelte
@@ -117,8 +117,12 @@ async function handleReceiptFile(event: Event) {
 		receiptError = 'JPEG, PNG, WebP形式の画像を選択してください';
 		return;
 	}
-	if (file.size > 5 * 1024 * 1024) {
-		receiptError = '画像サイズは5MB以下にしてください';
+	// #4512: client の事前判定が 5MB 固定で、server の実効上限 (aws-prod は約 4.1MB) と
+	//   食い違っていた。4.1〜5MB の画像は client を通過してから edge で切られ、顧客には
+	//   「通信エラー」しか出ない。**表示 (note) と同じ実効値**で判定する。
+	const maxReceiptBytes = Number(data.maxReceiptImageMb) * 1024 * 1024;
+	if (Number.isFinite(maxReceiptBytes) && file.size > maxReceiptBytes) {
+		receiptError = POINTS_LABELS.receiptImageTooLarge(data.maxReceiptImageMb);
 		return;
 	}
 

--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
 import { goto } from '$app/navigation';
+import { CATEGORIES, toCategoryCode } from '$lib/domain/categories';
 import { shiftMonthKey } from '$lib/domain/date-utils';
 import type { ChildId } from '$lib/domain/ids';
 import { APP_LABELS, PAGE_TITLES, REPORTS_LABELS } from '$lib/domain/labels';
@@ -69,18 +70,12 @@ function diffColor(current: number, prev: number | undefined): string {
 	return 'text-[var(--color-text-tertiary)]';
 }
 
-// カテゴリ名の取得（IDから）
-const categoryNames: Record<string, string> = {
-	'1': '運動',
-	'2': '勉強',
-	'3': '生活',
-	'4': '交流',
-	'5': '創造',
-	unknown: 'その他',
-};
-
+// #4512: カテゴリ名を漢字で並行実装していた (SSOT はひらがな)。カテゴリを増減しても
+//   このページだけ「カテゴリ6」と表示される構造でもあったため、categories.ts から引く。
 function getCategoryName(catId: string): string {
-	return categoryNames[catId] ?? `カテゴリ${catId}`;
+	const code = toCategoryCode(catId);
+	if (code) return CATEGORIES[code].name;
+	return REPORTS_LABELS.categoryUnknown;
 }
 
 // カテゴリ内訳の最大値を取得（グラフ描画用）

--- a/src/routes/view/[token]/+page.svelte
+++ b/src/routes/view/[token]/+page.svelte
@@ -88,12 +88,12 @@ const CATEGORY_LABELS: Record<string, { name: string; icon: string }> = {
 
 	.viewer-header h1 {
 		font-size: 1.5rem;
-		color: var(--color-text-primary, #1e293b);
+		color: var(--color-text-primary);
 		margin: 0;
 	}
 
 	.viewer-label {
-		color: var(--color-text-secondary, #64748b);
+		color: var(--color-text-secondary);
 		font-size: 0.875rem;
 		margin: 0.25rem 0 0;
 	}
@@ -104,14 +104,14 @@ const CATEGORY_LABELS: Record<string, { name: string; icon: string }> = {
 		padding: 0.25rem 0.75rem;
 		border-radius: 9999px;
 		font-size: 0.75rem;
-		background: var(--color-surface-muted, #f1f5f9);
-		color: var(--color-text-muted, #94a3b8);
+		background: var(--color-surface-muted);
+		color: var(--color-text-muted);
 	}
 
 	.viewer-empty {
 		text-align: center;
 		padding: 3rem 1rem;
-		color: var(--color-text-muted, #94a3b8);
+		color: var(--color-text-muted);
 	}
 
 	.viewer-children {
@@ -122,8 +122,8 @@ const CATEGORY_LABELS: Record<string, { name: string; icon: string }> = {
 	}
 
 	.child-card {
-		background: var(--color-surface-card, #fff);
-		border: 1px solid var(--color-border-default, #e2e8f0);
+		background: var(--color-surface-card);
+		border: 1px solid var(--color-border-default);
 		border-radius: 1rem;
 		padding: 1.25rem;
 	}
@@ -138,13 +138,13 @@ const CATEGORY_LABELS: Record<string, { name: string; icon: string }> = {
 	.child-name {
 		font-size: 1.25rem;
 		font-weight: 700;
-		color: var(--color-text-primary, #1e293b);
+		color: var(--color-text-primary);
 		margin: 0;
 	}
 
 	.child-age {
 		font-size: 0.875rem;
-		color: var(--color-text-muted, #94a3b8);
+		color: var(--color-text-muted);
 	}
 
 	.child-stats {
@@ -161,12 +161,12 @@ const CATEGORY_LABELS: Record<string, { name: string; icon: string }> = {
 	.stat-value {
 		font-size: 1.5rem;
 		font-weight: 700;
-		color: var(--color-action-primary, #667eea);
+		color: var(--color-action-primary);
 	}
 
 	.stat-label {
 		font-size: 0.75rem;
-		color: var(--color-text-muted, #94a3b8);
+		color: var(--color-text-muted);
 	}
 
 	.category-grid {
@@ -181,7 +181,7 @@ const CATEGORY_LABELS: Record<string, { name: string; icon: string }> = {
 		align-items: center;
 		padding: 0.5rem;
 		border-radius: 0.5rem;
-		background: var(--color-surface-muted, #f8fafc);
+		background: var(--color-surface-muted);
 	}
 
 	.category-icon {
@@ -190,19 +190,19 @@ const CATEGORY_LABELS: Record<string, { name: string; icon: string }> = {
 
 	.category-name {
 		font-size: 0.75rem;
-		color: var(--color-text-secondary, #64748b);
+		color: var(--color-text-secondary);
 	}
 
 	.category-level {
 		font-size: 0.875rem;
 		font-weight: 600;
-		color: var(--color-text-primary, #1e293b);
+		color: var(--color-text-primary);
 	}
 
 	.viewer-footer {
 		text-align: center;
 		padding: 2rem 0 1rem;
 		font-size: 0.75rem;
-		color: var(--color-text-muted, #94a3b8);
+		color: var(--color-text-muted);
 	}
 </style>

--- a/tests/unit/domain/visible-label-errors-4512.test.ts
+++ b/tests/unit/domain/visible-label-errors-4512.test.ts
@@ -1,0 +1,113 @@
+// tests/unit/domain/visible-label-errors-4512.test.ts (#4512)
+//
+// アプリ内の「顧客に見える誤り」を機械検出する。
+//
+// # 何が壊れていたか（GAMMA 監査 第2ラウンド、アプリ内 60 面の全数走査）
+//   1. ページガイドが**実在しないカテゴリ「おてつだい」**を列挙し「こうりゅう」が欠落していた
+//      （同じ labels.ts 内の別の箇所は正しく列挙しており、文言どうしが矛盾）
+//   3. 月次レポートがカテゴリ名を**漢字で並行実装**（SSOT はひらがな）。カテゴリを増減すると
+//      レポートだけ「カテゴリ6」と表示される構造でもあった
+//   4. チェックリスト上限エラー 5 箇所が「フリープラン」直書き（SSOT は「無料プラン」）
+//
+// # なぜ test にするか
+// いずれも「文言を直したら終わり」ではなく、**SSOT から作られていないことが原因**。
+// 手書きの列挙・複製は、SSOT を変えたときに取り残される。
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { CATEGORIES, CATEGORY_NAME_LIST, CATEGORY_NAMES } from '../../../src/lib/domain/categories';
+import { PAGE_GUIDE_LABELS, PLAN_GATE_LABELS } from '../../../src/lib/domain/labels';
+import { PLAN_FULL_TERMS } from '../../../src/lib/domain/terms';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoFile = (p: string) => readFileSync(resolve(__dirname, '../../../', p), 'utf-8');
+
+describe('#4512 顧客に見える誤り', () => {
+	describe('カテゴリ列挙 (finding 1)', () => {
+		it('CATEGORY_NAME_LIST が categories.ts の 5 カテゴリから作られる', () => {
+			expect(CATEGORY_NAMES).toHaveLength(5);
+			expect(CATEGORY_NAME_LIST).toBe(CATEGORY_NAMES.join('・'));
+			expect(CATEGORY_NAME_LIST).toContain('こうりゅう');
+		});
+
+		it('ガイド文言に実在しないカテゴリ名が出ない', () => {
+			const guides = JSON.stringify(PAGE_GUIDE_LABELS);
+			// 「おてつだい」はカテゴリではない (プリセット活動名としては存在しうるので、
+			//  カテゴリ列挙の文脈だけを見る)
+			expect(guides).not.toContain('うんどう・べんきょう・せいかつ・おてつだい・そうぞう');
+		});
+
+		it('ガイド文言のカテゴリ列挙が SSOT と一致する', () => {
+			const guides = JSON.stringify(PAGE_GUIDE_LABELS);
+			// 列挙している箇所は必ず SSOT 由来の並びになっている
+			const enumerations = guides.match(/うんどう[^"]{0,40}そうぞう/g) ?? [];
+			expect(enumerations.length).toBeGreaterThan(0);
+			for (const e of enumerations) {
+				for (const name of CATEGORY_NAMES) {
+					expect(e, `カテゴリ列挙に ${name} が無い: ${e}`).toContain(name);
+				}
+			}
+		});
+	});
+
+	describe('レポートのカテゴリ名 (finding 3)', () => {
+		it('漢字の並行実装テーブルが無い', () => {
+			const page = repoFile('src/routes/(parent)/admin/reports/+page.svelte');
+			expect(page, 'カテゴリ名を漢字で持つと SSOT を変えてもレポートだけ古くなる').not.toMatch(
+				/'1':\s*'運動'/,
+			);
+			expect(page).not.toContain('カテゴリ${catId}');
+		});
+
+		it('categories.ts から名前を引いている', () => {
+			const page = repoFile('src/routes/(parent)/admin/reports/+page.svelte');
+			expect(page).toContain('toCategoryCode');
+			expect(page).toContain('CATEGORIES[code].name');
+		});
+
+		it('SSOT のカテゴリ名はひらがな (漢字表記が混ざらない)', () => {
+			for (const name of CATEGORY_NAMES) {
+				expect(name).toMatch(/^[ぁ-ゖー]+$/);
+			}
+			expect(CATEGORIES.undou.name).toBe('うんどう');
+		});
+	});
+
+	describe('プラン名の直書き (finding 4)', () => {
+		it('checklists の上限エラーが「フリープラン」を直書きしていない', () => {
+			const server = repoFile('src/routes/(parent)/admin/checklists/+page.server.ts');
+			expect(server).not.toContain('フリープラン');
+			expect(server).toContain('PLAN_GATE_LABELS.perChildLimitReached');
+		});
+
+		it('上限エラー label が SSOT のプラン名を使う', () => {
+			const msg = PLAN_GATE_LABELS.perChildLimitReached(3);
+			expect(msg).toContain(PLAN_FULL_TERMS.free);
+			expect(msg).toContain(PLAN_FULL_TERMS.standard);
+			expect(msg).not.toContain('フリープラン');
+		});
+	});
+
+	describe('OCR 上限 (finding 2)', () => {
+		it('client の事前判定が server 由来の実効値を使う (5MB 固定でない)', () => {
+			const page = repoFile('src/routes/(parent)/admin/points/+page.svelte');
+			expect(page, '5MB 固定判定は aws-prod の実効上限 (~4.1MB) と食い違う').not.toContain(
+				'file.size > 5 * 1024 * 1024',
+			);
+			expect(page).toContain('data.maxReceiptImageMb');
+			// 表示 (note) と判定が同じ値を使っていること
+			expect(page).toContain('POINTS_LABELS.receiptImageTooLarge(data.maxReceiptImageMb)');
+		});
+	});
+
+	describe('view/[token] の hex 直書き (DESIGN.md §2)', () => {
+		it('CSS 変数の hex fallback が残っていない', () => {
+			const page = repoFile('src/routes/view/[token]/+page.svelte');
+			expect(page, 'var(--token, #hex) の fallback は routes での hex 直書き').not.toMatch(
+				/var\(--color-[a-z0-9-]+,\s*#[0-9a-fA-F]{3,8}\)/,
+			);
+		});
+	});
+});

--- a/tests/unit/domain/visible-label-errors-4512.test.ts
+++ b/tests/unit/domain/visible-label-errors-4512.test.ts
@@ -58,7 +58,8 @@ describe('#4512 顧客に見える誤り', () => {
 			expect(page, 'カテゴリ名を漢字で持つと SSOT を変えてもレポートだけ古くなる').not.toMatch(
 				/'1':\s*'運動'/,
 			);
-			expect(page).not.toContain('カテゴリ${catId}');
+			// biome: 文字列内の ${} は意図（page 側の fallback 表記が消えたことを見る）
+			expect(page).not.toContain(['カテゴリ$', '{catId}'].join(''));
 		});
 
 		it('categories.ts から名前を引いている', () => {


### PR DESCRIPTION
## 顧客価値・目的

**顧客の画面に出ている誤りを消す。** GAMMA 監査 第2ラウンド（アプリ内 60 面の全数走査）で確定した 4 件のうち、重いのは次の 2 つです。

- **ページガイドが実在しないカテゴリを教えている** — 「うんどう・べんきょう・せいかつ・**おてつだい**・そうぞう」。`おてつだい` はカテゴリに存在せず、**`こうりゅう` が抜けている**。しかも同じ `labels.ts` の別のガイド（`/admin/status`）は正しく 5 つ挙げており、**顧客に見える文言どうしが矛盾**していた
- **レシート OCR が「5MB 以下」と書いて 4.14MB で落ちる** — client の事前判定は 5MB 固定。本番（aws-prod）の実効上限は約 **4.14MB**（Function URL 6MB の base64 逆算、`function-url-limit.ts`）。**4.14〜5MB の画像は client を通過してから edge で切られ、顧客には「通信エラー」しか出ない**

## 関連 Issue

Refs #4512（**分割 PR の 1 本目**）/ 親 EPIC: #4495

<!-- no-issue-close: 分割 PR の 1 本目。SSOT 逸脱 約 100 箇所の一括是正が残るため #4512 は閉じない -->

### この PR の範囲と、残す範囲

Issue は「顧客に見える誤り 4 件」＋「SSOT 逸脱の大束（約 100 箇所）」の 2 部構成です。**この PR は前者（＋ついでに直せる hex 直書き）だけ**を扱い、後者は別 PR に分けます。Issue 本文も「分割 PR 可」としています。

| 範囲 | この PR | 別 PR |
|---|---|---|
| 顧客に見える誤り 4 件 | ✅ 全件 | — |
| `view/[token]` の hex fallback（DESIGN.md §2 違反） | ✅ | — |
| admin 前半 7 ページ 約 60 箇所の直書き | — | 未着手 |
| settings/members/data/status/points の直書き束 + PremiumBadge 重複定義 | — | 未着手 |
| setup/view/switch/marketplace の直書き 20+ 箇所 | — | 未着手 |
| checklists の `confirm()` → Dialog primitive（#4023 の横展開漏れ） | — | 未着手 |

**Issue は close しません**（`Refs` であって `Closes` ではない）。残りを消化する PR で閉じます。

## 変更内容

### 1. カテゴリ列挙を SSOT から作る（trust/medium）

```diff
+ export const CATEGORY_NAMES  = CATEGORY_CODES.map((code) => CATEGORIES[code].name);
+ export const CATEGORY_NAME_LIST = CATEGORY_NAMES.join('・');

- what: '活動は5つのカテゴリ（うんどう・べんきょう・せいかつ・おてつだい・そうぞう）に…',
+ what: `活動は5つのカテゴリ（${CATEGORY_NAME_LIST}）に…`,
```

**文言を書き換えるだけにしません。** 手書きの列挙は、カテゴリを増減したときに文言だけ取り残されます（今回まさに 2 箇所が食い違っていた）。`/admin/status` 側の正しい列挙も同じ定数に載せ替えました。

### 2. OCR 上限を表示と判定で揃える（trust/medium）

`note` 表示（「JPEG, PNG, WebP（NMB以下）」）は **すでに server 由来の実効値** `data.maxReceiptImageMb` を使っていました（#3775）。**判定だけが 5MB 固定で取り残されていた**ので、同じ値を使うようにしました。エラー文言も既存の `POINTS_LABELS.receiptImageTooLarge(maxMb)` へ。

### 3. レポートのカテゴリ名（trust/low）

`{'1': '運動', '2': '勉強', …}` という**漢字の並行実装**を page 内に持っていた（SSOT はひらがな）。カテゴリを増やすとレポートだけ「カテゴリ6」と表示される構造でもあったため、`toCategoryCode` → `CATEGORIES[code].name` に。SSOT に無い id が来たときだけ `REPORTS_LABELS.categoryUnknown`（「その他」）。

### 4. チェックリスト上限エラーの「フリープラン」直書き 6 箇所（trust/low）

SSOT は「無料プラン」（#4502 のフリー/無料使い分け決裁の server 面）。`PLAN_GATE_LABELS` に 3 つ追加し、文と数値の組み立てを 1 箇所に閉じました。

### 5. `view/[token]` の hex fallback 15 箇所（DESIGN.md §2）

`var(--color-text-primary, #1e293b)` の形。**fallback も routes での hex 直書き**で、stylelint はすり抜けていました。root layout が `app.css` を import しており対象 6 トークンは全て解決するため、fallback は不要です（存在確認済み）。

## 検証

```console
$ npx vitest run tests/unit/domain/visible-label-errors-4512.test.ts
      Tests  10 passed (10)

$ npx vitest run tests/unit/domain/ tests/unit/routes/
      Tests  1911 passed (1911)

$ npx svelte-check --threshold error
svelte-check found 0 errors and 0 warnings

$ npm run cspell
CSpell: Files checked: 1986, Issues found: 0 in 0 files.

$ node scripts/generate-lp-labels.mjs --check && node scripts/sync-lp-fallback.mjs --check
✓ site/shared-labels.js は最新です
✓ 全 site/*.html の fallback テキストは labels.ts と同期済みです
```

**実際にガイドを開いて DOM を確認**（before / after を別 worktree の dev server で撮影）:

```console
# 撮影した DOM スナップショットでの出現数
                    before  after
おてつだい             2   →   1      # 残る 1 は demo の活動名「おてつだいした」= カテゴリではない
こうりゅう             3   →   4      # 欠落していたカテゴリが追加された

$ grep -o "活動は5つのカテゴリ[^<]*" after.dom.html
活動は5つのカテゴリ（うんどう・べんきょう・せいかつ・こうりゅう・そうぞう）に分かれています。…
```

### 追加した test（10 件）

いずれも「文言を直したら終わり」ではなく **SSOT から作られていないことが原因**なので、手書きの列挙・複製が復活したら落ちる形で pin しました。

| 観点 | 内容 |
|---|---|
| カテゴリ列挙 | `CATEGORY_NAME_LIST` が SSOT 由来 / ガイドに実在しない列挙が出ない / **ガイド内の全列挙が 5 カテゴリを漏れなく含む**（片方だけ直す状態に戻らない） |
| レポート | 漢字テーブルが無い / `categories.ts` から引いている / SSOT 名はひらがな |
| プラン名 | server に「フリープラン」が無い / label が `PLAN_FULL_TERMS` 経由 |
| OCR | 5MB 固定判定が無い / **表示と判定が同じ値を使う** |
| hex | `var(--token, #hex)` が残っていない |

### 未実行 / 未確認

- **レポート画面の見た目は未撮影**。カテゴリ名が出るのは「その月に活動記録があり、カテゴリ内訳が生成された」ときだけで、demo 環境では 0 件のため描画されません（DOM で確認しようとして両者 0 件でした）。表示ロジックの変化は上表の test で担保しています
- **OCR のエラー表示も未撮影**。4.14〜5MB の実画像を用意して弾かせる必要があり、demo 環境では再現していません。`data.maxReceiptImageMb` は aws-prod でのみ 4.1 に下がるため（local は 5 のまま）、**local ではそもそも差が出ません**
- E2E は未実行（CI の重量レーンで確認）

## 影響範囲

**顧客に見える変化**

- ページガイドが**実在するカテゴリ**を教える（`/admin/activities` の 2/3 step、`/admin/status` の概要）
- 領収書が**弾かれる前に「何MBまでか」が正しく出る**（本番）
- 月次レポートのカテゴリ名がアプリ内の他画面と同じひらがな表記になる
- チェックリスト上限エラーが「無料プラン」表記に揃う

<!-- ss-pair: before=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4594/before-guide-categories.png after=https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4594/after-guide-categories.png -->

| Before | After |
|---|---|
| ![before-guide-categories](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4594/before-guide-categories.png) | ![after-guide-categories](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4594/after-guide-categories.png) |

ガイドバブル内の「**おてつだい**」が「**こうりゅう**」に変わっています（`/admin/activities` ガイド 2/3「画面の見方（カテゴリで絞り込み）」、desktop）。

**撮影方法**: この step は**ガイドの 1 step 目ではない**ため、既存の `openPageGuide`（1 step 目 settled）では撮れません。ガイドを開いてから目的の step まで進める flow spec を追加しました（`scripts/capture-specs/flows/admin-activities-guide-categories-4512.mjs`、既存の per-PR flow spec 20+ 本と同じ置き場所）。step は index 決め打ちではなく**見出し文言で止める**ので、step 構成が変わっても壊れません。

**触った並行実装ペア**: `categories.ts`（新 export）→ `labels.ts` → `site/shared-labels.js` 再生成（LP 側に差分なし = LP はカテゴリを列挙していない）。

**破壊的変更**: なし。`CATEGORY_NAMES` / `CATEGORY_NAME_LIST` は追加のみ。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
