### PR TITLE
fix(billing): #4585-2 上限超過リソースのアーカイブ発火条件を体験履歴からプラン遷移へ移す

### DIFF
--- a/docs/design/plan-change-flow.md
+++ b/docs/design/plan-change-flow.md
@@ -166,6 +166,13 @@ PO の「解約原因が見えない」「卒業 vs 離反比率が検証され�
 - **fallback (選ばずに手続きが完了した場合)**: 先に登録したものから順に無料プランの上限数だけ残し、
   超えた分をアーカイブする (`archiveExcessResources`)。この規則は解約画面に事前提示する
   (`CANCELLATION_LABELS.archiveFallback*`、上限値は `plan-limit-service` 由来)
+- **fallback の起動条件**: `hasRevertedToFreePlan` (`src/lib/domain/free-plan-reversion.ts`) が SSOT。
+  実効プランが free で、かつ (a) 体験の終了 または (b) 契約の終了 = S5
+  ([contract-state-matrix](billing-redesign/contract-state-matrix.md) §4) のいずれかであること。
+  解約フロー / 請求パネル / dunning はいずれも `customer.subscription.deleted` (同 §5 W5) で
+  S5 に着地するため、3 経路で条件は同一になる。S3 支払い猶予 / S4 停止 (契約が残り復帰しうる) では
+  発火しない。判定は `(parent)/admin/+layout.server.ts` の load で行い、archive 済みサマリの
+  表示も同じ述語で出し分ける
 - アーカイブは削除ではなく、再契約で復元できる
 
 #### 3.0.4 Anti-engagement 原則 (ADR-0012)

--- a/src/lib/domain/free-plan-reversion.ts
+++ b/src/lib/domain/free-plan-reversion.ts
@@ -1,0 +1,58 @@
+// src/lib/domain/free-plan-reversion.ts
+// #4585-2: 上限超過リソースの自動アーカイブを起動する条件の SSOT。
+//
+// 背景: 起動条件は `trialUsed && !isTrialActive` (体験を使ったか) だった。体験を経ずに
+// **直接課金した顧客が解約して無料プランに戻っても発火しない** ため、その顧客だけ
+// 無料プランの上限が効かないまま有料相当の量を持ち続けていた (#4585 ①)。
+// 「売っている制限が解約後に消える」= 有料の根拠が消える class の欠陥である。
+//
+// 是正: 判定軸を **体験の履歴** から **有料相当 → 無料プランへのプラン遷移** に変える。
+// 遷移の起点は 2 つしかない:
+//   (a) 体験の終了      … 契約は最初から無い (S1 のまま体験だけが切れる)
+//   (b) 契約の終了 (S5) … 解約フロー / 請求パネル / dunning のいずれも
+//                         `customer.subscription.deleted` (W5) が終端 S5 を書く
+// (b) は **3 経路とも同じ 4 列**に着地するため、経路ごとの分岐を持たない 1 つの述語で足りる
+// (契約状態 SSOT: docs/design/billing-redesign/contract-state-matrix.md §4 / §5 W5)。
+//
+// 発火条件を**広げる**変更なので、広げてはならない状態を明示的に false に落とす:
+//   - 実効プランがまだ有料 (体験中 / 支払い猶予 S3) … 上限がまだ効かない段階で消さない
+//   - S4 停止 (契約は残り復帰しうる)                 … 支払いが通れば有料に戻る。終端ではない
+//   - S1 未課金のまま (体験も契約も一度も無い)        … そもそも失うものが無い
+
+import type { PlanTier } from './constants/plan-tier';
+import type { SubscriptionStatus } from './constants/subscription-status';
+import { CONTRACT_STATE, resolveContractState } from './contract-state-view';
+
+export interface FreePlanReversionInput {
+	/** `resolveFullPlanTier` が返す**実効**プラン (体験中は有料相当になる) */
+	planTier: PlanTier;
+	/** `families.status` */
+	tenantStatus: SubscriptionStatus;
+	/** `families.stripe_subscription_id` (解約確定で NULL になる) */
+	stripeSubscriptionId?: string | null;
+	/** 体験を一度でも開始したか */
+	trialUsed: boolean;
+	/** 体験期間中か */
+	isTrialActive: boolean;
+}
+
+/**
+ * 「有料相当だったものが無料プランに戻った」= 上限超過分の扱いを確定させる状態か。
+ *
+ * `true` のときだけ `archiveExcessResources` (fallback) と archive 済みサマリ表示を起動する。
+ */
+export function hasRevertedToFreePlan(input: FreePlanReversionInput): boolean {
+	// 実効プランが有料のあいだは無料プランの上限を適用しない (体験中 / dunning 猶予中)。
+	if (input.planTier !== 'free') return false;
+
+	// (a) 体験の終了
+	if (input.trialUsed && !input.isTrialActive) return true;
+
+	// (b) 契約の終了 (S5)。S4 停止は契約が残るため対象外、S6 退会は hooks が画面ごと遮断する。
+	return (
+		resolveContractState({
+			status: input.tenantStatus,
+			stripeSubscriptionId: input.stripeSubscriptionId,
+		}) === CONTRACT_STATE.CANCELLED
+	);
+}

