### PR TITLE
test(legal): #4540 Q7 特商法・規約に注入される定数の値を pin する

### DIFF
--- a/tests/unit/domain/legal-injected-constants-pin.test.ts
+++ b/tests/unit/domain/legal-injected-constants-pin.test.ts
@@ -1,0 +1,141 @@
+// tests/unit/domain/legal-injected-constants-pin.test.ts (#4540 Q7)
+//
+// ⚠️ この値は特商法・利用規約に自動注入される。変更は約款変更にあたるため、周知の要否を判断すること。
+//
+// 本 file が落ちたということは、顧客と交わしている約款の記載内容が変わったということである。
+// test を現在値に書き換えるだけでは済まない。**周知 (掲示・メール等) の要否を判断**し、
+// 判断の結果を PR に残してから書き換えること (判断者は PO / オーナー)。
+//
+// なぜ test で担保するのか (#4540 Q7 PO 決裁):
+//   猶予日数 / 保持日数は domain 定数を 1 箇所直せば、生成を経て特商法・利用規約の本文まで
+//   自動で書き換わる。自動注入それ自体は正しい (実装と約款の食い違いを防ぐ) が、
+//   「気づかずに約款を変えられる」状態が残っていた。CODEOWNERS による承認点の追加は
+//   本リポジトリの承認体制 (オーナー + lab の 2 アカウントが全 PR を見ている、ADR-0022) では
+//   承認点が 1 つも増えないため不採用。代わりに**値を pin して必ず落とす**ことで、
+//   変更者が「これは約款変更である」と気づく地点を作る。
+//
+// 既存 test との分担:
+//   - 値 → atom → 表示文字列 の追随: cancel-vs-deletion-terminology.test.ts (#4496) /
+//     plan-retention-ssot.test.ts (#4477) が担う。本 file はそれらを繰り返さない。
+//   - 本 file の担当は 2 点のみ: (1) 値そのものの pin、(2) **法定表示への注入経路が実在すること**。
+//     値を pin しても注入経路が消えていれば pin の意味 (= 約款が動く) が変わるため、
+//     経路の生存も同じ file で見る。
+//   - grace-period-service.test.ts も猶予日数を pin しているが、あちらは server service の
+//     単体 test であり「約款変更である」という文脈を持たない。文脈を持つ pin は本 file が正。
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { DELETION_GRACE_PERIOD_DAYS } from '../../../src/lib/domain/constants/deletion-grace';
+import { PLAN_HISTORY_RETENTION_DAYS } from '../../../src/lib/domain/constants/plan-retention';
+import { LP_LEGAL_TERMS_LABELS, LP_LEGAL_TOKUSHOHO_LABELS } from '../../../src/lib/domain/labels';
+import { DELETION_GRACE_TERMS, PLAN_RETENTION_TERMS } from '../../../src/lib/domain/terms';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoFile = (p: string) => readFileSync(resolve(__dirname, '../../../', p), 'utf-8');
+
+/**
+ * 失敗メッセージの共通前文。落ちた人が最初に読む場所なので、
+ * 「何をしてはいけないか」ではなく「何を判断すべきか」を書く。
+ */
+const LEGAL_CHANGE_NOTICE = [
+	'この値は特商法・利用規約に自動注入される。変更は約款変更にあたるため、周知の要否を判断すること。',
+	'注入経路: src/lib/domain/constants/{deletion-grace,plan-retention}.ts',
+	'  → src/lib/domain/terms.ts (DELETION_GRACE_TERMS / PLAN_RETENTION_TERMS)',
+	'  → src/lib/domain/labels.ts (LP_LEGAL_TERMS_LABELS.section13 / LP_LEGAL_TOKUSHOHO_LABELS.tableContent)',
+	'  → scripts/generate-lp-labels.mjs (buildDeletionGraceTerms / buildPlanRetentionTerms)',
+	'  → site/shared-labels.js (生成物、コミット対象)',
+	'  → site/terms.html (第13条) / site/tokushoho.html (返品・キャンセル欄) の data-lp-key 注入',
+	'値を変える PR では、周知の要否の判断結果を PR 本文に残したうえで本 test を更新すること。',
+].join('\n');
+
+/** site/shared-labels.js (生成物) から namespace.key の値を取り出す。 */
+function sharedLabel(namespace: string, key: string): string {
+	const src = repoFile('site/shared-labels.js');
+	const nsStart = src.indexOf(`"${namespace}": {`);
+	if (nsStart < 0) {
+		throw new Error(
+			`site/shared-labels.js に namespace "${namespace}" が無い。法定表示への注入経路が壊れている。\n${LEGAL_CHANGE_NOTICE}`,
+		);
+	}
+	const nsEnd = src.indexOf('\n\t\t}', nsStart);
+	const block = src.slice(nsStart, nsEnd < 0 ? undefined : nsEnd);
+	const matched = block.match(new RegExp(`"${key}": ("(?:[^"\\\\]|\\\\.)*")`));
+	if (!matched?.[1]) {
+		throw new Error(
+			`site/shared-labels.js の ${namespace}.${key} を取り出せない。法定表示への注入経路が壊れている。\n${LEGAL_CHANGE_NOTICE}`,
+		);
+	}
+	return JSON.parse(matched[1]) as string;
+}
+
+describe('法定表示に注入される定数の pin (#4540 Q7)', () => {
+	describe('値の pin — 変えたら必ず落ちる', () => {
+		it('退会 (アカウント削除) の猶予日数', () => {
+			// free 0 = 申請と同時に物理削除 (取消し不可)。この 0 は特商法に
+			// 「無料プランは猶予期間がなくお申し込みと同時に削除されます」として載っている。
+			expect(DELETION_GRACE_PERIOD_DAYS, LEGAL_CHANGE_NOTICE).toEqual({
+				free: 0,
+				standard: 7,
+				family: 30,
+			});
+		});
+
+		it('プラン別の履歴保持日数', () => {
+			// null = 無期限。free 90 は特商法の「解約とデータの取扱い」欄に載っている。
+			expect(PLAN_HISTORY_RETENTION_DAYS, LEGAL_CHANGE_NOTICE).toEqual({
+				free: 90,
+				standard: 365,
+				family: null,
+			});
+		});
+	});
+
+	describe('注入経路が実在する — 経路が消えたら pin の意味が変わる', () => {
+		it('利用規約 第13条 (アカウント削除) が現在の猶予日数を述べている', () => {
+			const section13 = LP_LEGAL_TERMS_LABELS.section13;
+			for (const term of [
+				DELETION_GRACE_TERMS.free,
+				DELETION_GRACE_TERMS.standard,
+				DELETION_GRACE_TERMS.premium,
+			]) {
+				expect(section13, LEGAL_CHANGE_NOTICE).toContain(term);
+			}
+		});
+
+		it('特商法 返品・キャンセル欄が現在の猶予日数と保持日数を述べている', () => {
+			const cell = LP_LEGAL_TOKUSHOHO_LABELS.tableContent;
+			for (const term of [
+				DELETION_GRACE_TERMS.free,
+				DELETION_GRACE_TERMS.standardSpaced,
+				DELETION_GRACE_TERMS.premiumSpaced,
+				PLAN_RETENTION_TERMS.freeSpaced,
+			]) {
+				expect(cell, LEGAL_CHANGE_NOTICE).toContain(term);
+			}
+		});
+
+		it('生成物 site/shared-labels.js に同じ値が載っている', () => {
+			// labels.ts を直しても再生成を忘れれば、顧客が読む HTML は旧値のまま残る。
+			// (再生成漏れ自体は pre-ready の generate-lp-labels --check が別途 hard-fail する)
+			expect(sharedLabel('legalTerms', 'section13'), LEGAL_CHANGE_NOTICE).toContain(
+				DELETION_GRACE_TERMS.standard,
+			);
+			const tokushoho = sharedLabel('legalTokushoho', 'tableContent');
+			expect(tokushoho, LEGAL_CHANGE_NOTICE).toContain(DELETION_GRACE_TERMS.standardSpaced);
+			expect(tokushoho, LEGAL_CHANGE_NOTICE).toContain(PLAN_RETENTION_TERMS.freeSpaced);
+		});
+
+		it('法務 HTML が注入先の data-lp-key を保持している', () => {
+			// data-lp-key が外れると、生成物が正しくても顧客が読む本文は fallback 直書きのまま
+			// 固定される (= 値を変えても約款が動かない)。pin の前提が崩れるので同時に見る。
+			expect(repoFile('site/terms.html'), LEGAL_CHANGE_NOTICE).toContain(
+				'data-lp-key="legalTerms.section13"',
+			);
+			expect(repoFile('site/tokushoho.html'), LEGAL_CHANGE_NOTICE).toContain(
+				'data-lp-key="legalTokushoho.tableContent"',
+			);
+		});
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

顧客と交わしている約款（特商法表示・利用規約 第13条）の日数が、開発者が気づかないまま書き換わることが無くなる。猶予日数 / 保持日数は定数 1 行を直せば法務文書の本文まで自動注入されるため、これまでは「約款を変えたつもりがないのに変わっている」状態を誰も検出できなかった。

## 関連 Issue

Refs #4540
<!-- no-issue-close: #4540 は Q1/Q3/Q4/Q7 の複合で、本 PR は Q7 のみ。Q1 は申し送りのみ / Q3 は #4524 / Q4 は #4525 に合流済み。 -->

## 変更内容

PO 決裁（#4540 Q7、`gh issue view 4540 --comments` 最新コメント）に従い、**CODEOWNERS ではなく値 pin test** で担保する。CODEOWNERS はオーナー + lab の 2 アカウントが既に全 PR を見ている体制（ADR-0022）では承認点が増えないため不採用。

新規 file 1 本のみ（`tests/unit/domain/legal-injected-constants-pin.test.ts`）。新しい CI job / workflow / PR 宣言欄は追加していない。

- **値の pin**: `DELETION_GRACE_PERIOD_DAYS`（free 0 / standard 7 / family 30）と `PLAN_HISTORY_RETENTION_DAYS`（free 90 / standard 365 / family null）を record 丸ごと `toEqual` で pin（tier 追加も検出する）。**値そのものは変更していない**
- **失敗メッセージ**: 全 assert に共通前文を渡し、「この値は特商法・利用規約に自動注入される。変更は約款変更にあたるため、周知の要否を判断すること」+ 注入経路 6 hop を失敗出力に出す。単なる `toBe(7)` では落ちた人が何を判断すべきか分からないため
- **注入経路の生存 assert**: 値を pin しても経路が消えていれば pin の意味（= 約款が動く）が変わるので、① 利用規約 第13条 / ② 特商法 返品・キャンセル欄 / ③ 生成物 `site/shared-labels.js` / ④ `site/terms.html`・`site/tokushoho.html` の `data-lp-key` を同じ file で見る

**既存 pin との関係（重複回避）**: `DELETION_GRACE_PERIOD_DAYS` は `tests/unit/services/grace-period-service.test.ts` が既に 0/7/30 を pin していた（ただし server service の単体 test で「約款変更である」という文脈を持たない）。一方 **`PLAN_HISTORY_RETENTION_DAYS` はどこにも pin されておらず**、既存 test は全て定数から導出していた。生成物 `shared-labels.js` と法務 HTML の `data-lp-key` を見る unit test も 0 件だった。本 PR はその 3 点を埋め、値 → atom → 表示文字列の追随（#4496 / #4477 の既存 test）は繰り返していない。

## 検証

| 検査 | コマンド | 結果 |
|---|---|---|
| lint | `npx biome check --write tests` | Checked 945 files、Fixed 1 file（自動整形のみ） |
| cspell | `npm run cspell` | Files checked: 1986, **Issues found: 0** |
| 型 | `npx svelte-check --threshold error` | **0 ERRORS** 0 WARNINGS |
| 新規 test | `npx vitest run tests/unit/domain/legal-injected-constants-pin.test.ts` | **6 passed** |
| unit 全体（ローカル） | `npx vitest run tests/unit/` | **721 files / 10879 passed**、1 skipped、0 failed |
| unit 全体（CI、authoritative） | `unit-test (1)` / `unit-test (2)` | **どちらも pass**（11m31s / 12m28s） |
| CI lint 系（cspell / generate-lp-labels --check 等） | `lint-and-test` | **pass**（3m42s） |
| E2E / Storybook | — | 未実行（test file 追加のみで UI / route に触っていない） |

**mutation 検証（実出力）**: commit 済みの状態で `standard: 7 → 8` と `free: 90 → 91` を入れて実測。

```
FAIL  > 値の pin — 変えたら必ず落ちる > プラン別の履歴保持日数
AssertionError: この値は特商法・利用規約に自動注入される。変更は約款変更にあたるため、周知の要否を判断すること。
注入経路: src/lib/domain/constants/{deletion-grace,plan-retention}.ts
  → src/lib/domain/terms.ts (DELETION_GRACE_TERMS / PLAN_RETENTION_TERMS)
  → src/lib/domain/labels.ts (LP_LEGAL_TERMS_LABELS.section13 / LP_LEGAL_TOKUSHOHO_LABELS.tableContent)
  → scripts/generate-lp-labels.mjs (buildDeletionGraceTerms / buildPlanRetentionTerms)
  → site/shared-labels.js (生成物、コミット対象)
  → site/terms.html (第13条) / site/tokushoho.html (返品・キャンセル欄) の data-lp-key 注入
値を変える PR では、周知の要否の判断結果を PR 本文に残したうえで本 test を更新すること。
: expected { free: 91, standard: 365, …(1) } to deeply equal { free: 90, standard: 365, …(1) }

 Test Files  1 failed (1)
      Tests  3 failed | 3 passed (6)
```

3 件目の fail は生成物 assert（`expected '<h2>第13条…' to contain '8日'`）で、**定数を変えて `generate-lp-labels` を再生成し忘れた場合も落ちる**ことを示している。mutation は `git stash push -- <2 file>` で退避し、退避後に再実行して **6 passed** に戻ることを確認済み（`git checkout --` は hook が禁止しているため未使用）。

### lead 検収 — 決裁の前提が 1 つずれていた点を確認しました

決裁は定数の場所を `grace-period-service.ts` としていましたが、**#4496 で `src/lib/domain/constants/deletion-grace.ts` に移設済み**で、service 側は re-export のみでした（保持日数も `constants/plan-retention.ts`）。**実 SSOT 側に pin してあることを確認済み**です。

もう 1 点、**「既存 pin があるならコメント追記だけで済む」は成立しませんでした**。

| 定数 | 既存 pin |
|---|---|
| `DELETION_GRACE_PERIOD_DAYS` | `grace-period-service.test.ts:115-124` が 0/7/30 を pin **済** |
| **`PLAN_HISTORY_RETENTION_DAYS`** | **どこにも無し**（既存 test は全て定数からの導出で、90→120 に変えても落ちない） |

利用規約 第13条（`LP_LEGAL_TERMS_LABELS.section13`）/ 生成物 `site/shared-labels.js` / 法務 HTML の `data-lp-key` を見る unit test も **0 件**でした。**「自動注入されている」と言いながら、注入先を見ている test が無かった**わけです。

- `npm run pre-ready -- --pr 4610` **PASS**
- 該当 test 単独実行 **6 passed**

**mutation で「再生成忘れ」も捕まることを確認しました**: `standard: 7→8` / `free: 90→91` で **3 failed**。値 pin 2 件に加えて**生成物 assert も落ちます**（`expected '<h2>第13条…' to contain '8日'`）。定数だけ変えて `generate-lp-labels` を回し忘れた状態も検出されます。

## 影響範囲

- **顧客に見える変化: なし**。test 1 file の追加のみで、`src/` / `site/` は 1 行も変えていない（定数の値も不変）
- 触った並行実装ペア: なし
- 破壊的変更: なし
- 今後の副作用: `DELETION_GRACE_PERIOD_DAYS` / `PLAN_HISTORY_RETENTION_DAYS` を変える PR は本 test が必ず落ちる（意図した設計）。落ちた人は周知の要否を判断し、判断結果を PR 本文に残してから test を更新する

UI 変更なし（test file の追加のみ）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

