### PR TITLE
fix(docs): #4605 CLAUDE.md の「CI で hard-fail する検査」列挙を実測に合わせ、ci.yml と突合する guard を置く

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,52 @@ Ready 化前は依然として `npm run pre-ready -- --pr <num>` 全 step PASS �
 
 1. biome check / 2. svelte-check / 7. check-no-plan-literals (#972) / 7g. check-local-tz-date-getters (#4015 / #4127, TZ 依存の日付導出禁止 / JST SSOT 強制) / 9. Readiness gate = check-pr-body (PR 番号必須) / 11b. SS embed gate (#2918, UI 変更 PR の SS 未 embed hard-fail)
 
-**選定基準は ADR-0007 §1-2 判断原則 v2** (#4121): 類型 1 (証跡の真正性 = Step 9 / 11b) と 類型 2 (顧客に見える正しさ = Step 1 / 2 / 7 / 7g) のうち安価なものだけを残す。**pre-ready から外しても CI で hard-fail し続ける検査**は以下がその全部である — vitest は CI `unit-test`、cspell / license-key-leak / CLI entry guard (`check-cli-entry-guard.mjs`) / generate-lp-labels --check は CI `lint-and-test`、LP 寸法は `lp-metrics.yml` (対応表は `--help`)。**`gh pr checks <num>` でこれらが pass (skipped でない) ことを確認してから Ready 化する**。**ここに挙がっていない検査は CI にも無い** — 「pre-ready に無い検査は CI が拾ってくれる」と一般化しないこと。
+**選定基準は ADR-0007 §1-2 判断原則 v2** (#4121): 類型 1 (証跡の真正性 = Step 9 / 11b) と 類型 2 (顧客に見える正しさ = Step 1 / 2 / 7 / 7g) のうち安価なものだけを残す。**pre-ready の 6 step は CI が hard-fail させる検査のごく一部でしかない**。`gh pr checks <num>` で CI 側が pass (skipped でない) ことを確認してから Ready 化する。
+
+#### CI `ci.yml` で hard-fail する検査（実測 SSOT、#4605）
+
+以下 2 ブロックは `.github/workflows/ci.yml` の実測（`continue-on-error: true` も `|| true` も付かない step）であり、`tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts` が ci.yml と突合する（列挙漏れ / 陳腐化 / 理由なし除外 / job 新設漏れで CI fail）。**手で足さない — ci.yml を変えたら test の指示どおり本ブロックを直す。**
+
+`lint-and-test` job の hard-fail step（ローカルで個別に回すときのコマンドがそのまま key）:
+
+<!-- ci-hard-fail-steps:start -->
+- `npx biome check --error-on-warnings .` — Biome (pre-ready Step 1 と同一)
+- `npm run lint:parallel` — 並行実装 SSOT (generate-lp-labels --check / LP innerHTML / @html)
+- `node scripts/check-no-plan-literals.mjs` — プラン文字列直書き (pre-ready Step 7)
+- `node scripts/check-cli-entry-guard.mjs` — CLI entry 判定の方言禁止
+- `node scripts/check-workflow-sparse-checkout-closure.mjs` — sparse-checkout 列挙の閉包
+- `node scripts/check-readdir-rotation-guard.mjs` — 緩い一致で世代を数える class の禁止
+- `node scripts/check-repo-scan-test-declaration.mjs` — repo 走査 test の区分宣言
+- `node scripts/check-local-tz-date-getters.mjs` — TZ 依存の日付導出禁止 (pre-ready Step 7g)
+- `node scripts/check-license-key-leak.mjs --budget-ms 120000` — license key 再導入禁止
+- `node scripts/check-no-direct-env-access.mjs` — `process.env` 直参照禁止
+- `node scripts/check-no-waitfortimeout.mjs` — `scripts/` の `waitForTimeout` 禁止
+- `node --test "scripts/__tests__/**/*.test.mjs"` — scripts の node:test 全件
+- `npm run check:no-demo-route-dup` — demo route 二重実装禁止
+- `npm run cspell` — スペルチェック (warning=error)
+- `npx stylelint "src/**/*.css"` — CSS hex 直書き
+- `npx eslint "tests/**/*.ts"` — ESLint Playwright (no-networkidle / no-wait-for-timeout)
+- `npm run lint:typed` — ESLint type-aware (no-floating-promises / no-misused-promises、CI 限定)
+- `npm run lint:svelte` — **ESLint Svelte** (recommended + XSS AST。`eslint-suppressions.json` で baseline 凍結 + ratchet = 新規違反のみ fail)
+- `npx svelte-kit sync && npx svelte-check --tsconfig ./tsconfig.json --threshold warning` — **pre-ready Step 2 より厳しい**（CI は warning も fail）
+- `cd infra && npx tsc --noEmit` — CDK 型検査
+- `npm run type-coverage` — 型カバレッジ ratchet
+- `npm run build` — 本体ビルド
+- `npm run build-storybook -- --quiet` — Storybook ビルド (stories 変更時のみ)
+<!-- ci-hard-fail-steps:end -->
+
+`ci.yml` のその他 hard-fail job（`lint-and-test` 以外。中身の step までは列挙しない）:
+
+<!-- ci-hard-fail-jobs:start -->
+- `marketplace-registry-integrity-check` / `deps-supply-chain-check` / `dependency-cruiser` / `cdk-cfn-lint`
+- `unit-test` (vitest 2 shard) / `unit-test-merge` (coverage 閾値 ratchet + test anti-pattern)
+- `storybook-test` / `e2e-test` / `e2e-matrix` / `e2e-cognito-dev` / `e2e-demo-lambda` / `a11y`
+- `docker-build`
+- `new-env-distribution-check` / `schema-change-tests-check` / `schema-migration-completeness-check`
+- `main-pr-base-guard`
+<!-- ci-hard-fail-jobs:end -->
+
+**本ブロックが保証するのは `ci.yml` の範囲だけ**。他の workflow（`lp-metrics.yml` の LP 寸法・禁止語、visual regression 3 層、`pr-template-gate.yml` 等の PR body 系 gate）は突合対象外なので、`gh pr checks <num>` で個別に見る（`ci-gate` は skipped を failure に数えないため ci-gate green を根拠にしない）。
 
 **Step 番号は表示上の識別子であり実行順ではない (#4048)**。実行は cheap-fail-first — PR body だけを見る検査 (Step 9) → 静的テキスト検査 (1 / 7 / 7g) → 型検査 (2) → SS 系 (11b) の順。
 

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -11,9 +11,12 @@
  * #4121 (E5 Wave 2): step が 20 本まで増えて 1 PR が 1 日で回らなくなったため、
  * **hard-fail は 6 本**に絞った。選定は ADR-0007 §1-2「判断原則 v2」に従い、
  * 類型 1 (証跡の真正性 / 不可逆な損失) と 類型 2 (顧客に見える正しさ) のうち安価なものだけを残す。
- * **pre-ready から外しても CI で hard-fail し続ける検査**は ci.yml lint-and-test / unit-test、
- * lp-metrics.yml のみ（#4322 で doc-code-references / hardcoded-strings / terminology-coherence /
- * lp-fallback-check.yml 等 20 件は script/workflow ごと削除済み、#4420）。対応表は `--help` を参照。
+ * **pre-ready の 6 step は CI が hard-fail させる検査のごく一部**であり、「pre-ready に無い検査は
+ * CI にも無い」ではない（#4605。ci.yml lint-and-test には pre-ready に一度も入っていない hard-fail
+ * step が多数ある = eslint svelte / type-aware / stylelint / type-coverage …）。CI 側の実測一覧は
+ * ルート CLAUDE.md の `ci-hard-fail-steps` / `ci-hard-fail-jobs` marker block が SSOT で、
+ * tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts が ci.yml と突合する。
+ * 下の「pre-ready から外した検査の行き先」は **移した先の記録であって CI 全体の一覧ではない**。
  *
  * 6 step を順次実行し、各 fail で即 exit 1 + 修正方針を表示する。
  * 各 Step は既存の `scripts/*.mjs` / `npm run *` を子プロセスで呼ぶラッパー（独自実装は最小化）。
@@ -142,6 +145,14 @@ step の前に走る preflight:
   pre-ready に残す。残りは CI 側で hard-fail のまま走る。
     - 類型 1: Step 9 (Ready checklist / AC 証跡 / 禁止語) / Step 11b (SS 証跡)
     - 類型 2: Step 1 / 2 / 7 / 7g
+
+CI 側の hard-fail 検査の一覧 (#4605):
+  本 --help は **pre-ready から外した検査の行き先**しか書かない。CI が hard-fail させる検査は
+  これより多い (eslint svelte / eslint type-aware / stylelint / CDK tsc / type-coverage / build …)。
+  実測一覧はルート CLAUDE.md の marker block (ci-hard-fail-steps / ci-hard-fail-jobs) が SSOT で、
+  tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts が ci.yml と突合する
+  (列挙漏れ / 陳腐化 / 理由なし除外 / job 新設漏れで fail)。
+  なお svelte-check は **CI の方が厳しい** (CI = --threshold warning / Step 2 = error 閾値)。
 
 pre-ready から外した検査の行き先 (#4121。**現存するものは CI で hard-fail のまま走る**):
   cspell / license-key-leak / cli-entry-guard /
@@ -761,7 +772,9 @@ export function buildSummary({
 		`  pre-ready が保証するのは上の 6 step だけです。以下は保証しません:\n` +
 		`    - 負荷 / タイミング依存の失敗   空いた local では再現しない (実測 #4385: 同一 test が 1,860→6,398ms)\n` +
 		`    - vitest / e2e / Storybook / visual regression   CI (unit-test 2 shard / 重量レーン) で走る\n` +
-		`    - lint-and-test 系   cspell / license-key-leak / CLI entry guard 系 / generate-lp-labels --check ほか\n` +
+		`    - lint-and-test 系   eslint svelte / eslint type-aware / stylelint / cspell / license-key-leak /\n` +
+		`                         CLI entry guard 系 / CDK tsc / type-coverage / build ほか (実測一覧は\n` +
+		`                         CLAUDE.md の ci-hard-fail-steps ブロック。svelte-check は CI の方が厳しい)\n` +
 		`      (hardcoded-strings / doc-code-references / terminology-coherence / lp-fallback-check は #4322 で\n` +
 		`       script/workflow ごと削除済み — CI にも無い。機械強制は無い、#4420)\n` +
 		`    - LP 系   lp-metrics (寸法・禁止語)\n` +

--- a/tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts
+++ b/tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts
@@ -1,0 +1,239 @@
+// tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts
+// #4605: ルート CLAUDE.md の「CI で hard-fail する検査」列挙を、`.github/workflows/ci.yml` の実測と突合する。
+//
+// 背景 (なぜ手書きの列挙では駄目だったか):
+//   CLAUDE.md は #4121 (pre-ready を 6 step に絞った時点) の一覧を「以下がその全部である」
+//   「ここに挙がっていない検査は CI にも無い」と断定したまま置かれていた。その後 ci.yml には
+//   #3877 (lint:typed) / #3878 (lint:svelte) / #3969 / #3978 / #4015 / #4085 … と hard-fail step が
+//   足され続けたが、doc は一度も追随していない。ci.yml を触る PR は CLAUDE.md を開かないので、
+//   列挙は step が増えるたびに静かに古くなる。
+//
+//   実害 (PR #4603): 担当は CLAUDE.md の断定から「eslint svelte は CI に無い」と判断して Ready 化し、
+//   `lint-and-test` が `svelte/no-useless-children-snippet` で fail → 1 往復。
+//   **doc の誤りがそのまま PR 往復のコストになる**。人の注意では追随しないので機械に持たせる
+//   (ADR-0061 same-class-N→guard)。形は tests/unit/docs/stripe-webhook-subscribed-events-ssot.test.ts
+//   (doc の marker block ⇄ 実装 case の突合 + 未登録の silent gap 検出) と同型。
+//
+// 本 gate が検出するもの / しないもの:
+//   検出する: (1) ci.yml にあるが doc の marker block に無い hard-fail step (列挙漏れ)
+//             (2) doc にあるが ci.yml に無い step (陳腐化)
+//             (3) ci.yml の job が doc にも除外リストにも無い (job 新設の silent gap)
+//             (4) 除外リストの理由が理由になっていない (exclusion-reason.mjs の判定)
+//             (5) marker block の欠落 / 0 件マッチ (検査の空振り)
+//   検出しない: ci.yml 以外の workflow (lp-metrics.yml 等)。doc 側でも「対象外」と明記している。
+//               step の中身 (script が実際に何を検査するか) の正しさ。
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+import { findReasonDefect } from '../../../scripts/lib/ci/exclusion-reason.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const CLAUDE_MD = 'CLAUDE.md';
+const CI_YML = '.github/workflows/ci.yml';
+
+/** step 単位で列挙する job。ここだけは「全 hard-fail step が doc に並ぶ」ことを要求する。 */
+const STEP_ENUMERATED_JOB = 'lint-and-test';
+
+/**
+ * `lint-and-test` の hard-fail step のうち、doc に列挙しないもの (+ その理由)。
+ *
+ * key は ci.yml の `run` を正規化した文字列 (= doc の列挙 key と同じ形)。
+ * 理由は `scripts/lib/ci/exclusion-reason.mjs` の判定を通すため、stub / 機械生成文言では通らない。
+ */
+const EXCLUDED_STEPS: Record<string, string> = {
+	'npm ci':
+		'依存 install であって検査ではない。落ちても「検査に引っかかった」ではなく環境の失敗であり、読み手が Ready 化前に回すコマンドでもない',
+	'cd infra && npm ci': '同上 (infra 側の依存 install)。検査ではない',
+};
+
+/**
+ * doc に列挙しない ci.yml の job (+ その理由)。
+ *
+ * 「新しい gate job を足したのに doc も除外リストも触っていない」を fail させるための no-silent-gap
+ * 用リスト。検査 job をここに逃がすのは不可 (理由が成立しなくなる)。
+ */
+const EXCLUDED_JOBS: Record<string, string> = {
+	changes:
+		'paths-filter で後続 job の実行要否を出力するだけの分岐 job。落ちる検査を 1 つも持たない',
+	'lint-and-test':
+		'step 単位で列挙する job なので、job 名の列挙対象からは外す (上のブロックが担う)',
+	'e2e-merge-reports': 'blob report を HTML に結合するだけの後処理。合否判定は e2e-test 側が持つ',
+	'ci-gate': '他 job の結果を集約して 1 つの required context にするゲート。固有の検査を持たない',
+	'integration-evidence':
+		'統合 PR (release/* → main) 専用の証跡生成 job。個別 PR の Ready 化判断で読む対象ではない',
+};
+
+type Step = { name?: string; run?: string; 'continue-on-error'?: boolean };
+type Job = { steps?: Step[]; 'continue-on-error'?: boolean };
+
+function read(relPath: string): string {
+	return readFileSync(path.join(REPO_ROOT, relPath), 'utf-8');
+}
+
+/** doc / ci.yml のどちらから来ても同じ形になるようコマンド文字列を正規化する。 */
+function normalizeCommand(raw: string): string {
+	return raw.trim().replace(/\s+/g, ' ');
+}
+
+/**
+ * step が hard-fail か判定する。
+ *
+ * `continue-on-error: true` だけでなく **末尾 `|| true`** も soft と見なす
+ * (`Color usage report` が実際にこの形。exit code を握り潰す step を「hard-fail」と数えると、
+ * doc が「落ちる」と言っているのに落ちない嘘になる)。
+ */
+function isHardFail(step: Step): boolean {
+	if (typeof step.run !== 'string') return false; // `uses:` (checkout / cache / upload) は対象外
+	if (step['continue-on-error'] === true) return false;
+	return !/\|\|\s*true\s*$/.test(step.run.trim());
+}
+
+function ciJobs(): Record<string, Job> {
+	const parsed = parse(read(CI_YML)) as { jobs?: Record<string, Job> };
+	if (!parsed.jobs) throw new Error(`${CI_YML} から jobs を読めません (構造が変わった?)`);
+	return parsed.jobs;
+}
+
+/** `lint-and-test` の hard-fail step を「正規化コマンド → step 名」で返す。 */
+function hardFailStepsOfLintAndTest(): Map<string, string> {
+	const job = ciJobs()[STEP_ENUMERATED_JOB];
+	if (!job) throw new Error(`${CI_YML} に job ${STEP_ENUMERATED_JOB} がありません`);
+	if (job['continue-on-error'] === true) {
+		throw new Error(
+			`${STEP_ENUMERATED_JOB} が job 単位で continue-on-error になっています。` +
+				'本 gate は step 単位の判定しかしないため、doc の記述ごと見直すこと',
+		);
+	}
+	const out = new Map<string, string>();
+	for (const step of job.steps ?? []) {
+		if (!isHardFail(step)) continue;
+		const command = normalizeCommand((step.run as string).split('\n')[0] ?? '');
+		out.set(command, step.name ?? '(name なし)');
+	}
+	return out;
+}
+
+/** ci.yml の全 job 名 (job 単位 continue-on-error のものは hard-fail ではないので除く)。 */
+function hardFailJobNames(): string[] {
+	return Object.entries(ciJobs())
+		.filter(([, job]) => job['continue-on-error'] !== true)
+		.map(([name]) => name)
+		.sort();
+}
+
+/**
+ * CLAUDE.md の marker block 内の箇条書きから、バッククォート囲みの key を取り出す。
+ *
+ * `firstPerLine` は block ごとの書式差を吸収する:
+ *   - step block: 1 行 = 1 コマンド + 説明文。説明文中のコード span (`eslint-suppressions.json` 等) を
+ *     key と誤認しないよう **行頭の最初の span だけ**を key にする
+ *   - job block: 1 行に複数 job を並べる (`e2e-test` / `e2e-matrix` …) ので全 span を key にする
+ */
+function declaredKeys(marker: string, { firstPerLine = false } = {}): string[] {
+	const content = read(CLAUDE_MD);
+	const start = content.indexOf(`<!-- ${marker}:start -->`);
+	const end = content.indexOf(`<!-- ${marker}:end -->`);
+	if (start < 0 || end < 0 || end < start) {
+		throw new Error(
+			`${CLAUDE_MD} に marker block (<!-- ${marker}:start --> 〜 <!-- ${marker}:end -->) がありません。` +
+				'列挙は marker で囲むこと (囲まないと機械突合できない)',
+		);
+	}
+	const block = content.slice(start + `<!-- ${marker}:start -->`.length, end);
+	return [...block.matchAll(/^\s*-\s+(.*)$/gm)].flatMap((line) => {
+		const spans = [...(line[1] ?? '').matchAll(/`([^`]+)`/g)]
+			.map((m) => m[1])
+			.filter((v): v is string => v !== undefined)
+			.map(normalizeCommand);
+		return firstPerLine ? spans.slice(0, 1) : spans;
+	});
+}
+
+describe('#4605: CLAUDE.md の CI hard-fail 検査一覧 ↔ ci.yml の実測', () => {
+	const ciSteps = hardFailStepsOfLintAndTest();
+	const docSteps = declaredKeys('ci-hard-fail-steps', { firstPerLine: true });
+
+	it('[C0] ci.yml / CLAUDE.md の双方から 1 件以上抽出できる (0 件マッチの素通りを防ぐ)', () => {
+		expect(ciSteps.size).toBeGreaterThan(0);
+		expect(docSteps.length).toBeGreaterThan(0);
+	});
+
+	it('[C1] lint-and-test の hard-fail step が全て CLAUDE.md に列挙されている', () => {
+		const missing = [...ciSteps.entries()]
+			.filter(([command]) => !docSteps.includes(command) && !(command in EXCLUDED_STEPS))
+			.map(([command, name]) => `${command}   (step: ${name})`);
+		expect(
+			missing,
+			`ci.yml ${STEP_ENUMERATED_JOB} の hard-fail step が CLAUDE.md の ci-hard-fail-steps ブロックにありません。\n` +
+				'列挙するか、検査でないなら本 test の EXCLUDED_STEPS に理由付きで登録すること:\n' +
+				missing.map((m) => `  - ${m}`).join('\n'),
+		).toEqual([]);
+	});
+
+	it('[C2] CLAUDE.md の列挙に ci.yml から消えた step が残っていない', () => {
+		const stale = docSteps.filter((command) => !ciSteps.has(command));
+		expect(
+			stale,
+			'CLAUDE.md が「CI で hard-fail する」と書いている検査が ci.yml にありません ' +
+				'(step の削除 / コマンド変更に doc が追随していない):\n' +
+				stale.map((m) => `  - ${m}`).join('\n'),
+		).toEqual([]);
+	});
+
+	it('[C3] CLAUDE.md の列挙に重複がない (数を水増ししない)', () => {
+		const duplicated = docSteps.filter((command, i) => docSteps.indexOf(command) !== i);
+		expect(duplicated).toEqual([]);
+	});
+
+	it('[C4] EXCLUDED_STEPS の理由が理由として成立している', () => {
+		const defects = Object.entries(EXCLUDED_STEPS)
+			.map(([entry, reason]) => ({ entry, defect: findReasonDefect(reason) }))
+			.filter((d) => d.defect !== null);
+		expect(defects).toEqual([]);
+	});
+
+	it('[C5] EXCLUDED_STEPS に ci.yml から消えた step が残っていない', () => {
+		const stale = Object.keys(EXCLUDED_STEPS).filter((command) => !ciSteps.has(command));
+		expect(stale).toEqual([]);
+	});
+});
+
+describe('#4605: ci.yml の job が CLAUDE.md か除外リストのどちらかに現れる (no-silent-gap)', () => {
+	const jobs = hardFailJobNames();
+	const docJobs = declaredKeys('ci-hard-fail-jobs');
+
+	it('[J0] ci.yml から job を 1 件以上抽出できる', () => {
+		expect(jobs.length).toBeGreaterThan(0);
+		expect(docJobs.length).toBeGreaterThan(0);
+	});
+
+	it('[J1] 全 job が CLAUDE.md の列挙か EXCLUDED_JOBS に現れる', () => {
+		const missing = jobs.filter((name) => !docJobs.includes(name) && !(name in EXCLUDED_JOBS));
+		expect(
+			missing,
+			'ci.yml の job が CLAUDE.md の ci-hard-fail-jobs ブロックにも EXCLUDED_JOBS にもありません。\n' +
+				'新設した gate job は doc に列挙し、検査を持たない job は理由付きで除外すること:\n' +
+				missing.map((m) => `  - ${m}`).join('\n'),
+		).toEqual([]);
+	});
+
+	it('[J2] CLAUDE.md / EXCLUDED_JOBS に ci.yml から消えた job が残っていない', () => {
+		const stale = [...docJobs, ...Object.keys(EXCLUDED_JOBS)].filter(
+			(name) => !jobs.includes(name),
+		);
+		expect(stale).toEqual([]);
+	});
+
+	it('[J3] EXCLUDED_JOBS の理由が理由として成立している', () => {
+		const defects = Object.entries(EXCLUDED_JOBS)
+			.map(([entry, reason]) => ({ entry, defect: findReasonDefect(reason) }))
+			.filter((d) => d.defect !== null);
+		expect(defects).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

Dev が `CLAUDE.md` を読んで「この検査は CI に無い」と判断できるようにする。現状の列挙は実測と食い違っており（PR #4603 で 1 往復）、doc の誤りがそのまま PR 往復のコストになっていた。列挙を実測に合わせたうえで、**同じ食い違いが二度と静かに発生しない**よう ci.yml と突合する guard を置く。

## 関連 Issue

Closes #4605

## 変更内容

### 1. 列挙を実測に合わせた（`CLAUDE.md`）

旧記述は「**pre-ready から外しても CI で hard-fail し続ける検査**は以下がその全部である」「**ここに挙がっていない検査は CI にも無い**」と断定していたが、`ci.yml` の `lint-and-test` には `continue-on-error` の付かない step が他に 20 本以上ある。断定を削り、marker block で全数を列挙した。

**洗い出しの方法**（推測ではなく実測）— `yaml` で ci.yml を parse し、step 単位で判定:

```js
// 判定: run を持つ && continue-on-error !== true && 末尾が `|| true` でない
const hard = (job.steps ?? []).filter(
  (s) => s.run && s['continue-on-error'] !== true && !/\|\|\s*true\s*$/.test(s.run.trim()),
);
```

`|| true` も soft に数えている点が要点（`Color usage report` = `node scripts/lint-color-classes.mjs || true` が実際にこの形。exit code を握り潰す step を「hard-fail」と数えると doc が別の嘘になる）。

**洗い出し結果**（`lint-and-test`、setup 2 件を除く 23 件）: biome / `lint:parallel` / check-no-plan-literals / check-cli-entry-guard / check-workflow-sparse-checkout-closure / check-readdir-rotation-guard / check-repo-scan-test-declaration / check-local-tz-date-getters / check-license-key-leak / check-no-direct-env-access / check-no-waitfortimeout / `node --test scripts/__tests__` / check:no-demo-route-dup / cspell / stylelint / `eslint tests/**` / **`lint:typed`** / **`lint:svelte`** / **svelte-check (`--threshold warning`)** / CDK `tsc --noEmit` / type-coverage / build / build-storybook。

**旧列挙に載っていなかったもの**（= 実害の温床）: `lint:svelte`・`lint:typed`・`eslint tests/**`・stylelint・`lint:parallel`・sparse-checkout closure・readdir rotation・repo-scan 宣言・TZ getter・process.env 直参照・waitForTimeout・scripts の node:test・demo route 重複・CDK tsc・type-coverage・build・build-storybook。加えて **svelte-check は CI の方が厳しい**（CI = `--threshold warning` / pre-ready Step 2 = error 閾値）ことも書いていなかったので明記した。

`lint-and-test` 以外の hard-fail job も job 名で列挙した（`unit-test` / `unit-test-merge` / `dependency-cruiser` / `cdk-cfn-lint` / e2e 系 / `a11y` / `docker-build` / schema 系 / `main-pr-base-guard` ほか）。**保証範囲は ci.yml だけ**であることも明記した（`lp-metrics.yml` 等は対象外 → `gh pr checks` で個別に見る）。

### 2. `--help` 側の同種記述（`scripts/pre-ready.mjs`）

`npm run pre-ready -- --help` の「pre-ready から外した検査の行き先」は**枠としては嘘ではない**（移した検査の行き先の記録）が、CLAUDE.md の「これが全部」という断定の裏付けとして名指し参照されていた。以下を是正:

- ファイル冒頭コメントの「CI で hard-fail し続ける検査は ci.yml lint-and-test / unit-test、lp-metrics.yml のみ」を削除し、CI 側一覧の SSOT が CLAUDE.md の marker block であることを指す
- `--help` に「本 help は移設先しか書かない。CI の hard-fail はこれより多い」節を追加（svelte-check の閾値差も明記）
- 実行後 summary の「lint-and-test 系 cspell / … ほか」に eslint svelte / type-aware / stylelint / CDK tsc / type-coverage / build を追加

### 3. 再発しない形にした（本体、`tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts`）

`ci.yml` を parse して CLAUDE.md の marker block と突合する。既存前例（`tests/unit/docs/stripe-webhook-subscribed-events-ssot.test.ts` = doc の marker block ⇄ 実装 `case` の突合 + 未登録 doc 検出）と同型。

| 検査 | 落ちる条件 |
|---|---|
| [C1] | ci.yml の hard-fail step が doc の列挙に無い（**列挙漏れ** = 今回の drift そのもの） |
| [C2] | doc にあるが ci.yml に無い（**陳腐化**: step 削除 / コマンド変更に doc が追随していない） |
| [C3] | doc 内の重複（列挙数の水増し） |
| [C4] / [C5] | 除外リストの理由が理由になっていない / ci.yml から消えた除外が残っている |
| [J1] | **ci.yml の job が doc にも除外リストにも無い**（新規 gate job の silent gap） |
| [J2] / [J3] | 消えた job の残存 / 除外理由の非成立 |
| [C0] / [J0] | 双方から 1 件も抽出できない（**検査の空振り**） |

- **除外は理由必須**。判定は既存 `scripts/lib/ci/exclusion-reason.mjs`（`findReasonDefect`、stub / 機械生成文言を弾く）を再利用した。現在の除外は step 2 件（`npm ci` / `cd infra && npm ci` = 依存 install で検査ではない）、job 5 件（`changes` / `lint-and-test`(step 単位で列挙) / `e2e-merge-reports` / `ci-gate` / `integration-evidence`）
- **CI の step 自体は変更していない**（列挙を実測に合わせただけで、検査は弱めていない）

## 検証

| 検査 | コマンド | 結果 |
|---|---|---|
| 新規 guard 単体 | `npx vitest run tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts` | PASS (10 tests) |
| `tests/unit/docs/` 全体 | `npx vitest run tests/unit/docs/` | PASS (3 files / 39 tests) |
| pre-ready 関連 test の非破壊 | `npx vitest run tests/unit/scripts/` | PASS (52 files / 1174 tests, 1 skipped) |
| repo 走査 test 宣言 gate | `node scripts/check-repo-scan-test-declaration.mjs` | OK（新規 test は `bounded` 判定 = 追加宣言不要） |
| lint | `npx biome check --write tests` → `npx biome check tests scripts/pre-ready.mjs` | Fixed 1 file → No fixes applied |
| cspell | `npm run cspell` | `Issues found: 0 in 0 files` |
| `--help` の描画 | `npm run pre-ready -- --help` | 正常出力（新節が表示される） |

### mutation 検証（guard が vacuous でないことの実測）

commit 済みの状態から CLAUDE.md の列挙を **1 行だけ削って**実行した（`git checkout --` は hook で禁止のため、commit → 変更 → 実行 → `git stash push` → drop の順）。

削った行: `` - `npm run lint:svelte` — **ESLint Svelte** (…) ``

```
 ❯ tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts (10 tests | 1 failed)
     × [C1] lint-and-test の hard-fail step が全て CLAUDE.md に列挙されている

AssertionError: ci.yml lint-and-test の hard-fail step が CLAUDE.md の ci-hard-fail-steps ブロックにありません。
列挙するか、検査でないなら本 test の EXCLUDED_STEPS に理由付きで登録すること:
  - npm run lint:svelte   (step: ESLint Svelte (eslint-plugin-svelte recommended + XSS AST,)

 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)
```

= **PR #4603 を起こした状態そのものが機械で落ちる**ことを確認した。復元後は再度 PASS（`npx vitest run tests/unit/docs/` → 39 passed）。

## 影響範囲

- **顧客に見える変化**: なし（doc / test / CLI help のみ）。UI 変更なし
- **CI**: `ci.yml` は無変更。新規 test 1 本が `unit-test` job に加わる（読むのは `CLAUDE.md` と `ci.yml` の 2 file のみ、実測 7ms）
- **今後 ci.yml を触る PR への影響**: `lint-and-test` に step を足す / job を新設すると、CLAUDE.md の marker block（または除外リストに理由付き）への追記を求められる。これが本 PR の狙い
- 並行実装ペア: なし。破壊的変更: なし

## AC 検証マップ

| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
|---|---|---|---|
| AC1 | CLAUDE.md の hard-fail 一覧が ci.yml の実測と一致し、「ここに挙がっていない検査は CI にも無い」の誤断定が消えている | 新規 guard [C1]/[C2] + 該当文の削除 | PASS。§変更内容 1 の洗い出し結果どおりに列挙、誤断定の文は削除済 |
| AC2 | `scripts/pre-ready.mjs` の `--help` / summary に同種の誤断定が残っていない | 冒頭コメント / `--help` / `buildSummary` を修正し `npm run pre-ready -- --help` で確認 | PASS。CI 側一覧の SSOT が CLAUDE.md marker block であることを指す記述に置換 |
| AC3 | 列挙漏れで落ちる test がある（列挙漏れ / 陳腐化 / 理由なし除外 / job 新設漏れの 4 方向） | `npx vitest run tests/unit/docs/ci-hard-fail-check-list-ssot.test.ts` | PASS (10 tests)。[C1] 列挙漏れ / [C2] 陳腐化 / [C4][J3] 理由 / [J1] job 新設漏れ を実装 |
| AC4 | test が vacuous でないことを実出力で示す | 列挙 1 行削除 → 実行 → 復元（mutation 検証） | PASS。§検証 の mutation 出力（[C1] が fail）を掲載 |
| AC5 | `npx vitest run tests/unit/docs/` が green | 同コマンド | PASS (3 files / 39 tests) |

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->
