### PR TITLE
fix(billing): #4585-3 選ばずに戻ったときは最近記録があるお子さまを残す + 支払い失敗経路を実装する

### DIFF
--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -3831,11 +3831,12 @@ export const CANCELLATION_LABELS = {
 	portalSupportLink: 'サポート窓口に連絡する',
 
 	// #4585-1: 解約フローも「どの記録を残すか」の選択 UI に合流させる (PO 決裁 = 案 A)。
-	// 選択せずに手続きが完了した場合の fallback は archiveExcessResources と同じ
-	// 「先に登録したものから順に上限数だけ残す」。規則を内部に閉じず、解約画面で先に伝える。
+	// #4585-3: fallback 規則を子供だけ「直近の利用順」に変更 (PO 決裁 Q1 / Q3)。
+	// 顧客に伝えるのは「お子さまは最近記録がある方を残す」ところまで。活動・チェックリストの
+	// 並び順 (登録順) までは書かない — 復元でき、かつ選択 UI で顧客自身が選べるため。
 	archiveFallbackHeading: ARCHIVE_FALLBACK_HEADING,
 	archiveFallbackRule: (maxChildren: number, maxActivities: number, maxChecklists: number) =>
-		`${PLAN_FULL_TERMS.free}に戻ると、${CHILD_TERMS.neutral}は${maxChildren}人・活動は${maxActivities}個・チェックリストは${CHILD_TERMS.neutral}1人あたり${maxChecklists}個までになります。残すものを選ばないまま手続きが完了した場合は、先に登録したものから順にこの数だけ残し、超えた分をアーカイブします。`,
+		`${PLAN_FULL_TERMS.free}に戻ると、${CHILD_TERMS.neutral}は${maxChildren}人・活動は${maxActivities}個・チェックリストは${CHILD_TERMS.neutral}1人あたり${maxChecklists}個までになります。残すものを選ばないまま手続きが完了した場合は、この数だけ残して超えた分をアーカイブします。${CHILD_TERMS.honorific}は、最近記録がある${CHILD_TERMS.honorific}から順に残します。`,
 	archiveFallbackRestore: `アーカイブしたデータは削除しません。再度${SIGNUP_TERMS.canonical}いただくと元に戻せます。`,
 	selectionButton: '残すデータを選ぶ',
 	selectionLoading: '確認しています…',

--- a/src/lib/server/services/resource-archive-service.ts
+++ b/src/lib/server/services/resource-archive-service.ts
@@ -3,10 +3,12 @@ import type { ActivityId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/resource-archive-service.ts
 // #783: トライアル終了時の超過リソース archive / アップグレード時の restore
 
-import type { ArchivedReason } from '$lib/domain/archive-types';
+import { ARCHIVED_REASONS, type ArchivedReason } from '$lib/domain/archive-types';
+import { jstDateOfIso } from '$lib/domain/date-utils';
 import {
 	archiveActivities,
 	findActivities,
+	findActivityLogs,
 	restoreArchivedActivities,
 } from '$lib/server/db/activity-repo';
 import {
@@ -31,19 +33,95 @@ function compareOpaqueIdAsc(a: string, b: string): number {
 }
 
 const ARCHIVE_REASON: ArchivedReason = 'trial_expired';
-// #738: downgrade-service と同じ値。循環参照を避けるため直接定義
-const DOWNGRADE_ARCHIVE_REASON: ArchivedReason = 'downgrade_user_selected';
 
 /**
- * トライアル終了時に free プランの上限を超えるリソースを archive する。
+ * 顧客が「残すもの」を選ばないまま無料プランに戻ったときの archive reason (#4585-3)。
  *
- * - 子供: 古い順に maxChildren 件を残し、残りを archive
- * - 活動: source='custom' のうち古い順に maxActivities 件を残し、残りを archive
- * - チェックリスト: 各子供について maxChecklistTemplates 件を残し、残りを archive
+ * - `trial_expired`: 体験終了で無料プランに戻った
+ * - `dunning_canceled`: 支払い失敗で契約が消え、**顧客が操作しないまま**無料プランに戻った
  *
- * 「古い順に残す」= 最初に作成したリソースを優先保持する
+ * 顧客自身が選んで archive した分は `downgrade_user_selected` (downgrade-service) であり、
+ * 本経路では書かない。ログから「体験終了 / 支払い失敗 / 顧客の選択」を区別するための分離。
  */
-export async function archiveExcessResources(tenantId: string): Promise<{
+export type AutoArchiveReason = Extract<ArchivedReason, 'trial_expired' | 'dunning_canceled'>;
+
+/**
+ * 子供の並べ替えキー = `coalesce(最終記録日, 登録日)` の JST 暦日 (#4585-3、PO 決裁 Q3)。
+ *
+ * 日付は **JST 暦日**で出す。ISO 文字列の slice は UTC 暦日になり、JST 00:00〜09:00 の記録が
+ * 前日へ落ちる (#4120)。導出は `deletion-export-service.ts` の `lastRecordDate` と同じ形。
+ *
+ * 解決できない (記録も登録日も読めない) 場合は空文字 = 最も古い扱い。ここで `undefined` を
+ * 返して比較不能にすると並びが入力順に依存し、fallback が「実行のたびに結果が変わる」
+ * ものになる (安定ソートの要求)。
+ */
+function lastUsedDayJst(createdAt: string | null | undefined, recordedAtList: string[]): string {
+	const recordedDays = recordedAtList
+		.filter((recordedAt): recordedAt is string => typeof recordedAt === 'string' && !!recordedAt)
+		.map(safeJstDate)
+		.filter((day) => day !== '')
+		.sort();
+	const lastRecordDay = recordedDays[recordedDays.length - 1];
+	if (lastRecordDay) return lastRecordDay;
+	return createdAt ? safeJstDate(createdAt) : '';
+}
+
+/** 壊れた timestamp で並びを崩さないための `jstDateOfIso` ラッパ。 */
+function safeJstDate(isoTimestamp: string): string {
+	if (Number.isNaN(new Date(isoTimestamp).getTime())) return '';
+	return jstDateOfIso(isoTimestamp);
+}
+
+/**
+ * 「残す子供」を決める順に並べ替える (#4585-3)。
+ *
+ * `coalesce(最終記録日, 登録日)` の **新しい順**に残す。同点は id 昇順で解く
+ * (キーが同点でも id は一意なので順序が全順序になり、入力順に依存しない = 安定)。
+ *
+ * 活動 / チェックリストは**登録順のまま**にする (PO 決裁 Q1: 適用は子供だけ)。1 件単位で
+ * 落ちる資源と違い、子供が archive されるとその子に紐づくすべてが一度に見えなくなるため、
+ * 「毎日使っている下の子が消えて、使っていない上の子が残る」を子供でだけ潰す。
+ */
+async function sortChildrenByRecentUse<T extends { id: ChildId; createdAt?: string | null }>(
+	children: T[],
+	tenantId: string,
+): Promise<T[]> {
+	// 最終記録日は 1 子供 1 クエリ。上限超過時にしか呼ばれない (通常運用では 0 クエリ)。
+	const lastUsedDays = await Promise.all(
+		children.map(async (child) => {
+			const logs = await findActivityLogs(child.id, tenantId);
+			return lastUsedDayJst(
+				child.createdAt,
+				logs.map((log) => log.recordedAt),
+			);
+		}),
+	);
+	const keyById = new Map(children.map((child, i) => [child.id, lastUsedDays[i] ?? '']));
+	return [...children].sort((a, b) => {
+		const keyA = keyById.get(a.id) ?? '';
+		const keyB = keyById.get(b.id) ?? '';
+		if (keyA !== keyB) return keyA < keyB ? 1 : -1; // 新しい順
+		return compareOpaqueIdAsc(a.id, b.id);
+	});
+}
+
+/**
+ * 顧客が残すものを選ばないまま無料プランに戻ったとき、上限を超えるリソースを archive する。
+ *
+ * - 子供: `coalesce(最終記録日, 登録日)` の新しい順に maxChildren 件を残し、残りを archive
+ *   (同点は id 昇順。#4585-3 PO 決裁 Q1 / Q3)
+ * - 活動: source='custom' のうち古い順に maxActivities 件を残し、残りを archive
+ * - チェックリスト: 各子供について古い順に maxChecklistTemplates 件を残し、残りを archive
+ *
+ * この規則は 3 経路 (解約フロー / 請求パネル / dunning) で共有する。経路ごとに残るものが
+ * 変わると顧客にも説明できないため、規則は本関数 1 箇所だけが持つ。
+ *
+ * @param reason 無料プランに戻った理由。ログで体験終了と支払い失敗を区別するために刻む
+ */
+export async function archiveExcessResources(
+	tenantId: string,
+	reason: AutoArchiveReason = ARCHIVE_REASON,
+): Promise<{
 	archivedChildIds: ChildId[];
 	archivedActivityIds: ActivityId[];
 	archivedChecklistTemplateIds: string[];
@@ -59,11 +137,11 @@ export async function archiveExcessResources(tenantId: string): Promise<{
 	if (limits.maxChildren !== null) {
 		const children = await findAllChildren(tenantId);
 		if (children.length > limits.maxChildren) {
-			// id 昇順 = 古い順にソートし、上限以降を archive
-			const sorted = [...children].sort((a, b) => compareOpaqueIdAsc(a.id, b.id));
+			// 直近の利用が新しい順にソートし、上限以降を archive (#4585-3)
+			const sorted = await sortChildrenByRecentUse(children, tenantId);
 			const excess = sorted.slice(limits.maxChildren);
 			const ids = excess.map((c) => c.id);
-			await archiveChildren(ids, ARCHIVE_REASON, tenantId);
+			await archiveChildren(ids, reason, tenantId);
 			result.archivedChildIds = ids;
 		}
 	}
@@ -76,7 +154,7 @@ export async function archiveExcessResources(tenantId: string): Promise<{
 			const sorted = [...custom].sort((a, b) => compareOpaqueIdAsc(a.id, b.id));
 			const excess = sorted.slice(limits.maxActivities);
 			const ids = excess.map((a) => a.id);
-			await archiveActivities(ids, ARCHIVE_REASON, tenantId);
+			await archiveActivities(ids, reason, tenantId);
 			result.archivedActivityIds = ids;
 		}
 	}
@@ -92,7 +170,7 @@ export async function archiveExcessResources(tenantId: string): Promise<{
 				const sorted = [...templates].sort((a, b) => compareOpaqueIdAsc(a.id, b.id));
 				const excess = sorted.slice(limits.maxChecklistTemplates);
 				const ids = excess.map((t) => t.id);
-				await archiveChecklistTemplates(ids, ARCHIVE_REASON, tenantId);
+				await archiveChecklistTemplates(ids, reason, tenantId);
 				result.archivedChecklistTemplateIds.push(...ids);
 			}
 		}
@@ -102,17 +180,18 @@ export async function archiveExcessResources(tenantId: string): Promise<{
 }
 
 /**
- * アップグレード時に trial_expired / downgrade_user_selected で archive されたリソースを全て復元する。
+ * アップグレード時に archive されたリソースを **全 reason** について復元する。
+ *
+ * reason は enum SSOT (`ARCHIVED_REASONS`) を全件回す (#4585-3)。列挙を手で並べていると
+ * reason を足したときに復元だけ取りこぼし、その顧客は再契約しても記録が戻らないまま残る
+ * (`dunning_canceled` が実際にその状態だった)。
  */
 export async function restoreArchivedResources(tenantId: string): Promise<void> {
-	// #783: trial_expired で archive されたリソースを復元
-	await restoreArchivedChildren(ARCHIVE_REASON, tenantId);
-	await restoreArchivedActivities(ARCHIVE_REASON, tenantId);
-	await restoreArchivedChecklistTemplates(ARCHIVE_REASON, tenantId);
-	// #738: downgrade_user_selected で archive されたリソースも復元
-	await restoreArchivedChildren(DOWNGRADE_ARCHIVE_REASON, tenantId);
-	await restoreArchivedActivities(DOWNGRADE_ARCHIVE_REASON, tenantId);
-	await restoreArchivedChecklistTemplates(DOWNGRADE_ARCHIVE_REASON, tenantId);
+	for (const reason of ARCHIVED_REASONS) {
+		await restoreArchivedChildren(reason, tenantId);
+		await restoreArchivedActivities(reason, tenantId);
+		await restoreArchivedChecklistTemplates(reason, tenantId);
+	}
 }
 
 /**

--- a/src/lib/server/services/resource-archive-service.ts
+++ b/src/lib/server/services/resource-archive-service.ts
@@ -3,7 +3,7 @@ import type { ActivityId, ChildId } from '$lib/domain/ids';
 // src/lib/server/services/resource-archive-service.ts
 // #783: トライアル終了時の超過リソース archive / アップグレード時の restore
 
-import { ARCHIVED_REASONS, type ArchivedReason } from '$lib/domain/archive-types';
+import type { ArchivedReason } from '$lib/domain/archive-types';
 import { jstDateOfIso } from '$lib/domain/date-utils';
 import {
 	archiveActivities,
@@ -32,7 +32,7 @@ function compareOpaqueIdAsc(a: string, b: string): number {
 	return a.length - b.length || a.localeCompare(b);
 }
 
-const ARCHIVE_REASON: ArchivedReason = 'trial_expired';
+const ARCHIVE_REASON: AutoArchiveReason = 'trial_expired';
 
 /**
  * 顧客が「残すもの」を選ばないまま無料プランに戻ったときの archive reason (#4585-3)。
@@ -180,18 +180,42 @@ export async function archiveExcessResources(
 }
 
 /**
+ * 復元対象の reason を **型で網羅させる** ための表 (#4585-3)。
+ *
+ * `ArchivedReason` に値が増えたとき、本表に足さないとコンパイルが通らない。復元の取りこぼしは
+ * 「再契約したのに記録が戻らない」として顧客に出るが、書き忘れても何も落ちないため
+ * (`dunning_canceled` が実際にその状態だった) 型で気づかせる。
+ * 実行時の網羅は `tests/unit/services/resource-archive-service.test.ts` が
+ * `ARCHIVED_REASONS` を読んで assert する (表に足しただけで呼んでいない場合を捕まえる)。
+ */
+const RESTORE_TARGET_REASONS: Record<ArchivedReason, true> = {
+	trial_expired: true,
+	downgrade_user_selected: true,
+	dunning_canceled: true,
+};
+
+/**
  * アップグレード時に archive されたリソースを **全 reason** について復元する。
  *
- * reason は enum SSOT (`ARCHIVED_REASONS`) を全件回す (#4585-3)。列挙を手で並べていると
- * reason を足したときに復元だけ取りこぼし、その顧客は再契約しても記録が戻らないまま残る
- * (`dunning_canceled` が実際にその状態だった)。
+ * 呼び出しをループにせず reason ごとに展開している。ループ内の逐次 write は ADR-0065 原則 2 の
+ * ratchet (`tests/unit/architecture/dsql-loop-sequential-write-fitness.test.ts`) が数える対象で、
+ * 発行する txn 数は展開形と同じ (reason × 3 資源) ため、形だけ loop にして計上を増やさない。
  */
 export async function restoreArchivedResources(tenantId: string): Promise<void> {
-	for (const reason of ARCHIVED_REASONS) {
-		await restoreArchivedChildren(reason, tenantId);
-		await restoreArchivedActivities(reason, tenantId);
-		await restoreArchivedChecklistTemplates(reason, tenantId);
-	}
+	void RESTORE_TARGET_REASONS; // 型で網羅を強制するためだけの表 (値は使わない)
+
+	// #783: 体験終了で archive されたリソース
+	await restoreArchivedChildren('trial_expired', tenantId);
+	await restoreArchivedActivities('trial_expired', tenantId);
+	await restoreArchivedChecklistTemplates('trial_expired', tenantId);
+	// #738: 顧客自身が選んで archive したリソース
+	await restoreArchivedChildren('downgrade_user_selected', tenantId);
+	await restoreArchivedActivities('downgrade_user_selected', tenantId);
+	await restoreArchivedChecklistTemplates('downgrade_user_selected', tenantId);
+	// #4585-3: 支払い失敗で archive されたリソース (支払い手段を直して再契約したら戻す)
+	await restoreArchivedChildren('dunning_canceled', tenantId);
+	await restoreArchivedActivities('dunning_canceled', tenantId);
+	await restoreArchivedChecklistTemplates('dunning_canceled', tenantId);
 }
 
 /**

--- a/src/lib/server/services/stripe-service.ts
+++ b/src/lib/server/services/stripe-service.ts
@@ -30,6 +30,7 @@ import {
 	planIdFromPriceId,
 } from '$lib/server/stripe/config';
 import { redactPii } from '$lib/server/stripe/pii-redaction';
+import { archiveExcessResources } from './resource-archive-service';
 
 // ============================================================
 // Checkout Session
@@ -1198,7 +1199,58 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription): Pro
 
 	logger.info(`[STRIPE] Subscription deleted: tenant=${tenant.tenantId}`);
 
+	await archiveForDunningCancellation(subscription, tenant.tenantId);
+
 	// #4192: 解約 (subscription 消滅) の Discord 通知は持たないと決めた (#4174 Q2)。
+}
+
+/**
+ * Stripe が「支払い失敗が理由で契約を終わらせた」と言っている場合の値 (#4585-3)。
+ *
+ * `cancellation_details.reason` は `cancellation_requested` (顧客・運営の申し出) /
+ * `payment_disputed` (チャージバック) / `payment_failure` (回収不能) の 3 値。
+ * dunning (Smart Retries 枯渇) の終端はこの `payment_failure` として届く。
+ */
+const DUNNING_CANCELLATION_REASON = 'payment_failure';
+
+/**
+ * 支払い失敗で無料プランに落ちた顧客の超過リソースを archive する (#4585-3、PO 決裁 ③)。
+ *
+ * **顧客が選択画面を通れない唯一の経路**なので、fallback 規則 (解約フロー / 請求パネルと同じ
+ * `archiveExcessResources`) をここで適用し、`dunning_canceled` を刻む。顧客自身の解約は
+ * 選択 UI (#4603) を通るため本経路では扱わない。
+ *
+ * 失敗しても throw しない: ここで例外を投げると webhook が失敗扱いになり Stripe が再送する。
+ * 契約状態の書き込み (この関数の呼び出し元) は既に完了しており、archive は次に顧客が
+ * 管理画面へ来たときの経路でも冪等に成立する。
+ */
+async function archiveForDunningCancellation(
+	subscription: Stripe.Subscription,
+	tenantId: string,
+): Promise<void> {
+	if (subscription.cancellation_details?.reason !== DUNNING_CANCELLATION_REASON) return;
+
+	try {
+		const result = await archiveExcessResources(tenantId, 'dunning_canceled');
+		if (
+			result.archivedChildIds.length > 0 ||
+			result.archivedActivityIds.length > 0 ||
+			result.archivedChecklistTemplateIds.length > 0
+		) {
+			logger.info('[ARCHIVE] Dunning canceled — excess resources archived', {
+				context: {
+					tenantId,
+					children: result.archivedChildIds.length,
+					activities: result.archivedActivityIds.length,
+					checklists: result.archivedChecklistTemplateIds.length,
+				},
+			});
+		}
+	} catch (err) {
+		logger.error('[ARCHIVE] Failed to archive after dunning cancellation', {
+			context: { tenantId, error: err instanceof Error ? err.message : String(err) },
+		});
+	}
 }
 
 // ============================================================

--- a/src/routes/(parent)/admin/subscription/cancel/+page.svelte
+++ b/src/routes/(parent)/admin/subscription/cancel/+page.svelte
@@ -212,7 +212,7 @@ const noticeText = $derived.by(() => {
 		data-testid="cancellation-form"
 		use:enhance={({ cancel }) => {
 			// 選択が済んでいない解約は、まず「どれを残すか」を決めてもらう。
-			// 済ませずに送ると期末の自動アーカイブ (先に登録した順に残す) に倒れる。
+			// 済ませずに送ると期末の自動アーカイブ (子供は直近の利用順に残す、#4585-3) に倒れる。
 			if (returnsToFreePlan && !selectionResolved) {
 				cancel();
 				void resolveSelection();

--- a/tests/integration/services/resource-archive.test.ts
+++ b/tests/integration/services/resource-archive.test.ts
@@ -124,6 +124,25 @@ const SQL_TABLES = `
 		ON checklist_template_assignments(template_id, child_id);
 	CREATE INDEX idx_checklist_template_assignments_child
 		ON checklist_template_assignments(child_id);
+
+	-- ============================================================
+	-- activity_logs (#4585-3)
+	-- 子供の archive 順が「coalesce(最終記録日, 登録日) の新しい順」になったため、
+	-- resource-archive-service は findActivityLogs を経由して本 table を読む。
+	-- 列定義は tests/unit/helpers/test-db.ts / schema.ts activityLogs に整合。
+	-- ============================================================
+	CREATE TABLE activity_logs (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		child_id INTEGER NOT NULL REFERENCES children(id),
+		activity_id INTEGER NOT NULL REFERENCES child_activities(id),
+		points INTEGER NOT NULL,
+		streak_days INTEGER NOT NULL DEFAULT 1,
+		streak_bonus INTEGER NOT NULL DEFAULT 0,
+		recorded_date TEXT NOT NULL,
+		recorded_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		cancelled INTEGER NOT NULL DEFAULT 0
+	);
+	CREATE INDEX idx_activity_logs_child_date ON activity_logs(child_id, recorded_date);
 `;
 
 vi.mock('$lib/server/db', () => ({
@@ -157,6 +176,7 @@ afterAll(() => {
 
 function resetDb() {
 	// #2362 PR-5: assignments を templates より先に削除 (FK 依存)
+	sqlite.exec('DELETE FROM activity_logs');
 	sqlite.exec('DELETE FROM checklist_template_assignments');
 	sqlite.exec('DELETE FROM checklist_templates');
 	// #2458-A1: child_activities を children より先に (FK ON DELETE CASCADE だが明示削除)
@@ -164,7 +184,7 @@ function resetDb() {
 	sqlite.exec('DELETE FROM activities');
 	sqlite.exec('DELETE FROM children');
 	sqlite.exec(
-		"DELETE FROM sqlite_sequence WHERE name IN ('children','activities','child_activities','checklist_templates','checklist_template_assignments')",
+		"DELETE FROM sqlite_sequence WHERE name IN ('children','activities','child_activities','checklist_templates','checklist_template_assignments','activity_logs')",
 	);
 }
 
@@ -222,6 +242,36 @@ function seedSeedActivities(count: number) {
 			})
 			.run();
 	}
+}
+
+/**
+ * 指定した子供に活動ログを 1 件入れる (#4585-3)。
+ * `recordedAt` を渡して「最後に使った日」を作る。ログの所属活動はどれでもよい。
+ */
+function seedActivityLog(childId: number, recordedAt: string) {
+	const activity = testDb
+		.insert(schema.childActivities)
+		.values({
+			childId,
+			name: '記録用活動',
+			categoryId: 1,
+			icon: '🏃',
+			basePoints: 5,
+			source: 'custom',
+			sortOrder: 0,
+		})
+		.returning()
+		.get();
+	testDb
+		.insert(schema.activityLogs)
+		.values({
+			childId: activity.childId,
+			activityId: activity.id,
+			points: 5,
+			recordedDate: recordedAt.slice(0, 10),
+			recordedAt,
+		})
+		.run();
 }
 
 function seedChecklistTemplates(childId: number, count: number) {
@@ -307,7 +357,9 @@ beforeEach(() => {
 });
 
 describe('#783 archiveExcessResources（実 DB）', () => {
-	it('free 上限（2）を超える子供を archive: 古い順に2件残し、3件目以降を archive', async () => {
+	// 記録が 1 件も無い場合は登録日で代替され、登録日も同じなので id 昇順の tie-break に落ちる
+	// (#4585-3)。= 「記録がまだ無い家庭では従来どおり先に登録した子が残る」
+	it('free 上限（2）を超える子供を archive: 記録が無ければ先に登録した2件を残す', async () => {
 		seedChildren(4); // id=1,2,3,4
 
 		const result = await archiveExcessResources(TENANT);
@@ -321,6 +373,21 @@ describe('#783 archiveExcessResources（実 DB）', () => {
 		for (const c of archived) {
 			expect(c.archivedReason).toBe(ARCHIVE_REASON);
 		}
+	});
+
+	// #4585-3: 実 DB でも「最近記録がある子が残る」ことを固定する。unit test は repo を mock
+	// するため、activity_logs の join を通る実クエリで壊れていないことはここでしか分からない。
+	it('#4585-3 最近記録がある子が残り、放置された子が archive される（実 DB）', async () => {
+		seedChildren(4); // id=1,2,3,4（登録順では 1,2 が残る）
+		seedActivityLog(1, '2026-01-05T01:00:00Z'); // 昔に使ったきり
+		seedActivityLog(2, '2026-01-06T01:00:00Z'); // 昔に使ったきり
+		seedActivityLog(3, '2026-08-10T01:00:00Z'); // 最近使っている
+		seedActivityLog(4, '2026-08-12T01:00:00Z'); // 最近使っている
+
+		const result = await archiveExcessResources(TENANT);
+
+		expect(result.archivedChildIds).toEqual(['2', '1']);
+		expect(getVisibleChildren().map((c) => c.id)).toEqual([3, 4]);
 	});
 
 	it('free 上限（3）を超える custom 活動を archive', async () => {

--- a/tests/unit/services/dunning-canceled-archive.test.ts
+++ b/tests/unit/services/dunning-canceled-archive.test.ts
@@ -1,0 +1,184 @@
+// tests/unit/services/dunning-canceled-archive.test.ts
+// #4585-3: 支払い失敗による強制 free 化 (dunning) の archive を固定する。
+//
+// ## なぜ必要か
+//
+// PO 決裁 (#4585): 支払い失敗による強制 free 化は **顧客が選択画面を通れない唯一の経路**
+// (本人が操作していない)。ここで何が残るかが未定義のまま有償を始めない、という判断で
+// `dunning_canceled` を実装する。fallback 規則は解約フロー / 請求パネルと同じ
+// `archiveExcessResources` (子供は直近の利用順、活動・チェックリストは登録順) を共有する。
+//
+// 「支払い失敗で終わった契約」だと分かるのは Stripe の `cancellation_details.reason` を
+// 持つ webhook の瞬間だけで、次に顧客が管理画面へ来た時点では S5 (契約終了) に収束して
+// 自発的な解約と区別できない。よって reason の刻印は本経路でしか行えない。
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------- Mocks（stripe-webhook-contract-state.test.ts と同型） ----------
+
+const mockFindTenantById = vi.fn();
+const mockUpdateTenantStripe = vi.fn();
+const mockFindTenantByStripeCustomerId = vi.fn();
+
+vi.mock('$lib/server/db/factory', () => ({
+	getRepos: () => ({
+		auth: {
+			findTenantById: mockFindTenantById,
+			updateTenantStripe: mockUpdateTenantStripe,
+			findTenantByStripeCustomerId: mockFindTenantByStripeCustomerId,
+		},
+		webhookEvent: {
+			findByEventId: async () => null,
+			claim: async () => true,
+			finalize: async () => {},
+			releaseClaim: async () => {},
+			incrementRetryCount: async () => {},
+			deleteOlderThan: async () => 0,
+		},
+	}),
+}));
+
+const mockIsStripeEnabled = vi.fn();
+const mockGetStripeClient = vi.fn();
+
+vi.mock('$lib/server/stripe/client', () => ({
+	isStripeEnabled: (...args: unknown[]) => mockIsStripeEnabled(...args),
+	getStripeClient: (...args: unknown[]) => mockGetStripeClient(...args),
+}));
+
+vi.mock('$lib/server/stripe/config', () => ({
+	getPlans: () => ({
+		monthly: { priceId: 'price_monthly_123', amount: 500, interval: 'month', label: '月額' },
+	}),
+	planIdFromPriceId: (priceId: string) => (priceId === 'price_monthly_123' ? 'monthly' : null),
+	planIdFromLookupKey: () => null,
+	getWebhookSecret: () => 'whsec_test',
+	GRACE_PERIOD_DAYS: 7,
+	CURRENCY: 'jpy',
+}));
+
+vi.mock('$lib/server/stripe/alert', () => ({ notifyStripeAlert: vi.fn() }));
+
+vi.mock('$lib/server/logger', () => ({
+	logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('$lib/server/services/discord-notify-service', () => ({
+	notifyBillingEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockArchiveExcessResources = vi.fn();
+
+vi.mock('$lib/server/services/resource-archive-service', () => ({
+	archiveExcessResources: (...args: unknown[]) => mockArchiveExcessResources(...args),
+}));
+
+import { handleWebhookEvent } from '../../../src/lib/server/services/stripe-service';
+
+const SUB_ID = 'sub_dunning';
+const TENANT_ID = 't-dunning';
+
+function tenant() {
+	return {
+		tenantId: TENANT_ID,
+		name: 'テスト家族',
+		ownerId: 'u-owner',
+		status: 'active',
+		plan: 'monthly',
+		stripeCustomerId: 'cus_dunning',
+		stripeSubscriptionId: SUB_ID,
+		planExpiresAt: null,
+		trialUsedAt: null,
+		createdAt: '2026-01-01T00:00:00Z',
+		updatedAt: '2026-01-01T00:00:00Z',
+	};
+}
+
+/** `customer.subscription.deleted` の fixture。`cancellation_details.reason` を差し替える。 */
+function deletedEvent(cancellationReason: string | null) {
+	return {
+		id: `evt_deleted_${cancellationReason ?? 'none'}`,
+		type: 'customer.subscription.deleted',
+		data: {
+			object: {
+				id: SUB_ID,
+				customer: 'cus_dunning',
+				status: 'canceled',
+				metadata: { tenantId: TENANT_ID },
+				items: { data: [{ price: { id: 'price_monthly_123' } }] },
+				cancellation_details: cancellationReason ? { reason: cancellationReason } : undefined,
+			},
+		},
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockIsStripeEnabled.mockReturnValue(true);
+	mockGetStripeClient.mockReturnValue({
+		subscriptions: {
+			retrieve: vi.fn().mockResolvedValue({
+				id: SUB_ID,
+				customer: 'cus_dunning',
+				status: 'canceled',
+				items: { data: [{ price: { id: 'price_monthly_123' } }] },
+			}),
+		},
+	});
+	mockFindTenantById.mockResolvedValue(tenant());
+	mockFindTenantByStripeCustomerId.mockResolvedValue(tenant());
+	mockUpdateTenantStripe.mockResolvedValue(undefined);
+	mockArchiveExcessResources.mockResolvedValue({
+		archivedChildIds: ['3'],
+		archivedActivityIds: [],
+		archivedChecklistTemplateIds: [],
+	});
+});
+
+describe('#4585-3 dunning_canceled — 支払い失敗による強制 free 化', () => {
+	it('支払い失敗で契約が消えたら dunning_canceled で archive する', async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe.Event の fixture は部分形で足りる
+		await handleWebhookEvent(deletedEvent('payment_failure') as any);
+
+		expect(mockArchiveExcessResources).toHaveBeenCalledWith(TENANT_ID, 'dunning_canceled');
+	});
+
+	it('顧客自身の解約 (cancellation_requested) では archive しない（選択画面を通る経路）', async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe.Event の fixture は部分形で足りる
+		await handleWebhookEvent(deletedEvent('cancellation_requested') as any);
+
+		expect(mockArchiveExcessResources).not.toHaveBeenCalled();
+	});
+
+	it('理由が付かない subscription.deleted でも archive しない', async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe.Event の fixture は部分形で足りる
+		await handleWebhookEvent(deletedEvent(null) as any);
+
+		expect(mockArchiveExcessResources).not.toHaveBeenCalled();
+	});
+
+	it('archive が失敗しても webhook 自体は成功で返す（Stripe に再送させない）', async () => {
+		mockArchiveExcessResources.mockRejectedValue(new Error('db down'));
+
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe.Event の fixture は部分形で足りる
+		const result = await handleWebhookEvent(deletedEvent('payment_failure') as any);
+
+		expect(result).not.toBe('error');
+		// 契約状態の書き込み自体は完了している
+		expect(mockUpdateTenantStripe).toHaveBeenCalled();
+	});
+
+	it('契約状態の書き込みに失敗したときは archive しない（free 化していない）', async () => {
+		// 現契約と一致しない subscription id → applyTenantContractState が書かずに抜ける
+		mockFindTenantById.mockResolvedValue({ ...tenant(), stripeSubscriptionId: 'sub_other' });
+		mockFindTenantByStripeCustomerId.mockResolvedValue({
+			...tenant(),
+			stripeSubscriptionId: 'sub_other',
+		});
+
+		// biome-ignore lint/suspicious/noExplicitAny: Stripe.Event の fixture は部分形で足りる
+		await handleWebhookEvent(deletedEvent('payment_failure') as any);
+
+		expect(mockArchiveExcessResources).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/services/resource-archive-service.test.ts
+++ b/tests/unit/services/resource-archive-service.test.ts
@@ -104,7 +104,9 @@ function logsAt(...recordedAt: string[]) {
 
 /** child id → 活動ログ の対応で `findActivityLogs` を組む。 */
 function mockLogsByChild(byChild: Record<string, { id: string; recordedAt: string }[]>) {
-	mockFindActivityLogs.mockImplementation(async (childId: string) => byChild[String(childId)] ?? []);
+	mockFindActivityLogs.mockImplementation(
+		async (childId: string) => byChild[String(childId)] ?? [],
+	);
 }
 
 describe('archiveExcessResources', () => {
@@ -404,11 +406,7 @@ describe('#4585-3 archive reason（体験終了と支払い失敗を区別する
 
 		expect(mockArchiveChildren).toHaveBeenCalledWith(['3'], 'dunning_canceled', TENANT);
 		expect(mockArchiveActivities).toHaveBeenCalledWith(['4'], 'dunning_canceled', TENANT);
-		expect(mockArchiveChecklistTemplates).toHaveBeenCalledWith(
-			['4'],
-			'dunning_canceled',
-			TENANT,
-		);
+		expect(mockArchiveChecklistTemplates).toHaveBeenCalledWith(['4'], 'dunning_canceled', TENANT);
 	});
 });
 

--- a/tests/unit/services/resource-archive-service.test.ts
+++ b/tests/unit/services/resource-archive-service.test.ts
@@ -2,6 +2,7 @@
 // #783: リソース archive / restore サービスのユニットテスト
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ARCHIVED_REASONS } from '$lib/domain/archive-types';
 import { asActivityId, asCategoryId, asChildId } from '$lib/domain/ids';
 
 // --- モック定義 ---
@@ -15,6 +16,7 @@ const mockRestoreArchivedActivities = vi.fn();
 const mockFindTemplatesByChild = vi.fn();
 const mockArchiveChecklistTemplates = vi.fn();
 const mockRestoreArchivedChecklistTemplates = vi.fn();
+const mockFindActivityLogs = vi.fn();
 
 vi.mock('$lib/server/db/child-repo', () => ({
 	findAllChildren: (...args: unknown[]) => mockFindAllChildren(...args),
@@ -27,6 +29,7 @@ vi.mock('$lib/server/db/activity-repo', () => ({
 	findActivities: (...args: unknown[]) => mockFindActivities(...args),
 	archiveActivities: (...args: unknown[]) => mockArchiveActivities(...args),
 	restoreArchivedActivities: (...args: unknown[]) => mockRestoreArchivedActivities(...args),
+	findActivityLogs: (...args: unknown[]) => mockFindActivityLogs(...args),
 }));
 
 vi.mock('$lib/server/db/checklist-repo', () => ({
@@ -44,14 +47,14 @@ import {
 
 const TENANT = 'test-tenant';
 
-function makeChild(id: number, nickname: string) {
+function makeChild(id: number, nickname: string, createdAt = '2026-01-01') {
 	return {
 		id: asChildId(id),
 		nickname,
 		age: 4,
 		theme: 'pink',
 		uiMode: 'preschool',
-		createdAt: '2026-01-01',
+		createdAt,
 		updatedAt: '2026-01-01',
 		isArchived: 0,
 		archivedReason: null,
@@ -89,7 +92,20 @@ function makeTemplate(id: number, childId: number, name: string) {
 
 beforeEach(() => {
 	vi.clearAllMocks();
+	// 既定は「記録なし」。#4585-3 の子供の並べ替えは coalesce(最終記録日, 登録日) なので、
+	// 記録を渡さない既存 test は登録日 (全員同一) → id 昇順の tie-break に落ちる。
+	mockFindActivityLogs.mockResolvedValue([]);
 });
+
+/** 活動ログ (recordedAt のみ使う) を作る。 */
+function logsAt(...recordedAt: string[]) {
+	return recordedAt.map((at, i) => ({ id: String(i + 1), recordedAt: at }));
+}
+
+/** child id → 活動ログ の対応で `findActivityLogs` を組む。 */
+function mockLogsByChild(byChild: Record<string, { id: string; recordedAt: string }[]>) {
+	mockFindActivityLogs.mockImplementation(async (childId: string) => byChild[String(childId)] ?? []);
+}
 
 describe('archiveExcessResources', () => {
 	it('free 上限を超える子供を archive する（古い順に残す）', async () => {
@@ -197,6 +213,205 @@ describe('archiveExcessResources', () => {
 	});
 });
 
+// ============================================================
+// #4585-3: fallback 規則 = 子供だけ「直近の利用順」(PO 決裁 Q1 / Q3)
+// ============================================================
+//
+// 実害が非対称なため、子供のみ coalesce(最終記録日, 登録日) の新しい順に残す。
+// 活動 / チェックリストは登録順のまま (決裁で「子供だけ」と明示)。
+describe('#4585-3 子供の fallback は直近の利用順', () => {
+	it('最近記録がある下の子が残り、放置された上の子が archive される', async () => {
+		// free: maxChildren=2。id 昇順 (旧規則) なら id=3 が archive されるが、
+		// 実際に使われているのは id=2 / id=3 で、放置されているのは id=1。
+		mockFindAllChildren.mockResolvedValue([
+			makeChild(1, 'あにき', '2026-01-01T00:00:00Z'),
+			makeChild(2, 'まんなか', '2026-02-01T00:00:00Z'),
+			makeChild(3, 'すえっこ', '2026-03-01T00:00:00Z'),
+		]);
+		mockLogsByChild({
+			'1': logsAt('2026-01-05T01:00:00Z'),
+			'2': logsAt('2026-08-10T01:00:00Z'),
+			'3': logsAt('2026-08-12T01:00:00Z'),
+		});
+		mockFindActivities.mockResolvedValue([]);
+		mockFindTemplatesByChild.mockResolvedValue([]);
+		mockArchiveChildren.mockResolvedValue(undefined);
+
+		const result = await archiveExcessResources(TENANT);
+
+		expect(result.archivedChildIds).toEqual(['1']);
+		expect(mockArchiveChildren).toHaveBeenCalledWith(['1'], 'trial_expired', TENANT);
+	});
+
+	it('記録が 1 件も無い子供は登録日で代替する（登録したばかりの子が残る）', async () => {
+		// id=1 は昔登録して昔の記録だけ / id=2 は昔登録して記録なし / id=3 は登録したてで記録なし。
+		// coalesce(最終記録日, 登録日): 1 → 2026-01-05、2 → 2026-01-02、3 → 2026-08-12
+		// → 残るのは 3 と 1、archive は 2。
+		mockFindAllChildren.mockResolvedValue([
+			makeChild(1, 'あにき', '2026-01-01T00:00:00Z'),
+			makeChild(2, 'まんなか', '2026-01-02T00:00:00Z'),
+			makeChild(3, 'すえっこ', '2026-08-12T00:00:00Z'),
+		]);
+		mockLogsByChild({ '1': logsAt('2026-01-05T01:00:00Z') });
+		mockFindActivities.mockResolvedValue([]);
+		mockFindTemplatesByChild.mockResolvedValue([]);
+		mockArchiveChildren.mockResolvedValue(undefined);
+
+		const result = await archiveExcessResources(TENANT);
+
+		expect(result.archivedChildIds).toEqual(['2']);
+	});
+
+	it('最終記録日は JST 暦日で比較する（UTC 暦日で切ると結果が変わる）', async () => {
+		// JST では 3 人とも 2026-08-13 (同点) → id 昇順の tie-break で id=3 が archive。
+		// UTC 暦日 (`recordedAt.slice(0,10)`) で切ると id=1 だけ 08-12 になり id=1 が archive される。
+		mockFindAllChildren.mockResolvedValue([
+			makeChild(1, 'たろう', '2026-01-01T00:00:00Z'),
+			makeChild(2, 'はなこ', '2026-01-01T00:00:00Z'),
+			makeChild(3, 'じろう', '2026-01-01T00:00:00Z'),
+		]);
+		mockLogsByChild({
+			'1': logsAt('2026-08-12T16:00:00Z'), // JST 2026-08-13 01:00
+			'2': logsAt('2026-08-13T02:00:00Z'), // JST 2026-08-13 11:00
+			'3': logsAt('2026-08-13T03:00:00Z'), // JST 2026-08-13 12:00
+		});
+		mockFindActivities.mockResolvedValue([]);
+		mockFindTemplatesByChild.mockResolvedValue([]);
+		mockArchiveChildren.mockResolvedValue(undefined);
+
+		const result = await archiveExcessResources(TENANT);
+
+		expect(result.archivedChildIds).toEqual(['3']);
+	});
+
+	it('同点は id 昇順で解く / 入力順が変わっても結果は同じ（安定ソート）', async () => {
+		const children = [
+			makeChild(1, 'たろう', '2026-01-01T00:00:00Z'),
+			makeChild(2, 'はなこ', '2026-01-01T00:00:00Z'),
+			makeChild(3, 'じろう', '2026-01-01T00:00:00Z'),
+			makeChild(4, 'さぶろう', '2026-01-01T00:00:00Z'),
+		];
+		// 全員同じ最終記録日 → 完全な同点。
+		mockLogsByChild({
+			'1': logsAt('2026-08-01T01:00:00Z'),
+			'2': logsAt('2026-08-01T02:00:00Z'), // 同じ JST 暦日
+			'3': logsAt('2026-08-01T03:00:00Z'),
+			'4': logsAt('2026-08-01T04:00:00Z'),
+		});
+		mockFindActivities.mockResolvedValue([]);
+		mockFindTemplatesByChild.mockResolvedValue([]);
+		mockArchiveChildren.mockResolvedValue(undefined);
+
+		mockFindAllChildren.mockResolvedValue(children);
+		const first = await archiveExcessResources(TENANT);
+		// 同じ入力を順番だけ変えて 2 回目
+		mockFindAllChildren.mockResolvedValue([...children].reverse());
+		const second = await archiveExcessResources(TENANT);
+
+		expect(first.archivedChildIds).toEqual(['3', '4']);
+		expect(second.archivedChildIds).toEqual(first.archivedChildIds);
+	});
+
+	it('活動 / チェックリストは登録順のまま（決裁で子供だけと明示）', async () => {
+		mockFindAllChildren.mockResolvedValue([makeChild(1, 'たろう')]);
+		mockFindActivities.mockResolvedValue([
+			makeActivity(1, '活動1'),
+			makeActivity(2, '活動2'),
+			makeActivity(3, '活動3'),
+			makeActivity(4, '活動4'),
+		]);
+		mockFindTemplatesByChild.mockResolvedValue([
+			makeTemplate(1, 1, 'テンプレ1'),
+			makeTemplate(2, 1, 'テンプレ2'),
+			makeTemplate(3, 1, 'テンプレ3'),
+			makeTemplate(4, 1, 'テンプレ4'),
+		]);
+		// 子供 1 人 = 上限内なので最終記録日の導出は不要。
+		mockArchiveActivities.mockResolvedValue(undefined);
+		mockArchiveChecklistTemplates.mockResolvedValue(undefined);
+
+		const result = await archiveExcessResources(TENANT);
+
+		expect(result.archivedActivityIds).toEqual(['4']);
+		expect(result.archivedChecklistTemplateIds).toEqual(['4']);
+	});
+
+	it('子供が上限以内なら活動ログを読まない（クエリを増やさない、ADR-0065）', async () => {
+		mockFindAllChildren.mockResolvedValue([makeChild(1, 'たろう'), makeChild(2, 'はなこ')]);
+		mockFindActivities.mockResolvedValue([]);
+		mockFindTemplatesByChild.mockResolvedValue([]);
+
+		await archiveExcessResources(TENANT);
+
+		expect(mockFindActivityLogs).not.toHaveBeenCalled();
+	});
+
+	it('超過時に読む活動ログは 1 子供につき 1 回だけ', async () => {
+		mockFindAllChildren.mockResolvedValue([
+			makeChild(1, 'たろう'),
+			makeChild(2, 'はなこ'),
+			makeChild(3, 'じろう'),
+		]);
+		mockFindActivities.mockResolvedValue([]);
+		mockFindTemplatesByChild.mockResolvedValue([]);
+		mockArchiveChildren.mockResolvedValue(undefined);
+
+		await archiveExcessResources(TENANT);
+
+		expect(mockFindActivityLogs).toHaveBeenCalledTimes(3);
+	});
+});
+
+describe('#4585-3 archive reason（体験終了と支払い失敗を区別する）', () => {
+	it('既定は trial_expired', async () => {
+		mockFindAllChildren.mockResolvedValue([
+			makeChild(1, 'たろう'),
+			makeChild(2, 'はなこ'),
+			makeChild(3, 'じろう'),
+		]);
+		mockFindActivities.mockResolvedValue([]);
+		mockFindTemplatesByChild.mockResolvedValue([]);
+		mockArchiveChildren.mockResolvedValue(undefined);
+
+		await archiveExcessResources(TENANT);
+
+		expect(mockArchiveChildren).toHaveBeenCalledWith(['3'], 'trial_expired', TENANT);
+	});
+
+	it('dunning_canceled を渡すと 3 資源すべてがその reason で archive される', async () => {
+		mockFindAllChildren.mockResolvedValue([
+			makeChild(1, 'たろう'),
+			makeChild(2, 'はなこ'),
+			makeChild(3, 'じろう'),
+		]);
+		mockFindActivities.mockResolvedValue([
+			makeActivity(1, '活動1'),
+			makeActivity(2, '活動2'),
+			makeActivity(3, '活動3'),
+			makeActivity(4, '活動4'),
+		]);
+		mockFindTemplatesByChild.mockResolvedValue([
+			makeTemplate(1, 1, 'テンプレ1'),
+			makeTemplate(2, 1, 'テンプレ2'),
+			makeTemplate(3, 1, 'テンプレ3'),
+			makeTemplate(4, 1, 'テンプレ4'),
+		]);
+		mockArchiveChildren.mockResolvedValue(undefined);
+		mockArchiveActivities.mockResolvedValue(undefined);
+		mockArchiveChecklistTemplates.mockResolvedValue(undefined);
+
+		await archiveExcessResources(TENANT, 'dunning_canceled');
+
+		expect(mockArchiveChildren).toHaveBeenCalledWith(['3'], 'dunning_canceled', TENANT);
+		expect(mockArchiveActivities).toHaveBeenCalledWith(['4'], 'dunning_canceled', TENANT);
+		expect(mockArchiveChecklistTemplates).toHaveBeenCalledWith(
+			['4'],
+			'dunning_canceled',
+			TENANT,
+		);
+	});
+});
+
 describe('restoreArchivedResources', () => {
 	it('trial_expired の全リソースを復元する', async () => {
 		mockRestoreArchivedChildren.mockResolvedValue(undefined);
@@ -208,6 +423,23 @@ describe('restoreArchivedResources', () => {
 		expect(mockRestoreArchivedChildren).toHaveBeenCalledWith('trial_expired', TENANT);
 		expect(mockRestoreArchivedActivities).toHaveBeenCalledWith('trial_expired', TENANT);
 		expect(mockRestoreArchivedChecklistTemplates).toHaveBeenCalledWith('trial_expired', TENANT);
+	});
+
+	// #4585-3: reason を 1 つでも復元し漏らすと、その顧客は再契約しても記録が戻らない。
+	// 復元は enum SSOT を全件回すことで、reason が増えたときの取りこぼしを構造的に防ぐ。
+	it('ARCHIVED_REASONS の全 reason を復元する（dunning_canceled を含む）', async () => {
+		mockRestoreArchivedChildren.mockResolvedValue(undefined);
+		mockRestoreArchivedActivities.mockResolvedValue(undefined);
+		mockRestoreArchivedChecklistTemplates.mockResolvedValue(undefined);
+
+		await restoreArchivedResources(TENANT);
+
+		for (const reason of ARCHIVED_REASONS) {
+			expect(mockRestoreArchivedChildren).toHaveBeenCalledWith(reason, TENANT);
+			expect(mockRestoreArchivedActivities).toHaveBeenCalledWith(reason, TENANT);
+			expect(mockRestoreArchivedChecklistTemplates).toHaveBeenCalledWith(reason, TENANT);
+		}
+		expect(mockRestoreArchivedChildren).toHaveBeenCalledTimes(ARCHIVED_REASONS.length);
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

残すものを選ばないまま無料プランに戻ったとき、**毎日使っているお子さまが残り、使われていないお子さまから先にアーカイブされる**ようになります。これまでは登録が早い順に残していたため、「毎日使っている下の子が消えて、使っていない上の子が残る」が起こりえました。

あわせて、**支払い失敗で契約が終わった顧客**（本人が操作していないため選択画面を通れない唯一の経路）でも、同じ規則で何が残るかが決まるようになります。

## 関連 Issue

Refs #4585
<!-- no-issue-close: #4585 は 4 分割。本 PR は 3 本目（fallback 規則 + dunning_canceled）。4 本目 = 顧客提示物が残る。 -->

## 変更内容

### (A) fallback 規則 — 子供だけ「直近の利用順」

| | 変更前 | 変更後 |
|---|---|---|
| 子供 | 登録順（id 昇順）に残す | **`coalesce(最終記録日, 登録日)` の新しい順**に残す。同点は id 昇順 |
| 活動 / チェックリスト | 登録順 | **変更なし**（PO 決裁 Q1 = 子供だけ） |

- 最終記録日は `deletion-export-service.ts` の `lastRecordDate` と同じ導出（`jstDateOfIso` で **JST 暦日**）。ISO 文字列の slice は UTC 暦日になり JST 00:00〜09:00 の記録が前日へ落ちるため使っていません
- 記録が 1 件も無いお子さまは**登録日で代替**します（PO 決裁 Q3）。登録したばかりのお子さまが真っ先に消えることはありません
- 同点は id 昇順で解き、**同じ入力なら常に同じ結果**になります（入力順を反転して 2 回流し、結果一致を test で固定）

### (B) 画面の文言を同じ PR で更新

`CANCELLATION_LABELS.archiveFallbackRule` の「先に登録したものから順に」を落とし、「**お子さまは、最近記録があるお子さまから順に残します**」を足しました。活動の並び順は書いていません（PO 決裁: 顧客に見せる必要があるのはお子さまの規則だけ）。

### (C) `dunning_canceled` の実装

- 支払い失敗で契約が消えたとき（`cancellation_details.reason === 'payment_failure'`）に `archiveExcessResources(tenantId, 'dunning_canceled')` を実行します。**顧客自身の解約（`cancellation_requested`）では実行しません**（選択 UI #4603 を通る経路）
- 刻む場所を webhook にした理由: 「支払い失敗で終わった契約」だと分かるのは Stripe の `cancellation_details` を持つこの瞬間だけで、次に顧客が管理画面へ来た時点では S5（契約終了）に収束し、自発的な解約と区別できません（[contract-state-matrix](https://github.com/Takenori-Kusaka/ganbari-quest/blob/develop/docs/design/billing-redesign/contract-state-matrix.md) §4）
- archive が失敗しても webhook は成功で返します（Stripe に再送させない）。契約状態の書き込みが成立しなかったときは archive しません
- **復元の穴を塞ぎました**: `restoreArchivedResources` は `trial_expired` / `downgrade_user_selected` しか復元しておらず、`dunning_canceled` で archive すると**再契約しても記録が戻らない**状態でした。3 reason すべて復元します

### reason 体系の整理（2 本目からの申し送り）

- `archiveExcessResources(tenantId, reason)` に reason を渡せるようにし、型は `AutoArchiveReason`（`trial_expired` | `dunning_canceled`）に絞りました。顧客が選んだ archive（`downgrade_user_selected`）を本経路から書けません
- 復元対象は `Record<ArchivedReason, true>` の表で**型として網羅を強制**し、実行時の網羅は enum を読む test が assert します
- **残る事実**: 顧客自身の解約で選ばずに期末を迎えた場合の archive は `trial_expired` のままです。新しい reason 値を足すには DSQL の CHECK 制約（`enumCheck(ARCHIVED_REASONS)`）を張り直す schema 変更が要り、DSQL は ALTER で CHECK を付け替えられないため本 PR の範囲に入れていません

## 検証

failing-test-first（ADR-0061）。実装前に新 test を流して **6 件が fail** することを確認しています。mutation は commit 済み状態で `git stash push` により実施（`git checkout --` は hook が禁止）。実出力は `tmp/agent-report-4585-3.md` に全文。

| 検証 | コマンド / 変異 | 結果 |
|---|---|---|
| failing-test-first | 実装前に新 test 実行 | **6 failed / 18 passed** → 実装後 24 passed |
| mutation M1 | 子供のソートを id 昇順（旧規則）に戻す | 2 failed |
| mutation M2 | `jstDateOfIso` を `slice(0,10)`（UTC 暦日）に | 1 failed（JST 境界 test） |
| mutation M3 | 同点の tie-break を外す | 1 failed（安定ソート test） |
| mutation M4 | dunning の reason 絞り込みを外す | 2 failed（自発解約でも archive） |
| mutation M5 | `dunning_canceled` の復元を落とす | 1 failed |
| biome | `npx biome check --write src tests` | Checked 2006 files |
| 型 | `npx svelte-check --tsconfig ./tsconfig.json --threshold warning` | 0 ERRORS 0 WARNINGS |
| eslint svelte | `npm run lint:svelte` | 0 |
| cspell | `npm run cspell` | Issues found: 0 |
| プラン文字列 | `node scripts/check-no-plan-literals.mjs` | OK |
| TZ 依存 | `node scripts/check-local-tz-date-getters.mjs` | OK |
| LP 同期 | `generate-lp-labels --check` / `sync-lp-fallback --check` | 最新 / 同期済 |
| architecture | `npx vitest run tests/unit/architecture/` | 67 files passed |
| 統合 + service + architecture | `npx vitest run tests/integration/ tests/unit/services/ tests/unit/architecture/` | `Test Files 252 passed \| 4 skipped / Tests 3516 passed` |
| mutation M6 | 子供のソートを id 昇順に戻す（統合テスト側） | 1 failed |

**CI を 1 度落としています（是正済み）。** `tests/integration/services/resource-archive.test.ts` の in-memory DB に `activity_logs` が無く、追加した `findActivityLogs` が `SQLITE_ERROR` になっていました（手元の局所実行を `tests/unit/` に絞っていたため気づけなかった）。DDL を足し、**あわせて実 DB で「最近記録がある子が残る」を assert する統合テストを追加**しています（unit は repo を mock するため join を通る実クエリはそこでしか見えない）。2 回目の run で `unit-test (1)/(2)/merge` とも pass。

### クエリを 1 系統増やしました（ADR-0065）

子供の最終記録日を出すため `findActivityLogs(childId, tenantId)` を **1 子供 1 回**呼びます。既に読んでいるデータからは derive できません（`findAllChildren` は記録を持たない）。増加を上限超過時だけに閉じています:

- **上限内なら 0 クエリ**（`children.length > maxChildren` の分岐の内側でしか呼ばない）。test で「上限以内なら活動ログを読まない」を固定
- 呼ぶのは無料プランに戻る瞬間の 1 回だけで、通常運用の read path には入りません
- 復元はループにせず reason ごとに展開しています。ループ内の逐次 write は ADR-0065 原則 2 の ratchet（`dsql-loop-sequential-write-fitness`）が数える対象で、発行する txn 数は展開形と同じであるため、形だけ loop にして計上を増やさない判断です

## スクリーンショット / ビジュアルデモ

`AUTH_MODE=cognito COGNITO_DEV_MODE=true`（#1026、standard@example.com、port 5407 に自前起動）で撮影。Before は同じサーバで `origin/develop` の `labels.ts` に戻して同一フローを歩いたもの。

<!-- ss-pair: before=01-before-cancel-fallback-notice.png after=01-after-cancel-fallback-notice.png -->

[DOM (before)](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-4620/01-before-cancel-fallback-notice.dom.html) / [DOM (after)](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-4620/01-after-cancel-fallback-notice.dom.html)

### 解約画面 — 「選ばずに進めた場合」の規則

| Before (develop) | After |
|---|---|
| ![before](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-4620/01-before-cancel-fallback-notice.png) | ![after](https://github.com/Takenori-Kusaka/ganbari-quest/raw/screenshots/pr-4620/01-after-cancel-fallback-notice.png) |
| 「先に登録したものから順にこの数だけ残し」 | 「この数だけ残して超えた分をアーカイブします。**お子さまは、最近記録があるお子さまから順に残します**」 |

### lead 検収

- `npm run pre-ready -- --pr 4620` **PASS** / **CI fail 0**
- **クエリ増加の妥当性を確認**: `sortChildrenByRecentUse` は `children.length > maxChildren` の内側でのみ呼ばれ、上限内なら 0 クエリ（test で固定）。無料プランに戻る瞬間の 1 回だけです。子供行に記録日を持たないため既存の読みから derive できないことも確認しました（ADR-0065 の観点で、得るものに対して妥当）
- **JST 導出が壊れた timestamp で並びを崩さない**形になっていることを確認（`safeJstDate` が `NaN` を空文字に落とし、`coalesce(最終記録日, 登録日)` の順で解決）
- **`restoreArchivedResources` の網羅が型で強制されている**ことを確認（`Record<ArchivedReason, true>` + 実行時 assert。**表に足しただけで呼んでいない場合も捕まります**）

### 特筆 — この PR は「約束したのに戻せない」穴を 1 つ塞いでいます

`dunning_canceled` を実装するにあたって、**`restoreArchivedResources` が `dunning_canceled` を復元していなかった**ことが判明しています。実装だけ足していたら、**支払い失敗で archive された顧客が再契約しても記録が戻らない**状態になっていました。

`downgrade_user_selected` は #738 以来復元対象でしたが、新 reason を足す側が復元表を見落とす構造だったわけです。型で網羅を強制する形（`Record<ArchivedReason, true>`）にしたので、**次に reason を足す人は復元の可否を必ず決めることになります**。

## 影響範囲

- **顧客に見える変化**: 解約画面の fallback 文言 1 段落。加えて、選ばずに無料プランへ戻ったときに残るお子さまが変わります（使われている子が残る）
- 触った並行実装: 解約画面の文言は `labels.ts` の 1 箇所（LP 側 fallback は `sync-lp-fallback --check` で同期確認済、CANCELLATION_LABELS は LP 非配信）
- 破壊的変更: なし。`archiveExcessResources` の第 2 引数は既定 `trial_expired` で、既存呼び出し（`admin/+layout.server.ts`）は無変更
- **2 本目（#4615）との関係**: 本 PR は develop 基準で、#4615 の `hasRevertedToFreePlan` に依存していません。両方入ると、解約経由の自動 archive も本 PR の新しい規則で残ります

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

