### PR TITLE
fix(ci): #4623 到達不能な判定関数を配線ごと削除し、この class を fitness function で機械検出する

### DIFF
--- a/.claude/skills/dev-open-pr/SKILL.md
+++ b/.claude/skills/dev-open-pr/SKILL.md
@@ -154,9 +154,10 @@ npm run pre-ready -- --pr <PR番号後で発番>
 `check-pr-body.mjs` は以下を検出:
 - 必須セクション欠落（PR template / SSOT JSON との完全一致、#2060 で SSOT 化）
 - 禁止語混入（`予定` / `follow-up` / `PENDING` / `DEFERRED` / `別途` / `個別起票` / `TODO`）
-- AC 検証マップの 4 列空セル / コメントのみセル
-- Ready チェックリスト未チェック残置
-- **変更タイプ checkbox 未選択（`- [x]` 1 つ以上必須、#3846）** — CI 必須 gate「変更タイプの選択」(`pr-template-gate.yml`) と同一 SSOT (`scripts/pr-template-gate-checks.mjs` `checkChangeType`) を PR 作成前に実行。未選択のまま提出して CI hard-fail → QM body-only remediation が 3 PR 連続再発 (#3835 / #3837 / #3844) した same-class defect (ADR-0061) の shift-left 対策。**`gh pr create` 前に必ず本 `--body-file` 検証を PASS させる**
+- **`## 検証` の根拠コマンドが他 PR を指している（`--pr <番号>` が自 PR と不一致、#4074 / 走査節は #4612 で是正）** — 別 PR で再現した実測ログを意図して載せている場合のみ `<!-- evidence-pr-ref-ok: <理由 12 文字以上> -->` で通せる
+- Ready チェックリスト未チェック残置（integration lane のみ。feature / hotfix lane の checklist 検証は #4305 で撤去済）
+
+**AC 検証マップの 4 列検証 / 変更タイプ checkbox 未選択検出は無い。** #4305 が両節を PR テンプレートから撤去した際に対の CI job も外れており、判定関数だけが残っていたものを #4612 で削除した（`ac-map-*` / `change-type-unselected` の違反 id はどこからも出力されない）。
 
 検証 PASS まで雛形を更新する。Skill 雛形は **PR template SSOT (`.github/PR_TEMPLATE_SECTIONS.json` 経由) に完全準拠** した状態で提供されるが、雛形時点では「AC 検証マップの検証手段 / 結果列」「Ready for Review チェックリスト」が空のため `check-pr-body.mjs` は fail する。**Agent がステップ 2 の穴埋めを完了してから検証 PASS する**設計。穴埋め完了の signal として、本検証 CLI の PASS を使用する。
 

