### PR TITLE
fix(plan): #4584 canCustomReward が参照ゼロで有料ゲートが掛かっていない + PlanLimits fitness function

### DIFF
--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -61,6 +61,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'bounded',
 		note: 'Dockerfile* / infra/lib/**/*.ts / .github/workflows/*.yml の 3 系統に限定して Node major 宣言を突き合わせる (#4199 AC5)。glob は限定的だが `**/Dockerfile*` がツリーを歩くため、判定が bounded でも明示 timeout を置いている',
 	},
+	'tests/unit/architecture/plan-limits-field-enforcement.test.ts': {
+		scope: 'bounded',
+		note: 'src 配下の .ts / .svelte を glob し、PlanLimits の全フィールドが production code から実際に参照されているかを検査する (#4584)。参照ゼロ = 有料の根拠として売っている機能にゲートが掛かっていない状態',
+	},
 	'tests/unit/architecture/ai-suggest-gate-derivation.test.ts': {
 		scope: 'repo',
 		note: 'src/routes 配下の +page.svelte を走査し、AI 提案パネルの isFamily 導出が共有述語 isAiSuggestUnlocked() を経由しているかを検査する (#4506 AC5)',

--- a/src/lib/domain/custom-reward-gate.ts
+++ b/src/lib/domain/custom-reward-gate.ts
@@ -1,0 +1,29 @@
+// src/lib/domain/custom-reward-gate.ts (#4584)
+//
+// 「特別なごほうび設定（即時付与）」の解放判定。**表示と実行が同じ述語を読む**ための SSOT。
+//
+// # なぜ独立した module にするか
+//
+// この機能は `site/pricing.html` の有料列と `plan-features.ts` で**有料の根拠として売られて
+// いる**が、それを表す `PLAN_LIMITS.canCustomReward` は production code から一度も参照されて
+// いなかった (#4584)。実際の拒否は admin/rewards の各 action が `isPaidTier(tier)` を直接
+// 呼んで行っており、**フラグと実装が別々の真実**になっていた。フラグを変えても挙動は変わらず、
+// 逆に実装を変えてもフラグは古いままになる。
+//
+// そこで判定を 1 つの述語に集約し、`PLAN_LIMITS.canCustomReward` はここから導出、
+// 拒否もここを読む。以後どちらか片方だけを変えることはできない。
+//
+// 同型: `canFreeTextMessage` (#4504)。同 class の 3 件目を機械で止める fitness function は
+// `tests/unit/architecture/plan-limits-field-enforcement.test.ts`。
+
+import type { PlanTier } from './constants/plan-tier';
+
+/**
+ * 特別なごほうび設定を使えるか (スタンダード以上)。
+ *
+ * **server の拒否と UI の出し分けの両方がこれを読む。** 表示だけ絞って実行を素通しにすると
+ * 「見えないのに叩けば通る」、逆だと「押せるのに 403」になる (#4506 の実害)。
+ */
+export function isCustomRewardUnlocked(tier: PlanTier): boolean {
+	return tier === 'standard' || tier === 'family';
+}

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -6,6 +6,7 @@ import { countsTowardActivityQuota } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { PLAN_HISTORY_RETENTION_DAYS } from '$lib/domain/constants/plan-retention';
 import type { PlanTier } from '$lib/domain/constants/plan-tier';
+import { isCustomRewardUnlocked } from '$lib/domain/custom-reward-gate';
 import { addDaysJST, prevDateJST, todayDateJST } from '$lib/domain/date-utils';
 import { getAuthMode } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
@@ -22,7 +23,14 @@ export interface PlanLimits {
 	historyRetentionDays: number | null;
 	canExport: boolean;
 	canFreeTextMessage: boolean; // 自由テキストメッセージ（PLAN_LABELS.family 限定）
-	canCustomReward: boolean; // 特別なごほうび設定（スタンダード以上） #728
+	/**
+	 * 特別なごほうび設定（スタンダード以上、#728）。
+	 *
+	 * #4584: 値は `isCustomRewardUnlocked` から導出する。旧実装はここに真偽値を直書きし、
+	 * 実際の拒否は admin/rewards が `isPaidTier` を直接呼んでいたため、**このフラグは
+	 * 誰にも読まれていなかった** (参照ゼロ)。フラグと実装が別々の真実になっていた。
+	 */
+	canCustomReward: boolean;
 	canSiblingRanking: boolean; // きょうだいランキング（PLAN_LABELS.family 限定） #782
 	maxCloudExports: number; // クラウド保管の同時保管数上限
 }
@@ -45,7 +53,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.free,
 		canExport: false,
 		canFreeTextMessage: false,
-		canCustomReward: false,
+		canCustomReward: isCustomRewardUnlocked('free'),
 		canSiblingRanking: false,
 		maxCloudExports: 0,
 	},
