### PR TITLE
fix(labels): #4512 admin 画面の文言 SSOT 逸脱を集約（定義済みラベルの未使用 = 二重定義の解消）

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -76,6 +76,8 @@ import {
 	TRIAL_TERMS,
 	UPGRADE_TERMS,
 	VISIBILITY_CHIP_TERMS,
+	WEEKDAY_NAMES_SUNDAY_FIRST,
+	WEEKDAY_TERMS,
 } from './terms';
 import type { UiMode } from './validation/age-tier-types';
 // #980: age-tier-types.ts に型・正規化関数を集約し循環依存を解消
@@ -253,6 +255,19 @@ export function formatPeople(n: number): string {
 }
 export function formatDateRange(start: string, end: string): string {
 	return `${start} 〜 ${end}`;
+}
+/**
+ * 「YYYY年M月」表記 (#4512)。
+ *
+ * 旧実装は admin/reports・admin/growth-book・ADMIN_HOME_LABELS・OPS_COSTS_LABELS が
+ * それぞれ同じ組版を持っていた。年月の見せ方を変えるときに 4 箇所直す状態を解消する。
+ */
+export function formatYearMonth(year: number | string, month: number | string): string {
+	return `${year}年${Number(month)}月`;
+}
+/** 「M月」表記 (年を伴わない月見出し、#4512) */
+export function formatMonthOnly(month: number | string): string {
+	return `${Number(month)}月`;
 }
 
 // ============================================================
@@ -434,6 +449,14 @@ export const PLAN_GATE_LABELS = {
 	 *   - server/errors.ts: 'この機能はスタンダードプラン以上でご利用いただけます。プランをアップグレードしてください。'
 	 */
 	standardOrAboveGenericWithUpgrade: `この機能は${PLAN_FULL_TERMS.standard}以上でご利用いただけます。プランをアップグレードしてください。`,
+
+	/**
+	 * "スタンダード以上" — バッジ / タグ用の短縮形 (#4512)
+	 *
+	 * PremiumBadge の label / ヘッダーの premium バッジ / pricing の家族パターンタグが
+	 * それぞれ同じ文字列を持っていた (3 重定義)。短縮プラン名 atom から組み立てる。
+	 */
+	standardOrAboveBadge: `${PLAN_TERMS.standard}以上`,
 
 	/**
 	 * "{feature}はファミリープラン限定です。アップグレードすると利用できます。"
@@ -2238,6 +2261,12 @@ export const OYAKAGI_LABELS = {
 	lockedError: `${OYAKAGI_TERMS.name}の入力に連続して失敗したため、しばらく待ってから再度お試しください`,
 	formatError: `${OYAKAGI_TERMS.name}は4〜6桁の数字で入力してください`,
 	numberOnlyError: `${OYAKAGI_TERMS.name}は数字のみです`,
+	// #4512: 変更フォームのラベル / エラー (旧: settings/account の svelte + server 直書き)
+	currentInputLabel: `現在の${OYAKAGI_TERMS.name}`,
+	newInputLabel: `新しい${OYAKAGI_TERMS.name}（4〜8桁）`,
+	newConfirmInputLabel: `新しい${OYAKAGI_TERMS.name}（確認）`,
+	confirmMismatchError: `新しい${OYAKAGI_TERMS.name}が一致しません`,
+	currentInvalidError: `現在の${OYAKAGI_TERMS.name}が正しくありません`,
 	// EPIC #2310 子#2312: /switch PIN gate modal UI (Apple Screen Time 同設計)
 	gateModalTitle: `${OYAKAGI_TERMS.name}を入力してください`,
 	gateModalDescription: `${ADMIN_VIEW_TERMS.canonical}には${PARENT_TERMS.neutral}のみが入れます。${OYAKAGI_TERMS.name}を入力してください。`,
@@ -2477,6 +2506,11 @@ export const SETTINGS_LABELS = {
 	notificationAchievementLabel: '達成通知（記録完了・レベルアップ時）',
 	notificationQuietSeparator: '〜',
 	notificationSaveAction: '通知設定を保存',
+	// #4512: settings/notifications の直書き文言 (FormField ラベル / hint / 検証エラー)
+	notificationReminderTimeLabel: 'リマインダー時刻',
+	notificationQuietLabel: 'サイレント時間帯',
+	notificationQuietHint: 'この時間帯は通知を送信しません',
+	notificationTimeFormatInvalid: '時刻の形式が不正です',
 
 	// ポイント表示設定
 	pointSectionTitle: '💰 ポイント表示設定',
@@ -2485,6 +2519,24 @@ export const SETTINGS_LABELS = {
 	pointModePoint: 'ポイント（P）',
 	pointModeCurrency: '通貨で表示',
 	pointPreviewLabel: (n: number) => `プレビュー（${n}P の場合）`,
+	// #4512: 活動・ポイント設定 (settings/activities) の直書き文言。
+	pointCurrencyLabel: `${CURRENCY_TERMS.canonical}`,
+	pointRateLabel: (symbol: string) => `レート（1P = ？${symbol}）`,
+	pointRateHint: '例: 1P = 1円なら「1」、1P = 0.01ドルなら「0.01」',
+	pointModeInvalid: 'モードが不正です',
+	pointCurrencyInvalid: `${CURRENCY_TERMS.canonical}コードが不正です`,
+	pointRateRange: 'レートは0より大きく10000以下で入力してください',
+	defaultChildIdInvalid: '子供IDが不正です',
+	defaultChildNotFound: '指定された子供が見つかりません',
+	// ステータス減少強度 (DECAY_OPTIONS)
+	decayOptionNoneLabel: 'なし',
+	decayOptionNoneDesc: '減少しません（練習や導入期間向け）',
+	decayOptionGentleLabel: 'ゆるやか',
+	decayOptionGentleDesc: '通常の半分の速度で減少します',
+	decayOptionNormalLabel: 'ふつう',
+	decayOptionNormalDesc: '猶予2日後にゆるやかに減少します',
+	decayOptionStrictLabel: 'きびしめ',
+	decayOptionStrictDesc: '上級者向け。1.5倍の速度で減少します',
 	pointSaveAction: 'ポイント設定を保存',
 
 	// データ管理 (#backup-terms: 内部フォーマット JSON/ZIP は UI 露出しない。BACKUP_TERMS 統一)
@@ -2698,6 +2750,18 @@ export const SETTINGS_LABELS = {
 		'返信のためメールアドレスを入力してください（通常 1〜2 日以内）。',
 	feedbackConsultReplyRequiredError: '相談・困りごとは返信先メールアドレスを入力してください',
 	feedbackInvalidIntentError: 'ご用件の選択が不正です',
+	// #4512: 旧実装は上 2 つの error label を定義しながら +page.server.ts 側で同じ文字列を
+	// 直書きしており (二重定義)、残りの validation メッセージも server にしか無かった。
+	feedbackContentRequiredError: '内容を入力してください',
+	feedbackContentTooLongError: '1000文字以内で入力してください',
+	feedbackInvalidCategoryError: 'カテゴリが不正です',
+	feedbackInvalidEmailError: 'メールアドレスの形式が正しくありません',
+	feedbackChildAgeTooLongError: 'お子さまの年齢は100文字以内で入力してください',
+	feedbackSendFailedError: '送信に失敗しました。お手数ですが時間をおいて再度お試しください',
+	/** 問い合わせ本文に付記する年齢の見出し (Discord / 問い合わせレコード向け) */
+	feedbackChildAgeBodyPrefix: (childAge: string) => `【お子さまの年齢】${childAge}`,
+	/** 通知本文で使う分類名 (intent=consult は「（返信を希望）」を含まない短い形) */
+	feedbackCategoryConsult: '相談・困りごと',
 	feedbackSubmitButton: '送信する',
 	feedbackSubmittingText: '送信中...',
 	feedbackSuccessConsult: (inquiryId: string) =>
@@ -2784,6 +2848,21 @@ export const SETTINGS_LABELS = {
 	accountDeleteFullOption: '家族グループを全て削除する',
 	accountDeleteFullOptionDesc: '全メンバーの所属が解除され、全データが削除されます。',
 	accountDeleteCancelAction: 'キャンセル',
+	// #4512: 退会フローの確認テキスト / ボタン / エラー (旧: settings/account/+page.svelte 直書き)。
+	// 合言葉は入力欄・placeholder・判定の 3 箇所が同じ定数を見るようにする
+	// (data グループの clearConfirmKeyword と同型)。
+	accountDeleteConfirmKeyword: 'アカウントを削除します',
+	accountDeleteConfirmFieldLabel: '確認のため「アカウントを削除します」と入力してください',
+	accountDeleteTransferPlaceholder: '移譲先を選択...',
+	accountDeleteTransferSubmit: `移譲して${CANCEL_TERMS.account}`,
+	accountDeleteFullSubmit: '全て削除する',
+	accountDeleteSubmit: 'アカウントを削除する',
+	accountDeleteProcessing: '処理中...',
+	accountDeleteInfoFetchFailed: '情報取得に失敗しました',
+	accountDeleteFailed: 'アカウント削除に失敗しました',
+	// おやカギコード変更フォーム
+	oyakagiChangeSubmitting: '変更中...',
+	oyakagiAllFieldsRequired: 'すべてのフィールドを入力してください',
 
 	// ログアウト
 	logoutSectionTitle: 'ログアウト',
@@ -2819,6 +2898,16 @@ export const SETTINGS_LABELS = {
 	dangerStep2Label: '手順 2: 同意チェック',
 	dangerStep3Label: '手順 3: 実行ボタン',
 	clearDangerConsentLabel: 'すべてのデータを削除することに同意します',
+	// #4512: データクリアの確認テキスト / 実行ボタン。旧実装は画面 (+page.svelte) と
+	// 検証 (+page.server.ts) が '削除' を別々に直書きしており、合言葉を変えると
+	// 「入力しても通らない」状態になり得た。両者が同じ定数を見るようにする。
+	clearConfirmKeyword: '削除',
+	clearConfirmFieldLabel: '確認のため「削除」と入力してください',
+	clearConfirmRequired: '確認テキスト「削除」を入力してください',
+	clearAgreeRequired: '同意チェックを入れてください',
+	clearSubmitting: 'データクリア中...',
+	clearSubmitButton: 'すべてのデータを削除',
+	clearFailed: 'データクリアに失敗しました',
 	accountDeleteDangerConsentLabel: 'このアカウントを削除することに同意します（元に戻せません）',
 	// 削除前のデータ持ち出し (#740 API / #4472 導線)。プランに関係なく提供する
 	accountDeleteExportTitle: `${CANCEL_TERMS.account}する前にデータを持ち出す`,
@@ -3273,6 +3362,10 @@ export const REPORTS_LABELS = {
 	weeklySettingsUpgradeNote: 'スタンダードプラン以上でメール配信設定を変更できます',
 	weeklySettingsEnableLabel: '週次レポートを有効にする',
 	weeklySettingsDayLabel: '配信曜日',
+	// #4512: 配信曜日セレクトの表示名。旧実装は +page.svelte で 7 曜日を別に列挙していた
+	// (WEEKDAY_TERMS atom の直書き複製、ADR-0045 §3.3)。
+	weeklySettingsDayNames: WEEKDAY_TERMS as Record<string, string>,
+	weeklySettingsDayInvalid: '無効な曜日です',
 	weeklySettingsSave: '保存',
 
 	// 週次レポート - 空状態
@@ -3468,6 +3561,17 @@ export const POINTS_LABELS = {
 	receiptConfirmButton: 'この金額で変換する',
 	receiptConfirmedLabel: '金額確定済み',
 	receiptRetakeOtherButton: '別の領収書を撮影する',
+	// #4512: OCR 呼び出しの失敗表示 (旧: +page.svelte 直書き)。
+	// receiptScanFailed は API が error.message を返さなかったときの fallback。
+	receiptScanFailed: '読み取りに失敗しました',
+	receiptNetworkError: '通信エラーが発生しました',
+	// #4512: convert action の validation / service エラー表示 (旧: +page.server.ts 直書き)
+	convertInputInvalid: '入力が不正です',
+	convertAmountNotInteger: `${POINT_TERMS.unitFull}は整数で入力してください`,
+	convertPresetUnit: `${POINT_TERMS.unitFull}は500単位で変換できます`,
+	convertChildNotFound: 'こどもが見つかりません',
+	convertInsufficientPoints: `${POINT_TERMS.unitFull}が足りません`,
+	convertInvalidAmount: '金額が不正です',
 	// #4366: AI 側の事情 (未設定 / 権限なし) と画像が読めなかったことを言い分ける。前者で撮り直しを
 	// 促すと顧客は自分の写真が悪いと誤解する。どちらも次アクション (手入力) を必ず示す (ADR-0062)。
 	//
@@ -4796,6 +4900,16 @@ export const STATUS_LABELS = {
 	// Form labels
 	meanLabel: '平均（目安値）',
 	sdLabel: 'SD（ばらつき）',
+
+	// #4512: 偏差値帯 → 親向け自然言語 (旧: +page.svelte の getAnalysisText 内直書き)
+	analysisHigh: '同年齢の中でも特に活発です',
+	analysisAverage: '平均的なペースで成長しています',
+	analysisLow: 'これから伸びる余地がたくさんあります',
+
+	// #4512: benchmark form action の validation メッセージ (旧: +page.server.ts 直書き)
+	levelInvalid: 'レベルが不正です',
+	titleLengthInvalid: '称号は1〜20文字で入力してください',
+	benchmarkValueInvalid: '平均は0以上、標準偏差は0より大きい値を入力してください',
 } as const;
 
 // ============================================================
@@ -4917,7 +5031,7 @@ export const OPS_COSTS_LABELS = {
 	pageTitle: 'OPS - AWS費用',
 	prevMonthLink: '← 前月',
 	nextMonthLink: '翌月 →',
-	yearMonthDisplay: (year: number, month: number) => `${year}年${month}月`,
+	yearMonthDisplay: (year: number, month: number) => formatYearMonth(year, month),
 	currentCostLabel: '当月 AWS 費用',
 	prevMonthDiffLabel: '前月比',
 	serviceCountLabel: 'サービス数',
@@ -5063,6 +5177,10 @@ export const CHEER_LABELS = {
 	iconHint: '絵文字を入れてください',
 	extraTitle: '6. 付随スタンプ / メッセージ（任意）',
 	extraDescription: 'いつものスタンプや、ひとことメッセージも一緒に届けられます',
+	// #4512: 旧実装は +page.svelte に直書きしていた入力補助文言
+	reasonCounterHint: (length: number, maxLength: number, remaining: number) =>
+		`${length}/${maxLength}（あと${remaining}文字）`,
+	bodyPlaceholder: 'ひとことメッセージを足す（任意）',
 	confirmTitle: `7. 内容を確認して${CHEER_TERMS.action}`,
 	grantButton: CHEER_TERMS.action,
 	grantButtonDisabled: '理由とポイントを入力してください',
@@ -5113,11 +5231,16 @@ export const CHEER_LABELS = {
 	confirmCategoryLabel: 'カテゴリ',
 	confirmIconLabel: 'アイコン',
 	// エラーメッセージ
+	// #4512: 旧実装はここに固定値 (1〜10000 / 100文字) を持ちつつ、実際に表示していたのは
+	// +page.server.ts が cheer-service の定数から組み立てた別の文字列だった (二重定義)。
+	// 上限値は server 側 (cheer-service.ts) が SSOT なので、labels は引数で受ける形にする。
 	errorReasonRequired: `${CHEER_TERMS.canonical}の理由を入力してください`,
-	errorReasonTooLong: '理由は100文字以内で入力してください',
-	errorPointsRequired: 'ポイントは1〜10000の範囲で入力してください',
+	errorReasonTooLong: (maxLength: number) => `理由は${maxLength}文字以内で入力してください`,
+	errorPointsRange: (min: number, max: number) =>
+		`ポイントは${min}〜${max}の範囲で入力してください`,
 	errorCategoryRequired: 'カテゴリを選択してください',
 	errorChildRequired: 'こどもを選択してください',
+	errorChildNotFound: 'こどもが見つかりません',
 } as const;
 
 // ============================================================
@@ -5286,6 +5409,11 @@ export const CERTIFICATE_DETAIL_LABELS = {
 	downloadButton: '📥 画像をダウンロード',
 	closeButton: '閉じる',
 	showShareCardButton: '🎉 シェアカードを表示',
+	// #4512: シェアカード生成 (canvas) / ダウンロード結果の文言を SSOT へ集約
+	shareCardBrandText: APP_LABELS.name,
+	downloadSuccess: 'ダウンロードしました！',
+	downloadFailed: 'ダウンロードに失敗しました',
+	certificateNotFound: '証明書が見つかりません',
 } as const;
 
 export const DEMO_CHILD_HOME_LABELS = {
@@ -5437,6 +5565,58 @@ export const MARKETPLACE_IMPORT_FEEDBACK_LABELS = {
  * admin/activities ページ用ラベル (#2362 PR-3 Phase 4)
  * 子供別タブ切替 + 兄弟共通化 UX (copy / 一括追加) の SSOT。
  */
+/**
+ * admin 各ページの form action が返す共通エラーメッセージ (#4512)
+ *
+ * `fail(400, { error: '名前を入力してください' })` のような同一文言が admin 配下の
+ * `+page.server.ts` 11 ファイルに散在し、同じ語を最大 6 箇所で別々に持っていた
+ * (docs/DESIGN.md §6 / ADR-0045)。ページ固有の文言は各ページの `*_PAGE_LABELS` に置き、
+ * 「ID が不正」「保存に失敗」のようにリソース非依存で使い回されるものだけを本 namespace に集約する。
+ *
+ * 表示先は form の `form?.error` (顧客に見えるエラーバナー)。logger.* の内部ログ文言は
+ * 顧客に見えないため対象外 (SSOT 集約しない)。
+ */
+export const ADMIN_FORM_ERROR_LABELS = {
+	// ---- 識別子 ----
+	idRequired: 'IDが必要です',
+	idInvalid: 'IDが不正です',
+	presetIdRequired: 'プリセットIDが必要です',
+	presetNotFound: 'プリセットが見つかりません',
+	presetNotFoundNamed: (presetId: string) => `プリセット「${presetId}」が見つかりません`,
+	presetNotSpecified: 'プリセットが指定されていません',
+	packIdRequired: 'パックIDが必要です',
+	packNotFound: 'パックが見つかりません',
+	templateIdInvalid: 'テンプレートIDが不正です',
+	itemIdInvalid: 'アイテムIDが不正です',
+	// ---- 入力必須 ----
+	nameRequired: '名前を入力してください',
+	itemNameRequired: 'アイテム名を入力してください',
+	itemInvalid: 'アイテムが不正です',
+	categoryRequired: 'カテゴリを選択してください',
+	dateRequired: '日付を入力してください',
+	requiredFieldsMissing: '必須項目が不足しています',
+	// ---- 子供の指定 ----
+	childRequired: 'こどもを選択してください',
+	childRequiredHonorific: `${CHILD_TERMS.honorific}を選択してください`,
+	targetChildRequired: `対象の${CHILD_TERMS.honorific}を選択してください`,
+	sameChildNotAllowed: `違う${CHILD_TERMS.honorific}を選んでください`,
+	childNotFound: 'こどもが見つかりません',
+	childNotFoundNeutral: `${CHILD_TERMS.neutral}が見つかりません`,
+	someChildrenNotFound: `指定された${CHILD_TERMS.honorific}の一部が見つかりませんでした`,
+	childrenNotFound: `指定された${CHILD_TERMS.honorific}が見つかりませんでした`,
+	noValidTargets: '有効な対象が指定されていません',
+	// ---- 保存系の失敗 ----
+	addFailed: '追加に失敗しました',
+	updateFailed: '更新に失敗しました',
+	deleteFailed: '削除に失敗しました',
+	importFailed: 'インポートに失敗しました',
+	copyFailed: 'コピーに失敗しました',
+	bulkAddFailed: '一括追加に失敗しました',
+	bulkClearFailed: '一括クリアに失敗しました',
+	fileParseFailed: 'ファイルの解析に失敗しました',
+	genericError: 'エラーが発生しました',
+} as const;
+
 export const ADMIN_ACTIVITIES_PAGE_LABELS = {
 	// #3097 (EPIC #3096): 検索ラベルを SSOT 化 (旧 inline hardcoded `活動名で検索` を labels へ移管)
 	searchLabel: '活動を検索',
@@ -5505,6 +5685,19 @@ export const ADMIN_ACTIVITIES_PAGE_LABELS = {
 	ageFilterBypassedHint: (name: string, age: number) =>
 		`年齢フィルタ無効 (${name}${CHILD_TERMS.honorific} ${age}歳)。全 family scope activity を表示中`,
 	ageFilterReapply: '年齢フィルタを再適用',
+	// #4512: +page.svelte / +page.server.ts に直書きされていた活動固有の action 結果・
+	// validation メッセージ。リソース非依存のものは ADMIN_FORM_ERROR_LABELS を参照する。
+	copySuccess: 'コピーが完了しました',
+	bulkAddSuccess: '一括追加しました',
+	activityIdInvalid: '不正な活動IDです',
+	activityNotFound: '活動が見つかりません',
+	sameChildCopyNotAllowed: `同じ${CHILD_TERMS.honorific}にはコピーできません`,
+	copySourceChildRequired: `コピー元の${CHILD_TERMS.honorific}が必要です`,
+	copyTargetChildRequired: `コピー先の${CHILD_TERMS.honorific}が必要です`,
+	noActivitiesSelectedToImport: '取り込む活動が選択されていません',
+	// max は plan-limit service が上限なしのとき null を返すため null も受ける (挙動維持)
+	customActivityLimitReached: (max: number | null) =>
+		`カスタム活動は最大${max}個まで作成できます。プランをアップグレードしてください。`,
 } as const;
 
 /**
@@ -5663,7 +5856,7 @@ export const ADMIN_HOME_LABELS = {
 	summaryChildrenLabel: 'こどもの数',
 	summaryPointsAria: '全ポイント合計',
 	summaryPointsTotalPrefix: '合計',
-	monthLabel: (year: string, month: string) => `${year}年${month}月`,
+	monthLabel: (year: string, month: string) => formatYearMonth(year, month),
 	monthlyHeadingPrefix: '📊 ',
 	monthlyHeadingSuffix: 'のがんばり',
 	monthlyDetailsLink: '詳しく見る →',
@@ -5863,6 +6056,23 @@ export const ADMIN_CHILDREN_PAGE_LABELS = {
 	agePlaceholder: '4',
 	birthdayOrAgeRequired: '誕生日または年齢を入力してください',
 	ageRange: '0〜18で入力してください',
+	// #4512: +page.svelte / +page.server.ts に直書きされていた子供管理固有の文言。
+	// リソース非依存のものは ADMIN_FORM_ERROR_LABELS を参照する。
+	nicknamePlaceholder: '例: たろうくん',
+	childLimitReached: (max: number | null) =>
+		`子供は最大${max}人まで登録できます。プランをアップグレードしてください。`,
+	nicknameRequired: 'ニックネームを入力してください',
+	birthdayFormatInvalid: '誕生日の形式が正しくありません（YYYY-MM-DD）',
+	birthdayFutureNotAllowed: '未来の日付は設定できません',
+	statusValueRange: '値は0〜100000の範囲で入力してください',
+	birthdayMultiplierRange: '倍率は0.5〜3.0の範囲で設定してください',
+	// おうえんボイス (uploadVoice action)
+	voiceLabelRequired: 'ラベルを入力してください',
+	voiceFileRequired: '音声ファイルを選択してください',
+	voiceErrorInvalidFile: 'ファイルが不正です',
+	voiceErrorFileTooLarge: '5MB以下にしてください',
+	voiceErrorUnsupportedType: 'MP3/M4A/WAV/WebM/OGG形式のみ',
+	voiceErrorTooMany: '10件まで登録可能です',
 } as const;
 
 // #2362 PR-7 (ADR-0055、User §6): per-child challenge instance + 兄弟連動 UI
@@ -5903,6 +6113,11 @@ export const ADMIN_CHALLENGES_PAGE_LABELS = {
 	deleteConfirmTitle: 'このチャレンジを削除しますか？',
 	deleteConfirmBody: (challengeTitle: string, childName: string) =>
 		`「${challengeTitle}」（${childName}）を削除します。削除すると、このお子さまの今の進捗も一緒に消えます。`,
+	// #4512: 家族ストリークの今日の記録状況 (旧: +page.svelte の三項演算子内直書き)
+	familyStreakRecordedToday: (recorderCount: number) => `今日は${recorderCount}人が記録済み`,
+	familyStreakNoneToday: '今日はまだ誰も記録していません',
+	// #4512: 兄弟 instance がある場合の削除ボタンラベル (旧: 直書きの ` を削除`)
+	deleteChildButton: (childName: string) => `${childName} を削除`,
 } as const;
 
 export const CERTIFICATES_PAGE_LABELS = {
@@ -5914,6 +6129,14 @@ export const CERTIFICATES_PAGE_LABELS = {
 	emptyTitle: 'まだ証明書がありません',
 	emptyDesc: '活動を記録すると、マイルストーン達成時に証明書が発行されます',
 	noChildrenTitle: '子供が登録されていません',
+	// #4512: 証明書カテゴリ見出し (旧: +page.svelte の categoryNames 直書き)
+	categoryNames: {
+		streak: '🔥 連続記録',
+		level: '🌟 レベルアップ',
+		monthly: '📜 月間がんばり',
+		category_master: '🎓 カテゴリマスター',
+		annual: '🏆 年間がんばり大賞',
+	} as Record<string, string>,
 } as const;
 
 export const PACKS_PAGE_LABELS = {
@@ -6230,7 +6453,7 @@ const CHILD_CHECKLIST_KANJI: ChildChecklistTextVariant = {
 	completeTitle: '全部できた！',
 	completeMsg: '忘れ物なし！すごい！',
 	completeButton: 'やったね！',
-	dayNames: ['日曜日', '月曜日', '火曜日', '水曜日', '木曜日', '金曜日', '土曜日'],
+	dayNames: [...WEEKDAY_NAMES_SUNDAY_FIRST],
 	timeSlotLabels: {
 		morning: '朝',
 		afternoon: '昼',
@@ -6394,6 +6617,14 @@ export const ADMIN_CHECKLISTS_PAGE_LABELS = {
 	copyNoChange: '取り込めるチェックリストがありませんでした（すでに配信済み）',
 	copySuccess: (added: number) => `${added} 件のチェックリストを取り込みました`,
 	copyFailed: '取り込みに失敗しました',
+	// #4512: +page.server.ts に直書きされていたチェックリスト固有の validation / 結果文言。
+	// リソース非依存のものは ADMIN_FORM_ERROR_LABELS を参照する。
+	timeSlotInvalid: '時間帯が不正です',
+	overrideIdInvalid: 'オーバーライドIDが不正です',
+	templateNameRequired: 'テンプレート名が必要です',
+	distributionSyncFailed: '配信先の同期に失敗しました',
+	copyAlreadyDistributedNote: (count: number) => `（${count} 件はすでに配信済みでした）`,
+	restoreFallbackName: '復元したチェックリスト',
 } as const;
 
 // ============================================================
@@ -6435,6 +6666,10 @@ export const ADMIN_RULES_PAGE_LABELS = {
 	importToastNotFound: (presetId: string) => `プリセット「${presetId}」が見つかりません。`,
 	// #2823: demo 環境の no-op 取込を正直に明示 (他 4 type と同文言、5 type 統一)。
 	importDemo: 'デモではお試し用です（実際の追加は行われません）',
+	// #4512: form action の失敗メッセージ (旧: +page.server.ts 直書き)
+	rewardApprovalUpdateFailed: 'ごほうび交換設定の更新に失敗しました',
+	updateFailed: 'ルール更新に失敗しました',
+	removeFailed: 'ルール削除に失敗しました',
 	// #3339: ごほうび交換の即時交換（親承認スキップ）設定。既定 = 承認必須。
 	rewardApprovalSectionTitle: `${CONCEPT_ICONS.reward} ごほうび交換のしかた`,
 	rewardApprovalSectionDesc:
@@ -6840,7 +7075,9 @@ export const LP_PRICING_LABELS = {
 	familyPatternSharedTitle: '親アカウント共用型',
 	familyPatternSharedDesc:
 		'親が1つのアカウントを作成し、同じ端末でお子さまと画面を切り替えて使います。設定も操作もシンプルで、すぐに始められます。無料プランを含む全プランで利用できます。',
-	familyPatternInviteTag: 'スタンダード以上',
+	// #4512: PLAN_GATE_LABELS.standardOrAboveBadge と同値。LP 生成 (generate-lp-labels) は
+	// namespace 跨ぎの参照を解決できないため、ここは atom を直接 template literal で参照する。
+	familyPatternInviteTag: `${PLAN_TERMS.standard}以上`,
 	familyPatternInviteTitle: '個別アカウント＋招待リンク型',
 	familyPatternInviteDesc:
 		'家族グループを作成し、招待リンクで家族を招待。家族メンバーがそれぞれの端末からアクセスでき、離れた場所からもお子さまの成長を見守れます。スタンダードは4人まで、ファミリープランは無制限で招待できます。',
@@ -7763,7 +8000,7 @@ export const UI_COMPONENTS_LABELS = {
 	googleSignInLabel: 'Google でログイン',
 
 	// ---- Header ----
-	headerPremiumTitle: 'スタンダード以上',
+	headerPremiumTitle: PLAN_GATE_LABELS.standardOrAboveBadge,
 	headerHelpAriaLabel: 'つかいかたガイド',
 	headerStampAriaLabel: 'スタンプカードを見る',
 
@@ -10242,6 +10479,8 @@ export const UNRESOLVED_ENTITY_LABELS = {
 	child: `不明な${CHILD_TERMS.honorific}`,
 	/** カテゴリ定義から引けなかったカテゴリの表示名 */
 	category: '不明なカテゴリ',
+	/** 認証基盤から email を解決できなかったメンバーの表示 (#4512) */
+	email: '(不明)',
 } as const;
 
 // #3593 ④: system 生成 ポイント台帳 (point_ledger) description の SSOT。

--- a/src/lib/domain/terms.ts
+++ b/src/lib/domain/terms.ts
@@ -315,6 +315,8 @@ export const POINT_TERMS = {
 export const CURRENCY_TERMS = {
 	yen: '¥',
 	yenFull: '円',
+	/** 「通貨」そのものを指す名詞 (設定画面の選択ラベル等、#4512) */
+	canonical: '通貨',
 } as const;
 
 // ============================================================
@@ -1238,3 +1240,36 @@ export const DELETION_GRACE_TERMS = {
 	/** 同上・LP 本文の組版に合わせた半角スペース入り (例: 「30 日」) */
 	premiumSpaced: formatDeletionGracePeriod(DELETION_GRACE_PERIOD_DAYS.family, { spaced: true }),
 } as const;
+
+// ============================================================
+// WEEKDAY_TERMS — 曜日名 atom (漢字フル形、#4512)
+// ============================================================
+//
+// 「月曜日」等の曜日名は本 atom が SSOT。以前は週次レポート設定 (admin/reports) と
+// 子供チェックリスト (labels.ts CHILD_CHECKLIST_KANJI) がそれぞれ別に列挙しており、
+// 同じ語を 2 箇所で持っていた (ADR-0045 §3.3 atom 直書き複製)。
+//
+// ひらがな形 (「げつようび」) は子供 UI の年齢帯 variant であり、本 atom とは別値として
+// labels.ts の CHILD_CHECKLIST_HIRAGANA が持つ (漢字/ひらがなは同一 atom の表記ゆれではなく
+// 対象年齢で出し分ける別文言のため、ここには置かない)。
+
+export const WEEKDAY_TERMS = {
+	sunday: '日曜日',
+	monday: '月曜日',
+	tuesday: '火曜日',
+	wednesday: '水曜日',
+	thursday: '木曜日',
+	friday: '金曜日',
+	saturday: '土曜日',
+} as const;
+
+/** 日曜始まりの曜日名配列 (Date#getDay() の index と一致する) */
+export const WEEKDAY_NAMES_SUNDAY_FIRST = [
+	WEEKDAY_TERMS.sunday,
+	WEEKDAY_TERMS.monday,
+	WEEKDAY_TERMS.tuesday,
+	WEEKDAY_TERMS.wednesday,
+	WEEKDAY_TERMS.thursday,
+	WEEKDAY_TERMS.friday,
+	WEEKDAY_TERMS.saturday,
+] as const;

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -5,6 +5,8 @@ import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asActivityId, asCategoryId, asChildId, type ChildId } from '$lib/domain/ids';
+// #4512: form action のエラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { ADMIN_ACTIVITIES_PAGE_LABELS, ADMIN_FORM_ERROR_LABELS } from '$lib/domain/labels';
 import {
 	CATEGORY_DEFS,
 	getCategoryById,
@@ -129,7 +131,7 @@ export const actions: Actions = {
 		const id = asActivityId(formIdString(formData.get('id')));
 		const visible = formData.get('visible') === 'true';
 
-		if (!id) return fail(400, { error: 'IDが必要です' });
+		if (!id) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idRequired });
 
 		try {
 			await setActivityVisibility(id, visible, tenantId);
@@ -140,7 +142,7 @@ export const actions: Actions = {
 				stack: e instanceof Error ? e.stack : undefined,
 				context: { id, visible },
 			});
-			return fail(500, { error: '更新に失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.updateFailed });
 		}
 	},
 
@@ -165,9 +167,9 @@ export const actions: Actions = {
 		const childId =
 			childIdRaw != null && String(childIdRaw) !== '' ? asChildId(String(childIdRaw)) : undefined;
 
-		if (!name) return fail(400, { error: '名前を入力してください' });
+		if (!name) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.nameRequired });
 		if (!categoryId || !getCategoryById(categoryId)) {
-			return fail(400, { error: 'カテゴリを選択してください' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.categoryRequired });
 		}
 
 		// プラン制限チェック（カスタム活動数）
@@ -180,7 +182,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					ADMIN_ACTIVITIES_PAGE_LABELS.customActivityLimitReached(activityLimitCheck.max),
 				),
 			});
 		}
@@ -210,7 +212,7 @@ export const actions: Actions = {
 				stack: e instanceof Error ? e.stack : undefined,
 				context: { name, categoryId },
 			});
-			return fail(500, { error: '追加に失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.addFailed });
 		}
 	},
 
@@ -236,10 +238,10 @@ export const actions: Actions = {
 		const priorityRaw = formData.get('priority');
 		const priority: 'must' | 'optional' = priorityRaw === 'must' ? 'must' : 'optional';
 
-		if (!id) return fail(400, { error: 'IDが必要です' });
-		if (!name) return fail(400, { error: '名前を入力してください' });
+		if (!id) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idRequired });
+		if (!name) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.nameRequired });
 		if (!categoryId || !getCategoryById(categoryId)) {
-			return fail(400, { error: 'カテゴリを選択してください' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.categoryRequired });
 		}
 
 		try {
@@ -267,7 +269,7 @@ export const actions: Actions = {
 				stack: e instanceof Error ? e.stack : undefined,
 				context: { id, name, priority },
 			});
-			return fail(500, { error: '更新に失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.updateFailed });
 		}
 	},
 
@@ -276,7 +278,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const packId = String(formData.get('packId') ?? '').trim();
 
-		if (!packId) return fail(400, { error: 'パックIDが必要です' });
+		if (!packId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.packIdRequired });
 
 		// #2894 AC2: marketplace 取込経路でも free tier のカスタム活動上限を enforce
 		// (importPackToChildren と同型、`create` 単発の gate を取込経路に横展開)。
