### PR TITLE
fix(plan-limit): #4622 上限メッセージに null が出うる型の穴を塞ぐ

### DIFF
--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -53,6 +53,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'scripts/ai-evaluation 配下を走査して inline inject 経路の残存を検査する',
 	},
+	'tests/unit/services/plan-limit-check-null-type-hole.test.ts': {
+		scope: 'repo',
+		note: 'src/routes 配下を再帰 walk し、プラン上限メッセージ本文が labels.ts SSOT を経由せず直書きに戻っていないかを検査する (#4622)。直書きに戻ると `max: number` の関門が消え、上限メッセージに null を埋められるようになるため、走査範囲は routes 全体でなければ意味を持たない',
+	},
 	'tests/unit/arch/no-direct-db-access.test.ts': {
 		scope: 'repo',
 		note: 'src 配下を走査して直接 DB アクセスを検出する',

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -458,8 +458,46 @@ export const PLAN_GATE_LABELS = {
 	 * 家族メンバー招待の quota 上限 (maxFamilyMembers) 到達時の 403 文言 (#1111 / EPIC #3533 §10.7)。
 	 * 旧 `api/v1/admin/invites/+server.ts` 内ハードコードを SSOT 経由に是正 (ADR-0045 / P5)。
 	 */
-	memberLimitReached: (max: number | string) =>
+	memberLimitReached: (max: number) =>
 		`メンバー上限（${max}人）に達しています。プランをアップグレードしてください。`,
+
+	/**
+	 * "カスタム活動は最大{max}個まで作成できます。プランをアップグレードしてください。"
+	 *
+	 * 活動 quota 上限 (maxActivities) 到達時の 403 文言 (#4622)。
+	 * 旧実装は routes 7 箇所に直書きされ、`checkActivityLimit` の `max: number | null` を
+	 * そのまま埋めていたため「最大 null 個」を出しうる型の穴になっていた。
+	 * 引数を `number` に狭めることで、null を渡す呼び出しがコンパイルで落ちる。
+	 *
+	 * @param max 上限値。`allowed: false` の分岐でのみ呼ぶこと (無制限プランは上限に達しない)
+	 */
+	activityLimitReached: (max: number) =>
+		`カスタム活動は最大${max}個まで作成できます。プランをアップグレードしてください。`,
+
+	/**
+	 * "子供は最大{max}人まで登録できます。プランをアップグレードしてください。"
+	 *
+	 * 子供 quota 上限 (maxChildren) 到達時の 403 文言 (#4622)。activityLimitReached と同型。
+	 */
+	childLimitReached: (max: number) =>
+		`子供は最大${max}人まで登録できます。プランをアップグレードしてください。`,
+
+	/**
+	 * "フリープランではお子さま1人あたり {max} 個までです。"
+	 *
+	 * チェックリストテンプレート quota 上限 (maxChecklistTemplates) 到達時の 403 文言 (#4622)。
+	 * アップグレード導線を併記しない短い版。
+	 */
+	checklistTemplateLimitReached: (max: number) =>
+		`フリープランではお子さま1人あたり ${max} 個までです。`,
+
+	/**
+	 * "フリープランではお子さま1人あたり {max} 個までです。スタンダード以上に…"
+	 *
+	 * 上と同じ上限のアップグレード導線併記版 (#4622)。
+	 */
+	checklistTemplateLimitReachedWithUpgrade: (max: number) =>
+		`フリープランではお子さま1人あたり ${max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
 
 	/**
 	 * プラン制限エラー banner / toast に併記するアップグレード導線リンクのラベル (#2894 AC3)。

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -31,6 +31,26 @@ export interface PlanLimits {
 // 既存の 50 箇所以上ある import 元を壊さないため、ここから再 export する。
 export type { PlanTier };
 
+/**
+ * 上限チェックの結果 (#4622)。
+ *
+ * `max: null` は「無制限」を意味するので、**上限に達した状態 (`allowed: false`) と
+ * 同時には成立しない**。旧実装は `{ allowed: boolean; max: number | null }` という
+ * 単一 shape だったため、この不変条件を型が持たず、`if (!check.allowed)` の内側でも
+ * `max` が `number | null` のままだった。結果、上限到達メッセージに
+ * 「カスタム活動は最大 null 個まで作成できます」と出しうる型の穴が空いていた。
+ *
+ * discriminated union にすることで不正な状態を型で表現不能にし (ADR-0061)、
+ * `!allowed` 側では `max` が `number` に narrowing される。
+ * 上限メッセージのラベル関数 (`PLAN_GATE_LABELS.*LimitReached`) は `max: number` を
+ * 要求するので、この不変条件を崩した瞬間に呼び出し側がコンパイルで落ちる。
+ */
+export type PlanLimitCheck =
+	/** 未到達。`max: null` は無制限プラン (上限なし) を表す */
+	| { allowed: true; current: number; max: number | null }
+	/** 上限到達。到達しうるのは上限が具体値のプランだけなので `max` は必ず number */
+	| { allowed: false; current: number; max: number };
+
 const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 	free: {
 		maxChildren: 2,
@@ -224,7 +244,7 @@ export async function hasArchivedData(
 export async function checkChildLimit(
 	tenantId: string,
 	licenseStatus: string,
-): Promise<{ allowed: boolean; current: number; max: number | null }> {
+): Promise<PlanLimitCheck> {
 	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
 	if (limits.maxChildren === null) {
 		return { allowed: true, current: 0, max: null };
@@ -250,7 +270,7 @@ export async function checkChildLimit(
 export async function checkActivityLimit(
 	tenantId: string,
 	licenseStatus: string,
-): Promise<{ allowed: boolean; current: number; max: number | null }> {
+): Promise<PlanLimitCheck> {
 	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
 	if (limits.maxActivities === null) {
 		return { allowed: true, current: 0, max: null };
@@ -284,7 +304,7 @@ export async function checkChecklistTemplateLimit(
 	tenantId: string,
 	licenseStatus: string,
 	childId: ChildId,
-): Promise<{ allowed: boolean; current: number; max: number | null }> {
+): Promise<PlanLimitCheck> {
 	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
 	if (limits.maxChecklistTemplates === null) {
 		return { allowed: true, current: 0, max: null };
@@ -312,7 +332,7 @@ export async function checkChecklistTemplateLimit(
 export async function checkFamilyMemberLimit(
 	tenantId: string,
 	licenseStatus: string,
-): Promise<{ allowed: boolean; current: number; max: number | null }> {
+): Promise<PlanLimitCheck> {
 	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
 	if (limits.maxFamilyMembers === null) {
 		return { allowed: true, current: 0, max: null };

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -5,6 +5,7 @@ import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asActivityId, asCategoryId, asChildId, type ChildId } from '$lib/domain/ids';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import {
 	CATEGORY_DEFS,
 	getCategoryById,
@@ -180,7 +181,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(activityLimitCheck.max),
 				),
 			});
 		}
@@ -292,7 +293,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${importPackLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(importPackLimitCheck.max),
 				),
 			});
 		}
@@ -433,7 +434,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(activityLimitCheck.max),
 				),
 			});
 		}
@@ -543,7 +544,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${copyLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(copyLimitCheck.max),
 				),
 			});
 		}
@@ -609,7 +610,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${bulkActivityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(bulkActivityLimitCheck.max),
 				),
 			});
 		}

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -174,7 +174,7 @@ const importMarketplaceChecklistAction: Action = async ({ request, locals }) => 
 			error: createPlanLimitError(
 				tier,
 				'standard',
-				`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+				PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(limit.max),
 			),
 			upgradeRequired: true,
 		});