--- a/docs/design/08-データベース設計書.md
+++ b/docs/design/08-データベース設計書.md
@@ -2617,7 +2617,7 @@ dim 4 漏れによる data orphan が発生した場合の復旧手順は [docs/
 - **判定方式**: 完全 SQL parser でなく `git diff --unified=0` の drizzle column 定義行を正規表現で解析する
   (#2520 AC7)。検出ロジック (`detectBreakingChanges`) の unit test は
   `tests/unit/scripts/check-schema-migration-completeness.test.ts`。
-- **skip**: 純フォーマット変更等は PR 本文に `[skip-schema-migration-check]` を含める。
+- **skip**: 純フォーマット変更等は PR 本文に `[skip-schema-migration-check]` を**宣言として**書く。HTML コメント / コードブロック / 引用 / 未チェック checkbox / 案内文の中の同じ文字列は skip として扱わない (判定規律の SSOT は `scripts/lib/ci/pr-body-sections.mjs`、#4348)。
 - **#2519 との棲み分け**: 本 gate は **PR 時の static schema diff** (gate)。#2519 は **runtime data orphan**
   (startup assert、data 側)。#2507 (full 版: schema / create-tables / lazy の 3 dimension 完全同期) は別途。
 

--- a/scripts/check-ac-verification-map.mjs
+++ b/scripts/check-ac-verification-map.mjs
@@ -27,39 +27,6 @@ export const NG_DECLARATION_SECTION = 'NG 0 件 / カバレッジ宣言';
 export const NG_NONZERO_ACCEPTED_KEY = 'ng-nonzero-accepted';
 
 /**
- * #1539: AC マップ 4 列目（結果/エビデンス列）の未完了表記検出パターン。
- *
- * **`follow[\s-]up`（区切り 1 文字必須）の意図（#3488 BLOCK fix）**:
- * `?` で区切りを optional にすると、区切り無しの slug `followup` が部分一致してしまい
- * `docs/research/2026-06-29-followup-treadmill-root-cause.md` のような**完了済エビデンス参照の
- * ファイル名**を未完了表記として誤検出していた（false-positive → gate fail）。
- * 未完了マーカーとしての「follow-up」「follow up」は語間に区切り（空白 or ハイフン）を必ず持つため、
- * 区切り 1 文字必須にすれば slug `followup` を除外しつつ「別途 follow-up で対応」等は検出し続ける。
- * 拡張子 whitelist による strip 前処理は脆く（bypass + 非収録拡張子の FP）、撤去して生 cell に
- * 本パターンを直接適用する方針に戻した（#3488）。
- *
- * **inline-code strip（#3846 / #3844 BLOCK fix）**: 拡張子 whitelist strip（#3488 で撤去）とは別に、
- * evidence cell の **inline-code (`...`) 内トークンのみ** は判定前に strip する。inline-code は
- * 定数名 / コマンド / ファイル参照などの機械トークンであり（例: 定数名 `RANGE_SSOT_TODO` が
- * #3844 で `todo` に部分一致し false-positive gate fail）、未完了宣言の prose ではない。
- * 未完了マーカーを backtick で囲んで逃避する pattern は QM レビュー + PR body 禁止語 gate
- * (`check-pr-body.mjs`) の別層で扱う。prose（コード外）の未完了表記検出は従来どおり生 cell。
- */
-const TODO_PATTERN = /todo|予定|追加予定|別途|follow[\s-]up|後で/i;
-
-/**
- * evidence cell 内の inline-code span（`...`）を除去する（#3846）。
- * table cell は `|` split 済のため改行を含まず、backtick 対を単純除去すれば十分。
- * 対にならない孤立 backtick は残す（除去しすぎによる検出漏れ防止）。
- *
- * @param {string} cell
- * @returns {string}
- */
-function stripInlineCode(cell) {
-	return cell.replace(/`[^`]*`/g, '');
-}
-
-/**
  * 残 NG **件数** の宣言を読み取るパターン（#4333）。件数を capture group 1 で取り出す。
  *
  * 旧実装は `/残\s*NG[^\n|]*[:：]?\s*0\b|NG\s*0\s*件/` を **本文全体**に `test()` するだけで、
@@ -109,49 +76,6 @@ export function parseNgCountDeclarations(sectionText) {
 		}
 	}
 	return found;
-}
-
-/**
- * 次の `## ` 見出し（H2）の直前までを切り出す。見出しが無ければ全体を返す。
- *
- * `###` 以降の下位見出しでは止めない（同一セクション内の小見出しは表の所属を変えないため）。
- *
- * @param {string} text 見出し行を除いたセクション以降のテキスト
- * @returns {string} 当該セクション本体
- */
-function sliceUntilNextH2(text) {
-	const lines = text.split('\n');
-	const end = lines.findIndex((l) => l.startsWith('## '));
-	return end === -1 ? text : lines.slice(0, end).join('\n');
-}
-
-/**
- * AC 検証マップの 4 列行を本文から抽出する（共通 util）。
- * ヘッダー行（`| AC 番号 | AC 内容 ...` 等）とセパレーター（`|---|---|`）を除外する。
- *
- * **走査は当該セクション内で閉じる**（次の `## ` 見出しで停止、#4243）。
- * 本文末尾まで見ていた旧実装は、統合 PR template が「マージ判定エビデンス」の**後ろ**に
- * 4 列の表（Accepted residual 等）を持つため、**別表の行を evidence の行として数えていた**。
- * 壊れ方は 2 方向あった:
- *
- *   - false positive: 後続表のプレースホルダ行を空欄と誤判定し、evidence 表が正しくても fail
- *     （bot 生成の統合 PR が生まれた瞬間に落ちる。#4241 で実測）
- *   - false negative: evidence 表が**空でも**後続表の 4 列行で `rows.length === 0` を通過し、
- *     「main 反映前に evidence を必ず埋めさせる」という gate の目的が満たされない（より危険）
- *
- * @param {string} body PR 本文
- * @param {number} fromIdx 抽出開始 index（section 見出し以降に限定する用途）
- * @returns {string[]} 4 列のデータ行（生のマークダウン行）
- */
-function extractFourColumnRows(body, fromIdx) {
-	const rest = body.slice(fromIdx);
-	// 見出し行自身を飛ばしてから、次の `## ` 見出しまでを section 本体とする。
-	const afterHeading = rest.indexOf('\n');
-	const section =
-		afterHeading === -1
-			? rest
-			: rest.slice(0, afterHeading + 1) + sliceUntilNextH2(rest.slice(afterHeading + 1));
-	return pickFourColumnRows(section);
 }
 
 /**
@@ -223,91 +147,6 @@ export function shouldSkip({ body, labels, lane }) {
  * @property {string} [error] FAIL 時のメッセージ（複数行）
  * @property {string[]} [info] 補助ログ行
  */
-
-/**
- * feature / hotfix lane の AC 検証マップ検証（現行ロジックを維持、AC4 回帰ゼロ）。
- *
- * @param {string} body PR 本文
- * @param {'feature'|'hotfix'} lane
- * @returns {AcCheckResult}
- */
-export function checkPerPrAcMap(body, lane) {
-	const mapHeaderIdx = body.indexOf('AC 検証マップ');
-	if (mapHeaderIdx === -1) {
-		return {
-			ok: false,
-			lane,
-			error:
-				'❌ PR 本文に「AC 検証マップ」セクションが見つかりません (ADR-0038)\n' +
-				'PR テンプレートのセクションが削除されています。',
-		};
-	}
-
-	const rows = extractFourColumnRows(body, mapHeaderIdx);
-	const emptyRows = findEmptyRows(rows);
-	const info = [`AC map rows found: ${rows.length}, empty/placeholder rows: ${emptyRows.length}`];
-
-	if (rows.length === 0) {
-		return {
-			ok: false,
-			lane,
-			info,
-			error:
-				'❌ AC 検証マップに行が 1 件もありません (ADR-0038)\n\n' +
-				'Issue の Acceptance Criteria 1 行ごとに 1 行を埋めてください。\n' +
-				'例:\n| AC1 | ログイン後にダッシュボードが表示される | `npx playwright test auth.spec.ts` | PASS |',
-		};
-	}
-
-	if (emptyRows.length > 0) {
-		const details = emptyRows.map((r) => `  ${r.slice(0, 120)}`).join('\n');
-		return {
-			ok: false,
-			lane,
-			info,
-			error:
-				`❌ AC 検証マップに ${emptyRows.length} 件の空欄/プレースホルダ行があります (ADR-0038)\n\n` +
-				'「AC 内容」「検証手段」「結果 / エビデンス」の全列を埋めてください。\n' +
-				'目視確認のみは不可。機械検証可能なコマンド / ファイルパス / スクリーンショット番号で記入してください。\n\n' +
-				`空欄行:\n${details}`,
-		};
-	}
-
-	// #1539: 4 列目（結果/エビデンス列）に未完了表記が含まれる場合 FAIL
-	const todoRows = rows
-		.map((row, idx) => {
-			const cells = row
-				.split('|')
-				.slice(1, -1)
-				.map((c) => c.trim());
-			const evidenceCell = cells[3] ?? '';
-			// #3846: inline-code 内の機械トークン（定数名 / コマンド / ファイル参照）は判定対象外
-			if (TODO_PATTERN.test(stripInlineCode(evidenceCell))) {
-				const acId = cells[0] || `行 ${idx + 1}`;
-				return { acId, evidenceCell };
-			}
-			return null;
-		})
-		.filter(/** @returns {x is {acId: string; evidenceCell: string}} */ (x) => x !== null);
-
-	if (todoRows.length > 0) {
-		const details = todoRows
-			.map((item) => `  ${item.acId}: 「${item.evidenceCell.slice(0, 80)}」`)
-			.join('\n');
-		return {
-			ok: false,
-			lane,
-			info,
-			error:
-				`❌ AC 検証マップの「結果/エビデンス」列に未完了表記が ${todoRows.length} 件あります (#1539)\n\n` +
-				'「TODO」「予定」「追加予定」「別途」「follow-up」「後で」は未完了を示します。\n' +
-				'全 AC を実際に検証した上で、具体的なエビデンス（PASS / スクリーンショット番号 / コマンド結果）を記入してください。\n\n' +
-				`未完了行:\n${details}`,
-		};
-	}
-
-	return { ok: true, lane, info, reason: 'AC 検証マップ: 全行 埋まっています ✓' };
-}
 
 /**
  * integration lane の「マージ判定エビデンス表」検証（AC3）。
@@ -468,6 +307,18 @@ export function checkNgZeroDeclaration(body) {
 
 /**
  * lane に応じて AC 検証観点を切替えるエントリ（job は全 lane で実行され、内部で観点を切替える）。
+ *
+ * # feature / hotfix lane に per-PR AC マップ判定は無い（#4305 → #4348 で残骸を削除）
+ *
+ * #4305 が **PR テンプレートから `## AC 検証マップ` 節ごと撤去**し（現テンプレートは 7 節）、
+ * 本 entry も feature / hotfix lane を無条件 PASS に変えた。判定関数 `checkPerPrAcMap` は
+ * その時に呼び出し元を失い、**唯一の呼び出しが自身の unit test だけ**という状態で
+ * 8 ヶ月ぶんの改修（#3488 / #3846 等）を受け続けていた。#4348 で削除した。
+ *
+ * 再導入するなら、判定関数だけを戻しても機能しない。**PR テンプレートの節・
+ * `.github/PR_TEMPLATE_SECTIONS.json`・本 entry の分岐・workflow 配線をセットで**戻すこと。
+ * 「判定関数だけが存在して誰も呼ばない」状態は `tests/unit/scripts/check-ac-verification-map.test.ts`
+ * の class-lock が落とす。
  *
  * @param {{
  *   body: string;

--- a/scripts/check-admin-bypass-evidence.mjs
+++ b/scripts/check-admin-bypass-evidence.mjs
@@ -26,6 +26,8 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { hasDeclarationLine } from './lib/ci/pr-body-sections.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /**
  * @typedef {Object} PrFile
@@ -75,16 +77,28 @@ const DRY_RUN = process.env.DRY_RUN === 'true';
 const OUTPUT_MODE = process.env.OUTPUT_MODE || 'text';
 const SUMMARY_ONLY = process.env.SUMMARY_ONLY === 'true';
 
-const EVIDENCE_MARKER_PATTERNS = [
+export const EVIDENCE_MARKER_PATTERNS = [
 	/^##\s*Self-Review 証跡/m,
 	/^##\s*Self-Review\s*\(admin bypass\)/m,
 ];
 
 const BOT_COMMENT_MARKER = '<!-- admin-bypass-evidence-check -->';
 
-if (!REPO) {
-	console.error('[admin-bypass-evidence] REPO env var is required (owner/repo)');
-	process.exit(2);
+/**
+ * REPO env var を必須として解決する。
+ *
+ * 旧実装は module top-level で `process.exit(2)` していたため、**import しただけで
+ * process が落ちる**。判定関数 (`hasEvidenceSection`) を unit test から呼べず、
+ * 判定の回帰が test で固定できない状態だった (#4348)。検証は実際に gh を叩く直前に行う。
+ *
+ * @returns {string}
+ */
+function requireRepo() {
+	if (!REPO) {
+		console.error('[admin-bypass-evidence] REPO env var is required (owner/repo)');
+		process.exit(2);
+	}
+	return REPO;
 }
 
 /**
@@ -124,7 +138,7 @@ function listRecentMergedPrs(sinceIso) {
 		'pr',
 		'list',
 		'--repo',
-		REPO,
+		requireRepo(),
 		'--state',
 		'merged',
 		'--limit',
@@ -160,12 +174,26 @@ function isExempted(pr) {
 }
 
 /**
+ * PR 本文に Self-Review 証跡セクションが **宣言として** 書かれているか (ADR-0044)。
+ *
+ * # なぜ行単位 + 文脈除外なのか (#4348 対象 #3)
+ *
+ * 旧実装は本文全体への `re.test(body)` で、`^##` の行頭アンカーはあっても
+ * **HTML コメント / fenced code block の中の見出し**を区別できなかった。
+ * 本 script 自身が投稿する追記依頼コメントは証跡セクションのテンプレートを
+ * ```` ```markdown ```` fence で囲んで提示するため、**その bot コメントを PR 本文に
+ * 貼り戻すだけで「証跡あり」になる**。証跡を 1 文字も書かずに追跡から外れる形で、
+ * #4333 (テンプレートを消さずに出すだけで gate が成立する) と同型である。
+ *
+ * 判定規律は PR body を読む他の gate と同じ SSOT
+ * (`scripts/lib/ci/pr-body-sections.mjs` の `hasDeclarationLine`) に揃える。
+ *
  * @param {string | null} body
  * @returns {boolean}
  */
-function hasEvidenceSection(body) {
+export function hasEvidenceSection(body) {
 	if (!body) return false;
-	return EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body));
+	return hasDeclarationLine(body, EVIDENCE_MARKER_PATTERNS);
 }
 
 /**
@@ -216,7 +244,7 @@ async function postMissingEvidenceComment(prNumber) {
 		return;
 	}
 
-	gh(['pr', 'comment', String(prNumber), '--repo', REPO, '--body', body]);
+	gh(['pr', 'comment', String(prNumber), '--repo', requireRepo(), '--body', body]);
 }
 
 /**
@@ -306,8 +334,12 @@ async function main() {
 	process.exit(0);
 }
 
-main().catch((/** @type {unknown} */ err) => {
-	const msg = err instanceof Error ? err.message : String(err);
-	console.error('[admin-bypass-evidence] unexpected error', msg);
-	process.exit(2);
-});
+// CLI として直接実行された場合のみ main() を起動 (test からの import 時は実行しない)。
+// 判定は scripts/lib/is-main.mjs (SSOT、#3969) に委譲する。
+if (isMainModule(import.meta.url)) {
+	main().catch((/** @type {unknown} */ err) => {
+		const msg = err instanceof Error ? err.message : String(err);
+		console.error('[admin-bypass-evidence] unexpected error', msg);
+		process.exit(2);
+	});
+}

--- a/scripts/check-admin-bypass-evidence.mjs
+++ b/scripts/check-admin-bypass-evidence.mjs
@@ -39,6 +39,7 @@ import { isMain as isMainModule } from './lib/is-main.mjs';
 /**
  * @typedef {Object} PrAuthor
  * @property {string} login
+ * @property {boolean} [is_bot] `gh` が GraphQL `author.__typename == 'Bot'` を写した値 (#4612)
  */
 
 /**
@@ -151,14 +152,36 @@ function listRecentMergedPrs(sinceIso) {
 }
 
 /**
+ * PR の作成者が **bot アクターか** を判定する (#4612)。
+ *
+ * # なぜ login 文字列で判定しないのか
+ *
+ * 旧実装は `login.endsWith('[bot]')` と `login === 'dependabot' | 'renovate'` の 3 パターンで、
+ * **GitHub App が作成した PR を拾えなかった**。App の actor は `gh` では
+ * `app/<slug>` (例: `app/ganbari-quest-integrator` / `app/dependabot`) と表示され、
+ * `[bot]` サフィックスを持たない。結果として統合 PR (App 作成) が毎回 exempt から漏れ、
+ * 証跡の追記依頼コメントが投稿され続けていた (実測: 2026-08-13 16:05Z に PR #4534 へ投稿)。
+ *
+ * `is_bot` は `gh` が GraphQL の `author.__typename == 'Bot'` を写したもので、
+ * **アカウント種別そのもの**。login 文字列と違い利用者側で騙れない (ユーザー名に `[` は
+ * 使えないため旧判定も詐称はできなかったが、App を拾えないという別の穴があった)。
+ * 未定義 / 非 boolean のときは **exempt しない**方向 (= 催促は出る) に倒す。
+ * 緩める判定を「値が無いから true」に倒さない。
+ *
+ * @param {GhPr} pr
+ * @returns {boolean}
+ */
+export function isBotAuthored(pr) {
+	return pr?.author?.is_bot === true;
+}
+
+/**
  * @param {GhPr} pr
  * @returns {{ exempted: boolean, reason?: string }}
  */
 function isExempted(pr) {
-	const author = pr.author?.login || '';
-	if (author.endsWith('[bot]')) return { exempted: true, reason: 'bot-authored PR' };
-	if (author === 'dependabot' || author === 'renovate') {
-		return { exempted: true, reason: 'dependabot/renovate' };
+	if (isBotAuthored(pr)) {
+		return { exempted: true, reason: `bot-authored PR (${pr.author?.login ?? 'unknown'})` };
 	}
 	const files = pr.files || [];
 	const nonDocs = files.filter((/** @type {PrFile} */ f) => !f.path.startsWith('docs/'));

--- a/scripts/check-cdk-replacement.mjs
+++ b/scripts/check-cdk-replacement.mjs
@@ -29,18 +29,10 @@ export function stripAnsi(str) {
 	return str.replace(ANSI_ESCAPE, '');
 }
 
-/**
- * CDK diff 出力行からリソースの論理 ID を抽出する
- * 形式: [~|+|-] AWS::Type LogicalId [CFHash] [(action)]
- * @param {string} line stripped line
- * @returns {string}
- */
-export function extractLogicalId(line) {
-	// トークン: [0]=[~], [1]=AWS::Type, [2]=LogicalId, [3]=CFHash (optional), [4+]=(action) (optional)
-	const tokens = line.trim().split(/\s+/);
-	// tokens[2] が存在しない場合は line 全体を返す
-	return tokens[2] ?? line.trim();
-}
+// 旧 `extractLogicalId` は削除した (#4623)。export されていたが呼び出し元が 1 つも無く
+// (test すら import していなかった)、論理 ID の抽出は `detectReplacements` 内の
+// `resourceMatch[3]` が唯一の生きた経路である。同じ抽出を 2 通り持つと、行形式が変わった
+// ときに片方だけ直す事故を作る。
 
 /**
  * CDK diff の stdout 行リストを解析して Replacement/Destroy リソースを抽出する

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -1584,9 +1584,17 @@ export function resolveLabels(args, fetched) {
  * | 本 script の id | 引き続き hard-fail する job (script) |
  * |---|---|
  * | `missing-required-sections` | `pr-template-gate.yml`「必須セクションの存在確認」(`checkSectionPresence`) |
- * | `change-type-unselected` | 同「変更タイプの選択」(`checkChangeType`) |
- * | `ac-map-missing` / `-empty` / `-incomplete` | `pr-ac-verification-check.yml`「Verify AC map in PR body」(`checkPerPrAcMap`) |
- * | `unchecked-ready-checklist` | `pr-merge-gate.yml`「PR チェックリスト完了確認」(`checkMergeGateChecklist`) |
+ * | `unchecked-ready-checklist` | `pr-merge-gate.yml`「PR チェックリスト完了確認」(`checkMergeGateChecklist`)。**ただし integration lane のみ** — feature / hotfix lane の checklist 検証は #4305 で撤去済 |
+ *
+ * ### #4305 で対になる hard-fail が消えた id (#4348 で是正)
+ *
+ * 本表はかつて `change-type-unselected` / `ac-map-*` も「別 job が hard-fail する」と書いていたが、
+ * **#4305 が PR テンプレートから該当節ごと撤去した時点で嘘になっていた**。対の job は無く、
+ * さらに本 script 側の判定関数 (`checkChangeTypeSelection` / `checkAcMap`) も runner から
+ * 呼ばれておらず、**これらの id はどこからも出力されない**。advisory ですらない。
+ *
+ * 復活させるなら判定関数だけでは足りない — テンプレート節 / `.github/PR_TEMPLATE_SECTIONS.json` /
+ * runner の呼び出し / workflow 配線をセットで戻すこと。
  *
  * 残り (mojibake / placeholder 各種 / forbidden-terms / hotfix env 節 / mergeable-conflicting) は
  * 本 script が唯一の検出点なので、**真に advisory になる**。うち `mergeable-conflicting` は

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -8,12 +8,13 @@
  *   1. 必須セクション見出しの完全一致漏れ（PR #1718/#1746/#1760）
  *   2. PR body 全体での禁止語 (`予定` `follow-up` `PENDING` `DEFERRED` `別途` `個別起票` `TODO`) 混入
  *      （PR #1763/#1770 の AC マップ外混入を含めて検出する）
- *   3. AC 検証マップの 4 列フォーマット欠落 / 空行
- *   4. Ready for Review チェックリストの未チェック残置
+ *   3. `## 検証` の根拠コマンド `--pr <番号>` が本 PR 以外を指している（#4074、走査節は #4612 で是正）
+ *   4. Ready for Review チェックリストの未チェック残置（integration lane のみ、#4305）
  *   5. `mergeable: CONFLICTING` 事前検知（GitHub API 経由）
- *   6. 変更タイプ checkbox 未選択（#3846、CI gate「変更タイプの選択」の shift-left。
- *      判定は scripts/pr-template-gate-checks.mjs の checkChangeType を SSOT として再利用）
- *   7. `po-decision:required` label 付きなのに PO 決裁ブリーフが body にない（#3944/#3956/#3962）
+ *   6. `po-decision:required` label 付きなのに PO 決裁ブリーフが body にない（#3944/#3956/#3962）
+ *
+ * AC 検証マップ 4 列 / 変更タイプ checkbox の検査は #4305 で対象節ごと撤去され、
+ * 残っていた判定関数も #4612 で削除した（呼ばれない判定を「検査がある」と誤読させないため）。
  *
  * 必須セクション SSOT:
  *   `.github/PULL_REQUEST_TEMPLATE.md` を runtime parse し、
@@ -37,9 +38,10 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { checkIntegrationEvidenceTable } from './check-ac-verification-map.mjs';
 import { extractClosedIssues } from './integration-pr-body.mjs';
+import { extractH2Section, stripHtmlComments } from './lib/ci/pr-body-sections.mjs';
+import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 import { classifyLane } from './pr-lane.mjs';
-import { checkChangeType } from './pr-template-gate-checks.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -216,107 +218,53 @@ export function scanForbiddenTerms(body) {
 }
 
 // ---------------------------------------------------------------------------
-// AC 検証マップ 4 列フォーマット検証
+// AC 検証マップ 4 列フォーマット検証は **存在しない** (#4305 で撤去 → #4612 で残骸を削除)
+//
+// `checkAcMap` / `extractAcMapSection` は 2026-08-05 の #4305 で
+// `.github/PULL_REQUEST_TEMPLATE.md` から `## AC 検証マップ (ADR-0004)` 節が消えた時点で
+// **入力を失っていた**。それでも判定関数だけが残り、`collectViolations` からは 1 度も
+// 呼ばれないまま `ac-map-missing` / `-empty` / `-incomplete` の 3 id が
+// 「別 job が hard-fail し続ける」表に載り続けた (#4611 で表だけ是正、#4612 で関数を削除)。
+//
+// **再導入するなら判定関数だけでは足りない。** テンプレート節 /
+// `.github/PR_TEMPLATE_SECTIONS.json` / `collectViolations` の呼び出し / workflow 配線を
+// セットで戻すこと。class-lock: tests/unit/scripts/check-pr-body.test.ts
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// 検証根拠の参照整合 (#4074、走査対象を `## 検証` に付け替え #4612)
+//
+// ## 旧実装がなぜ空振りしていたか (#4612 で実測)
+//
+// 旧実装は `## AC 検証マップ` 節だけを走査していた。その節は #4305 で PR テンプレートから
+// 消えており、**BLOCKING gate なのに何も検査していない**疑いがあった。merged PR 200 本
+// (#4215〜#4573) を判定関数に直接当てて確定させた:
+//
+//   - `--pr <数字>` を含む body: 87 / 200
+//   - そのうち `## AC 検証マップ` 節の中に書かれていたもの: **4 / 200**
+//   - 旧実装の発火: **0 / 200** (BLOCKING gate が 1 度も働いていない)
+//
+// 根拠コマンドが実際に書かれている節は `## 検証` (36 本) と `## テスト・品質セルフチェック`
+// (41 本、#4305 で撤去された旧テンプレートの検証節) だった。#4074 が狙った「宛先違いの証跡」も
+// そこに 2 件実在した (#4317 が `--pr 4312` / #4278 が `--pr 4276`)。**gate の対象節だけが
+// 証跡の置き場所と食い違っていた**ため、狙った欠陥が 2 件とも素通りしていた。
+//
+// よって走査対象を現行テンプレートの検証節 `## 検証` に付け替える。旧節名は列挙しない —
+// 「入力の来ない節を検査基準に残す」のが本 Issue の欠陥そのものだからである。
+// ---------------------------------------------------------------------------
+
+/** 根拠コマンドを走査する section 見出し。SSOT は `.github/PULL_REQUEST_TEMPLATE.md`。 */
+export const EVIDENCE_SECTION_HEADING = '検証';
 
 /**
- * AC 検証マップセクションを抽出する。`## AC 検証マップ ...` の見出し以降、次の `## ` まで。
- * @param {string} body
- * @returns {string | null}
+ * 「別 PR を指した根拠コマンドを意図して載せている」ことの明示宣言 key (#4612)。
+ *
+ * 実測 (merged PR #4519): 他 PR (#4513) で gate の空振りを再現した console ログを
+ * `## 検証` に貼るのは**正当な証跡**で、走査を `## 検証` に広げるとこれが誤検出になる。
+ * hard-fail のまま逃げ道を塞ぐと「実測ログを削る」方向のインセンティブになるため、
+ * 理由必須の宣言でのみ通す (`ss-identical-ok` / `ng-nonzero-accepted` と同じ SSOT・同じ思想)。
  */
-export function extractAcMapSection(body) {
-	const startMatch = body.match(/^## AC 検証マップ.*$/m);
-	if (!startMatch) return null;
-	const startIdx = body.indexOf(startMatch[0]);
-	const remaining = body.slice(startIdx + startMatch[0].length);
-	const nextSectionIdx = remaining.search(/^## /m);
-	return nextSectionIdx === -1 ? remaining : remaining.slice(0, nextSectionIdx);
-}
-
-/**
- * AC 検証マップの table が「4 列 (`AC 番号 / AC 内容 / 検証手段 / 結果`) を埋めて」いるかを検証する。
- *
- * 検出する違反:
- *   - 空セルが残っている (`| | | | |`)
- *   - Markdown コメントだけのセル (`| <!-- ... --> |`) のみで実体がない
- *   - そもそもデータ行が 1 行も無い
- *
- * skip マーカーがある場合は検証をスキップ（template の `<!-- ac-verification-skip: ... -->`）。
- *
- * @param {string} body
- * @returns {{ id: string; message: string } | null}
- */
-export function checkAcMap(body) {
-	const skipMatch = body.match(/<!--\s*ac-verification-skip:[^>]+-->/);
-	if (skipMatch) return null;
-
-	const section = extractAcMapSection(body);
-	if (!section) {
-		return {
-			id: 'ac-map-missing',
-			message:
-				'`## AC 検証マップ (ADR-0004)` セクションが見つかりません。PR template を使用してください。',
-		};
-	}
-
-	const lines = section.split('\n').map((l) => l.trim());
-	// データ行: `|` で始まり、ヘッダ (`AC 番号`) でも区切り (`---`) でもないもの
-	const dataRows = lines.filter(
-		(l) =>
-			l.startsWith('|') &&
-			!l.includes('AC 番号') &&
-			!/^\|[\s|:-]+\|$/.test(l) &&
-			!/^\|\s*-+\s*\|/.test(l),
-	);
-
-	if (dataRows.length === 0) {
-		return {
-			id: 'ac-map-empty',
-			message:
-				'AC 検証マップのデータ行が 1 行もありません。Issue の Acceptance Criteria 1 行ごとに 1 行を埋めてください。\n' +
-				'  期待形式 (4 列固定): `| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |`\n' +
-				'  参考 PR (4 列 SSOT 実装例): #2588 / #2599',
-		};
-	}
-
-	// 各行が 4 列以上で、各セルがコメント以外の実体を持つかを検証
-	const emptyRows = [];
-	for (const row of dataRows) {
-		// 行頭・行末の `|` を除いた中身を `|` で split
-		const inner = row.replace(/^\|/, '').replace(/\|$/, '');
-		const cells = inner.split('|').map((c) => c.trim());
-		if (cells.length < 4) {
-			emptyRows.push({ row, reason: `列数不足 (${cells.length} < 4)` });
-			continue;
-		}
-		// 各セルから Markdown コメントを除いて空かを判定
-		const filledCells = cells.slice(0, 4).map((c) => stripMarkdownComments(c).trim());
-		if (filledCells.some((c) => c === '')) {
-			emptyRows.push({ row, reason: `空セル (実体: ${JSON.stringify(filledCells)})` });
-		}
-	}
-
-	if (emptyRows.length > 0) {
-		return {
-			id: 'ac-map-incomplete',
-			message:
-				`AC 検証マップに未記入セルが ${emptyRows.length} 行あります:\n` +
-				emptyRows
-					.slice(0, 5)
-					.map((e) => `  - ${e.reason}: ${e.row.slice(0, 100)}`)
-					.join('\n') +
-				`\n  期待形式 (4 列固定): \`| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |\`\n` +
-				`  参考 PR (4 列 SSOT 実装例): #2588 / #2599\n` +
-				`  修正手順: PR body の AC マップを上記 4 列 header に置換、各セルに HEAD SHA + file:line + grep + 実体根拠を付与する (2 列簡略形式禁止、#1775 AC2 / #2586)`,
-		};
-	}
-
-	return null;
-}
-
-// ---------------------------------------------------------------------------
-// AC 検証マップ 根拠の参照整合 (#4074)
-// ---------------------------------------------------------------------------
+export const EVIDENCE_PR_REF_OK_KEY = 'evidence-pr-ref-ok';
 
 /**
  * 根拠欄に現れる `--pr <番号>` の PR 番号を抽出する (#4074)。
@@ -327,8 +275,15 @@ export function checkAcMap(body) {
  * @returns {number[]} 出現順・重複除去済みの PR 番号
  */
 export function extractEvidencePrNumbers(body) {
-	const section = extractAcMapSection(body);
-	if (!section) return [];
+	// scrub: false — 根拠コマンドは fenced code block (`$ npm run pre-ready -- --pr N`) に
+	// 書くのが標準形なので、code block を落とすと検査対象がほぼ空になる。
+	// HTML コメントだけは落とす (テンプレートの説明文を根拠と見なさない)。
+	const { found: hasSection, text: section } = extractH2Section(
+		stripHtmlComments(body ?? ''),
+		EVIDENCE_SECTION_HEADING,
+		{ scrub: false },
+	);
+	if (!hasSection) return [];
 	/** @type {number[]} */
 	const found = [];
 	for (const m of section.matchAll(/--pr[=\s]+(\d+)\b/g)) {
@@ -367,14 +322,25 @@ export function checkEvidencePrReferences(body, prNumber) {
 	const mismatched = extractEvidencePrNumbers(body).filter((n) => n !== self);
 	if (mismatched.length === 0) return null;
 
+	// 他 PR を指した根拠を意図して載せている場合は、理由付き宣言で通す (#4612)。
+	// 理由が stub (`TODO` / `n/a` / 12 文字未満) なら宣言として認めない。
+	const declared = parseReasonDeclaration(body, EVIDENCE_PR_REF_OK_KEY);
+	if (declared.present && declared.valid) return null;
+
+	const declHint = declared.present
+		? `  \`<!-- ${EVIDENCE_PR_REF_OK_KEY}: ... -->\` は書かれていますが理由が ${MIN_REASON_LENGTH} 文字未満 / 定型 stub のため宣言と認めません。\n`
+		: `  他 PR のログを意図して載せている場合 (別 PR で再現した実測など) は ` +
+			`\`<!-- ${EVIDENCE_PR_REF_OK_KEY}: <理由 ${MIN_REASON_LENGTH} 文字以上> -->\` を本文に書いてください。\n`;
+
 	return {
 		id: 'evidence-pr-mismatch',
 		message:
-			`AC 検証マップの根拠が本 PR (#${self}) 以外の PR 番号を指しています: ` +
+			`\`## ${EVIDENCE_SECTION_HEADING}\` の根拠が本 PR (#${self}) 以外の PR 番号を指しています: ` +
 			`${mismatched.map((n) => `--pr ${n}`).join(' / ')}\n` +
 			`  根拠コマンドの \`--pr <番号>\` は **その PR 自身**を検証したものでなければ証跡になりません ` +
 			`(別 PR / 存在しない番号を指した状態で Ready 化を通した実測: PR #4063 の \`--pr 4059\`)。\n` +
 			`  対応: 根拠欄の番号を ${self} に直し、\`npm run pre-ready -- --pr ${self}\` を実際に実行し直して結果を貼る。\n` +
+			declHint +
 			`  番号を書かない形式 (\`--pr <num>\` 等のプレースホルダ) は従来どおり通ります。`,
 	};
 }
@@ -1204,46 +1170,19 @@ export function detectMojibake(body) {
 }
 
 // ---------------------------------------------------------------------------
-// 変更タイプ checkbox 未選択検出 (#3846、shift-left)
+// 変更タイプ checkbox 未選択検出は **存在しない** (#4305 で撤去 → #4612 で残骸を削除)
+//
+// `checkChangeTypeSelection` (#3846) は `## 変更タイプ` 節を見る shift-left 検査だったが、
+// #4305 が同節を「A 削除」判定でテンプレートから外し (`.github/CLAUDE.md` が
+// 「title 接頭辞が SSOT で、本欄はその可読補助」と自認していたため)、
+// `pr-template-gate.yml` の対の job も同時に撤去された。以後この関数は
+// `collectViolations` から呼ばれず、`change-type-unselected` はどこからも出力されない。
+//
+// 判定本体だった `pr-template-gate-checks.mjs` の `checkChangeType` /
+// `detectChangeTypeHeading` も本 PR で同時に削除した (CHECKS registry に無く、
+// 唯一の呼び出しがここだったため)。**配線ごと消す**のが「呼ばれない判定を残さない」の意味。
+// class-lock: tests/unit/scripts/check-pr-body.test.ts
 // ---------------------------------------------------------------------------
-
-/**
- * `## 変更タイプ` セクションで `- [x]` が 1 つも選択されていない場合に violation を返す (#3846)。
- *
- * 背景: PR body の変更タイプ checkbox 未選択のまま提出 → CI 必須 gate「変更タイプの選択」
- * (`pr-template-gate.yml`) hard-fail が 3 PR 連続再発 (#3835 / #3837 / #3844)。いずれも実装は
- * 健全で body checkbox のみが原因 = ADR-0061 same-class-N→guard 対象。本検出により
- * `--body-file` mode (PR 作成前) / `--pr` mode (pre-ready Step 9 / pre-push hook) の両方で
- * CI より手前 (shift-left) で機械検出する。
- *
- * 検証ロジックは CI gate と同一 SSOT (`scripts/pr-template-gate-checks.mjs` の `checkChangeType`)
- * を再利用する (二重実装なし)。lane は本 CLI の対象 (feature / hotfix per-PR self-check) で
- * 判定が同一のため 'feature' 固定。section 欠落時は missing-required-sections gate に委譲
- * (checkChangeType 側が skipped=true を返す)。
- *
- * @param {string} body
- * @param {string} template `.github/PULL_REQUEST_TEMPLATE.md` の内容
- * @param {string[]} labels PR ラベル (dependencies label skip は SSOT 側で処理)
- * @returns {{ id: string; message: string } | null}
- */
-export function checkChangeTypeSelection(body, template, labels = []) {
-	const result = checkChangeType({
-		body,
-		labels,
-		template,
-		ssotSections: null,
-		lane: 'feature',
-	});
-	if (result.ok) return null;
-	return {
-		id: 'change-type-unselected',
-		message:
-			`${result.message}\n` +
-			'背景: 未選択のまま提出 → CI 必須 gate「変更タイプの選択」hard-fail が 3 PR 連続再発 (#3835 / #3837 / #3844)。\n' +
-			'対応: PR 作成前に `node scripts/check-pr-body.mjs --body-file <path> --skip-mergeable --no-labels` で本検証を PASS させる。\n' +
-			'      `npm run dev:open-pr -- --issue <num>` 経由なら Issue の type:* label から自動 [x] 化される (init-pr-body.mjs)。',
-	};
-}
 
 // ---------------------------------------------------------------------------
 // Self-Review 証跡検出 (#2475 Phase 2 / #2815 D-1、PO 判断 2026-06-04: 導入必須)
@@ -1591,10 +1530,12 @@ export function resolveLabels(args, fetched) {
  * 本表はかつて `change-type-unselected` / `ac-map-*` も「別 job が hard-fail する」と書いていたが、
  * **#4305 が PR テンプレートから該当節ごと撤去した時点で嘘になっていた**。対の job は無く、
  * さらに本 script 側の判定関数 (`checkChangeTypeSelection` / `checkAcMap`) も runner から
- * 呼ばれておらず、**これらの id はどこからも出力されない**。advisory ですらない。
+ * 呼ばれておらず、**これらの id はどこからも出力されなかった**。advisory ですらない。
  *
- * 復活させるなら判定関数だけでは足りない — テンプレート節 / `.github/PR_TEMPLATE_SECTIONS.json` /
- * runner の呼び出し / workflow 配線をセットで戻すこと。
+ * #4611 で表を是正し、**#4612 で判定関数そのものを削除した** — 呼ばれない判定を残すと、
+ * 次に読む人が「検査がある」と誤読して同じ調査を繰り返す。復活させるなら判定関数だけでは
+ * 足りない: テンプレート節 / `.github/PR_TEMPLATE_SECTIONS.json` / runner の呼び出し /
+ * workflow 配線をセットで戻すこと (class-lock: tests/unit/scripts/check-pr-body.test.ts)。
  *
  * 残り (mojibake / placeholder 各種 / forbidden-terms / hotfix env 節 / mergeable-conflicting) は
  * 本 script が唯一の検出点なので、**真に advisory になる**。うち `mergeable-conflicting` は
@@ -2334,10 +2275,8 @@ export function collectViolations(body, requiredSections, _template, args, notes
 	const poDecision = checkPoDecisionBrief(body, labels);
 	if (poDecision) violations.push({ ...poDecision, issue: '#3944/#3956/#3962' });
 
-	// #3846: 変更タイプ checkbox 未選択 validation is removed as part of Issue #4305.
-	if (!isIntegration) {
-		// Bypassed for feature/hotfix lanes
-	}
+	// #3846 変更タイプ checkbox 未選択 / AC 検証マップ 4 列は #4305 で撤去済 (判定関数も #4612 で削除)。
+	// 「呼ばれない分岐」を残すと next reader が検査があると誤読するため、空 if ごと消してある。
 
 	return violations;
 }

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -294,9 +294,9 @@ export function extractEvidencePrNumbers(body) {
 }
 
 /**
- * AC 検証マップの根拠が **その PR 自身**を検証したものかを検証する (#4074 AC1)。
+ * `## 検証` の根拠が **その PR 自身**を検証したものかを検証する (#4074 AC1)。
  *
- * 実測 (#4074): PR #4063 の AC 検証マップに `npm run pre-ready -- --pr 4059` と書かれていた。
+ * 実測 (#4074): PR #4063 の根拠欄に `npm run pre-ready -- --pr 4059` と書かれていた。
  * #4059 は存在しない PR (`gh api .../pulls/4059` → 404) だが、`check-pr-body.mjs --pr 4063` は
  * 「OK — 違反なし」を返し CI も全 pass した。**宛先違いの証跡でも Ready 化を通過できた。**
  *
@@ -305,8 +305,8 @@ export function extractEvidencePrNumbers(body) {
  * 一方「自 PR と一致しない番号」は実在・非実在を問わず宛先違いなので、一致判定だけで
  * 本 Issue の欠陥 (実在しない 4059 / 別 PR の番号) を両方とも落とせる。ネットワーク非依存。
  *
- * 対象は AC 検証マップセクションのみ。body の他所 (背景・関連 PR への言及) は正当に他 PR 番号を
- * 含むため対象外にして誤検出を作らない (AC3)。
+ * 対象は `## 検証` セクションのみ (#4612 で走査節を是正)。body の他所 (背景・関連 PR への言及) は
+ * 正当に他 PR 番号を含むため対象外にして誤検出を作らない (AC3)。
  *
  * @param {string} body
  * @param {string | number | null | undefined} prNumber 自 PR 番号 (`--body-file` dry-run では null)

--- a/scripts/check-pr-screenshot.mjs
+++ b/scripts/check-pr-screenshot.mjs
@@ -144,6 +144,11 @@ export function detectBeforeAfterLabels(body) {
 }
 
 import { existsSync, readdirSync } from 'node:fs';
+import {
+	extractH2Section,
+	findDeclarationLines,
+	hasDeclarationLine,
+} from './lib/ci/pr-body-sections.mjs';
 import { MIN_REASON_LENGTH, parseReasonDeclaration } from './lib/ci/reason-declaration.mjs';
 
 /**
@@ -278,19 +283,13 @@ const UI_NOT_APPLICABLE_PATTERNS = [
 	/UI\s*変更\s*なし/i,
 ];
 
-/**
- * 同じ行に現れたら **宣言ではない** と判断する文脈 (#4255 横展開)。
- *
- * 「UI 変更なし」の 6 文字は、否定・引用・手順説明の中にも普通に現れる。
- * 出現しただけで opt-out にすると、**書いていない宣言を書いたことにされる**。
+/*
+ * 「同じ行に現れたら宣言ではない」文脈の一覧は
+ * `scripts/lib/ci/pr-body-sections.mjs` の `DECLARATION_DISQUALIFYING_PATTERNS` が SSOT
+ * (#4255 で本 file に置いたものを #4348 で共有化)。
+ * DOM 参照 / 統合 VR evidence / schema skip marker も同じ規律で判定するため、
+ * 本 file 内に二重実装を残さない。
  */
-const MARKER_DISQUALIFYING_PATTERNS = [
-	/^\s*>/, // 引用 — 他所の文言を貼っただけ
-	/^\s*[-*]\s*\[\s\]/, // 未チェック checkbox — チェックしていない = 宣言していない
-	/ではありません|ではない|ではなく|とは限らない|とは言えない/, // 否定 (#4255 と同型)
-	/嘘|虚偽/, // gate 自身の説明文の引用
-	/なしの場合|と書く/, // 手順書の条件節 / 引用符付きの言及
-];
 
 /**
  * 「該当なし」明示記述の検出。refactor / docs / chore のみで UI 影響がない PR の opt-out 用。
@@ -318,19 +317,7 @@ const MARKER_DISQUALIFYING_PATTERNS = [
  * @returns {boolean}
  */
 export function hasUiNotApplicableMarker(body) {
-	let inFence = false;
-	for (const raw of (body ?? '').split(/\r?\n/)) {
-		if (/^\s*(?:```|~~~)/.test(raw)) {
-			inFence = !inFence;
-			continue;
-		}
-		if (inFence) continue;
-		// インラインコード (`...`) は言及であって宣言ではない
-		const line = raw.replace(/`[^`]*`/g, ' ');
-		if (MARKER_DISQUALIFYING_PATTERNS.some((p) => p.test(line))) continue;
-		if (UI_NOT_APPLICABLE_PATTERNS.some((p) => p.test(line))) return true;
-	}
-	return false;
+	return hasDeclarationLine(body, UI_NOT_APPLICABLE_PATTERNS);
 }
 
 /**
@@ -417,11 +404,16 @@ export function isUserAttachmentAssetUrl(url) {
  * - Markdown link: `[DOM HTML](https://.../foo.dom.html)`
  * - 素の URL: `https://.../foo.dom.html`
  *
+ * **行単位 + 文脈除外で判定する (#4348 対象 #4)**。旧実装は本文全体への `PATTERN.test(body)` で、
+ * HTML コメント / code block / 引用 / 否定文 / 未チェック checkbox の中の URL でも
+ * 「参照がある」と判定し、DOM 併記検証をまるごと消せた (#4255 の `hasStorybookStoryReference` /
+ * `hasUiNotApplicableMarker` と同 class)。判定規律は `pr-body-sections.mjs` に集約している。
+ *
  * @param {string} body
  * @returns {boolean}
  */
 export function hasDomSnapshotReference(body) {
-	return DOM_REF_PATTERN.test(body);
+	return hasDeclarationLine(body, [DOM_REF_PATTERN]);
 }
 
 // ---------------------------------------------------------------------------
@@ -449,10 +441,15 @@ const INTEGRATION_VR_EVIDENCE_PATTERNS = [
 	/\*?-visual-regression\.yml/i,
 	/(?:lp|child-home|app)[\s-]*(?:visual|vr|pixelmatch|baseline)/i,
 	// 含有 PR 群が develop 取込時に SS 検証済である宣言
-	/含有\s*PR/,
 	/(?:取込|取り込み)\s*(?:済|時).*(?:SS|スクリーンショット|スクショ|検証)/,
-	/統合\s*(?:対象|状態|smoke)/,
+	/統合\s*smoke/,
 ];
+
+/** 含有 PR 一覧 section の見出し (統合 PR template と同値、`.github/INTEGRATION_PR_TEMPLATE.md`)。 */
+const INTEGRATION_PR_LIST_SECTION = '含有 PR 一覧';
+
+/** 含有 PR の行と認める形 (PR / Issue 番号を持つ行)。 */
+const PR_REFERENCE_PATTERN = /#\d{2,}/;
 
 /**
  * integration lane (統合 PR) の SS 観点 evidence が PR body に含まれるかを判定 (#2946)。
@@ -465,11 +462,26 @@ const INTEGRATION_VR_EVIDENCE_PATTERNS = [
  * 「観点の移譲」であって「検証の放棄」ではない (no-go: 見た目検証を完全に消さない) ため、
  * いずれの evidence も無い場合は違反として扱う (warn / error は MODE 依存)。
  *
+ * # なぜ行単位 + 構造判定なのか (#4348 対象 #4)
+ *
+ * 旧実装は本文全体に 6 本の正規表現を当てるだけで、うち `/含有\s*PR/` と
+ * `/統合\s*(?:対象|状態|smoke)/` は**統合 PR template 自身が 3 箇所で満たしていた**
+ * (説明文 1 / HTML コメント 1 / 引用 2 — 実測)。つまり **VR 証跡の有無に関係なく
+ * 統合 PR は常に緑**で、#4333 (見出しの存在だけで NG-0 が常に緑) と同じ形だった。
+ *
+ * 是正は 2 点:
+ *   1. 宣言の判定を行単位 + 文脈除外に揃える (`pr-body-sections.mjs` SSOT)
+ *   2. 「含有 PR」は prose の言及ではなく **`## 含有 PR 一覧` section に実際の PR 参照が
+ *      1 行以上ある**という構造で見る (見出しだけ / 自動生成待ちの空 section は evidence にしない)
+ *
  * @param {string} body
  * @returns {boolean}
  */
 export function hasIntegrationVrEvidence(body) {
-	return INTEGRATION_VR_EVIDENCE_PATTERNS.some((p) => p.test(body));
+	if (hasDeclarationLine(body, INTEGRATION_VR_EVIDENCE_PATTERNS)) return true;
+	const section = extractH2Section(body, INTEGRATION_PR_LIST_SECTION);
+	if (!section.found) return false;
+	return findDeclarationLines(section.text, [PR_REFERENCE_PATTERN]).length > 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -721,7 +733,10 @@ function checkDomSnapshotViolation(body) {
 			`\n背景:\n` +
 			`  PR #1717 で発生した「SS と実機が乖離していた」事故の再発防止のため、\n` +
 			`  SS と DOM が同一プロセス・同一 page で取得されたことを構造的に保証します（#1747 AC4）。\n` +
-			`\nDOM スナップショットを意図的に省略する場合は、--no-dom-snapshot 指定の理由を PR body に明記してください。`,
+			`\n本 gate に「理由を書けば省略できる」経路はありません (#4348)。\n` +
+			`  DOM 併記を省く逃げ道として --no-dom-snapshot の理由記述を案内していましたが、\n` +
+			`  それを読む判定は実装のどこにも無く、案内どおり書いても落ち続ける状態でした。\n` +
+			`  撮影に使う環境で原理的に描画できない UI なら ss-render-impossible 宣言 (#4087) を使ってください。`,
 	};
 }
 

--- a/scripts/check-recent-deploy-deletion.mjs
+++ b/scripts/check-recent-deploy-deletion.mjs
@@ -320,27 +320,16 @@ export function resolveSinceWindow(opts) {
 	};
 }
 
-/**
- * 直近 N 日に main に merge された commit から、touch した file 一覧を収集する。
- *
- * `git log --merges --since=<N days ago> --name-only --pretty='format:%H|%ai' <base>`
- * を実行。各 merge commit ごとに { commit, date, files: [] } を返す。
- *
- * @param {string} base 対象 ref (例: 'origin/main')
- * @param {number} days 遡及日数
- * @returns {Array<{commit: string, date: string, files: string[]}>|null}
- */
-export function getRecentMergedFiles(base, days) {
-	return getMergedFilesSince(base, `${days} days ago`);
-}
+// 旧 `getRecentMergedFiles(base, days)` は削除した (#4623)。`getMergedFilesSince` への
+// 1 行 wrapper だったが呼び出し元が 0 で (test すら import していない)、日数指定は
+// `resolveSinceWindow` が fallback で `${N} days ago` を組み立て、`getMergedFilesSince` に渡す。
 
 /**
  * 任意の `--since=<spec>` (git log の `--since=` accepts ISO 8601 / `N days ago`
  * / human-readable strings) に基づき main の merged file 一覧を収集する (#2615)。
  *
- * `getRecentMergedFiles(base, days)` の内部実装としても利用される (`days` を
- * `${N} days ago` に組み立てて pass)。time-aware mode (`--since` / `--since-ref`
- * / `--since-recent`) では ISO timestamp が直接渡される。
+ * time-aware mode (`--since` / `--since-ref` / `--since-recent`) では ISO timestamp が
+ * 直接渡される。日数指定 (`--days N`) は `${N} days ago` に組み立てて pass される。
  *
  * @param {string} base 対象 ref (例: 'origin/main')
  * @param {string} sinceSpec git log `--since=` の値 (ISO 8601 / `N days ago` 等)

--- a/scripts/check-schema-change-tests.mjs
+++ b/scripts/check-schema-change-tests.mjs
@@ -60,11 +60,16 @@ for (const arg of process.argv.slice(2)) {
 	}
 }
 
+/**
+ * @param {string[]} args
+ * @returns {string}
+ */
 function runGit(args) {
 	try {
 		return execFileSync('git', args, { encoding: 'utf8' });
 	} catch (err) {
-		console.error('[check-schema-change-tests] git command failed:', err.message);
+		const message = err instanceof Error ? err.message : String(err);
+		console.error('[check-schema-change-tests] git command failed:', message);
 		process.exit(2);
 	}
 }

--- a/scripts/check-schema-change-tests.mjs
+++ b/scripts/check-schema-change-tests.mjs
@@ -26,10 +26,28 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { escapeRegExp } from './lib/ci/escape-regexp.mjs';
+import { hasDeclarationLine } from './lib/ci/pr-body-sections.mjs';
+import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF_DEFAULT = 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
-const SKIP_MARKER = '[skip-schema-test-check]';
+export const SKIP_MARKER = '[skip-schema-test-check]';
+
+/**
+ * PR body に skip marker が **宣言として** 書かれているか (#4348)。
+ *
+ * 旧実装は `PR_BODY.includes(SKIP_MARKER)` で、marker の文字列が本文のどこか
+ * (HTML コメント / code block の手順説明 / 引用 / 否定文 / 本 script の案内文の貼り戻し) に
+ * あるだけで **検査がまるごと消えた**。判定規律は他の PR body gate と同じ SSOT
+ * (`scripts/lib/ci/pr-body-sections.mjs`) に揃え、行単位 + 文脈除外で見る。
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasSkipMarker(body) {
+	return hasDeclarationLine(body, [new RegExp(escapeRegExp(SKIP_MARKER))]);
+}
 
 const SCHEMA_FILE = 'src/lib/server/db/schema.ts';
 const TEST_DIR_PREFIXES = ['tests/unit/db/', 'tests/unit/services/'];
@@ -60,7 +78,7 @@ function getChangedFiles() {
 }
 
 function main() {
-	if (PR_BODY.includes(SKIP_MARKER)) {
+	if (hasSkipMarker(PR_BODY)) {
 		console.log(`[check-schema-change-tests] ${SKIP_MARKER} marker found — skipping.`);
 		return;
 	}
@@ -105,4 +123,8 @@ function main() {
 	console.warn('');
 }
 
-main();
+// CLI として直接実行された場合のみ main() を起動 (test からの import 時は実行しない)。
+// 判定は scripts/lib/is-main.mjs (SSOT、#3969) に委譲する。
+if (isMainModule(import.meta.url)) {
+	main();
+}

--- a/scripts/check-schema-migration-completeness.mjs
+++ b/scripts/check-schema-migration-completeness.mjs
@@ -58,11 +58,28 @@
  */
 
 import { execFileSync } from 'node:child_process';
+import { escapeRegExp } from './lib/ci/escape-regexp.mjs';
+import { hasDeclarationLine } from './lib/ci/pr-body-sections.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 const BASE_REF_DEFAULT = 'origin/main';
 const PR_BODY = process.env.PR_BODY || '';
-const SKIP_MARKER = '[skip-schema-migration-check]';
+export const SKIP_MARKER = '[skip-schema-migration-check]';
+
+/**
+ * PR body に skip marker が **宣言として** 書かれているか (#4348)。
+ *
+ * 旧実装は `PR_BODY.includes(SKIP_MARKER)` で、marker の文字列が本文のどこか
+ * (HTML コメント / code block の手順説明 / 引用 / 否定文 / 本 script の案内文の貼り戻し) に
+ * あるだけで **検査がまるごと消えた**。判定規律は他の PR body gate と同じ SSOT
+ * (`scripts/lib/ci/pr-body-sections.mjs`) に揃え、行単位 + 文脈除外で見る。
+ *
+ * @param {string} body
+ * @returns {boolean}
+ */
+export function hasSkipMarker(body) {
+	return hasDeclarationLine(body, [new RegExp(escapeRegExp(SKIP_MARKER))]);
+}
 
 const SCHEMA_FILE = 'src/lib/server/db/schema.ts';
 const LAZY_MIGRATION_FILE = 'src/lib/server/db/migration/lazy-startup-migrations.ts';
@@ -376,7 +393,7 @@ export function detectBreakingChanges(diff, options = {}) {
 }
 
 function main() {
-	if (PR_BODY.includes(SKIP_MARKER)) {
+	if (hasSkipMarker(PR_BODY)) {
 		console.log(`[check-schema-migration-completeness] ${SKIP_MARKER} marker found — skipping.`);
 		return;
 	}

--- a/scripts/lib/ci/pr-body-sections.mjs
+++ b/scripts/lib/ci/pr-body-sections.mjs
@@ -137,3 +137,77 @@ export function extractH2Section(body, heading, options = {}) {
 export function hasH2Section(body, heading) {
 	return extractH2Section(body, heading).found;
 }
+
+// ---------------------------------------------------------------------------
+// 宣言 (declaration) の判定 — 「その行が宣言か」を見る (#4255 → #4348 で共有化)
+//
+// gate を skip / pass に倒す marker (「UI 変更なし」「[skip-schema-test-check]」等) や
+// evidence 参照 (`.dom.html` リンク / VR 層への紐づけ) を **本文全体への 1 本の正規表現**で
+// 判定すると、以下が全部「書いてある」ことになる:
+//
+//   - HTML コメント (template の説明文。顧客にも監査にも見えない)
+//   - fenced code block / インラインコード (書式の例示)
+//   - 引用行 (他所の文言を貼っただけ)
+//   - 否定文 (「〜ではありません」— 文意と逆に判定される)
+//   - 未チェック checkbox (チェックしていない = 宣言していない)
+//   - 手順・案内文 (「〜と書いてください」— gate 自身のエラー出力を貼り戻すと成立する)
+//
+// 判定できないときは **宣言なし**に倒す (「確認できなかった」を「確認した」と同じ扱いにしない)。
+// ---------------------------------------------------------------------------
+
+/**
+ * 同じ行に現れたら **宣言ではない** と判断する文脈 (#4255 で `check-pr-screenshot.mjs` に
+ * 置いたものを #4348 で共有化)。
+ */
+export const DECLARATION_DISQUALIFYING_PATTERNS = [
+	/^\s*>/, // 引用 — 他所の文言を貼っただけ
+	/^\s*[-*]\s*\[\s\]/, // 未チェック checkbox — チェックしていない = 宣言していない
+	// 否定 (#4255 の実績セットを変えない)。
+	// 「していない」等の一般的な否定動詞は足さない — 「UI 変更なし (コードを 1 行も変更して
+	// いないため)」のような**正しい宣言**を落とす (merged PR #4464 で実測)。
+	/ではありません|ではない|ではなく|とは限らない|とは言えない/,
+	/嘘|虚偽/, // gate 自身の説明文の引用
+	/なしの場合|の場合は|場合:|と書く|と明記|を含めて|してください/, // 手順書の条件節 / 案内文
+];
+
+/**
+ * PR body から「宣言として成立している行」を拾う。
+ *
+ * @param {string} body PR 本文
+ * @param {RegExp[]} patterns 宣言とみなすパターン (行に対して `test` する)
+ * @param {{ extraDisqualifying?: RegExp[] }} [options]
+ * @returns {string[]} 宣言として成立した行 (前後の空白を落としたもの)
+ */
+export function findDeclarationLines(body, patterns, options = {}) {
+	const disqualifying = [
+		...DECLARATION_DISQUALIFYING_PATTERNS,
+		...(options.extraDisqualifying ?? []),
+	];
+	/** @type {string[]} */
+	const found = [];
+	let inFence = false;
+	for (const raw of stripHtmlComments((body ?? '').replace(/\r\n?/g, '\n')).split('\n')) {
+		if (/^\s*(?:```|~~~)/.test(raw)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
+		// インラインコード (`...`) は言及であって宣言ではない
+		const line = raw.replace(/`[^`]*`/g, ' ');
+		if (disqualifying.some((p) => p.test(line))) continue;
+		if (patterns.some((p) => p.test(line))) found.push(line.trim());
+	}
+	return found;
+}
+
+/**
+ * PR body に「宣言として成立している行」が 1 行でもあるか。
+ *
+ * @param {string} body
+ * @param {RegExp[]} patterns
+ * @param {{ extraDisqualifying?: RegExp[] }} [options]
+ * @returns {boolean}
+ */
+export function hasDeclarationLine(body, patterns, options = {}) {
+	return findDeclarationLines(body, patterns, options).length > 0;
+}

--- a/scripts/lib/ci/pr-body-sections.mjs
+++ b/scripts/lib/ci/pr-body-sections.mjs
@@ -88,10 +88,36 @@ export function parseHeadingSpec(heading, defaultLevel = 2) {
 }
 
 /**
+ * 各行が fenced code block の内側かどうかを返す (CommonMark: fence 内の `#` は見出しではない)。
+ *
+ * `scrub: true` では fence ごと除去されるので影響しないが、**fence の中身を残したまま
+ * section を切り出す用途** (`scrub: false`) では必須。`$ npm run x  # コメント` のような
+ * console 貼り付け行を H1 見出しと誤認すると、そこで section が打ち切られる。
+ * 実測 (#4612): merged PR #4519 の `## 検証` 節は 3 行目の `# ...` で切れており、
+ * その先にある根拠コマンド 4 行が検査対象から丸ごと外れていた。
+ *
+ * @param {string[]} lines
+ * @returns {boolean[]}
+ */
+function markFencedLines(lines) {
+	/** @type {boolean[]} */
+	const inFence = [];
+	let open = false;
+	for (const line of lines) {
+		const isFenceMarker = /^\s*(?:```|~~~)/.test(line);
+		// fence の開始 / 終了行そのものも「見出しではない」側に倒す
+		inFence.push(open || isFenceMarker);
+		if (isFenceMarker) open = !open;
+	}
+	return inFence;
+}
+
+/**
  * 指定見出しの section 本体を切り出す (**見出し行そのものは含まない**)。
  *
  * 終端は **同レベル以上の見出し** (H2 指定なら `## ` か `# `) の直前。下位見出し (`### `) では
- * 止めない (同一 section 内の小見出しは所属を変えないため)。
+ * 止めない (同一 section 内の小見出しは所属を変えないため)。fenced code block 内の
+ * `#` 始まり行は見出しとして扱わない (#4612)。
  *
  * @param {string} body PR 本文
  * @param {string} heading 見出し (`## X` / `### X` / `X` のいずれか。`#` 省略時は H2)
@@ -103,11 +129,14 @@ export function extractSection(body, heading, options = {}) {
 	const { level, title } = parseHeadingSpec(heading);
 	const source = scrub ? scrubPrBody(body) : (body ?? '').replace(/\r\n?/g, '\n');
 	const lines = source.split('\n');
+	const fenced = markFencedLines(lines);
 	const marker = '#'.repeat(level);
-	const start = lines.findIndex((l) => l.trim() === `${marker} ${title}`);
+	const start = lines.findIndex((l, i) => !fenced[i] && l.trim() === `${marker} ${title}`);
 	if (start === -1) return { found: false, text: '' };
 	const rest = lines.slice(start + 1);
-	const end = rest.findIndex((l) => {
+	const restFenced = fenced.slice(start + 1);
+	const end = rest.findIndex((l, i) => {
+		if (restFenced[i]) return false;
 		const m = l.match(/^(#{1,6})\s/);
 		return m !== null && (m[1] ?? '').length <= level;
 	});

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -57,6 +57,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'src 配下を走査して直接 DB アクセスを検出する',
 	},
+	'tests/unit/architecture/unreachable-script-export-fitness.test.ts': {
+		scope: 'repo',
+		note: 'scripts/**/*.mjs と .claude/hooks/*.mjs を TypeScript parser で AST 化し、entry / registry から到達しない export された判定関数を検出する (#4623)',
+	},
 	'tests/unit/architecture/node-version-fitness.test.ts': {
 		scope: 'bounded',
 		note: 'Dockerfile* / infra/lib/**/*.ts / .github/workflows/*.yml の 3 系統に限定して Node major 宣言を突き合わせる (#4199 AC5)。glob は限定的だが `**/Dockerfile*` がツリーを歩くため、判定が bounded でも明示 timeout を置いている',

--- a/scripts/lib/db/drizzle-journal-gate.mjs
+++ b/scripts/lib/db/drizzle-journal-gate.mjs
@@ -178,15 +178,10 @@ export function findJournalWhenViolations(entries, options = {}) {
 	return violations;
 }
 
-/**
- * 違反配列を人間可読な 1 本のメッセージへ整形する。
- *
- * @param {{ rule: string, tag: string, when: number, message: string }[]} violations
- * @returns {string}
- */
-export function formatJournalWhenViolations(violations) {
-	return violations.map((v) => `  [${v.rule}] ${v.tag}: ${v.message}`).join('\n');
-}
+// 旧 `formatJournalWhenViolations` は削除した (#4623)。#3953 の glob 化で整形が
+// `formatAllJournalViolations` (file 名を含む) に一般化されたあとも単一 journal 版の整形だけが
+// 残り、呼び出し元が 1 つも無かった (test すら import していない)。整形が 2 本あると、
+// メッセージ書式を直すときに死んでいる方を直す事故を作る。
 
 // ---------------------------------------------------------------------------
 // 全 dialect 走査 (#3953 — #3951 監査 accepted-residual 対象 1)

--- a/scripts/lib/gh-command.mjs
+++ b/scripts/lib/gh-command.mjs
@@ -291,16 +291,10 @@ export function isPullsCollectionPath(path) {
 	return /^repos\/[^/]+\/[^/]+\/pulls$/i.test(path);
 }
 
-/**
- * `repos/<owner>/<repo>/pulls/<n>/<subresource>` か。
- *
- * @param {string} path  normalizeApiPath 済みのパス
- * @param {string} subresource  `reviews` / `merge` 等 (正規表現に埋め込むため呼出側で定数を渡すこと)
- * @returns {boolean}
- */
-export function isPullsSubresourcePath(path, subresource) {
-	return new RegExp(`^repos/[^/]+/[^/]+/pulls/\\d+/${subresource}(?:/.*)?$`, 'i').test(path);
-}
+// 旧 `isPullsSubresourcePath` (PR 識別子を `\d+` に固定した版) は削除した (#4623)。
+// #4057 が「番号の書き方だけで approve gate の有無が変わる」欠陥として下の
+// `isPullsSubresourcePathAnyRef` に置き換えたあとも export だけが残り、呼び出し元は 0 だった。
+// **すり抜ける方の述語が選べる状態で並んでいること自体が危険**なため、生きている側だけを残す。
 
 /**
  * `repos/<owner>/<repo>/pulls/<何か>/<subresource>` か — **PR 識別子の形を問わない** (#4057)。

--- a/scripts/pr-template-gate-checks.mjs
+++ b/scripts/pr-template-gate-checks.mjs
@@ -40,9 +40,8 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { INTEGRATION_EVIDENCE_SECTION } from './check-ac-verification-map.mjs';
 import { extractClosedIssues } from './integration-pr-body.mjs';
-import { extractSection, hasH2Section } from './lib/ci/pr-body-sections.mjs';
+import { hasH2Section } from './lib/ci/pr-body-sections.mjs';
 import { isMain as isMainModule } from './lib/is-main.mjs';
 
 /**
@@ -580,150 +579,22 @@ export function checkCustomerValue({ body, labels, template, lane }) {
 	};
 }
 
-/**
- * template からテスト結果テーブルを含むセクション名を動的取得。
- * @param {string} template
- * @returns {string}
- */
-export function detectTestSectionKeyword(template) {
-	return detectTestSectionHeading(template).replace(/^#{1,6}\s+/, '');
-}
-
-/**
- * template からテスト結果テーブルを含むセクションの **見出し行**（`## X` / `### X`）を取得する。
- *
- * #4348: section の切り出しを見出し行の完全一致で行うため、見出しの**レベルまで**必要になった
- * （`detectTestSectionKeyword` は見出し文字列だけを返すため、H2 / H3 の区別が失われる）。
- *
- * @param {string} template
- * @returns {string} 見出し行（例: `## テスト・品質セルフチェック`）
- */
-export function detectTestSectionHeading(template) {
-	const lines = template.split('\n');
-	let heading = '## テスト実行結果';
-	const tableHeaderIdx = lines.findIndex((l) => /テスト種別.*コマンド.*結果/.test(l));
-	if (tableHeaderIdx !== -1) {
-		for (let i = tableHeaderIdx; i >= 0; i -= 1) {
-			const line = lines[i] ?? '';
-			if (/^###?\s/.test(line)) {
-				heading = line.trim();
-				break;
-			}
-		}
-	}
-	return heading;
-}
-
-/**
- * Check 5: テスト実行結果の記入 (lane-aware)。
- * - feature/hotfix: 現行どおり結果列の placeholder / 空欄検出 (type:docs は skip)。
- * - integration: per-PR コマンド結果でなく「統合エビデンス表 (マージ判定エビデンス) の存在」を検証 (#2944)。
- *   → audit-team.md §3.5 のマージ判定エビデンス表。統合 PR では per-PR コマンド表ではなく
- *     最重厚レーンの集約結果表の存在を要求する。本 phase では「テスト結果テーブルが 1 行以上存在し、
- *     その結果列が placeholder/空でない」= エビデンス表が記入されていることを検証する
- *     (feature と同じ table 検証だが、表の意味付けが「集約エビデンス」)。
- * - dependabot / type:docs: skip。
- *
- * @param {CheckInput} input
- * @returns {CheckResult}
- */
-export function checkTestResults({ body, labels, template, lane }) {
-	const dep = dependabotSkip(lane);
-	if (dep) return dep;
-	if (hasDependenciesLabel(labels, lane)) {
-		return { ok: true, skipped: true, message: '依存関係更新 PR のためスキップ', lane };
-	}
-	// integration lane では type:docs による skip を無効化する (#3071、空洞化防止)。
-	if (lane !== 'integration' && labels.includes('type:docs')) {
-		return { ok: true, skipped: true, message: 'type:docs PR のためスキップ', lane };
-	}
-
-	// #4348: section の探索を「本文の部分一致 + 見つからなければ skip」から
-	// 「H2 見出し行の完全一致 + 見つからなければ fail」に変える。旧実装の壊れ方は 2 つあった:
-	//
-	//   (a) skip に倒れる: keyword が本文になければ pass 扱い。section-presence への「委譲」を
-	//       名目にしていたが、その section-presence 自身も部分一致だったため
-	//       「コメント内の文字列で section-presence が緑 + 本体不在で本 check が skip」の
-	//       二重空振りが成立していた (#4348 表 #5)。
-	//   (b) integration lane で常に skip: keyword は feature template から導出されるため
-	//       (`テスト・品質セルフチェック`)、その見出しを持たない統合 PR template では必ず
-	//       `indexOf === -1` になり、統合エビデンス表の検証分岐が **一度も実行されていなかった**
-	//       (実測: merged 統合 PR 12 本すべてで skip)。lane ごとに見る section を解決する。
-	const heading =
-		lane === 'integration'
-			? `## ${INTEGRATION_EVIDENCE_SECTION}`
-			: detectTestSectionHeading(template);
-	const keyword = heading.replace(/^#{1,6}\s+/, '');
-	const { found, text: section } = extractSection(body, heading);
-	if (!found) {
-		return {
-			ok: false,
-			lane,
-			message:
-				`❌ 「${heading}」セクションが PR 本文にありません。\n\n` +
-				`見出しは **行全体の完全一致** (\`${heading}\`) で判定します。\n` +
-				'HTML コメント / code block の中や本文中の言及は見出しとして数えません (#4348)。\n' +
-				'PR テンプレートのセクション見出しを削除せず、表に結果を記入してください。',
-		};
-	}
-
-	const tableRows = section
-		.split('\n')
-		.filter((l) => /^\|[^|]+\|[^|]+\|[^|]+\|/.test(l))
-		.filter((l) => !/^\|\s*[-:]+\s*\|/.test(l))
-		.filter((l) => !/テスト種別\s*\|/.test(l));
-
-	if (tableRows.length === 0) {
-		if (lane === 'integration') {
-			// 統合 PR ではエビデンス表 (1 行以上) の存在を必須とする (空洞化禁止)。
-			return {
-				ok: false,
-				lane,
-				message:
-					`❌ [integration] 「${keyword}」に統合エビデンス表 (マージ判定エビデンス) がありません。\n\n` +
-					'統合 PR は per-PR コマンド結果ではなく、最重厚レーンの集約結果 / マージ判定エビデンス表\n' +
-					'(audit-team.md §3.5) を 1 行以上記載してください。\n例:\n' +
-					'| 検証観点 | 集約結果 | エビデンス |\n' +
-					'| 重量レーン E2E | PASS (含有 5 PR 分) | run #12345 |',
-			};
-		}
-		return {
-			ok: true,
-			skipped: true,
-			lane,
-			message: 'テスト実行結果テーブルの行が見つかりません (docs / infra のみの変更の可能性)',
-		};
-	}
-
-	const placeholderPattern = /<!--[^>]*?(?:PASS|FAIL|例:)[^>]*?-->/i;
-	const placeholderRows = tableRows.filter((r) => placeholderPattern.test(r));
-	const emptyResultRows = tableRows.filter((row) => {
-		const cells = row
-			.split('|')
-			.slice(1, -1)
-			.map((c) => c.trim());
-		return cells.length >= 3 && cells[2] === '';
-	});
-	const violations = [...new Set([...placeholderRows, ...emptyResultRows])];
-
-	if (violations.length > 0) {
-		const examples = violations
-			.slice(0, 3)
-			.map((r) => `  ${r.slice(0, 100)}`)
-			.join('\n');
-		const prefix = lane === 'integration' ? '[integration] 統合エビデンス表 ' : '';
-		return {
-			ok: false,
-			lane,
-			message:
-				`❌ ${prefix}「${keyword}」テーブルに ${violations.length} 件の未記入行があります。\n\n` +
-				'各行の「結果」列に結果を記入してください (PASS / FAIL / 実行件数 等)。\n\n' +
-				`未記入行（最大 3 件）:\n${examples}`,
-		};
-	}
-	const tag = lane === 'integration' ? '[integration] 統合エビデンス表' : 'テスト実行結果';
-	return { ok: true, lane, message: `✅ ${tag}: ${tableRows.length} 行すべて記入済み` };
-}
+// 旧 Check 5「テスト実行結果」(`checkTestResults` / `detectTestSectionHeading` /
+// `detectTestSectionKeyword`) は削除した (#4623)。
+// #4305 が `pr-template-gate.yml` の対 job を撤去した際に判定関数だけが残り、`CHECKS`
+// registry に載らないまま (= CLI から起動不能) 到達不能になっていた。#4612 / #4614 の
+// `checkChangeType` と同型。
+//
+// 再配線はできない状態でもあった: 走査対象の `## テスト実行結果` /
+// `テスト種別 | コマンド | 結果` 表はどちらも現行 `.github/PULL_REQUEST_TEMPLATE.md`
+// (7 節) に無く、registry に戻すと feature lane の全 PR が「セクションがありません」で
+// hard-fail する。
+//
+// integration lane が担っていた「マージ判定エビデンス表」の記入検証は
+// `check-ac-verification-map.mjs` の `checkIntegrationEvidenceTable` が**生きた経路で**
+// 継続している (`check-pr-body.mjs` + `.github/workflows/pr-ac-verification-check.yml`)。
+// 復活させるならテンプレート節 / `PR_TEMPLATE_SECTIONS.json` / `CHECKS` 登録 / workflow job を
+// セットで戻すこと (class-lock: tests/unit/github/pr-template-gate-checks.test.ts)。
 
 /** check 名 → 関数の dispatch table (CLI 用)。 */
 export const CHECKS = {

--- a/scripts/pr-template-gate-checks.mjs
+++ b/scripts/pr-template-gate-checks.mjs
@@ -464,82 +464,13 @@ export function checkClosingKeyword({ body, labels, lane }) {
 	};
 }
 
-/**
- * template から複数の `- [ ]` を持つ変更タイプセクション見出しを動的取得。
- * @param {string} template
- * @returns {string}
- */
-export function detectChangeTypeHeading(template) {
-	const lines = template.split('\n');
-	let heading = '## 変更タイプ';
-	for (let i = 0; i < lines.length; i += 1) {
-		const line = lines[i] ?? '';
-		if (/^## /.test(line)) {
-			const sectionEndIdx = lines.findIndex((l, idx) => idx > i && /^## /.test(l));
-			const lookaheadEnd = sectionEndIdx === -1 ? Math.min(i + 50, lines.length) : sectionEndIdx;
-			const lookahead = lines.slice(i + 1, lookaheadEnd);
-			if (lookahead.filter((l) => /^- \[ \]/.test(l)).length >= 3) {
-				heading = line.trim();
-				break;
-			}
-		}
-	}
-	return heading;
-}
-
-/**
- * Check 3: 変更タイプの選択 (lane-aware)。
- * - feature/hotfix: 1 つ以上 [x] (現行どおり)。
- * - integration: 複数タイプ混在を許容 (統合 PR は feat/fix/docs 混在が正常)。1 つ以上 [x] は維持 (#2944)。
- *   → 閾値は feature と同じ (1 つ以上) だが、複数選択を violation 扱いしない点が明示的に異なる
- *     (現行ロジックも複数選択を fail にはしないため、integration では「混在 OK」を message で明示する)。
- * - dependabot: skip。
- *
- * @param {CheckInput} input
- * @returns {CheckResult}
- */
-export function checkChangeType({ body, labels, template, lane }) {
-	const dep = dependabotSkip(lane);
-	if (dep) return dep;
-	if (hasDependenciesLabel(labels, lane)) {
-		return { ok: true, skipped: true, message: '依存関係更新 PR のためスキップ', lane };
-	}
-
-	const heading = detectChangeTypeHeading(template);
-	const start = body.indexOf(heading);
-	if (start === -1) {
-		// 現行は warning + return (section-presence に委譲)。ここでも ok 扱い (skip)。
-		return {
-			ok: true,
-			skipped: true,
-			lane,
-			message: `「${heading}」セクションが見つかりません (section-presence チェックに委譲)`,
-		};
-	}
-	const end = body.indexOf('\n## ', start + 1);
-	const section = body.slice(start, end > start ? end : start + 600);
-	const checked = section.match(/- \[[xX]\]/g);
-
-	if (!checked || checked.length === 0) {
-		return {
-			ok: false,
-			lane,
-			message:
-				`❌ 「${heading}」で何も選択されていません。\n\n` +
-				'該当する変更タイプのチェックボックスを選択してください。\n\n例:\n```\n- [x] feat: 新機能\n```',
-		};
-	}
-
-	const items = (section.match(/- \[[xX]\] (.+)/g) || []).map((i) => i.replace(/- \[[xX]\] /, ''));
-	if (lane === 'integration') {
-		return {
-			ok: true,
-			lane,
-			message: `✅ [integration] 変更タイプ (複数混在 OK): ${items.join(' / ')}`,
-		};
-	}
-	return { ok: true, lane, message: `✅ 変更タイプ: ${items.join(' / ')}` };
-}
+// 旧 Check 3「変更タイプの選択」(`detectChangeTypeHeading` / `checkChangeType`) は削除した (#4612)。
+// #4305 が `## 変更タイプ` 節をテンプレートから外し、`pr-template-gate.yml` の対の job も
+// 同時に撤去したため、本関数は `CHECKS` registry に載らず (= CLI からは起動不能)、
+// 唯一の呼び出し元が `check-pr-body.mjs` の `checkChangeTypeSelection` だった。その
+// `checkChangeTypeSelection` 自身も runner から呼ばれておらず、chain 全体が死んでいた。
+// 復活させるならテンプレート節 / `PR_TEMPLATE_SECTIONS.json` / `CHECKS` 登録 / workflow job を
+// セットで戻すこと (class-lock: tests/unit/github/pr-template-gate-checks.test.ts)。
 
 /**
  * template の「最初の `## ` セクション本文」(見出し行から次の `## ` の直前まで) を返す。

--- a/scripts/pre-ready.mjs
+++ b/scripts/pre-ready.mjs
@@ -291,7 +291,8 @@ export const PRE_READY_GATE_SSOT_PATHS = /** @type {const} */ ([
 	'scripts/check-ac-verification-map.mjs',
 	'scripts/integration-pr-body.mjs',
 	'scripts/pr-lane.mjs',
-	'scripts/pr-template-gate-checks.mjs',
+	// `scripts/pr-template-gate-checks.mjs` は #4612 で閉包から外れた
+	// (`check-pr-body.mjs` が唯一 import していた `checkChangeType` を削除したため)。
 	'scripts/lib/is-main.mjs',
 	'scripts/lib/ci/pr-body-sections.mjs',
 	'scripts/lib/ci/pr-input.mjs',

--- a/src/routes/CLAUDE.md
+++ b/src/routes/CLAUDE.md
@@ -115,7 +115,16 @@ node scripts/capture.mjs --pr <N>            # 修正後 SS を撮り直す
 
 - 否定文（「UI 変更なし**ではありません**」）/ 引用行（`> …`）/ コードブロック・インラインコード内
 - **未チェックの checkbox**（`- [ ] UI 変更なし`）— チェックしていない = 宣言していない
-- 手順・条件節（「UI 変更なし**の場合**: …」）
+- 手順・条件節（「UI 変更なし**の場合**: …」）/ 案内文（「〜と書いてください」）
+- **HTML コメント内**（`<!-- UI 変更なし -->`）— レンダリングされた PR body に出ないため、レビュアーにも監査にも見えない（#4348）。宣言は**本文に見える形で**書く
+
+この判定規律（行単位 + HTML コメント / コードブロック / 引用 / 否定 / 未チェック checkbox / 案内文の除外）は `scripts/lib/ci/pr-body-sections.mjs` が SSOT で、**PR body を読む他の gate も同じ規律を使う**（#4348）:
+
+| 判定 | 対象 |
+|---|---|
+| `.dom.html` 参照の有無 | DOM スナップショット併記検証（`check-pr-screenshot.mjs`） |
+| 統合 PR の VR 証跡 | 統合 lane の SS 観点。加えて「含有 PR」は prose の言及ではなく **`## 含有 PR 一覧` に実際の PR 参照がある**ことで判定する |
+| `[skip-schema-test-check]` / `[skip-schema-migration-check]` | schema 系 gate の skip marker |
 
 **テンプレートや案内文に opt-out 宣言そのものを書かない。** テンプレートを消さずに出しただけで gate が skip されるため、案内は「何を書くか」の説明にとどめる（`tests/unit/scripts/check-pr-screenshot.test.ts` が実テンプレートを読んで検証している）。
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -329,7 +329,7 @@ it('is_archived が NULL の既存行もアクティブとして返される', (
 
 「NULL = 既定値扱い」セマンティクスなら `or(eq(col, default), isNull(col))` または **マイグレーションで backfill**。片側だけは不十分。
 
-CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.ts` diff があるのに `tests/unit/db/` または `tests/unit/services/` diff が無い場合警告。skip 必要時は PR 本文に `[skip-schema-test-check]`。
+CI 自動チェック (`scripts/check-schema-change-tests.mjs`、warn): `schema.ts` diff があるのに `tests/unit/db/` または `tests/unit/services/` diff が無い場合警告。skip 必要時は PR 本文に `[skip-schema-test-check]` を**宣言として**書く (HTML コメント / コードブロック / 引用 / 未チェック checkbox / 案内文の中の同じ文字列では skip しない、#4348)。
 
 ### backend 並行実装の整合性
 

--- a/tests/unit/architecture/pr-body-partial-match-guard.test.ts
+++ b/tests/unit/architecture/pr-body-partial-match-guard.test.ts
@@ -28,8 +28,16 @@ vi.setConfig({ testTimeout: 60_000 });
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 const SCAN_DIR = resolve(REPO_ROOT, 'scripts');
 
-/** PR body を指す変数名 (これらに対する部分一致判定を検出対象にする)。 */
-const BODY_IDENT = String.raw`(?:[A-Za-z_$][\w$]*)?[Bb]ody`;
+/**
+ * PR body を指す変数名 (これらに対する部分一致判定を検出対象にする)。
+ *
+ * **大文字の `PR_BODY` も含める (#4348 で追加)**。旧実装は `[Bb]ody` しか見ておらず、
+ * env 由来の定数名 `PR_BODY` に対する `.includes(...)` が検出器から漏れていた。
+ * 実際に schema 系 gate 2 本が `PR_BODY.includes(SKIP_MARKER)` で **gate 全体を skip** しており、
+ * 「本 Issue の対象一覧にも ALLOWLIST にも載らない同 class」が残っていた。
+ * 検出できない形を残すと guard 自体が「検査できなかったのに緑」になる (#4084 と同じ穴)。
+ */
+const BODY_IDENT = String.raw`(?:[A-Za-z_$][\w$]*)?(?:[Bb]ody|BODY)`;
 
 /** `<body>.indexOf(` / `<body>.includes(` — 部分一致で section / 宣言を探す形。 */
 const SUBSTRING_RE = new RegExp(String.raw`\b(${BODY_IDENT})\s*\.\s*(indexOf|includes)\s*\(`, 'g');
@@ -49,11 +57,6 @@ const ALLOWLIST: Record<string, string> = {
 		'#4348 残置 (対象 #6): feature lane の AC マップ section 探索。全 feature PR に波及するため別 PR で corpus 比較のうえ是正する',
 	'scripts/check-admin-bypass-evidence.mjs::return EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body));':
 		'#4348 残置 (対象 #3): admin bypass 証跡マーカーの存在検査。nightly 監査 script で PR gate とは別経路のため別 PR で是正する',
-	'scripts/check-pr-screenshot.mjs::return DOM_REF_PATTERN.test(body);':
-		'#4348 残置 (対象 #4): DOM スナップショット参照の存在検査。#4255 の兄弟関数と同様に実在検査へ寄せる別 PR で是正する',
-	'scripts/check-pr-screenshot.mjs::return INTEGRATION_VR_EVIDENCE_PATTERNS.some((p) => p.test(body));':
-		'#4348 残置 (対象 #4): 統合 PR の VR 証跡の存在検査。同上',
-
 	// --- 構造化識別子ではなく prose (自然文) を探す用途。本文全体を見るのが正しい ---
 	'scripts/check-pr-screenshot.mjs::hasBefore: BEFORE_LABEL_PATTERN.test(body),':
 		'prose 検査: 「修正前」ラベルの表記ゆれを本文から探す用途で、見出し等の構造化識別子ではない',

--- a/tests/unit/architecture/pr-body-partial-match-guard.test.ts
+++ b/tests/unit/architecture/pr-body-partial-match-guard.test.ts
@@ -52,11 +52,11 @@ const WHOLE_BODY_TEST_RE = new RegExp(String.raw`\.test\(\s*(${BODY_IDENT})\s*\)
  * 「この判定を触ったならもう一度理由を書け」という強制になる。
  */
 const ALLOWLIST: Record<string, string> = {
-	// --- #4348 で是正しなかった残置 (Issue #4348 に残件として記録、1 箇所ずつ corpus 比較して消化) ---
-	"scripts/check-ac-verification-map.mjs::const mapHeaderIdx = body.indexOf('AC 検証マップ');":
-		'#4348 残置 (対象 #6): feature lane の AC マップ section 探索。全 feature PR に波及するため別 PR で corpus 比較のうえ是正する',
-	'scripts/check-admin-bypass-evidence.mjs::return EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body));':
-		'#4348 残置 (対象 #3): admin bypass 証跡マーカーの存在検査。nightly 監査 script で PR gate とは別経路のため別 PR で是正する',
+	// #4348 の対象 6 箇所は全て消化済 (残置エントリなし)。
+	//   対象 #6 は **判定関数ごと削除**した — #4305 で PR テンプレートから `## AC 検証マップ` 節が
+	//   消え entry からも外れており、呼び出しが自身の test だけの死んだコードだったため、
+	//   厳格化ではなく削除が正しい対処だった (経緯は check-ac-verification-map.mjs の entry コメント)。
+	//   対象 #3 (admin bypass 証跡 marker) は `hasDeclarationLine` へ移行済。
 	// --- 構造化識別子ではなく prose (自然文) を探す用途。本文全体を見るのが正しい ---
 	'scripts/check-pr-screenshot.mjs::hasBefore: BEFORE_LABEL_PATTERN.test(body),':
 		'prose 検査: 「修正前」ラベルの表記ゆれを本文から探す用途で、見出し等の構造化識別子ではない',

--- a/tests/unit/architecture/pr-body-partial-match-guard.test.ts
+++ b/tests/unit/architecture/pr-body-partial-match-guard.test.ts
@@ -75,7 +75,7 @@ const ALLOWLIST: Record<string, string> = {
 	'scripts/check-pr-body.mjs::const startIdx = body.indexOf(section);':
 		'#4348 scope 外: check-pr-body の section 切り出し。同上',
 	'scripts/pr-template-gate-checks.mjs::const start = body.indexOf(heading);':
-		'#4348 scope 外: sliceSection / detectChangeTypeHeading の見出し探索。同 class のため後続 PR で移行する',
+		'#4348 scope 外: sliceSection の見出し探索 (detectChangeTypeHeading は #4612 で削除済)。同 class のため後続 PR で移行する',
 	"scripts/pr-template-gate-checks.mjs::const end = body.indexOf('\\n## ', start + 1);":
 		'#4348 scope 外: 上記 sliceSection の終端探索 (見出しの存在判定ではない)。同上',
 	'scripts/pr-template-gate-checks.mjs::const idx = body.indexOf(`**${field}**:`);':

--- a/tests/unit/architecture/unreachable-script-export-fitness.test.ts
+++ b/tests/unit/architecture/unreachable-script-export-fitness.test.ts
@@ -23,7 +23,7 @@
 // grep でコメントを除去しようとすると正規表現リテラル (`/^https?:\/\//i`) の末尾を `//`
 // コメントと誤認する — 実測でこれが生きている `isUserAttachmentAssetUrl` を dead と誤検出した。
 //
-// 参照元 (CONSUMER_GLOBS) に **test を含めない**。含めると上記のとおり検査が無意味になる。
+// 参照元 (CONSUMER_ROOTS) に **test を含めない**。含めると上記のとおり検査が無意味になる。
 // 「fitness function からしか呼ばれないのが正しい」export は ALLOWLIST に理由付きで載せる。
 import { globSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -38,12 +38,15 @@ const TARGET_ROOTS = ['scripts'];
 /**
  * 参照元として数える production コードの走査 root。
  *
- * **test を入れてはならない** — test からの import を参照と数えると、本番経路が死んでいても
- * 「使われている」ことになり、本 gate が守りたいものを守れなくなる。
+ * **test を参照元に入れてはならない** — test からの import を参照と数えると、本番経路が死んで
+ * いても「使われている」ことになり、本 gate が守りたいものを守れなくなる。
+ *
+ * 除外は 2 経路で効いている: `tests/**` は `.ts` なので下の `.mjs` glob に入らない。
+ * `scripts/__tests__/**`(node:test) は `.mjs` なので `EXCLUDED_PATH_PARTS` で明示除外する。
  */
 const CONSUMER_ROOTS = ['scripts', '.claude/hooks'];
 
-/** 走査から外す path 断片 (自身の test / 一時ファイル)。 */
+/** 走査から外す path 断片 (test は参照元に数えない、上記参照)。 */
 const EXCLUDED_PATH_PARTS = ['__tests__', 'node_modules'];
 
 /**
@@ -52,7 +55,6 @@ const EXCLUDED_PATH_PARTS = ['__tests__', 'node_modules'];
  * 理由なし / stub な理由は置かない (理由の非強制を作らない、#3956 教訓)。ここに足すときは
  * **なぜ production から呼ばれないのが正しいのか**を書く。単に「まだ使っていない」は理由に
  * ならない — その場合は削除する。
- *
  */
 const ALLOWLIST: Record<string, string> = {
 	'scripts/lib/ci/workflow-judgment-registry.mjs#findJudgment':
@@ -213,6 +215,15 @@ describe('#4623 scripts/ の export された判定関数は entry / registry �
 			].join('\n'),
 		).toEqual([]);
 	}, 60_000);
+
+	// 現時点では「scripts/__tests__ からしか参照されない export」が存在しないため、除外を外しても
+	// 検出結果は変わらない (実測)。つまり除外の効きは検出結果からは確認できない。効かなくなった
+	// ことに後から気づけるよう、参照元集合そのものを直接 assert する。
+	it('参照元集合に test は 1 件も入っていない（test を生存証明にしない）', () => {
+		const consumers = expandRoots(CONSUMER_ROOTS);
+		expect(consumers.length, '参照元が 0 件 = 全 export が dead 判定される').toBeGreaterThan(0);
+		expect(consumers.filter((f) => f.includes('__tests__') || /\.test\.mjs$/.test(f))).toEqual([]);
+	});
 
 	it('ALLOWLIST の理由は stub でない', () => {
 		for (const [key, reason] of Object.entries(ALLOWLIST)) {

--- a/tests/unit/architecture/unreachable-script-export-fitness.test.ts
+++ b/tests/unit/architecture/unreachable-script-export-fitness.test.ts
@@ -1,0 +1,223 @@
+// tests/unit/architecture/unreachable-script-export-fitness.test.ts (#4623)
+//
+// # 何を守るか
+//
+// `scripts/**` に **export されているが、どの entry / registry / 他モジュールからも呼ばれない
+// 判定関数**が残るのを禁止する。
+//
+// # なぜ機械化するか
+//
+// 同 class が 4 件連続した (ADR-0061 same-class-N→guard):
+//   #4611 `checkPerPrAcMap` / #4614 `checkAcMap` `checkChangeTypeSelection` `checkChangeType`
+//   / #4623 `checkTestResults` `detectTestSectionHeading` `detectTestSectionKeyword`
+// いずれも「CI job を撤去したときに判定関数だけ置き去りにした」残骸で、**読む人が毎回
+// registry / workflow / import を辿らないと生死が分からない**。しかも死んだ判定を善意で
+// 配線し直すと、入力側 (テンプレートの節) が既に無いため全 PR が hard-fail する。
+//
+// knip では捕まらない: unit test が import している限り「使われている」と見えるため、
+// **test が生存証明として機能してしまう**。判定関数は本番経路が死んでも test は緑のままになる。
+//
+// # 判定方法
+//
+// 文字列 grep ではなく TypeScript の parser で AST を作り、Identifier の出現数で参照を数える。
+// grep でコメントを除去しようとすると正規表現リテラル (`/^https?:\/\//i`) の末尾を `//`
+// コメントと誤認する — 実測でこれが生きている `isUserAttachmentAssetUrl` を dead と誤検出した。
+//
+// 参照元 (CONSUMER_GLOBS) に **test を含めない**。含めると上記のとおり検査が無意味になる。
+// 「fitness function からしか呼ばれないのが正しい」export は ALLOWLIST に理由付きで載せる。
+import { globSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../..');
+
+/** 検査対象の走査 root (ここに宣言された export function を見る)。 */
+const TARGET_ROOTS = ['scripts'];
+
+/**
+ * 参照元として数える production コードの走査 root。
+ *
+ * **test を入れてはならない** — test からの import を参照と数えると、本番経路が死んでいても
+ * 「使われている」ことになり、本 gate が守りたいものを守れなくなる。
+ */
+const CONSUMER_ROOTS = ['scripts', '.claude/hooks'];
+
+/** 走査から外す path 断片 (自身の test / 一時ファイル)。 */
+const EXCLUDED_PATH_PARTS = ['__tests__', 'node_modules'];
+
+/**
+ * 「到達しないが残してよい」export と、その理由。
+ *
+ * 理由なし / stub な理由は置かない (理由の非強制を作らない、#3956 教訓)。ここに足すときは
+ * **なぜ production から呼ばれないのが正しいのか**を書く。単に「まだ使っていない」は理由に
+ * ならない — その場合は削除する。
+ *
+ */
+const ALLOWLIST: Record<string, string> = {
+	'scripts/lib/ci/workflow-judgment-registry.mjs#findJudgment':
+		'本 registry の consumer は tests/unit/architecture/workflow-judgment-delegation-guard.test.ts (CI unit lane で常時実行される fitness function) であり、それが production consumer そのもの。findJudgment は [D1] no-silent-gap (covered workflow の全 job が registry に宣言されているか) を実装する唯一の経路で、消すと [D1] が表現できなくなる',
+	'scripts/claude-hook-prevent-qa-account-pr.mjs#containsGhPrCreate':
+		'#4624 で扱う。detectPrCreation の boolean wrapper で production からは呼ばれないが、ADR-0022 の cross-hook 整合 guard (tests/unit/hooks/qm-session-approve-hook-consistency.test.ts) を含む 2 test file 約 30 assertion の呼び先になっている。削除は呼び先の書き換えを伴うため別 Issue',
+	'scripts/collect-integration-prs.mjs#isAtOrAfterInstant':
+		'#4624 で扱う。#4053 が時刻比較そのものを廃した (merge 履歴ベースへ) ため production 経路から外れたが、AC1「時刻比較は必ず epoch 正規化を通す」の sanctioned API として意図的に残された経緯がある。存置/削除の判断は別 Issue',
+	'scripts/collect-integration-prs.mjs#compareIsoInstant':
+		'#4624 で扱う。isAtOrAfterInstant の内部実装で、同じ判断に従う',
+	'scripts/issue-close-gate-skip-judge.mjs#judgeSkipAcGate':
+		'#4624 で扱う。呼び元の issue-close-gate.yml は #4322 で削除済 (完全に死んでいる) が、.github/CLAUDE.md / copilot-instructions.md / ADR-0004 が今も gate の存在を前提に書かれている。script だけ消すと docs が実在しない SSOT を指し続けるため、doc 側の是正と同一 PR で行う',
+	'scripts/issue-close-gate-skip-judge.mjs#countAcCheckboxes':
+		'#4624 で扱う。judgeSkipAcGate と同じ file / 同じ判断に従う',
+};
+
+type Decl = { file: string; name: string; start: number; end: number; nameStart: number };
+
+const norm = (p: string) => p.replace(/\\/g, '/');
+const included = (p: string) => !EXCLUDED_PATH_PARTS.some((part) => p.includes(part));
+
+function expandRoots(roots: string[]): string[] {
+	const out = new Set<string>();
+	for (const root of roots) {
+		for (const f of globSync(`${root}/**/*.mjs`, { cwd: REPO_ROOT })) {
+			const rel = norm(String(f));
+			if (included(rel)) out.add(rel);
+		}
+	}
+	return [...out].sort();
+}
+
+function parse(rel: string): ts.SourceFile {
+	const text = readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+	return ts.createSourceFile(rel, text, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+}
+
+/** top-level の `export function NAME` 宣言を、その本文の範囲つきで返す。 */
+function exportedFunctionDecls(rel: string, sf: ts.SourceFile): Decl[] {
+	const out: Decl[] = [];
+	for (const st of sf.statements) {
+		if (!ts.isFunctionDeclaration(st) || !st.name) continue;
+		const exported = st.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+		if (!exported) continue;
+		out.push({
+			file: rel,
+			name: st.name.text,
+			start: st.getStart(sf),
+			end: st.getEnd(),
+			nameStart: st.name.getStart(sf),
+		});
+	}
+	return out;
+}
+
+/** file 内の全 Identifier 出現 (AST 由来なのでコメント / 文字列は含まれない)。 */
+function identifiers(sf: ts.SourceFile): { name: string; pos: number }[] {
+	const out: { name: string; pos: number }[] = [];
+	const visit = (node: ts.Node) => {
+		if (ts.isIdentifier(node)) out.push({ name: node.text, pos: node.getStart(sf) });
+		ts.forEachChild(node, visit);
+	};
+	ts.forEachChild(sf, visit);
+	return out;
+}
+
+type Index = {
+	targets: string[];
+	consumers: string[];
+	declsOf: Map<string, Decl[]>;
+	identsOf: Map<string, { name: string; pos: number }[]>;
+};
+
+function buildIndex(): Index {
+	const targets = expandRoots(TARGET_ROOTS);
+	const consumers = expandRoots(CONSUMER_ROOTS);
+	const declsOf = new Map<string, Decl[]>();
+	const identsOf = new Map<string, { name: string; pos: number }[]>();
+	for (const rel of new Set([...targets, ...consumers])) {
+		const sf = parse(rel);
+		declsOf.set(rel, exportedFunctionDecls(rel, sf));
+		identsOf.set(rel, identifiers(sf));
+	}
+	return { targets, consumers, declsOf, identsOf };
+}
+
+/**
+ * `decl` への参照数を数える。
+ *
+ * すでに死んでいると分かった関数の本体からの参照は数えない (chain 全体が死んでいる場合に、
+ * 片端だけ生き残って見えるのを防ぐ)。
+ */
+function countReferences(index: Index, decl: Decl, dead: Set<string>): number {
+	let refs = 0;
+	for (const cf of index.consumers) {
+		const deadSpans = (index.declsOf.get(cf) ?? []).filter((x) => dead.has(`${cf}#${x.name}`));
+		for (const id of index.identsOf.get(cf) ?? []) {
+			if (id.name !== decl.name) continue;
+			if (cf === decl.file && id.pos === decl.nameStart) continue; // 宣言そのもの
+			if (deadSpans.some((s) => id.pos >= s.start && id.pos < s.end)) continue;
+			refs += 1;
+		}
+	}
+	return refs;
+}
+
+/** 到達不能な export を `<file>#<name>` の形で返す (収束するまで繰り返す)。 */
+function findUnreachable(): string[] {
+	const index = buildIndex();
+	const dead = new Set<string>();
+	for (let round = 0; round < 20; round += 1) {
+		let changed = false;
+		for (const file of index.targets) {
+			for (const decl of index.declsOf.get(file) ?? []) {
+				const key = `${file}#${decl.name}`;
+				if (dead.has(key)) continue;
+				if (countReferences(index, decl, dead) > 0) continue;
+				dead.add(key);
+				changed = true;
+			}
+		}
+		if (!changed) break;
+	}
+	return [...dead].sort();
+}
+
+describe('#4623 scripts/ の export された判定関数は entry / registry から到達できる', () => {
+	it('到達不能な export は ALLOWLIST に理由付きで載っているものだけ', () => {
+		const unreachable = findUnreachable();
+		const undeclared = unreachable.filter((key) => !(key in ALLOWLIST));
+
+		expect(
+			undeclared,
+			[
+				'export されているが、どの entry / registry / 他モジュールからも呼ばれない判定関数を検出しました (#4623)。',
+				'',
+				'次のどれかを行ってください:',
+				'  (a) 削除する — 配線 (workflow job / registry 登録 / テンプレート節) ごと消えているなら、判定関数だけ残さない',
+				'  (b) 配線し直す — 入力側 (テンプレートの節 / workflow の invoke) が実在することを確認してから registry に載せる',
+				'  (c) ALLOWLIST に載せる — 「production から呼ばれないのが正しい」理由を書く。「まだ使っていない」は理由になりません',
+				'',
+				`検出: ${undeclared.join(', ')}`,
+			].join('\n'),
+		).toEqual([]);
+	}, 60_000);
+
+	it('ALLOWLIST に stale なエントリが無い（到達するようになったら宣言を消す）', () => {
+		const unreachable = new Set(findUnreachable());
+		const stale = Object.keys(ALLOWLIST).filter((key) => !unreachable.has(key));
+
+		expect(
+			stale,
+			[
+				'ALLOWLIST のエントリが到達可能になっている / 対象が消えています (#4623)。',
+				'宣言を残したままにすると、次に同じ名前が死んだときに黙って見逃します。該当行を削除してください。',
+				'',
+				`stale: ${stale.join(', ')}`,
+			].join('\n'),
+		).toEqual([]);
+	}, 60_000);
+
+	it('ALLOWLIST の理由は stub でない', () => {
+		for (const [key, reason] of Object.entries(ALLOWLIST)) {
+			expect(reason.trim().length, `${key} の理由が短すぎます`).toBeGreaterThanOrEqual(30);
+			expect(reason, `${key} の理由が定型 stub です`).not.toMatch(/^(TODO|n\/a|なし|未定)$/i);
+		}
+	});
+});

--- a/tests/unit/github/pr-template-gate-checks.test.ts
+++ b/tests/unit/github/pr-template-gate-checks.test.ts
@@ -20,9 +20,7 @@ import {
 	checkCustomerValue,
 	checkIssueReference,
 	checkSectionPresence,
-	checkTestResults,
 	detectIssueSectionHeading,
-	detectTestSectionKeyword,
 	extractTemplateSections,
 	INTEGRATION_REQUIRED_SECTIONS,
 	parseArgs,
@@ -166,9 +164,6 @@ describe('helper detectors (#2944)', () => {
 	it('detectIssueSectionHeading は closes # を含む section を返す', () => {
 		expect(detectIssueSectionHeading(TEMPLATE)).toBe('## 関連 Issue');
 	});
-	it('detectTestSectionKeyword はテスト結果テーブル直近の見出しを返す', () => {
-		expect(detectTestSectionKeyword(TEMPLATE)).toBe('テスト実行結果');
-	});
 });
 
 // =====================================================================
@@ -263,24 +258,6 @@ describe('feature lane: 現行観点維持 (#2944 AC4)', () => {
 		const r = checkCustomerValue({ ...base, template: tplNoComment, body });
 		expect(r.ok).toBe(false);
 		expect(r.message).toContain('対象ユーザー');
-	});
-	it('test-results PASS: 結果列記入済み', () => {
-		expect(checkTestResults({ ...base, body: VALID_FEATURE_BODY }).ok).toBe(true);
-	});
-	it('test-results FAIL: 結果列 placeholder 残存', () => {
-		const r = checkTestResults({
-			...base,
-			body: VALID_FEATURE_BODY.replace(
-				'| Lint | `npx biome check .` | PASS | |',
-				'| Lint | `npx biome check .` | <!-- PASS / FAIL --> | |',
-			),
-		});
-		expect(r.ok).toBe(false);
-	});
-	it('test-results skip: type:docs label', () => {
-		const r = checkTestResults({ ...base, labels: ['type:docs'], body: VALID_FEATURE_BODY });
-		expect(r.ok).toBe(true);
-		expect(r.skipped).toBe(true);
 	});
 });
 
@@ -387,10 +364,6 @@ describe('integration lane: 観点切替・空洞化なし (#2944 AC2/AC3)', () 
 		expect(r.skipped).toBeFalsy();
 		expect(r.ok).toBe(true);
 	});
-	it('integration + type:docs label でも test-results は skip しない (#3071)', () => {
-		const r = checkTestResults({ ...base, labels: ['type:docs'], body: INTEGRATION_BODY });
-		expect(r.skipped).toBeFalsy();
-	});
 	it('section-presence FAIL: 統合必須 section 欠落で fail (空洞化していない証跡)', () => {
 		const r = checkSectionPresence({
 			...base,
@@ -417,21 +390,10 @@ describe('integration lane: 観点切替・空洞化なし (#2944 AC2/AC3)', () 
 		expect(checkIssueReference({ ...base, body: INTEGRATION_BODY }).ok).toBe(true);
 		expect(INTEGRATION_BODY).not.toContain('closes #');
 	});
-	it('test-results PASS: 統合エビデンス表 (1 行) があれば通過', () => {
-		const r = checkTestResults({ ...base, body: INTEGRATION_BODY });
-		expect(r.ok).toBe(true);
-		expect(r.message).toContain('統合エビデンス表');
-	});
-	it('test-results FAIL: エビデンス表 0 行は integration で fail (skip でなく fail = 空洞化なし)', () => {
-		const noTable = INTEGRATION_BODY.replace(
-			/## マージ判定エビデンス表[\s\S]*?(?=## レビュー依頼事項)/,
-			'## マージ判定エビデンス表\n\n（表なし）\n\n',
-		);
-		const r = checkTestResults({ ...base, body: noTable });
-		expect(r.ok).toBe(false);
-		expect(r.skipped).toBeFalsy();
-		expect(r.message).toContain('統合エビデンス表');
-	});
+	// 統合エビデンス表 (`## マージ判定エビデンス表`) の記入検証は、生きた経路である
+	// `check-ac-verification-map.mjs` の `checkIntegrationEvidenceTable` 側で担保する
+	// (`tests/unit/scripts/check-ac-verification-map.test.ts`)。ここにあった test-results
+	// 版は到達不能な判定関数を検証していたため #4623 で削除した。
 	it('customer-value PASS: placeholder 残存なし (リリースバッチサマリ)', () => {
 		const r = checkCustomerValue({ ...base, body: INTEGRATION_BODY });
 		expect(r.ok).toBe(true);
@@ -571,7 +533,6 @@ describe('dependabot lane: 全 check skip 相当 (#2944 AC5)', () => {
 		['section-presence', checkSectionPresence],
 		['issue-reference', checkIssueReference],
 		['customer-value', checkCustomerValue],
-		['test-results', checkTestResults],
 		['closing-keyword', checkClosingKeyword],
 	] as const) {
 		it(`${name}: dependabot は skip 相当 (ok:true skipped:true)`, () => {
@@ -882,57 +843,10 @@ describe('#4348: 見出し探索は行の完全一致 + 見つからなければ
 		expect(checkSectionPresence({ ...base, body: REAL_BODY }).ok).toBe(true);
 	});
 
-	it('test-results: section 不在は skip でなく fail (検査できなかったものを pass にしない)', () => {
-		const r = checkTestResults({ ...base, body: '## 顧客価値・目的\n\n本文だけ\n' });
-		expect(r.skipped, 'skip に倒れると gate が no-op になる').toBeFalsy();
-		expect(r.ok).toBe(false);
-	});
-
-	it('test-results: 本文中の言及が見出しより前にあっても本物の表を読む (#4325 / #4311 実例)', () => {
-		// 実 merged PR で観測: AC 表のセルに「下記「テスト・品質セルフチェック」参照」があり、
-		// 旧実装はそのセルから section を切り出して表 0 行 → skip していた。
-		const body = [
-			'## 顧客価値・目的',
-			'',
-			'| AC1 | 内容 | 手段 | 下記「テスト・品質セルフチェック」参照 |',
-			'',
-			'## テスト・品質セルフチェック',
-			'',
-			'| テスト種別 | コマンド | 結果 |',
-			'|---|---|---|',
-			'| pre-ready | `npm run pre-ready` | |',
-			'',
-		].join('\n');
-		const r = checkTestResults({ ...base, body });
-		expect(r.skipped).toBeFalsy();
-		expect(r.ok, '結果列が空の行を検出できていない').toBe(false);
-	});
-
-	it('test-results: 結果列が HTML コメントだけの行は未記入として検出する (#4278 実例)', () => {
-		const body = [
-			'## テスト・品質セルフチェック',
-			'',
-			'| テスト種別 | コマンド | 結果 |',
-			'|---|---|---|',
-			'| pre-ready | `npm run pre-ready` | <!-- 実行後に記入 --> |',
-			'',
-		].join('\n');
-		expect(checkTestResults({ ...base, body }).ok).toBe(false);
-	});
-
-	it('test-results: integration lane は統合 PR template のエビデンス表を読む (feature 見出しを探さない)', () => {
-		const body = [
-			'## マージ判定エビデンス表',
-			'',
-			'| 含有 PR | 領域 | テスト | 結果 |',
-			'|---|---|---|---|',
-			'| #1 | admin | unit×3 | pass |',
-			'',
-		].join('\n');
-		const r = checkTestResults({ ...base, lane: 'integration', body });
-		expect(r.skipped, 'feature template の見出しを探して skip していた (#4348)').toBeFalsy();
-		expect(r.ok).toBe(true);
-	});
+	// test-results 系 4 ケース (#4348 で追加) は #4623 で削除した。検証対象だった
+	// `checkTestResults` は `CHECKS` registry にも workflow にも載らない到達不能な判定で、
+	// 走査対象の `## テスト実行結果` / `テスト種別 | コマンド | 結果` 表も現行テンプレートに無い。
+	// integration lane の統合エビデンス表検証は `checkIntegrationEvidenceTable` が継続する。
 });
 
 // =====================================================================
@@ -952,5 +866,48 @@ describe('#4612 変更タイプ判定は存在しない（registry に無い判�
 
 	it('CHECKS registry に change-type は無い（CLI から起動できない）', () => {
 		expect(Object.keys(gateChecksModule.CHECKS)).not.toContain('change-type');
+	});
+});
+
+// =====================================================================
+// #4623: テスト実行結果判定も同じ class だった (class-lock、本 class の 4 件目)
+//
+// `checkTestResults` / `detectTestSectionHeading` / `detectTestSectionKeyword` は
+// #4305 が `pr-template-gate.yml` の「テスト実行結果」job を撤去したあとも残り、
+// `CHECKS` registry に載らないまま (= CLI から起動不能) 到達不能になっていた。
+//
+// 再配線もできない状態だった: 走査対象の `## テスト実行結果` /
+// `テスト種別 | コマンド | 結果` 表はどちらも現行テンプレート (7 節) に存在せず、
+// registry に戻せば feature lane の全 PR が「セクションがありません」で hard-fail する。
+// =====================================================================
+describe('#4623 テスト実行結果判定は存在しない（registry に無い判定を残さない）', () => {
+	for (const name of ['checkTestResults', 'detectTestSectionHeading', 'detectTestSectionKeyword']) {
+		it(`${name} は export されていない`, () => {
+			expect(Object.keys(gateChecksModule)).not.toContain(name);
+		});
+	}
+
+	it('CHECKS registry に test-results は無い（CLI から起動できない）', () => {
+		expect(Object.keys(gateChecksModule.CHECKS)).not.toContain('test-results');
+	});
+
+	it('CHECKS registry は pr-template-gate.yml が呼ぶ 4 check と一致する', () => {
+		// #4305 が残した 4 job。registry 側だけが増えると「CLI からは呼べるが CI では
+		// 走らない判定」= 本 class と同じ誤読を再生産するため、両者の一致を固定する。
+		expect(Object.keys(gateChecksModule.CHECKS).sort()).toEqual([
+			'closing-keyword',
+			'customer-value',
+			'issue-reference',
+			'section-presence',
+		]);
+	});
+
+	it('走査対象だった見出しは現行テンプレートに無い（配線し直しても入力が来ない）', () => {
+		const realTemplate = readFileSync(
+			resolve(dirname(fileURLToPath(import.meta.url)), '../../../.github/PULL_REQUEST_TEMPLATE.md'),
+			'utf8',
+		);
+		expect(realTemplate).not.toContain('## テスト実行結果');
+		expect(realTemplate).not.toMatch(/テスト種別.*コマンド.*結果/);
 	});
 });

--- a/tests/unit/github/pr-template-gate-checks.test.ts
+++ b/tests/unit/github/pr-template-gate-checks.test.ts
@@ -13,15 +13,14 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import * as gateChecksModule from '../../../scripts/pr-template-gate-checks.mjs';
 import {
 	CLOSING_KEYWORD_TARGET_LABELS,
-	checkChangeType,
 	checkClosingKeyword,
 	checkCustomerValue,
 	checkIssueReference,
 	checkSectionPresence,
 	checkTestResults,
-	detectChangeTypeHeading,
 	detectIssueSectionHeading,
 	detectTestSectionKeyword,
 	extractTemplateSections,
@@ -167,9 +166,6 @@ describe('helper detectors (#2944)', () => {
 	it('detectIssueSectionHeading は closes # を含む section を返す', () => {
 		expect(detectIssueSectionHeading(TEMPLATE)).toBe('## 関連 Issue');
 	});
-	it('detectChangeTypeHeading は 3 つ以上 [ ] を持つ section を返す', () => {
-		expect(detectChangeTypeHeading(TEMPLATE)).toBe('## 変更タイプ');
-	});
 	it('detectTestSectionKeyword はテスト結果テーブル直近の見出しを返す', () => {
 		expect(detectTestSectionKeyword(TEMPLATE)).toBe('テスト実行結果');
 	});
@@ -206,19 +202,6 @@ describe('feature lane: 現行観点維持 (#2944 AC4)', () => {
 		const r = checkIssueReference({
 			...base,
 			body: VALID_FEATURE_BODY.replace('closes #2944', 'closes #'),
-		});
-		expect(r.ok).toBe(false);
-	});
-	it('change-type PASS: 1 つ [x]', () => {
-		expect(checkChangeType({ ...base, body: VALID_FEATURE_BODY }).ok).toBe(true);
-	});
-	it('change-type FAIL: 0 件 [x]', () => {
-		const r = checkChangeType({
-			...base,
-			body: VALID_FEATURE_BODY.replace(
-				'- [x] infra: インフラ・CI/CD',
-				'- [ ] infra: インフラ・CI/CD',
-			),
 		});
 		expect(r.ok).toBe(false);
 	});
@@ -434,18 +417,6 @@ describe('integration lane: 観点切替・空洞化なし (#2944 AC2/AC3)', () 
 		expect(checkIssueReference({ ...base, body: INTEGRATION_BODY }).ok).toBe(true);
 		expect(INTEGRATION_BODY).not.toContain('closes #');
 	});
-	it('change-type PASS: 複数タイプ混在を許容 (AC2)', () => {
-		const r = checkChangeType({ ...base, body: INTEGRATION_BODY });
-		expect(r.ok).toBe(true);
-		expect(r.message).toContain('複数混在 OK');
-	});
-	it('change-type FAIL: 0 件 [x] は integration でも fail (1 つ以上は維持)', () => {
-		const r = checkChangeType({
-			...base,
-			body: INTEGRATION_BODY.replace(/- \[x\]/g, '- [ ]'),
-		});
-		expect(r.ok).toBe(false);
-	});
 	it('test-results PASS: 統合エビデンス表 (1 行) があれば通過', () => {
 		const r = checkTestResults({ ...base, body: INTEGRATION_BODY });
 		expect(r.ok).toBe(true);
@@ -599,7 +570,6 @@ describe('dependabot lane: 全 check skip 相当 (#2944 AC5)', () => {
 	for (const [name, fn] of [
 		['section-presence', checkSectionPresence],
 		['issue-reference', checkIssueReference],
-		['change-type', checkChangeType],
 		['customer-value', checkCustomerValue],
 		['test-results', checkTestResults],
 		['closing-keyword', checkClosingKeyword],
@@ -962,5 +932,25 @@ describe('#4348: 見出し探索は行の完全一致 + 見つからなければ
 		const r = checkTestResults({ ...base, lane: 'integration', body });
 		expect(r.skipped, 'feature template の見出しを探して skip していた (#4348)').toBeFalsy();
 		expect(r.ok).toBe(true);
+	});
+});
+
+// =====================================================================
+// #4612: CHECKS registry に載らない判定関数を残さない (class-lock)
+//
+// `checkChangeType` は #4305 で `pr-template-gate.yml` の対 job が撤去されたあとも残り、
+// **CHECKS registry に無い = CLI からは起動できない**にもかかわらず存在し続けた。
+// 唯一の呼び出し元 `check-pr-body.mjs` の `checkChangeTypeSelection` 自身も runner から
+// 呼ばれておらず、chain 全体が死んでいた (#4612 で両端とも削除)。
+// =====================================================================
+describe('#4612 変更タイプ判定は存在しない（registry に無い判定を残さない）', () => {
+	for (const name of ['checkChangeType', 'detectChangeTypeHeading']) {
+		it(`${name} は export されていない`, () => {
+			expect(Object.keys(gateChecksModule)).not.toContain(name);
+		});
+	}
+
+	it('CHECKS registry に change-type は無い（CLI から起動できない）', () => {
+		expect(Object.keys(gateChecksModule.CHECKS)).not.toContain('change-type');
 	});
 });

--- a/tests/unit/scripts/check-ac-verification-map.test.ts
+++ b/tests/unit/scripts/check-ac-verification-map.test.ts
@@ -1,12 +1,14 @@
 // Issue #2945 (Phase A/A-3、親 #2942) AC3/AC4: lane-aware AC 検証マップ judge の unit test。
-// feature/hotfix lane = 現行 AC マップ観点 (回帰ゼロ)、integration lane = マージ判定エビデンス表観点。
+// integration lane = マージ判定エビデンス表観点。
+// feature / hotfix lane は #4305 で AC マップ検証そのものが撤去され、entry は無条件 PASS を返す
+// (判定関数の残骸は #4348 で削除。下部の class-lock がその状態を固定する)。
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import * as acModule from '../../../scripts/check-ac-verification-map.mjs';
 import {
 	checkAcVerification,
 	checkIntegrationEvidenceTable,
-	checkPerPrAcMap,
 	extractH2Section,
 	INTEGRATION_EVIDENCE_SECTION,
 	NG_DECLARATION_SECTION,
@@ -35,109 +37,6 @@ const FEATURE_AC_MAP_EMPTY_CELL = `
 | AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
 |---|---|---|---|
 | AC1 | ログイン後 | \`vitest\` |  |
-`;
-
-// js/bad-tag-filter (#3021 CodeQL): `--!>` 終端のコメントは旧 regex `/^<!--.*-->$/` が
-// 検出できず空欄プレースホルダのまま gate を通過した。robust 化後は空欄扱いで検出される。
-const FEATURE_AC_MAP_COMMENT_EVASION = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | <!-- まだ書いてない --!> |
-`;
-
-const FEATURE_AC_MAP_TODO = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | 別途追加予定 |
-`;
-
-// #3488: ファイル名 slug の "followup"（区切り無し）は完了済エビデンス参照のトークンであり、
-// 未完了マーカー "follow-up" / "follow up"（区切り 1 文字必須）とは別物。
-// `follow[\s-]up`（区切り必須）にすることで slug を誤検出しない（false-positive 回帰防止）。
-// 拡張子 whitelist の strip 前処理は脆い（収録外拡張子で FP / 密着未完了語で bypass）ため撤去し、
-// 生 cell に直接 pattern を当てる方針（#3488 定方針）。
-const FEATURE_AC_MAP_FILENAME_FOLLOWUP = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC5 | research SSOT を docs/research に保存 | grep | HEAD \`f183e397a\` / docs/research/2026-06-29-followup-treadmill-root-cause.md |
-`;
-
-// #3488: 旧 strip の収録外拡張子で FP 再発していたケース（.sql / .pdf）も、slug "followup"（区切り無し）
-// なので新 pattern では PASS する（strip 不要で FP 回避）。
-const FEATURE_AC_MAP_SLUG_FOLLOWUP_VARIANTS = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | schema 反映 | drizzle | migrations/schema-followup.sql 適用済 |
-| AC2 | 図版 | review | docs/followup.pdf レビュー済 |
-`;
-
-// #3488: 未完了マーカーは区切り 1 文字（空白 or ハイフン）を必ず持つため検出継続する。
-// prose（inline-code 外）の `/` 隣接 / 日本語連続トークンは生 cell に当たる
-// （#3846 で inline-code 内のみ strip 対象になったが、prose 検出は不変）。
-const FEATURE_AC_MAP_TODO_FOLLOWUP_SPACE = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | 別途 follow-up で対応 |
-`;
-
-const FEATURE_AC_MAP_TODO_FILENAME_SCHEDULED = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | 対応予定.md を参照 |
-`;
-
-const FEATURE_AC_MAP_TODO_JP_TOKEN = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | \`vitest\` | 後で対応する予定 |
-`;
-
-const FEATURE_AC_MAP_MISSING_SECTION = `
-## 概要
-AC マップ section が無い PR
-`;
-
-// #3846 / #3844 BLOCK fix: inline-code (`...`) 内の定数名 \`RANGE_SSOT_TODO\` が
-// TODO_PATTERN の \`todo\` に部分一致して false-positive gate fail していた。
-// inline-code は機械トークン（定数名 / コマンド / ファイル参照）であり未完了宣言の prose ではない。
-const FEATURE_AC_MAP_INLINE_CODE_CONSTANT = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC2 | 値域定数 SSOT 化 | grep | HEAD \`abc1234\` / \`RANGE_SSOT_TODO\` を domain 層へ集約 (src/lib/domain/range.ts:12) |
-`;
-
-// #3846: inline-code 内にコマンド由来の "todo" / "予定" 相当トークンがあっても PASS する。
-const FEATURE_AC_MAP_INLINE_CODE_COMMAND = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | todo list 機能の unit 検証 | vitest | \`npx vitest run tests/unit/todo-list.test.ts\` 12 passed |
-`;
-
-// #3846: inline-code strip 後も prose 側の未完了表記は従来どおり検出する（strip し過ぎ防止）。
-const FEATURE_AC_MAP_INLINE_CODE_PLUS_PROSE_TODO = `
-## AC 検証マップ
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | ログイン | vitest | \`RANGE_SSOT_TODO\` は集約済、残りは後で対応 |
 `;
 
 // #4333: 残 NG 件数の宣言は `## NG 0 件 / カバレッジ宣言` section 内でのみ読む。
@@ -224,94 +123,6 @@ const INTEGRATION_EVIDENCE_NO_ROWS = `
 
 （表をまだ埋めていない）
 ${NG_ZERO_SECTION}`;
-
-// --- feature / hotfix lane (AC4 回帰ゼロ) ---
-
-describe('checkPerPrAcMap (feature/hotfix lane、AC4)', () => {
-	it('PASS: 4 列全行が埋まっている', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_PASS, 'feature');
-		expect(r.ok).toBe(true);
-		expect(r.lane).toBe('feature');
-	});
-
-	it('FAIL: AC マップ section が無い', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_MISSING_SECTION, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('AC 検証マップ');
-	});
-
-	it('FAIL: 空欄セルがある', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_EMPTY_CELL, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('空欄');
-	});
-
-	it('FAIL: `--!>` 終端のコメントプレースホルダも空欄扱い (js/bad-tag-filter, #3021)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_COMMENT_EVASION, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('空欄');
-	});
-
-	it('FAIL: 4 列目に未完了表記 (#1539)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_TODO, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-
-	it('PASS: filename 中の "followup"（区切り無し slug）を未完了表記と誤検出しない (#3488)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_FILENAME_FOLLOWUP, 'feature');
-		expect(r.ok).toBe(true);
-	});
-
-	// #3488: 旧 strip の収録外拡張子 FP（.sql / .pdf）も slug followup なので新 pattern で PASS。
-	it('PASS: schema-followup.sql / docs/followup.pdf を誤検出しない (#3488 FP 回避)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_SLUG_FOLLOWUP_VARIANTS, 'feature');
-		expect(r.ok).toBe(true);
-	});
-
-	// #3488: 区切り 1 文字を持つ未完了マーカーは検出継続する（strip 全廃で生 cell に当たる）。
-	it('FAIL: "follow-up" / "follow up"（区切りあり）は検出 (#3488)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_TODO_FOLLOWUP_SPACE, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-
-	it('FAIL: "対応予定.md" の "予定" を検出（strip 全廃で生 cell 検出、#3488）', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_TODO_FILENAME_SCHEDULED, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-
-	it('FAIL: 未完了マーカーを日本語連続トークンに置いても検出 (#3488)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_TODO_JP_TOKEN, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-
-	it('hotfix lane も同観点 (PASS)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_PASS, 'hotfix');
-		expect(r.ok).toBe(true);
-		expect(r.lane).toBe('hotfix');
-	});
-
-	// --- #3846 / #3844: evidence cell の inline-code strip (定数名 false-positive 解消) ---
-
-	it('PASS: inline-code 内の定数名 `RANGE_SSOT_TODO` を未完了表記と誤検出しない (#3846 / #3844)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_CONSTANT, 'feature');
-		expect(r.ok).toBe(true);
-	});
-
-	it('PASS: inline-code 内のコマンド (`npx vitest run tests/unit/todo-list.test.ts`) を誤検出しない (#3846)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_COMMAND, 'feature');
-		expect(r.ok).toBe(true);
-	});
-
-	it('FAIL: inline-code strip 後も prose 側の未完了表記 (「後で対応」) は検出継続 (#3846 strip し過ぎ防止)', () => {
-		const r = checkPerPrAcMap(FEATURE_AC_MAP_INLINE_CODE_PLUS_PROSE_TODO, 'feature');
-		expect(r.ok).toBe(false);
-		expect(r.error).toContain('未完了表記');
-	});
-});
 
 // --- integration lane (AC3) ---
 
@@ -615,5 +426,31 @@ describe('checkAcVerification (lane エントリ、AC3/AC4)', () => {
 		});
 		expect(r.ok).toBe(true);
 		expect(r.reason).toContain('removed');
+	});
+});
+
+// --- #4348 対象 #6: 誰も呼ばない判定関数を置き去りにしない (class-lock) ---
+
+describe('#4348 feature lane の per-PR AC マップ判定は存在しない（呼ばれない判定を残さない）', () => {
+	// 背景: #4305 が PR テンプレートから `## AC 検証マップ` 節を撤去し、entry も feature /
+	// hotfix lane を無条件 PASS に変えた。しかし判定関数 `checkPerPrAcMap` は残り、
+	// **唯一の呼び出しが本 test file だけ**という状態で改修 (#3488 / #3846) を受け続けた。
+	// 「検査しているように見えて誰も呼んでいない」状態を再生産させないための固定。
+	//
+	// 再導入するなら判定関数だけでは足りない — テンプレート節 / PR_TEMPLATE_SECTIONS.json /
+	// entry の分岐 / workflow 配線をセットで戻し、本 test も同時に更新すること。
+	it('checkPerPrAcMap は export されていない', () => {
+		expect(Object.keys(acModule)).not.toContain('checkPerPrAcMap');
+	});
+
+	it('entry は feature / hotfix lane で body を一切見ずに PASS を返す', () => {
+		for (const lane of ['feature', 'hotfix'] as const) {
+			const empty = checkAcVerification({ body: '', labels: [], lane });
+			const filled = checkAcVerification({ body: FEATURE_AC_MAP_PASS, labels: [], lane });
+			const broken = checkAcVerification({ body: FEATURE_AC_MAP_EMPTY_CELL, labels: [], lane });
+			expect([empty.ok, filled.ok, broken.ok]).toEqual([true, true, true]);
+			expect(empty.reason).toBe(filled.reason);
+			expect(empty.reason).toBe(broken.reason);
+		}
 	});
 });

--- a/tests/unit/scripts/check-admin-bypass-evidence.test.ts
+++ b/tests/unit/scripts/check-admin-bypass-evidence.test.ts
@@ -100,27 +100,35 @@ describe('import しても process が落ちない（判定を test から呼べ
 // ---------------------------------------------------------------------------
 
 describe('isBotAuthored — App 作成 PR を拾い、値が無ければ exempt しない', () => {
+	/**
+	 * `gh pr list --json ...` の生 JSON を渡す想定の判定なので、test では PR の一部だけを
+	 * 与える (型を満たすためだけのダミー全項目は、何を検証しているかを隠す)。
+	 * 非 boolean の `is_bot` は「壊れた入力でも exempt しない」ことの負例なので、型を通すためだけに
+	 * 直すと negative case が消える。
+	 */
+	const pr = (partial: unknown) => partial as Parameters<typeof isBotAuthored>[0];
+
 	// 実測値 (`gh pr list --json author`、2026-08-13)。
 	it.each([
 		['app/ganbari-quest-integrator', true],
 		['app/dependabot', true],
 	])('App actor %s は bot と判定する (実測: is_bot=true)', (login, expected) => {
-		expect(isBotAuthored({ author: { login, is_bot: true } })).toBe(expected);
+		expect(isBotAuthored(pr({ author: { login, is_bot: true } }))).toBe(expected);
 	});
 
 	it('人間の作成者は bot ではない', () => {
-		expect(isBotAuthored({ author: { login: 'Takenori-Kusaka', is_bot: false } })).toBe(false);
+		expect(isBotAuthored(pr({ author: { login: 'Takenori-Kusaka', is_bot: false } }))).toBe(false);
 	});
 
 	it('is_bot が無い / author 自体が無いときは exempt しない (fail-closed)', () => {
 		// `[bot]` を含む login を騙っても、種別が取れなければ exempt しない。
-		expect(isBotAuthored({ author: { login: 'not-really-a[bot]' } })).toBe(false);
-		expect(isBotAuthored({ author: null })).toBe(false);
-		expect(isBotAuthored({})).toBe(false);
+		expect(isBotAuthored(pr({ author: { login: 'not-really-a[bot]' } }))).toBe(false);
+		expect(isBotAuthored(pr({ author: null }))).toBe(false);
+		expect(isBotAuthored(pr({}))).toBe(false);
 	});
 
 	it('is_bot が boolean でない値 (文字列 "true" 等) では exempt しない', () => {
-		expect(isBotAuthored({ author: { login: 'x', is_bot: 'true' } })).toBe(false);
-		expect(isBotAuthored({ author: { login: 'x', is_bot: 1 } })).toBe(false);
+		expect(isBotAuthored(pr({ author: { login: 'x', is_bot: 'true' } }))).toBe(false);
+		expect(isBotAuthored(pr({ author: { login: 'x', is_bot: 1 } }))).toBe(false);
 	});
 });

--- a/tests/unit/scripts/check-admin-bypass-evidence.test.ts
+++ b/tests/unit/scripts/check-admin-bypass-evidence.test.ts
@@ -1,0 +1,90 @@
+/**
+ * tests/unit/scripts/check-admin-bypass-evidence.test.ts (#4348 対象 #3)
+ *
+ * admin bypass merge の Self-Review 証跡検出 (ADR-0044 / #1201) の判定 test。
+ *
+ * ## 何を守るか
+ *
+ * 旧実装は `EVIDENCE_MARKER_PATTERNS.some((re) => re.test(body))` で本文全体を見ていた。
+ * `^##` の行頭アンカーはあるが、**HTML コメント / fenced code block の中の見出し**を
+ * 区別できない。本 script 自身が投稿する追記依頼コメントは証跡テンプレートを
+ * ```markdown fence で囲んで提示するため、**bot コメントを PR 本文に貼り戻すだけで
+ * 「証跡あり」**になり、証跡を 1 文字も書かずに追跡から外れられた。
+ *
+ * 判定規律は他の PR body gate と同じ SSOT (`scripts/lib/ci/pr-body-sections.mjs`) に揃える。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	EVIDENCE_MARKER_PATTERNS,
+	hasEvidenceSection,
+} from '../../../scripts/check-admin-bypass-evidence.mjs';
+
+/** bot (`postMissingEvidenceComment`) が投稿する追記依頼コメントの実物と同型。 */
+const BOT_COMMENT_PASTED_INTO_BODY = [
+	'<!-- admin-bypass-evidence-check -->',
+	'## 🔍 admin bypass merge — Self-Review 証跡の追記依頼 (ADR-0044)',
+	'',
+	'以下のテンプレートを PR 本文末尾に追記してください（事後追記で構いません）:',
+	'',
+	'```markdown',
+	'## Self-Review 証跡 (admin bypass)',
+	'',
+	'### 確認した観点',
+	'- [ ] Issue AC 全項目突合',
+	'```',
+].join('\n');
+
+const REAL_EVIDENCE = [
+	'## 変更内容',
+	'',
+	'admin bypass で merge したため証跡を残す。',
+	'',
+	'## Self-Review 証跡 (admin bypass)',
+	'',
+	'### 確認した観点',
+	'- [x] Issue AC 全項目突合 — `npx vitest run tests/unit/` 全 PASS',
+].join('\n');
+
+describe('hasEvidenceSection — 証跡セクションは「宣言」として書かれていることを要求する', () => {
+	it('本文に見出しとして書かれていれば証跡ありと判定する', () => {
+		expect(hasEvidenceSection(REAL_EVIDENCE)).toBe(true);
+	});
+
+	it('別表記 `## Self-Review (admin bypass)` も証跡ありと判定する', () => {
+		expect(hasEvidenceSection('## Self-Review (admin bypass)\n\n- [x] AC 突合')).toBe(true);
+	});
+
+	it('bot の追記依頼コメントを本文に貼り戻しただけでは証跡と認めない', () => {
+		// 旧実装ではここが true になり、証跡を書かずに追跡から外れられた。
+		expect(hasEvidenceSection(BOT_COMMENT_PASTED_INTO_BODY)).toBe(false);
+	});
+
+	it('HTML コメント内の見出しは証跡と認めない（レンダリング後の本文に出ない）', () => {
+		const body = ['## 変更内容', '<!--', '## Self-Review 証跡', '-->'].join('\n');
+		expect(hasEvidenceSection(body)).toBe(false);
+	});
+
+	it('code fence 内の見出し（書式の例示）は証跡と認めない', () => {
+		const body = ['## 変更内容', '', '```markdown', '## Self-Review 証跡', '```'].join('\n');
+		expect(hasEvidenceSection(body)).toBe(false);
+	});
+
+	it('body が空 / null なら証跡なし', () => {
+		expect(hasEvidenceSection('')).toBe(false);
+		expect(hasEvidenceSection(null)).toBe(false);
+	});
+
+	it('marker パターンは 2 種類（表記ゆれ）を維持する', () => {
+		expect(EVIDENCE_MARKER_PATTERNS).toHaveLength(2);
+	});
+});
+
+describe('import しても process が落ちない（判定を test から呼べる）', () => {
+	// 旧実装は module top-level で `REPO` 未設定なら `process.exit(2)` していたため、
+	// import した時点で vitest ごと落ちて判定の回帰を固定できなかった。
+	it('REPO 未設定でも import 済みの判定関数が呼べる', () => {
+		expect(process.env.REPO).toBeUndefined();
+		expect(typeof hasEvidenceSection).toBe('function');
+	});
+});

--- a/tests/unit/scripts/check-admin-bypass-evidence.test.ts
+++ b/tests/unit/scripts/check-admin-bypass-evidence.test.ts
@@ -18,6 +18,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	EVIDENCE_MARKER_PATTERNS,
 	hasEvidenceSection,
+	isBotAuthored,
 } from '../../../scripts/check-admin-bypass-evidence.mjs';
 
 /** bot (`postMissingEvidenceComment`) が投稿する追記依頼コメントの実物と同型。 */
@@ -86,5 +87,40 @@ describe('import しても process が落ちない（判定を test から呼べ
 	it('REPO 未設定でも import 済みの判定関数が呼べる', () => {
 		expect(process.env.REPO).toBeUndefined();
 		expect(typeof hasEvidenceSection).toBe('function');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4612: bot 判定は login 文字列ではなくアカウント種別 (`is_bot`) で行う
+//
+// 旧実装は `login.endsWith('[bot]')` で、GitHub App が作成した PR (`app/<slug>`) を
+// 1 件も拾えなかった。統合 PR (App 作成) が毎回 exempt から漏れ、証跡の追記依頼コメントが
+// 投稿され続けた (実測: 2026-08-13 16:05Z に PR #4534 へ投稿)。
+// `is_bot` は gh が GraphQL `author.__typename == 'Bot'` を写した値で、利用者側で騙れない。
+// ---------------------------------------------------------------------------
+
+describe('isBotAuthored — App 作成 PR を拾い、値が無ければ exempt しない', () => {
+	// 実測値 (`gh pr list --json author`、2026-08-13)。
+	it.each([
+		['app/ganbari-quest-integrator', true],
+		['app/dependabot', true],
+	])('App actor %s は bot と判定する (実測: is_bot=true)', (login, expected) => {
+		expect(isBotAuthored({ author: { login, is_bot: true } })).toBe(expected);
+	});
+
+	it('人間の作成者は bot ではない', () => {
+		expect(isBotAuthored({ author: { login: 'Takenori-Kusaka', is_bot: false } })).toBe(false);
+	});
+
+	it('is_bot が無い / author 自体が無いときは exempt しない (fail-closed)', () => {
+		// `[bot]` を含む login を騙っても、種別が取れなければ exempt しない。
+		expect(isBotAuthored({ author: { login: 'not-really-a[bot]' } })).toBe(false);
+		expect(isBotAuthored({ author: null })).toBe(false);
+		expect(isBotAuthored({})).toBe(false);
+	});
+
+	it('is_bot が boolean でない値 (文字列 "true" 等) では exempt しない', () => {
+		expect(isBotAuthored({ author: { login: 'x', is_bot: 'true' } })).toBe(false);
+		expect(isBotAuthored({ author: { login: 'x', is_bot: 1 } })).toBe(false);
 	});
 });

--- a/tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts
+++ b/tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts
@@ -1,50 +1,64 @@
 /**
- * tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts (#4074)
+ * tests/unit/scripts/check-pr-body-evidence-pr-ref.test.ts (#4074、走査節の是正は #4612)
  *
- * 検証対象: AC 検証マップの根拠欄に書かれた `--pr <番号>` が **その PR 自身**を指しているか。
+ * 検証対象: `## 検証` に書かれた根拠コマンドの `--pr <番号>` が **その PR 自身**を指しているか。
  *
  * 旧実装では根拠欄が自由記述で、`--pr <番号>` に別 PR / 実在しない PR 番号が書かれていても
  * どの gate も検出しなかった。PR #4063 の AC 検証マップに `npm run pre-ready -- --pr 4059`
  * (= 404、存在しない PR) が書かれたまま `check-pr-body.mjs --pr 4063` が「OK — 違反なし」を
  * 返した (#4074 実測)。宛先違いの証跡で Ready 化を通過できる状態だった。
  *
- * 本 test は実測値 `--pr 4059` / 自 PR `4063` を実名 fixture として固定する (AC2)。
+ * #4612: その #4074 実装は走査対象が `## AC 検証マップ` 節に固定されており、#4305 で同節が
+ * テンプレートから消えたあとも直っていなかった。merged PR 200 本 (#4215〜#4573) に判定関数を
+ * 当てた結果 **発火 0 / 200** で、`--pr <数字>` が同節に書かれていた body は 4 本しかなかった。
+ * 実際の置き場所は `## 検証` (36 本) と旧 `## テスト・品質セルフチェック` (41 本) で、
+ * #4074 が狙った宛先違いもそこに 2 件実在した (#4317 の `--pr 4312` / #4278 の `--pr 4276`)。
+ * 走査対象を現行テンプレートの検証節 `## 検証` に付け替え、実測 2 件を fixture として固定する。
  */
 
 import { describe, expect, it } from 'vitest';
 import {
 	checkEvidencePrReferences,
+	EVIDENCE_PR_REF_OK_KEY,
 	extractEvidencePrNumbers,
 } from '../../../scripts/check-pr-body.mjs';
 
-/** #4063 の AC 検証マップ実物 (根拠が別 PR = 存在しない #4059 を指していた行を含む)。 */
-const PR_4063_AC_MAP_WITH_WRONG_PR = `## AC 検証マップ (ADR-0004)
+/** #4063 の根拠 (別 PR = 存在しない #4059 を指していた行) を現行テンプレートの節に置いた形。 */
+const PR_4063_EVIDENCE_WITH_WRONG_PR = `## 検証
 
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | CRLF shebang import が落ちない | \`npx vitest run tests/unit/scripts/crlf-shebang-import.test.ts\` | PASS |
-| 共通-AC | \`npm run pre-ready -- --pr <num>\` 全 Step PASS | \`npm run pre-ready -- --pr 4059\` | PASS — §証跡 4 |
+| 検査 | コマンド | 結果 |
+|---|---|---|
+| unit | \`npx vitest run tests/unit/scripts/crlf-shebang-import.test.ts\` | PASS |
+| pre-ready | \`npm run pre-ready -- --pr 4059\` | PASS — §証跡 4 |
 
-## 次のセクション
+## 影響範囲
 `;
 
 /** 同じ body の根拠を自 PR 番号に是正したもの (正当な pass 経路)。 */
-const PR_4063_AC_MAP_CORRECT = PR_4063_AC_MAP_WITH_WRONG_PR.replace('--pr 4059', '--pr 4063');
+const PR_4063_EVIDENCE_CORRECT = PR_4063_EVIDENCE_WITH_WRONG_PR.replace('--pr 4059', '--pr 4063');
 
 /** 根拠欄に PR 番号を書かない従来形式 (AC3 後方互換)。 */
-const AC_MAP_WITHOUT_PR_NUMBER = `## AC 検証マップ (ADR-0004)
+const EVIDENCE_WITHOUT_PR_NUMBER = `## 検証
 
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---|---|---|---|
-| AC1 | gate が落ちる | \`npx vitest run tests/unit/scripts/foo.test.ts\` | PASS (12 tests) |
-| 共通-AC | pre-ready 全 Step PASS | \`npm run pre-ready -- --pr <num>\` | PASS |
+| 検査 | コマンド | 結果 |
+|---|---|---|
+| unit | \`npx vitest run tests/unit/scripts/foo.test.ts\` | PASS (12 tests) |
+| pre-ready | \`npm run pre-ready -- --pr <num>\` | PASS |
 
-## 次のセクション
+## 影響範囲
 `;
 
-describe('#4074 AC 検証マップの根拠が指す PR 番号の参照整合', () => {
+/** merged PR #4278 実物 (自 PR は 4278 なのに根拠が `--pr 4276`)。#4612 corpus 実測。 */
+const MERGED_PR_4278_SHAPE = `## 検証
+
+| 項目 | コマンド | 結果 |
+|---|---|---|
+| pre-ready | \`npm run pre-ready -- --pr 4276\` | <!-- 実行後に記入 --> |
+`;
+
+describe('#4074 検証根拠が指す PR 番号の参照整合 (走査節は #4612 で `## 検証` に是正)', () => {
 	it('[E1] 別 PR / 実在しない PR 番号を指す根拠を検出する (実測: --pr 4059 @ PR #4063)', () => {
-		const v = checkEvidencePrReferences(PR_4063_AC_MAP_WITH_WRONG_PR, '4063');
+		const v = checkEvidencePrReferences(PR_4063_EVIDENCE_WITH_WRONG_PR, '4063');
 		expect(v).not.toBeNull();
 		expect(v?.id).toBe('evidence-pr-mismatch');
 		expect(v?.message).toContain('4059');
@@ -52,36 +66,79 @@ describe('#4074 AC 検証マップの根拠が指す PR 番号の参照整合', 
 	});
 
 	it('[E2] 根拠が自 PR 番号なら通す (是正後の正当な pass 経路)', () => {
-		expect(checkEvidencePrReferences(PR_4063_AC_MAP_CORRECT, '4063')).toBeNull();
+		expect(checkEvidencePrReferences(PR_4063_EVIDENCE_CORRECT, '4063')).toBeNull();
 	});
 
 	it('[E3] 根拠欄に PR 番号を書かない従来形式は通す (AC3 後方互換)', () => {
-		expect(checkEvidencePrReferences(AC_MAP_WITHOUT_PR_NUMBER, '4063')).toBeNull();
+		expect(checkEvidencePrReferences(EVIDENCE_WITHOUT_PR_NUMBER, '4063')).toBeNull();
 		// プレースホルダ `<num>` を PR 番号と誤認しない
-		expect(extractEvidencePrNumbers(AC_MAP_WITHOUT_PR_NUMBER)).toEqual([]);
+		expect(extractEvidencePrNumbers(EVIDENCE_WITHOUT_PR_NUMBER)).toEqual([]);
 	});
 
-	it('[E4] AC マップ外 (他 PR への言及) は対象外 — 誤検出を作らない', () => {
-		const body = `## 背景
+	it('[E4] `## 検証` 外 (背景での他 PR への言及) は対象外 — 誤検出を作らない', () => {
+		const body = `## 変更内容
 
 PR #4066 では \`npm run pre-ready -- --pr 4066\` が 2 度連続 red になった。
 
-${AC_MAP_WITHOUT_PR_NUMBER}`;
+${EVIDENCE_WITHOUT_PR_NUMBER}`;
 		expect(checkEvidencePrReferences(body, '4090')).toBeNull();
 	});
 
 	it('[E5] 自 PR 番号が不明 (--body-file dry-run) なら判定しない', () => {
-		expect(checkEvidencePrReferences(PR_4063_AC_MAP_WITH_WRONG_PR, null)).toBeNull();
+		expect(checkEvidencePrReferences(PR_4063_EVIDENCE_WITH_WRONG_PR, null)).toBeNull();
 	});
 
 	it('[E6] 複数の不一致をすべて列挙する (1 件目で打ち切らない)', () => {
-		const body = PR_4063_AC_MAP_WITH_WRONG_PR.replace('--pr <num>', '--pr 1234');
-		const v = checkEvidencePrReferences(body, '4063');
+		const body = PR_4063_EVIDENCE_WITH_WRONG_PR.replace('--pr <num>', '--pr 1234').replace(
+			'| PASS (12 tests) |',
+			'| `npm run pre-ready -- --pr 1234` |',
+		);
+		const withSecond = `${body}\n`.replace(
+			'| pre-ready | `npm run pre-ready -- --pr 4059` |',
+			'| pre-ready | `npm run pre-ready -- --pr 4059` / `--pr 1234` |',
+		);
+		const v = checkEvidencePrReferences(withSecond, '4063');
 		expect(v?.message).toContain('4059');
 		expect(v?.message).toContain('1234');
 	});
 
-	it('[E7] AC マップが無い body では判定しない (ac-map-missing が別途出る)', () => {
-		expect(checkEvidencePrReferences('## 変更概要\n\nなし\n', '4063')).toBeNull();
+	it('[E7] `## 検証` 節が無い body では判定しない (missing-required-sections が別途出る)', () => {
+		expect(checkEvidencePrReferences('## 変更内容\n\nなし\n', '4063')).toBeNull();
+	});
+
+	// --- #4612: corpus 実測で見つかった実物の形を固定する ---
+
+	it('[E8] merged PR #4278 の形 (自 PR 4278 / 根拠 --pr 4276) を検出する', () => {
+		const v = checkEvidencePrReferences(MERGED_PR_4278_SHAPE, '4278');
+		expect(v?.id).toBe('evidence-pr-mismatch');
+		expect(v?.message).toContain('4276');
+	});
+
+	it('[E9] 旧走査節 (`## AC 検証マップ`) だけに書かれた不一致はもう見ない (節はテンプレートに無い)', () => {
+		const legacyOnly = `## AC 検証マップ (ADR-0004)
+
+| AC 番号 | AC 内容 | 検証手段 | 結果 |
+|---|---|---|---|
+| AC1 | 何か | \`npm run pre-ready -- --pr 4059\` | PASS |
+`;
+		expect(checkEvidencePrReferences(legacyOnly, '4063')).toBeNull();
+	});
+
+	// --- #4612: 他 PR のログを意図して載せる正当ケースの逃げ道 ---
+
+	it('[E10] 理由付き宣言があれば通す (merged PR #4519 = 他 PR で不具合を再現したログ)', () => {
+		const body = `${MERGED_PR_4278_SHAPE}
+<!-- ${EVIDENCE_PR_REF_OK_KEY}: PR #4276 で gate の空振りを再現した実測ログをそのまま載せているため -->
+`;
+		expect(checkEvidencePrReferences(body, '4278')).toBeNull();
+	});
+
+	it('[E11] 宣言があっても理由が stub なら通さない (理由の非強制を作らない、#3956)', () => {
+		for (const reason of ['TODO', 'n/a', '短い']) {
+			const body = `${MERGED_PR_4278_SHAPE}\n<!-- ${EVIDENCE_PR_REF_OK_KEY}: ${reason} -->\n`;
+			const v = checkEvidencePrReferences(body, '4278');
+			expect(v?.id).toBe('evidence-pr-mismatch');
+			expect(v?.message).toContain('stub');
+		}
 	});
 });

--- a/tests/unit/scripts/check-pr-body.test.ts
+++ b/tests/unit/scripts/check-pr-body.test.ts
@@ -17,16 +17,14 @@ import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 import { checkIntegrationEvidenceTable } from '../../../scripts/check-ac-verification-map.mjs';
+import * as prBodyModule from '../../../scripts/check-pr-body.mjs';
 import {
-	checkAcMap,
-	checkChangeTypeSelection,
 	checkEnvDistributionForHotfix,
 	checkPlaceholders,
 	checkPoDecisionBrief,
 	checkSelfReviewEvidence,
 	collectViolations,
 	detectMojibake,
-	extractAcMapSection,
 	extractEnvDistributionSection,
 	extractLabelNames,
 	extractLaneRefs,
@@ -189,66 +187,6 @@ inline \`予定\` も除外。
 		for (const term of FORBIDDEN_TERMS) {
 			expect(detectedTerms.has(term)).toBe(true);
 		}
-	});
-});
-
-describe('extractAcMapSection', () => {
-	it('AC 検証マップセクションを次の ## まで抽出', () => {
-		const body = `## 関連 Issue\n本文1\n\n## AC 検証マップ (ADR-0004)\n\n| AC | 内容 |\n| AC1 | OK |\n\n## 変更タイプ\n`;
-		const section = extractAcMapSection(body);
-		expect(section).toContain('AC1');
-		expect(section).not.toContain('変更タイプ');
-	});
-
-	it('セクションが無ければ null', () => {
-		expect(extractAcMapSection('## A\n本文\n')).toBe(null);
-	});
-});
-
-describe('checkAcMap', () => {
-	it('skip マーカーで検証スキップ', () => {
-		const body = `## AC 検証マップ (ADR-0004)\n<!-- ac-verification-skip: docs only -->\n`;
-		expect(checkAcMap(body)).toBe(null);
-	});
-
-	it('セクション欠落で fail', () => {
-		const body = `## A\n本文\n`;
-		const result = checkAcMap(body);
-		expect(result?.id).toBe('ac-map-missing');
-	});
-
-	it('データ行 0 件で fail (ヘッダのみ)', () => {
-		const body = `## AC 検証マップ (ADR-0004)\n\n| AC 番号 | AC 内容 | 検証手段 | 結果 |\n|---------|---------|---------|------|\n\n## 次\n`;
-		const result = checkAcMap(body);
-		expect(result?.id).toBe('ac-map-empty');
-	});
-
-	it('空セルで fail', () => {
-		const body = `
-## AC 検証マップ (ADR-0004)
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 |
-|---------|---------|---------|------|
-| AC1 | <!-- 未記入 --> | command | result |
-
-## 次
-`;
-		const result = checkAcMap(body);
-		expect(result?.id).toBe('ac-map-incomplete');
-	});
-
-	it('全セル埋まっていれば pass', () => {
-		const body = `
-## AC 検証マップ (ADR-0004)
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 |
-|---------|---------|---------|------|
-| AC1 | 機能A | npx vitest | PASS |
-| AC2 | 機能B | scripts/foo | PASS |
-
-## 次
-`;
-		expect(checkAcMap(body)).toBe(null);
 	});
 });
 
@@ -429,64 +367,18 @@ describe('detectMojibake (#2562 / #2576)', () => {
 	});
 });
 
-describe('checkAcMap error message (#2586)', () => {
-	it('AC マップ列数不足時の error message は 4 列形式期待 + 参考 PR を含む', () => {
-		// 2 列 (簡略形式) の AC マップ — re-review 浪費の根本原因 pattern
-		const body = `
-## AC 検証マップ (ADR-0004)
-
-| AC | 結果 |
-|-----|------|
-| AC1 | PASS |
-
-## 次
-`;
-		const result = checkAcMap(body);
-		expect(result?.id).toBe('ac-map-incomplete');
-		const msg = result?.message ?? '';
-		// 4 列形式の期待を明示
-		expect(msg).toMatch(/4 列/);
-		// 参考 PR を明示
-		expect(msg).toMatch(/#2588/);
-		expect(msg).toMatch(/#2599/);
-		// 修正手順を明示
-		expect(msg).toMatch(/修正手順/);
-	});
-
-	it('AC マップが 4 列で全セル埋まっていれば PASS (dogfood)', () => {
-		const body = `
-## AC 検証マップ (ADR-0004)
-
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---------|--------|---------|------------------|
-| AC1 | BOM heuristic threshold 強化 | npx vitest | HEAD abc1234 / 12 passed |
-| AC2 | AC 4 列 SSOT enforcement | check-pr-body | dogfood PASS |
-
-## 次
-`;
-		expect(checkAcMap(body)).toBeNull();
-	});
-
-	it('AC マップデータ 0 件時の error message も 4 列形式期待 + 参考 PR を含む', () => {
-		const body = `## AC 検証マップ (ADR-0004)\n\n| AC 番号 | AC 内容 | 検証手段 | 結果 |\n|---------|---------|---------|------|\n\n## 次\n`;
-		const result = checkAcMap(body);
-		expect(result?.id).toBe('ac-map-empty');
-		const msg = result?.message ?? '';
-		expect(msg).toMatch(/4 列/);
-		expect(msg).toMatch(/#2588/);
-		expect(msg).toMatch(/#2599/);
-	});
-});
-
 // ---------------------------------------------------------------------------
-// #2632: Readiness gate 統合検証 (Ready checklist + AC 4 列 + forbidden-terms)
+// #2632: Readiness gate 統合検証 (Ready checklist + forbidden-terms)
 // QA self-implement 第 5 弾。本日 (2026-05-29) 7 連続再発の構造的予防。
-// 既存 unit (findUncheckedReadyChecklist / checkAcMap / scanForbiddenTerms) は単独テスト済。
-// 本 describe では「Readiness gate として 3 検査が同一 body に対して整合的に動く」ことを統合的に verify。
-// pre-ready.mjs Step 9 ラベル変更 (label: 'Readiness gate ...') 整合の dogfood test 群。
+// 本 describe では「Readiness gate として複数検査が同一 body に対して整合的に動く」ことを verify。
+//
+// **AC 4 列 (`checkAcMap`) の観点は #4612 で削除した。** #4305 が PR テンプレートから
+// `## AC 検証マップ` 節を撤去した時点で入力が来なくなり、判定関数も runner から呼ばれて
+// いなかったため (= 通っていたのは fixture だけ)。Ready checklist も #4305 以降は
+// integration lane でのみ検査される。
 // ---------------------------------------------------------------------------
 
-describe('#2632 Readiness gate 統合 (Ready checklist + AC 4 列 + forbidden-terms)', () => {
+describe('#2632 Readiness gate 統合 (Ready checklist + forbidden-terms)', () => {
 	const READY_PASS_BODY = `
 ## Ready for Review チェックリスト
 
@@ -494,18 +386,14 @@ describe('#2632 Readiness gate 統合 (Ready checklist + AC 4 列 + forbidden-te
 - [x] QM 承認・動作確認が完了している
 - [x] pre-ready 全 step PASS
 
-## AC 検証マップ (ADR-0004)
+## 検証
 
-| AC 番号 | AC 内容 | 検証手段 | 結果 / エビデンス |
-|---------|--------|---------|------------------|
-| AC1 | pre-ready Step 9 強化 | npx vitest run tests/unit/scripts/check-pr-body.test.ts | HEAD abc1234 / dogfood PASS |
-| AC2 | SKILL.md prelude 追加 | node scripts/check-pr-body.mjs --body-file | dogfood PASS |
+\`npx vitest run tests/unit/scripts/check-pr-body.test.ts\` → PASS (HEAD abc1234)
 `;
 
-	it('AC1: Ready checklist 全 [x] + AC 4 列 + 禁止語 0 の body は 3 検査すべて pass (#2632 dogfood)', () => {
+	it('AC1: Ready checklist 全 [x] + 禁止語 0 の body は 2 検査すべて pass (#2632 dogfood)', () => {
 		const body = READY_PASS_BODY;
 		expect(findUncheckedReadyChecklist(body)).toEqual([]);
-		expect(checkAcMap(body)).toBeNull();
 		expect(scanForbiddenTerms(body)).toEqual([]);
 	});
 
@@ -519,20 +407,6 @@ describe('#2632 Readiness gate 統合 (Ready checklist + AC 4 列 + forbidden-te
 		const result = findUncheckedReadyChecklist(body);
 		expect(result).toHaveLength(1);
 		expect(result[0]?.uncheckedCount).toBe(1);
-	});
-
-	it('AC3: AC 検証マップ 2 列簡略形式は BLOCK (本日 #2626 再発 pattern)', () => {
-		const body = `
-## AC 検証マップ (ADR-0004)
-
-| AC | 結果 |
-|-----|------|
-| AC1 | PASS |
-
-## 次
-`;
-		const result = checkAcMap(body);
-		expect(result?.id).toBe('ac-map-incomplete');
 	});
 
 	it('AC4: forbidden-terms (「予定」「follow-up」「TODO」等) 混入で BLOCK', () => {
@@ -551,18 +425,12 @@ TODO: 後日テスト追加。
 		expect(detectedTerms.has('TODO')).toBe(true);
 	});
 
-	it('AC5: 同一 body に 3 違反共存時、全検査が独立して BLOCK 返す (gate 整合性)', () => {
+	it('AC5: 同一 body に 2 違反共存時、各検査が独立して BLOCK 返す (gate 整合性)', () => {
 		const body = `
 ## Ready for Review チェックリスト
 
 - [ ] 未完了
 - [ ] QM 承認・動作確認が完了している
-
-## AC 検証マップ (ADR-0004)
-
-| AC | 結果 |
-|-----|------|
-| AC1 | PASS |
 
 ## 補足
 
@@ -570,26 +438,13 @@ TODO: 後日テスト追加。
 
 ## 次
 `;
-		// 全 3 検査が独立して BLOCK 検出
 		const unchecked = findUncheckedReadyChecklist(body);
 		expect(unchecked.length).toBeGreaterThanOrEqual(1);
 		expect(unchecked[0]?.uncheckedCount).toBe(2);
 
-		const acResult = checkAcMap(body);
-		expect(acResult?.id).toBe('ac-map-incomplete');
-
 		const forbidden = scanForbiddenTerms(body);
 		expect(forbidden.length).toBeGreaterThanOrEqual(1);
 		expect(forbidden.some((v) => v.term === '予定')).toBe(true);
-	});
-
-	it('AC6: dogfood — 本 PR (#2632) の AC 4 列形式雛形が gate PASS する', () => {
-		// 本 PR 自身が新 gate を満たすことの dogfood 検証 (self-implement 第 5 弾、AC3)
-		const body = READY_PASS_BODY;
-		// 3 検査すべて null / 空配列 = PASS
-		expect(findUncheckedReadyChecklist(body)).toEqual([]);
-		expect(checkAcMap(body)).toBeNull();
-		expect(scanForbiddenTerms(body)).toEqual([]);
 	});
 });
 
@@ -667,80 +522,6 @@ describe('checkSelfReviewEvidence (#2475 Phase 2 / #2815 D-1)', () => {
 			'- [ ] **SOLID**: 未確認',
 		].join('\n');
 		expect(checkSelfReviewEvidence(body)).toBeNull();
-	});
-});
-
-// ---------------------------------------------------------------------------
-// #3846: 変更タイプ checkbox 未選択の shift-left 検出
-// CI 必須 gate「変更タイプの選択」hard-fail が 3 PR 連続再発 (#3835 / #3837 / #3844) した
-// same-class defect (ADR-0061) を、PR 作成前 (--body-file) / pre-ready Step 9 (--pr) で機械検出する。
-// 判定 SSOT は scripts/pr-template-gate-checks.mjs の checkChangeType (二重実装なし)。
-// ---------------------------------------------------------------------------
-
-describe('checkChangeTypeSelection (#3846)', () => {
-	// detectChangeTypeHeading は「`- [ ]` を 3 行以上持つ ## セクション」を変更タイプと判定する。
-	// 実 template (.github/PULL_REQUEST_TEMPLATE.md) と同構造の最小 fixture。
-	const TEMPLATE = [
-		'## 顧客価値・目的',
-		'',
-		'本文',
-		'',
-		'## 変更タイプ',
-		'',
-		'- [ ] feat: 新機能',
-		'- [ ] fix: バグ修正',
-		'- [ ] refactor: リファクタリング',
-		'- [ ] infra: インフラ・CI/CD',
-		'',
-		'## 関連 Issue',
-	].join('\n');
-
-	it('FAIL: checkbox 未選択 (- [ ] のみ) → change-type-unselected (#3835/#3837/#3844 再発 pattern)', () => {
-		const body = [
-			'## 変更タイプ',
-			'',
-			'- [ ] feat: 新機能',
-			'- [ ] fix: バグ修正',
-			'- [ ] refactor: リファクタリング',
-			'- [ ] infra: インフラ・CI/CD',
-			'',
-			'## 関連 Issue',
-		].join('\n');
-		const result = checkChangeTypeSelection(body, TEMPLATE);
-		expect(result).not.toBeNull();
-		expect(result?.id).toBe('change-type-unselected');
-		// self-serve 修正を高速化する guidance を含む (issue #3846 提案 2)
-		expect(result?.message).toMatch(/- \[x\]/);
-		expect(result?.message).toMatch(/--body-file/);
-		expect(result?.message).toMatch(/#3835/);
-	});
-
-	it('PASS: 1 つ以上 [x] 選択済み → null', () => {
-		const body = [
-			'## 変更タイプ',
-			'',
-			'- [ ] feat: 新機能',
-			'- [ ] fix: バグ修正',
-			'- [x] infra: インフラ・CI/CD',
-			'',
-			'## 関連 Issue',
-		].join('\n');
-		expect(checkChangeTypeSelection(body, TEMPLATE)).toBeNull();
-	});
-
-	it('PASS: 大文字 [X] も選択として認める (CI gate checkChangeType と同一判定)', () => {
-		const body = ['## 変更タイプ', '', '- [X] fix: バグ修正', '', '## 関連 Issue'].join('\n');
-		expect(checkChangeTypeSelection(body, TEMPLATE)).toBeNull();
-	});
-
-	it('セクション欠落は missing-required-sections gate に委譲 (null)', () => {
-		const body = '## 顧客価値・目的\n本文\n';
-		expect(checkChangeTypeSelection(body, TEMPLATE)).toBeNull();
-	});
-
-	it('dependencies label PR は skip (Dependabot exempt、#1808 整合)', () => {
-		const body = ['## 変更タイプ', '', '- [ ] feat: 新機能', '', '## 関連 Issue'].join('\n');
-		expect(checkChangeTypeSelection(body, TEMPLATE, ['dependencies'])).toBeNull();
 	});
 });
 
@@ -1345,5 +1126,58 @@ describe('lane-aware 化 (#4130)', () => {
 			source: 'default',
 		});
 		expect(laneUnused).not.toHaveBeenCalled();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #4612: 呼ばれない判定関数を置き去りにしない (class-lock)
+//
+// #4305 が PR テンプレートから `## AC 検証マップ` / `## 変更タイプ` の 2 節を撤去し、
+// 対の CI job も同時に外した。しかし判定関数 `checkAcMap` / `checkChangeTypeSelection` は
+// 残り、**唯一の呼び出しが本 test file だけ**の状態で「別 job が hard-fail し続ける」表に
+// 3 行載り続けた (#4611 が表を是正、#4612 が関数を削除)。
+//
+// 再導入するなら判定関数だけでは足りない — テンプレート節 / PR_TEMPLATE_SECTIONS.json /
+// collectViolations の呼び出し / workflow 配線をセットで戻し、本 test も同時に更新すること。
+// ---------------------------------------------------------------------------
+
+describe('#4612 撤去済み節の判定関数は存在しない（呼ばれない判定を残さない）', () => {
+	for (const name of ['checkAcMap', 'extractAcMapSection', 'checkChangeTypeSelection']) {
+		it(`${name} は export されていない`, () => {
+			expect(Object.keys(prBodyModule)).not.toContain(name);
+		});
+	}
+
+	it('撤去済み節の違反 id は collectViolations からどのような body でも出力されない', () => {
+		const { template, requiredSections } = loadTemplateForLane('feature');
+		// 旧 gate が落としていた形 (AC マップ 2 列 / 変更タイプ全て未選択) をわざと含む body。
+		const body = [
+			'## AC 検証マップ (ADR-0004)',
+			'',
+			'| AC | 結果 |',
+			'|-----|------|',
+			'| AC1 | PASS |',
+			'',
+			'## 変更タイプ',
+			'',
+			'- [ ] feat: 新機能',
+			'- [ ] fix: バグ修正',
+			'- [ ] refactor: リファクタリング',
+		].join('\n');
+		const ids = collectViolations(
+			body,
+			requiredSections,
+			template,
+			{ pr: null, skipMergeable: true, labels: [], lane: 'feature' },
+			[],
+		).map((v: { id: string }) => v.id);
+		for (const dead of [
+			'ac-map-missing',
+			'ac-map-empty',
+			'ac-map-incomplete',
+			'change-type-unselected',
+		]) {
+			expect(ids).not.toContain(dead);
+		}
 	});
 });

--- a/tests/unit/scripts/check-pr-screenshot.test.ts
+++ b/tests/unit/scripts/check-pr-screenshot.test.ts
@@ -139,6 +139,13 @@ describe('hasUiNotApplicableMarker', () => {
 			expect(hasUiNotApplicableMarker('判定は `UI 変更なし` の有無で行う')).toBe(false);
 		});
 
+		// #4348: HTML コメントは顧客にも監査にも見えないので宣言ではない
+		// (コメント除去は他の PR body gate と同じ規律に揃えた)。
+		it('HTML コメント内の記述は宣言として扱わない', () => {
+			expect(hasUiNotApplicableMarker('<!-- UI 変更なし の場合はここに書く -->')).toBe(false);
+			expect(hasUiNotApplicableMarker('<!-- 該当なし（refactor / docs / chore） -->')).toBe(false);
+		});
+
 		it('**未チェックの checkbox は宣言として扱わない**（チェックしていない = 宣言していない）', () => {
 			expect(hasUiNotApplicableMarker('- [ ] UI 変更なし')).toBe(false);
 			expect(hasUiNotApplicableMarker('- [x] UI 変更なし')).toBe(true);
@@ -317,6 +324,46 @@ describe('hasDomSnapshotReference (#1766 / #1747 AC4)', () => {
 		// URL ではなく説明文中の言及なので検出されない
 		expect(hasDomSnapshotReference(body)).toBe(false);
 	});
+
+	// #4348 (対象 #4): 本文全体への 1 本の正規表現をやめ、行単位 + 文脈除外に揃える。
+	// 「参照がある」と判定されると DOM 併記検証がまるごと消えるため、
+	// **書いていない参照を書いたことにされる**経路を塞ぐ (#4255 / hasUiNotApplicableMarker と同型)。
+	describe('行単位 + 文脈除外 (#4348 対象 #4)', () => {
+		it('HTML コメント内の .dom.html URL は参照として扱わない', () => {
+			const body =
+				'![after](https://example.com/a.png)\n<!-- [DOM HTML](https://x/foo.dom.html) -->';
+			expect(hasDomSnapshotReference(body)).toBe(false);
+		});
+
+		it('コードブロック内の .dom.html URL は参照として扱わない', () => {
+			const body = ['```md', '[DOM HTML](https://example.com/foo.dom.html)', '```'].join('\n');
+			expect(hasDomSnapshotReference(body)).toBe(false);
+		});
+
+		it('インラインコード内の .dom.html URL は参照として扱わない（書式の説明）', () => {
+			expect(hasDomSnapshotReference('書式: `[DOM HTML](https://example.com/x.dom.html)`')).toBe(
+				false,
+			);
+		});
+
+		it('引用行 / 否定文の .dom.html URL は参照として扱わない', () => {
+			expect(hasDomSnapshotReference('> [DOM](https://example.com/foo.dom.html) を貼ること')).toBe(
+				false,
+			);
+			expect(
+				hasDomSnapshotReference('https://example.com/foo.dom.html は撮れていないため添付ではない'),
+			).toBe(false);
+		});
+
+		it('未チェック checkbox 行の .dom.html URL は参照として扱わない', () => {
+			expect(hasDomSnapshotReference('- [ ] [DOM HTML](https://example.com/foo.dom.html)')).toBe(
+				false,
+			);
+			expect(hasDomSnapshotReference('- [x] [DOM HTML](https://example.com/foo.dom.html)')).toBe(
+				true,
+			);
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -492,10 +539,9 @@ describe('hasIntegrationVrEvidence (#2946 — integration lane SS 観点)', () =
 		expect(hasIntegrationVrEvidence('app pixelmatch baseline 比較で回帰未検出。')).toBe(true);
 	});
 
-	it('含有 PR への言及があれば true', () => {
-		expect(
-			hasIntegrationVrEvidence('含有 PR: #3001 / #3002 / #3003 (いずれも develop 取込済み)。'),
-		).toBe(true);
+	it('`## 含有 PR 一覧` section に含有 PR の行があれば true', () => {
+		const body = ['## 含有 PR 一覧', '', '- #3001 活動追加', '- #3002 ごほうび修正'].join('\n');
+		expect(hasIntegrationVrEvidence(body)).toBe(true);
 	});
 
 	it('取込時 SS 検証済の宣言があれば true', () => {
@@ -503,11 +549,39 @@ describe('hasIntegrationVrEvidence (#2946 — integration lane SS 観点)', () =
 		expect(hasIntegrationVrEvidence('含有 PR は取込済で個別に SS 検証されている。')).toBe(true);
 	});
 
-	it('統合対象 / 統合状態 / 統合 smoke への言及があれば true', () => {
-		expect(hasIntegrationVrEvidence('本 PR は統合対象 PR 群を束ねる develop→main 統合 PR。')).toBe(
-			true,
-		);
+	it('統合 smoke への言及があれば true', () => {
 		expect(hasIntegrationVrEvidence('統合 smoke を実行し問題なし。')).toBe(true);
+	});
+
+	// #4348 (対象 #4): 旧実装は本文全体に 6 本の正規表現を当てるだけで、
+	// 「含有 PR」「統合対象」の 4 文字が本文のどこか (説明文 / HTML コメント / 引用) にあれば
+	// 緑になっていた。統合 PR template はその 4 文字を 3 通りで含むため、
+	// **統合 PR は VR 証跡の有無に関係なく常に緑**だった (#4333 と同じ形)。
+	describe('行単位 + 構造判定 (#4348 対象 #4)', () => {
+		it('PR を束ねる自己紹介文だけでは false (evidence ではない)', () => {
+			expect(
+				hasIntegrationVrEvidence('本 PR は統合対象 PR 群を束ねる develop→main 統合 PR。'),
+			).toBe(false);
+			expect(hasIntegrationVrEvidence('含有 PR 一覧は B-3 が自動生成します。')).toBe(false);
+		});
+
+		it('HTML コメント / 引用 / 否定文の言及は evidence として扱わない', () => {
+			expect(hasIntegrationVrEvidence('<!-- visual regression の結果をここに書く -->')).toBe(false);
+			expect(hasIntegrationVrEvidence('> visual regression の結果を貼ること')).toBe(false);
+			expect(hasIntegrationVrEvidence('本 PR は visual regression の対象ではない')).toBe(false);
+		});
+
+		it('`## 含有 PR 一覧` が空 (見出しだけ) なら false', () => {
+			expect(hasIntegrationVrEvidence('## 含有 PR 一覧\n\n<!-- B-3 が自動生成 -->')).toBe(false);
+		});
+
+		// 生成側 assert: 統合 PR template を素で出しただけで evidence 成立させない (#4348 AC7)。
+		it('統合 PR テンプレートを素で生成した body は evidence を成立させない', () => {
+			expect(
+				hasIntegrationVrEvidence(readFileSync('.github/INTEGRATION_PR_TEMPLATE.md', 'utf8')),
+				'template を貼るだけで統合 PR の SS 観点検証が緑になる',
+			).toBe(false);
+		});
 	});
 
 	it('generic な本文 (VR 言及 / 含有 PR / 取込検証なし) なら false', () => {

--- a/tests/unit/scripts/check-schema-skip-marker.test.ts
+++ b/tests/unit/scripts/check-schema-skip-marker.test.ts
@@ -1,0 +1,71 @@
+/**
+ * tests/unit/scripts/check-schema-skip-marker.test.ts (#4348)
+ *
+ * schema 系 gate 2 本の **skip marker 判定**の unit test。
+ *
+ * この 2 本は marker を `PR_BODY.includes('[skip-...]')` で見ており、
+ * marker 文字列が本文のどこか (HTML コメント / 引用 / 否定文 / gate 自身のエラー出力の貼り付け /
+ * コードブロック内の手順説明) にあるだけで **gate がまるごと skip** されていた。
+ * #4348 の対象一覧には無かったが、`.includes` を大文字 `PR_BODY` に対して行うため
+ * fitness function の検出器 (`pr-body-partial-match-guard.test.ts`) からも見えていなかった。
+ *
+ * skip は「宣言」であって「言及」ではない。判定は行単位で、他の PR body gate と同じ規律
+ * (`scripts/lib/ci/pr-body-sections.mjs` の `hasDeclarationLine`) に揃える。
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	hasSkipMarker as hasTestCheckSkipMarker,
+	SKIP_MARKER as TEST_CHECK_MARKER,
+} from '../../../scripts/check-schema-change-tests.mjs';
+import {
+	hasSkipMarker as hasMigrationSkipMarker,
+	SKIP_MARKER as MIGRATION_MARKER,
+} from '../../../scripts/check-schema-migration-completeness.mjs';
+
+const CASES = [
+	{ name: 'check-schema-change-tests', marker: TEST_CHECK_MARKER, has: hasTestCheckSkipMarker },
+	{
+		name: 'check-schema-migration-completeness',
+		marker: MIGRATION_MARKER,
+		has: hasMigrationSkipMarker,
+	},
+] as const;
+
+for (const { name, marker, has } of CASES) {
+	describe(`${name}: skip marker は宣言としてのみ成立する (#4348)`, () => {
+		it('本文に単独で書かれた marker は skip する (既存挙動)', () => {
+			expect(has(`純フォーマット変更のみ。${marker}`)).toBe(true);
+		});
+
+		it('marker が無ければ skip しない', () => {
+			expect(has('schema.ts に列を追加しました。')).toBe(false);
+			expect(has('')).toBe(false);
+		});
+
+		it('HTML コメント内の marker では skip しない (顧客にも監査にも見えない)', () => {
+			expect(has(`<!-- skip したいときは ${marker} と書く -->`)).toBe(false);
+		});
+
+		it('コードブロック / インラインコード内の marker では skip しない (手順の引用)', () => {
+			expect(has(['```', `PR 本文に ${marker} を含める`, '```'].join('\n'))).toBe(false);
+			expect(has(`skip 方法は \`${marker}\` です`)).toBe(false);
+		});
+
+		it('引用行 / 否定文 / 未チェック checkbox の marker では skip しない', () => {
+			expect(has(`> ${marker} を書けば skip されます`)).toBe(false);
+			expect(has(`本 PR は ${marker} ではありません`)).toBe(false);
+			expect(has(`- [ ] ${marker}`)).toBe(false);
+			expect(has(`- [x] ${marker}`)).toBe(true);
+		});
+
+		it('gate 自身の案内文をそのまま貼っても skip しない (出力の貼り戻しで検査が消えない)', () => {
+			// 実際の案内文 (`check-schema-migration-completeness.mjs`) と同じ形。
+			expect(
+				has(
+					`  純フォーマット変更など意図的に skip する場合は PR 本文に "${marker}" を含めてください。`,
+				),
+			).toBe(false);
+		});
+	});
+}


### PR DESCRIPTION
## 顧客価値・目的

PR body の gate を読む人が「この検査は本当に動いているのか」を毎回調べ直さずに済むようにする。**到達不能な判定 5 件を配線ごと削除**し、**同じ class を機械で検出する fitness function** を置いて、以後この状態が入ったら CI が落ちるようにする。

## 関連 Issue

Closes #4623

**merge 順は #4602 → #4611 → #4614 → 本 PR**（本 PR は #4614 の HEAD 上に積んである。同じ file 群を触るため develop から切ると conflict する）。

**push 時に `origin/develop` へ rebase した**（pre-push の drift verify が `1 commits ahead` で BLOCK したため）。rebase は stack の親 commit（#4602 / #4611 / #4614）を replay して保持するので、**stack は壊れていない**。conflict はゼロ（develop 側の #4603 は billing、本 stack は `scripts/` / `tests/`）。

## 変更内容

### 1. `checkTestResults` + chain 2 件 — **削除**した

推測で消さず、呼び出し元から洗った:

| 調べたこと | 結果 |
|---|---|
| 呼び出し元 | `grep -rn "checkTestResults" scripts/ tests/ .github/` → **ヒットは自身の宣言と unit test だけ**。他モジュールからの import ゼロ |
| `CHECKS` registry | **載っていない** = `--check test-results` で CLI から起動できない |
| workflow の invoke | `pr-template-gate.yml` が呼ぶのは `section-presence` / `issue-reference` / `customer-value` / `closing-keyword` の 4 つ。**`test-results` は無い** |
| #4305 の判定表 | 「`pr-template-gate.yml` … 6 ジョブのうち『変更タイプ』『テスト実行結果』を撤去。残りは … の 4」と**明記**。`## テスト・品質セルフチェック` は **A 削減** |
| 入力側（テンプレート） | `.github/PULL_REQUEST_TEMPLATE.md` は 7 節で、**`## テスト実行結果` も `テスト種別 \| コマンド \| 結果` 表も存在しない** |

**再配線という選択肢が無いことまで確認した**のが本件の要点。`detectTestSectionHeading` は表ヘッダが見つからなければ `## テスト実行結果` に fallback するが、その節が現行テンプレートに無い。**registry に戻すと `found=false` → `ok:false` で feature lane の全 PR が hard-fail する。**

**chain の反対端も同時に削除**した（#4614 と同じ形）: `detectTestSectionHeading` は `checkTestResults` と `detectTestSectionKeyword` からのみ呼ばれ、その `detectTestSectionKeyword` 自身の参照は**別 docstring 内の言及 1 件だけ**だった。片端だけ消すと同じ誤読を再生産する。

**消してよい根拠（AC2）**: `checkTestResults` の integration lane 分岐が担っていた「`## マージ判定エビデンス表` に記入済みの行があるか」の検証は、**`check-ac-verification-map.mjs` の `checkIntegrationEvidenceTable` が生きた経路で継続している** — `check-pr-body.mjs:2184` から呼ばれ、`.github/workflows/pr-ac-verification-check.yml`（required context `Verify AC map in PR body`）が実行する。section 不在 / 0 行 / 空欄行の 3 パターンとも `tests/unit/scripts/check-ac-verification-map.test.ts` が固定している。**検査は失われない。**

class-lock: `tests/unit/github/pr-template-gate-checks.test.ts`（3 関数が export されていない + `CHECKS` に `test-results` が無い + **`CHECKS` が workflow の呼ぶ 4 check と完全一致** + **走査対象だった見出しが実テンプレートに無い**）。

### 2. 横展開 — `scripts/**` 全件を AST で洗った

`grep` ではなく TypeScript parser で `export function` と Identifier 参照を数え、**参照元に test を含めずに**到達性を判定した。死んだ関数の本体からの参照は数えず、収束するまで反復する（chain の片端が生き残って見えるのを防ぐ）。

**検出 13 件の全件表**:

| # | export | file | 分類 | 判断根拠 |
|---|---|---|---|---|
| 1 | `checkTestResults` | `scripts/pr-template-gate-checks.mjs` | **(a) 削除** | 本 Issue 本体。上記のとおり |
| 2 | `detectTestSectionHeading` | 同上 | **(a) 削除** | 1 の chain。呼び元は 1 と 3 のみ |
| 3 | `detectTestSectionKeyword` | 同上 | **(a) 削除** | 参照は別 docstring 内の言及 1 件だけ |
| 4 | `extractLogicalId` | `scripts/check-cdk-replacement.mjs` | **(a) 削除** | 参照ゼロ（**test すら import していない**）。論理 ID の抽出は生きている `detectReplacements` が `resourceMatch[3]` で内製している = 同じ抽出が 2 通り存在していた |
| 5 | `formatJournalWhenViolations` | `scripts/lib/db/drizzle-journal-gate.mjs` | **(a) 削除** | 参照ゼロ（test も import していない）。#3953 の glob 化で整形が `formatAllJournalViolations`（file 名を含む）に一般化されたあとの取り残し |
| 6 | `isPullsSubresourcePath` | `scripts/lib/gh-command.mjs` | **(a) 削除** | 参照は後継 `isPullsSubresourcePathAnyRef` の docstring 内の言及だけ。**#4057 が「PR 番号の書き方だけで approve gate の有無が変わる」欠陥として置き換えた、すり抜ける側の述語**。選べる状態で並んでいること自体が危険 |
| 7 | `getRecentMergedFiles` | `scripts/check-recent-deploy-deletion.mjs` | **(a) 削除** | `getMergedFilesSince` への 1 行 wrapper で参照ゼロ。日数指定は `resolveSinceWindow` が `${N} days ago` を組んで直接渡している |
| 8 | `findJudgment` | `scripts/lib/ci/workflow-judgment-registry.mjs` | **(b) 生きている** | consumer が `tests/unit/architecture/workflow-judgment-delegation-guard.test.ts`（CI unit lane で常時走る fitness function）= **それが production consumer そのもの**。`[D1] no-silent-gap`（covered workflow の全 job が registry に宣言されているか）を実装する唯一の経路で、消すと [D1] が表現できなくなる。ALLOWLIST に恒久登録 |
| 9 | `containsGhPrCreate` | `scripts/claude-hook-prevent-qa-account-pr.mjs` | **(c) 別 Issue #4624** | `main()` は `detectPrCreation` を呼ぶので production 未到達。ただし **ADR-0022 の cross-hook 整合 guard を含む 2 test file の ~30 assertion** の呼び先。削除は呼び先の書き換えを伴う |
| 10 | `isAtOrAfterInstant` | `scripts/collect-integration-prs.mjs` | **(c) 別 Issue #4624** | #4053 が**時刻比較そのものを廃した**（merge 履歴ベースへ）ため経路から外れたが、AC1「時刻比較は必ず epoch 正規化を通す」の sanctioned API / 回帰ロックとして意図的に置かれた経緯がある |
| 11 | `compareIsoInstant` | 同上 | **(c) 別 Issue #4624** | 10 の内部実装。同じ判断に従う |
| 12 | `judgeSkipAcGate` | `scripts/issue-close-gate-skip-judge.mjs` | **(c) 別 Issue #4624** | **呼び元の `issue-close-gate.yml` は #4322 で削除済**（`git log --diff-filter=D` で確認）= 13 件中もっとも完全に死んでいる。ただし `.github/CLAUDE.md` / `copilot-instructions.md` / ADR-0004 §4 / `integration-pr.yml` のコメントが今も gate 前提で書かれており、**script だけ消すと docs が実在しない SSOT を指し続ける** |
| 13 | `countAcCheckboxes` | 同上 | **(c) 別 Issue #4624** | 12 と同 file / 同じ判断 |

**(c) は申し送りにせず #4624 を起票済み**（3 群それぞれの選択肢と、削除時に同一 PR で直すべき参照先を明記）。

### 3. fitness function — `tests/unit/architecture/unreachable-script-export-fitness.test.ts`（本命）

同 class 4 件目のため機械化した（ADR-0061 same-class-N→guard）。

- **grep ではなく AST**（`typescript` は直接 devDependency）。素朴なコメント除去は**正規表現リテラル `/^https?:\/\//i` の末尾 `\//` を `//` コメントと誤認**し、実測で生きている `isUserAttachmentAssetUrl` を dead と誤検出した（下の §検証 に出力あり）。AST なら構造上コメントも文字列も混ざらない
- **参照元に test を含めない**。knip がこの class を捕まえられないのは、unit test が import している限り「使われている」と見えるため — **test が生存証明として機能してしまう**
- **ALLOWLIST は理由必須**（30 文字未満 / 定型 stub を弾く。#3956「理由の非強制を作らない」整合）
- **stale 検査つき**。到達可能になった / 対象が消えたエントリを残すと fail するので、「消したのに宣言だけ残る」が起きない
- **repo 走査 test の区分宣言**を `scripts/lib/ci/repo-scan-test-registry.mjs` に追加（`scope: 'repo'` + 明示 timeout 60s、#4085）

**限界を 1 つ明記しておく**: 検出は `export function` 宣言に限る（`export const f = () => …` は見ない）。本 class の 13 件は全て `export function` であり、対象を広げると判定が重くなるため現状は据え置いた。

## 検証

```console
$ npx biome check --write scripts tests
Checked 1210 files in 4s. No fixes applied.

$ npm run cspell
CSpell: Files checked: 1988, Issues found: 0 in 0 files.

$ node --test "scripts/__tests__/**/*.test.mjs"
# pass 206
# fail 0

$ npx vitest run tests/unit/scripts/ tests/unit/architecture/ tests/unit/github/
 Test Files  134 passed (134)
      Tests  2037 passed | 1 skipped (2038)

$ npx svelte-check --tsconfig ./tsconfig.json --threshold warning
COMPLETED 8214 FILES 0 ERRORS 0 WARNINGS 0 FILES_WITH_PROBLEMS

$ node scripts/check-repo-scan-test-declaration.mjs
[repo-scan-test-declaration] OK — repo 走査 test 59 件すべて区分宣言済 (scope='repo' は明示 timeout ≥ 20000ms を確認)
```

### 削除の裏取り（実測）

```console
$ grep -rn "checkTestResults" scripts/ tests/ .github/     # 削除前
scripts/pr-template-gate-checks.mjs:699:export function checkTestResults(...)   ← 宣言のみ
tests/unit/github/pr-template-gate-checks.test.ts:...                            ← test のみ
  （他モジュール / workflow からの参照は 0 件）

$ grep -n "node scripts/pr-template-gate-checks.mjs" -A1 .github/workflows/pr-template-gate.yml
  --check section-presence / --check issue-reference / --check customer-value / --check closing-keyword
  （test-results は無い）

$ grep -n "^## " .github/PULL_REQUEST_TEMPLATE.md
顧客価値・目的 / 関連 Issue / 変更内容 / 検証 / 影響範囲 / 配布済み env / QM レビュー結果   ← 7 節
$ grep -n "テスト種別\|テスト実行結果" .github/PULL_REQUEST_TEMPLATE.md
  （0 件 = 配線し直しても入力が来ない）
```

### AST に切り替えた理由（誤検出の実測）

素朴な行単位コメント除去（`//` 以降を捨てる）で走査したとき:

```console
round 1: scripts/check-pr-screenshot.mjs   isUserAttachmentAssetUrl   ← 誤検出
```

`check-pr-screenshot.mjs:555` の `(url) => /^https?:\/\//i.test(url) && (… || isUserAttachmentAssetUrl(url))` が、正規表現リテラル末尾の `\//` を `//` コメント開始と誤認して丸ごと捨てられていた。**生きている関数を「消してよい」と報告する誤り**なので、AST に切り替えた。切替後の検出は 13 件で `isUserAttachmentAssetUrl` は含まれない。

### mutation 検証

実装を commit（`89e41f109` / `91719cc51`）してから mutation を入れ、確認後に戻した。

**M1: 到達不能な判定関数を（配線せずに）復活させる**

```console
$ # scripts/pr-template-gate-checks.mjs に export function checkTestResults を追記
$ npx vitest run tests/unit/github/pr-template-gate-checks.test.ts tests/unit/architecture/unreachable-script-export-fitness.test.ts
     × 到達不能な export は ALLOWLIST に理由付きで載っているものだけ 1965ms
     × checkTestResults は export されていない 9ms
AssertionError: export されているが、どの entry / registry / 他モジュールからも呼ばれない判定関数を検出しました (#4623)。
検出: scripts/pr-template-gate-checks.mjs#checkTestResults: expected [ Array(1) ] to deeply equal []
AssertionError: expected [ …(13) ] to not include 'checkTestResults'
 Test Files  2 failed (2)
      Tests  2 failed | 70 passed (72)
```

class-lock と新設 fitness function が**両方**落ちる。

**M2: さらに `CHECKS` registry に載せて「到達可能」にする**

```console
$ # CHECKS に 'test-results': checkTestResults を追加
$ npx vitest run tests/unit/github/pr-template-gate-checks.test.ts tests/unit/architecture/unreachable-script-export-fitness.test.ts
     × checkTestResults は export されていない 9ms
     × CHECKS registry に test-results は無い（CLI から起動できない） 1ms
     × CHECKS registry は pr-template-gate.yml が呼ぶ 4 check と一致する 5ms
AssertionError: expected [ 'closing-keyword', …(4) ] to deeply equal [ 'closing-keyword', …(3) ]
 Test Files  1 failed | 1 passed (2)
      Tests  3 failed | 69 passed (72)
```

fitness function は PASS に転じる（実際に到達可能になったので正しい挙動）。**代わりに registry ↔ workflow の一致 test が落ちる** — 「CLI からは呼べるが CI では走らない判定」を作れない。

**M3: 別 file で削除した述語を復活させる（guard が汎化しているか）**

```console
$ # scripts/lib/gh-command.mjs に export function isPullsSubresourcePath を戻す
$ npx vitest run tests/unit/architecture/unreachable-script-export-fitness.test.ts
     × 到達不能な export は ALLOWLIST に理由付きで載っているものだけ 2464ms
検出: scripts/lib/gh-command.mjs#isPullsSubresourcePath: expected [ Array(1) ] to deeply equal []
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

pr-template 系に限らず `scripts/**` 全体で効く。

**M4: 参照元から test を除外している設定を外す（gate の効きを殺せるか）**

```console
$ # EXCLUDED_PATH_PARTS から '__tests__' を外す
$ npx vitest run tests/unit/architecture/unreachable-script-export-fitness.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)      ← 落ちない
```

**落ちなかった。** 現時点では「`scripts/__tests__` からしか参照されない export」が存在しないため、除外を外しても検出結果が変わらない = **除外が効いているかどうかを検出結果から確認できない**状態だった。効かなくなっても気づけないので、参照元集合そのものを assert する guard を足した（commit `91719cc51`）。同じ mutation を再実行:

```console
$ npx vitest run tests/unit/architecture/unreachable-script-export-fitness.test.ts
     × 参照元集合に test は 1 件も入っていない（test を生存証明にしない） 18ms
AssertionError: expected [ …(12) ] to deeply equal []
 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```

### 特筆すべき点

**gate を書いている最中に、その gate 自身が「効いていないのに緑」だった**のが本 PR の学びです。M4 で除外設定を外しても落ちなかった＝この PR が潰そうとしている「検査が空振りしているのに緑」と**同じ形**を自分で作りかけていました。検出結果に現れない設定は assert で直接固定する必要があります。

もう 1 点、**grep ベースの調査を信じていたら生きている関数を消していました**（`isUserAttachmentAssetUrl`）。「コメントを除いて grep」は正規表現リテラルの前で壊れます。

### lead 検収

- `npm run pre-ready -- --pr 4627` **PASS** / fitness function 単独 **4 passed**
- **merge 順: #4602 → #4611 → #4614 → 本 PR**

### 本 PR の価値は「4 件目でようやく機械化した」ことです

到達不能な判定関数は #4348（`checkPerPrAcMap`）→ #4612（`checkAcMap` / `checkChangeTypeSelection`）→ 本 PR（`checkTestResults`）と**3 回手で潰してきた class**です。ADR-0061 の same-class-N→guard は 2 回目で機械強制を求めており、**遅れていました**。本 PR の fitness function でようやく次から自動検出されます。

**grep ではなく TypeScript の AST で参照を数えている**点が実装上の要点です。素朴なコメント除去では正規表現リテラル `/^https?:\/\//i` の末尾を `//` と誤認し、**生きている `isUserAttachmentAssetUrl` を dead と誤検出**しました。

そして**参照元に test を含めない**のがこの class の本質です。knip がこれを捕まえられない理由がまさに「**test が生存証明として機能してしまう**」ことでした。

### 担当が自己申告した失敗（重要）

**M4 mutation で、この gate 自身が「効いていないのに緑」でした。** 参照元から test を外す設定を無効化しても検出結果が変わらず、**設定が効いているか確認できない状態**だったとのことです。**本 PR が潰そうとしている欠陥と同じ形**を、guard 自身が持っていたことになります。参照元集合を直接 assert する guard を追加して落ちるようにしています。

### 特筆すべき削除物

`isPullsSubresourcePath` は、**#4057 が「PR 番号の書き方だけで approve gate が消える」欠陥として置換した、すり抜ける側の述語**でした。置換後も選べる状態で残っていたため削除しています。

## 影響範囲

- 顧客に見える変化: なし（CI / hook の内部判定のみ）
- 破壊的変更: なし
- **検査を弱める変更はゼロ**。削除した 5 件はいずれも実行経路が無く、`checkTestResults` の integration lane 分岐が担っていた検証は `checkIntegrationEvidenceTable` が生きた経路で継続している（§1 で裏取り済）。むしろ `isPullsSubresourcePath` の削除は「すり抜ける側の述語を選べる状態」を閉じるので防御が上がる
- **#4602 / #4611 / #4614 に依存する**。merge 順は #4602 → #4611 → #4614 → 本 PR
- **横展開で判断保留にした 6 件は #4624 に起票済み**。ALLOWLIST に理由と Issue 番号を書いてあり、stale 検査があるので放置すると気づける
- UI 変更なし

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