@@ -58,7 +66,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.standard,
 		canExport: true,
 		canFreeTextMessage: false,
-		canCustomReward: true,
+		canCustomReward: isCustomRewardUnlocked('standard'),
 		canSiblingRanking: false,
 		maxCloudExports: 3,
 	},
@@ -71,7 +79,7 @@ const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 		historyRetentionDays: PLAN_HISTORY_RETENTION_DAYS.family,
 		canExport: true,
 		canFreeTextMessage: true,
-		canCustomReward: true,
+		canCustomReward: isCustomRewardUnlocked('family'),
 		canSiblingRanking: true,
 		maxCloudExports: 10,
 	},

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -7,6 +7,7 @@ import { getMarketplaceItem } from '$lib/data/marketplace';
 // 「marketplace 取込はマーケットプレイス画面に一本化、admin 内ブラウズ UI 二重管理禁止」)。
 // 旧 `PRESET_REWARD_GROUPS` の in-page render は撤去済 (本 file の load 出力からも削除)。
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { isCustomRewardUnlocked } from '$lib/domain/custom-reward-gate';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asChildId, type ChildId } from '$lib/domain/ids';
@@ -60,7 +61,11 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 	const tenantId = requireTenantId(locals);
 	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const tier = await resolveFullPlanTier(tenantId, licenseStatus, locals.context?.plan);
-	const isPremium = isPaidTier(tier);
+	// #4584: 表示 (isPremium) と実行 (各 action の gate) を **同じ述語**から出す。
+	// 旧実装は両方 isPaidTier(tier) を直接呼んでおり、PLAN_LIMITS.canCustomReward という
+	// 「有料の根拠として売っている機能フラグ」は誰にも読まれていなかった (参照ゼロ)。
+	// フラグを変えても挙動が変わらない = フラグと実装が別々の真実になっていた。
+	const isPremium = isCustomRewardUnlocked(tier);
 
 	const children = await getAllChildren(tenantId);
 	const templates = await getRewardTemplates(tenantId);