@@ -324,7 +324,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+					PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(limit.max),
 				),
 				upgradeRequired: true,
 			});
@@ -490,7 +490,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。`,
+					PLAN_GATE_LABELS.checklistTemplateLimitReached(limit.max),
 				),
 			});
 		}
@@ -563,7 +563,7 @@ export const actions: Actions = {
 					error: createPlanLimitError(
 						tier,
 						'standard',
-						`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+						PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(limit.max),
 					),
 					upgradeRequired: true,
 				});
@@ -753,7 +753,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+					PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(limit.max),
 				),
 				upgradeRequired: true,
 			});

--- a/src/routes/(parent)/admin/children/+page.server.ts
+++ b/src/routes/(parent)/admin/children/+page.server.ts
@@ -4,7 +4,7 @@ import { calculateAgeFromBirthDate } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asCategoryId, asChildId } from '$lib/domain/ids';
-import { ADMIN_CHILDREN_PAGE_LABELS } from '$lib/domain/labels';
+import { ADMIN_CHILDREN_PAGE_LABELS, PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
@@ -181,7 +181,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`子供は最大${childLimitCheck.max}人まで登録できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.childLimitReached(childLimitCheck.max),
 				),
 			});
 		}

--- a/src/routes/api/v1/activities/+server.ts
+++ b/src/routes/api/v1/activities/+server.ts
@@ -3,6 +3,7 @@ import * as v from 'valibot';
 // #3740: client-facing 経路の wire source は信頼せず正準 'custom' を強制する (trust 境界分離)
 import { PARENT_CREATED_SOURCE } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { activitiesQuerySchema, createActivitySchema } from '$lib/domain/validation/activity';
 import { findChildById } from '$lib/server/db/activity-repo';
 import { apiError, validationError } from '$lib/server/errors';
@@ -53,11 +54,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const licenseStatus = context.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const limitCheck = await checkActivityLimit(tenantId, licenseStatus);
 	if (!limitCheck.allowed) {
-		return apiError(
-			'PLAN_LIMIT_EXCEEDED',
-			`カスタム活動は最大${limitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
-			{ current: limitCheck.current, max: limitCheck.max },
-		);
+		return apiError('PLAN_LIMIT_EXCEEDED', PLAN_GATE_LABELS.activityLimitReached(limitCheck.max), {
+			current: limitCheck.current,
+			max: limitCheck.max,
+		});
 	}
 
 	// #3740: wire `source` ('seed'/'curriculum' 含む) を信頼すると quota 集計対象外の値を