@@ -292,7 +294,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${importPackLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					ADMIN_ACTIVITIES_PAGE_LABELS.customActivityLimitReached(importPackLimitCheck.max),
 				),
 			});
 		}
@@ -309,13 +311,13 @@ export const actions: Actions = {
 			return result;
 		} catch (e) {
 			if (e instanceof Error && e.message.includes('not found in marketplace SSOT')) {
-				return fail(404, { error: 'パックが見つかりません' });
+				return fail(404, { error: ADMIN_FORM_ERROR_LABELS.packNotFound });
 			}
 			logger.error('[admin/activities] パックインポート失敗', {
 				error: e instanceof Error ? e.message : String(e),
 				context: { packId },
 			});
-			return fail(500, { error: 'インポートに失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.importFailed });
 		}
 	},
 
@@ -324,7 +326,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const id = asActivityId(formIdString(formData.get('id')));
 
-		if (!id) return fail(400, { error: 'IDが必要です' });
+		if (!id) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idRequired });
 
 		try {
 			if (await hasActivityLogs(id, tenantId)) {
@@ -348,7 +350,7 @@ export const actions: Actions = {
 				stack: e instanceof Error ? e.stack : undefined,
 				context: { id },
 			});
-			return fail(500, { error: '削除に失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.deleteFailed });
 		}
 	},
 
@@ -371,7 +373,7 @@ export const actions: Actions = {
 			logger.error('[admin/activities] ファイル解析失敗', {
 				error: e instanceof Error ? e.message : String(e),
 			});
-			return fail(400, { error: 'ファイルの解析に失敗しました' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.fileParseFailed });
 		}
 
 		try {
@@ -386,7 +388,7 @@ export const actions: Actions = {
 			logger.error('[admin/activities] ファイルインポート失敗', {
 				error: e instanceof Error ? e.message : String(e),
 			});
-			return fail(500, { error: 'インポートに失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.importFailed });
 		}
 	},
 
@@ -396,7 +398,7 @@ export const actions: Actions = {
 		const id = asActivityId(formIdString(formData.get('id')));
 		const enabled = formData.get('enabled') === 'true';
 
-		if (!id) return fail(400, { error: 'IDが必要です' });
+		if (!id) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idRequired });
 
 		const result = await setMainQuest(id, enabled, tenantId);
 		if ('error' in result) {
@@ -418,8 +420,8 @@ export const actions: Actions = {
 		const childIdsRaw = String(formData.get('childIds') ?? '').trim();
 		const selectedIndexesRaw = String(formData.get('selectedIndexes') ?? '').trim();
 
-		if (!packId) return fail(400, { error: 'パックIDが必要です' });
-		if (!childIdsRaw) return fail(400, { error: '対象のお子さまを選択してください' });
+		if (!packId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.packIdRequired });
+		if (!childIdsRaw) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.targetChildRequired });
 
 		// #2894 AC2: free tier のカスタム活動上限 (maxActivities=3, tenant-wide) を取込経路でも
 		// enforce する。`create` action には上限 check があったが import 経路は漏れており
@@ -433,7 +435,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					ADMIN_ACTIVITIES_PAGE_LABELS.customActivityLimitReached(activityLimitCheck.max),
 				),
 			});
 		}
