### PR TITLE
fix(admin): #4524 退会の同意チェックが有料プランの猶予と矛盾する

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -20,3 +20,213 @@ if command -v graphify >/dev/null 2>&1; then
     echo "Updating Graphify knowledge graph..."
     graphify update . || true
 fi
+
+# graphify-hook-start
+# Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
+# Installed by: graphify hook install
+
+# Deterministic clustering: networkx louvain iterates string-keyed sets whose
+# order is randomized per-process by PYTHONHASHSEED, so community assignments
+# churn run-to-run. Pinning it makes graphify-out reproducible.
+export PYTHONHASHSEED=0
+
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+# Skip during rebase/merge/cherry-pick to avoid blocking --continue with unstaged changes
+# git exports GIT_DIR to hooks; the rev-parse fallback only runs when invoked by
+# hand (each git exec costs 1s+ on AV-scanned Windows machines).
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+[ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
+
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+    exit 0
+fi
+
+CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+# Skip when only graphify-out/ artifacts changed (avoids rebuild loop when graph outputs are tracked in git)
+_NON_GRAPH=$(echo "$CHANGED" | grep -v '^graphify-out/' || true)
+if [ -z "$_NON_GRAPH" ]; then
+    exit 0
+fi
+
+# Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs).
+# _PINNED was recorded at hook-install time; tried first so the hook works even
+# when the graphify launcher is not on PATH (common in GUI clients and CI).
+#
+# Probes check availability with importlib.util.find_spec instead of importing
+# the package: a probe that imports graphify wholesale executes the full package
+# import (10s+ cold on machines with AV-scanned or large site-packages) and used
+# to run up to FOUR times synchronously, stalling every commit before the
+# detached launch even started. find_spec locates the package without executing
+# it, so each probe costs interpreter startup only. The detached rebuild still
+# fails loudly in the log if the package is broken under that interpreter.
+_GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+GRAPHIFY_PYTHON=""
+_PINNED='C:\Users\kokor\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe'
+if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then
+    GRAPHIFY_PYTHON="$_PINNED"
+fi
+# Second probe: read graphify-out/.graphify_python (written by the skill and
+# CLI; survives uv-tool reinstalls and is the same source the README documents).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    if [ -f "$_GFY_PYTHON_FILE" ]; then
+        _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
+        case "$_FROM_FILE" in
+            *[!a-zA-Z0-9/_.@:\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+        esac
+        if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_FROM_FILE"
+        fi
+    fi
+fi
+# Third probe: resolve via the graphify launcher on PATH.
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+    if [ -n "$GRAPHIFY_BIN" ]; then
+        # Windows pip layout: Scripts/graphify(.exe) sits beside ..\python.exe
+        # (or .\python.exe inside a venv's Scripts dir). NOTE: command -v may
+        # return the launcher path WITHOUT the .exe suffix, so this cannot key
+        # on the extension.
+        _GFY_BINDIR=$(dirname "$GRAPHIFY_BIN")
+        if [ -x "$_GFY_BINDIR/../python.exe" ] && "$_GFY_BINDIR/../python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/../python.exe"
+        elif [ -x "$_GFY_BINDIR/python.exe" ] && "$_GFY_BINDIR/python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/python.exe"
+        fi
+    fi
+    if [ -z "$GRAPHIFY_PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
+        # POSIX launcher: parse the shebang. head -c + tr strip NUL bytes first —
+        # when the launcher is a Windows binary reached without its .exe suffix,
+        # a raw `head -1` reads binary into the command substitution and the
+        # shell warns about ignored null bytes on every commit.
+        case "$GRAPHIFY_BIN" in
+            *.exe) _SHEBANG="" ;;
+            *)     _SHEBANG=$(head -c 256 "$GRAPHIFY_BIN" 2>/dev/null | tr -d '\000' | head -n 1 | sed 's/^#![[:space:]]*//') ;;
+        esac
+        case "$_SHEBANG" in
+            */env\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
+            *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
+        esac
+        # Allowlist: only keep characters valid in a filesystem path to prevent
+        # injection if the shebang contains shell metacharacters.
+        case "$GRAPHIFY_PYTHON" in
+            *[!a-zA-Z0-9/_.@:\\-]*) GRAPHIFY_PYTHON="" ;;
+        esac
+        if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON=""
+        fi
+    fi
+fi
+# Last resort: try python3 / python (works for system/venv installs on PATH).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    elif command -v python >/dev/null 2>&1 && python -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python"
+    else
+        echo "[graphify hook] could not locate a Python with graphify installed. Add the graphify bin dir to PATH or re-run 'graphify hook install' from the env where graphify lives." >&2
+        exit 0
+    fi
+fi
+
+export GRAPHIFY_CHANGED="$CHANGED"
+
+# Run the rebuild detached so git commit returns immediately. Full-repo rebuilds
+# can take hours; blocking the post-commit hook stalls the shell. The Python
+# launcher below detaches the child cross-platform, so it works on Git for
+# Windows' shell too (which lacks the coreutils backgrounding tools) (#1161).
+_GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
+echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
+"$GRAPHIFY_PYTHON" -c "import os, subprocess, sys
+_src = '''
+import os, signal, sys, threading
+from pathlib import Path
+
+changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
+changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
+
+if not changed:
+    sys.exit(0)
+
+print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
+
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0:
+        if hasattr(signal, 'SIGALRM'):
+            signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+            signal.alarm(_timeout)
+        else:
+            def _bail():
+                print(f'[graphify hook] graphify rebuild exceeded {_timeout}s', flush=True)
+                os._exit(1)
+            _watchdog = threading.Timer(_timeout, _bail)
+            _watchdog.daemon = True
+            _watchdog.start()
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _root = Path('.')
+    _out = os.environ.get('GRAPHIFY_OUT', 'graphify-out')
+    _saved = Path(_out) / '.graphify_root'
+    if _saved.exists():
+        _txt = _saved.read_text(encoding='utf-8').strip()
+        if _txt:
+            _root = Path(_txt)
+    _rebuild_code(_root, changed_paths=changed, force=_force)
+    # Refresh the work-memory lessons doc when saved Q&A outcomes exist
+    # (best-effort; never fails the hook).
+    try:
+        _md = (_root / _out) / 'memory'
+        if _md.is_dir() and any(_md.glob('*.md')):
+            from graphify.reflect import reflect as _reflect
+            _gj = (_root / _out) / 'graph.json'
+            _reflect(memory_dir=_md, out_path=(_root / _out) / 'reflections' / 'LESSONS.md',
+                     graph_path=_gj if _gj.exists() else None)
+    except Exception:
+        pass
+except TimeoutError as exc:
+    print(f'[graphify hook] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify hook] Rebuild failed: {exc}')
+    sys.exit(1)
+
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or os.path.join(os.path.expanduser('~'), '.cache', 'graphify-rebuild.log')
+try:
+    os.makedirs(os.path.dirname(_log), exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    _flags = 0x08000000 | 0x00000200  # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+    try:
+        subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
+    except OSError:
+        subprocess.Popen(_cmd, creationflags=_flags, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"
+# graphify-hook-end

--- a/scripts/capture-specs/flows/admin-account-delete-consent-4524.mjs
+++ b/scripts/capture-specs/flows/admin-account-delete-consent-4524.mjs
@@ -1,0 +1,119 @@
+/**
+ * scripts/capture-specs/flows/admin-account-delete-consent-4524.mjs (#4524 / EPIC #4495)
+ *
+ * `/admin/settings/account` の Danger Zone を **プラン別に実 account でログインして**撮る。
+ * 同意チェックの文言が猶予 notice と同じ事実を述べているか（= プラン差そのもの）が本 Issue の
+ * 主題なので、demo env (`DATA_SOURCE=demo`) では検証にならず `AUTH_MODE=cognito`
+ * (`npm run dev:cognito`、#1026) の DEV_USERS を使う。
+ *
+ * - free (`free@example.com`)         … 猶予 0 日。「元に戻せません」が**正しい**ので維持される
+ * - standard (`standard@example.com`) … 猶予 7 日。旧実装はここで notice と矛盾していた（本丸）
+ * - family (`family@example.com`)     … 猶予 30 日。同上
+ *
+ * Before / After は同一 flow を **コードの状態を変えて 2 回**回して撮る (#2059 手順)。
+ * label prefix は `SS_LABEL_PREFIX` で与える (`before-` / `after-`)。
+ *
+ * 使用例:
+ *   MSYS_NO_PATHCONV=1 SS_LABEL_PREFIX=after- BASE_URL=http://localhost:5174 \
+ *     node scripts/capture.mjs --pr 4595 \
+ *     --flow admin-account-delete-consent-4524 \
+ *     --url /admin/settings/account \
+ *     --actions scripts/capture-specs/flows/admin-account-delete-consent-4524.mjs \
+ *     --presets desktop
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5174';
+const PREFIX = process.env.SS_LABEL_PREFIX || '';
+
+/** DEV_USERS SSOT: src/lib/server/auth/providers/cognito-dev.ts */
+const ACCOUNTS = [
+	{ slug: 'free', email: 'free@example.com', password: 'Gq!Dev#Free2026xy' },
+	{ slug: 'standard', email: 'standard@example.com', password: 'Gq!Dev#Std2026xyz' },
+	{ slug: 'family', email: 'family@example.com', password: 'Gq!Dev#Fam2026xyz' },
+];
+
+/**
+ * 描画 frame を n 回待つ。`page.waitForTimeout()` は scripts/ 配下で禁止 (#1208)。
+ */
+async function waitFrames(page, frames = 1) {
+	for (let i = 0; i < frames; i++) {
+		await page.evaluate(
+			() =>
+				new Promise((resolve) =>
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+				),
+		);
+	}
+}
+
+/** cognito-dev のログインフォームを通す (admin-checklists-ai-gate-4506.mjs と同型) */
+async function login(page, email, password) {
+	await page.goto(`${BASE_URL}/auth/login`);
+	await page.getByLabel('メールアドレス').waitFor({ state: 'visible', timeout: 15_000 });
+	await page.waitForFunction(
+		() => document.querySelector('input[name="email"]')?.getAttribute('type') === 'email',
+		{ timeout: 15_000 },
+	);
+
+	await page.getByLabel('メールアドレス').click();
+	await page.keyboard.type(email, { delay: 20 });
+	await page.getByLabel('パスワード', { exact: true }).click();
+	await page.keyboard.type(password, { delay: 20 });
+
+	await page
+		.locator('button[type="submit"]:not([disabled])')
+		.first()
+		.waitFor({ state: 'visible', timeout: 30_000 });
+	await page.getByRole('button', { name: 'ログイン' }).click();
+	await page.waitForURL(/\/(admin|ops|setup|billing|switch|child)/, { timeout: 30_000 });
+}
+
+async function logout(page) {
+	await page.goto(`${BASE_URL}/auth/logout`).catch(() => {});
+	await page.context().clearCookies();
+}
+
+/** 初回 welcome overlay / ページガイドが被る場合は閉じる */
+async function dismissOverlays(page) {
+	const welcome = page.locator('.welcome-overlay');
+	if (await welcome.isVisible({ timeout: 1500 }).catch(() => false)) {
+		await welcome
+			.locator('.welcome-cta')
+			.click()
+			.catch(() => {});
+		await welcome.waitFor({ state: 'hidden', timeout: 3000 }).catch(() => {});
+	}
+}
+
+/**
+ * Danger Zone を開き、猶予 notice と同意チェックが同一視界に入る状態にする。
+ * 猶予 notice は非同期に解決される (`deletionGraceDays === null` の間は出ない) ため、
+ * notice か「猶予を出さない」確定のどちらかに落ち着くまで待つ。
+ */
+async function openDangerZone(page) {
+	await page.goto(`${BASE_URL}/admin/settings/account`);
+	await dismissOverlays(page);
+
+	const consent = page.getByTestId('account-danger-agree-checkbox');
+	await consent.waitFor({ state: 'visible', timeout: 20_000 });
+	// 猶予 notice の解決待ち (owner のみ表示。出ない場合もあるので存在は必須にしない)
+	await page
+		.getByTestId('account-delete-grace-notice')
+		.waitFor({ state: 'visible', timeout: 10_000 })
+		.catch(() => {});
+	await consent.scrollIntoViewIfNeeded();
+	await waitFrames(page, 2);
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	for (const { slug, email, password } of ACCOUNTS) {
+		await logout(page);
+		await login(page, email, password);
+		await openDangerZone(page);
+		await capture(`${PREFIX}account-delete-consent-${slug}`);
+	}
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2819,7 +2819,20 @@ export const SETTINGS_LABELS = {
 	dangerStep2Label: '手順 2: 同意チェック',
 	dangerStep3Label: '手順 3: 実行ボタン',
 	clearDangerConsentLabel: 'すべてのデータを削除することに同意します',
-	accountDeleteDangerConsentLabel: 'このアカウントを削除することに同意します（元に戻せません）',
+	// #4524: 同意チェックの文言は猶予 notice (accountDeleteGraceNotice) と **同じ事実**を述べる。
+	//   旧実装はプランに依らない固定文で「元に戻せません」と断定しており、猶予のある有料プラン
+	//   では直上の notice (「N 日間は復元で取り消せます」) と正面から矛盾していた。最も不可逆性の
+	//   高い操作の直前で 2 文が食い違うと、警告全体が信用されなくなる。
+	//
+	//   graceDays が null (プラン未解決) のときに `?? 'free'` 相当へ倒さない: 猶予のある親に
+	//   「元に戻せません」を見せるのは事実と異なる誤誘導になるため、断定しない中立文にする
+	//   (accountDeleteGraceNotice / deletionGraceDays の扱いと同じ、#4517)。
+	accountDeleteDangerConsentLabel: (graceDays: number | null) =>
+		graceDays === null
+			? 'このアカウントを削除することに同意します'
+			: graceDays === 0
+				? 'このアカウントを削除することに同意します（元に戻せません）'
+				: `このアカウントを削除することに同意します（${graceDays} 日以内なら「復元」ボタンで取り消せます）`,
 	// 削除前のデータ持ち出し (#740 API / #4472 導線)。プランに関係なく提供する
 	accountDeleteExportTitle: `${CANCEL_TERMS.account}する前にデータを持ち出す`,
 	accountDeleteExportAction: 'データをダウンロード',

--- a/src/routes/(parent)/admin/settings/account/+page.svelte
+++ b/src/routes/(parent)/admin/settings/account/+page.svelte
@@ -205,6 +205,11 @@ const deletionGraceDays = $derived(
 	deletionGracePlanTier === null ? null : DELETION_GRACE_PERIOD_DAYS[deletionGracePlanTier],
 );
 
+// #4524: 同意チェックの文言に載せる猶予日数。owner 以外 (child / member) の削除は
+//   猶予なしで即時にログイン情報が消える (accountDeleteChildWarning / MemberWarning 整合)
+//   ため 0 を渡す。owner は plan 由来の猶予をそのまま使う (未解決なら null = 断定しない)。
+const consentGraceDays = $derived($page.data.userRole === 'owner' ? deletionGraceDays : 0);
+
 const canConfirmDelete = $derived(
 	deleteConfirmText === 'アカウントを削除します' && deleteAgreeChecked,
 );
@@ -519,7 +524,7 @@ const canConfirmDelete = $derived(
 								data-testid="account-danger-agree-checkbox"
 							/>
 							<span class="text-sm text-[var(--color-text)]">
-								{SETTINGS_LABELS.accountDeleteDangerConsentLabel}
+								{SETTINGS_LABELS.accountDeleteDangerConsentLabel(consentGraceDays)}
 							</span>
 						</label>
 					</div>

--- a/tests/unit/domain/cancel-vs-deletion-terminology.test.ts
+++ b/tests/unit/domain/cancel-vs-deletion-terminology.test.ts
@@ -190,6 +190,48 @@ describe('解約 / 退会 の用語分離 (#4496)', () => {
 			).toContain(`${DELETION_GRACE_PERIOD_DAYS.standard} 日間は「復元」ボタンで取り消せます`);
 		});
 
+		// #4524: 同意チェックの文言は猶予 notice と同じ事実を述べる。旧実装はプラン非依存の
+		//   固定文で「元に戻せません」と断定しており、猶予のある有料プランでは直上の notice と
+		//   同一画面で正面から矛盾していた (最も不可逆性の高い操作の直前で警告が信用を失う)。
+		it('同意チェックは有料プランで「元に戻せません」と断定しない', () => {
+			const paid = SETTINGS_LABELS.accountDeleteDangerConsentLabel(
+				DELETION_GRACE_PERIOD_DAYS.standard,
+			);
+			expect(paid).not.toContain('元に戻せません');
+			expect(paid).toContain(`${DELETION_GRACE_PERIOD_DAYS.standard} 日以内`);
+			expect(paid).toContain('「復元」ボタンで取り消せます');
+		});
+
+		it('同意チェックは猶予 0 日 (無料 / 非 owner) で不可逆を明言する', () => {
+			// 単純な文言撤去で無料プランの警告を弱めない (#4496 の元の実害を再発させない)
+			expect(SETTINGS_LABELS.accountDeleteDangerConsentLabel(0)).toContain('元に戻せません');
+		});
+
+		it('同意チェックはプラン未解決時に猶予を断定しない', () => {
+			// `?? 'free'` へ倒すと、猶予のある親に「元に戻せません」を見せる誤誘導になる (#4517 整合)
+			const unknown = SETTINGS_LABELS.accountDeleteDangerConsentLabel(null);
+			expect(unknown).not.toContain('元に戻せません');
+			expect(unknown).not.toContain('取り消せます');
+			expect(unknown).toContain('削除することに同意します');
+		});
+
+		it('同意チェックと猶予 notice が同じ事実を述べる (同一画面で矛盾しない)', () => {
+			for (const days of [
+				0,
+				DELETION_GRACE_PERIOD_DAYS.standard,
+				DELETION_GRACE_PERIOD_DAYS.family,
+			]) {
+				const consent = SETTINGS_LABELS.accountDeleteDangerConsentLabel(days);
+				const notice = SETTINGS_LABELS.accountDeleteGraceNotice(days);
+				const consentSaysReversible = consent.includes('取り消せます');
+				const noticeSaysReversible = notice.includes('取り消せます');
+				expect(
+					consentSaysReversible,
+					`猶予 ${days} 日で consent と notice の可逆性の主張が食い違う: consent="${consent}" / notice="${notice}"`,
+				).toBe(noticeSaysReversible);
+			}
+		});
+
 		it('削除猶予バナーは残日数として述べる (引数は daysRemaining)', () => {
 			expect(SETTINGS_LABELS.deletionGraceDesc(3, '2026-08-15')).toBe(
 				'あと 3 日（2026-08-15）ですべてのデータが完全に削除されます。それまでであれば「復元」ボタンで取り消せます。',


### PR DESCRIPTION
## 顧客価値・目的

**退会画面で、最も不可逆性の高い操作の直前に置かれた 2 文が正面から食い違っていました。**

```
猶予 notice (#4496):「お申し込みから 7 日間は「復元」ボタンで取り消せます」
同意チェック      :「このアカウントを削除することに同意します（元に戻せません）」
```

猶予は `DELETION_GRACE_PERIOD_DAYS = {free: 0, standard: 7, family: 30}` でプラン別なので、**「元に戻せません」は有料プランでは事実と異なります**。同じ画面の 2 文が矛盾すると、警告そのものが信用されなくなります。

一方で**単純に文言を撤去すると無料プランの警告が弱まります**（猶予 0 = 申請と同時に物理削除）。それは #4496 が潰した元の実害「取り消せないと知らないまま退会してデータ全損」の再発です。どちらも成立させるため、猶予 notice と**同じ事実**を述べる形にしました。

## 関連 Issue

Closes #4524 / 親 EPIC: #4495 / 関連: #4496・PR #4517（猶予 notice の追加）・#4545（notice の variant 出し分け）

## 変更内容

`accountDeleteGraceNotice` と同じく猶予日数を引数に取る関数にしました。

| `graceDays` | 文言 | 根拠 |
|---|---|---|
| `0` | このアカウントを削除することに同意します（**元に戻せません**） | 無料 / 非 owner は申請と同時に削除。**維持**（警告を弱めない） |
| `> 0` | このアカウントを削除することに同意します（**N 日以内なら「復元」ボタンで取り消せます**） | 猶予中は復元できる = notice と同じ事実 |
| `null` | このアカウントを削除することに同意します | プラン未解決。**断定しない** |

**`null` を `'free'` に倒していません。** 猶予のある親に「元に戻せません」を見せるのは事実と異なる誤誘導で、同じ判断を `deletionGraceDays` 側が既に採っています（#4517）。

**owner 以外（child / member）には `0` を渡します。** これらの削除は猶予なしで即時にログイン情報が消えるため（`accountDeleteChildWarning` / `MemberWarning` と整合）、「元に戻せません」が正しい表示です。

### 実行ボタン直前での再掲について（Issue の「検討する」項）

**別途の再掲は足しませんでした。** 同意チェック（手順 2）は実行ボタン（手順 3）の直上にあり、その文言自体が猶予の事実を持つようになったため、**再掲は本 PR の変更で達成されています**。ここにもう 1 つ警告を積むと、同じことを 3 回言う画面になります（ADR-0012 の趣旨に反する）。notice の `role` は #4545 で `danger`（猶予 0）/ `warning`（猶予あり）に出し分け済みです。

## 検証

```console
$ npx vitest run tests/unit/domain/cancel-vs-deletion-terminology.test.ts
      Tests  40 passed (40)

$ npx vitest run tests/unit/domain/
      Tests  1185 passed (1185)

$ npx svelte-check --threshold error
svelte-check found 0 errors and 0 warnings

$ npm run cspell
CSpell: Files checked: 1985, Issues found: 0 in 0 files.
```

**mutation 検証**（test が本当に効くか）:

```console
$ git stash push -- src/lib/domain/labels.ts   # 旧ラベルに戻す
$ npx vitest run tests/unit/domain/cancel-vs-deletion-terminology.test.ts
 ❯ cancel-vs-deletion-terminology.test.ts (40 tests | 4 failed)
$ git stash pop
```

**実画面でプラン別に確認**（`AUTH_MODE=cognito` の DEV_USERS でログイン、#1026）。撮影した DOM から:

| プラン | Before | After |
|---|---|---|
| free（猶予 0） | …同意します（元に戻せません） | …同意します（**元に戻せません**）← 変わらないのが正しい |
| standard（猶予 7） | …同意します（**元に戻せません**）← notice と矛盾 | …同意します（**7 日以内なら「復元」ボタンで取り消せます**） |
| family（猶予 30） | …同意します（**元に戻せません**）← 同上 | …同意します（**30 日以内なら「復元」ボタンで取り消せます**） |

### 追加した test（4 件、Issue 指摘の是正）

Issue の指摘どおり、既存 test は `accountDeleteOwnerWarning` しか見ておらず **consent ラベルを一切検査していませんでした**。

| 観点 | 内容 |
|---|---|
| 有料 | 「元に戻せません」と断定しない / 日数と「復元」を述べる |
| 猶予 0 | 「元に戻せません」を**明言する**（警告を弱める方向の退行を止める） |
| 未解決 | 可逆・不可逆どちらも断定しない |
| **整合** | **consent と notice の「取り消せます」の有無が猶予 0 / 7 / 30 で一致する**——片方だけ直した状態には戻れない |

### 未実行

- E2E は未実行（CI の重量レーンで確認）
- 実際に削除を申請して復元まで通す動線は未検証（本 PR は文言のみで、`grace-period-service.ts` / API は無変更）

## 影響範囲

**顧客に見える変化**: `/admin/settings/account` の Danger Zone 手順 2 の同意文言のみ。**有料プランで「元に戻せません」が消え、猶予日数と復元手段が出ます**。無料プランは変わりません。

<!-- ss-pair-prefix: before=before- after=after- -->

| プラン | Before | After |
|---|---|---|
| standard（猶予 7 日） | ![before-consent-standard](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4595/before-consent-standard.png) | ![after-consent-standard](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4595/after-consent-standard.png) |
| family（猶予 30 日） | ![before-consent-family](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4595/before-consent-family.png) | ![after-consent-family](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4595/after-consent-family.png) |

**free（猶予 0 日）は変わらないのが正しい**ので、before/after のペアではなく after 1 枚だけを対照として置きます（同一画像のペアを作らない、#2059）:

![after-consent-free-unchanged](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4595/after-consent-free-unchanged.png)

**撮影方法**: プラン差そのものが主題なので demo env（`DATA_SOURCE=demo`）では検証にならず、cognito-dev の 3 account でログインして撮る flow spec を追加しました（`scripts/capture-specs/flows/admin-account-delete-consent-4524.mjs`、`admin-checklists-ai-gate-4506.mjs` と同型）。

**破壊的変更**: `accountDeleteDangerConsentLabel` が文字列 → 関数になります。callsite は 1 箇所のみ（同ページ）で、同 PR 内で更新済み。型で検出されます。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