--- a/src/routes/api/v1/activities/import/+server.ts
+++ b/src/routes/api/v1/activities/import/+server.ts
@@ -1,6 +1,7 @@
 import { error, json } from '@sveltejs/kit';
 import type { ActivityPackItem } from '$lib/domain/activity-pack';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { CATEGORY_CODES } from '$lib/domain/validation/activity';
 // #2365 (ADR-0052): 新 Strategy + dispatchImport 経由
 import { dispatchImport, marketplaceRegistry } from '$lib/marketplace';
@@ -104,7 +105,7 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
 		if (!limitCheck.allowed) {
 			return apiError(
 				'PLAN_LIMIT_EXCEEDED',
-				`カスタム活動は最大${limitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+				PLAN_GATE_LABELS.activityLimitReached(limitCheck.max),
 				{ current: limitCheck.current, max: limitCheck.max },
 			);
 		}

--- a/src/routes/api/v1/admin/invites/+server.ts
+++ b/src/routes/api/v1/admin/invites/+server.ts
@@ -56,7 +56,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return json(
 			{
 				error: 'MEMBER_LIMIT_REACHED',
-				message: PLAN_GATE_LABELS.memberLimitReached(memberLimit.max ?? 0),
+				// #4622: PlanLimitCheck が discriminated union になり、!allowed 側で max は number に確定する。
+				// 旧 `?? 0` fallback は「メンバー上限（0人）」という別の嘘を出しうるため撤去した。
+				message: PLAN_GATE_LABELS.memberLimitReached(memberLimit.max),
 				current: memberLimit.current,
 				max: memberLimit.max,
 			},

--- a/tests/unit/services/plan-limit-check-null-type-hole.test.ts
+++ b/tests/unit/services/plan-limit-check-null-type-hole.test.ts
@@ -16,9 +16,13 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import type { PlanLimitCheck } from '$lib/server/services/plan-limit-service';
+
+// #4085: 本 file は src/routes ツリーを walk する repo 走査 test (registry に scope:'repo' で宣言済)。
+// unit lane の並列実行では既定 5s を超えうるため明示 timeout を置く。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = path.resolve(__dirname, '../../..');
 const ROUTES_DIR = path.join(REPO_ROOT, 'src', 'routes');

--- a/tests/unit/services/plan-limit-check-null-type-hole.test.ts
+++ b/tests/unit/services/plan-limit-check-null-type-hole.test.ts
@@ -1,0 +1,120 @@
+// #4622: プラン上限メッセージに null が出うる型の穴の回帰ロック。
+//
+// 旧実装は上限チェック 4 関数が `{ allowed: boolean; current: number; max: number | null }` を
+// 返しており、「allowed:false なら max は必ず具体値」という不変条件を型が持っていなかった。
+// そのため `if (!check.allowed)` の内側でも max は `number | null` のままで、
+// `カスタム活動は最大${check.max}個まで作成できます` が型検査を通り、
+// 顧客の画面に「最大 null 個」と出しうる状態だった (routes 13 箇所)。
+//
+// 本 test が守るのは以下の 3 点:
+//   1. PlanLimitCheck が discriminated union で、allowed:false + max:null が**型として作れない**
+//   2. 上限メッセージのラベル関数が `max: number` を要求し、null を渡すと型エラーになる
+//   3. メッセージ本文が routes に再び直書きされない (SSOT = labels.ts、ADR-0045)
+//
+// 1 と 2 は `@ts-expect-error` で固定しているため、型が緩められると
+// 「未使用の @ts-expect-error」として svelte-check (pre-ready Step 2 / CI) が落ちる。
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import type { PlanLimitCheck } from '$lib/server/services/plan-limit-service';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const ROUTES_DIR = path.join(REPO_ROOT, 'src', 'routes');
+
+function collectTsFiles(dir: string, acc: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		const full = path.join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			collectTsFiles(full, acc);
+		} else if (full.endsWith('.ts') || full.endsWith('.svelte')) {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+describe('#4622 PlanLimitCheck — 不正な状態 (allowed:false + max:null) を型で表現不能にする', () => {
+	it('allowed:false のとき max は number しか代入できない', () => {
+		const reached: PlanLimitCheck = { allowed: false, current: 3, max: 3 };
+		expect(reached.allowed).toBe(false);
+
+		// 上限到達なのに「上限は無制限」という矛盾した状態は型として作れない。
+		// この @ts-expect-error が不要になる = 型が緩んだ、ということなので tsc が落ちる。
+		// @ts-expect-error allowed:false のとき max:null は不正な状態 (#4622)
+		const broken: PlanLimitCheck = { allowed: false, current: 3, max: null };
+		expect(broken).toBeDefined();
+	});
+
+	it('allowed:true のときだけ max:null (= 無制限) を表現できる', () => {
+		const unlimited: PlanLimitCheck = { allowed: true, current: 0, max: null };
+		expect(unlimited.max).toBeNull();
+	});
+
+	it('!allowed で narrowing すると max が number に確定する', () => {
+		const check: PlanLimitCheck = { allowed: false, current: 3, max: 3 };
+		if (!check.allowed) {
+			// narrowing 後は null 許容ではないので、number を要求する関数にそのまま渡せる。
+			const message: string = PLAN_GATE_LABELS.activityLimitReached(check.max);
+			expect(message).not.toContain('null');
+		}
+	});
+});
+
+describe('#4622 上限メッセージのラベル関数は null を受け取れない', () => {
+	it('null を渡すと型エラーになる', () => {
+		// @ts-expect-error 上限到達メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.activityLimitReached(null)).toBeTypeOf('string');
+		// @ts-expect-error 上限到達メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.childLimitReached(null)).toBeTypeOf('string');
+		// @ts-expect-error 上限到達メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.checklistTemplateLimitReached(null)).toBeTypeOf('string');
+		// @ts-expect-error 上限到達メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(null)).toBeTypeOf('string');
+		// @ts-expect-error メンバー上限メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.memberLimitReached(null)).toBeTypeOf('string');
+	});
+
+	it('文言は移設前とバイト一致で不変', () => {
+		expect(PLAN_GATE_LABELS.activityLimitReached(3)).toBe(
+			'カスタム活動は最大3個まで作成できます。プランをアップグレードしてください。',
+		);
+		expect(PLAN_GATE_LABELS.childLimitReached(2)).toBe(
+			'子供は最大2人まで登録できます。プランをアップグレードしてください。',
+		);
+		expect(PLAN_GATE_LABELS.checklistTemplateLimitReached(3)).toBe(
+			'フリープランではお子さま1人あたり 3 個までです。',
+		);
+		expect(PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(3)).toBe(
+			'フリープランではお子さま1人あたり 3 個までです。スタンダード以上にアップグレードすると無制限に作成できます。',
+		);
+		expect(PLAN_GATE_LABELS.memberLimitReached(4)).toBe(
+			'メンバー上限（4人）に達しています。プランをアップグレードしてください。',
+		);
+	});
+});
+
+describe('#4622 fitness — 上限メッセージ本文を routes に直書きし戻さない', () => {
+	// labels.ts を経由しない直書きに戻すと `max: number` の関門が消え、
+	// 再び `${check.max}` に null を埋められるようになる。文面の断片で検出する。
+	const FORBIDDEN_FRAGMENTS = [
+		'個まで作成できます',
+		'人まで登録できます',
+		'個までです。',
+		'人）に達しています',
+	];
+
+	it('src/routes 配下に上限メッセージの直書きが無い', () => {
+		const offenders: string[] = [];
+		for (const file of collectTsFiles(ROUTES_DIR)) {
+			const source = readFileSync(file, 'utf8');
+			for (const fragment of FORBIDDEN_FRAGMENTS) {
+				if (source.includes(fragment)) {
+					offenders.push(`${path.relative(REPO_ROOT, file)}: "${fragment}"`);
+				}
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

プラン上限に達したときのエラー本文に、内部値 `null` が混ざって「カスタム活動は最大 **null** 個まで作成できます」と表示されうる型の穴を塞ぐ。顧客が読む文面から内部値が漏れる経路を、型で成立しないようにする。

## 関連 Issue

Closes #4622

## 変更内容

### 1. 不正な状態を型で表現不能にする（根本）

`plan-limit-service.ts` の上限チェック 4 関数の戻り型を discriminated union にした。

```ts
export type PlanLimitCheck =
	| { allowed: true; current: number; max: number | null } // null = 無制限
	| { allowed: false; current: number; max: number };      // 到達時は必ず具体値
```

「`max: null`（無制限）と `allowed: false`（上限到達）は同時に成立しない」という実装上の不変条件を、型が持つようにした。`if (!check.allowed)` の内側で `max` が `number` に narrowing される。ランタイム挙動は不変（返している値は前と同じ）。

### 2. メッセージを `max: number` の関門に通す（機械停止点）

union だけでは、`allowed: true` 側の `max` を template literal に埋める新規コードを型が止められない（`${null}` は合法）。そこで **routes に日本語直書きされていた上限メッセージ 13 箇所**を `PLAN_GATE_LABELS` の `max: number` を取るラベル関数経由に集約した。null を渡すコードは svelte-check で落ちる。ADR-0045（terms/labels SSOT）逸脱も同時に解消。

`memberLimitReached` の引数も `number | string` → `number` に狭め、呼び出し側の `?? 0` を撤去した（`?? 0` は null の代わりに「メンバー上限（**0人**）に達しています」という別の嘘を出す band-aid だった）。

**表示文言はバイト一致で不変**。`null` → `'無制限'` の置換は採っていない（「上限に達しました」と「無制限です」が同じ関数から出るのは意味が壊れるため）。

### 3. 回帰ロック

`tests/unit/services/plan-limit-check-null-type-hole.test.ts`:

- `@ts-expect-error` で「`allowed:false` + `max:null` が作れない」「ラベル関数に null を渡せない」を固定。型を緩めると **未使用の `@ts-expect-error`** として svelte-check（pre-ready Step 2 / CI）が落ちる
- fitness function: `src/routes/**` にメッセージ本文が再び直書きされていないことを assert（直書きに戻すと `max: number` の関門が消えるため）
- 文言のバイト一致 assert（移設で文面が変わっていないこと）

## 検証

### failing-test-first

実装前に、現行型が不正な状態を許すことを svelte-check で確認した（`{ allowed:false, max:null }` が代入でき、`@ts-expect-error` が「未使用」になる = 穴の存在証明）:

```
$ npx svelte-check --tsconfig ./tsconfig.json --threshold error   # 実装前
ERROR "src\lib\server\services\zz-type-hole-probe.ts" 8:1 "Unused '@ts-expect-error' directive."

$ node -e "const broken={allowed:false,current:3,max:null}; console.log(`カスタム活動は最大${broken.max}個まで作成できます。`)"
カスタム活動は最大null個まで作成できます。
```

回帰テストも実装前は fail:

```
$ npx vitest run tests/unit/services/plan-limit-check-null-type-hole.test.ts   # 実装前
 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
```

### mutation 検証（先に commit → `git stash push` で退避・復元）

| # | 入れた mutation | 結果 |
|---|---|---|
| M1 | union の `allowed:false` 側を `max: number \| null` に戻す | svelte-check **16 ERRORS**（routes 13 箇所 + test の `Unused '@ts-expect-error'`）→ 検出 |
| M2 | `activityLimitReached` の引数を `number \| null` に戻す | svelte-check **1 ERROR** `Unused '@ts-expect-error' directive.` → 検出 |
| M3 | `children/+page.server.ts` のメッセージを直書きに戻す | vitest fitness **1 failed**（`admin\children\+page.server.ts: "人まで登録できます"`）→ 検出 |

### コマンドと結果

```
npx biome check --write src tests                     → Checked 2006 files, Fixed 3 files (整形のみ)
npx svelte-check --threshold warning                  → 8213 FILES 0 ERRORS 0 WARNINGS
npm run lint:svelte                                   → エラーなし
npm run cspell                                        → Issues found: 0 in 0 files
node scripts/check-no-plan-literals.mjs               → OK — リテラル直書きなし
node scripts/check-repo-scan-test-declaration.mjs     → OK — repo 走査 test 59 件すべて区分宣言済
npx vitest run tests/unit/routes/ tests/unit/services/
                                                      → Test Files 261 passed (261) / Tests 3658 passed (3658)
npx vitest run src/lib/domain/ src/lib/server/services/ src/routes/ tests/unit/
                                                      → Test Files 723 passed (723) / Tests 10893 passed | 1 skipped
```

CI (HEAD `5221c14e6`): **fail 0 / pending 0 で全 settle**。`lint-and-test` / `unit-test (1)` / `unit-test (2)` / `unit-test-merge` / `ci-gate` / `dependency-cruiser` すべて pass。

初回 push で CI `lint-and-test` の「repo 走査 test の区分宣言 guard (#4085)」を落とした。追加した fitness test が `src/routes` を walk するため `scripts/lib/ci/repo-scan-test-registry.mjs` への `scope: 'repo'` 宣言 + 明示 timeout が必要という既存規約（`tests/CLAUDE.md`）を踏んでいなかった。registry 1 行追加 + `vi.setConfig({ testTimeout: 60_000 })` で解消（`5221c14e6`）。

### lead 検収 — **私の指示のほうが 1 段浅い認識でした**

私は「`labels.ts` の `customActivityLimitReached` が `number | null` を受けている」と指示しましたが、**その関数は develop / main に存在しません**。私が読んだのは #4512（PR #4607、未 merge）が集約した後の worktree でした。

`origin/develop` の実物:

```
183: `カスタム活動は最大${activityLimitCheck.max}個まで作成できます。…`   ← route に直書き
295: 同上
436: 同上
```

**穴はもう 1 段深いところにありました** — 型が保証していないだけでなく、**`max` を `number` に絞る関数境界がそもそも存在しない**。同じ形が **13 箇所**（activities 7 / checklists 5 / children 1）。

さらに私が挙げていなかったものを担当が見つけています: `api/v1/admin/invites/+server.ts:59` の `memberLimit.max ?? 0` は「メンバー上限（**0人**）に達しています」という**別の嘘**を出す band-aid でした。

### 設計 — union だけでは塞がらない

私が推奨した discriminated union に加えて、**label 境界を作った**判断が正しいと確認しました。**union だけでは `allowed: true` 側の `${check.max}` が依然として合法**なので、次の穴を止められません。13 箇所を `PLAN_GATE_LABELS.*(max: number)` に移して初めてコンパイラが止めます（ADR-0045 の SSOT 逸脱も同時に解消）。

**表示文字列は byte 単位で不変**、test で assert 済み。`'無制限'` 置換はしていません。

二重の回帰ロック: `@ts-expect-error`（型を緩めると "unused directive" で svelte-check が落ちる）+ fitness function（route に再インライン化すると vitest が落ちる）。

### 横展開

`labels.ts` の nullable 引数 12 関数を全件分類し、**11 が (b) 正しく分岐済み**、**1 が (c) 到達不能**（`trialActiveUntil`、根拠を明記）。うち 4 つは `max: number | null` を**意図的に**受けています — **現在の上限を表示する**用途で、`allowed: true` + `max: null` が正当に来るためです。`*LimitReached` 系とは意味が違います。service 層で `getPlanLimits()` を直接埋める 6 箇所も掃いています。

### 記録された構造的事実（本 PR の scope 外）

**`TrialStatus` が同じ構造の穴を持っています**（`isTrialActive: boolean` + `trialEndDate: string | null`）。20+ 参照で影響範囲が違うため本 PR には含めず、**事実として記録**しました。

- `npm run pre-ready -- --pr 4625` **PASS** / CI fail 0 / pending 0

## 影響範囲

顧客に見える変化: **なし**（表示文言はバイト一致で不変、ランタイム挙動も不変）。型と、文言の置き場所だけが変わる。

触ったファイル:

- `src/lib/server/services/plan-limit-service.ts`（型のみ）
- `src/lib/domain/labels.ts`（`PLAN_GATE_LABELS` に 4 関数追加 + `memberLimitReached` の引数を狭める）
- `src/routes/(parent)/admin/{activities,checklists,children}/+page.server.ts`
- `src/routes/api/v1/activities/+server.ts` / `.../activities/import/+server.ts` / `.../admin/invites/+server.ts`

並行実装ペア: UI ラベルの SSOT は `labels.ts`。今回追加したのは server 側 403 本文のみで、LP (`site/shared-labels.js`) には配信されない（`generate-lp-labels --check` 影響なし）。破壊的変更なし。

### 横展開: `labels.ts` の nullable 引数関数 全 12 件

`grep -nE "\(.*: (number|string) \| null\) =>" src/lib/domain/labels.ts` の全ヒットを分類した。

| # | 関数 | 分類 | 根拠 |
|---|---|---|---|
| 1 | `TRIAL_EMAIL_LABELS.freeRetentionLine` (756) | (b) | `formatRetentionPeriod(days)` に委譲。同関数は `days === null` で `'無期限'` を返す |
| 2 | `TRIAL_EMAIL_LABELS.retentionIrreversibleLine` (769) | (b) | `days === null` で分岐し「保持期間に上限はありません」を返す（#4512 と同じ正しい形） |
| 3 | `SUBSCRIPTION_PAGE_LABELS.trialActiveUntil` (2926) | (c) | `${date ?? ''}` で `null` リテラルは出ない。呼び出しは `SaasLicensePanel.svelte:723` の 1 箇所のみで `{#if trialStatus.isTrialActive}` 配下。`computeTrialStatus` の `isTrialActive: true` を返す 2 分岐（debug override / `latest` あり）はいずれも `trialEndDate` に非 null を入れており、null になる 3 分岐はすべて `isTrialActive: false`。※`TrialStatus` 自体も flag と値の結合を型で保証していない同型の穴だが、20+ 箇所が参照する別 blast radius のため本 PR の対象外 |
| 4 | `SUBSCRIPTION_PAGE_LABELS.churnLostRetentionDays` (3095) | (b) | `formatRetentionPeriod` に委譲（#1 と同じ） |
| 5 | `OPS_*.bypassUnavailableReason` (3379) | (b) | `${reason ?? '…接続できませんでした'}` で null 分岐済み |
| 6 | `demoPlanUsageRetentionValue` (3108) | (b) | `days === null ? '無制限' : …` |
| 7 | `demoPlanUsageMaxValue` (3109) | (b) | `max === null ? '無制限' : String(max)` |
| 8 | `DOWNGRADE_*.retentionWarning` (5715) | (b) | `currentDays === null` を明示分岐、`targetDays` は `formatRetentionPeriod` 経由 |
| 9 | `childrenSectionTitle` (5724) | (b) | `${max ?? '無制限'}`。ダウングレード確認画面は無制限プランからの遷移で `max: null` が正当に来る |
| 10 | `activitiesSectionTitle` (5731) | (b) | 同上 |
| 11 | `checklistsSectionTitle` (5736) | (b) | 同上 |
| 12 | `activityLimitBanner.title` (8265) | (b) | `${max ?? '無制限'}`。`checkActivityLimit` の結果を load 経由で受けるため `allowed: true`（無制限）でも呼ばれる |

**(a) = 本 PR で塞いだもの**: `PLAN_GATE_LABELS.memberLimitReached`（上の grep pattern には `number | string` のため掛からないが同一 class。`?? 0` band-aid を撤去して `number` に狭めた）+ routes 直書き 13 箇所（そもそも labels.ts に無かった）。

9 / 10 / 11 / 12 は `max ?? '無制限'` を持つが、これは**上限メッセージではなく「現在の上限を表示する」文脈**であり、`allowed: true` で `max: null` が正当に到達する。今回狭めた `*LimitReached` 系（上限到達時のみ呼ばれる）とは意味が異なるため、`number | null` のまま正しい。

### service 層の同型パターン（本 PR 対象外、根拠付き）

`getPlanLimits()` の `maxX: number | null` を直接埋めている 6 箇所も確認した:

- `downgrade-service.ts:153/166/184` → いずれも `if (limits.maxX !== null)` の内側。**(b)**
- `cloud-export-service.ts:221` → `maxCloudExports` は `number`（nullable でない）。**対象外**
- `trial-notification-service.ts:111/112` → `getPlanLimits('free')` と tier リテラル固定で、`PLAN_LIMITS.free.maxChildren = 2` / `maxActivities = 3` は定数。**(c)**（無料プランを無制限にする決定が下れば到達する。その決定は「無料プランに上限がある」前提のメール文面自体を書き換える変更なので、同じ PR で必ず目に入る）

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