@@ -452,7 +454,7 @@ export const actions: Actions = {
 		}
 
 		if (!childIds || childIds.length === 0) {
-			return fail(400, { error: '有効な対象が指定されていません' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.noValidTargets });
 		}
 
 		// Round 18 Cluster H: subset 取込 — selectedIndexes が指定されたら payload を slice。
@@ -463,7 +465,7 @@ export const actions: Actions = {
 		// 明示的な空指定 ('' でない空 csv 例: ',,,') は次の `=== ''` 分岐で fail させる。
 		const selectedIndexes = parseImportIndexes(selectedIndexesRaw);
 		if (selectedIndexesRaw !== '' && selectedIndexes === null) {
-			return fail(400, { error: '取り込む活動が選択されていません' });
+			return fail(400, { error: ADMIN_ACTIVITIES_PAGE_LABELS.noActivitiesSelectedToImport });
 		}
 
 		try {
@@ -476,7 +478,7 @@ export const actions: Actions = {
 					.filter((i) => i < allActivities.length)
 					.map((i) => allActivities[i]);
 				if (subset.length === 0) {
-					return fail(400, { error: '取り込む活動が選択されていません' });
+					return fail(400, { error: ADMIN_ACTIVITIES_PAGE_LABELS.noActivitiesSelectedToImport });
 				}
 				rawPayload = {
 					...(source.payload as Record<string, unknown>),
@@ -492,13 +494,13 @@ export const actions: Actions = {
 			return { perChildImport: true, ...result };
 		} catch (e) {
 			if (e instanceof Error && e.message.includes('not found in marketplace SSOT')) {
-				return fail(404, { error: 'パックが見つかりません' });
+				return fail(404, { error: ADMIN_FORM_ERROR_LABELS.packNotFound });
 			}
 			logger.error('[admin/activities] per-child 取込失敗', {
 				error: e instanceof Error ? e.message : String(e),
 				context: { packId, childIds, selectedIndexCount: selectedIndexes?.length ?? null },
 			});
-			return fail(500, { error: 'インポートに失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.importFailed });
 		}
 	},
 
@@ -513,7 +515,7 @@ export const actions: Actions = {
 		const singleTargetChildId = asChildId(formIdString(formData.get('targetChildId')));
 
 		if (!sourceChildId) {
-			return fail(400, { error: 'コピー元のお子さまが必要です' });
+			return fail(400, { error: ADMIN_ACTIVITIES_PAGE_LABELS.copySourceChildRequired });
 		}
 
 		// targetChildIds (CSV) 優先、なければ targetChildId (単一) を使う
@@ -529,7 +531,7 @@ export const actions: Actions = {
 		}
 
 		if (!targetChildIds || targetChildIds.length === 0) {
-			return fail(400, { error: 'コピー先のお子さまが必要です' });
+			return fail(400, { error: ADMIN_ACTIVITIES_PAGE_LABELS.copyTargetChildRequired });
 		}
 
 		// #3740: copy は元活動の source ('custom' 含む) を保全して複製するため quota を消費する。
@@ -543,7 +545,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${copyLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					ADMIN_ACTIVITIES_PAGE_LABELS.customActivityLimitReached(copyLimitCheck.max),
 				),
 			});
 		}
@@ -552,7 +554,7 @@ export const actions: Actions = {
 			const target = targetChildIds[0];
 			if (targetChildIds.length === 1 && target !== undefined) {
 				if (sourceChildId === target) {
-					return fail(400, { error: '同じお子さまにはコピーできません' });
+					return fail(400, { error: ADMIN_ACTIVITIES_PAGE_LABELS.sameChildCopyNotAllowed });
 				}
 				const copied = await copyChildActivitiesToSibling(tenantId, sourceChildId, target);
 				return { copyResult: true, copiedCount: copied.length };
@@ -577,7 +579,7 @@ export const actions: Actions = {
 				error: e instanceof Error ? e.message : String(e),
 				context: { sourceChildId, targetChildIds },
 			});
-			return fail(500, { error: 'コピーに失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.copyFailed });
 		}
 	},
 
@@ -594,11 +596,11 @@ export const actions: Actions = {
 		const dailyLimit = sanitizeDailyLimit(dailyLimitRaw); // #3463 item4: NaN/負/巨大/非整数を [0,99] int or null に clamp
 		const childIdsRaw = String(formData.get('childIds') ?? '').trim();
 
-		if (!name) return fail(400, { error: '名前を入力してください' });
+		if (!name) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.nameRequired });
 		if (!categoryId || !getCategoryById(categoryId)) {
-			return fail(400, { error: 'カテゴリを選択してください' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.categoryRequired });
 		}
-		if (!childIdsRaw) return fail(400, { error: '対象のお子さまを選択してください' });
+		if (!childIdsRaw) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.targetChildRequired });
 
 		// #2894 AC2: bulk create も free tier のカスタム活動上限を enforce (`create` 単発と同型)。
 		const bulkLicenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
@@ -609,7 +611,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${bulkActivityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					ADMIN_ACTIVITIES_PAGE_LABELS.customActivityLimitReached(bulkActivityLimitCheck.max),
 				),
 			});
 		}
@@ -626,7 +628,7 @@ export const actions: Actions = {
 				.map(asChildId);
 		}
 		if (childIds.length === 0) {
-			return fail(400, { error: '有効な対象が指定されていません' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.noValidTargets });
 		}
 
 		const repos = getRepos();
@@ -648,7 +650,7 @@ export const actions: Actions = {
 				error: e instanceof Error ? e.message : String(e),
 				context: { name, categoryId, childIds },
 			});
-			return fail(500, { error: '一括追加に失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.bulkAddFailed });
 		}
 	},
 
@@ -675,7 +677,7 @@ export const actions: Actions = {
 			logger.error('[admin/activities] 一括クリア失敗', {
 				error: e instanceof Error ? e.message : String(e),
 			});
-			return fail(500, { error: '一括クリアに失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.bulkClearFailed });
 		}
 	},
 };

--- a/src/routes/(parent)/admin/activities/+page.svelte
+++ b/src/routes/(parent)/admin/activities/+page.svelte
@@ -7,6 +7,7 @@ import { splitIcon } from '$lib/domain/icon-utils';
 import { asCategoryId, asChildId, type CategoryId, type ChildId } from '$lib/domain/ids';
 import {
 	ADMIN_ACTIVITIES_PAGE_LABELS,
+	ADMIN_FORM_ERROR_LABELS,
 	APP_LABELS,
 	FEATURES_LABELS,
 	PAGE_TITLES,
@@ -398,7 +399,7 @@ async function handleRestoreSubmit(event: SubmitEvent) {
 // 「他の子供から copy」action
 async function handleCopyFromChild() {
 	if (!copySourceChildId || !selectedChildId || copySourceChildId === selectedChildId) {
-		actionMessage = '違うお子さまを選んでください';
+		actionMessage = ADMIN_FORM_ERROR_LABELS.sameChildNotAllowed;
 		return;
 	}
 	const formData = new FormData();
@@ -407,12 +408,12 @@ async function handleCopyFromChild() {
 
 	const resp = await fetch('?/copyFromChild', { method: 'POST', body: formData });
 	if (resp.ok) {
-		actionMessage = 'コピーが完了しました';
+		actionMessage = ADMIN_ACTIVITIES_PAGE_LABELS.copySuccess;
 		showCopyFromChildDialog = false;
 		copySourceChildId = null;
 		await invalidateAll();
 	} else {
-		actionMessage = 'コピーに失敗しました';
+		actionMessage = ADMIN_FORM_ERROR_LABELS.copyFailed;
 	}
 }
 
@@ -426,7 +427,7 @@ let bulkTargets = $state<'all' | ChildId[]>('all');
 
 async function handleBulkCreate(targets: 'all' | ChildId[]) {
 	if (!bulkName.trim()) {
-		actionMessage = '名前を入力してください';
+		actionMessage = ADMIN_FORM_ERROR_LABELS.nameRequired;
 		return;
 	}
 	const childIdsValue = targets === 'all' ? 'all' : targets.join(',');
@@ -439,12 +440,12 @@ async function handleBulkCreate(targets: 'all' | ChildId[]) {
 
 	const resp = await fetch('?/bulkCreateForChildren', { method: 'POST', body: formData });
 	if (resp.ok) {
-		actionMessage = '一括追加しました';
+		actionMessage = ADMIN_ACTIVITIES_PAGE_LABELS.bulkAddSuccess;
 		showBulkCreateDialog = false;
 		bulkName = '';
 		await invalidateAll();
 	} else {
-		actionMessage = '一括追加に失敗しました';
+		actionMessage = ADMIN_FORM_ERROR_LABELS.bulkAddFailed;
 	}
 }
 

--- a/src/routes/(parent)/admin/activities/[id]/edit/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/[id]/edit/+page.server.ts
@@ -5,6 +5,8 @@
 import { error, fail, redirect } from '@sveltejs/kit';
 import { formIdString } from '$lib/domain/form-value';
 import { asActivityId, asCategoryId } from '$lib/domain/ids';
+// #4512: form action のエラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { ADMIN_ACTIVITIES_PAGE_LABELS, ADMIN_FORM_ERROR_LABELS } from '$lib/domain/labels';
 import {
 	CATEGORY_DEFS,
 	getCategoryById,
@@ -20,11 +22,11 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 	const tenantId = requireTenantId(locals);
 	const id = asActivityId(params.id);
 	if (!id) {
-		error(400, '不正な活動IDです');
+		error(400, ADMIN_ACTIVITIES_PAGE_LABELS.activityIdInvalid);
 	}
 	const activity = await getActivityById(id, tenantId);
 	if (!activity) {
-		error(404, '活動が見つかりません');
+		error(404, ADMIN_ACTIVITIES_PAGE_LABELS.activityNotFound);
 	}
 	return {
 		activity,
@@ -38,7 +40,7 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 		const id = asActivityId(params.id);
 		if (!id) {
-			return fail(400, { error: '不正な活動IDです' });
+			return fail(400, { error: ADMIN_ACTIVITIES_PAGE_LABELS.activityIdInvalid });
 		}
 
 		const formData = await request.formData();
@@ -61,9 +63,9 @@ export const actions: Actions = {
 		const priorityRaw = formData.get('priority');
 		const priority: 'must' | 'optional' = priorityRaw === 'must' ? 'must' : 'optional';
 
-		if (!name) return fail(400, { error: '名前を入力してください' });
+		if (!name) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.nameRequired });
 		if (!categoryId || !getCategoryById(categoryId)) {
-			return fail(400, { error: 'カテゴリを選択してください' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.categoryRequired });
 		}
 
 		try {
@@ -90,7 +92,7 @@ export const actions: Actions = {
 				stack: e instanceof Error ? e.stack : undefined,
 				context: { id, name, priority },
 			});
-			return fail(500, { error: '更新に失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.updateFailed });
 		}
 
 		// 更新成功 → 一覧画面にリダイレクト

--- a/src/routes/(parent)/admin/certificates/+page.svelte
+++ b/src/routes/(parent)/admin/certificates/+page.svelte
@@ -27,13 +27,7 @@ const groupedCerts = $derived.by(() => {
 });
 
 const categoryOrder = ['streak', 'level', 'monthly', 'category_master', 'annual'] as const;
-const categoryNames: Record<string, string> = {
-	streak: '🔥 連続記録',
-	level: '🌟 レベルアップ',
-	monthly: '📜 月間がんばり',
-	category_master: '🎓 カテゴリマスター',
-	annual: '🏆 年間がんばり大賞',
-};
+const categoryNames = CERTIFICATES_PAGE_LABELS.categoryNames;
 </script>
 
 <svelte:head>

--- a/src/routes/(parent)/admin/certificates/[id]/+page.server.ts
+++ b/src/routes/(parent)/admin/certificates/[id]/+page.server.ts
@@ -1,5 +1,7 @@
 import { error } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+// #4512: エラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { ADMIN_FORM_ERROR_LABELS, CERTIFICATE_DETAIL_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { buildRenderData, getCertificateDetail } from '$lib/server/services/certificate-service';
 import { getChildById } from '$lib/server/services/child-service';
@@ -9,13 +11,13 @@ import type { PageServerLoad } from './$types';
 export const load: PageServerLoad = async ({ params, locals }) => {
 	const tenantId = requireTenantId(locals);
 	const certId = params.id;
-	if (!certId) error(404, '証明書が見つかりません');
+	if (!certId) error(404, CERTIFICATE_DETAIL_LABELS.certificateNotFound);
 
 	const cert = await getCertificateDetail(certId, tenantId);
-	if (!cert) error(404, '証明書が見つかりません');
+	if (!cert) error(404, CERTIFICATE_DETAIL_LABELS.certificateNotFound);
 
 	const child = await getChildById(cert.childId, tenantId);
-	if (!child) error(404, '子供が見つかりません');
+	if (!child) error(404, ADMIN_FORM_ERROR_LABELS.childNotFoundNeutral);
 
 	const renderData = buildRenderData(cert, child.nickname);
 

--- a/src/routes/(parent)/admin/certificates/[id]/+page.svelte
+++ b/src/routes/(parent)/admin/certificates/[id]/+page.svelte
@@ -66,19 +66,19 @@ async function handleShareDownload() {
 		// Branding
 		ctx.fillStyle = '#9ca3af';
 		ctx.font = '14px sans-serif';
-		ctx.fillText('がんばりクエスト', 320, 440);
+		ctx.fillText(CERTIFICATE_DETAIL_LABELS.shareCardBrandText, 320, 440);
 
 		// Download
 		const link = document.createElement('a');
 		link.download = `certificate-${data.certificate.id}.png`;
 		link.href = canvas.toDataURL('image/png');
 		link.click();
-		shareStatus = 'ダウンロードしました！';
+		shareStatus = CERTIFICATE_DETAIL_LABELS.downloadSuccess;
 		setTimeout(() => {
 			shareStatus = '';
 		}, 3000);
 	} catch {
-		shareStatus = 'ダウンロードに失敗しました';
+		shareStatus = CERTIFICATE_DETAIL_LABELS.downloadFailed;
 		setTimeout(() => {
 			shareStatus = '';
 		}, 3000);

--- a/src/routes/(parent)/admin/challenges/+page.server.ts
+++ b/src/routes/(parent)/admin/challenges/+page.server.ts
@@ -9,6 +9,8 @@
 import { fail } from '@sveltejs/kit';
 import { formIdString } from '$lib/domain/form-value';
 import { asChildId } from '$lib/domain/ids';
+// #4512: form action のエラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { ADMIN_FORM_ERROR_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { warnOrphanChildReferences } from '$lib/server/orphan-child-reference';
 import {
@@ -61,7 +63,7 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 		const fd = await request.formData();
 		const id = formIdString(fd.get('id'));
-		if (!id) return fail(400, { error: 'IDが不正です' });
+		if (!id) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idInvalid });
 		await deleteChildChallenge(id, tenantId);
 		return { deleted: true };
 	},

--- a/src/routes/(parent)/admin/challenges/+page.svelte
+++ b/src/routes/(parent)/admin/challenges/+page.svelte
@@ -131,8 +131,10 @@ function tabHref(childId: ChildId | 'all'): string {
 			</div>
 			<p class="text-xs text-[var(--color-text-muted)]">
 				{data.familyStreak.hasRecordedToday
-					? `今日は${data.familyStreak.todayRecorders.length + '人'}が記録済み`
-					: '今日はまだ誰も記録していません'}
+					? ADMIN_CHALLENGES_PAGE_LABELS.familyStreakRecordedToday(
+							data.familyStreak.todayRecorders.length,
+						)
+					: ADMIN_CHALLENGES_PAGE_LABELS.familyStreakNoneToday}
 			</p>
 		</div>
 	{/if}
@@ -277,7 +279,7 @@ function tabHref(childId: ChildId | 'all'): string {
 									size="sm"
 									data-testid="admin-challenge-delete-{instance.id}"
 								>
-									{group.instances.length >= 2 ? `${child?.nickname ?? UNRESOLVED_ENTITY_LABELS.child} を削除` : CHALLENGES_LABELS.deleteButton}
+									{group.instances.length >= 2 ? ADMIN_CHALLENGES_PAGE_LABELS.deleteChildButton(child?.nickname ?? UNRESOLVED_ENTITY_LABELS.child) : CHALLENGES_LABELS.deleteButton}
 								</Button>
 							</form>
 						{/each}

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -6,7 +6,13 @@ import { todayDateJST } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asChildId, type ChildId } from '$lib/domain/ids';
-import { PLAN_GATE_LABELS, UNRESOLVED_ENTITY_LABELS } from '$lib/domain/labels';
+// #4512: form action のエラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import {
+	ADMIN_CHECKLISTS_PAGE_LABELS,
+	ADMIN_FORM_ERROR_LABELS,
+	PLAN_GATE_LABELS,
+	UNRESOLVED_ENTITY_LABELS,
+} from '$lib/domain/labels';
 import type { ChecklistPayload } from '$lib/domain/marketplace-item';
 // #3151 slice3 (ADR-0066): item label / icon の値域 SSOT。admin authoring 経路と wire schema が
 // 同一境界を共有し、authoring 可能な item ⊆ export/import 往復可能な item を成立させる。
@@ -162,8 +168,9 @@ const importMarketplaceChecklistAction: Action = async ({ request, locals }) => 
 	const childId = asChildId(formIdString(formData.get('childId')));
 	const presetId = String(formData.get('presetId') ?? '').trim();
 
-	if (!childId || childId === asChildId(0)) return fail(400, { error: 'こどもを選択してください' });
-	if (!presetId) return fail(400, { error: 'プリセットIDが必要です' });
+	if (!childId || childId === asChildId(0))
+		return fail(400, { error: ADMIN_FORM_ERROR_LABELS.childRequired });
+	if (!presetId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.presetIdRequired });
 
 	// プラン制限 (Free プランのテンプレート数)
 	const licenseStatus = locals.context?.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
@@ -187,7 +194,7 @@ const importMarketplaceChecklistAction: Action = async ({ request, locals }) => 
 	// parse/preview/apply の重複実行 (二重 DB read) も解消。
 	const item = getMarketplaceItem('checklist', presetId);
 	if (!item) {
-		return fail(404, { error: 'プリセットが見つかりません' });
+		return fail(404, { error: ADMIN_FORM_ERROR_LABELS.presetNotFound });
 	}
 	const payload = item.payload as ChecklistPayload;
 	try {
@@ -217,7 +224,7 @@ const importMarketplaceChecklistAction: Action = async ({ request, locals }) => 
 			error: e instanceof Error ? e.message : String(e),
 			context: { presetId, childId },
 		});
-		return fail(500, { error: 'インポートに失敗しました' });
+		return fail(500, { error: ADMIN_FORM_ERROR_LABELS.importFailed });
 	}
 };
 
@@ -305,12 +312,12 @@ export const actions: Actions = {
 		const icon = String(formData.get('icon') ?? '📋').trim();
 
 		if (!childId || childId === asChildId(0))
-			return fail(400, { error: 'こどもを選択してください' });
-		if (!name) return fail(400, { error: '名前を入力してください' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.childRequired });
+		if (!name) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.nameRequired });
 
 		const timeSlot = String(formData.get('timeSlot') ?? 'anytime').trim();
 		if (!(VALID_TIME_SLOTS as readonly string[]).includes(timeSlot))
