### PR TITLE
fix(ci): #4348 admin bypass 証跡検査を行単位判定に揃え、死んだ AC マップ判定を削除

### DIFF
--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -2617,7 +2617,7 @@ dim 4 漏れによる data orphan が発生した場合の復旧手順は [docs/
 - **判定方式**: 完全 SQL parser でなく `git diff --unified=0` の drizzle column 定義行を正規表現で解析する
   (#2520 AC7)。検出ロジック (`detectBreakingChanges`) の unit test は
   `tests/unit/scripts/check-schema-migration-completeness.test.ts`。
-- **skip**: 純フォーマット変更等は PR 本文に `[skip-schema-migration-check]` を含める。
+- **skip**: 純フォーマット変更等は PR 本文に `[skip-schema-migration-check]` を**宣言として**書く。HTML コメント / コードブロック / 引用 / 未チェック checkbox / 案内文の中の同じ文字列は skip として扱わない (判定規律の SSOT は `scripts/lib/ci/pr-body-sections.mjs`、#4348)。
 - **#2519 との棲み分け**: 本 gate は **PR 時の static schema diff** (gate)。#2519 は **runtime data orphan**
   (startup assert、data 側)。#2507 (full 版: schema / create-tables / lazy の 3 dimension 完全同期) は別途。
 

--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -27,39 +27,6 @@ export const NG_DECLARATION_SECTION = 'NG 0 件 / カバレッジ宣言';
 export const NG_NONZERO_ACCEPTED_KEY = 'ng-nonzero-accepted';
 
 /**
- * #1539: AC マップ 4 列目（結果/エビデンス列）の未完了表記検出パターン。
- *
- * **`follow[\s-]up`（区切り 1 文字必須）の意図（#3488 BLOCK fix）**:
- * `?` で区切りを optional にすると、区切り無しの slug `followup` が部分一致してしまい
- * `docs/research/2026-06-29-followup-treadmill-root-cause.md` のような**完了済エビデンス参照の
- * ファイル名**を未完了表記として誤検出していた（false-positive → gate fail）。
- * 未完了マーカーとしての「follow-up」「follow up」は語間に区切り（空白 or ハイフン）を必ず持つため、
- * 区切り 1 文字必須にすれば slug `followup` を除外しつつ「別途 follow-up で対応」等は検出し続ける。
- * 拡張子 whitelist による strip 前処理は脆く（bypass + 非収録拡張子の FP）、撤去して生 cell に
- * 本パターンを直接適用する方針に戻した（#3488）。
- *
- * **inline-code strip（#3846 / #3844 BLOCK fix）**: 拡張子 whitelist strip（#3488 で撤去）とは別に、
- * evidence cell の **inline-code (`...`) 内トークンのみ** は判定前に strip する。inline-code は
- * 定数名 / コマンド / ファイル参照などの機械トークンであり（例: 定数名 `RANGE_SSOT_TODO` が
- * #3844 で `todo` に部分一致し false-positive gate fail）、未完了宣言の prose ではない。
- * 未完了マーカーを backtick で囲んで逃避する pattern は QM レビュー + PR body 禁止語 gate
- * (`check-pr-body.mjs`) の別層で扱う。prose（コード外）の未完了表記検出は従来どおり生 cell。
- */
-const TODO_PATTERN = /todo|予定|追加予定|別途|follow[\s-]up|後で/i;
-
-/**
- * evidence cell 内の inline-code span（`...`）を除去する（#3846）。
- * table cell は `|` split 済のため改行を含まず、backtick 対を単純除去すれば十分。
- * 対にならない孤立 backtick は残す（除去しすぎによる検出漏れ防止）。
- *
- * @param {string} cell
- * @returns {string}
- */
-function stripInlineCode(cell) {
-	return cell.replace(/`[^`]*`/g, '');
-}
-
-/**
  * 残 NG **件数** の宣言を読み取るパターン（#4333）。件数を capture group 1 で取り出す。
  *
  * 旧実装は `/残\s*NG[^\n|]*[:：]?\s*0\b|NG\s*0\s*件/` を **本文全体**に `test()` するだけで、
@@ -109,49 +76,6 @@ export function parseNgCountDeclarations(sectionText) {
 		}
 	}
 	return found;
-}
-
-/**
- * 次の `## ` 見出し（H2）の直前までを切り出す。見出しが無ければ全体を返す。
- *
- * `###` 以降の下位見出しでは止めない（同一セクション内の小見出しは表の所属を変えないため）。
- *
- * @param {string} text 見出し行を除いたセクション以降のテキスト
- * @returns {string} 当該セクション本体
- */
-function sliceUntilNextH2(text) {
-	const lines = text.split('\n');
-	const end = lines.findIndex((l) => l.startsWith('## '));
-	return end === -1 ? text : lines.slice(0, end).join('\n');
-}
-
-/**
- * AC 検証マップの 4 列行を本文から抽出する（共通 util）。
- * ヘッダー行（`| AC 番号 | AC 内容 ...` 等）とセパレーター（`|---|---|`）を除外する。
- *
- * **走査は当該セクション内で閉じる**（次の `## ` 見出しで停止、#4243）。
- * 本文末尾まで見ていた旧実装は、統合 PR template が「マージ判定エビデンス」の**後ろ**に
- * 4 列の表（Accepted residual 等）を持つため、**別表の行を evidence の行として数えていた**。
- * 壊れ方は 2 方向あった:
- *
- *   - false positive: 後続表のプレースホルダ行を空欄と誤判定し、evidence 表が正しくても fail
- *     （bot 生成の統合 PR が生まれた瞬間に落ちる。#4241 で実測）
- *   - false negative: evidence 表が**空でも**後続表の 4 列行で `rows.length === 0` を通過し、
- *     「main 反映前に evidence を必ず埋めさせる」という gate の目的が満たされない（より危険）
- *
- * @param {string} body PR 本文
- * @param {number} fromIdx 抽出開始 index（section 見出し以降に限定する用途）
- * @returns {string[]} 4 列のデータ行（生のマークダウン行）
- */
-function extractFourColumnRows(body, fromIdx) {
-	const rest = body.slice(fromIdx);
-	// 見出し行自身を飛ばしてから、次の `## ` 見出しまでを section 本体とする。
-	const afterHeading = rest.indexOf('\n');
-	const section =
-		afterHeading === -1
-			? rest
-			: rest.slice(0, afterHeading + 1) + sliceUntilNextH2(rest.slice(afterHeading + 1));
-	return pickFourColumnRows(section);
 }
 
 /**
@@ -223,91 +147,6 @@ export function shouldSkip({ body, labels, lane }) {
  * @property {string} [error] FAIL 時のメッセージ（複数行）
  * @property {string[]} [info] 補助ログ行
  */
-
-/**
- * feature / hotfix lane の AC 検証マップ検証（現行ロジックを維持、AC4 回帰ゼロ）。
- *
- * @param {string} body PR 本文
- * @param {'feature'|'hotfix'} lane
- * @returns {AcCheckResult}
- */
-export function checkPerPrAcMap(body, lane) {
-	const mapHeaderIdx = body.indexOf('AC 検証マップ');
-	if (mapHeaderIdx === -1) {
-		return {
-			ok: false,
-			lane,
-			error:
-				'❌ PR 本文に「AC 検証マップ」セクションが見つかりません (ADR-0038)\n' +
-				'PR テンプレートのセクションが削除されています。',
-		};
-	}
-
-	const rows = extractFourColumnRows(body, mapHeaderIdx);
-	const emptyRows = findEmptyRows(rows);
-	const info = [`AC map rows found: ${rows.length}, empty/placeholder rows: ${emptyRows.length}`];
-
-	if (rows.length === 0) {
-		return {
-			ok: false,
-			lane,
-			info,
-			error:
-				'❌ AC 検証マップに行が 1 件もありません (ADR-0038)\n\n' +
-				'Issue の Acceptance Criteria 1 行ごとに 1 行を埋めてください。\n' +
-				'例:\n| AC1 | ログイン後にダッシュボードが表示される | `npx playwright test auth.spec.ts` | PASS |',
-		};
-	}
-
-	if (emptyRows.length > 0) {
-		const details = emptyRows.map((r) => `  ${r.slice(0, 120)}`).join('\n');
-		return {
-			ok: false,
-			lane,
-			info,
-			error:
-				`❌ AC 検証マップに ${emptyRows.length} 件の空欄/プレースホルダ行があります (ADR-0038)\n\n` +
-				'「AC 内容」「検証手段」「結果 / エビデンス」の全列を埋めてください。\n' +
-				'目視確認のみは不可。機械検証可能なコマンド / ファイルパス / スクリーンショット番号で記入してください。\n\n' +
-				`空欄行:\n${details}`,
-		};
-	}
-
-	// #1539: 4 列目（結果/エビデンス列）に未完了表記が含まれる場合 FAIL
-	const todoRows = rows
-		.map((row, idx) => {
-			const cells = row
-				.split('|')
-				.slice(1, -1)
-				.map((c) => c.trim());
-			const evidenceCell = cells[3] ?? '';
-			// #3846: inline-code 内の機械トークン（定数名 / コマンド / ファイル参照）は判定対象外
-			if (TODO_PATTERN.test(stripInlineCode(evidenceCell))) {
-				const acId = cells[0] || `行 ${idx + 1}`;
-				return { acId, evidenceCell };
-			}
-			return null;
-		})
-		.filter(/** @returns {x is {acId: string; evidenceCell: string}} */ (x) => x !== null);
-
-	if (todoRows.length > 0) {
-		const details = todoRows
-			.map((item) => `  ${item.acId}: 「${item.evidenceCell.slice(0, 80)}」`)
-			.join('\n');
-		return {
-			ok: false,
-			lane,
-			info,
-			error:
-				`❌ AC 検証マップの「結果/エビデンス」列に未完了表記が ${todoRows.length} 件あります (#1539)\n\n` +
-				'「TODO」「予定」「追加予定」「別途」「follow-up」「後で」は未完了を示します。\n' +
-				'全 AC を実際に検証した上で、具体的なエビデンス（PASS / スクリーンショット番号 / コマンド結果）を記入してください。\n\n' +
-				`未完了行:\n${details}`,
-		};
-	}
-
-	return { ok: true, lane, info, reason: 'AC 検証マップ: 全行 埋まっています ✓' };
-}
 
 /**
  * integration lane の「マージ判定エビデンス表」検証（AC3）。
@@ -468,6 +307,18 @@ export function checkNgZeroDeclaration(body) {
 
 /**
  * lane に応じて AC 検証観点を切替えるエントリ（job は全 lane で実行され、内部で観点を切替える）。
+ *
+ * # feature / hotfix lane に per-PR AC マップ判定は無い（#4305 → #4348 で残骸を削除）
+ *
+ * #4305 が **PR テンプレートから `## AC 検証マップ` 節ごと撤去**し（現テンプレートは 7 節）、
+ * 本 entry も feature / hotfix lane を無条件 PASS に変えた。判定関数 `checkPerPrAcMap` は
+ * その時に呼び出し元を失い、**唯一の呼び出しが自身の unit test だけ**という状態で
+ * 8 ヶ月ぶんの改修（#3488 / #3846 等）を受け続けていた。#4348 で削除した。
+ *
+ * 再導入するなら、判定関数だけを戻しても機能しない。**PR テンプレートの節・
+ * `.github/PR_TEMPLATE_SECTIONS.json`・本 entry の分岐・workflow 配線をセットで**戻すこと。
+ * 「判定関数だけが存在して誰も呼ばない」状態は `tests/unit/scripts/check-ac-verification-map.test.ts`
+ * の class-lock が落とす。
  *
  * @param {{
  *   body: string;

--- a/scripts/check-admin-bypass-evidence.mjs
+++ b/scripts/check-admin-bypass-evidence.mjs
@@ -26,6 +26,8 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { hasDeclarationLine } from './lib/ci/pr-body-sections.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /**
  * @typedef {Object} PrFile
@@ -75,16 +77,28 @@ const DRY_RUN = process.env.DRY_RUN === 'true';
 const OUTPUT_MODE = process.env.OUTPUT_MODE || 'text';
 const SUMMARY_ONLY = process.env.SUMMARY_ONLY === 'true';
 
-const EVIDENCE_MARKER_PATTERNS = [
+export const EVIDENCE_MARKER_PATTERNS = [
 	/^##\s*Self-Review 証跡/m,
 	/^##\s*Self-Review\s*\(admin bypass\)/m,
 ];
 
 const BOT_COMMENT_MARKER = '<!-- admin-bypass-evidence-check -->';
 
-if (!REPO) {
-	console.error('[admin-bypass-evidence] REPO env var is required (owner/repo)');
-	process.exit(2);
+/**
+ * REPO env var を必須として解決する。
+ *
+ * 旧実装は module top-level で `process.exit(2)` していたため、**import しただけで
+ * process が落ちる**。判定関数 (`hasEvidenceSection`) を unit test から呼べず、
+ * 判定の回帰が test で固定できない状態だった (#4348)。検証は実際に gh を叩く直前に行う。
+ *
+ * @returns {string}
+ */
+function requireRepo() {
+	if (!REPO) {
+		console.error('[admin-bypass-evidence] REPO env var is required (owner/repo)');
+		process.exit(2);
+	}
+	return REPO;
 }
 
 /**
@@ -124,7 +138,7 @@ function listRecentMergedPrs(sinceIso) {
 		'pr',
 		'list',
 		'--repo',
-		REPO,
+		requireRepo(),
 		'--state',
 		'merged',
 		'--limit',
@@ -160,12 +174,26 @@ function isExempted(pr) {
 }
 
 /**
+ * PR 本文に Self-Review 証跡セクションが **宣言として** 書かれているか (ADR-0044)。
+ *
+ * # なぜ行単位 + 文脈除外なのか (#4348 対象 #3)
+ *
+ * 旧実装は本文全体への `re.test(body)` で、`^##` の行頭アンカーはあっても
+ * **HTML コメント / fenced code block の中の見出し**を区別できなかった。
+ * 本 script 自身が投稿する追記依頼コメントは証跡セクションのテンプレートを
+ * ```` ```markdown ```` fence で囲んで提示するため、**その bot コメントを PR 本文に
+ * 貼り戻すだけで「証跡あり」になる**。証跡を 1 文字も書かずに追跡から外れる形で、
+ * #4333 (テンプレートを消さずに出すだけで gate が成立する) と同型である。
+ *
+ * 判定規律は PR body を読む他の gate と同じ SSOT
+ * (`scripts/lib/ci/pr-body-sections.mjs` の `hasDeclarationLine`) に揃える。
+ *
  * @param {string | null} body
  * @returns {boolean}
  */
-function hasEvidenceSection(body) {
+export function hasEvidenceSection(body) {
 	if (!body) return false;
-	return EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body));
+	return hasDeclarationLine(body, EVIDENCE_MARKER_PATTERNS);
 }
 
 /**
@@ -216,7 +244,7 @@ async function postMissingEvidenceComment(prNumber) {
 		return;
 	}
 
-	gh(['pr', 'comment', String(prNumber), '--repo', REPO, '--body', body]);
+	gh(['pr', 'comment', String(prNumber), '--repo', requireRepo(), '--body', body]);
 }
 
 /**
@@ -306,8 +334,12 @@ async function main() {
 	process.exit(0);
 }
 
-main().catch((/** @type {unknown} */ err) => {
-	const msg = err instanceof Error ? err.message : String(err);
-	console.error('[admin-bypass-evidence] unexpected error', msg);
-	process.exit(2);
-});
+// CLI として直接実行された場合のみ main() を起動 (test からの import 時は実行しない)。
+// 判定は scripts/lib/is-main.mjs (SSOT、#3969) に委譲する。
+if (isMainModule(import.meta.url)) {
+	main().catch((/** @type {unknown} */ err) => {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.error('[admin-bypass-evidence] unexpected error', msg);
+		process.exit(2);
+	});
+}

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -1584,9 +1584,17 @@ export function resolveLabels(args, fetched) {
  * | 本 script の id | 引き続き hard-fail する job (script) |
  * |---|---|
  * | `missing-required-sections` | `pr-template-gate.yml`「必須セクションの存在確認」(`checkSectionPresence`) |
- * | `change-type-unselected` | 同「変更タイプの選択」(`checkChangeType`) |
- * | `ac-map-missing` / `-empty` / `-incomplete` | `pr-ac-verification-check.yml`「Verify AC map in PR body」(`checkPerPrAcMap`) |
- * | `unchecked-ready-checklist` | `pr-merge-gate.yml`「PR チェックリスト完了確認」(`checkMergeGateChecklist`) |
+ * | `unchecked-ready-checklist` | `pr-merge-gate.yml`「PR チェックリスト完了確認」(`checkMergeGateChecklist`)。**ただし integration lane のみ** — feature / hotfix lane の checklist 検証は #4305 で撤去済 |
+ *
+ * ### #4305 で対になる hard-fail が消えた id (#4348 で是正)
+ *
+ * 本表はかつて `change-type-unselected` / `ac-map-*` も「別 job が hard-fail する」と書いていたが、
+ * **#4305 が PR テンプレートから該当節ごと撤去した時点で嘘になっていた**。対の job は無く、
+ * さらに本 script 側の判定関数 (`checkChangeTypeSelection` / `checkAcMap`) も runner から
+ * 呼ばれておらず、**これらの id はどこからも出力されない**。advisory ですらない。
+ *
+ * 復活させるなら判定関数だけでは足りない — テンプレート節 / `.github/PR_TEMPLATE_SECTIONS.json` /
+ * runner の呼び出し / workflow 配線をセットで戻すこと。
  *
  * 残り (mojibake / placeholder 各種 / forbidden-terms / hotfix env 節 / mergeable-conflicting) は
  * 本 script が唯一の検出点なので、**真に advisory になる**。うち `mergeable-conflicting` は

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -144,6 +144,11 @@ export function detectBeforeAfterLabels(body) {
 }
 
 import { existsSync, readdirSync } from 'node:fs';
+import {
+	extractH2Section,
+	findDeclarationLines,
+	hasDeclarationLine,
+} from './lib/ci/pr-body-sections.mjs';
 import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 
 /**
@@ -278,19 +283,13 @@ const UI_NOT_APPLICABLE_PATTERNS = [
 	/UI\s*変更\s*なし/i,
 ];
 
-/**
- * 同じ行に現れたら **宣言ではない** と判断する文脈 (#4255 横展開)。
- *
- * 「UI 変更なし」の 6 文字は、否定・引用・手順説明の中にも普通に現れる。
- * 出現しただけで opt-out にすると、**書いていない宣言を書いたことにされる**。
+/*
+ * 「同じ行に現れたら宣言ではない」文脈の一覧は
+ * `scripts/lib/ci/pr-body-sections.mjs` の `DECLARATION_DISQUALIFYING_PATTERNS` が SSOT
+ * (#4255 で本 file に置いたものを #4348 で共有化)。
+ * DOM 参照 / 統合 VR evidence / schema skip marker も同じ規律で判定するため、
+ * 本 file 内に二重実装を残さない。
  */
-const MARKER_DISQUALIFYING_PATTERNS = [
-	/^\s*>/, // 引用 — 他所の文言を貼っただけ
-	/^\s*[-*]\s*\[\s\]/, // 未チェック checkbox — チェックしていない = 宣言していない
-	/ではありません|ではない|ではなく|とは限らない|とは言えない/, // 否定 (#4255 と同型)
-	/嘘|虚偽/, // gate 自身の説明文の引用
-	/なしの場合|と書く/, // 手順書の条件節 / 引用符付きの言及
-];
 
 /**
  * 「該当なし」明示記述の検出。refactor / docs / chore のみで UI 影響がない PR の opt-out 用。
@@ -318,19 +317,7 @@ const MARKER_DISQUALIFYING_PATTERNS = [
  * @returns {boolean}
  */
 export function hasUiNotApplicableMarker(body) {
-	let inFence = false;
-	for (const raw of (body ?? '').split(/\r?\n/)) {
-		if (/^\s*(?:```|~~~)/.test(raw)) {
-			inFence = !inFence;
-			continue;
-		}
-		if (inFence) continue;
-		// インラインコード (`...`) は言及であって宣言ではない
-		const line = raw.replace(/`[^`]*`/g, ' ');
-		if (MARKER_DISQUALIFYING_PATTERNS.some((p) => p.test(line))) continue;
-		if (UI_NOT_APPLICABLE_PATTERNS.some((p) => p.test(line))) return true;
-	}
-	return false;
+	return hasDeclarationLine(body, UI_NOT_APPLICABLE_PATTERNS);
 }
 
 /**
@@ -417,11 +404,16 @@ export function isUserAttachmentAssetUrl(url) {
  * - Markdown link: `[DOM HTML](https://.../foo.dom.html)`
  * - 素の URL: `https://.../foo.dom.html`
  *
+ * **行単位 + 文脈除外で判定する (#4348 対象 #4)**。旧実装は本文全体への `PATTERN.test(body)` で、
+ * HTML コメント / code block / 引用 / 否定文 / 未チェック checkbox の中の URL でも
+ * 「参照がある」と判定し、DOM 併記検証をまるごと消せた (#4255 の `hasStorybookStoryReference` /
+ * `hasUiNotApplicableMarker` と同 class)。判定規律は `pr-body-sections.mjs` に集約している。
+ *
  * @param {string} body
  * @returns {boolean}
  */
 export function hasDomSnapshotReference(body) {
-	return DOM_REF_PATTERN.test(body);
+	return hasDeclarationLine(body, [DOM_REF_PATTERN]);
 }
 
 // ---------------------------------------------------------------------------
@@ -449,10 +441,15 @@ const INTEGRATION_VR_EVIDENCE_PATTERNS = [
 	/\*?-visual-regression\.yml/i,
 	/(?:lp|child-home|app)[\s-]*(?:visual|vr|pixelmatch|baseline)/i,
 	// 含有 PR 群が develop 取込時に SS 検証済である宣言
-	/含有\s*PR/,
 	/(?:取込|取り込み)\s*(?:済|時).*(?:SS|スクリーンショット|スクショ|検証)/,
-	/統合\s*(?:対象|状態|smoke)/,
+	/統合\s*smoke/,
 ];
+
+/** 含有 PR 一覧 section の見出し (統合 PR template と同値、`.github/INTEGRATION_PR_TEMPLATE.md`)。 */
+const INTEGRATION_PR_LIST_SECTION = '含有 PR 一覧';
+
+/** 含有 PR の行と認める形 (PR / Issue 番号を持つ行)。 */
+const PR_REFERENCE_PATTERN = /#\d{2,}/;
 
 /**
  * integration lane (統合 PR) の SS 観点 evidence が PR body に含まれるかを判定 (#2946)。
@@ -465,11 +462,26 @@ const INTEGRATION_VR_EVIDENCE_PATTERNS = [
  * 「観点の移譲」であって「検証の放棄」ではない (no-go: 見た目検証を完全に消さない) ため、
  * いずれの evidence も無い場合は違反として扱う (warn / error は MODE 依存)。
  *
+ * # なぜ行単位 + 構造判定なのか (#4348 対象 #4)
+ *
+ * 旧実装は本文全体に 6 本の正規表現を当てるだけで、うち `/含有\s*PR/` と
+ * `/統合\s*(?:対象|状態|smoke)/` は**統合 PR template 自身が 3 箇所で満たしていた**
+ * (説明文 1 / HTML コメント 1 / 引用 2 — 実測)。つまり **VR 証跡の有無に関係なく
+ * 統合 PR は常に緑**で、#4333 (見出しの存在だけで NG-0 が常に緑) と同じ形だった。
+ *
+ * 是正は 2 点:
+ *   1. 宣言の判定を行単位 + 文脈除外に揃える (`pr-body-sections.mjs` SSOT)
+ *   2. 「含有 PR」は prose の言及ではなく **`## 含有 PR 一覧` section に実際の PR 参照が
+ *      1 行以上ある**という構造で見る (見出しだけ / 自動生成待ちの空 section は evidence にしない)
+ *
  * @param {string} body
  * @returns {boolean}
  */
 export function hasIntegrationVrEvidence(body) {
-	return INTEGRATION_VR_EVIDENCE_PATTERNS.some((p) => p.test(body));
+	if (hasDeclarationLine(body, INTEGRATION_VR_EVIDENCE_PATTERNS)) return true;
+	const section = extractH2Section(body, INTEGRATION_PR_LIST_SECTION);
+	if (!section.found) return false;
+	return findDeclarationLines(section.text, [PR_REFERENCE_PATTERN]).length > 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -721,7 +733,10 @@ function checkDomSnapshotViolation(body) {
 			`\n背景:\n` +
 			`  PR #1717 で発生した「SS と実機が乖離していた」事故の再発防止のため、\n` +
 			`  SS と DOM が同一プロセス・同一 page で取得されたことを構造的に保証します（#1747 AC4）。\n` +
-			`\nDOM スナップショットを意図的に省略する場合は、--no-dom-snapshot 指定の理由を PR body に明記してください。`,
+			`\n本 gate に「理由を書けば省略できる」経路はありません (#4348)。\n` +
+			`  DOM 併記を省く逃げ道として --no-dom-snapshot の理由記述を案内していましたが、\n` +
+			`  それを読む判定は実装のどこにも無く、案内どおり書いても落ち続ける状態でした。\n` +
+			`  撮影に使う環境で原理的に描画できない UI なら ss-render-impossible 宣言 (#4087) を使ってください。`,
 	};
 }
 

--- a/scripts/check-schema-change-tests.mjs
+++ b/scripts/check-schema-change-tests.mjs
@@ -60,11 +60,16 @@ for (const arg of process.argv.slice(2)) {
 	}
 }
 
+/**
+ * @param {string[]} args
+ * @returns {string}
+ */
 function runGit(args) {
 	try {
 		return execFileSync('git', args, { encoding: 'utf8' });
 	} catch (err) {
-		console.error('[check-schema-change-tests] git command failed:', err.message);
+		const message = err instanceof Error ? err.message : String(err);
+		console.error('[check-schema-change-tests] git command failed:', message);
 		process.exit(2);
 	}
 }

--- a/scripts/check-schema-change-tests.mjs
+++ b/scripts/check-schema-change-tests.mjs
@@ -26,10 +26,28 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { escapeRegExp } from './lib/ci/escape-regexp.mjs';
+import { hasDeclarationLine } from './lib/ci/pr-body-sections.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF_DEFAULT = 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
-const SKIP_MARKER = '[skip-schema-test-check]';
+export const SKIP_MARKER = '[skip-schema-test-check]';
+
+/**
+ * PR body に skip marker が **宣言として** 書かれているか (#4348)。
+ *
+ * 旧実装は `PR_BODY.includes(SKIP_MARKER)` で、marker の文字列が本文のどこか
+ * (HTML コメント / code block の手順説明 / 引用 / 否定文 / 本 script の案内文の貼り戻し) に
+ * あるだけで **検査がまるごと消えた**。判定規律は他の PR body gate と同じ SSOT
+ * (`scripts/lib/ci/pr-body-sections.mjs`) に揃え、行単位 + 文脈除外で見る。
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasSkipMarker(body) {
+	return hasDeclarationLine(body, [new RegExp(escapeRegExp(SKIP_MARKER))]);
+}
 
 const SCHEMA_FILE = 'src/lib/server/db/schema.ts';
 const TEST_DIR_PREFIXES = ['tests/unit/db/', 'tests/unit/services/'];
@@ -60,7 +78,7 @@ function getChangedFiles() {
 }
 
 function main() {
-	if (PR_BODY.includes(SKIP_MARKER)) {
+	if (hasSkipMarker(PR_BODY)) {
 		console.log(`[check-schema-change-tests] ${SKIP_MARKER} marker found — skipping.`);
 		return;
 	}
@@ -105,4 +123,8 @@ function main() {
 	console.warn('');
 }
 
-main();
+// CLI として直接実行された場合のみ main() を起動 (test からの import 時は実行しない)。
+// 判定は scripts/lib/is-main.mjs (SSOT、#3969) に委譲する。
+if (isMainModule(import.meta.url)) {
+	main();
+}

--- a/scripts/check-schema-migration-completeness.mjs
+++ b/scripts/check-schema-migration-completeness.mjs
@@ -58,11 +58,28 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { escapeRegExp } from './lib/ci/escape-regexp.mjs';
+import { hasDeclarationLine } from './lib/ci/pr-body-sections.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF_DEFAULT = 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
-const SKIP_MARKER = '[skip-schema-migration-check]';
+export const SKIP_MARKER = '[skip-schema-migration-check]';
+
+/**
+ * PR body に skip marker が **宣言として** 書かれているか (#4348)。
+ *
+ * 旧実装は `PR_BODY.includes(SKIP_MARKER)` で、marker の文字列が本文のどこか
+ * (HTML コメント / code block の手順説明 / 引用 / 否定文 / 本 script の案内文の貼り戻し) に
+ * あるだけで **検査がまるごと消えた**。判定規律は他の PR body gate と同じ SSOT
+ * (`scripts/lib/ci/pr-body-sections.mjs`) に揃え、行単位 + 文脈除外で見る。
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasSkipMarker(body) {
+	return hasDeclarationLine(body, [new RegExp(escapeRegExp(SKIP_MARKER))]);
+}
 
 const SCHEMA_FILE = 'src/lib/server/db/schema.ts';
 const LAZY_MIGRATION_FILE = 'src/lib/server/db/migration/lazy-startup-migrations.ts';
@@ -376,7 +393,7 @@ export function detectBreakingChanges(diff, options = {}) {
 }
 
 function main() {
-	if (PR_BODY.includes(SKIP_MARKER)) {
+	if (hasSkipMarker(PR_BODY)) {
 		console.log(`[check-schema-migration-completeness] ${SKIP_MARKER} marker found — skipping.`);
 		return;
 	}

--- a/scripts/lib/ci/pr-body-sections.mjs
+++ b/scripts/lib/ci/pr-body-sections.mjs
@@ -137,3 +137,77 @@ export function extractH2Section(body, heading, options = {}) {
 export function hasH2Section(body, heading) {
 	return extractH2Section(body, heading).found;
 }
+
+// ---------------------------------------------------------------------------
+// 宣言 (declaration) の判定 — 「その行が宣言か」を見る (#4255 → #4348 で共有化)
+//
+// gate を skip / pass に倒す marker (「UI 変更なし」「[skip-schema-test-check]」等) や
+// evidence 参照 (`.dom.html` リンク / VR 層への紐づけ) を **本文全体への 1 本の正規表現**で
+// 判定すると、以下が全部「書いてある」ことになる:
+//
+//   - HTML コメント (template の説明文。顧客にも監査にも見えない)
+//   - fenced code block / インラインコード (書式の例示)
+//   - 引用行 (他所の文言を貼っただけ)
+//   - 否定文 (「〜ではありません」— 文意と逆に判定される)
+//   - 未チェック checkbox (チェックしていない = 宣言していない)
+//   - 手順・案内文 (「〜と書いてください」— gate 自身のエラー出力を貼り戻すと成立する)
+//
+// 判定できないときは **宣言なし**に倒す (「確認できなかった」を「確認した」と同じ扱いにしない)。
+// ---------------------------------------------------------------------------
+
+/**
+ * 同じ行に現れたら **宣言ではない** と判断する文脈 (#4255 で `check-pr-screenshot.mjs` に
+ * 置いたものを #4348 で共有化)。
+ */
+export const DECLARATION_DISQUALIFYING_PATTERNS = [
+	/^\s*>/, // 引用 — 他所の文言を貼っただけ
+	/^\s*[-*]\s*\[\s\]/, // 未チェック checkbox — チェックしていない = 宣言していない
+	// 否定 (#4255 の実績セットを変えない)。
+	// 「していない」等の一般的な否定動詞は足さない — 「UI 変更なし (コードを 1 行も変更して
+	// いないため)」のような**正しい宣言**を落とす (merged PR #4464 で実測)。
+	/ではありません|ではない|ではなく|とは限らない|とは言えない/,
+	/嘘|虚偽/, // gate 自身の説明文の引用
+	/なしの場合|の場合は|場合:|と書く|と明記|を含めて|してください/, // 手順書の条件節 / 案内文
+];
+
+/**
+ * PR body から「宣言として成立している行」を拾う。
+ *
+ * @param {string} body PR 本文
+ * @param {RegExp[]} patterns 宣言とみなすパターン (行に対して `test` する)
+ * @param {{ extraDisqualifying?: RegExp[] }} [options]
+ * @returns {string[]} 宣言として成立した行 (前後の空白を落としたもの)
+ */
+export function findDeclarationLines(body, patterns, options = {}) {
+	const disqualifying = [
+		...DECLARATION_DISQUALIFYING_PATTERNS,
+		...(options.extraDisqualifying ?? []),
+	];
+	/** @type {string[]} */
+	const found = [];
+	let inFence = false;
+	for (const raw of stripHtmlComments((body ?? '').replace(/\r\n?/g, '\n')).split('\n')) {
+		if (/^\s*(?:```|~~~)/.test(raw)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
+		// インラインコード (`...`) は言及であって宣言ではない
+		const line = raw.replace(/`[^`]*`/g, ' ');
+		if (disqualifying.some((p) => p.test(line))) continue;
+		if (patterns.some((p) => p.test(line))) found.push(line.trim());
+	}
+	return found;
+}
+
+/**
+ * PR body に「宣言として成立している行」が 1 行でもあるか。
+ *
+ * @param {string} body
+ * @param {RegExp[]} patterns
+ * @param {{ extraDisqualifying?: RegExp[] }} [options]
+ * @returns {boolean}
+ */
+export function hasDeclarationLine(body, patterns, options = {}) {
+	return findDeclarationLines(body, patterns, options).length > 0;
+}

--- a/src/routes/CLAUDE.md
+++ b/src/routes/CLAUDE.md
@@ -115,7 +115,16 @@ node scripts/capture.mjs --pr <N>            # 修正後 SS を撮り直す
 
 - 否定文（「UI 変更なし**ではありません**」）/ 引用行（`> …`）/ コードブロック・インラインコード内
 - **未チェックの checkbox**（`- [ ] UI 変更なし`）— チェックしていない = 宣言していない
-- 手順・条件節（「UI 変更なし**の場合**: …」）
+- 手順・条件節（「UI 変更なし**の場合**: …」）/ 案内文（「〜と書いてください」）
+- **HTML コメント内**（`<!-- UI 変更なし -->`）— レンダリングされた PR body に出ないため、レビュアーにも監査にも見えない（#4348）。宣言は**本文に見える形で**書く
+
+この判定規律（行単位 + HTML コメント / コードブロック / 引用 / 否定 / 未チェック checkbox / 案内文の除外）は `scripts/lib/ci/pr-body-sections.mjs` が SSOT で、**PR body を読む他の gate も同じ規律を使う**（#4348）:
+
+| 判定 | 対象 |
+|---|---|
+| `.dom.html` 参照の有無 | DOM スナップショット併記検証（`check-pr-screenshot.mjs`） |
+| 統合 PR の VR 証跡 | 統合 lane の SS 観点。加えて「含有 PR」は prose の言及ではなく **`## 含有 PR 一覧` に実際の PR 参照がある**ことで判定する |
+| `[skip-schema-test-check]` / `[skip-schema-migration-check]` | schema 系 gate の skip marker |
 
 **テンプレートや案内文に opt-out 宣言そのものを書かない。** テンプレートを消さずに出しただけで gate が skip されるため、案内は「何を書くか」の説明にとどめる（`tests/unit/scripts/check-pr-screenshot.test.ts` が実テンプレートを読んで検証している）。
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -329,7 +329,7 @@ it('is_archived が NULL の既存行もアクティブとして返される', (
 
 「NULL = 既定値扱い」セマンティクスなら `or(eq(col, default), isNull(col))` または **マイグレーションで backfill**。片側だけは不十分。
 
-CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.ts` diff があるのに `tests/unit/db/` または `tests/unit/services/` diff が無い場合警告。skip 必要時は PR 本文に `[skip-schema-test-check]`。
+CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.ts` diff があるのに `tests/unit/db/` または `tests/unit/services/` diff が無い場合警告。skip 必要時は PR 本文に `[skip-schema-test-check]` を**宣言として**書く (HTML コメント / コードブロック / 引用 / 未チェック checkbox / 案内文の中の同じ文字列では skip しない、#4348)。
 
 ### backend 並行実装の整合性
 

--- a/tests/unit/architecture/pr-body-partial-match-guard.test.ts
+++ b/tests/unit/architecture/pr-body-partial-match-guard.test.ts
@@ -28,8 +28,16 @@ vi.setConfig({ testTimeout: 60_000 });
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SCAN_DIR = resolve(REPO_ROOT, 'scripts');
 
-/** PR body を指す変数名 (これらに対する部分一致判定を検出対象にする)。 */
-const BODY_IDENT = String.raw`(?:[A-Za-z_$][\w$]*)?[Bb]ody`;
+/**
+ * PR body を指す変数名 (これらに対する部分一致判定を検出対象にする)。
+ *
+ * **大文字の `PR_BODY` も含める (#4348 で追加)**。旧実装は `[Bb]ody` しか見ておらず、
+ * env 由来の定数名 `PR_BODY` に対する `.includes(...)` が検出器から漏れていた。
+ * 実際に schema 系 gate 2 本が `PR_BODY.includes(SKIP_MARKER)` で **gate 全体を skip** しており、
+ * 「本 Issue の対象一覧にも ALLOWLIST にも載らない同 class」が残っていた。
+ * 検出できない形を残すと guard 自体が「検査できなかったのに緑」になる (#4084 と同じ穴)。
+ */
+const BODY_IDENT = String.raw`(?:[A-Za-z_$][\w$]*)?(?:[Bb]ody|BODY)`;
 
 /** `<body>.indexOf(` / `<body>.includes(` — 部分一致で section / 宣言を探す形。 */
 const SUBSTRING_RE = new RegExp(String.raw`\b(${BODY_IDENT})\s*\.\s*(indexOf|includes)\s*\(`, 'g');
@@ -49,11 +57,6 @@ const ALLOWLIST: Record<string, string> = {
 		'#4348 残置 (対象 #6): feature lane の AC マップ section 探索。全 feature PR に波及するため別 PR で corpus 比較のうえ是正する',
 	'scripts/check-admin-bypass-evidence.mjs::return EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body));':
 		'#4348 残置 (対象 #3): admin bypass 証跡マーカーの存在検査。nightly 監査 script で PR gate とは別経路のため別 PR で是正する',
-	'scripts/check-pr-screenshot.mjs::return DOM_REF_PATTERN.test(body);':
-		'#4348 残置 (対象 #4): DOM スナップショット参照の存在検査。#4255 の兄弟関数と同様に実在検査へ寄せる別 PR で是正する',
-	'scripts/check-pr-screenshot.mjs::return INTEGRATION_VR_EVIDENCE_PATTERNS.some((p) => p.test(body));':
-		'#4348 残置 (対象 #4): 統合 PR の VR 証跡の存在検査。同上',
-
 	// --- 構造化識別子ではなく prose (自然文) を探す用途。本文全体を見るのが正しい ---
 	'scripts/check-pr-screenshot.mjs::hasBefore: BEFORE_LABEL_PATTERN.test(body),':
 		'prose 検査: 「修正前」ラベルの表記ゆれを本文から探す用途で、見出し等の構造化識別子ではない',

--- a/tests/unit/architecture/pr-body-partial-match-guard.test.ts
+++ b/tests/unit/architecture/pr-body-partial-match-guard.test.ts
@@ -52,11 +52,11 @@ const WHOLE_BODY_TEST_RE = new RegExp(String.raw`\.test\(\s*(${BODY_IDENT})\s*\)
  * 「この判定を触ったならもう一度理由を書け」という強制になる。
  */
 const ALLOWLIST: Record<string, string> = {
-	// --- #4348 で是正しなかった残置 (Issue #4348 に残件として記録、1 箇所ずつ corpus 比較して消化) ---
-	"scripts/check-ac-verification-map.mjs::const mapHeaderIdx = body.indexOf('AC 検証マップ');":
-		'#4348 残置 (対象 #6): feature lane の AC マップ section 探索。全 feature PR に波及するため別 PR で corpus 比較のうえ是正する',
-	'scripts/check-admin-bypass-evidence.mjs::return EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body));':
-		'#4348 残置 (対象 #3): admin bypass 証跡マーカーの存在検査。nightly 監査 script で PR gate とは別経路のため別 PR で是正する',
+	// #4348 の対象 6 箇所は全て消化済 (残置エントリなし)。
+	//   対象 #6 は **判定関数ごと削除**した — #4305 で PR テンプレートから `## AC 検証マップ` 節が
+	//   消え entry からも外れており、呼び出しが自身の test だけの死んだコードだったため、
+	//   厳格化ではなく削除が正しい対処だった (経緯は check-ac-verification-map.mjs の entry コメント)。
+	//   対象 #3 (admin bypass 証跡 marker) は `hasDeclarationLine` へ移行済。
 	// --- 構造化識別子ではなく prose (自然文) を探す用途。本文全体を見るのが正しい ---
 	'scripts/check-pr-screenshot.mjs::hasBefore: BEFORE_LABEL_PATTERN.test(body),':
 		'prose 検査: 「修正前」ラベルの表記ゆれを本文から探す用途で、見出し等の構造化識別子ではない',

--- a/tests/unit/scripts/check-ac-verification-map.test.ts
+++ b/tests/unit/scripts/check-ac-verification-map.test.ts
@@ -1,12 +1,14 @@
 // Issue #2945 (Phase A/A-3、親 #2942) AC3/AC4: lane-aware AC 検証マップ judge の unit test。
-// feature/hotfix lane = 現行 AC マップ観点 (回帰ゼロ)、integration lane = マージ判定エビデンス表観点。
+// integration lane = マージ判定エビデンス表観点。
+// feature / hotfix lane は #4305 で AC マップ検証そのものが撤去され、entry は無条件 PASS を返す
+// (判定関数の残骸は #4348 で削除。下部の class-lock がその状態を固定する)。
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import * as acModule from '../../../scripts/check-ac-verification-map.mjs';
 import {
 	checkAcVerification,
 	checkIntegrationEvidenceTable,
-	checkPerPrAcMap,
 	extractH2Section,
 	INTEGRATION_EVIDENCE_SECTION,
 	NG_DECLARATION_SECTION,
@@ -35,109 +37,6 @@ const FEATURE_AC_MAP_EMPTY_CELL = `
 | AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
 |---|---|---|---|
 | AC1 | ログイン後 | \`vitest\` |  |
-`;
-
-// js/bad-tag-filter (#3021 CodeQL): `--!>` 終端のコメントは旧 regex `/^<!--.*-->$/` が
-// 検出できず空欄プレースホルダのまま gate を通過した。robust 化後は空欄扱いで検出される。
-const FEATURE_AC_MAP_COMMENT_EVASION = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | <!-- まだ書いてない --!> |
-`;
-
-const FEATURE_AC_MAP_TODO = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | 別途追加予定 |
-`;
-
-// #3488: ファイル名 slug の "followup"（区切り無し）は完了済エビデンス参照のトークンであり、
-// 未完了マーカー "follow-up" / "follow up"（区切り 1 文字必須）とは別物。
-// `follow[\s-]up`（区切り必須）にすることで slug を誤検出しない（false-positive 回帰防止）。
-// 拡張子 whitelist の strip 前処理は脆い（収録外拡張子で FP / 密着未完了語で bypass）ため撤去し、
-// 生 cell に直接 pattern を当てる方針（#3488 定方針）。
-const FEATURE_AC_MAP_FILENAME_FOLLOWUP = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC5 | research SSOT を docs/research に保存 | grep | HEAD \`f183e397a\` / docs/research/2026-06-29-followup-treadmill-root-cause.md |
-`;
-
-// #3488: 旧 strip の収録外拡張子で FP 再発していたケース（.sql / .pdf）も、slug "followup"（区切り無し）
-// なので新 pattern では PASS する（strip 不要で FP 回避）。
-const FEATURE_AC_MAP_SLUG_FOLLOWUP_VARIANTS = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | schema 反映 | drizzle | migrations/schema-followup.sql 適用済 |
-| AC2 | 図版 | review | docs/followup.pdf レビュー済 |
-`;
-
-// #3488: 未完了マーカーは区切り 1 文字（空白 or ハイフン）を必ず持つため検出継続する。
-// prose（inline-code 外）の `/` 隣接 / 日本語連続トークンは生 cell に当たる
-// （#3846 で inline-code 内のみ strip 対象になったが、prose 検出は不変）。
-const FEATURE_AC_MAP_TODO_FOLLOWUP_SPACE = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | 別途 follow-up で対応 |
-`;
-
-const FEATURE_AC_MAP_TODO_FILENAME_SCHEDULED = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | 対応予定.md を参照 |
-`;
-
-const FEATURE_AC_MAP_TODO_JP_TOKEN = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | 後で対応する予定 |
-`;
-
-const FEATURE_AC_MAP_MISSING_SECTION = `
-## 概要
-AC マップ section が無い PR
-`;
-
-// #3846 / #3844 BLOCK fix: inline-code (`...`) 内の定数名 \`RANGE_SSOT_TODO\` が
-// TODO_PATTERN の \`todo\` に部分一致して false-positive gate fail していた。
-// inline-code は機械トークン（定数名 / コマンド / ファイル参照）であり未完了宣言の prose ではない。
-const FEATURE_AC_MAP_INLINE_CODE_CONSTANT = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC2 | 値域定数 SSOT 化 | grep | HEAD \`abc1234\` / \`RANGE_SSOT_TODO\` を domain 層へ集約 (src/lib/domain/range.ts:12) |
-`;
-
-// #3846: inline-code 内にコマンド由来の "todo" / "予定" 相当トークンがあっても PASS する。
-const FEATURE_AC_MAP_INLINE_CODE_COMMAND = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | todo list 機能の unit 検証 | vitest | \`npx vitest run tests/unit/todo-list.test.ts\` 12 passed |
-`;
-
-// #3846: inline-code strip 後も prose 側の未完了表記は従来どおり検出する（strip し過ぎ防止）。
-const FEATURE_AC_MAP_INLINE_CODE_PLUS_PROSE_TODO = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | vitest | \`RANGE_SSOT_TODO\` は集約済、残りは後で対応 |
 `;
 
 // #4333: 残 NG 件数の宣言は `## NG 0 件 / カバレッジ宣言` section 内でのみ読む。
@@ -224,94 +123,6 @@ const INTEGRATION_EVIDENCE_NO_ROWS = `
 
 （表をまだ埋めていない）
 ${NG_ZERO_SECTION}`;
-
-// --- feature / hotfix lane (AC4 回帰ゼロ) ---
-
-describe('checkPerPrAcMap (feature/hotfix lane、AC4)', () => {
-	it('PASS: 4 列全行が埋まっている', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_PASS, 'feature');
-		expect(r.ok).toBe(true);
-		expect(r.lane).toBe('feature');
-	});
-
-	it('FAIL: AC マップ section が無い', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_MISSING_SECTION, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('AC 検証マップ');
-	});
-
-	it('FAIL: 空欄セルがある', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_EMPTY_CELL, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('空欄');
-	});
-
-	it('FAIL: `--!>` 終端のコメントプレースホルダも空欄扱い (js/bad-tag-filter, #3021)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_COMMENT_EVASION, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('空欄');
-	});
-
-	it('FAIL: 4 列目に未完了表記 (#1539)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_TODO, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-
-	it('PASS: filename 中の "followup"（区切り無し slug）を未完了表記と誤検出しない (#3488)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_FILENAME_FOLLOWUP, 'feature');
-		expect(r.ok).toBe(true);
-	});
-
-	// #3488: 旧 strip の収録外拡張子 FP（.sql / .pdf）も slug followup なので新 pattern で PASS。
-	it('PASS: schema-followup.sql / docs/followup.pdf を誤検出しない (#3488 FP 回避)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_SLUG_FOLLOWUP_VARIANTS, 'feature');
-		expect(r.ok).toBe(true);
-	});
-
-	// #3488: 区切り 1 文字を持つ未完了マーカーは検出継続する（strip 全廃で生 cell に当たる）。
-	it('FAIL: "follow-up" / "follow up"（区切りあり）は検出 (#3488)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_TODO_FOLLOWUP_SPACE, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-
-	it('FAIL: "対応予定.md" の "予定" を検出（strip 全廃で生 cell 検出、#3488）', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_TODO_FILENAME_SCHEDULED, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-
-	it('FAIL: 未完了マーカーを日本語連続トークンに置いても検出 (#3488)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_TODO_JP_TOKEN, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-
-	it('hotfix lane も同観点 (PASS)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_PASS, 'hotfix');
-		expect(r.ok).toBe(true);
-		expect(r.lane).toBe('hotfix');
-	});
-
-	// --- #3846 / #3844: evidence cell の inline-code strip (定数名 false-positive 解消) ---
-
-	it('PASS: inline-code 内の定数名 `RANGE_SSOT_TODO` を未完了表記と誤検出しない (#3846 / #3844)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_CONSTANT, 'feature');
-		expect(r.ok).toBe(true);
-	});
-
-	it('PASS: inline-code 内のコマンド (`npx vitest run tests/unit/todo-list.test.ts`) を誤検出しない (#3846)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_COMMAND, 'feature');
-		expect(r.ok).toBe(true);
-	});
-
-	it('FAIL: inline-code strip 後も prose 側の未完了表記 (「後で対応」) は検出継続 (#3846 strip し過ぎ防止)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_PLUS_PROSE_TODO, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-});
 
 // --- integration lane (AC3) ---
 
@@ -615,5 +426,31 @@ describe('checkAcVerification (lane エントリ、AC3/AC4)', () => {
 		});
 		expect(r.ok).toBe(true);
 		expect(r.reason).toContain('removed');
+	});
+});
+
+// --- #4348 対象 #6: 誰も呼ばない判定関数を置き去りにしない (class-lock) ---
+
+describe('#4348 feature lane の per-PR AC マップ判定は存在しない（呼ばれない判定を残さない）', () => {
+	// 背景: #4305 が PR テンプレートから `## AC 検証マップ` 節を撤去し、entry も feature /
+	// hotfix lane を無条件 PASS に変えた。しかし判定関数 `checkPerPrAcMap` は残り、
+	// **唯一の呼び出しが本 test file だけ**という状態で改修 (#3488 / #3846) を受け続けた。
+	// 「検査しているように見えて誰も呼んでいない」状態を再生産させないための固定。
+	//
+	// 再導入するなら判定関数だけでは足りない — テンプレート節 / PR_TEMPLATE_SECTIONS.json /
+	// entry の分岐 / workflow 配線をセットで戻し、本 test も同時に更新すること。
+	it('checkPerPrAcMap は export されていない', () => {
+		expect(Object.keys(acModule)).not.toContain('checkPerPrAcMap');
+	});
+
+	it('entry は feature / hotfix lane で body を一切見ずに PASS を返す', () => {
+		for (const lane of ['feature', 'hotfix'] as const) {
+			const empty = checkAcVerification({ body: '', labels: [], lane });
+			const filled = checkAcVerification({ body: FEATURE_AC_MAP_PASS, labels: [], lane });
+			const broken = checkAcVerification({ body: FEATURE_AC_MAP_EMPTY_CELL, labels: [], lane });
+			expect([empty.ok, filled.ok, broken.ok]).toEqual([true, true, true]);
+			expect(empty.reason).toBe(filled.reason);
+			expect(empty.reason).toBe(broken.reason);
+		}
 	});
 });

--- a/tests/unit/scripts/check-admin-bypass-evidence.test.ts
+++ b/tests/unit/scripts/check-admin-bypass-evidence.test.ts
@@ -1,0 +1,90 @@
+/**
+ * tests/unit/scripts/check-admin-bypass-evidence.test.ts (#4348 対象 #3)
+ *
+ * admin bypass merge の Self-Review 証跡検出 (ADR-0044 / #1201) の判定 test。
+ *
+ * ## 何を守るか
+ *
+ * 旧実装は `EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body))` で本文全体を見ていた。
+ * `^##` の行頭アンカーはあるが、**HTML コメント / fenced code block の中の見出し**を
+ * 区別できない。本 script 自身が投稿する追記依頼コメントは証跡テンプレートを
+ * ```markdown fence で囲んで提示するため、**bot コメントを PR 本文に貼り戻すだけで
+ * 「証跡あり」**になり、証跡を 1 文字も書かずに追跡から外れられた。
+ *
+ * 判定規律は他の PR body gate と同じ SSOT (`scripts/lib/ci/pr-body-sections.mjs`) に揃える。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	EVIDENCE_MARKER_PATTERNS,
+	hasEvidenceSection,
+} from '../../../scripts/check-admin-bypass-evidence.mjs';
+
+/** bot (`postMissingEvidenceComment`) が投稿する追記依頼コメントの実物と同型。 */
+const BOT_COMMENT_PASTED_INTO_BODY = [
+	'<!-- admin-bypass-evidence-check -->',
+	'## 🔍 admin bypass merge — Self-Review 証跡の追記依頼 (ADR-0044)',
+	'',
+	'以下のテンプレートを PR 本文末尾に追記してください（事後追記で構いません）:',
+	'',
+	'```markdown',
+	'## Self-Review 証跡 (admin bypass)',
+	'',
+	'### 確認した観点',
+	'- [ ] Issue AC 全項目突合',
+	'```',
+].join('\n');
+
+const REAL_EVIDENCE = [
+	'## 変更内容',
+	'',
+	'admin bypass で merge したため証跡を残す。',
+	'',
+	'## Self-Review 証跡 (admin bypass)',
+	'',
+	'### 確認した観点',
+	'- [x] Issue AC 全項目突合 — `npx vitest run tests/unit/` 全 PASS',
+].join('\n');
+
+describe('hasEvidenceSection — 証跡セクションは「宣言」として書かれていることを要求する', () => {
+	it('本文に見出しとして書かれていれば証跡ありと判定する', () => {
+		expect(hasEvidenceSection(REAL_EVIDENCE)).toBe(true);
+	});
+
+	it('別表記 `## Self-Review (admin bypass)` も証跡ありと判定する', () => {
+		expect(hasEvidenceSection('## Self-Review (admin bypass)\n\n- [x] AC 突合')).toBe(true);
+	});
+
+	it('bot の追記依頼コメントを本文に貼り戻しただけでは証跡と認めない', () => {
+		// 旧実装ではここが true になり、証跡を書かずに追跡から外れられた。
+		expect(hasEvidenceSection(BOT_COMMENT_PASTED_INTO_BODY)).toBe(false);
+	});
+
+	it('HTML コメント内の見出しは証跡と認めない（レンダリング後の本文に出ない）', () => {
+		const body = ['## 変更内容', '<!--', '## Self-Review 証跡', '-->'].join('\n');
+		expect(hasEvidenceSection(body)).toBe(false);
+	});
+
+	it('code fence 内の見出し（書式の例示）は証跡と認めない', () => {
+		const body = ['## 変更内容', '', '```markdown', '## Self-Review 証跡', '```'].join('\n');
+		expect(hasEvidenceSection(body)).toBe(false);
+	});
+
+	it('body が空 / null なら証跡なし', () => {
+		expect(hasEvidenceSection('')).toBe(false);
+		expect(hasEvidenceSection(null)).toBe(false);
+	});
+
+	it('marker パターンは 2 種類（表記ゆれ）を維持する', () => {
+		expect(EVIDENCE_MARKER_PATTERNS).toHaveLength(2);
+	});
+});
+
+describe('import しても process が落ちない（判定を test から呼べる）', () => {
+	// 旧実装は module top-level で `REPO` 未設定なら `process.exit(2)` していたため、
+	// import した時点で vitest ごと落ちて判定の回帰を固定できなかった。
+	it('REPO 未設定でも import 済みの判定関数が呼べる', () => {
+		expect(process.env.REPO).toBeUndefined();
+		expect(typeof hasEvidenceSection).toBe('function');
+	});
+});

--- a/tests/unit/scripts/check-pr-screenshot.test.ts
+++ b/tests/unit/scripts/check-pr-screenshot.test.ts
@@ -139,6 +139,13 @@ describe('hasUiNotApplicableMarker', () => {
 			expect(hasUiNotApplicableMarker('判定は `UI 変更なし` の有無で行う')).toBe(false);
 		});
 
+		// #4348: HTML コメントは顧客にも監査にも見えないので宣言ではない
+		// (コメント除去は他の PR body gate と同じ規律に揃えた)。
+		it('HTML コメント内の記述は宣言として扱わない', () => {
+			expect(hasUiNotApplicableMarker('<!-- UI 変更なし の場合はここに書く -->')).toBe(false);
+			expect(hasUiNotApplicableMarker('<!-- 該当なし（refactor / docs / chore） -->')).toBe(false);
+		});
+
 		it('**未チェックの checkbox は宣言として扱わない**（チェックしていない = 宣言していない）', () => {
 			expect(hasUiNotApplicableMarker('- [ ] UI 変更なし')).toBe(false);
 			expect(hasUiNotApplicableMarker('- [x] UI 変更なし')).toBe(true);
@@ -317,6 +324,46 @@ describe('hasDomSnapshotReference (#1766 / #1747 AC4)', () => {
 		// URL ではなく説明文中の言及なので検出されない
 		expect(hasDomSnapshotReference(body)).toBe(false);
 	});
+
+	// #4348 (対象 #4): 本文全体への 1 本の正規表現をやめ、行単位 + 文脈除外に揃える。
+	// 「参照がある」と判定されると DOM 併記検証がまるごと消えるため、
+	// **書いていない参照を書いたことにされる**経路を塞ぐ (#4255 / hasUiNotApplicableMarker と同型)。
+	describe('行単位 + 文脈除外 (#4348 対象 #4)', () => {
+		it('HTML コメント内の .dom.html URL は参照として扱わない', () => {
+			const body =
+				'![after](https://example.com/a.png)\n<!-- [DOM HTML](https://x/foo.dom.html) -->';
+			expect(hasDomSnapshotReference(body)).toBe(false);
+		});
+
+		it('コードブロック内の .dom.html URL は参照として扱わない', () => {
+			const body = ['```md', '[DOM HTML](https://example.com/foo.dom.html)', '```'].join('\n');
+			expect(hasDomSnapshotReference(body)).toBe(false);
+		});
+
+		it('インラインコード内の .dom.html URL は参照として扱わない（書式の説明）', () => {
+			expect(hasDomSnapshotReference('書式: `[DOM HTML](https://example.com/x.dom.html)`')).toBe(
+				false,
+			);
+		});
+
+		it('引用行 / 否定文の .dom.html URL は参照として扱わない', () => {
+			expect(hasDomSnapshotReference('> [DOM](https://example.com/foo.dom.html) を貼ること')).toBe(
+				false,
+			);
+			expect(
+				hasDomSnapshotReference('https://example.com/foo.dom.html は撮れていないため添付ではない'),
+			).toBe(false);
+		});
+
+		it('未チェック checkbox 行の .dom.html URL は参照として扱わない', () => {
+			expect(hasDomSnapshotReference('- [ ] [DOM HTML](https://example.com/foo.dom.html)')).toBe(
+				false,
+			);
+			expect(hasDomSnapshotReference('- [x] [DOM HTML](https://example.com/foo.dom.html)')).toBe(
+				true,
+			);
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -492,10 +539,9 @@ describe('hasIntegrationVrEvidence (#2946 — integration lane SS 観点)', () =
 		expect(hasIntegrationVrEvidence('app pixelmatch baseline 比較で回帰未検出。')).toBe(true);
 	});
 
-	it('含有 PR への言及があれば true', () => {
-		expect(
-			hasIntegrationVrEvidence('含有 PR: #3001 / #3002 / #3003 (いずれも develop 取込済み)。'),
-		).toBe(true);
+	it('`## 含有 PR 一覧` section に含有 PR の行があれば true', () => {
+		const body = ['## 含有 PR 一覧', '', '- #3001 活動追加', '- #3002 ごほうび修正'].join('\n');
+		expect(hasIntegrationVrEvidence(body)).toBe(true);
 	});
 
 	it('取込時 SS 検証済の宣言があれば true', () => {
@@ -503,11 +549,39 @@ describe('hasIntegrationVrEvidence (#2946 — integration lane SS 観点)', () =
 		expect(hasIntegrationVrEvidence('含有 PR は取込済で個別に SS 検証されている。')).toBe(true);
 	});
 
-	it('統合対象 / 統合状態 / 統合 smoke への言及があれば true', () => {
-		expect(hasIntegrationVrEvidence('本 PR は統合対象 PR 群を束ねる develop→main 統合 PR。')).toBe(
-			true,
-		);
+	it('統合 smoke への言及があれば true', () => {
 		expect(hasIntegrationVrEvidence('統合 smoke を実行し問題なし。')).toBe(true);
+	});
+
+	// #4348 (対象 #4): 旧実装は本文全体に 6 本の正規表現を当てるだけで、
+	// 「含有 PR」「統合対象」の 4 文字が本文のどこか (説明文 / HTML コメント / 引用) にあれば
+	// 緑になっていた。統合 PR template はその 4 文字を 3 通りで含むため、
+	// **統合 PR は VR 証跡の有無に関係なく常に緑**だった (#4333 と同じ形)。
+	describe('行単位 + 構造判定 (#4348 対象 #4)', () => {
+		it('PR を束ねる自己紹介文だけでは false (evidence ではない)', () => {
+			expect(
+				hasIntegrationVrEvidence('本 PR は統合対象 PR 群を束ねる develop→main 統合 PR。'),
+			).toBe(false);
+			expect(hasIntegrationVrEvidence('含有 PR 一覧は B-3 が自動生成します。')).toBe(false);
+		});
+
+		it('HTML コメント / 引用 / 否定文の言及は evidence として扱わない', () => {
+			expect(hasIntegrationVrEvidence('<!-- visual regression の結果をここに書く -->')).toBe(false);
+			expect(hasIntegrationVrEvidence('> visual regression の結果を貼ること')).toBe(false);
+			expect(hasIntegrationVrEvidence('本 PR は visual regression の対象ではない')).toBe(false);
+		});
+
+		it('`## 含有 PR 一覧` が空 (見出しだけ) なら false', () => {
+			expect(hasIntegrationVrEvidence('## 含有 PR 一覧\n\n<!-- B-3 が自動生成 -->')).toBe(false);
+		});
+
+		// 生成側 assert: 統合 PR template を素で出しただけで evidence 成立させない (#4348 AC7)。
+		it('統合 PR テンプレートを素で生成した body は evidence を成立させない', () => {
+			expect(
+				hasIntegrationVrEvidence(readFileSync('.github/INTEGRATION_PR_TEMPLATE.md', 'utf8')),
+				'template を貼るだけで統合 PR の SS 観点検証が緑になる',
+			).toBe(false);
+		});
 	});
 
 	it('generic な本文 (VR 言及 / 含有 PR / 取込検証なし) なら false', () => {

--- a/tests/unit/scripts/check-schema-skip-marker.test.ts
+++ b/tests/unit/scripts/check-schema-skip-marker.test.ts
@@ -1,0 +1,71 @@
+/**
+ * tests/unit/scripts/check-schema-skip-marker.test.ts (#4348)
+ *
+ * schema 系 gate 2 本の **skip marker 判定**の unit test。
+ *
+ * この 2 本は marker を `PR_BODY.includes('[skip-...]')` で見ており、
+ * marker 文字列が本文のどこか (HTML コメント / 引用 / 否定文 / gate 自身のエラー出力の貼り付け /
+ * コードブロック内の手順説明) にあるだけで **gate がまるごと skip** されていた。
+ * #4348 の対象一覧には無かったが、`.includes` を大文字 `PR_BODY` に対して行うため
+ * fitness function の検出器 (`pr-body-partial-match-guard.test.ts`) からも見えていなかった。
+ *
+ * skip は「宣言」であって「言及」ではない。判定は行単位で、他の PR body gate と同じ規律
+ * (`scripts/lib/ci/pr-body-sections.mjs` の `hasDeclarationLine`) に揃える。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	hasSkipMarker as hasTestCheckSkipMarker,
+	SKIP_MARKER as TEST_CHECK_MARKER,
+} from '../../../scripts/check-schema-change-tests.mjs';
+import {
+	hasSkipMarker as hasMigrationSkipMarker,
+	SKIP_MARKER as MIGRATION_MARKER,
+} from '../../../scripts/check-schema-migration-completeness.mjs';
+
+const CASES = [
+	{ name: 'check-schema-change-tests', marker: TEST_CHECK_MARKER, has: hasTestCheckSkipMarker },
+	{
+		name: 'check-schema-migration-completeness',
+		marker: MIGRATION_MARKER,
+		has: hasMigrationSkipMarker,
+	},
+] as const;
+
+for (const { name, marker, has } of CASES) {
+	describe(`${name}: skip marker は宣言としてのみ成立する (#4348)`, () => {
+		it('本文に単独で書かれた marker は skip する (既存挙動)', () => {
+			expect(has(`純フォーマット変更のみ。${marker}`)).toBe(true);
+		});
+
+		it('marker が無ければ skip しない', () => {
+			expect(has('schema.ts に列を追加しました。')).toBe(false);
+			expect(has('')).toBe(false);
+		});
+
+		it('HTML コメント内の marker では skip しない (顧客にも監査にも見えない)', () => {
+			expect(has(`<!-- skip したいときは ${marker} と書く -->`)).toBe(false);
+		});
+
+		it('コードブロック / インラインコード内の marker では skip しない (手順の引用)', () => {
+			expect(has(['```', `PR 本文に ${marker} を含める`, '```'].join('\n'))).toBe(false);
+			expect(has(`skip 方法は \`${marker}\` です`)).toBe(false);
+		});
+
+		it('引用行 / 否定文 / 未チェック checkbox の marker では skip しない', () => {
+			expect(has(`> ${marker} を書けば skip されます`)).toBe(false);
+			expect(has(`本 PR は ${marker} ではありません`)).toBe(false);
+			expect(has(`- [ ] ${marker}`)).toBe(false);
+			expect(has(`- [x] ${marker}`)).toBe(true);
+		});
+
+		it('gate 自身の案内文をそのまま貼っても skip しない (出力の貼り戻しで検査が消えない)', () => {
+			// 実際の案内文 (`check-schema-migration-completeness.mjs`) と同じ形。
+			expect(
+				has(
+					`  純フォーマット変更など意図的に skip する場合は PR 本文に "${marker}" を含めてください。`,
+				),
+			).toBe(false);
+		});
+	});
+}


### PR DESCRIPTION
## 顧客価値・目的

admin bypass で merge された PR の Self-Review 証跡（ADR-0044）を、**bot 自身の催促コメントを本文に貼り戻すだけで「証跡あり」にできてしまう**状態を塞ぐ。あわせて、検査しているように見えて誰も呼んでいない AC マップ判定の残骸を削り、「この gate は生きているのか」を次に読む人が調べ直さずに済むようにする。

## 関連 Issue

Closes #4348

## 変更内容

### 対象 #3 — `check-admin-bypass-evidence.mjs`（**生きている検査**）

まず「この検査は今も動いているか」を確認した（#6 と同じ罠を踏まないため）:

- `.github/workflows/admin-bypass-evidence.yml` が日次 cron（15:10 UTC）で `node scripts/check-admin-bypass-evidence.mjs` を実行している
- 直近 5 run のうち 4 run が success（1 run failure、2026-08-11）
- 実際に **2026-08-13 16:05Z に PR #4534 へ bot コメントが投稿されている**（`<!-- admin-bypass-evidence-check -->`）

生きているので、PR #4602 の SSOT（`hasDeclarationLine`）に揃えた:

| 変更 | 内容 |
|---|---|
| `hasEvidenceSection` | `EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body))` → `hasDeclarationLine(body, EVIDENCE_MARKER_PATTERNS)` |
| export | 判定関数と marker 配列を export（test から呼べるようにする） |
| entry guard | module top-level の `process.exit(2)`（`REPO` 未設定）を `requireRepo()` に移し、`main()` を `isMain` guard 化 |

**なぜ行単位判定が正しいか**: 証跡セクションは「宣言」であり、marker は `^##` で行頭アンカーされていたが、**HTML コメント / fenced code block の中の見出しを区別できなかった**。本 script が投稿する催促コメントは証跡テンプレートを ` ```markdown ` fence に入れて提示するため、**催促された人がそのコメントを本文に貼るだけで検査が満たされる**。#4333（テンプレートを消さずに出すだけで gate が成立する）と同型。

**entry guard を触った理由**: 旧実装は import した時点で `process.exit(2)` するため、判定関数を unit test から呼べなかった。「判定の回帰を test で固定できない」こと自体が、この gate が 1 度も test されていなかった原因。

### 対象 #6 — `checkPerPrAcMap` は削除した

**判断: 削除。** 根拠は以下（コードにも同じ内容を残した）:

| 調べたこと | 結果 |
|---|---|
| 呼び出し元 | `checkAcVerification` は `lane !== 'integration'` で即 `ok:true`。workflow は entry しか呼ばない。**呼び出しは自身の test だけ** |
| #4305 の意図 | Issue 本文が「`pr-ac-verification-check.yml`（feature lane）: **AC 検証マップの 4 列強制を撤去**。integration lane のエビデンス表検証は維持」と明記。**「将来戻す」と読める記述は無い** |
| テンプレート側 | `.github/PULL_REQUEST_TEMPLATE.md` は 7 節で `## AC 検証マップ` が**存在しない**。判定関数だけ戻しても入力が来ない |

死んだコードに corpus 実測を積む意味がないため、厳格化ではなく削除で対処した。削除したのは `checkPerPrAcMap` と、それだけが使っていた `extractFourColumnRows` / `sliceUntilNextH2` / `TODO_PATTERN` / `stripInlineCode`（integration lane が使う `pickFourColumnRows` / `findEmptyRows` は残置）。

再導入時に「関数だけ戻して配線を忘れる」を防ぐ class-lock を追加した（export されていないこと + entry が body を見ずに PASS すること）。

### 作業中に見つかった、対象一覧に無かったもの

`check-pr-body.mjs` の「advisory に落としても別 job が hard-fail し続ける」表が、**#4305 以降 2 行が嘘になっていた**:

| id | 表の記述 | 実際 |
|---|---|---|
| `ac-map-missing` / `-empty` / `-incomplete` | 「`pr-ac-verification-check.yml` が `checkPerPrAcMap` で hard-fail」 | 対の job は無い。さらに **`checkAcMap` 自体が runner から呼ばれておらず、この id はどこからも出力されない** |
| `change-type-unselected` | 「`pr-template-gate.yml`「変更タイプの選択」」 | 該当 job は `pr-template-gate.yml` に無い（#4305 で撤去）。`checkChangeTypeSelection` も runner 未呼び出し |
| `unchecked-ready-checklist` | 「`pr-merge-gate.yml` が hard-fail」 | **integration lane のみ**成立。feature / hotfix lane の checklist 検証は #4305 で撤去済 |

表を実態に合わせて是正した。**advisory 降格の根拠として書かれていた「別 job が見ている」が成立しない id がある**ことを明示してある（gate の severity 自体は本 PR では動かしていない）。

## 検証

```console
$ npx biome check --write scripts tests
(no output)

$ npm run cspell
CSpell: Files checked: 1987, Issues found: 0 in 0 files.

$ node --test "scripts/__tests__/**/*.test.mjs"
# pass 206
# fail 0

$ npx vitest run tests/unit/scripts/ tests/unit/architecture/
Test Files  121 passed (121)
     Tests  1671 passed | 1 skipped (1672)

$ npx svelte-check --tsconfig ./tsconfig.json --threshold warning
COMPLETED 8213 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS
```

### AC4 corpus 実測（対象 #3、旧判定 vs 新判定）

**corpus の作り方が PR gate 系と違う**。この検査は PR gate ではなく nightly 監査で、対象は「merge 済 かつ `reviewDecision` が空 / `REVIEW_REQUIRED`」の PR。よって merged PR を広く取り、判定関数を同一入力に当てて比較した:

```console
$ gh pr list --state merged --limit 200 --json number,title,body,reviewDecision,author,mergedAt,baseRefName
corpus=200 adminBypass=2   (#4215 2026-08-01 〜 #4573 2026-08-13)
evidence あり: old=0 new=0
判定変化: 0 / 200
```

**変化 0 / 200。** 内訳と、なぜ 0 なのか:

- **admin bypass PR は 200 中 2 件のみ**（#4534 / #4447、いずれも GitHub App `ganbari-quest-integrator` の統合 PR）。ADR-0022 の lab QM approve 体制で人間の admin bypass merge はほぼ消えている
- **本文に `Self-Review` の文字列を含む PR が 0 / 200**。証跡セクションは実運用で 1 度も書かれていない（bot は催促コメントを投稿しているが、本文への追記は行われていない）

corpus に該当形が無いため、**旧判定が誤って true を返す形を合成入力で実測**した（実物の bot コメント文面をそのまま使用）:

| 入力 | 旧判定 | 新判定 |
|---|---|---|
| bot の催促コメントを本文に貼り戻し（fence 内テンプレート） | **true** | false |
| HTML コメント内に見出しだけ | **true** | false |
| 実際に証跡を書いた本文 | true | true |

対象 #6 は死んだコードのため corpus 実測は行っていない（判定が実行される経路が存在しない）。

### mutation 検証

実装を commit（`5f85c4592`）してから mutation を入れ、`git stash push` で退避して戻した。

**M1: 対象 #3 の判定を旧実装に戻す**

```console
$ # hasDeclarationLine(...) → EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body))
$ npx vitest run tests/unit/scripts/check-admin-bypass-evidence.test.ts
     × bot の追記依頼コメントを本文に貼り戻しただけでは証跡と認めない 6ms
     × HTML コメント内の見出しは証跡と認めない（レンダリング後の本文に出ない） 1ms
     × code fence 内の見出し（書式の例示）は証跡と認めない 1ms
AssertionError: expected true to be false // Object.is equality
 Test Files  1 failed (1)
      Tests  3 failed | 5 passed (8)
```

**M2: 対象 #6 の判定関数を（配線せずに）復活させる**

```console
$ # export function checkPerPrAcMap(body, lane) { return { ok: body.includes('AC 検証マップ'), lane }; }
$ npx vitest run tests/unit/scripts/check-ac-verification-map.test.ts tests/unit/architecture/pr-body-partial-match-guard.test.ts
     × checkPerPrAcMap は export されていない 5ms
     × ALLOWLIST 外の部分一致判定が存在しない 8ms
AssertionError: expected [ …(12) ] to not include 'checkPerPrAcMap'
AssertionError: PR body の見出し / 宣言を部分一致で判定する新規コードを検出しました (#4348 / ADR-0061)。
 Test Files  2 failed (2)
      Tests  2 failed | 45 passed (47)
```

### lead 検収

- `npm run pre-ready -- --pr 4611` **PASS** / `svelte-check --threshold warning` **0 ERRORS 0 WARNINGS**
- `npx vitest run tests/unit/scripts/ tests/unit/architecture/` → **121 files / 1671 passed**
- `node --test "scripts/__tests__/**/*.test.mjs"` → **206 pass / 0 fail**
- **#4602 の上に積まれていることを確認済み**（`hasDeclarationLine` が未 merge のため）。**merge 順は #4602 → 本 PR**

### この PR で分かった「検査が存在しない」もの（scope 外・未着手）

本 PR は触っていませんが、調査で判明した事実を残します。**次に触る人が同じ調査を繰り返さないため**です。

- **`checkAcMap` / `checkChangeTypeSelection` は runner から呼ばれていません。** したがって `ac-map-*` / `change-type-unselected` の違反 id は**どこからも出力されません**。`check-pr-body.mjs` の「別 job が hard-fail し続ける」表が 3 行そう書いていたので、表だけ是正しました（severity は動かしていません）
- **`evidence-pr-mismatch`（BLOCKING gate）が実質空振りの疑い**。`extractAcMapSection` が探す節が `PULL_REQUEST_TEMPLATE.md` から消えており、新規 PR では常に空を返します
- **`admin-bypass-evidence` の exemption が GitHub App を拾えていません**（`app/ganbari-quest-integrator` を `[bot]` 判定で拾えず、統合 PR に毎回催促が飛んでいます）。**緩める方向の変更**なので手を付けていません

## 影響範囲

- 顧客に見える変化: なし（CI / nightly 監査の内部判定のみ）
- 破壊的変更: なし
- **PR #4602 に依存する**。本 PR は `hasDeclarationLine`（#4602 で追加）を import しており、branch も #4602 の HEAD 上に積んでいる。#4602 が merge されるまで diff に #4602 の 2 commit が含まれる
- `tests/unit/architecture/pr-body-partial-match-guard.test.ts` の ALLOWLIST から #4348 残置 2 件を削除（#4348 の対象 6 箇所は残置ゼロ）
- UI 変更なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