--- a/src/lib/server/auth/tenant-entitlement.ts
+++ b/src/lib/server/auth/tenant-entitlement.ts
@@ -37,6 +37,10 @@ export function deriveTenantEntitlement(tenant: Tenant | undefined): TenantEntit
 		licenseStatus,
 		tenantStatus: tenant?.status ?? SUBSCRIPTION_STATUS.ACTIVE,
 		plan: tenant?.plan,
+		// #4585-2: `status` 単独では S4 停止 (契約が残る) と S5 契約終了 (解約確定) を区別できない
+		// (contract-state-matrix §4)。区別できないと「解約したのか、支払いが止まっているだけか」で
+		// 挙動を変えられないため、既に読んでいる同じ行から契約の有無も持ち回る (追加クエリなし)。
+		stripeSubscriptionId: tenant?.stripeSubscriptionId ?? null,
 	};
 }
 

--- a/src/lib/server/auth/types.ts
+++ b/src/lib/server/auth/types.ts
@@ -61,6 +61,13 @@ export interface AuthContext {
 	tenantStatus?: SubscriptionStatus;
 	plan?: string;
 	/**
+	 * #4585-2: `families.stripe_subscription_id`。**`tenantStatus` と対で読む**。
+	 * `suspended` は「契約が残る停止 (S4)」と「解約確定 (S5)」を兼ねており、契約の有無 (本値)
+	 * が無いと区別できない (docs/design/billing-redesign/contract-state-matrix.md §4)。
+	 * サーバー側 `locals.context` にのみ載り、クライアントには配布しない。
+	 */
+	stripeSubscriptionId?: string | null;
+	/**
 	 * #4266: **このセッションが MFA を経て開始されたか**。ログイン時に ID token の `amr` から
 	 * 確定し、context token (署名付き) で保持する。
 	 *
@@ -94,4 +101,5 @@ export interface TenantEntitlement {
 	licenseStatus: AuthContext['licenseStatus'];
 	tenantStatus: NonNullable<AuthContext['tenantStatus']>;
 	plan?: string;
+	stripeSubscriptionId?: AuthContext['stripeSubscriptionId'];
 }

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -1300,7 +1300,7 @@ type TenantContractStatePatch = Parameters<
  * (`resolveSubscriptionContext` の customer 逆引きの鍵でもあり、消すと後続 webhook が
  * tenant を解決できなくなる)。
  */
-const TERMINAL_CONTRACT_STATE = {
+export const TERMINAL_CONTRACT_STATE = {
 	stripeSubscriptionId: null,
 	plan: null,
 	status: SUBSCRIPTION_STATUS.SUSPENDED,

--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -1,6 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { hasRevertedToFreePlan } from '$lib/domain/free-plan-reversion';
 import type { CurrencyCode, PointSettings, PointUnitMode } from '$lib/domain/point-display';
 import { DEFAULT_POINT_SETTINGS } from '$lib/domain/point-display';
 import { INVITE_ACCEPT_ERROR_COOKIE_NAME } from '$lib/domain/validation/auth';
@@ -123,10 +124,22 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
 		cookies.delete(TRIAL_WAS_ACTIVE_COOKIE, { path: '/', secure: COOKIE_SECURE });
 	}
 
-	// #783: トライアル終了後に free プランの上限を超えるリソースを archive する。
+	// #783 / #4585-2: 有料相当から無料プランに戻ったテナントで、無料プランの上限を超える
+	// リソースを archive する (顧客が選ばずに手続きを終えた場合の fallback)。
 	// 冪等: 既に archive 済みなら超過はなく何もしない。
-	const isTrialExpired = trialStatus.trialUsed && !trialStatus.isTrialActive;
-	if (planTier === 'free' && isTrialExpired) {
+	//
+	// #4585-2: 起動条件を `trialUsed` (体験の履歴) から**プラン遷移**へ移した。判定は
+	// `hasRevertedToFreePlan` が SSOT で、解約フロー / 請求パネル / dunning の 3 経路とも
+	// 同じ終端 (contract-state-matrix S5) を見る。体験を経ず直接課金した顧客が解約しても
+	// 発火しなかった穴 (#4585 ①) が塞がり、#4603 が解約画面で示した fallback が実際に起きる。
+	const revertedToFreePlan = hasRevertedToFreePlan({
+		planTier,
+		tenantStatus,
+		stripeSubscriptionId: locals.context?.stripeSubscriptionId,
+		trialUsed: trialStatus.trialUsed,
+		isTrialActive: trialStatus.isTrialActive,
+	});
+	if (revertedToFreePlan) {
 		try {
 			const result = await archiveExcessResources(tenantId);
 			if (
@@ -134,7 +147,7 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
 				result.archivedActivityIds.length > 0 ||
 				result.archivedChecklistTemplateIds.length > 0
 			) {
-				logger.info('[ARCHIVE] Trial expired — excess resources archived', {
+				logger.info('[ARCHIVE] Reverted to free plan — excess resources archived', {
 					context: {
 						tenantId,
 						children: result.archivedChildIds.length,
@@ -150,11 +163,12 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
 		}
 	}
 
-	// #783: archive 済みリソースの概要（UI 表示用）
-	const archivedSummary =
-		planTier === 'free' && isTrialExpired
-			? await getArchivedResourceSummary(tenantId)
-			: { archivedChildCount: 0, hasArchivedResources: false };
+	// #783: archive 済みリソースの概要（UI 表示用）。
+	// #4585-2: 起動条件と同じ述語で判定する。ここだけ体験基準のままだと、解約した顧客に
+	// 「アーカイブしました」の告知が出ないまま archive だけが進む。
+	const archivedSummary = revertedToFreePlan
+		? await getArchivedResourceSummary(tenantId)
+		: { archivedChildCount: 0, hasArchivedResources: false };
 
 	// #1781: 解約後グレースピリオド状態（settings 画面で「あと N 日 / 復元」UI を出すため）
 	const gracePeriodStatus = await getGracePeriodStatus(tenantId);

--- a/tests/unit/auth/tenant-entitlement.test.ts
+++ b/tests/unit/auth/tenant-entitlement.test.ts
@@ -74,9 +74,12 @@ describe('deriveTenantEntitlement (#3963)', () => {
 
 	// #4585-2: `status` 単独では S4 停止 (契約が残る) と S5 契約終了 (解約確定) を区別できない。
 	// 契約の有無を entitlement に載せることで、読み手が同じ 1 行から両方を読める。
-	it.each([
+	// repo は NULL 列を `undefined` に写す (`auth-repo.ts:95` の `?? undefined`)。
+	// Tenant entity 側も `stripeSubscriptionId?: string` なので、契約なしは `undefined` で入る。
+	// entitlement は読み手が 1 行で扱えるよう `null` に正規化する (`types.ts:69` は `string | null`)。
+	it.each<[string, string | undefined, string | null]>([
 		['契約あり (S4 停止)', 'sub_1', 'sub_1'],
-		['契約なし (S5 契約終了)', null, null],
+		['契約なし (S5 契約終了)', undefined, null],
 	])('%s の stripeSubscriptionId をそのまま持ち回る', (_name, stored, expected) => {
 		const result = deriveTenantEntitlement(
 			makeTenant({ status: SUBSCRIPTION_STATUS.SUSPENDED, stripeSubscriptionId: stored }),

--- a/tests/unit/auth/tenant-entitlement.test.ts
+++ b/tests/unit/auth/tenant-entitlement.test.ts
@@ -68,7 +68,20 @@ describe('deriveTenantEntitlement (#3963)', () => {
 			licenseStatus: AUTH_LICENSE_STATUS.NONE,
 			tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
 			plan: undefined,
+			stripeSubscriptionId: null,
 		});
+	});
+
+	// #4585-2: `status` 単独では S4 停止 (契約が残る) と S5 契約終了 (解約確定) を区別できない。
+	// 契約の有無を entitlement に載せることで、読み手が同じ 1 行から両方を読める。
+	it.each([
+		['契約あり (S4 停止)', 'sub_1', 'sub_1'],
+		['契約なし (S5 契約終了)', null, null],
+	])('%s の stripeSubscriptionId をそのまま持ち回る', (_name, stored, expected) => {
+		const result = deriveTenantEntitlement(
+			makeTenant({ status: SUBSCRIPTION_STATUS.SUSPENDED, stripeSubscriptionId: stored }),
+		);
+		expect(result.stripeSubscriptionId).toBe(expected);
 	});
 
 	// active / grace_period のみ機能利用可 (ENTITLED_SUBSCRIPTION_STATUSES と整合)
@@ -109,6 +122,7 @@ describe('resolveTenantEntitlement (#3963)', () => {
 			licenseStatus: AUTH_LICENSE_STATUS.ACTIVE,
 			tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
 			plan: 'family-monthly',
+			stripeSubscriptionId: 'sub_1',
 		});
 	});
 

--- a/tests/unit/domain/free-plan-reversion.test.ts
+++ b/tests/unit/domain/free-plan-reversion.test.ts
@@ -1,0 +1,153 @@
+// tests/unit/domain/free-plan-reversion.test.ts
+// #4585-2: 上限超過リソースの自動アーカイブ起動条件 (`hasRevertedToFreePlan`) の回帰。
+//
+// 本 test の主眼は 2 つ:
+//   1. **体験を経ずに直接課金 → 解約**した顧客で発火すること (#4585 ①。旧条件
+//      `trialUsed && !isTrialActive` では永久に false だった)
+//   2. 発火条件を広げたことで、**広げてはならない状態で発火しない**こと
+//      (体験中 / 支払い猶予 / 停止 / 未課金)。顧客の記録が消える経路なので、
+//      「発火する」条件と同じ強さで「発火しない」条件を固定する
+//
+// 契約状態の呼称は docs/design/billing-redesign/contract-state-matrix.md §4 (S1〜S6) に揃える。
+
+import { describe, expect, it } from 'vitest';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import {
+	type FreePlanReversionInput,
+	hasRevertedToFreePlan,
+} from '$lib/domain/free-plan-reversion';
+import { TERMINAL_CONTRACT_STATE } from '$lib/server/services/stripe-service';
+
+/** 体験を一度も使っていない顧客 (直接課金した顧客はここに属する) */
+const NEVER_TRIALED = { trialUsed: false, isTrialActive: false } as const;
+
+/**
+ * S5 契約終了。**3 経路 (解約フロー / 請求パネル / dunning) の終端はすべてここ**で、
+ * `customer.subscription.deleted` (W5) が `TERMINAL_CONTRACT_STATE` を書く。
+ * 期待値をベタ書きせず実物を読むことで、書き手が変わればこの test が落ちる。
+ */
+const S5_CONTRACT_ENDED = {
+	tenantStatus: TERMINAL_CONTRACT_STATE.status,
+	stripeSubscriptionId: TERMINAL_CONTRACT_STATE.stripeSubscriptionId,
+} as const;
+
+describe('hasRevertedToFreePlan (#4585-2 自動アーカイブの起動条件)', () => {
+	describe('発火する', () => {
+		it('体験を使わず直接課金した顧客が解約して無料プランに戻ったとき (#4585 ①)', () => {
+			// 旧条件 `trialUsed && !isTrialActive` は trialUsed=false のため false のままで、
+			// この顧客だけ無料プランの上限が一切効かなかった。
+			expect(
+				hasRevertedToFreePlan({
+					planTier: 'free',
+					...S5_CONTRACT_ENDED,
+					...NEVER_TRIALED,
+				}),
+			).toBe(true);
+		});
+
+		it('3 経路 (解約フロー / 請求パネル / dunning) が同じ条件で発火する', () => {
+			// 3 経路は入口が違うだけで、契約の終端は同じ 4 列 (S5) に着地する。
+			// 経路名で分岐する実装を作ると「経路ごとに残るものが変わる」ため、
+			// 同一入力に対する結果が 1 つであることを固定する。
+			const routes = ['解約フロー', '請求パネル', 'dunning'] as const;
+			const results = routes.map((route) => ({
+				route,
+				fired: hasRevertedToFreePlan({
+					planTier: 'free',
+					...S5_CONTRACT_ENDED,
+					...NEVER_TRIALED,
+				}),
+			}));
+			expect(results).toEqual(routes.map((route) => ({ route, fired: true })));
+		});
+
+		it('体験終了で無料プランに戻ったとき (従来経路。契約は最初から無い)', () => {
+			expect(
+				hasRevertedToFreePlan({
+					planTier: 'free',
+					tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
+					stripeSubscriptionId: null,
+					trialUsed: true,
+					isTrialActive: false,
+				}),
+			).toBe(true);
+		});
+
+		it('体験も契約も経た顧客が解約したとき', () => {
+			expect(
+				hasRevertedToFreePlan({
+					planTier: 'free',
+					...S5_CONTRACT_ENDED,
+					trialUsed: true,
+					isTrialActive: false,
+				}),
+			).toBe(true);
+		});
+	});
+
+	describe('発火しない (顧客の記録が消える経路を広げすぎない)', () => {
+		const cases: { name: string; input: FreePlanReversionInput }[] = [
+			{
+				name: 'S1 未課金のまま (体験も契約も一度も無い)',
+				input: {
+					planTier: 'free',
+					tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
+					stripeSubscriptionId: null,
+					...NEVER_TRIALED,
+				},
+			},
+			{
+				name: '体験期間中 (実効プランは有料相当。上限はまだ効かない)',
+				input: {
+					planTier: 'standard',
+					tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
+					stripeSubscriptionId: null,
+					trialUsed: true,
+					isTrialActive: true,
+				},
+			},
+			{
+				name: 'S2 課金中',
+				input: {
+					planTier: 'standard',
+					tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
+					stripeSubscriptionId: 'sub_active',
+					...NEVER_TRIALED,
+				},
+			},
+			{
+				name: 'S3 支払い失敗猶予 (dunning 中。有料機能は維持される)',
+				input: {
+					planTier: 'standard',
+					tenantStatus: SUBSCRIPTION_STATUS.GRACE_PERIOD,
+					stripeSubscriptionId: 'sub_dunning',
+					...NEVER_TRIALED,
+				},
+			},
+			{
+				name: 'S4 停止 (契約が残り、支払いが通れば有料に戻る)',
+				input: {
+					planTier: 'free',
+					tenantStatus: SUBSCRIPTION_STATUS.SUSPENDED,
+					stripeSubscriptionId: 'sub_unpaid',
+					...NEVER_TRIALED,
+				},
+			},
+			{
+				name: 'S6 退会済 (hooks が画面到達前に遮断する。archive の対象ではない)',
+				input: {
+					planTier: 'free',
+					tenantStatus: SUBSCRIPTION_STATUS.TERMINATED,
+					stripeSubscriptionId: null,
+					...NEVER_TRIALED,
+				},
+			},
+		];
+
+		for (const { name, input } of cases) {
+			it(name, () => {
+				expect(hasRevertedToFreePlan(input)).toBe(false);
+			});
+		}
+	});
+});

--- a/tests/unit/routes/admin-layout-archive-trigger.test.ts
+++ b/tests/unit/routes/admin-layout-archive-trigger.test.ts
@@ -1,0 +1,198 @@
+// tests/unit/routes/admin-layout-archive-trigger.test.ts
+// #4585-2: `(parent)/admin/+layout.server.ts` が上限超過リソースの自動アーカイブを
+// **どの状態で起動するか** の回帰。
+//
+// 旧実装は `trialUsed && !isTrialActive` を条件にしていたため、体験を経ずに直接課金した顧客が
+// 解約して無料プランに戻っても永久に発火しなかった (#4585 ①)。#4603 が解約画面で
+// 「選ばずに進めた場合はこう残ります」と提示した fallback が、その顧客には起きない状態だった。
+//
+// 判定そのものの網羅は `tests/unit/domain/free-plan-reversion.test.ts` が持つ。本 test は
+// **layout が実際にその判定で archive を呼ぶ / 呼ばない**という配線を固定する。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+
+const mockResolveFullPlanTier = vi.fn();
+const mockArchiveExcessResources = vi.fn();
+const mockGetArchivedResourceSummary = vi.fn();
+const mockGetTrialStatus = vi.fn();
+
+vi.mock('$lib/server/services/plan-limit-service', async () => {
+	const actual = await vi.importActual<typeof import('$lib/server/services/plan-limit-service')>(
+		'$lib/server/services/plan-limit-service',
+	);
+	return {
+		...actual,
+		resolveFullPlanTier: (...args: unknown[]) => mockResolveFullPlanTier(...args),
+	};
+});
+
+vi.mock('$lib/server/services/resource-archive-service', () => ({
+	archiveExcessResources: (...args: unknown[]) => mockArchiveExcessResources(...args),
+	getArchivedResourceSummary: (...args: unknown[]) => mockGetArchivedResourceSummary(...args),
+}));
+
+vi.mock('$lib/server/services/trial-service', () => ({
+	getTrialStatus: (...args: unknown[]) => mockGetTrialStatus(...args),
+}));
+
+vi.mock('$lib/server/auth/factory', () => ({
+	requireTenantId: (locals: { context?: { tenantId?: string } }) => {
+		if (!locals.context?.tenantId) throw new Error('Unauthorized');
+		return locals.context.tenantId;
+	},
+	getAuthMode: vi.fn(() => 'cognito'),
+	// cognito-dev モード = 親 PIN gate 無効。本 test の関心は archive 起動条件のみ。
+	isCognitoDevMode: vi.fn(() => true),
+}));
+
+vi.mock('$lib/server/db/settings-repo', () => ({
+	getSettings: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('$lib/server/services/grace-period-service', () => ({
+	getGracePeriodStatus: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('$lib/server/services/onboarding-service', () => ({
+	getOnboardingProgress: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('$lib/server/debug-plan', () => ({
+	getDebugPlanSummary: vi.fn(() => null),
+}));
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: vi.fn(() => true),
+}));
+
+const { load } = await import('../../../src/routes/(parent)/admin/+layout.server');
+
+const TENANT = 'tenant-4585';
+
+function makeEvent(context: Record<string, unknown>) {
+	return {
+		locals: {
+			context: { tenantId: TENANT, role: 'owner', ...context },
+			runtimeMode: 'aws-prod',
+		},
+		cookies: {
+			get: vi.fn(() => undefined),
+			set: vi.fn(),
+			delete: vi.fn(),
+		},
+		url: new URL('https://example.test/admin'),
+		// biome-ignore lint/suspicious/noExplicitAny: SvelteKit の LayoutServerLoadEvent を最小構成で満たす
+	} as any;
+}
+
+/** 体験を一度も使っていない (= 直接課金した顧客) */
+function neverTrialed() {
+	mockGetTrialStatus.mockResolvedValue({
+		isTrialActive: false,
+		trialUsed: false,
+		trialStartDate: null,
+		trialEndDate: null,
+		trialTier: null,
+		daysRemaining: 0,
+		source: null,
+	});
+}
+
+describe('(parent)/admin/+layout.server.ts — 上限超過リソースの自動アーカイブ起動 (#4585-2)', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockResolveFullPlanTier.mockResolvedValue('free');
+		mockArchiveExcessResources.mockResolvedValue({
+			archivedChildIds: [],
+			archivedActivityIds: [],
+			archivedChecklistTemplateIds: [],
+		});
+		mockGetArchivedResourceSummary.mockResolvedValue({
+			archivedChildCount: 2,
+			hasArchivedResources: true,
+		});
+	});
+
+	it('体験を使わず直接課金した顧客が解約 (S5) して無料プランに戻ると archive が発火する', async () => {
+		neverTrialed();
+
+		await load(
+			makeEvent({
+				licenseStatus: 'none',
+				tenantStatus: SUBSCRIPTION_STATUS.SUSPENDED,
+				plan: null,
+				stripeSubscriptionId: null,
+			}),
+		);
+
+		expect(mockArchiveExcessResources).toHaveBeenCalledWith(TENANT);
+	});
+
+	it('解約済みの顧客に archive 済みサマリを配布する (告知だけ体験基準に取り残さない)', async () => {
+		neverTrialed();
+
+		const result = await load(
+			makeEvent({
+				licenseStatus: 'none',
+				tenantStatus: SUBSCRIPTION_STATUS.SUSPENDED,
+				stripeSubscriptionId: null,
+			}),
+		);
+
+		expect(result).toMatchObject({
+			archivedSummary: { archivedChildCount: 2, hasArchivedResources: true },
+		});
+	});
+
+	it('S4 停止 (契約が残り復帰しうる) では archive を発火しない', async () => {
+		neverTrialed();
+
+		await load(
+			makeEvent({
+				licenseStatus: 'suspended',
+				tenantStatus: SUBSCRIPTION_STATUS.SUSPENDED,
+				plan: 'standard_monthly',
+				stripeSubscriptionId: 'sub_unpaid',
+			}),
+		);
+
+		expect(mockArchiveExcessResources).not.toHaveBeenCalled();
+	});
+
+	it('S1 未課金のまま (体験も契約も無い) では archive を発火しない', async () => {
+		neverTrialed();
+
+		await load(
+			makeEvent({
+				licenseStatus: 'none',
+				tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
+				stripeSubscriptionId: null,
+			}),
+		);
+
+		expect(mockArchiveExcessResources).not.toHaveBeenCalled();
+	});
+
+	it('体験終了で無料プランに戻った従来経路でも発火し続ける', async () => {
+		mockGetTrialStatus.mockResolvedValue({
+			isTrialActive: false,
+			trialUsed: true,
+			trialStartDate: '2026-07-01',
+			trialEndDate: '2026-07-08',
+			trialTier: 'standard',
+			daysRemaining: 0,
+			source: 'user_initiated',
+		});
+
+		await load(
+			makeEvent({
+				licenseStatus: 'none',
+				tenantStatus: SUBSCRIPTION_STATUS.ACTIVE,
+				stripeSubscriptionId: null,
+			}),
+		);
+
+		expect(mockArchiveExcessResources).toHaveBeenCalledWith(TENANT);
+	});
+});

--- a/tests/unit/services/cognito-provider.test.ts
+++ b/tests/unit/services/cognito-provider.test.ts
@@ -187,6 +187,8 @@ describe('CognitoAuthProvider', () => {
 				licenseStatus: 'none',
 				tenantStatus: 'active',
 				plan: undefined,
+				// #4585-2: 契約の有無 (S4 停止 / S5 契約終了 の判別軸) も DB から解決する
+				stripeSubscriptionId: null,
 			});
 			// Cookie が有効なのでメンバーシップ再解決は走らないが、課金状態のため DB は引く
 			expect(mockFindUserTenants).not.toHaveBeenCalled();
@@ -247,6 +249,8 @@ describe('CognitoAuthProvider', () => {
 				licenseStatus: 'none',
 				tenantStatus: 'active',
 				plan: undefined,
+				// #4585-2: 契約の有無 (S4 停止 / S5 契約終了 の判別軸) も DB から解決する
+				stripeSubscriptionId: null,
 			});
 			expect(mockFindUserByEmail).toHaveBeenCalledWith('owner@family.com');
 			expect(mockFindUserTenants).toHaveBeenCalledWith('u-member');


### PR DESCRIPTION
## 顧客価値・目的

体験を使わず直接お申し込みしたお客さまが解約して無料プランに戻ったとき、**無料プランの上限がまったく効かないまま**でした。有料の根拠が解約後に消える状態です。本 PR で、有料相当から無料プランに戻った時点で上限超過分の扱いが確定するようになります。

あわせて、**#4603 が解約画面で約束した fallback（「選ばずに進めた場合はこう残ります」）が、その顧客には実際には起きない**状態も解消します。画面の説明と実装が一致します。

## 関連 Issue

Refs #4585
<!-- no-issue-close: #4585 は 4 分割。本 PR は 2 本目（発火条件）のみ。1 本目 = #4603 (merge 済) / 3 本目 = fallback 規則 + dunning_canceled / 4 本目 = 顧客提示物。 -->

### PO 決裁の前提（**公開前に入ることが条件**）

[PO 決裁](https://github.com/Takenori-Kusaka/ganbari-quest/issues/4585#issuecomment-5289396122)（2〜4 本目の判断事項）により、**遡及対応・移行時の予告・段階適用はいずれも実装していません**。本番 `/ops` 実測で有料テナント 0（課金が 1 度も成立していない）ため、「直接課金して解約した顧客」が定義上 0 人で遡及対象が空、という判断です。

**この前提は「第 22 回（一般公開）より前に本 PR が入る」ことに依存します。** 有償公開より後にずれ込む場合は、公開後に契約 → 解約した顧客が対象になるため前提が崩れます。その場合は merge 前に PO へ戻してください。

## 変更内容

発火条件を **体験の履歴（`trialUsed`）** から **有料相当 → 無料プランへのプラン遷移** に変えました。

| | 変更前 | 変更後 |
|---|---|---|
| 判定 | `trialUsed && !isTrialActive && planTier === 'free'` | `hasRevertedToFreePlan()` = 実効プラン free × (体験終了 \| 契約終了 S5) |
| 直接課金 → 解約 | **発火しない**（上限が効かない） | 発火する |
| 判定の置き場所 | `admin/+layout.server.ts` に直書き | `src/lib/domain/free-plan-reversion.ts`（SSOT、純関数） |

- **3 経路が同じ条件になること**: 解約フロー / 請求パネル / dunning は入口が違うだけで、いずれも `customer.subscription.deleted`（[contract-state-matrix](https://github.com/Takenori-Kusaka/ganbari-quest/blob/develop/docs/design/billing-redesign/contract-state-matrix.md) §5 W5）が終端 S5 の 4 列を書きます。経路名で分岐せず、**S5 という 1 つの状態**を見ることで条件が構造的に一致します。test は期待値をベタ書きせず、実物の `TERMINAL_CONTRACT_STATE` を読んで組み立てています（書き手が変われば test が落ちる）。
- **広げてはならない状態は明示的に false**: S3 支払い猶予（有料機能は維持）/ S4 停止（契約が残り復帰しうる）/ S1 未課金のまま / 体験期間中。顧客のデータが archive される経路なので、「発火する」条件と同じ強さで固定しました。
- **どれを見るのが正しいかの根拠**（#4603 QM 指摘の `isPaidPlan=false` だが実効プランは有料、と同型の罠）: `isPaidPlan`（Stripe 契約の有無）は体験中の顧客を無料扱いにするため使わず、**実効プラン `resolveFullPlanTier`** を上限適用の軸にしました。`status` 単独では S4 と S5 を区別できない（同 §4）ため、契約の有無を併せて読み、S4/S5 の判別は既存 SSOT `resolveContractState` に委ねています。
- `stripeSubscriptionId` を `TenantEntitlement` に載せました。**追加クエリはありません**（`resolveTenantEntitlement` が既に読んでいる同じ tenant 行から derive、ADR-0065）。サーバー側 `locals.context` にのみ載り、クライアントには配布しません。
- archive 済みサマリ（UI 告知）も同じ述語で出し分けます。ここだけ体験基準に残すと、解約した顧客に告知が出ないまま archive だけ進みます。

**本 PR でやっていないこと**: fallback 規則の変更（「先に登録した順」→「直近の利用順」）と `dunning_canceled` の実装は **3 本目**、顧客提示物は **4 本目**です。archive の reason は `trial_expired` のまま（reason 体系の見直しは 3 本目の範囲）。

## 検証

failing-test-first（ADR-0061）と mutation は commit 済み状態で `git stash push` により検証しました（`git checkout --` は hook が禁止）。実出力は `tmp/agent-report-4585-2.md` に全文を記載しています。

| 検証 | コマンド | 結果 |
|---|---|---|
| failing-test-first | 発火条件を旧 `trialUsed && !isTrialActive` に戻して新 test 実行 | **2 test 失敗**（直接課金→解約で archive が発火する / 解約済み顧客への archive サマリ配布）→ 戻すと 15 passed |
| mutation（広げすぎ検知） | `hasRevertedToFreePlan` を常に true に | **6 test 失敗**（S1 / 体験中 / S2 / S3 / S4 / S6 の非発火） |
| biome | `npx biome check --write src tests` | 2 files fixed → clean |
| 型 | `npx svelte-check --tsconfig ./tsconfig.json --threshold warning` | 0 errors 0 warnings |
| cspell | `npm run cspell` | Issues found: 0 |
| unit | `npx vitest run src/lib/server/services/ src/routes/ tests/unit/` | `Test Files 724 passed (724) / Tests 10904 passed \| 1 skipped (10905)` |

初回の unit 実行では `tests/unit/services/cognito-provider.test.ts` の 2 件が落ちました。`resolveContext` の戻り値を `toEqual` で厳密一致させており、`TenantEntitlement` に増えた `stripeSubscriptionId` を知らなかったためです。**期待値に新フィールドを足して修正**しました（`e0e1f55ef`、assertion は弱めていません）。

E2E / Storybook は未実行（UI 変更なし）。`npm run lint:svelte` も未実行（`.svelte` を 1 file も触っていないため）。ただし `git push` の pre-push hook が eslint を実行し `OK: eslint (src 変更 file、違反なし)`。

## 影響範囲

- **顧客に見える変化**: 有料契約を終了して無料プランに戻ったテナントで、次回の管理画面アクセス時に上限超過分が archive されます（アーカイブは削除ではなく、再契約で復元されます）。上限内であれば何も起きません。**現時点で本番に該当顧客は存在しません**（有料テナント 0）。
- **UI 変更なし** — 描画の分岐・文言は一切変えていません。archive 済みサマリの出し分け条件のみが変わります（該当顧客が現存しないため描画差分は出ません）。
- 並行実装ペア: 該当なし（labels / 年齢モード / demo / ナビ / DB スキーマ いずれも未変更）。
- 破壊的変更: なし。`TenantEntitlement.stripeSubscriptionId` は optional 追加で、他の provider（local / anonymous / cognito-dev）は未設定のまま従来どおり動作します。
- `TERMINAL_CONTRACT_STATE` を export しました（test が実物の終端状態を読むため。実装の挙動は不変）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->


## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["🟡 archive は復元可能"]
    R2["顧客面: 解約後に上限が効く"]
    R3["遡及対象 0 人（有料契約 0）"]
  end
  subgraph TRADE["② trade-off (ADR-0010)"]
    T1["得る: 売った制限が解約後も効く"]
    T2["捨てる: 遡及・予告を作らない"]
  end
  subgraph OBJ["③ 反対理由 (adversarial-reviewer 転記)"]
    O1["business: 🔴 前提を機械で固定していない"]
    O2["UX: 🟡 fallback を見ない経路が残る"]
    O3["security: 🟡 契約 id を認可 context に載せた"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢 UI 変更なし（.svelte 0 file）"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: 公開後にずれたら戻す運用で可か"]
    Q2["Q2: 契約 id は真偽値で足りないか"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R3,C1,T1 ok
  class R1,R2,T2,O2,O3 warn
  class O1 danger
  class Q1,Q2 ask
```

### ③ の補足（`tmp/adversarial-evidence/4615.json` から転記、schema PASS）

- **business（最も重い）**: 決裁の根拠「有料契約が 1 度も成立していないので遡及対象は空」は**決裁時点のスナップショット**です。**merge から有償公開までの間に 1 件でも直接課金が成立すれば前提が崩れます**。実装側にその前提を守る仕掛けは無く、守れているかを確かめる手段もありません。**忘れられたときに最初の有料顧客が予告なく archive されます**
- **UX**: #4603 の fallback 提示は**解約フローを通った顧客だけ**が見ます。請求パネル経由 / dunning 経由で無料に戻る顧客は**一度も見ないまま**子供や活動が見えなくなります。さらに archive の reason が `trial_expired` のままなので、**体験終了で消えたのか解約で消えたのかをログから区別できません**（3 本目で整理予定）
- **security**: `stripeSubscriptionId` を `TenantEntitlement`（request context として広く配られる値）に載せました。追加クエリはありませんが、**ログ / エラー / デバッグダンプ経由の露出経路が増えます**。判定に必要なのは「契約の有無」の真偽値だけではなかったか、は検討の余地があります

### ⑤ の判断依頼

**Q1: 前提を運用で守るかたちで可か。** 決裁は「公開前に入る」が前提です。**merge 後に公開がずれても機械では止まりません。** (a) このまま運用で守る / (b) 有料契約が 1 件でも存在したら落ちる test を足す、のどちらかをご指定ください。**(b) は 1 行の assert で書けます。**

**Q2: `stripeSubscriptionId` を entitlement に載せてよいか。** 判定に必要なのは「契約が有るか無いか」だけです。**`hasActiveContract: boolean` に落とせば識別子を配らずに済みます**。そのほうが望ましければ変更します（実装は小さい）。