-			return fail(400, { error: '時間帯が不正です' });
+			return fail(400, { error: ADMIN_CHECKLISTS_PAGE_LABELS.timeSlotInvalid });
 
 		// #1755 (#1709-A): kind 削除 — 持ち物純化（旧 'routine' は activities.priority='must' に役割移管）
 
@@ -340,9 +347,9 @@ export const actions: Actions = {
 		const templateId = formIdString(formData.get('templateId'));
 		const timeSlot = String(formData.get('timeSlot') ?? 'anytime').trim();
 
-		if (!templateId) return fail(400, { error: 'テンプレートIDが不正です' });
+		if (!templateId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.templateIdInvalid });
 		if (!(VALID_TIME_SLOTS as readonly string[]).includes(timeSlot))
-			return fail(400, { error: '時間帯が不正です' });
+			return fail(400, { error: ADMIN_CHECKLISTS_PAGE_LABELS.timeSlotInvalid });
 
 		await editTemplate(templateId, { timeSlot }, tenantId);
 		return { success: true };
@@ -354,7 +361,7 @@ export const actions: Actions = {
 		const templateId = formIdString(formData.get('templateId'));
 		const isActive = Number(formData.get('isActive'));
 
-		if (!templateId) return fail(400, { error: 'テンプレートIDが不正です' });
+		if (!templateId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.templateIdInvalid });
 
 		await editTemplate(templateId, { isActive: isActive ? 0 : 1 }, tenantId);
 		return { success: true };
@@ -365,7 +372,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const templateId = formIdString(formData.get('templateId'));
 
-		if (!templateId) return fail(400, { error: 'テンプレートIDが不正です' });
+		if (!templateId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.templateIdInvalid });
 
 		await removeTemplate(templateId, tenantId);
 		return { success: true };
@@ -380,8 +387,8 @@ export const actions: Actions = {
 		const frequency = String(formData.get('frequency') ?? 'daily');
 		const direction = String(formData.get('direction') ?? 'bring');
 
-		if (!templateId) return fail(400, { error: 'テンプレートIDが不正です' });
-		if (!name) return fail(400, { error: 'アイテム名を入力してください' });
+		if (!templateId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.templateIdInvalid });
+		if (!name) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.itemNameRequired });
 
 		// #3151 slice3 (ADR-0066): label / icon を domain SSOT で検証し、export/import 往復不能な
 		// item (100 文字超 label / 3 個以上の絵文字 icon) の authoring を default-deny する。
@@ -392,7 +399,9 @@ export const actions: Actions = {
 			icon,
 		});
 		if (!itemCheck.success) {
-			return fail(400, { error: itemCheck.issues[0]?.message ?? 'アイテムが不正です' });
+			return fail(400, {
+				error: itemCheck.issues[0]?.message ?? ADMIN_FORM_ERROR_LABELS.itemInvalid,
+			});
 		}
 
 		await addTemplateItem({ templateId, name, icon, frequency, direction }, tenantId);
@@ -405,8 +414,8 @@ export const actions: Actions = {
 		const templateId = formIdString(formData.get('templateId'));
 		const itemId = formIdString(formData.get('itemId'));
 
-		if (!templateId) return fail(400, { error: 'テンプレートIDが不正です' });
-		if (!itemId) return fail(400, { error: 'アイテムIDが不正です' });
+		if (!templateId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.templateIdInvalid });
+		if (!itemId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.itemIdInvalid });
 
 		// #2845 B1: templateId 所有権検証付き (composite key)。不一致なら no-op
 		await removeTemplateItem(templateId, itemId, tenantId);
@@ -423,9 +432,9 @@ export const actions: Actions = {
 		const icon = String(formData.get('icon') ?? '📦').trim();
 
 		if (!childId || childId === asChildId(0))
-			return fail(400, { error: 'こどもを選択してください' });
-		if (!targetDate) return fail(400, { error: '日付を入力してください' });
-		if (!itemName) return fail(400, { error: 'アイテム名を入力してください' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.childRequired });
+		if (!targetDate) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.dateRequired });
+		if (!itemName) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.itemNameRequired });
 
 		await addOverride({ childId, targetDate, action, itemName, icon }, tenantId);
 		return { success: true };
@@ -438,8 +447,8 @@ export const actions: Actions = {
 		const overrideId = formIdString(formData.get('overrideId'));
 
 		if (!childId || childId === asChildId(0))
-			return fail(400, { error: 'こどもを選択してください' });
-		if (!overrideId) return fail(400, { error: 'オーバーライドIDが不正です' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.childRequired });
+		if (!overrideId) return fail(400, { error: ADMIN_CHECKLISTS_PAGE_LABELS.overrideIdInvalid });
 
 		// #2845 B1: childId 所有権検証付き (composite key)。不一致なら no-op
 		await removeOverride(childId, overrideId, tenantId);
@@ -469,8 +478,9 @@ export const actions: Actions = {
 		const itemsJson = String(formData.get('items') ?? '[]');
 
 		if (!childId || childId === asChildId(0))
-			return fail(400, { error: 'こどもを選択してください' });
-		if (!templateName) return fail(400, { error: 'テンプレート名が必要です' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.childRequired });
+		if (!templateName)
+			return fail(400, { error: ADMIN_CHECKLISTS_PAGE_LABELS.templateNameRequired });
 
 		// JSON パース + バリデーションを DB 作成前に実行（パース失敗時に空テンプレートが残る問題を防ぐ）
 		let items: { name: string; icon: string; frequency: string; direction: string }[];
@@ -538,7 +548,7 @@ export const actions: Actions = {
 		const presetId = String(formData.get('presetId') ?? '').trim();
 		const childIdsRaw = String(formData.get('childIds') ?? '').trim();
 
-		if (!presetId) return fail(400, { error: 'プリセットが指定されていません' });
+		if (!presetId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.presetNotSpecified });
 
 		// プラン制限 (Free プランのテンプレート数、per-child quota: LP「3個/子まで」と整合)
 		// 配信先 child 0 件でも family template 自体は作成可能 (後で distribution 編集)
@@ -592,13 +602,13 @@ export const actions: Actions = {
 				context: { presetId, foreignChildIds, tenantId },
 			});
 			return fail(403, {
-				error: '指定されたお子さまの一部が見つかりませんでした',
+				error: ADMIN_FORM_ERROR_LABELS.someChildrenNotFound,
 			});
 		}
 
 		const item = getMarketplaceItem('checklist', presetId);
 		if (!item) {
-			return fail(404, { error: `プリセット「${presetId}」が見つかりません` });
+			return fail(404, { error: ADMIN_FORM_ERROR_LABELS.presetNotFoundNamed(presetId) });
 		}
 		const payload = item.payload as ChecklistPayload;
 
@@ -630,7 +640,7 @@ export const actions: Actions = {
 				error: e instanceof Error ? e.message : String(e),
 				context: { presetId, childIds },
 			});
-			return fail(500, { error: 'インポートに失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.importFailed });
 		}
 	},
 
@@ -643,7 +653,7 @@ export const actions: Actions = {
 		const templateId = formIdString(formData.get('templateId'));
 		const childIdsRaw = String(formData.get('childIds') ?? '').trim();
 
-		if (!templateId) return fail(400, { error: 'テンプレートIDが不正です' });
+		if (!templateId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.templateIdInvalid });
 
 		const tenantChildren = await getAllChildren(tenantId);
 		const allowedChildIdSet = new Set(tenantChildren.map((c) => c.id));
@@ -668,7 +678,7 @@ export const actions: Actions = {
 				context: { templateId, foreignChildIds, tenantId },
 			});
 			return fail(403, {
-				error: '指定されたお子さまの一部が見つかりませんでした',
+				error: ADMIN_FORM_ERROR_LABELS.someChildrenNotFound,
 			});
 		}
 
@@ -685,7 +695,7 @@ export const actions: Actions = {
 				error: e instanceof Error ? e.message : String(e),
 				context: { templateId, desiredChildIds },
 			});
-			return fail(500, { error: '配信先の同期に失敗しました' });
+			return fail(500, { error: ADMIN_CHECKLISTS_PAGE_LABELS.distributionSyncFailed });
 		}
 	},
 
@@ -702,10 +712,10 @@ export const actions: Actions = {
 		const targetChildId = asChildId(formIdString(formData.get('targetChildId')));
 
 		if (!sourceChildId || !targetChildId) {
-			return fail(400, { error: 'お子さまを選択してください' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.childRequiredHonorific });
 		}
 		if (sourceChildId === targetChildId) {
-			return fail(400, { error: '違うお子さまを選んでください' });
+			return fail(400, { error: ADMIN_CHECKLISTS_PAGE_LABELS.copyDifferentChildError });
 		}
 
 		// #3474 item 3: 監査 actor を全 AUTH_MODE で解決 (NUC=local は nuc-local、旧実装は undefined)。
@@ -729,7 +739,7 @@ export const actions: Actions = {
 					},
 				},
 			);
-			return fail(403, { error: '指定されたお子さまが見つかりませんでした' });
+			return fail(403, { error: ADMIN_FORM_ERROR_LABELS.childrenNotFound });
 		}
 
 		// per-child quota: free プランは target child のテンプレ上限を超えないか確認。
@@ -797,7 +807,9 @@ export const actions: Actions = {
 			const dropped = alreadyDistributed + limitRejected;
 			if (limitReached) {
 				const skipNote =
-					alreadyDistributed > 0 ? `（${alreadyDistributed} 件はすでに配信済みでした）` : '';
+					alreadyDistributed > 0
+						? ADMIN_CHECKLISTS_PAGE_LABELS.copyAlreadyDistributedNote(alreadyDistributed)
+						: '';
 				return {
 					copiedFromChild: true,
 					added,
@@ -815,7 +827,7 @@ export const actions: Actions = {
 				error: e instanceof Error ? e.message : String(e),
 				context: { sourceChildId, targetChildId },
 			});
-			return fail(500, { error: '取り込みに失敗しました' });
+			return fail(500, { error: ADMIN_CHECKLISTS_PAGE_LABELS.copyFailed });
 		}
 	},
 
@@ -847,7 +859,7 @@ export const actions: Actions = {
 			loaded = await loadChecklistFromFile(file as File);
 		} catch (e) {
 			if (e instanceof FileSourceError) return fail(400, { error: e.message });
-			return fail(400, { error: 'ファイルの解析に失敗しました' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.fileParseFailed });
 		}
 
 		const templateName = deriveRestoreTemplateName(loaded.displayName);
@@ -894,7 +906,7 @@ export const actions: Actions = {
 			loaded = await loadChecklistFromFile(file as File);
 		} catch (e) {
 			if (e instanceof FileSourceError) return fail(400, { error: e.message });
-			return fail(400, { error: 'ファイルの解析に失敗しました' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.fileParseFailed });
 		}
 
 		const templateName = deriveRestoreTemplateName(loaded.displayName);
@@ -918,7 +930,7 @@ export const actions: Actions = {
 			logger.error('[admin/checklists] 復元失敗', {
 				error: e instanceof Error ? e.message : String(e),
 			});
-			return fail(500, { error: 'インポートに失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.importFailed });
 		}
 	},
 };
@@ -935,5 +947,5 @@ function deriveRestoreTemplateName(fileName: string): string {
 	const base = fileName.replace(/\.json$/i, '');
 	const stripped = base.startsWith('checklist-') ? base.slice('checklist-'.length) : base;
 	const cleaned = stripped.replace(/_/g, ' ').trim();
-	return cleaned.length > 0 ? cleaned : '復元したチェックリスト';
+	return cleaned.length > 0 ? cleaned : ADMIN_CHECKLISTS_PAGE_LABELS.restoreFallbackName;
 }

--- a/src/routes/(parent)/admin/cheer/+page.server.ts
+++ b/src/routes/(parent)/admin/cheer/+page.server.ts
@@ -9,6 +9,9 @@ import { fail } from '@sveltejs/kit';
 import { getErrorMessage } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asChildId } from '$lib/domain/ids';
+// #4512: エラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)。
+// 上限値そのものは cheer-service.ts が SSOT で、labels 側は引数で受ける。
+import { ADMIN_FORM_ERROR_LABELS, CHEER_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import {
 	CHEER_CATEGORIES,
@@ -44,8 +47,8 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 // 入力バリデーションエラーメッセージ表 (route + service 層で共通利用)
-const POINTS_ERROR_MSG = `ポイントは${CHEER_POINTS_MIN}〜${CHEER_POINTS_MAX}の範囲で入力してください`;
-const REASON_TOO_LONG_MSG = `理由は${CHEER_REASON_MAX_LENGTH}文字以内で入力してください`;
+const POINTS_ERROR_MSG = CHEER_LABELS.errorPointsRange(CHEER_POINTS_MIN, CHEER_POINTS_MAX);
+const REASON_TOO_LONG_MSG = CHEER_LABELS.errorReasonTooLong(CHEER_REASON_MAX_LENGTH);
 
 /** form input をパースして validation 結果を返す (フォーム / service 層エラーいずれにも対応する分岐回避) */
 function parseAndValidateForm(
@@ -62,8 +65,8 @@ function parseAndValidateForm(
 	const bodyRaw = String(formData.get('body') ?? '').trim();
 
 	if (!childId || childId === asChildId(0))
-		return { ok: false, status: 400, error: 'こどもを選択してください' };
-	if (!reason) return { ok: false, status: 400, error: '応援の理由を入力してください' };
+		return { ok: false, status: 400, error: CHEER_LABELS.errorChildRequired };
+	if (!reason) return { ok: false, status: 400, error: CHEER_LABELS.errorReasonRequired };
 	if (reason.length > CHEER_REASON_MAX_LENGTH) {
 		return { ok: false, status: 400, error: REASON_TOO_LONG_MSG };
 	}
@@ -71,7 +74,7 @@ function parseAndValidateForm(
 		return { ok: false, status: 400, error: POINTS_ERROR_MSG };
 	}
 	if (!CHEER_CATEGORIES.includes(category as CheerCategory)) {
-		return { ok: false, status: 400, error: 'カテゴリを選択してください' };
+		return { ok: false, status: 400, error: CHEER_LABELS.errorCategoryRequired };
 	}
 	return {
 		ok: true,
@@ -88,10 +91,10 @@ function parseAndValidateForm(
 }
 
 const SERVICE_ERROR_MESSAGES: Record<string, { status: 400 | 404; message: string }> = {
-	NOT_FOUND: { status: 404, message: 'こどもが見つかりません' },
-	INVALID_REASON: { status: 400, message: '応援の理由を入力してください' },
+	NOT_FOUND: { status: 404, message: CHEER_LABELS.errorChildNotFound },
+	INVALID_REASON: { status: 400, message: CHEER_LABELS.errorReasonRequired },
 	INVALID_POINTS: { status: 400, message: POINTS_ERROR_MSG },
-	INVALID_CATEGORY: { status: 400, message: 'カテゴリを選択してください' },
+	INVALID_CATEGORY: { status: 400, message: CHEER_LABELS.errorCategoryRequired },
 };
 
 export const actions: Actions = {
@@ -113,7 +116,7 @@ export const actions: Actions = {
 					error: mapped.status === 404 ? getErrorMessage(mapped.message) : mapped.message,
 				});
 			}
-			return fail(400, { error: 'エラーが発生しました' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.genericError });
 		}
 
 		return {

--- a/src/routes/(parent)/admin/cheer/+page.svelte
+++ b/src/routes/(parent)/admin/cheer/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 import { enhance } from '$app/forms';
+// #4512: 既定カテゴリ名は categories.ts (SSOT) から引く (旧: 画面側に直書き)
+import { CATEGORIES } from '$lib/domain/categories';
 import type { ChildId } from '$lib/domain/ids';
 import { APP_LABELS, CHEER_LABELS, PAGE_TITLES } from '$lib/domain/labels';
 import { notifyActionError } from '$lib/ui/error-notify';
@@ -23,7 +25,7 @@ $effect(() => {
 
 let reason = $state('');
 let points = $state(50);
-let category = $state<string>('うんどう');
+let category = $state<string>(CATEGORIES.undou.name);
 let icon = $state('🎉');
 let stampCode = $state('');
 let body = $state('');
@@ -48,7 +50,7 @@ const categoryOptions = $derived(data.categories.map((c) => ({ value: c, label: 
 function resetForm() {
 	reason = '';
 	points = 50;
-	category = 'うんどう';
+	category = CATEGORIES.undou.name;
 	icon = '🎉';
 	stampCode = '';
 	body = '';
@@ -165,7 +167,7 @@ $effect(() => {
 						name="reason"
 						maxlength={data.reasonMaxLength}
 						placeholder={CHEER_LABELS.reasonPlaceholder}
-						hint="{reasonLength}/{data.reasonMaxLength}（あと{reasonRemaining}文字）"
+						hint={CHEER_LABELS.reasonCounterHint(reasonLength, data.reasonMaxLength, reasonRemaining)}
 						bind:value={reason}
 					/>
 				</Card>
@@ -236,7 +238,7 @@ $effect(() => {
 						rows={2}
 						name="body"
 						maxlength={120}
-						placeholder="ひとことメッセージを足す（任意）"
+						placeholder={CHEER_LABELS.bodyPlaceholder}
 						bind:value={body}
 					/>
 					<input type="hidden" name="stampCode" value={stampCode} />

--- a/src/routes/(parent)/admin/children/+page.server.ts
+++ b/src/routes/(parent)/admin/children/+page.server.ts
@@ -4,7 +4,7 @@ import { calculateAgeFromBirthDate } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asCategoryId, asChildId } from '$lib/domain/ids';
-import { ADMIN_CHILDREN_PAGE_LABELS } from '$lib/domain/labels';
+import { ADMIN_CHILDREN_PAGE_LABELS, ADMIN_FORM_ERROR_LABELS } from '$lib/domain/labels';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
@@ -147,15 +147,15 @@ export const actions: Actions = {
 		const birthDate = formData.get('birthDate')?.toString() || null;
 
 		if (!nickname || nickname.length === 0) {
-			return fail(400, { error: 'ニックネームを入力してください' });
+			return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.nicknameRequired });
 		}
 
 		// 誕生日バリデーション
 		if (birthDate && !/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) {
-			return fail(400, { error: '誕生日の形式が正しくありません（YYYY-MM-DD）' });
+			return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.birthdayFormatInvalid });
 		}
 		if (birthDate && new Date(birthDate) > new Date()) {
-			return fail(400, { error: '未来の日付は設定できません' });
+			return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.birthdayFutureNotAllowed });
 		}
 
 		// 誕生日から年齢を自動計算、なければ手動入力 (#1380: 両方空はエラー)
@@ -181,7 +181,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`子供は最大${childLimitCheck.max}人まで登録できます。プランをアップグレードしてください。`,
+					ADMIN_CHILDREN_PAGE_LABELS.childLimitReached(childLimitCheck.max),
 				),
 			});
 		}
@@ -204,15 +204,15 @@ export const actions: Actions = {
 		const birthDate = formData.get('birthDate')?.toString();
 
 		if (!childId) {
-			return fail(400, { error: 'IDが不正です' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idInvalid });
 		}
 
 		// 誕生日バリデーション
 		if (birthDate && !/^\d{4}-\d{2}-\d{2}$/.test(birthDate)) {
-			return fail(400, { error: '誕生日の形式が正しくありません（YYYY-MM-DD）' });
+			return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.birthdayFormatInvalid });
 		}
 		if (birthDate && new Date(birthDate) > new Date()) {
-			return fail(400, { error: '未来の日付は設定できません' });
+			return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.birthdayFutureNotAllowed });
 		}
 
 		const updates: Record<string, string | number | null> = {};
@@ -245,7 +245,7 @@ export const actions: Actions = {
 		const childId = asChildId(formIdString(formData.get('childId')));
 
 		if (!childId) {
-			return fail(400, { error: 'IDが不正です' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idInvalid });
 		}
 
 		await removeChild(childId, tenantId);
@@ -260,16 +260,16 @@ export const actions: Actions = {
 		const newValue = Number(form.get('value'));
 
 		if (!childId || !categoryId) {
-			return fail(400, { error: '必須項目が不足しています' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.requiredFieldsMissing });
 		}
 
 		const currentStatus = await getChildStatus(childId, tenantId);
 		if ('error' in currentStatus) {
-			return fail(404, { error: '子供が見つかりません' });
+			return fail(404, { error: ADMIN_FORM_ERROR_LABELS.childNotFoundNeutral });
 		}
 
 		if (Number.isNaN(newValue) || newValue < 0 || newValue > 100000) {
-			return fail(400, { error: '値は0〜100000の範囲で入力してください' });
+			return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.statusValueRange });
 		}
 
 		const currentValue = currentStatus.statuses[categoryId]?.value ?? 0;
@@ -291,21 +291,21 @@ export const actions: Actions = {
 		const label = String(formData.get('label') ?? '').trim();
 		const durationMs = formData.get('durationMs') ? Number(formData.get('durationMs')) : undefined;
 
-		if (!childId) return fail(400, { error: 'IDが不正です' });
-		if (!label) return fail(400, { error: 'ラベルを入力してください' });
+		if (!childId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idInvalid });
+		if (!label) return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.voiceLabelRequired });
 		if (!(file instanceof File) || file.size === 0) {
-			return fail(400, { error: '音声ファイルを選択してください' });
+			return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.voiceFileRequired });
 		}
 
 		const result = await uploadVoice(childId, tenantId, file, label, 'complete', durationMs);
 		if ('error' in result) {
 			const msgs: Record<string, string> = {
-				INVALID_FILE: 'ファイルが不正です',
-				FILE_TOO_LARGE: '5MB以下にしてください',
-				UNSUPPORTED_TYPE: 'MP3/M4A/WAV/WebM/OGG形式のみ',
-				TOO_MANY_VOICES: '10件まで登録可能です',
+				INVALID_FILE: ADMIN_CHILDREN_PAGE_LABELS.voiceErrorInvalidFile,
+				FILE_TOO_LARGE: ADMIN_CHILDREN_PAGE_LABELS.voiceErrorFileTooLarge,
+				UNSUPPORTED_TYPE: ADMIN_CHILDREN_PAGE_LABELS.voiceErrorUnsupportedType,
+				TOO_MANY_VOICES: ADMIN_CHILDREN_PAGE_LABELS.voiceErrorTooMany,
 			};
-			return fail(400, { error: msgs[result.error] ?? 'エラーが発生しました' });
+			return fail(400, { error: msgs[result.error] ?? ADMIN_FORM_ERROR_LABELS.genericError });
 		}
 		return { success: true, voiceUploaded: true };
 	},