@@ -162,7 +167,7 @@ export const actions: Actions = {
 		// #728: プランゲート — 無料プランはカスタム報酬追加不可
 		// #787: PlanLimitError 形式に統一
 		const tier = await resolveTier(locals, tenantId);
-		if (!isPaidTier(tier)) {
+		if (!isCustomRewardUnlocked(tier)) {
 			return fail(403, {
 				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
 			});
@@ -203,7 +208,7 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 
 		const tier = await resolveTier(locals, tenantId);
-		if (!isPaidTier(tier)) {
+		if (!isCustomRewardUnlocked(tier)) {
 			return fail(403, {
 				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
 			});
@@ -276,7 +281,7 @@ export const actions: Actions = {
 		// #728: プランゲート — 無料プランはプリセットの取り込みも不可
 		// #787: PlanLimitError 形式に統一
 		const tier = await resolveTier(locals, tenantId);
-		if (!isPaidTier(tier)) {
+		if (!isCustomRewardUnlocked(tier)) {
 			return fail(403, {
 				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
 			});
@@ -312,7 +317,7 @@ export const actions: Actions = {
 
 		// プランゲート: 無料プランは特別ごほうび設定不可（grant と同等）
 		const tier = await resolveTier(locals, tenantId);
-		if (!isPaidTier(tier)) {
+		if (!isCustomRewardUnlocked(tier)) {
 			return fail(403, {
 				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
 			});
@@ -373,7 +378,7 @@ export const actions: Actions = {
 
 		// プラン制限ガード (既存 form と同じ)
 		const tier = await resolveTier(locals, tenantId);
-		if (!isPaidTier(tier)) {
+		if (!isCustomRewardUnlocked(tier)) {
 			return fail(403, {
 				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
 			});
@@ -517,7 +522,7 @@ export const actions: Actions = {
 
 		// プラン制限ガード
 		const tier = await resolveTier(locals, tenantId);
-		if (!isPaidTier(tier)) {
+		if (!isCustomRewardUnlocked(tier)) {
 			return fail(403, {
 				error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE),
 			});
@@ -602,7 +607,7 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 
 		const tier = await resolveTier(locals, tenantId);
-		if (!isPaidTier(tier)) {
+		if (!isCustomRewardUnlocked(tier)) {
 			return fail(403, { error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE) });
 		}
 
@@ -660,7 +665,7 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 
 		const tier = await resolveTier(locals, tenantId);
-		if (!isPaidTier(tier)) {
+		if (!isCustomRewardUnlocked(tier)) {
 			return fail(403, { error: createPlanLimitError(tier, 'standard', UPGRADE_MESSAGE) });
 		}
 

--- a/src/routes/(parent)/admin/rewards/+page.server.ts
+++ b/src/routes/(parent)/admin/rewards/+page.server.ts
@@ -31,11 +31,7 @@ import {
 	copyChildRewardsToSiblings,
 } from '$lib/server/services/child-reward-copy-service';
 import { getAllChildren } from '$lib/server/services/child-service';
-import {
-	isPaidTier,
-	type PlanTier,
-	resolveFullPlanTier,
-} from '$lib/server/services/plan-limit-service';
+import { type PlanTier, resolveFullPlanTier } from '$lib/server/services/plan-limit-service';
 import { getRedemptionRequestsForParent } from '$lib/server/services/reward-redemption-service';
 import {
 	addReward,

--- a/tests/unit/architecture/plan-limits-field-enforcement.test.ts
+++ b/tests/unit/architecture/plan-limits-field-enforcement.test.ts
@@ -1,0 +1,161 @@
+// tests/unit/architecture/plan-limits-field-enforcement.test.ts (#4584 / ADR-0061 same-class-N→guard)
+//
+// **`PlanLimits` の全フィールドが production code から実際に読まれていること**を機械検証する。
+//
+// # なぜ必要か
+//
+// 「有料の根拠として売っている機能フラグが、誰にも参照されていない」が 2 件出た:
+//
+//   | # | flag | 状態 |
+//   |---|---|---|
+//   | #4504 | `canFreeTextMessage` | 定義のみ・参照ゼロ |
+//   | #4584 | `canCustomReward`    | 定義のみ・参照ゼロ (拒否は別途 `isPaidTier` 直呼びで実装) |
+//
+// フラグは値としては正しく、既存 test も `getPlanLimits()` が正しい真偽値を返すことを
+// assert していた。**しかしその値によって何かが制限されることは 1 本も検証していなかった。**
+// 値の正しさと、値が効いていることは別物である。
+//
+// 2 件目が出た時点でこれは個別バグではなく class なので、3 件目を機械で止める。
+//
+// # 何を fail させるか
+//
+// `PlanLimits` にフィールドを足したのに production code のどこからも読まない状態。
+// 意図的に未配線で残すなら `UNWIRED_FIELDS` に**理由と追跡 Issue を書いて**通す
+// (黙って除外しない — 除外そのものが記録として残る)。
+
+// cspell:ignore UNWIRED — 「未配線」を表す定数名 (unwired の大文字表記)
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { globSync } from 'tinyglobby';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 60_000 });
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../../');
+
+/** 型定義と既定値を持つ SSOT 自身。ここでの出現は「参照」に数えない。 */
+const DEFINITION_FILE = 'src/lib/server/services/plan-limit-service.ts';
+
+/**
+ * 未配線のまま残すフィールド。**理由と追跡 Issue が必須**。
+ *
+ * 空にできるのが理想だが、空を強制すると「とりあえずどこかで参照する」だけの
+ * 死んだ参照を書いて通す動機になる。除外は残すが、理由ごと可視化する。
+ */
+const UNWIRED_FIELDS: Record<string, string> = {
+	canFreeTextMessage:
+		'#4504 で配線中 (PR #4579)。マージ後に本エントリを削除する。値は isFreeTextMessageUnlocked から導出される予定',
+	// 本 gate を書いて初めて見つかった 3 件目。招待の上限は plan-limit-service に値があるだけで、
+	// invite-service にも admin/members にも上限チェックが無い (grep で 0 件)。
+	maxFamilyMembers:
+		'#4577 で family-member-limit.ts に集約中。強制の有無は同 PR の scope。マージ後に本エントリを見直す',
+};
+
+/**
+ * **述語経由**で効いているフィールド。
+ *
+ * フラグ名を直接読む代わりに、共有述語を 1 つ置いて「値の導出」と「拒否」の両方がそれを読む形。
+ * この場合フィールド名は production に現れないので、代わりに **述語が導出と拒否の両方から
+ * 参照されていること**を検査する (名前が出ないことを口実に検査を消さない)。
+ */
+const PREDICATE_BACKED_FIELDS: Record<string, { predicate: string; enforcedIn: string[] }> = {
+	canCustomReward: {
+		predicate: 'isCustomRewardUnlocked',
+		enforcedIn: ['src/routes/(parent)/admin/rewards/+page.server.ts'],
+	},
+};
+
+/** `PlanLimits` インターフェースのフィールド名を型定義から読む (手書きの列挙を作らない)。 */
+function planLimitsFields(): string[] {
+	const src = readFileSync(join(REPO_ROOT, DEFINITION_FILE), 'utf-8');
+	const block = src.match(/export interface PlanLimits \{([\s\S]*?)\n\}/);
+	const body = block?.[1];
+	if (!body) throw new Error('PlanLimits インターフェースを型定義から読めませんでした');
+	const fields = [...body.matchAll(/^\t([a-zA-Z][a-zA-Z0-9]*)[?]?:/gm)]
+		.map((m) => m[1])
+		.filter((f): f is string => typeof f === 'string');
+	if (fields.length === 0) throw new Error('PlanLimits のフィールドを 1 つも抽出できませんでした');
+	return fields;
+}
+
+/**
+ * コメントを落とす。**コメント内の言及を「参照」と数えない**ため。
+ *
+ * これが無いと「フラグ名を doc コメントに書いただけ」で本 gate を通せてしまい、
+ * 検査が空振りする (実際、本 test の初版は述語 module の doc コメントを拾って
+ * 未配線状態でも緑になっていた)。
+ */
+function stripComments(text: string): string {
+	return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/** production code (src 配下、定義 file を除く) を全て読む。 */
+function productionSources(): { path: string; text: string }[] {
+	return globSync(['src/**/*.ts', 'src/**/*.svelte'], {
+		cwd: REPO_ROOT,
+		ignore: ['**/*.test.ts', '**/*.stories.svelte', DEFINITION_FILE],
+	}).map((p) => ({ path: p, text: stripComments(readFileSync(join(REPO_ROOT, p), 'utf-8')) }));
+}
+
+describe('#4584 PlanLimits の全フィールドが実際に効いている', () => {
+	const fields = planLimitsFields();
+	const sources = productionSources();
+
+	it('フィールドを型定義から抽出できる (この test 自体が空振りしない)', () => {
+		expect(fields.length).toBeGreaterThanOrEqual(8);
+		expect(fields).toContain('canCustomReward');
+		expect(sources.length).toBeGreaterThan(100);
+	});
+
+	it.each(fields)('%s が production code から参照されている', (field) => {
+		if (field in UNWIRED_FIELDS) return; // 別 it で理由を検証する
+		if (field in PREDICATE_BACKED_FIELDS) return; // 別 it で述語経由を検証する
+
+		const refs = sources.filter((s) => s.text.includes(field)).map((s) => s.path);
+		expect(
+			refs.length,
+			`PlanLimits.${field} が production code から一度も参照されていません。` +
+				`「有料プランの機能として売っているのにゲートが掛かっていない」状態です (#4504 / #4584 と同 class)。` +
+				`実際に制限を掛けるか、意図的に未配線なら UNWIRED_FIELDS に理由と追跡 Issue を書いてください。`,
+		).toBeGreaterThan(0);
+	});
+
+	it('未配線フィールドの除外には理由と追跡 Issue がある', () => {
+		for (const [field, reason] of Object.entries(UNWIRED_FIELDS)) {
+			expect(fields, `UNWIRED_FIELDS の ${field} は PlanLimits に存在しない (stale)`).toContain(
+				field,
+			);
+			expect(reason.length, `${field} の除外理由が短すぎる`).toBeGreaterThan(20);
+			expect(reason, `${field} の除外に追跡 Issue 番号がない`).toMatch(/#\d{3,}/);
+		}
+	});
+
+	it.each(
+		Object.keys(PREDICATE_BACKED_FIELDS),
+	)('%s は述語から導出され、拒否も同じ述語を読む (#4584 本丸)', (field) => {
+		const entry = PREDICATE_BACKED_FIELDS[field];
+		if (!entry) throw new Error(`PREDICATE_BACKED_FIELDS に ${field} がありません`);
+		const { predicate, enforcedIn } = entry;
+		const def = readFileSync(join(REPO_ROOT, DEFINITION_FILE), 'utf-8');
+
+		// 真偽値の直書きに戻したら落ちる (フラグと実装が再び別々の真実になる)
+		for (const tier of ['free', 'standard', 'family']) {
+			expect(def, `${field} の ${tier} が述語から導出されていません`).toContain(
+				`${field}: ${predicate}('${tier}')`,
+			);
+		}
+
+		// 拒否側が述語を読んでいること
+		for (const path of enforcedIn) {
+			const text = readFileSync(join(REPO_ROOT, path), 'utf-8');
+			expect(text, `${path} が ${predicate} を読んでいません`).toContain(predicate);
+			// 述語を経由せず isPaidTier 直呼びに戻ったら落ちる
+			expect(text, `${path} の拒否が述語を経由していません`).not.toContain(
+				'if (!isPaidTier(tier))',
+			);
+		}
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

**有料の根拠として売っている機能フラグが、誰にも読まれていませんでした。**

`PLAN_LIMITS.canCustomReward` は production code から一度も参照されていません（`src` 配下で定義行のみ）。一方この機能は `site/pricing.html` の有料列と `plan-features.ts` で「**特別なごほうび設定（即時付与）**」として顧客に提示されています。

実際の拒否は `admin/rewards` の各 action が `isPaidTier(tier)` を直接呼んで行っており、**フラグと実装が別々の真実**になっていました。フラグを変えても挙動は変わらず、実装を変えてもフラグは古いまま残ります。

**既存 test 4 本は「`getPlanLimits()` が正しい真偽値を返すこと」しか見ていませんでした。値の正しさと、値が効いていることは別物です。**

## 関連 Issue

Closes #4584 / 親 EPIC: #4495 / 同 class 1 件目: #4504（`canFreeTextMessage`、PR #4579 で対応中）

## 変更内容

### 1. フラグと拒否を 1 つの述語に集約

```diff
+ // src/lib/domain/custom-reward-gate.ts
+ export function isCustomRewardUnlocked(tier: PlanTier): boolean {
+   return tier === 'standard' || tier === 'family';
+ }

  // plan-limit-service.ts
- canCustomReward: false,   // free
+ canCustomReward: isCustomRewardUnlocked('free'),

  // admin/rewards/+page.server.ts（gate 8 箇所 + 表示 isPremium）
- if (!isPaidTier(tier)) {
+ if (!isCustomRewardUnlocked(tier)) {
```

**表示（`isPremium`）と実行（各 action の gate）が同じ述語を読みます。** 片方だけ絞ると「見えないのに叩けば通る」か「押せるのに 403」（#4506 の実害）になります。

### 2. 3 件目を機械で止める fitness function

`tests/unit/architecture/plan-limits-field-enforcement.test.ts` を追加しました（ADR-0061 same-class-N→guard）。`PlanLimits` の**全フィールドが production から実際に読まれていること**を検査します。

- フィールド名は**型定義から抽出**（手書きの列挙を作らない → フィールドを足せば自動で検査対象）
- **直接参照** と **述語経由** の 2 形式を許容。述語経由は「**導出と拒否の両方が同じ述語を読む**」ことまで確認する（名前が出ないことを口実に検査を消さない）
- 意図的な未配線は**理由と追跡 Issue 付きの allowlist** でのみ通る（黙って除外しない）

**コメント内の言及は参照に数えません。** 初版はこれが無く、述語 module の doc コメントに書いたフィールド名を拾って**未配線でも緑**になっていました（下記「検証」の mutation で自分で踏んで直しています）。

### この gate が見つけた 3 件目

**`maxFamilyMembers`（招待メンバー上限）も参照ゼロでした。** `invite-service.ts` にも `admin/members` にも上限チェックがありません（grep 0 件）。#4577 が `family-member-limit.ts` に集約中のため allowlist に理由付きで載せ、**同 PR マージ後に見直す**という形で残しています（この PR で勝手に実装を広げない）。

## 検証

```console
$ npx vitest run tests/unit/architecture/plan-limits-field-enforcement.test.ts
      Tests  13 passed (13)

$ npx vitest run tests/unit/routes/
      Tests  720 passed (720)

$ npx vitest run tests/unit/architecture/plan-limits-field-enforcement.test.ts \
                 tests/unit/services/plan-limit-service.test.ts
      Tests  94 passed (94)

$ npx svelte-check --threshold error
svelte-check found 0 errors and 0 warnings

$ npm run cspell
CSpell: Files checked: 1987, Issues found: 0 in 0 files.

$ node scripts/check-repo-scan-test-declaration.mjs
[repo-scan-test-declaration] OK — repo 走査 test 59 件すべて区分宣言済
```

**mutation 検証**（guard が本当に効くか）:

```console
# 拒否を isPaidTier 直呼びに戻す
$ git stash push -- "src/routes/(parent)/admin/rewards/+page.server.ts"
$ npx vitest run tests/unit/architecture/plan-limits-field-enforcement.test.ts
 ❯ (13 tests | 1 failed)  × canCustomReward は述語から導出され、拒否も同じ述語を読む
$ git stash pop
```

**guard 自身の空振りも検出しました。** コメント除去を入れる前は、同じ mutation で「参照されている」判定が通ってしまい（doc コメントのフィールド名を拾っていた）、そこで初めて `maxFamilyMembers` の未配線も見えました。

### 未実行 / 未確認

- **E2E は未実行**（CI の重量レーンで確認）。`admin/rewards` の 403 挙動は変わらないはず（`isPaidTier` と `isCustomRewardUnlocked` は現時点で同値）ですが、実ブラウザでの確認は未実施
- **`maxFamilyMembers` の実際の強制はこの PR では行っていません**（上記のとおり #4577 の scope）

## 影響範囲

**顧客に見える変化はありません。** `isCustomRewardUnlocked(tier)` は `isPaidTier(tier)` と現時点で同値なので、**拒否も表示も結果は変わりません**。変わるのは「どこを直せば挙動が変わるか」の構造です。

UI 変更なし

- `admin/rewards` の gate 8 箇所 + `isPremium` が述語経由になる（同値）
- `PLAN_LIMITS.canCustomReward` が述語から導出される（値は同じ）
- 新規 fitness function が CI `unit-test` で走る

**破壊的変更**: なし。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
