### PR TITLE
fix(ci): #4348 PR body gate の宣言判定を行単位に揃え、検出器の盲点 (PR_BODY) を閉じる

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -2617,7 +2617,7 @@ dim 4 漏れによる data orphan が発生した場合の復旧手順は [docs/
 - **判定方式**: 完全 SQL parser でなく `git diff --unified=0` の drizzle column 定義行を正規表現で解析する
   (#2520 AC7)。検出ロジック (`detectBreakingChanges`) の unit test は
   `tests/unit/scripts/check-schema-migration-completeness.test.ts`。
-- **skip**: 純フォーマット変更等は PR 本文に `[skip-schema-migration-check]` を含める。
+- **skip**: 純フォーマット変更等は PR 本文に `[skip-schema-migration-check]` を**宣言として**書く。HTML コメント / コードブロック / 引用 / 未チェック checkbox / 案内文の中の同じ文字列は skip として扱わない (判定規律の SSOT は `scripts/lib/ci/pr-body-sections.mjs`、#4348)。
 - **#2519 との棲み分け**: 本 gate は **PR 時の static schema diff** (gate)。#2519 は **runtime data orphan**
   (startup assert、data 側)。#2507 (full 版: schema / create-tables / lazy の 3 dimension 完全同期) は別途。
 

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -144,6 +144,11 @@ export function detectBeforeAfterLabels(body) {
 }
 
 import { existsSync, readdirSync } from 'node:fs';
+import {
+	extractH2Section,
+	findDeclarationLines,
+	hasDeclarationLine,
+} from './lib/ci/pr-body-sections.mjs';
 import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 
 /**
@@ -278,19 +283,13 @@ const UI_NOT_APPLICABLE_PATTERNS = [
 	/UI\s*変更\s*なし/i,
 ];
 
-/**
- * 同じ行に現れたら **宣言ではない** と判断する文脈 (#4255 横展開)。
- *
- * 「UI 変更なし」の 6 文字は、否定・引用・手順説明の中にも普通に現れる。
- * 出現しただけで opt-out にすると、**書いていない宣言を書いたことにされる**。
+/*
+ * 「同じ行に現れたら宣言ではない」文脈の一覧は
+ * `scripts/lib/ci/pr-body-sections.mjs` の `DECLARATION_DISQUALIFYING_PATTERNS` が SSOT
+ * (#4255 で本 file に置いたものを #4348 で共有化)。
+ * DOM 参照 / 統合 VR evidence / schema skip marker も同じ規律で判定するため、
+ * 本 file 内に二重実装を残さない。
  */
-const MARKER_DISQUALIFYING_PATTERNS = [
-	/^\s*>/, // 引用 — 他所の文言を貼っただけ
-	/^\s*[-*]\s*\[\s\]/, // 未チェック checkbox — チェックしていない = 宣言していない
-	/ではありません|ではない|ではなく|とは限らない|とは言えない/, // 否定 (#4255 と同型)
-	/嘘|虚偽/, // gate 自身の説明文の引用
-	/なしの場合|と書く/, // 手順書の条件節 / 引用符付きの言及
-];
 
 /**
  * 「該当なし」明示記述の検出。refactor / docs / chore のみで UI 影響がない PR の opt-out 用。
@@ -318,19 +317,7 @@ const MARKER_DISQUALIFYING_PATTERNS = [
  * @returns {boolean}
  */
 export function hasUiNotApplicableMarker(body) {
-	let inFence = false;
-	for (const raw of (body ?? '').split(/\r?\n/)) {
-		if (/^\s*(?:```|~~~)/.test(raw)) {
-			inFence = !inFence;
-			continue;
-		}
-		if (inFence) continue;
-		// インラインコード (`...`) は言及であって宣言ではない
-		const line = raw.replace(/`[^`]*`/g, ' ');
-		if (MARKER_DISQUALIFYING_PATTERNS.some((p) => p.test(line))) continue;
-		if (UI_NOT_APPLICABLE_PATTERNS.some((p) => p.test(line))) return true;
-	}
-	return false;
+	return hasDeclarationLine(body, UI_NOT_APPLICABLE_PATTERNS);
 }
 
 /**
@@ -417,11 +404,16 @@ export function isUserAttachmentAssetUrl(url) {
  * - Markdown link: `[DOM HTML](https://.../foo.dom.html)`
  * - 素の URL: `https://.../foo.dom.html`
  *
+ * **行単位 + 文脈除外で判定する (#4348 対象 #4)**。旧実装は本文全体への `PATTERN.test(body)` で、
+ * HTML コメント / code block / 引用 / 否定文 / 未チェック checkbox の中の URL でも
+ * 「参照がある」と判定し、DOM 併記検証をまるごと消せた (#4255 の `hasStorybookStoryReference` /
+ * `hasUiNotApplicableMarker` と同 class)。判定規律は `pr-body-sections.mjs` に集約している。
+ *
  * @param {string} body
  * @returns {boolean}
  */
 export function hasDomSnapshotReference(body) {
-	return DOM_REF_PATTERN.test(body);
+	return hasDeclarationLine(body, [DOM_REF_PATTERN]);
 }
 
 // ---------------------------------------------------------------------------
@@ -449,10 +441,15 @@ const INTEGRATION_VR_EVIDENCE_PATTERNS = [
 	/\*?-visual-regression\.yml/i,
 	/(?:lp|child-home|app)[\s-]*(?:visual|vr|pixelmatch|baseline)/i,
 	// 含有 PR 群が develop 取込時に SS 検証済である宣言
-	/含有\s*PR/,
 	/(?:取込|取り込み)\s*(?:済|時).*(?:SS|スクリーンショット|スクショ|検証)/,
-	/統合\s*(?:対象|状態|smoke)/,
+	/統合\s*smoke/,
 ];
+
+/** 含有 PR 一覧 section の見出し (統合 PR template と同値、`.github/INTEGRATION_PR_TEMPLATE.md`)。 */
+const INTEGRATION_PR_LIST_SECTION = '含有 PR 一覧';
+
+/** 含有 PR の行と認める形 (PR / Issue 番号を持つ行)。 */
+const PR_REFERENCE_PATTERN = /#\d{2,}/;
 
 /**
  * integration lane (統合 PR) の SS 観点 evidence が PR body に含まれるかを判定 (#2946)。
@@ -465,11 +462,26 @@ const INTEGRATION_VR_EVIDENCE_PATTERNS = [
  * 「観点の移譲」であって「検証の放棄」ではない (no-go: 見た目検証を完全に消さない) ため、
  * いずれの evidence も無い場合は違反として扱う (warn / error は MODE 依存)。
  *
+ * # なぜ行単位 + 構造判定なのか (#4348 対象 #4)
+ *
+ * 旧実装は本文全体に 6 本の正規表現を当てるだけで、うち `/含有\s*PR/` と
+ * `/統合\s*(?:対象|状態|smoke)/` は**統合 PR template 自身が 3 箇所で満たしていた**
+ * (説明文 1 / HTML コメント 1 / 引用 2 — 実測)。つまり **VR 証跡の有無に関係なく
+ * 統合 PR は常に緑**で、#4333 (見出しの存在だけで NG-0 が常に緑) と同じ形だった。
+ *
+ * 是正は 2 点:
+ *   1. 宣言の判定を行単位 + 文脈除外に揃える (`pr-body-sections.mjs` SSOT)
+ *   2. 「含有 PR」は prose の言及ではなく **`## 含有 PR 一覧` section に実際の PR 参照が
+ *      1 行以上ある**という構造で見る (見出しだけ / 自動生成待ちの空 section は evidence にしない)
+ *
  * @param {string} body
  * @returns {boolean}
  */
 export function hasIntegrationVrEvidence(body) {
-	return INTEGRATION_VR_EVIDENCE_PATTERNS.some((p) => p.test(body));
+	if (hasDeclarationLine(body, INTEGRATION_VR_EVIDENCE_PATTERNS)) return true;
+	const section = extractH2Section(body, INTEGRATION_PR_LIST_SECTION);
+	if (!section.found) return false;
+	return findDeclarationLines(section.text, [PR_REFERENCE_PATTERN]).length > 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -721,7 +733,10 @@ function checkDomSnapshotViolation(body) {
 			`\n背景:\n` +
 			`  PR #1717 で発生した「SS と実機が乖離していた」事故の再発防止のため、\n` +
 			`  SS と DOM が同一プロセス・同一 page で取得されたことを構造的に保証します（#1747 AC4）。\n` +
-			`\nDOM スナップショットを意図的に省略する場合は、--no-dom-snapshot 指定の理由を PR body に明記してください。`,
+			`\n本 gate に「理由を書けば省略できる」経路はありません (#4348)。\n` +
+			`  DOM 併記を省く逃げ道として --no-dom-snapshot の理由記述を案内していましたが、\n` +
+			`  それを読む判定は実装のどこにも無く、案内どおり書いても落ち続ける状態でした。\n` +
+			`  撮影に使う環境で原理的に描画できない UI なら ss-render-impossible 宣言 (#4087) を使ってください。`,
 	};
 }
 

--- a/scripts/check-schema-change-tests.mjs
+++ b/scripts/check-schema-change-tests.mjs
@@ -60,11 +60,16 @@ for (const arg of process.argv.slice(2)) {
 	}
 }
 
+/**
+ * @param {string[]} args
+ * @returns {string}
+ */
 function runGit(args) {
 	try {
 		return execFileSync('git', args, { encoding: 'utf8' });
 	} catch (err) {
-		console.error('[check-schema-change-tests] git command failed:', err.message);
+		const message = err instanceof Error ? err.message : String(err);
+		console.error('[check-schema-change-tests] git command failed:', message);
 		process.exit(2);
 	}
 }

--- a/scripts/check-schema-change-tests.mjs
+++ b/scripts/check-schema-change-tests.mjs
@@ -26,10 +26,28 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { escapeRegExp } from './lib/ci/escape-regexp.mjs';
+import { hasDeclarationLine } from './lib/ci/pr-body-sections.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF_DEFAULT = 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
-const SKIP_MARKER = '[skip-schema-test-check]';
+export const SKIP_MARKER = '[skip-schema-test-check]';
+
+/**
+ * PR body に skip marker が **宣言として** 書かれているか (#4348)。
+ *
+ * 旧実装は `PR_BODY.includes(SKIP_MARKER)` で、marker の文字列が本文のどこか
+ * (HTML コメント / code block の手順説明 / 引用 / 否定文 / 本 script の案内文の貼り戻し) に
+ * あるだけで **検査がまるごと消えた**。判定規律は他の PR body gate と同じ SSOT
+ * (`scripts/lib/ci/pr-body-sections.mjs`) に揃え、行単位 + 文脈除外で見る。
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasSkipMarker(body) {
+	return hasDeclarationLine(body, [new RegExp(escapeRegExp(SKIP_MARKER))]);
+}
 
 const SCHEMA_FILE = 'src/lib/server/db/schema.ts';
 const TEST_DIR_PREFIXES = ['tests/unit/db/', 'tests/unit/services/'];
@@ -60,7 +78,7 @@ function getChangedFiles() {
 }
 
 function main() {
-	if (PR_BODY.includes(SKIP_MARKER)) {
+	if (hasSkipMarker(PR_BODY)) {
 		console.log(`[check-schema-change-tests] ${SKIP_MARKER} marker found — skipping.`);
 		return;
 	}
@@ -105,4 +123,8 @@ function main() {
 	console.warn('');
 }
 
-main();
+// CLI として直接実行された場合のみ main() を起動 (test からの import 時は実行しない)。
+// 判定は scripts/lib/is-main.mjs (SSOT、#3969) に委譲する。
+if (isMainModule(import.meta.url)) {
+	main();
+}

--- a/scripts/check-schema-migration-completeness.mjs
+++ b/scripts/check-schema-migration-completeness.mjs
@@ -58,11 +58,28 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { escapeRegExp } from './lib/ci/escape-regexp.mjs';
+import { hasDeclarationLine } from './lib/ci/pr-body-sections.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF_DEFAULT = 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
-const SKIP_MARKER = '[skip-schema-migration-check]';
+export const SKIP_MARKER = '[skip-schema-migration-check]';
+
+/**
+ * PR body に skip marker が **宣言として** 書かれているか (#4348)。
+ *
+ * 旧実装は `PR_BODY.includes(SKIP_MARKER)` で、marker の文字列が本文のどこか
+ * (HTML コメント / code block の手順説明 / 引用 / 否定文 / 本 script の案内文の貼り戻し) に
+ * あるだけで **検査がまるごと消えた**。判定規律は他の PR body gate と同じ SSOT
+ * (`scripts/lib/ci/pr-body-sections.mjs`) に揃え、行単位 + 文脈除外で見る。
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasSkipMarker(body) {
+	return hasDeclarationLine(body, [new RegExp(escapeRegExp(SKIP_MARKER))]);
+}
 
 const SCHEMA_FILE = 'src/lib/server/db/schema.ts';
 const LAZY_MIGRATION_FILE = 'src/lib/server/db/migration/lazy-startup-migrations.ts';
@@ -376,7 +393,7 @@ export function detectBreakingChanges(diff, options = {}) {
 }
 
 function main() {
-	if (PR_BODY.includes(SKIP_MARKER)) {
+	if (hasSkipMarker(PR_BODY)) {
 		console.log(`[check-schema-migration-completeness] ${SKIP_MARKER} marker found — skipping.`);
 		return;
 	}

--- a/scripts/lib/ci/pr-body-sections.mjs
+++ b/scripts/lib/ci/pr-body-sections.mjs
@@ -137,3 +137,77 @@ export function extractH2Section(body, heading, options = {}) {
 export function hasH2Section(body, heading) {
 	return extractH2Section(body, heading).found;
 }
+
+// ---------------------------------------------------------------------------
+// 宣言 (declaration) の判定 — 「その行が宣言か」を見る (#4255 → #4348 で共有化)
+//
+// gate を skip / pass に倒す marker (「UI 変更なし」「[skip-schema-test-check]」等) や
+// evidence 参照 (`.dom.html` リンク / VR 層への紐づけ) を **本文全体への 1 本の正規表現**で
+// 判定すると、以下が全部「書いてある」ことになる:
+//
+//   - HTML コメント (template の説明文。顧客にも監査にも見えない)
+//   - fenced code block / インラインコード (書式の例示)
+//   - 引用行 (他所の文言を貼っただけ)
+//   - 否定文 (「〜ではありません」— 文意と逆に判定される)
+//   - 未チェック checkbox (チェックしていない = 宣言していない)
+//   - 手順・案内文 (「〜と書いてください」— gate 自身のエラー出力を貼り戻すと成立する)
+//
+// 判定できないときは **宣言なし**に倒す (「確認できなかった」を「確認した」と同じ扱いにしない)。
+// ---------------------------------------------------------------------------
+
+/**
+ * 同じ行に現れたら **宣言ではない** と判断する文脈 (#4255 で `check-pr-screenshot.mjs` に
+ * 置いたものを #4348 で共有化)。
+ */
+export const DECLARATION_DISQUALIFYING_PATTERNS = [
+	/^\s*>/, // 引用 — 他所の文言を貼っただけ
+	/^\s*[-*]\s*\[\s\]/, // 未チェック checkbox — チェックしていない = 宣言していない
+	// 否定 (#4255 の実績セットを変えない)。
+	// 「していない」等の一般的な否定動詞は足さない — 「UI 変更なし (コードを 1 行も変更して
+	// いないため)」のような**正しい宣言**を落とす (merged PR #4464 で実測)。
+	/ではありません|ではない|ではなく|とは限らない|とは言えない/,
+	/嘘|虚偽/, // gate 自身の説明文の引用
+	/なしの場合|の場合は|場合:|と書く|と明記|を含めて|してください/, // 手順書の条件節 / 案内文
+];
+
+/**
+ * PR body から「宣言として成立している行」を拾う。
+ *
+ * @param {string} body PR 本文
+ * @param {RegExp[]} patterns 宣言とみなすパターン (行に対して `test` する)
+ * @param {{ extraDisqualifying?: RegExp[] }} [options]
+ * @returns {string[]} 宣言として成立した行 (前後の空白を落としたもの)
+ */
+export function findDeclarationLines(body, patterns, options = {}) {
+	const disqualifying = [
+		...DECLARATION_DISQUALIFYING_PATTERNS,
+		...(options.extraDisqualifying ?? []),
+	];
+	/** @type {string[]} */
+	const found = [];
+	let inFence = false;
+	for (const raw of stripHtmlComments((body ?? '').replace(/\r\n?/g, '\n')).split('\n')) {
+		if (/^\s*(?:```|~~~)/.test(raw)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
+		// インラインコード (`...`) は言及であって宣言ではない
+		const line = raw.replace(/`[^`]*`/g, ' ');
+		if (disqualifying.some((p) => p.test(line))) continue;
+		if (patterns.some((p) => p.test(line))) found.push(line.trim());
+	}
+	return found;
+}
+
+/**
+ * PR body に「宣言として成立している行」が 1 行でもあるか。
+ *
+ * @param {string} body
+ * @param {RegExp[]} patterns
+ * @param {{ extraDisqualifying?: RegExp[] }} [options]
+ * @returns {boolean}
+ */
+export function hasDeclarationLine(body, patterns, options = {}) {
+	return findDeclarationLines(body, patterns, options).length > 0;
+}

--- a/src/routes/CLAUDE.md
+++ b/src/routes/CLAUDE.md
@@ -115,7 +115,16 @@ node scripts/capture.mjs --pr <N>            # 修正後 SS を撮り直す
 
 - 否定文（「UI 変更なし**ではありません**」）/ 引用行（`> …`）/ コードブロック・インラインコード内
 - **未チェックの checkbox**（`- [ ] UI 変更なし`）— チェックしていない = 宣言していない
-- 手順・条件節（「UI 変更なし**の場合**: …」）
+- 手順・条件節（「UI 変更なし**の場合**: …」）/ 案内文（「〜と書いてください」）
+- **HTML コメント内**（`<!-- UI 変更なし -->`）— レンダリングされた PR body に出ないため、レビュアーにも監査にも見えない（#4348）。宣言は**本文に見える形で**書く
+
+この判定規律（行単位 + HTML コメント / コードブロック / 引用 / 否定 / 未チェック checkbox / 案内文の除外）は `scripts/lib/ci/pr-body-sections.mjs` が SSOT で、**PR body を読む他の gate も同じ規律を使う**（#4348）:
+
+| 判定 | 対象 |
+|---|---|
+| `.dom.html` 参照の有無 | DOM スナップショット併記検証（`check-pr-screenshot.mjs`） |
+| 統合 PR の VR 証跡 | 統合 lane の SS 観点。加えて「含有 PR」は prose の言及ではなく **`## 含有 PR 一覧` に実際の PR 参照がある**ことで判定する |
+| `[skip-schema-test-check]` / `[skip-schema-migration-check]` | schema 系 gate の skip marker |
 
 **テンプレートや案内文に opt-out 宣言そのものを書かない。** テンプレートを消さずに出しただけで gate が skip されるため、案内は「何を書くか」の説明にとどめる（`tests/unit/scripts/check-pr-screenshot.test.ts` が実テンプレートを読んで検証している）。
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -329,7 +329,7 @@ it('is_archived が NULL の既存行もアクティブとして返される', (
 
 「NULL = 既定値扱い」セマンティクスなら `or(eq(col, default), isNull(col))` または **マイグレーションで backfill**。片側だけは不十分。
 
-CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.ts` diff があるのに `tests/unit/db/` または `tests/unit/services/` diff が無い場合警告。skip 必要時は PR 本文に `[skip-schema-test-check]`。
+CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.ts` diff があるのに `tests/unit/db/` または `tests/unit/services/` diff が無い場合警告。skip 必要時は PR 本文に `[skip-schema-test-check]` を**宣言として**書く (HTML コメント / コードブロック / 引用 / 未チェック checkbox / 案内文の中の同じ文字列では skip しない、#4348)。
 
 ### backend 並行実装の整合性
 

--- a/tests/unit/architecture/pr-body-partial-match-guard.test.ts
+++ b/tests/unit/architecture/pr-body-partial-match-guard.test.ts
@@ -28,8 +28,16 @@ vi.setConfig({ testTimeout: 60_000 });
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SCAN_DIR = resolve(REPO_ROOT, 'scripts');
 
-/** PR body を指す変数名 (これらに対する部分一致判定を検出対象にする)。 */
-const BODY_IDENT = String.raw`(?:[A-Za-z_$][\w$]*)?[Bb]ody`;
+/**
+ * PR body を指す変数名 (これらに対する部分一致判定を検出対象にする)。
+ *
+ * **大文字の `PR_BODY` も含める (#4348 で追加)**。旧実装は `[Bb]ody` しか見ておらず、
+ * env 由来の定数名 `PR_BODY` に対する `.includes(...)` が検出器から漏れていた。
+ * 実際に schema 系 gate 2 本が `PR_BODY.includes(SKIP_MARKER)` で **gate 全体を skip** しており、
+ * 「本 Issue の対象一覧にも ALLOWLIST にも載らない同 class」が残っていた。
+ * 検出できない形を残すと guard 自体が「検査できなかったのに緑」になる (#4084 と同じ穴)。
+ */
+const BODY_IDENT = String.raw`(?:[A-Za-z_$][\w$]*)?(?:[Bb]ody|BODY)`;
 
 /** `<body>.indexOf(` / `<body>.includes(` — 部分一致で section / 宣言を探す形。 */
 const SUBSTRING_RE = new RegExp(String.raw`\b(${BODY_IDENT})\s*\.\s*(indexOf|includes)\s*\(`, 'g');
@@ -49,11 +57,6 @@ const ALLOWLIST: Record<string, string> = {
 		'#4348 残置 (対象 #6): feature lane の AC マップ section 探索。全 feature PR に波及するため別 PR で corpus 比較のうえ是正する',
 	'scripts/check-admin-bypass-evidence.mjs::return EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body));':
 		'#4348 残置 (対象 #3): admin bypass 証跡マーカーの存在検査。nightly 監査 script で PR gate とは別経路のため別 PR で是正する',
-	'scripts/check-pr-screenshot.mjs::return DOM_REF_PATTERN.test(body);':
-		'#4348 残置 (対象 #4): DOM スナップショット参照の存在検査。#4255 の兄弟関数と同様に実在検査へ寄せる別 PR で是正する',
-	'scripts/check-pr-screenshot.mjs::return INTEGRATION_VR_EVIDENCE_PATTERNS.some((p) => p.test(body));':
-		'#4348 残置 (対象 #4): 統合 PR の VR 証跡の存在検査。同上',
-
 	// --- 構造化識別子ではなく prose (自然文) を探す用途。本文全体を見るのが正しい ---
 	'scripts/check-pr-screenshot.mjs::hasBefore: BEFORE_LABEL_PATTERN.test(body),':
 		'prose 検査: 「修正前」ラベルの表記ゆれを本文から探す用途で、見出し等の構造化識別子ではない',

--- a/tests/unit/scripts/check-pr-screenshot.test.ts
+++ b/tests/unit/scripts/check-pr-screenshot.test.ts
@@ -139,6 +139,13 @@ describe('hasUiNotApplicableMarker', () => {
 			expect(hasUiNotApplicableMarker('判定は `UI 変更なし` の有無で行う')).toBe(false);
 		});
 
+		// #4348: HTML コメントは顧客にも監査にも見えないので宣言ではない
+		// (コメント除去は他の PR body gate と同じ規律に揃えた)。
+		it('HTML コメント内の記述は宣言として扱わない', () => {
+			expect(hasUiNotApplicableMarker('<!-- UI 変更なし の場合はここに書く -->')).toBe(false);
+			expect(hasUiNotApplicableMarker('<!-- 該当なし（refactor / docs / chore） -->')).toBe(false);
+		});
+
 		it('**未チェックの checkbox は宣言として扱わない**（チェックしていない = 宣言していない）', () => {
 			expect(hasUiNotApplicableMarker('- [ ] UI 変更なし')).toBe(false);
 			expect(hasUiNotApplicableMarker('- [x] UI 変更なし')).toBe(true);
@@ -317,6 +324,46 @@ describe('hasDomSnapshotReference (#1766 / #1747 AC4)', () => {
 		// URL ではなく説明文中の言及なので検出されない
 		expect(hasDomSnapshotReference(body)).toBe(false);
 	});
+
+	// #4348 (対象 #4): 本文全体への 1 本の正規表現をやめ、行単位 + 文脈除外に揃える。
+	// 「参照がある」と判定されると DOM 併記検証がまるごと消えるため、
+	// **書いていない参照を書いたことにされる**経路を塞ぐ (#4255 / hasUiNotApplicableMarker と同型)。
+	describe('行単位 + 文脈除外 (#4348 対象 #4)', () => {
+		it('HTML コメント内の .dom.html URL は参照として扱わない', () => {
+			const body =
+				'![after](https://example.com/a.png)\n<!-- [DOM HTML](https://x/foo.dom.html) -->';
+			expect(hasDomSnapshotReference(body)).toBe(false);
+		});
+
+		it('コードブロック内の .dom.html URL は参照として扱わない', () => {
+			const body = ['```md', '[DOM HTML](https://example.com/foo.dom.html)', '```'].join('\n');
+			expect(hasDomSnapshotReference(body)).toBe(false);
+		});
+
+		it('インラインコード内の .dom.html URL は参照として扱わない（書式の説明）', () => {
+			expect(hasDomSnapshotReference('書式: `[DOM HTML](https://example.com/x.dom.html)`')).toBe(
+				false,
+			);
+		});
+
+		it('引用行 / 否定文の .dom.html URL は参照として扱わない', () => {
+			expect(hasDomSnapshotReference('> [DOM](https://example.com/foo.dom.html) を貼ること')).toBe(
+				false,
+			);
+			expect(
+				hasDomSnapshotReference('https://example.com/foo.dom.html は撮れていないため添付ではない'),
+			).toBe(false);
+		});
+
+		it('未チェック checkbox 行の .dom.html URL は参照として扱わない', () => {
+			expect(hasDomSnapshotReference('- [ ] [DOM HTML](https://example.com/foo.dom.html)')).toBe(
+				false,
+			);
+			expect(hasDomSnapshotReference('- [x] [DOM HTML](https://example.com/foo.dom.html)')).toBe(
+				true,
+			);
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -492,10 +539,9 @@ describe('hasIntegrationVrEvidence (#2946 — integration lane SS 観点)', () =
 		expect(hasIntegrationVrEvidence('app pixelmatch baseline 比較で回帰未検出。')).toBe(true);
 	});
 
-	it('含有 PR への言及があれば true', () => {
-		expect(
-			hasIntegrationVrEvidence('含有 PR: #3001 / #3002 / #3003 (いずれも develop 取込済み)。'),
-		).toBe(true);
+	it('`## 含有 PR 一覧` section に含有 PR の行があれば true', () => {
+		const body = ['## 含有 PR 一覧', '', '- #3001 活動追加', '- #3002 ごほうび修正'].join('\n');
+		expect(hasIntegrationVrEvidence(body)).toBe(true);
 	});
 
 	it('取込時 SS 検証済の宣言があれば true', () => {
@@ -503,11 +549,39 @@ describe('hasIntegrationVrEvidence (#2946 — integration lane SS 観点)', () =
 		expect(hasIntegrationVrEvidence('含有 PR は取込済で個別に SS 検証されている。')).toBe(true);
 	});
 
-	it('統合対象 / 統合状態 / 統合 smoke への言及があれば true', () => {
-		expect(hasIntegrationVrEvidence('本 PR は統合対象 PR 群を束ねる develop→main 統合 PR。')).toBe(
-			true,
-		);
+	it('統合 smoke への言及があれば true', () => {
 		expect(hasIntegrationVrEvidence('統合 smoke を実行し問題なし。')).toBe(true);
+	});
+
+	// #4348 (対象 #4): 旧実装は本文全体に 6 本の正規表現を当てるだけで、
+	// 「含有 PR」「統合対象」の 4 文字が本文のどこか (説明文 / HTML コメント / 引用) にあれば
+	// 緑になっていた。統合 PR template はその 4 文字を 3 通りで含むため、
+	// **統合 PR は VR 証跡の有無に関係なく常に緑**だった (#4333 と同じ形)。
+	describe('行単位 + 構造判定 (#4348 対象 #4)', () => {
+		it('PR を束ねる自己紹介文だけでは false (evidence ではない)', () => {
+			expect(
+				hasIntegrationVrEvidence('本 PR は統合対象 PR 群を束ねる develop→main 統合 PR。'),
+			).toBe(false);
+			expect(hasIntegrationVrEvidence('含有 PR 一覧は B-3 が自動生成します。')).toBe(false);
+		});
+
+		it('HTML コメント / 引用 / 否定文の言及は evidence として扱わない', () => {
+			expect(hasIntegrationVrEvidence('<!-- visual regression の結果をここに書く -->')).toBe(false);
+			expect(hasIntegrationVrEvidence('> visual regression の結果を貼ること')).toBe(false);
+			expect(hasIntegrationVrEvidence('本 PR は visual regression の対象ではない')).toBe(false);
+		});
+
+		it('`## 含有 PR 一覧` が空 (見出しだけ) なら false', () => {
+			expect(hasIntegrationVrEvidence('## 含有 PR 一覧\n\n<!-- B-3 が自動生成 -->')).toBe(false);
+		});
+
+		// 生成側 assert: 統合 PR template を素で出しただけで evidence 成立させない (#4348 AC7)。
+		it('統合 PR テンプレートを素で生成した body は evidence を成立させない', () => {
+			expect(
+				hasIntegrationVrEvidence(readFileSync('.github/INTEGRATION_PR_TEMPLATE.md', 'utf8')),
+				'template を貼るだけで統合 PR の SS 観点検証が緑になる',
+			).toBe(false);
+		});
 	});
 
 	it('generic な本文 (VR 言及 / 含有 PR / 取込検証なし) なら false', () => {

--- a/tests/unit/scripts/check-schema-skip-marker.test.ts
+++ b/tests/unit/scripts/check-schema-skip-marker.test.ts
@@ -1,0 +1,71 @@
+/**
+ * tests/unit/scripts/check-schema-skip-marker.test.ts (#4348)
+ *
+ * schema 系 gate 2 本の **skip marker 判定**の unit test。
+ *
+ * この 2 本は marker を `PR_BODY.includes('[skip-...]')` で見ており、
+ * marker 文字列が本文のどこか (HTML コメント / 引用 / 否定文 / gate 自身のエラー出力の貼り付け /
+ * コードブロック内の手順説明) にあるだけで **gate がまるごと skip** されていた。
+ * #4348 の対象一覧には無かったが、`.includes` を大文字 `PR_BODY` に対して行うため
+ * fitness function の検出器 (`pr-body-partial-match-guard.test.ts`) からも見えていなかった。
+ *
+ * skip は「宣言」であって「言及」ではない。判定は行単位で、他の PR body gate と同じ規律
+ * (`scripts/lib/ci/pr-body-sections.mjs` の `hasDeclarationLine`) に揃える。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	hasSkipMarker as hasTestCheckSkipMarker,
+	SKIP_MARKER as TEST_CHECK_MARKER,
+} from '../../../scripts/check-schema-change-tests.mjs';
+import {
+	hasSkipMarker as hasMigrationSkipMarker,
+	SKIP_MARKER as MIGRATION_MARKER,
+} from '../../../scripts/check-schema-migration-completeness.mjs';
+
+const CASES = [
+	{ name: 'check-schema-change-tests', marker: TEST_CHECK_MARKER, has: hasTestCheckSkipMarker },
+	{
+		name: 'check-schema-migration-completeness',
+		marker: MIGRATION_MARKER,
+		has: hasMigrationSkipMarker,
+	},
+] as const;
+
+for (const { name, marker, has } of CASES) {
+	describe(`${name}: skip marker は宣言としてのみ成立する (#4348)`, () => {
+		it('本文に単独で書かれた marker は skip する (既存挙動)', () => {
+			expect(has(`純フォーマット変更のみ。${marker}`)).toBe(true);
+		});
+
+		it('marker が無ければ skip しない', () => {
+			expect(has('schema.ts に列を追加しました。')).toBe(false);
+			expect(has('')).toBe(false);
+		});
+
+		it('HTML コメント内の marker では skip しない (顧客にも監査にも見えない)', () => {
+			expect(has(`<!-- skip したいときは ${marker} と書く -->`)).toBe(false);
+		});
+
+		it('コードブロック / インラインコード内の marker では skip しない (手順の引用)', () => {
+			expect(has(['```', `PR 本文に ${marker} を含める`, '```'].join('\n'))).toBe(false);
+			expect(has(`skip 方法は \`${marker}\` です`)).toBe(false);
+		});
+
+		it('引用行 / 否定文 / 未チェック checkbox の marker では skip しない', () => {
+			expect(has(`> ${marker} を書けば skip されます`)).toBe(false);
+			expect(has(`本 PR は ${marker} ではありません`)).toBe(false);
+			expect(has(`- [ ] ${marker}`)).toBe(false);
+			expect(has(`- [x] ${marker}`)).toBe(true);
+		});
+
+		it('gate 自身の案内文をそのまま貼っても skip しない (出力の貼り戻しで検査が消えない)', () => {
+			// 実際の案内文 (`check-schema-migration-completeness.mjs`) と同じ形。
+			expect(
+				has(
+					`  純フォーマット変更など意図的に skip する場合は PR 本文に "${marker}" を含めてください。`,
+				),
+			).toBe(false);
+		});
+	});
+}


### PR DESCRIPTION
## 顧客価値・目的

PR body を読む gate が「宣言らしき文字列が本文のどこかにあれば通る」形のままだと、**顧客に見える不具合が証跡ゼロで main まで進む**。本 PR は #4348 の残件のうち対象 #4 (SS gate 2 関数) を是正し、あわせて同 class の検出器が見落としていた形 (skip marker 2 本) を塞ぐ。

## 関連 Issue

Refs #4348（**close しません**）

<!-- no-issue-close: #4348 の対象一覧 3 件のうち #4 のみを是正した部分実装のため。残り 2 件は Issue 本文の「1 箇所ずつ corpus 実測」指示に従い別 PR。 -->

**本 PR は #4348 の部分実装です。** 対象一覧のうち **#4 のみ**を是正しました。Issue 本文が「6 箇所を 1 PR で一括変更しない（AC4 の実測が箇所ごとに必要）」と明示しているためです。

| 対象 | 状態 |
|---|---|
| **#4**（SS gate の 2 関数） | **本 PR で是正** |
| #3（`check-admin-bypass-evidence.mjs`） | 未着手。nightly 監査経路で corpus の作り方が PR gate と異なる |
| #6（`checkPerPrAcMap`） | 未着手。**ただし下記のとおり「厳格化」ではなく「削除」の判断が先** |

AC を満たしていないので close しません。

## 変更内容

- `scripts/lib/ci/pr-body-sections.mjs`: 宣言判定の SSOT に `findDeclarationLines` / `hasDeclarationLine` / `DECLARATION_DISQUALIFYING_PATTERNS` を追加（行単位 + HTML コメント / code block / インラインコード / 引用 / 否定 / 未チェック checkbox / 案内文の除外）
- `scripts/check-pr-screenshot.mjs`: `hasDomSnapshotReference` / `hasIntegrationVrEvidence` / `hasUiNotApplicableMarker` を上記 SSOT に統一。統合 PR の「含有 PR」は prose の言及ではなく `## 含有 PR 一覧` に実 PR 参照があることで判定。実装のどこにも無い `--no-dom-snapshot` の逃げ道案内を撤去
- `scripts/check-schema-change-tests.mjs` / `check-schema-migration-completeness.mjs`: skip marker 判定を `PR_BODY.includes()` から宣言判定に変更（+ 前者に isMain guard）
- `tests/unit/architecture/pr-body-partial-match-guard.test.ts`: 検出器が大文字 `PR_BODY` を見ていなかった盲点を修正、是正済み 2 件を ALLOWLIST から削除
- test 2 件 + docs 3 件（`src/routes/CLAUDE.md` / `tests/CLAUDE.md` / `docs/design/08-データベース設計書.md`）

## 検証

- `npx vitest run tests/unit/scripts/ tests/unit/architecture/pr-body-partial-match-guard.test.ts` → 54 files / 1204 passed
- `node --test "scripts/__tests__/**/*.test.mjs"` → 206 pass / 0 fail
- `npx biome check scripts tests` → clean / `npm run cspell` → Issues found: 0
- mutation 4 種すべてで対象 test が落ちることを実測（詳細は本文下部の表 / agent report）
- AC4 corpus: merged 85 PR で旧/新判定を同一入力比較 → 変化 2 件（いずれも意図した厳格化）

### 見つかったもの — 検出器自身が検査できていなかった

1. **統合 PR の SS 観点検証は、VR 証跡の有無に関係なく常に緑でした。** `.github/INTEGRATION_PR_TEMPLATE.md` を素で判定にかけると旧 `hasIntegrationVrEvidence` が **3 箇所で true**（説明文 1 行 / HTML コメント 1 行 / 引用 2 行）。テンプレートを消さずに出すだけで検証が成立していた形で、#4333 と同型です。実テンプレートを読む assert で pin しました

2. **fitness function の検出器が大文字 `PR_BODY` を見ていませんでした**（`[Bb]ody` しか見ていない）。そこに **skip marker 2 本**（成立すると gate 全体が消える）が隠れており、#4348 の対象一覧にも ALLOWLIST にも載っていませんでした。**検出器の盲点なので同 PR で塞ぎました**

3. **実装のどこにも無い逃げ道を案内していました** — `dom-snapshot-missing` のメッセージが「`--no-dom-snapshot` 指定の理由を PR body に明記してください」と言うのに、その option は存在しません（PR #4519 の申し送り）。**逃げ道を新設するのではなく、嘘の案内を撤去**しました（gate を緩める方向の変更はしていません）

### corpus 実測が私の実装バグを 1 件見つけました

merged 85 PR で旧 / 新を同一入力比較し、変化は **2 件のみ**（#3914 = 含有 PR 0 件の統合 PR / #4542 = HTML コメント内の宣言。どちらも意図した厳格化で、一斉赤化はありません）。

その過程で、否定表現に `していない` を入れた初期実装が **merged PR #4464 の正しい宣言**「UI 変更なし（プロダクションコードを 1 行も変更していないため…）」を落としていました。一般的な否定動詞は宣言の否定ではないため、#4255 の実績セットに戻しています。**corpus を回さなければ、正しい PR を落とす gate を出していました。**

### 申し送り: 対象 #6 は死んだコードです

`checkPerPrAcMap` は #4305 で entry から外れており、**呼び出しは自身の test だけ**です。Issue が付けた理由「全 feature PR に波及」は現時点で成立しません。**次に触る人は、厳格化ではなく削除の是非を先に判断してください**（死んだコードに corpus 実測を積む価値がありません）。

## 影響範囲

SS gate（`pr-quality-gate.yml` screenshot-check、mode=warn）と schema 系 gate 2 本の判定のみ。判定は厳格化方向で、緩めた箇所は無い。

## 配布済み env / secret (ADR-0006)

なし（新規 env / secret の追加なし）。



## QM レビュー結果

<!-- QM が記入 -->