@@ -315,7 +315,7 @@ export const actions: Actions = {
 		const form = await request.formData();
 		const voiceId = formIdString(form.get('voiceId'));
 		const childId = asChildId(formIdString(form.get('childId')));
-		if (!voiceId || !childId) return fail(400, { error: 'IDが不正です' });
+		if (!voiceId || !childId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idInvalid });
 
 		await activateVoice(voiceId, childId, 'complete', tenantId);
 		return { success: true, voiceActivated: true };
@@ -325,7 +325,7 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 		const form = await request.formData();
 		const voiceId = formIdString(form.get('voiceId'));
-		if (!voiceId) return fail(400, { error: 'IDが不正です' });
+		if (!voiceId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idInvalid });
 
 		await deleteVoice(voiceId, tenantId);
 		return { success: true, voiceDeleted: true };
@@ -337,9 +337,9 @@ export const actions: Actions = {
 		const childId = asChildId(formIdString(form.get('childId')));
 		const multiplier = Number(form.get('multiplier'));
 
-		if (!childId) return fail(400, { error: 'IDが不正です' });
+		if (!childId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.idInvalid });
 		if (Number.isNaN(multiplier) || multiplier < 0.5 || multiplier > 3.0) {
-			return fail(400, { error: '倍率は0.5〜3.0の範囲で設定してください' });
+			return fail(400, { error: ADMIN_CHILDREN_PAGE_LABELS.birthdayMultiplierRange });
 		}
 
 		await editChild(childId, { birthdayBonusMultiplier: multiplier }, tenantId);

--- a/src/routes/(parent)/admin/children/+page.svelte
+++ b/src/routes/(parent)/admin/children/+page.svelte
@@ -126,7 +126,7 @@ const addCalculatedAge = $derived(
 						id="add-nickname"
 						name="nickname"
 						required
-						placeholder="例: たろうくん"
+						placeholder={ADMIN_CHILDREN_PAGE_LABELS.nicknamePlaceholder}
 					/>
 					<BirthdayInput
 						name="birthDate"

--- a/src/routes/(parent)/admin/growth-book/+page.svelte
+++ b/src/routes/(parent)/admin/growth-book/+page.svelte
@@ -2,7 +2,7 @@
 import { goto } from '$app/navigation';
 import { formatChildName } from '$lib/domain/child-display';
 import type { ChildId } from '$lib/domain/ids';
-import { APP_LABELS, GROWTH_BOOK_LABELS, PAGE_TITLES } from '$lib/domain/labels';
+import { APP_LABELS, formatMonthOnly, GROWTH_BOOK_LABELS, PAGE_TITLES } from '$lib/domain/labels';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 
@@ -18,7 +18,7 @@ const categoryNames: Record<string, string> = {
 
 function formatMonth(ym: string): string {
 	const [_y, m] = ym.split('-');
-	return `${Number(m)}月`;
+	return formatMonthOnly(m ?? 0);
 }
 
 function handleChildChange(childId: ChildId) {

--- a/src/routes/(parent)/admin/members/+page.server.ts
+++ b/src/routes/(parent)/admin/members/+page.server.ts
@@ -1,5 +1,7 @@
 // /admin/members — メンバー管理（招待・一覧） (#0129, #0156, #371)
 
+// #4512: 解決できなかった値の表示は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { UNRESOLVED_ENTITY_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getRepos } from '$lib/server/db/factory';
 import { getAllChildren } from '$lib/server/services/child-service';
@@ -29,7 +31,7 @@ export const load: PageServerLoad = async ({ locals, parent }) => {
 				userId: m.userId,
 				role: m.role,
 				joinedAt: m.joinedAt,
-				email: user?.email ?? '(不明)',
+				email: user?.email ?? UNRESOLVED_ENTITY_LABELS.email,
 			};
 		}),
 	);

--- a/src/routes/(parent)/admin/members/+page.svelte
+++ b/src/routes/(parent)/admin/members/+page.svelte
@@ -535,9 +535,9 @@ const roleLabel = (role: string) => {
 						<NativeSelect
 							bind:value={viewerDuration}
 							options={[
-								{ value: '7d', label: '7日間' },
-								{ value: '30d', label: '30日間' },
-								{ value: 'unlimited', label: '無期限' },
+								{ value: '7d', label: MEMBERS_LABELS.viewerDuration7d },
+								{ value: '30d', label: MEMBERS_LABELS.viewerDuration30d },
+								{ value: 'unlimited', label: MEMBERS_LABELS.viewerDurationUnlimited },
 							]}
 						/>
 					{/snippet}

--- a/src/routes/(parent)/admin/points/+page.server.ts
+++ b/src/routes/(parent)/admin/points/+page.server.ts
@@ -1,6 +1,8 @@
 import { fail } from '@sveltejs/kit';
 import { formIdString } from '$lib/domain/form-value';
 import { asChildId } from '$lib/domain/ids';
+// #4512: form action のエラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { POINTS_LABELS } from '$lib/domain/labels';
 import { ConvertMode } from '$lib/domain/validation/point';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
@@ -56,24 +58,24 @@ export const actions: Actions = {
 		const mode = (formData.get('mode') as string) || ConvertMode.PRESET;
 
 		if (!childId || !amount || amount < 1) {
-			return fail(400, { error: '入力が不正です' });
+			return fail(400, { error: POINTS_LABELS.convertInputInvalid });
 		}
 
 		if (!Number.isInteger(amount)) {
-			return fail(400, { error: 'ポイントは整数で入力してください' });
+			return fail(400, { error: POINTS_LABELS.convertAmountNotInteger });
 		}
 
 		// プリセットモードは500P単位の制約を維持
 		if (mode === ConvertMode.PRESET && (amount < 500 || amount % 500 !== 0)) {
-			return fail(400, { error: 'ポイントは500単位で変換できます' });
+			return fail(400, { error: POINTS_LABELS.convertPresetUnit });
 		}
 
 		const result = await convertPoints(childId, amount, tenantId, mode as ConvertMode);
 		if ('error' in result) {
 			const messages: Record<string, string> = {
-				NOT_FOUND: 'こどもが見つかりません',
-				INSUFFICIENT_POINTS: 'ポイントが足りません',
-				INVALID_AMOUNT: '金額が不正です',
+				NOT_FOUND: POINTS_LABELS.convertChildNotFound,
+				INSUFFICIENT_POINTS: POINTS_LABELS.convertInsufficientPoints,
+				INVALID_AMOUNT: POINTS_LABELS.convertInvalidAmount,
 			};
 			return fail(400, { error: messages[result.error] ?? result.error });
 		}

--- a/src/routes/(parent)/admin/points/+page.svelte
+++ b/src/routes/(parent)/admin/points/+page.svelte
@@ -144,7 +144,7 @@ async function handleReceiptFile(event: Event) {
 
 			if (!res.ok) {
 				const errorBody = await res.json();
-				receiptError = errorBody.error?.message ?? '読み取りに失敗しました';
+				receiptError = errorBody.error?.message ?? POINTS_LABELS.receiptScanFailed;
 				receiptScanning = false;
 				return;
 			}
@@ -154,7 +154,7 @@ async function handleReceiptFile(event: Event) {
 			receiptRawText = data.rawText;
 			receiptScanning = false;
 		} catch {
-			receiptError = '通信エラーが発生しました';
+			receiptError = POINTS_LABELS.receiptNetworkError;
 			receiptScanning = false;
 		}
 	};

--- a/src/routes/(parent)/admin/reports/+page.server.ts
+++ b/src/routes/(parent)/admin/reports/+page.server.ts
@@ -2,7 +2,7 @@ import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { monthKeyJST } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
-import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import { PLAN_GATE_LABELS, REPORTS_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getSettings, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
@@ -158,7 +158,7 @@ export const actions: Actions = {
 			'sunday',
 		];
 		if (!validDays.includes(day)) {
-			return fail(400, { error: '無効な曜日です' });
+			return fail(400, { error: REPORTS_LABELS.weeklySettingsDayInvalid });
 		}
 
 		await setSetting('weekly_report_enabled', enabled, tenantId);

--- a/src/routes/(parent)/admin/reports/+page.svelte
+++ b/src/routes/(parent)/admin/reports/+page.svelte
@@ -3,7 +3,7 @@ import { enhance } from '$app/forms';
 import { goto } from '$app/navigation';
 import { shiftMonthKey } from '$lib/domain/date-utils';
 import type { ChildId } from '$lib/domain/ids';
-import { APP_LABELS, PAGE_TITLES, REPORTS_LABELS } from '$lib/domain/labels';
+import { APP_LABELS, formatYearMonth, PAGE_TITLES, REPORTS_LABELS } from '$lib/domain/labels';
 import ProgressFill from '$lib/ui/components/ProgressFill.svelte';
 import SiblingCategoryChart from '$lib/ui/components/SiblingCategoryChart.svelte';
 import SiblingTrendChart from '$lib/ui/components/SiblingTrendChart.svelte';
@@ -15,15 +15,7 @@ let { data, form } = $props();
 type TabId = 'monthly' | 'weekly';
 let activeTab = $state<TabId>('monthly');
 
-const dayLabels: Record<string, string> = {
-	monday: '月曜日',
-	tuesday: '火曜日',
-	wednesday: '水曜日',
-	thursday: '木曜日',
-	friday: '金曜日',
-	saturday: '土曜日',
-	sunday: '日曜日',
-};
+const dayLabels: Record<string, string> = REPORTS_LABELS.weeklySettingsDayNames;
 
 function formatWeek(start: string, end: string): string {
 	return `${start.replace(/-/g, '/')} 〜 ${end.replace(/-/g, '/')}`;
@@ -40,7 +32,7 @@ function progressPct(xp: number, level: number): number {
 
 function formatMonth(ym: string): string {
 	const [y, m] = ym.split('-');
-	return `${y}年${Number(m)}月`;
+	return formatYearMonth(y ?? '', m ?? '');
 }
 
 function navigateMonth(offset: number) {
@@ -297,7 +289,7 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 				</p>
 			{/if}
 			<div class="flex flex-wrap items-center gap-4">
-				<FormField label="週次レポートを有効にする">
+				<FormField label={REPORTS_LABELS.weeklySettingsEnableLabel}>
 					{#snippet children()}
 						<input
 							type="checkbox"
@@ -308,7 +300,7 @@ function maxCategoryCount(breakdown: Record<string, number>): number {
 						/>
 					{/snippet}
 				</FormField>
-				<FormField label="配信曜日">
+				<FormField label={REPORTS_LABELS.weeklySettingsDayLabel}>
 					{#snippet children()}
 						<select
 							name="day"

--- a/src/routes/(parent)/admin/settings/account/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/account/+page.server.ts
@@ -3,7 +3,7 @@
 // accountDelete / logout は client-side fetch + a href 遷移なので server action 不要。
 
 import { fail } from '@sveltejs/kit';
-import { OYAKAGI_LABELS } from '$lib/domain/labels';
+import { OYAKAGI_LABELS, SETTINGS_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { changePin } from '$lib/server/services/auth-service';
 import type { Actions, PageServerLoad } from './$types';
@@ -23,7 +23,7 @@ export const actions = {
 		const confirmPin = form.get('confirmPin')?.toString() ?? '';
 
 		if (!currentPin || !newPin || !confirmPin) {
-			return fail(400, { error: 'すべてのフィールドを入力してください' });
+			return fail(400, { error: SETTINGS_LABELS.oyakagiAllFieldsRequired });
 		}
 
 		if (newPin.length < 4 || newPin.length > 8) {
@@ -35,13 +35,13 @@ export const actions = {
 		}
 
 		if (newPin !== confirmPin) {
-			return fail(400, { error: `新しい${OYAKAGI_LABELS.name}が一致しません` });
+			return fail(400, { error: OYAKAGI_LABELS.confirmMismatchError });
 		}
 
 		const result = await changePin(currentPin, newPin, tenantId);
 		if ('error' in result) {
 			if (result.error === 'INVALID_CURRENT_PIN') {
-				return fail(400, { error: `現在の${OYAKAGI_LABELS.name}が正しくありません` });
+				return fail(400, { error: OYAKAGI_LABELS.currentInvalidError });
 			}
 			if (result.error === 'LOCKED_OUT') {
 				return fail(429, { error: OYAKAGI_LABELS.lockedError });

--- a/src/routes/(parent)/admin/settings/account/+page.svelte
+++ b/src/routes/(parent)/admin/settings/account/+page.svelte
@@ -98,10 +98,10 @@ async function fetchDeletionInfo() {
 	try {
 		const res = await fetch('/api/v1/admin/account/deletion-info');
 		const d = await res.json();
-		if (!res.ok) throw new Error(d.error ?? '情報取得に失敗しました');
+		if (!res.ok) throw new Error(d.error ?? SETTINGS_LABELS.accountDeleteInfoFetchFailed);
 		deletionInfo = d;
 	} catch (err) {
-		deleteError = err instanceof Error ? err.message : '情報取得に失敗しました';
+		deleteError = err instanceof Error ? err.message : SETTINGS_LABELS.accountDeleteInfoFetchFailed;
 	} finally {
 		deletionInfoLoading = false;
 	}
@@ -109,7 +109,8 @@ async function fetchDeletionInfo() {
 
 async function handleDeleteAccount() {
 	if (deleteSubmitting) return;
-	if (deleteConfirmText !== 'アカウントを削除します' || !deleteAgreeChecked) return;
+	if (deleteConfirmText !== SETTINGS_LABELS.accountDeleteConfirmKeyword || !deleteAgreeChecked)
+		return;
 	deleteSubmitting = true;
 	deleteError = '';
 
@@ -137,10 +138,10 @@ async function handleDeleteAccount() {
 			body: JSON.stringify({ pattern }),
 		});
 		const d = await res.json();
-		if (!res.ok) throw new Error(d.error ?? 'アカウント削除に失敗しました');
+		if (!res.ok) throw new Error(d.error ?? SETTINGS_LABELS.accountDeleteFailed);
 		window.location.href = '/auth/signout';
 	} catch (err) {
-		deleteError = err instanceof Error ? err.message : 'アカウント削除に失敗しました';
+		deleteError = err instanceof Error ? err.message : SETTINGS_LABELS.accountDeleteFailed;
 	} finally {
 		deleteSubmitting = false;
 	}
@@ -161,10 +162,10 @@ async function handleTransferAndDelete() {
 			}),
 		});
 		const d = await res.json();
-		if (!res.ok) throw new Error(d.error ?? 'アカウント削除に失敗しました');
+		if (!res.ok) throw new Error(d.error ?? SETTINGS_LABELS.accountDeleteFailed);
 		window.location.href = '/auth/signout';
 	} catch (err) {
-		deleteError = err instanceof Error ? err.message : 'アカウント削除に失敗しました';
+		deleteError = err instanceof Error ? err.message : SETTINGS_LABELS.accountDeleteFailed;
 	} finally {
 		deleteSubmitting = false;
 	}
@@ -182,10 +183,10 @@ async function handleFullDelete() {
 			body: JSON.stringify({ pattern: 'owner-full-delete' }),
 		});
 		const d = await res.json();
-		if (!res.ok) throw new Error(d.error ?? 'アカウント削除に失敗しました');
+		if (!res.ok) throw new Error(d.error ?? SETTINGS_LABELS.accountDeleteFailed);
 		window.location.href = '/auth/signout';
 	} catch (err) {
-		deleteError = err instanceof Error ? err.message : 'アカウント削除に失敗しました';
+		deleteError = err instanceof Error ? err.message : SETTINGS_LABELS.accountDeleteFailed;
 	} finally {
 		deleteSubmitting = false;
 	}
@@ -206,7 +207,7 @@ const deletionGraceDays = $derived(
 );
 
 const canConfirmDelete = $derived(
-	deleteConfirmText === 'アカウントを削除します' && deleteAgreeChecked,
+	deleteConfirmText === SETTINGS_LABELS.accountDeleteConfirmKeyword && deleteAgreeChecked,
 );
 </script>
 
@@ -282,7 +283,7 @@ const canConfirmDelete = $derived(
 			class="flex flex-col gap-4"
 		>
 			<FormField
-				label={`現在の${OYAKAGI_LABELS.name}`}
+				label={OYAKAGI_LABELS.currentInputLabel}
 				type="password"
 				id="currentPin"
 				name="currentPin"
@@ -290,7 +291,7 @@ const canConfirmDelete = $derived(
 			/>
 
 			<FormField
-				label={`新しい${OYAKAGI_LABELS.name}（4〜8桁）`}
+				label={OYAKAGI_LABELS.newInputLabel}
 				type="password"
 				id="newPin"
 				name="newPin"
@@ -298,7 +299,7 @@ const canConfirmDelete = $derived(
 			/>
 
 			<FormField
-				label={`新しい${OYAKAGI_LABELS.name}（確認）`}
+				label={OYAKAGI_LABELS.newConfirmInputLabel}
 				type="password"
 				id="confirmPin"
 				name="confirmPin"
@@ -312,7 +313,7 @@ const canConfirmDelete = $derived(
 				class="w-full"
 				disabled={submitting}
 			>
-				{submitting ? '変更中...' : OYAKAGI_LABELS.changeAction}
+				{submitting ? SETTINGS_LABELS.oyakagiChangeSubmitting : OYAKAGI_LABELS.changeAction}
 			</Button>
 		</form>
 	</Card>
@@ -437,7 +438,7 @@ const canConfirmDelete = $derived(
 										<NativeSelect
 											bind:value={transferTargetId}
 											options={[
-												{ value: '', label: '移譲先を選択...' },
+												{ value: '', label: SETTINGS_LABELS.accountDeleteTransferPlaceholder },
 												...deletionInfo.otherMembers
 													.filter((m) => m.role !== 'child')
 													.map((member) => ({
@@ -454,7 +455,7 @@ const canConfirmDelete = $derived(
 										disabled={deleteSubmitting || !transferTargetId}
 										onclick={handleTransferAndDelete}
 									>
-										{deleteSubmitting ? '処理中...' : '移譲して退会'}
+										{deleteSubmitting ? SETTINGS_LABELS.accountDeleteProcessing : SETTINGS_LABELS.accountDeleteTransferSubmit}
 									</Button>
 								</div>
 							</div>
@@ -475,7 +476,7 @@ const canConfirmDelete = $derived(
 									disabled={deleteSubmitting}
 									onclick={handleFullDelete}
 								>
-									{deleteSubmitting ? '処理中...' : '全て削除する'}
+									{deleteSubmitting ? SETTINGS_LABELS.accountDeleteProcessing : SETTINGS_LABELS.accountDeleteFullSubmit}
 								</Button>
 							</div>
 
@@ -498,11 +499,11 @@ const canConfirmDelete = $derived(
 							{SETTINGS_LABELS.dangerStep1Label}
 						</p>
 						<FormField
-							label="確認のため「アカウントを削除します」と入力してください"
+							label={SETTINGS_LABELS.accountDeleteConfirmFieldLabel}
 							type="text"
 							id="deleteConfirm"
 							bind:value={deleteConfirmText}
-							placeholder="アカウントを削除します"
+							placeholder={SETTINGS_LABELS.accountDeleteConfirmKeyword}
 						/>
 					</div>
 
@@ -544,8 +545,8 @@ const canConfirmDelete = $derived(
 							data-testid="account-danger-execute-button"
 						>
 							{deleteSubmitting || deletionInfoLoading
-								? '処理中...'
-								: 'アカウントを削除する'}
+								? SETTINGS_LABELS.accountDeleteProcessing
+								: SETTINGS_LABELS.accountDeleteSubmit}
 						</Button>
 					</div>
 				{/if}

--- a/src/routes/(parent)/admin/settings/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/activities/+page.server.ts
@@ -5,7 +5,7 @@ import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { asChildId, type ChildId } from '$lib/domain/ids';
-import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import { PLAN_GATE_LABELS, SETTINGS_LABELS } from '$lib/domain/labels';
 import type { CurrencyCode, PointUnitMode } from '$lib/domain/point-display';
 import { CURRENCY_CODES } from '$lib/domain/point-display';
 import { requireTenantId } from '$lib/server/auth/factory';
@@ -66,12 +66,12 @@ export const actions = {
 
 		const childId = asChildId(raw);
 		if (!childId) {
-			return fail(400, { defaultChildError: '子供IDが不正です' });
+			return fail(400, { defaultChildError: SETTINGS_LABELS.defaultChildIdInvalid });
 		}
 
 		const children = await getAllChildren(tenantId);
 		if (!children.some((c) => c.id === childId)) {
-			return fail(400, { defaultChildError: '指定された子供が見つかりません' });
+			return fail(400, { defaultChildError: SETTINGS_LABELS.defaultChildNotFound });
 		}
 
 		await setDefaultChildId(tenantId, childId);
@@ -86,14 +86,14 @@ export const actions = {
 		const rateStr = form.get('point_rate')?.toString() ?? '1';
 
 		if (mode !== 'point' && mode !== 'currency') {
-			return fail(400, { pointError: 'モードが不正です' });
+			return fail(400, { pointError: SETTINGS_LABELS.pointModeInvalid });
 		}
 		if (!CURRENCY_CODES.includes(currency as CurrencyCode)) {
-			return fail(400, { pointError: '通貨コードが不正です' });
+			return fail(400, { pointError: SETTINGS_LABELS.pointCurrencyInvalid });
 		}
 		const rate = Number.parseFloat(rateStr);
 		if (Number.isNaN(rate) || rate <= 0 || rate > 10000) {
-			return fail(400, { pointError: 'レートは0より大きく10000以下で入力してください' });
+			return fail(400, { pointError: SETTINGS_LABELS.pointRateRange });
 		}
 
 		await setSetting('point_unit_mode', mode as PointUnitMode, tenantId);

--- a/src/routes/(parent)/admin/settings/activities/+page.svelte
+++ b/src/routes/(parent)/admin/settings/activities/+page.svelte
@@ -32,10 +32,26 @@ $effect(() => {
 });
 
 const DECAY_OPTIONS = [
-	{ value: 'none', label: 'なし', desc: '減少しません（練習や導入期間向け）' },
-	{ value: 'gentle', label: 'ゆるやか', desc: '通常の半分の速度で減少します' },
-	{ value: 'normal', label: 'ふつう', desc: '猶予2日後にゆるやかに減少します' },
-	{ value: 'strict', label: 'きびしめ', desc: '上級者向け。1.5倍の速度で減少します' },
+	{
+		value: 'none',
+		label: SETTINGS_LABELS.decayOptionNoneLabel,
+		desc: SETTINGS_LABELS.decayOptionNoneDesc,
+	},
+	{
+		value: 'gentle',
+		label: SETTINGS_LABELS.decayOptionGentleLabel,
+		desc: SETTINGS_LABELS.decayOptionGentleDesc,
+	},
+	{
+		value: 'normal',
+		label: SETTINGS_LABELS.decayOptionNormalLabel,
+		desc: SETTINGS_LABELS.decayOptionNormalDesc,
+	},
+	{
+		value: 'strict',
+		label: SETTINGS_LABELS.decayOptionStrictLabel,
+		desc: SETTINGS_LABELS.decayOptionStrictDesc,
+	},
 ] as const;
 
 async function saveDecayIntensity() {
@@ -201,7 +217,7 @@ const previewFormatted = $derived(
 				<NativeSelect
 					id="pointCurrency"
 					name="point_currency"
-					label="通貨"
+					label={SETTINGS_LABELS.pointCurrencyLabel}
 					bind:value={pointCurrency}
 					options={CURRENCY_CODES.map((code) => ({
 						value: code,
@@ -210,7 +226,7 @@ const previewFormatted = $derived(
 				/>
 
 				<FormField
-					label="レート（1P = ？{CURRENCY_DEFS[pointCurrency].symbol}）"
+					label={SETTINGS_LABELS.pointRateLabel(CURRENCY_DEFS[pointCurrency].symbol)}
 					type="number"
 					id="pointRate"
 					name="point_rate"
@@ -219,7 +235,7 @@ const previewFormatted = $derived(
 					max="10000"
 					step="any"
 					required
-					hint="例: 1P = 1円なら「1」、1P = 0.01ドルなら「0.01」"
+					hint={SETTINGS_LABELS.pointRateHint}
 				/>
 			{/if}
 

--- a/src/routes/(parent)/admin/settings/data/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/data/+page.server.ts
@@ -4,6 +4,8 @@
 import { fail } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import type { ChildId } from '$lib/domain/ids';
+// #4512: 確認テキストの合言葉と文言は labels SSOT (画面側と同じ定数を見る)
+import { SETTINGS_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { notYetExportedSourceLabels } from '$lib/server/db/backup-entity-registry';
 import { findAllChildren } from '$lib/server/db/child-repo';
@@ -73,11 +75,11 @@ export const actions = {
 		const confirm = form.get('confirm')?.toString() ?? '';
 		const agree = form.get('agree')?.toString() ?? '';
 
-		if (confirm !== '削除') {
-			return fail(400, { clearError: '確認テキスト「削除」を入力してください' });
+		if (confirm !== SETTINGS_LABELS.clearConfirmKeyword) {
+			return fail(400, { clearError: SETTINGS_LABELS.clearConfirmRequired });
 		}
 		if (agree !== 'true') {
-			return fail(400, { clearError: '同意チェックを入れてください' });
+			return fail(400, { clearError: SETTINGS_LABELS.clearAgreeRequired });
 		}
 
 		try {
@@ -86,7 +88,7 @@ export const actions = {
 			return { clearSuccess: true, cleared: result.deleted };
 		} catch (err) {
 			logger.error('[data-clear] データクリア失敗', { error: String(err) });
-			return fail(500, { clearError: 'データクリアに失敗しました' });
+			return fail(500, { clearError: SETTINGS_LABELS.clearFailed });
 		}
 	},
 } satisfies Actions;

--- a/src/routes/(parent)/admin/settings/data/+page.svelte
+++ b/src/routes/(parent)/admin/settings/data/+page.svelte
@@ -12,6 +12,7 @@ import {
 	IMPORT_LABELS,
 	type ImportSkipReason,
 	PAGE_TITLES,
+	PLAN_GATE_LABELS,
 	SETTINGS_LABELS,
 } from '$lib/domain/labels';
 import { ErrorAlert, SuccessAlert } from '$lib/ui/components';
@@ -485,7 +486,9 @@ $effect(() => {
 	return () => clearInterval(timer);
 });
 
-const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChecked);
+const canConfirmClear = $derived(
+	clearConfirmText === SETTINGS_LABELS.clearConfirmKeyword && clearAgreeChecked,
+);
 </script>
 
 <svelte:head>
@@ -500,7 +503,7 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 				{SETTINGS_LABELS.dataSectionTitle}
 			</h3>
 			{#if !data.canExport}
-				<PremiumBadge size="sm" label="スタンダード以上" showLock />
+				<PremiumBadge size="sm" label={PLAN_GATE_LABELS.standardOrAboveBadge} showLock />
 			{/if}
 		</div>
 
@@ -951,7 +954,7 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 					{SETTINGS_LABELS.cloudSectionTitle}
 				</h3>
 				{#if data.maxCloudExports === 0}
-					<PremiumBadge size="sm" label="スタンダード以上" showLock />
+					<PremiumBadge size="sm" label={PLAN_GATE_LABELS.standardOrAboveBadge} showLock />
 				{:else}
 					<span
 						class="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-semibold bg-[var(--color-surface-muted)] text-[var(--color-text-secondary)] rounded-full"
@@ -1380,12 +1383,12 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 				<div class="danger-zone__step">
 					<p class="danger-zone__step-label">{SETTINGS_LABELS.dangerStep1Label}</p>
 					<FormField
-						label="確認のため「削除」と入力してください"
+						label={SETTINGS_LABELS.clearConfirmFieldLabel}
 						type="text"
 						id="clearConfirm"
 						name="confirm"
 						bind:value={clearConfirmText}
-						placeholder="削除"
+						placeholder={SETTINGS_LABELS.clearConfirmKeyword}
 					/>
 				</div>
 
@@ -1418,7 +1421,7 @@ const canConfirmClear = $derived(clearConfirmText === '削除' && clearAgreeChec
 						disabled={clearSubmitting || !canConfirmClear}
 						data-testid="data-danger-execute-button"
 					>
-						{clearSubmitting ? 'データクリア中...' : 'すべてのデータを削除'}
+						{clearSubmitting ? SETTINGS_LABELS.clearSubmitting : SETTINGS_LABELS.clearSubmitButton}
 					</Button>
 				</div>
 			</form>

--- a/src/routes/(parent)/admin/settings/notifications/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/notifications/+page.server.ts
@@ -3,6 +3,8 @@
 // 1 section だけのため軽量サブページ。
 
 import { fail } from '@sveltejs/kit';
+// #4512: form action のエラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { SETTINGS_LABELS } from '$lib/domain/labels';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { getSettings, setSetting } from '$lib/server/db/settings-repo';
 import { logger } from '$lib/server/logger';
@@ -61,7 +63,7 @@ export const actions = {
 
 		const timeRegex = /^\d{2}:\d{2}$/;
 		if (!timeRegex.test(reminderTime) || !timeRegex.test(quietStart) || !timeRegex.test(quietEnd)) {
-			return fail(400, { notificationError: '時刻の形式が不正です' });
+			return fail(400, { notificationError: SETTINGS_LABELS.notificationTimeFormatInvalid });
 		}
 
 		await setSetting('notification_reminders_enabled', remindersEnabled, tenantId);

--- a/src/routes/(parent)/admin/settings/notifications/+page.svelte
+++ b/src/routes/(parent)/admin/settings/notifications/+page.svelte
@@ -197,7 +197,7 @@ async function disableNotifications() {
 			{#if data.notificationSettings.remindersEnabled}
 				<div class="ml-6">
 					<FormField
-						label="リマインダー時刻"
+						label={SETTINGS_LABELS.notificationReminderTimeLabel}
 						type="time"
 						name="reminderTime"
 						value={data.notificationSettings.reminderTime}
@@ -227,7 +227,10 @@ async function disableNotifications() {
 				</span>
 			</label>
 			<div class="border-t border-[var(--color-border-default)] pt-4 mt-4">
-				<FormField label="サイレント時間帯" hint="この時間帯は通知を送信しません">
+				<FormField
+					label={SETTINGS_LABELS.notificationQuietLabel}
+					hint={SETTINGS_LABELS.notificationQuietHint}
+				>
 					{#snippet children()}
 						<div class="flex items-center gap-2">
 							<input

--- a/src/routes/(parent)/admin/settings/rules/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/rules/+page.server.ts
@@ -15,6 +15,8 @@
 
 import { fail } from '@sveltejs/kit';
 import { getMarketplaceItem } from '$lib/data/marketplace';
+// #4512: form action のエラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { ADMIN_FORM_ERROR_LABELS, ADMIN_RULES_PAGE_LABELS } from '$lib/domain/labels';
 // #2368 (ADR-0052): bonus state SSOT は marketplace strategy 配下に移動済。
 import { dispatchImport } from '$lib/marketplace';
 import {
@@ -94,7 +96,7 @@ export const actions: Actions = {
 				error: String(e),
 				context: { enabled },
 			});
-			return fail(500, { error: 'ごほうび交換設定の更新に失敗しました' });
+			return fail(500, { error: ADMIN_RULES_PAGE_LABELS.rewardApprovalUpdateFailed });
 		}
 	},
 
@@ -104,7 +106,7 @@ export const actions: Actions = {
 		const presetId = String(formData.get('presetId') ?? '').trim();
 		const enabledRaw = String(formData.get('enabled') ?? '').trim();
 
-		if (!presetId) return fail(400, { error: 'プリセットIDが必要です' });
+		if (!presetId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.presetIdRequired });
 		const enabled = enabledRaw === 'true';
 
 		try {
@@ -115,7 +117,7 @@ export const actions: Actions = {
 				error: String(e),
 				context: { presetId, enabled },
 			});
-			return fail(500, { error: 'ルール更新に失敗しました' });
+			return fail(500, { error: ADMIN_RULES_PAGE_LABELS.updateFailed });
 		}
 	},
 
@@ -124,7 +126,7 @@ export const actions: Actions = {
 		const formData = await request.formData();
 		const presetId = String(formData.get('presetId') ?? '').trim();
 
-		if (!presetId) return fail(400, { error: 'プリセットIDが必要です' });
+		if (!presetId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.presetIdRequired });
 
 		try {
 			await removeBonusPreset(presetId, tenantId);
@@ -134,7 +136,7 @@ export const actions: Actions = {
 				error: String(e),
 				context: { presetId },
 			});
-			return fail(500, { error: 'ルール削除に失敗しました' });
+			return fail(500, { error: ADMIN_RULES_PAGE_LABELS.removeFailed });
 		}
 	},
 
@@ -143,11 +145,11 @@ export const actions: Actions = {
 		const tenantId = requireTenantId(locals);
 		const formData = await request.formData();
 		const presetId = String(formData.get('presetId') ?? '').trim();
-		if (!presetId) return fail(400, { error: 'プリセットIDが必要です' });
+		if (!presetId) return fail(400, { error: ADMIN_FORM_ERROR_LABELS.presetIdRequired });
 
 		const item = getMarketplaceItem('rule-preset', presetId);
 		if (!item) {
-			return fail(404, { error: `プリセット「${presetId}」が見つかりません` });
+			return fail(404, { error: ADMIN_FORM_ERROR_LABELS.presetNotFoundNamed(presetId) });
 		}
 
 		try {
@@ -174,7 +176,7 @@ export const actions: Actions = {
 				stack: e instanceof Error ? e.stack : undefined,
 				context: { presetId },
 			});
-			return fail(500, { error: 'インポートに失敗しました' });
+			return fail(500, { error: ADMIN_FORM_ERROR_LABELS.importFailed });
 		}
 	},
 };

--- a/src/routes/(parent)/admin/settings/support/+page.server.ts
+++ b/src/routes/(parent)/admin/settings/support/+page.server.ts
@@ -8,6 +8,8 @@ import {
 	evaluateBackupHealth,
 	isBackupNotificationConfigured,
 } from '$lib/domain/backup-health';
+// #4512: validation / 通知本文の文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { SETTINGS_LABELS } from '$lib/domain/labels';
 import { getEnv } from '$lib/runtime/env';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { generateInquiryId, saveInquiry } from '$lib/server/db/inquiry-repo';
@@ -83,26 +85,26 @@ function validateFeedbackForm(
 	const rawCategory = form.get('category')?.toString() ?? '';
 
 	if (intent !== 'feedback' && intent !== 'consult') {
-		return { error: 'ご用件の選択が不正です' };
+		return { error: SETTINGS_LABELS.feedbackInvalidIntentError };
 	}
 	if (!text || text.length === 0) {
-		return { error: '内容を入力してください' };
+		return { error: SETTINGS_LABELS.feedbackContentRequiredError };
 	}
 	if (text.length > 1000) {
-		return { error: '1000文字以内で入力してください' };
+		return { error: SETTINGS_LABELS.feedbackContentTooLongError };
 	}
 	if (intent === 'feedback' && !['feature', 'bug', 'other'].includes(rawCategory)) {
-		return { error: 'カテゴリが不正です' };
+		return { error: SETTINGS_LABELS.feedbackInvalidCategoryError };
 	}
 	if (replyEmail && (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(replyEmail) || replyEmail.length > 254)) {
-		return { error: 'メールアドレスの形式が正しくありません' };
+		return { error: SETTINGS_LABELS.feedbackInvalidEmailError };
 	}
 	if (childAge && childAge.length > 100) {
-		return { error: 'お子さまの年齢は100文字以内で入力してください' };
+		return { error: SETTINGS_LABELS.feedbackChildAgeTooLongError };
 	}
 	// 相談は返信が前提のため、返信先 (入力 or アカウントメール) を必須にする。
 	if (intent === 'consult' && !replyEmail && !accountEmail) {
-		return { error: '相談・困りごとは返信先メールアドレスを入力してください' };
+		return { error: SETTINGS_LABELS.feedbackConsultReplyRequiredError };
 	}
 
 	// intent='consult' は category='consult' 固定。intent='feedback' のみ内容分類を要求する。
@@ -123,16 +125,18 @@ export const actions = {
 		const { intent, category, text, replyEmail, childAge } = parsed.ok;
 
 		const categoryLabel = {
-			feature: '機能要望',
-			bug: 'バグ報告',
-			other: 'その他',
-			consult: '相談・困りごと',
+			feature: SETTINGS_LABELS.feedbackCategoryFeature,
+			bug: SETTINGS_LABELS.feedbackCategoryBug,
+			other: SETTINGS_LABELS.feedbackCategoryOther,
+			consult: SETTINGS_LABELS.feedbackCategoryConsult,
 		}[category as 'feature' | 'bug' | 'other' | 'consult'];
 		const email = accountEmail || 'local-user';
 
 		// InquiryRecord は childAge 列を持たないため、相談時のみ本文先頭に付記する
 		// (3 repo schema 変更を避ける最小実装、ADR-0010)。
-		const body = childAge ? `【お子さまの年齢】${childAge}\n\n${text}` : text;
+		const body = childAge
+			? `${SETTINGS_LABELS.feedbackChildAgeBodyPrefix(childAge)}\n\n${text}`
+			: text;
 
 		let inquiryId = '';
 		try {
@@ -157,7 +161,7 @@ export const actions = {
 			// 「届いたのに誰からか分からない」状態にはならない。
 			notifyInquiry(category, body, inquiryId).catch(() => {});
 			return fail(500, {
-				feedbackError: '送信に失敗しました。お手数ですが時間をおいて再度お試しください',
+				feedbackError: SETTINGS_LABELS.feedbackSendFailedError,
 			});
 		}
 

--- a/src/routes/(parent)/admin/status/+page.server.ts
+++ b/src/routes/(parent)/admin/status/+page.server.ts
@@ -1,6 +1,8 @@
 import { fail } from '@sveltejs/kit';
 import { formIdString } from '$lib/domain/form-value';
 import { asCategoryId, asChildId } from '$lib/domain/ids';
+// #4512: form action のエラー文言は labels SSOT 経由 (docs/DESIGN.md §6 / ADR-0045)
+import { ADMIN_FORM_ERROR_LABELS, STATUS_LABELS } from '$lib/domain/labels';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { isOpsMember, requireGlobalMasterWriteAccess } from '$lib/server/auth/ops-authz';
@@ -82,10 +84,10 @@ export const actions = {
 		const customTitle = String(form.get('customTitle') ?? '').trim();
 
 		if (!level || level < 1 || level > 10) {
-			return fail(400, { error: 'レベルが不正です' });
+			return fail(400, { error: STATUS_LABELS.levelInvalid });
 		}
 		if (!customTitle || customTitle.length > 20) {
-			return fail(400, { error: '称号は1〜20文字で入力してください' });
+			return fail(400, { error: STATUS_LABELS.titleLengthInvalid });
 		}
 
 		await saveLevelTitle(tenantId, level, customTitle);
@@ -98,7 +100,7 @@ export const actions = {
 		const level = Number(form.get('level'));
 
 		if (!level || level < 1 || level > 10) {
-			return fail(400, { error: 'レベルが不正です' });
+			return fail(400, { error: STATUS_LABELS.levelInvalid });
 		}
 
 		await resetLevelTitle(tenantId, level);
@@ -124,10 +126,10 @@ export const actions = {
 		const stdDev = Number(form.get('stdDev'));
 
 		if (!age || !categoryId || Number.isNaN(mean) || Number.isNaN(stdDev)) {
-			return fail(400, { error: '必須項目が不足しています' });
+			return fail(400, { error: ADMIN_FORM_ERROR_LABELS.requiredFieldsMissing });
 		}
 		if (mean < 0 || stdDev <= 0) {
-			return fail(400, { error: '平均は0以上、標準偏差は0より大きい値を入力してください' });
+			return fail(400, { error: STATUS_LABELS.benchmarkValueInvalid });
 		}
 
 		// #2057: 内部 source identifier (DB 保存値、UI 表示なし)。既存レコードとの履歴整合のため

--- a/src/routes/(parent)/admin/status/+page.svelte
+++ b/src/routes/(parent)/admin/status/+page.svelte
@@ -2,7 +2,7 @@
 import { enhance } from '$app/forms';
 import { invalidateAll } from '$app/navigation';
 import { asChildId, type ChildId } from '$lib/domain/ids';
-import { APP_LABELS, PAGE_TITLES, STATUS_LABELS } from '$lib/domain/labels';
+import { APP_LABELS, formatAge, PAGE_TITLES, STATUS_LABELS } from '$lib/domain/labels';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { calcDeviationScore, getComparisonLabel } from '$lib/domain/validation/status';
 import { SuccessAlert } from '$lib/ui/components';
@@ -18,12 +18,12 @@ let { data } = $props();
 function getAnalysisText(deviationScore: number): { text: string; color: string } {
 	if (deviationScore >= 60)
 		return {
-			text: '同年齢の中でも特に活発です',
+			text: STATUS_LABELS.analysisHigh,
 			color: 'text-[var(--color-feedback-success-text)]',
 		};
 	if (deviationScore >= 45)
-		return { text: '平均的なペースで成長しています', color: 'text-[var(--color-brand-600)]' };
-	return { text: 'これから伸びる余地がたくさんあります', color: 'text-[var(--color-warning)]' };
+		return { text: STATUS_LABELS.analysisAverage, color: 'text-[var(--color-brand-600)]' };
+	return { text: STATUS_LABELS.analysisLow, color: 'text-[var(--color-warning)]' };
 }
 
 let benchmarkAge = $state(4);
@@ -348,7 +348,7 @@ let levelTitleInputs: Record<number, string> = $state({});
 					class="text-xs whitespace-nowrap {benchmarkAge === age ? '' : 'bg-[var(--color-surface-card)] text-[var(--color-text)] border-[var(--color-border-default)] hover:bg-[var(--color-surface-muted)]'}"
 					onclick={() => { benchmarkAge = age; benchmarkSuccess = false; bmInputMean = {}; bmInputSd = {}; }}
 				>
-					{age + '歳'}
+					{formatAge(age)}
 				</Button>
 			{/each}
 		</div>

--- a/tests/unit/domain/admin-labels-ssot-4512.test.ts
+++ b/tests/unit/domain/admin-labels-ssot-4512.test.ts
@@ -1,0 +1,325 @@
+// tests/unit/domain/admin-labels-ssot-4512.test.ts
+// #4512: admin 配下の UI 文言 SSOT 逸脱 (labels.ts / terms.ts を経由しない日本語直書き) の回帰固定。
+//
+// 背景: check-hardcoded-strings が #4322 で削除されて以降、この軸の機械強制はゼロで
+// 「labels.ts に定義済みなのに画面側が同じ文字列を直書きしている」二重定義が admin 全域に蓄積した
+// (docs/DESIGN.md §6 / ADR-0045、ルート CLAUDE.md §「機械強制が無くレビューで担保するもの」)。
+//
+// 本 test は 2 方向から固定する:
+//   (A) 是正済みファイルに literal が戻ってきたら落ちる (source を読む regression guard)
+//   (B) 集約先の label 値が変わっていない (本 PR は SSOT 集約であって文言変更ではない)
+//
+// 既存の labels-plan-literal-ratchet.test.ts (#3359) と同型の source 走査だが、
+// 対象が plan 名 atom ではなく「admin 画面で直書きされていた表示文言」である点が異なる。
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { CATEGORIES } from '../../../src/lib/domain/categories';
+import {
+	ADMIN_CHALLENGES_PAGE_LABELS,
+	ADMIN_CHECKLISTS_PAGE_LABELS,
+	ADMIN_CHILDREN_PAGE_LABELS,
+	ADMIN_FORM_ERROR_LABELS,
+	CERTIFICATE_DETAIL_LABELS,
+	CERTIFICATES_PAGE_LABELS,
+	CHEER_LABELS,
+	formatMonthOnly,
+	formatYearMonth,
+	MEMBERS_LABELS,
+	PLAN_GATE_LABELS,
+	POINTS_LABELS,
+	REPORTS_LABELS,
+	SETTINGS_LABELS,
+	STATUS_LABELS,
+	UI_COMPONENTS_LABELS,
+	UNRESOLVED_ENTITY_LABELS,
+} from '../../../src/lib/domain/labels';
+import { PLAN_TERMS, WEEKDAY_TERMS } from '../../../src/lib/domain/terms';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const ADMIN = 'src/routes/(parent)/admin';
+
+function read(relPath: string): string {
+	return readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+}
+
+// ------------------------------------------------------------
+// (A) 直書きが戻ってきたら落ちる regression guard
+//
+// 「その file にその文字列が現れてはいけない」の表。SSOT 側 (labels.ts / terms.ts) には当然
+// 存在するため、対象は route file のみに絞る。
+// ------------------------------------------------------------
+const FORBIDDEN_LITERALS: ReadonlyArray<readonly [file: string, literals: readonly string[]]> = [
+	[
+		`${ADMIN}/activities/+page.server.ts`,
+		[
+			'IDが必要です',
+			'名前を入力してください',
+			'カテゴリを選択してください',
+			'更新に失敗しました',
+			'インポートに失敗しました',
+			'カスタム活動は最大',
+			'対象のお子さまを選択してください',
+			'同じお子さまにはコピーできません',
+		],
+	],
+	[
+		`${ADMIN}/activities/+page.svelte`,
+		[
+			'違うお子さまを選んでください',
+			'コピーが完了しました',
+			'一括追加しました',
+			'名前を入力してください',
+		],
+	],
+	[`${ADMIN}/activities/[id]/edit/+page.server.ts`, ['不正な活動IDです', '活動が見つかりません']],
+	[`${ADMIN}/certificates/+page.svelte`, ['連続記録', 'カテゴリマスター', '年間がんばり大賞']],
+	[
+		`${ADMIN}/certificates/[id]/+page.svelte`,
+		['ダウンロードしました', 'ダウンロードに失敗しました', "'がんばりクエスト'"],
+	],
+	[
+		`${ADMIN}/certificates/[id]/+page.server.ts`,
+		['証明書が見つかりません', '子供が見つかりません'],
+	],
+	[`${ADMIN}/challenges/+page.server.ts`, ['IDが不正です']],
+	[`${ADMIN}/challenges/+page.svelte`, ['が記録済み', '今日はまだ誰も記録していません']],
+	[
+		`${ADMIN}/checklists/+page.server.ts`,
+		[
+			'こどもを選択してください',
+			'テンプレートIDが不正です',
+			'アイテム名を入力してください',
+			'時間帯が不正です',
+			'プリセットIDが必要です',
+			'配信先の同期に失敗しました',
+			'復元したチェックリスト',
+		],
+	],
+	[
+		`${ADMIN}/cheer/+page.server.ts`,
+		[
+			'こどもを選択してください',
+			'応援の理由を入力してください',
+			'カテゴリを選択してください',
+			'こどもが見つかりません',
+			'エラーが発生しました',
+			'の範囲で入力してください',
+			'文字以内で入力してください',
+		],
+	],
+	[`${ADMIN}/cheer/+page.svelte`, ["'うんどう'", 'ひとことメッセージを足す']],
+	[
+		`${ADMIN}/children/+page.server.ts`,
+		[
+			'ニックネームを入力してください',
+			'誕生日の形式が正しくありません',
+			'未来の日付は設定できません',
+			'IDが不正です',
+			'子供は最大',
+			'MP3/M4A/WAV/WebM/OGG形式のみ',
+		],
+	],
+	[`${ADMIN}/children/+page.svelte`, ['例: たろうくん']],
+	[`${ADMIN}/growth-book/+page.svelte`, ['月`']],
+	[`${ADMIN}/members/+page.svelte`, ["'7日間'", "'30日間'", "'無期限'"]],
+	[`${ADMIN}/members/+page.server.ts`, ['(不明)']],
+	[`${ADMIN}/points/+page.server.ts`, ['入力が不正です', 'ポイントは500単位で変換できます']],
+	[`${ADMIN}/points/+page.svelte`, ['読み取りに失敗しました', '通信エラーが発生しました']],
+	[
+		`${ADMIN}/reports/+page.svelte`,
+		['月曜日', '日曜日', '週次レポートを有効にする', '配信曜日', '年${'],
+	],
+	[`${ADMIN}/reports/+page.server.ts`, ['無効な曜日です']],
+	[
+		`${ADMIN}/settings/account/+page.svelte`,
+		[
+			'アカウントを削除します',
+			'アカウント削除に失敗しました',
+			'情報取得に失敗しました',
+			'移譲先を選択',
+			'移譲して退会',
+			'処理中...',
+			'変更中...',
+		],
+	],
+	[
+		`${ADMIN}/settings/account/+page.server.ts`,
+		['すべてのフィールドを入力してください', 'が一致しません', 'が正しくありません'],
+	],
+	[
+		`${ADMIN}/settings/activities/+page.svelte`,
+		['ゆるやか', 'きびしめ', '減少しません', '"通貨"', 'レート（1P'],
+	],
+	[
+		`${ADMIN}/settings/activities/+page.server.ts`,
+		['子供IDが不正です', 'モードが不正です', '通貨コードが不正です'],
+	],
+	[
+		`${ADMIN}/settings/data/+page.svelte`,
+		['スタンダード以上', 'データクリア中', 'すべてのデータを削除', '確認のため'],
+	],
+	[
+		`${ADMIN}/settings/data/+page.server.ts`,
+		["'削除'", '同意チェックを入れてください', 'データクリアに失敗しました'],
+	],
+	[
+		`${ADMIN}/settings/notifications/+page.svelte`,
+		['リマインダー時刻', 'サイレント時間帯', 'この時間帯は通知を送信しません'],
+	],
+	[`${ADMIN}/settings/notifications/+page.server.ts`, ['時刻の形式が不正です']],
+	[
+		`${ADMIN}/settings/rules/+page.server.ts`,
+		['ルール更新に失敗しました', 'ルール削除に失敗しました', 'プリセットIDが必要です'],
+	],
+	[
+		`${ADMIN}/settings/support/+page.server.ts`,
+		[
+			'ご用件の選択が不正です',
+			'内容を入力してください',
+			'カテゴリが不正です',
+			'機能要望',
+			'バグ報告',
+			'【お子さまの年齢】',
+			'送信に失敗しました',
+		],
+	],
+	[`${ADMIN}/status/+page.svelte`, ['同年齢の中でも特に活発です', '平均的なペースで', "+ '歳'"]],
+	[
+		`${ADMIN}/status/+page.server.ts`,
+		['レベルが不正です', '称号は1〜20文字で入力してください', '必須項目が不足しています'],
+	],
+];
+
+describe('#4512 (A) admin route の直書き復活を封じる', () => {
+	for (const [file, literals] of FORBIDDEN_LITERALS) {
+		it(`${file} に SSOT を経由しない表示文言が無い`, () => {
+			const src = read(file);
+			const found = literals.filter((literal) => src.includes(literal));
+			expect(
+				found,
+				`${file} に直書きが復活しています: ${found.join(' / ')}\n` +
+					'labels.ts (compound) / terms.ts (atom) から参照してください (docs/DESIGN.md §6 / ADR-0045)。',
+			).toEqual([]);
+		});
+	}
+});
+
+// ------------------------------------------------------------
+// (B) 集約先の値が変わっていない (文言変更ではなく SSOT 集約であることの固定)
+// ------------------------------------------------------------
+describe('#4512 (B) 集約した label の値が変わっていない', () => {
+	it('曜日名 atom は漢字フル形の 7 曜日', () => {
+		expect(WEEKDAY_TERMS.monday).toBe('月曜日');
+		expect(WEEKDAY_TERMS.sunday).toBe('日曜日');
+		expect(Object.keys(WEEKDAY_TERMS)).toHaveLength(7);
+		// admin/reports の配信曜日セレクトは本 atom を参照する (旧: 画面側で別に列挙)
+		expect(REPORTS_LABELS.weeklySettingsDayNames.monday).toBe('月曜日');
+	});
+
+	it('reports の定義済み未使用ラベル 2 件が画面から参照されている', () => {
+		const src = read(`${ADMIN}/reports/+page.svelte`);
+		expect(REPORTS_LABELS.weeklySettingsEnableLabel).toBe('週次レポートを有効にする');
+		expect(REPORTS_LABELS.weeklySettingsDayLabel).toBe('配信曜日');
+		expect(src).toContain('REPORTS_LABELS.weeklySettingsEnableLabel');
+		expect(src).toContain('REPORTS_LABELS.weeklySettingsDayLabel');
+	});
+
+	it('members の viewerDuration7d が画面から参照されている (旧: 直書きで未使用)', () => {
+		const src = read(`${ADMIN}/members/+page.svelte`);
+		expect(MEMBERS_LABELS.viewerDuration7d).toBe('7日間');
+		expect(src).toContain('MEMBERS_LABELS.viewerDuration7d');
+		expect(src).toContain('MEMBERS_LABELS.viewerDuration30d');
+		expect(src).toContain('MEMBERS_LABELS.viewerDurationUnlimited');
+	});
+
+	it('「スタンダード以上」は 1 箇所 (PLAN_GATE_LABELS) から組み立てられる', () => {
+		expect(PLAN_GATE_LABELS.standardOrAboveBadge).toBe(`${PLAN_TERMS.standard}以上`);
+		// ヘッダーの premium バッジも同じ compound を参照する (旧: 別々に直書き)
+		expect(UI_COMPONENTS_LABELS.headerPremiumTitle).toBe(PLAN_GATE_LABELS.standardOrAboveBadge);
+	});
+
+	it('証明書カテゴリ見出しは labels 側に移っても同じ 5 種', () => {
+		expect(CERTIFICATES_PAGE_LABELS.categoryNames).toEqual({
+			streak: '🔥 連続記録',
+			level: '🌟 レベルアップ',
+			monthly: '📜 月間がんばり',
+			category_master: '🎓 カテゴリマスター',
+			annual: '🏆 年間がんばり大賞',
+		});
+		expect(CERTIFICATE_DETAIL_LABELS.shareCardBrandText).toBe('がんばりクエスト');
+		expect(CERTIFICATE_DETAIL_LABELS.downloadSuccess).toBe('ダウンロードしました！');
+	});
+
+	it('cheer の上限メッセージは server 定数から組み立てても文面が同じ', () => {
+		// 旧: labels 側は 1〜10000 / 100 文字を固定値で持ち、実際の表示は server が別に組んでいた
+		expect(CHEER_LABELS.errorPointsRange(1, 10000)).toBe(
+			'ポイントは1〜10000の範囲で入力してください',
+		);
+		expect(CHEER_LABELS.errorReasonTooLong(100)).toBe('理由は100文字以内で入力してください');
+		expect(CHEER_LABELS.errorReasonRequired).toBe('応援の理由を入力してください');
+		expect(CHEER_LABELS.errorCategoryRequired).toBe('カテゴリを選択してください');
+	});
+
+	it('cheer の既定カテゴリは categories.ts (SSOT) の値', () => {
+		expect(CATEGORIES.undou.name).toBe('うんどう');
+		expect(read(`${ADMIN}/cheer/+page.svelte`)).toContain('CATEGORIES.undou.name');
+	});
+
+	it('年月フォーマッタの出力が旧実装と一致する', () => {
+		expect(formatYearMonth('2026', '08')).toBe('2026年8月');
+		expect(formatYearMonth(2026, 8)).toBe('2026年8月');
+		expect(formatMonthOnly('08')).toBe('8月');
+	});
+
+	it('共通 form エラーは CHILD_TERMS 由来の敬称を保つ', () => {
+		expect(ADMIN_FORM_ERROR_LABELS.childRequiredHonorific).toBe('お子さまを選択してください');
+		expect(ADMIN_FORM_ERROR_LABELS.targetChildRequired).toBe('対象のお子さまを選択してください');
+		expect(ADMIN_FORM_ERROR_LABELS.sameChildNotAllowed).toBe('違うお子さまを選んでください');
+		expect(ADMIN_FORM_ERROR_LABELS.someChildrenNotFound).toBe(
+			'指定されたお子さまの一部が見つかりませんでした',
+		);
+		expect(ADMIN_FORM_ERROR_LABELS.childNotFoundNeutral).toBe('子供が見つかりません');
+		expect(ADMIN_FORM_ERROR_LABELS.presetNotFoundNamed('abc')).toBe(
+			'プリセット「abc」が見つかりません',
+		);
+	});
+
+	it('プラン上限メッセージは max=null でも旧実装と同じ文面になる', () => {
+		expect(ADMIN_CHILDREN_PAGE_LABELS.childLimitReached(3)).toBe(
+			'子供は最大3人まで登録できます。プランをアップグレードしてください。',
+		);
+	});
+
+	it('画面固有ラベルの文面が変わっていない', () => {
+		expect(ADMIN_CHALLENGES_PAGE_LABELS.familyStreakRecordedToday(2)).toBe('今日は2人が記録済み');
+		expect(ADMIN_CHALLENGES_PAGE_LABELS.familyStreakNoneToday).toBe(
+			'今日はまだ誰も記録していません',
+		);
+		expect(ADMIN_CHALLENGES_PAGE_LABELS.deleteChildButton('たろう')).toBe('たろう を削除');
+		expect(ADMIN_CHECKLISTS_PAGE_LABELS.copyAlreadyDistributedNote(3)).toBe(
+			'（3 件はすでに配信済みでした）',
+		);
+		expect(STATUS_LABELS.analysisHigh).toBe('同年齢の中でも特に活発です');
+		expect(POINTS_LABELS.convertAmountNotInteger).toBe('ポイントは整数で入力してください');
+		expect(UNRESOLVED_ENTITY_LABELS.email).toBe('(不明)');
+	});
+
+	it('確認テキストの合言葉は画面と server で同じ定数を見る', () => {
+		// 旧: 画面 (placeholder / 判定) と server (検証) が '削除' / 'アカウントを削除します' を
+		// 別々に直書きしており、合言葉を変えると「入力しても通らない」状態になり得た。
+		expect(SETTINGS_LABELS.clearConfirmKeyword).toBe('削除');
+		expect(SETTINGS_LABELS.clearConfirmFieldLabel).toContain(SETTINGS_LABELS.clearConfirmKeyword);
+		expect(SETTINGS_LABELS.clearConfirmRequired).toContain(SETTINGS_LABELS.clearConfirmKeyword);
+		expect(read(`${ADMIN}/settings/data/+page.server.ts`)).toContain(
+			'SETTINGS_LABELS.clearConfirmKeyword',
+		);
+
+		expect(SETTINGS_LABELS.accountDeleteConfirmKeyword).toBe('アカウントを削除します');
+		expect(SETTINGS_LABELS.accountDeleteConfirmFieldLabel).toContain(
+			SETTINGS_LABELS.accountDeleteConfirmKeyword,
+		);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

親の管理画面で「同じ文言が labels.ts にあるのに画面側が別に直書きしている」状態を解消する。用語を 1 箇所直せば全画面に伝播する状態に戻すことで、今後の文言修正が「grep して 6 箇所直す」作業にならず、直し漏れによる画面間の表記ゆれ（顧客が見る不整合）が生まれなくなる。

とくに **確認テキストの合言葉**（データクリアの「削除」／退会の「アカウントを削除します」）は、旧実装では入力欄ラベル・placeholder・server 側の検証が別々の直書きだった。合言葉を変えたときに「画面の指示どおり入力しても通らない」行き止まりになり得たので、同一定数を見るようにした。

## 関連 Issue

<!-- no-issue-close: #4512 は分割対応中。本 PR は admin 系 2 AC のみで、setup / view / switch / marketplace の直書きと checklists の confirm() → Dialog 化が残るため閉じない -->
Refs #4512

## 変更内容

**表示文言は 1 文字も変えていない。** SSOT への集約のみ（値の変更ではない）。

### 参照化（labels.ts に定義済みだったのに使われず直書きされていた = 二重定義の解消）

| 集約先（既存） | 直書きしていた箇所 |
|---|---|
| `REPORTS_LABELS.weeklySettingsEnableLabel` / `.weeklySettingsDayLabel` | `admin/reports/+page.svelte:300,311`（Issue が指す reports 2 件） |
| `MEMBERS_LABELS.viewerDuration7d` / `.viewerDuration30d` / `.viewerDurationUnlimited` | `admin/members/+page.svelte:538-540` |
| `SETTINGS_LABELS.feedbackInvalidIntentError` / `.feedbackConsultReplyRequiredError` / `.feedbackCategoryFeature` / `.feedbackCategoryBug` / `.feedbackCategoryOther` | `admin/settings/support/+page.server.ts:86,105,126-128` |
| `CHEER_LABELS.errorReasonRequired` / `.errorCategoryRequired` / `.errorChildRequired` | `admin/cheer/+page.server.ts:65,66,74,92,94` |
| `ADMIN_CHECKLISTS_PAGE_LABELS.copyDifferentChildError` / `.copyFailed` | `admin/checklists/+page.server.ts:708,818` |
| `CATEGORIES.undou.name`（categories.ts SSOT） | `admin/cheer/+page.svelte:26,51`（既定カテゴリ `'うんどう'`） |
| `formatAge()`（既存 labels 関数） | `admin/status/+page.svelte:351`（`{age + '歳'}`） |
| `PLAN_GATE_LABELS.standardOrAboveBadge`（本 PR 新設）に 3 重定義を集約 | `settings/data/+page.svelte:503,954`（PremiumBadge label）+ `labels.ts` の `headerPremiumTitle` / `familyPatternInviteTag` |

`CHEER_LABELS.errorPointsRequired` / `.errorReasonTooLong` は **labels 側が固定値（1〜10000 / 100文字）を持ちながら、実際に表示されるのは server が `cheer-service` の定数から組み立てた別の文字列**という壊れ方だった。上限値の SSOT は server 側なので、labels を `errorPointsRange(min, max)` / `errorReasonTooLong(max)` の関数に変え、server がそれを呼ぶ形にした（文面は同一）。

### 新規追加

**atom（terms.ts）**
- `WEEKDAY_TERMS` + `WEEKDAY_NAMES_SUNDAY_FIRST` — 曜日名。旧: `admin/reports` と `labels.ts` の `CHILD_CHECKLIST_KANJI` が同じ 7 曜日を別に列挙していた
- `CURRENCY_TERMS.canonical`（「通貨」）

**compound（labels.ts）**
- `ADMIN_FORM_ERROR_LABELS` — admin の form action が返す共通エラー（`IDが不正です` / `名前を入力してください` / `更新に失敗しました` 等）。同一文言が `+page.server.ts` 11 ファイルに最大 6 箇所ずつ散在していた
- `formatYearMonth()` / `formatMonthOnly()` — 「YYYY年M月」の組版。`admin/reports` / `admin/growth-book` / `ADMIN_HOME_LABELS.monthLabel` / `OPS_COSTS_LABELS.yearMonthDisplay` の 4 重複を 1 本に
- 各 `*_PAGE_LABELS` への画面固有文言（証明書カテゴリ見出し 5 種 / status の偏差値帯コメント 3 種 / 減少強度 4 種 × label+desc / 退会・データクリアの確認テキスト / 領収書 OCR の失敗表示 ほか）

### 触っていないもの（別担当・別 PR）

- setup / view / switch / marketplace の直書き、`view/[token]` のカテゴリ重複、checklists の `confirm()` → Dialog 化
- **PR #4594 と重なる行は意図的に避けた**: `checklists/+page.server.ts` の「フリープラン」6 箇所、`reports/+page.svelte` のカテゴリ名（漢字並行実装）、`points/+page.svelte` の OCR 上限判定 2 行

## 検証

`.svelte` を触っているため eslint svelte を含めて全部ローカルで流した。

| コマンド | 結果 |
|---|---|
| `npx biome check --write src tests` | `Checked 2003 files in 4s. No fixes applied.` |
| `npx svelte-check --tsconfig ./tsconfig.json --threshold warning` | `COMPLETED 8210 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS` |
| `npm run lint:svelte` | exit 0（出力なし = 違反 0。`eslint-suppressions.json` の baseline 超過なし） |
| `npm run cspell` | `Files checked: 1986, Issues found: 0 in 0 files.` |
| `node scripts/check-no-plan-literals.mjs` | `OK — リテラル直書きなし` |
| `node scripts/generate-lp-labels.mjs --check` | `✓ site/shared-labels.js は最新です` |
| `node scripts/sync-lp-fallback.mjs --check` | `✓ 全 site/*.html の fallback テキストは labels.ts と同期済みです` |
| `node scripts/check-local-tz-date-getters.mjs` | `OK — allowlist (19 file、全件 kind 検証済) 外の TZ 依存日付導出なし` |
| `node scripts/check-repo-scan-test-declaration.mjs` | `OK — repo 走査 test 58 件すべて区分宣言済` |
| `npx vitest run src/lib/domain/ src/routes/ tests/unit/domain/ tests/unit/routes/ tests/unit/architecture/ tests/unit/lp/` | `Test Files 220 passed (220)` / `Tests 2459 passed (2459)` |
| `npx vitest run tests/unit/`（上記 4 ディレクトリを除いた残り全部） | `Test Files 501 passed (501)` / `Tests 8458 passed \| 1 skipped (8459)` |
| `npx vitest run tests/unit/domain/admin-labels-ssot-4512.test.ts` | `Test Files 1 passed (1)` / `Tests 44 passed (44)` |

vitest は 1 コマンドが実行上限に達したため 2 バッチに分割したが、合わせて `src/lib/domain/` + `src/routes/` + `tests/unit/` の全域を流している（failure 0）。E2E / Storybook は未実行。

`generate-lp-labels --check` は途中で 1 度落ちた。`familyPatternInviteTag` を `PLAN_GATE_LABELS.standardOrAboveBadge` 参照にしたところ、生成スクリプトが namespace 跨ぎの参照を解決できず **LP から key が丸ごと消えた**（= LP のタグが消失する）ため、その 1 箇所だけ atom を直接参照する template literal (`` `${PLAN_TERMS.standard}以上` ``) に戻し、コメントで理由を残した。再生成後 `site/` に diff は出ていない。

### 回帰の pin

`tests/unit/domain/admin-labels-ssot-4512.test.ts`（44 件）。既存 `labels-plan-literal-ratchet.test.ts` (#3359) と同型で route の source を読む:

- **(A)** 是正済み 27 ファイルに直書きが戻ってきたら落ちる（file × 禁止 literal の表）
- **(B)** 集約先の label 値を固定（曜日名 / 証明書カテゴリ 5 種 / cheer の上限メッセージ文面 / 年月フォーマッタ出力 / 敬称つき form エラー / 確認テキストの合言葉が画面と server で同一定数であること）

### lead による検収（#4512 分割 2 本目）

- `npm run pre-ready -- --pr 4607` **PASS**
- **`.svelte` の diff を抽出して literal → 同値定数の置換のみであることを確認**しました。例: `{age + '歳'}` → `{formatAge(age)}`（`formatAge(n) = \`${n}歳\`` で出力同一）、`'同年齢の中でも特に活発です'` → `STATUS_LABELS.analysisHigh`
- **SS を撮らない判断は妥当**と判断しました。出力文字列と DOM 構造が不変で、値の同一性は test (B) が固定しています

### 申し送り（本 PR では直していない）

`customActivityLimitReached(null)` が「最大 **null** 個まで作成できます」を出すのは **develop 由来の既存バグ**です。本 PR は挙動保存が目的なので触っていません。**顧客に見える文字列に `null` が出る**ため、別 Issue で拾います。

## 影響範囲

- **UI 変更なし** — 顧客に見える文言・DOM 構造とも不変。`.svelte` を **15 本**触っているが、変えたのは文字列リテラルを `labels.ts` の同値な定数参照に置き換えた箇所だけで、出力される文字列と要素構造は同一。値の同一性は `admin-labels-ssot-4512.test.ts` の (B) が固定している。したがって before/after SS は撮っていない（`refactor:internal-no-doc-impact` label は付けない — 顧客可視の文字列を触っているため）
- 触った並行実装ペア: **UI ラベル・用語**（`labels.ts` / `terms.ts` / `site/shared-labels.js` 再生成 — 生成物 diff は 0）。LP HTML・fallback は不変
- `labels.ts` 内で既存 export のシグネチャを変えたもの 2 件（**破壊的だが callsite 0 → 本 PR で追加した server 1 箇所のみ**）: `CHEER_LABELS.errorReasonTooLong` / `.errorPointsRequired`（後者は `.errorPointsRange` に改名）。改名前の値は誰も参照していなかった（`grep -rn` で確認済み、これが「定義済み未使用」の実体）
- PR #4594 とは同一ファイル 3 本を共有するが行が重ならないよう避けている。develop への取り込み順は問わない

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->



## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🟢 可逆: revert で全戻る"]
    R2["親画面 admin 19 route の文言"]
    R3["DB 変更なし・データ破壊なし"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 文言 1 行修正が全画面に届く"]
    T2["捨てる: labels.ts が 190 key 肥大"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: 🟡 正しさが自作 test 依存"]
    O2["UX: 🟡 SS 0 枚で svelte 15 本変更"]
    O3["security: 🟡 破壊操作の合言葉を文言 file に集約"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 表示は不変 (diff 抽出で確認済)"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: SS なしで可か (文言不変)"]
    Q2["Q2: null 表示バグは別 Issue で可か"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R1,R3,C1 ok
  class R2,T2,O1,O2,O3 warn
  class Q1,Q2 ask
```

### ③ の補足（`tmp/adversarial-evidence/4607.json` から転記、schema PASS）

- **business**: 「文言不変」を担保しているのは**本 PR が同時に追加した test** です。test 側の期待値が間違っていれば、誤った文言が「機械で固定された正しい文言」として恒久化されます。実際に `customActivityLimitReached(null)` が「最大 **null** 個まで作成できます」を出す既存バグを、挙動保存を理由に**温存したまま SSOT に取り込んでいます**
- **UX**: 「UI 変更なし」宣言は **SS 検証をまるごと skip させる opt-out** です。私が diff を抽出して literal → 同値定数のみと確認しましたが、**人間が実画面を見る機会は消えています**。文字列長が変われば `text-wrap: balance` の折り返しが変わるため、文字列を触る変更で見た目不変を宣言するのは検証として弱い側です
- **security**: 破壊的操作の合言葉（データクリアの「削除」/ 退会の「アカウントを削除します」）を単一定数に集約しました。集約は正しいのですが、**その定数が UI 文言ファイルに置かれ、文言変更のつもりで触れる場所にあります**。短い文字列に変えれば誤操作で全データ削除に到達しやすくなります。#4540 Q7（法務文書への数値自動注入に承認点を設けるか）と**同型の問題**です

### ⑤ の判断依頼

**Q1: SS なしで可か。** `.svelte` 15 本を触りながら before/after SS を撮っていません。diff は literal → 同値定数のみで、値の同一性は test が固定しています。**「文言を触る PR は SS 必須」を貫くなら撮り直します**（15 画面分）。

**Q2: `null` 表示バグを別 Issue にして可か。** 「最大 null 個まで作成できます」は develop 由来の既存バグです。本 PR は挙動保存が目的なので触っていませんが、**顧客に見える文字列に `null` が出ています**。本 PR に含めるべきなら含めます。
