### PR TITLE
fix(trial): #4628 トライアル期限表示に null が出うる型の穴を discriminated union + 射影境界で塞ぐ

### DIFF
--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -57,6 +57,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'src/routes 配下を再帰 walk し、プラン上限メッセージ本文が labels.ts SSOT を経由せず直書きに戻っていないかを検査する (#4622)。直書きに戻ると `max: number` の関門が消え、上限メッセージに null を埋められるようになるため、走査範囲は routes 全体でなければ意味を持たない',
 	},
+	'tests/unit/services/trial-status-null-type-hole.test.ts': {
+		scope: 'repo',
+		note: 'src/routes 配下を再帰 walk し、trial 状態 (flag + 期限 / ティア) を route で手で組み直していないかを検査する (#4628)。手組みすると discriminated union の相関が推論から消え、画面側の narrowing が効かなくなって期限表示に null を埋められるようになるため、走査範囲は routes 全体でなければ意味を持たない',
+	},
 	'tests/unit/arch/no-direct-db-access.test.ts': {
 		scope: 'repo',
 		note: 'src 配下を走査して直接 DB アクセスを検出する',

--- a/scripts/lib/ci/repo-scan-test-registry.mjs
+++ b/scripts/lib/ci/repo-scan-test-registry.mjs
@@ -53,6 +53,10 @@ export const REPO_SCAN_TEST_REGISTRY = {
 		scope: 'repo',
 		note: 'scripts/ai-evaluation 配下を走査して inline inject 経路の残存を検査する',
 	},
+	'tests/unit/services/plan-limit-check-null-type-hole.test.ts': {
+		scope: 'repo',
+		note: 'src/routes 配下を再帰 walk し、プラン上限メッセージ本文が labels.ts SSOT を経由せず直書きに戻っていないかを検査する (#4622)。直書きに戻ると `max: number` の関門が消え、上限メッセージに null を埋められるようになるため、走査範囲は routes 全体でなければ意味を持たない',
+	},
 	'tests/unit/arch/no-direct-db-access.test.ts': {
 		scope: 'repo',
 		note: 'src 配下を走査して直接 DB アクセスを検出する',

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -458,8 +458,46 @@ export const PLAN_GATE_LABELS = {
 	 * 家族メンバー招待の quota 上限 (maxFamilyMembers) 到達時の 403 文言 (#1111 / EPIC #3533 §10.7)。
 	 * 旧 `api/v1/admin/invites/+server.ts` 内ハードコードを SSOT 経由に是正 (ADR-0045 / P5)。
 	 */
-	memberLimitReached: (max: number | string) =>
+	memberLimitReached: (max: number) =>
 		`メンバー上限（${max}人）に達しています。プランをアップグレードしてください。`,
+
+	/**
+	 * "カスタム活動は最大{max}個まで作成できます。プランをアップグレードしてください。"
+	 *
+	 * 活動 quota 上限 (maxActivities) 到達時の 403 文言 (#4622)。
+	 * 旧実装は routes 7 箇所に直書きされ、`checkActivityLimit` の `max: number | null` を
+	 * そのまま埋めていたため「最大 null 個」を出しうる型の穴になっていた。
+	 * 引数を `number` に狭めることで、null を渡す呼び出しがコンパイルで落ちる。
+	 *
+	 * @param max 上限値。`allowed: false` の分岐でのみ呼ぶこと (無制限プランは上限に達しない)
+	 */
+	activityLimitReached: (max: number) =>
+		`カスタム活動は最大${max}個まで作成できます。プランをアップグレードしてください。`,
+
+	/**
+	 * "子供は最大{max}人まで登録できます。プランをアップグレードしてください。"
+	 *
+	 * 子供 quota 上限 (maxChildren) 到達時の 403 文言 (#4622)。activityLimitReached と同型。
+	 */
+	childLimitReached: (max: number) =>
+		`子供は最大${max}人まで登録できます。プランをアップグレードしてください。`,
+
+	/**
+	 * "フリープランではお子さま1人あたり {max} 個までです。"
+	 *
+	 * チェックリストテンプレート quota 上限 (maxChecklistTemplates) 到達時の 403 文言 (#4622)。
+	 * アップグレード導線を併記しない短い版。
+	 */
+	checklistTemplateLimitReached: (max: number) =>
+		`フリープランではお子さま1人あたり ${max} 個までです。`,
+
+	/**
+	 * "フリープランではお子さま1人あたり {max} 個までです。スタンダード以上に…"
+	 *
+	 * 上と同じ上限のアップグレード導線併記版 (#4622)。
+	 */
+	checklistTemplateLimitReachedWithUpgrade: (max: number) =>
+		`フリープランではお子さま1人あたり ${max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
 
 	/**
 	 * プラン制限エラー banner / toast に併記するアップグレード導線リンクのラベル (#2894 AC3)。

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -2961,7 +2961,9 @@ export const SUBSCRIPTION_PAGE_LABELS = {
 	// #1963: atom (PLAN_FULL_TERMS / TRIAL_TERMS) を terms.ts から参照
 	trialActiveTitle: `${PLAN_FULL_TERMS.standard} トライアル中`,
 	trialActiveDays: (days: number | string) => `残り ${days}日`,
-	trialActiveUntil: (date: string | null) => `${date ?? ''} まで`,
+	// #4628: トライアル中にしか出ない文なので期限は必ず具体値。旧 `date ?? ''` は
+	// null のとき日付の無い「 まで」を出す band-aid だった (#4622 の `?? 0` と同一 class)。
+	trialActiveUntil: (date: string) => `${date} まで`,
 	trialStartTitle: `${TRIAL_TERMS.duration} 無料でお試し`,
 	trialStartDesc: `${PLAN_FULL_TERMS.standard}の全機能を体験できます`,
 	trialStartButton: '無料トライアルを開始する',

--- a/src/lib/features/admin/components/PlanStatusCard.svelte
+++ b/src/lib/features/admin/components/PlanStatusCard.svelte
@@ -4,11 +4,15 @@ import { FEATURES_LABELS } from '$lib/domain/labels';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
 
+/**
+ * 本カードが読む部分だけ (SSOT は `TrialStatus` / `TrialStatusView`、trial-service.ts)。
+ * #4628: 描画しない `trialEndDate` を宣言していたため、`isTrialActive:true` + `trialEndDate:null`
+ * という不正な組み合わせをここでも構成できた (実際 test fixture が構成していた)。読まない値は持たない。
+ */
 interface TrialStatusProp {
 	isTrialActive: boolean;
 	trialUsed: boolean;
 	daysRemaining: number;
-	trialEndDate: string | null;
 	trialTier?: 'standard' | 'family' | null;
 }
 

--- a/src/lib/features/admin/components/SaasLicensePanel.svelte
+++ b/src/lib/features/admin/components/SaasLicensePanel.svelte
@@ -63,6 +63,7 @@ import {
 import { shouldOpenDowngradeSelector } from '$lib/features/admin/downgrade-dialog-policy';
 import ChurnPreventionModal from '$lib/features/loyalty/ChurnPreventionModal.svelte';
 import LoyaltyBadge from '$lib/features/loyalty/LoyaltyBadge.svelte';
+import type { TrialStatusView } from '$lib/server/services/trial-service';
 import Alert from '$lib/ui/primitives/Alert.svelte';
 import Button from '$lib/ui/primitives/Button.svelte';
 import Card from '$lib/ui/primitives/Card.svelte';
@@ -77,7 +78,10 @@ const license = $derived(data.license);
 const stripeEnabled = $derived(data.stripeEnabled);
 const planTier = $derived(data.planTier ?? 'free');
 const planStats = $derived(data.planStats);
-const trialStatus = $derived(data.trialStatus);
+// #4628: `data` は型注釈が無く any なので、trial 状態だけはここで型を付けて受ける。
+// これがないと `{#if trialStatus.isTrialActive}` の narrowing が働かず、期限表示に
+// null を渡すコードを型検査が素通りさせる (穴が画面まで残る)。
+const trialStatus: TrialStatusView | null = $derived(data.trialStatus ?? null);
 // #771: プラン変更時の二段階確認 (PIN 設定済みなら PIN 必須、未設定なら確認フレーズ)
 const pinConfigured = $derived(data.pinConfigured);
 // #736: 解約時のダウングレード先 (free) の保持期間。PLAN_LIMITS 由来の動的値。

--- a/src/lib/server/debug-plan.ts
+++ b/src/lib/server/debug-plan.ts
@@ -23,11 +23,15 @@ export interface DebugPlanOverride {
 	plan?: string;
 }
 
-export interface DebugTrialOverride {
-	endDate: string | null;
-	tier: TrialTier | null;
-	trialUsed: boolean;
-}
+/**
+ * #4628: 「期限があるならティアもある」(active) / 「どちらも無い」(expired / not-started) の
+ * 2 状態しか存在しないので、直積ではなく union で表す。直積のままだと
+ * `if (override.endDate)` で narrowing しても tier が `TrialTier | null` に残り、
+ * 呼び出し側 (`computeTrialStatus`) が `?? 'standard'` で埋める band-aid を要求してしまう。
+ */
+export type DebugTrialOverride =
+	| { endDate: string; tier: TrialTier; trialUsed: boolean }
+	| { endDate: null; tier: null; trialUsed: boolean };
 
 const VALID_PLANS: ReadonlySet<string> = new Set(['free', 'standard', 'family']);
 const VALID_TRIALS: ReadonlySet<string> = new Set(['active', 'expired', 'not-started']);

--- a/src/lib/server/services/plan-limit-service.ts
+++ b/src/lib/server/services/plan-limit-service.ts
@@ -31,6 +31,26 @@ export interface PlanLimits {
 // 既存の 50 箇所以上ある import 元を壊さないため、ここから再 export する。
 export type { PlanTier };
 
+/**
+ * 上限チェックの結果 (#4622)。
+ *
+ * `max: null` は「無制限」を意味するので、**上限に達した状態 (`allowed: false`) と
+ * 同時には成立しない**。旧実装は `{ allowed: boolean; max: number | null }` という
+ * 単一 shape だったため、この不変条件を型が持たず、`if (!check.allowed)` の内側でも
+ * `max` が `number | null` のままだった。結果、上限到達メッセージに
+ * 「カスタム活動は最大 null 個まで作成できます」と出しうる型の穴が空いていた。
+ *
+ * discriminated union にすることで不正な状態を型で表現不能にし (ADR-0061)、
+ * `!allowed` 側では `max` が `number` に narrowing される。
+ * 上限メッセージのラベル関数 (`PLAN_GATE_LABELS.*LimitReached`) は `max: number` を
+ * 要求するので、この不変条件を崩した瞬間に呼び出し側がコンパイルで落ちる。
+ */
+export type PlanLimitCheck =
+	/** 未到達。`max: null` は無制限プラン (上限なし) を表す */
+	| { allowed: true; current: number; max: number | null }
+	/** 上限到達。到達しうるのは上限が具体値のプランだけなので `max` は必ず number */
+	| { allowed: false; current: number; max: number };
+
 const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
 	free: {
 		maxChildren: 2,
@@ -224,7 +244,7 @@ export async function hasArchivedData(
 export async function checkChildLimit(
 	tenantId: string,
 	licenseStatus: string,
-): Promise<{ allowed: boolean; current: number; max: number | null }> {
+): Promise<PlanLimitCheck> {
 	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
 	if (limits.maxChildren === null) {
 		return { allowed: true, current: 0, max: null };
@@ -250,7 +270,7 @@ export async function checkChildLimit(
 export async function checkActivityLimit(
 	tenantId: string,
 	licenseStatus: string,
-): Promise<{ allowed: boolean; current: number; max: number | null }> {
+): Promise<PlanLimitCheck> {
 	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
 	if (limits.maxActivities === null) {
 		return { allowed: true, current: 0, max: null };
@@ -284,7 +304,7 @@ export async function checkChecklistTemplateLimit(
 	tenantId: string,
 	licenseStatus: string,
 	childId: ChildId,
-): Promise<{ allowed: boolean; current: number; max: number | null }> {
+): Promise<PlanLimitCheck> {
 	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
 	if (limits.maxChecklistTemplates === null) {
 		return { allowed: true, current: 0, max: null };
@@ -312,7 +332,7 @@ export async function checkChecklistTemplateLimit(
 export async function checkFamilyMemberLimit(
 	tenantId: string,
 	licenseStatus: string,
-): Promise<{ allowed: boolean; current: number; max: number | null }> {
+): Promise<PlanLimitCheck> {
 	const limits = getPlanLimits(await resolveFullPlanTier(tenantId, licenseStatus));
 	if (limits.maxFamilyMembers === null) {
 		return { allowed: true, current: 0, max: null };

--- a/src/lib/server/services/trial-notification-service.ts
+++ b/src/lib/server/services/trial-notification-service.ts
@@ -58,7 +58,10 @@ export async function getNotificationSchedule(
 ): Promise<TrialNotificationSchedule | null> {
 	const status = await getTrialStatus(tenantId);
 
-	if (!status.isTrialActive || !status.trialEndDate || !status.trialTier) {
+	// #4628: `isTrialActive` で narrowing すれば trialEndDate / trialTier は具体値に確定する
+	// (旧実装の `|| !status.trialEndDate || !status.trialTier` は、型が保証しない分を
+	// 実行時に手で埋め合わせていたもの)。
+	if (!status.isTrialActive) {
 		return null;
 	}
 

--- a/src/lib/server/services/trial-service.ts
+++ b/src/lib/server/services/trial-service.ts
@@ -14,14 +14,75 @@ const DEFAULT_TRIAL_TIER = 'standard' as const;
 export type TrialSource = 'user_initiated' | 'campaign' | 'admin_grant';
 export type TrialTier = 'standard' | 'family';
 
-export interface TrialStatus {
-	isTrialActive: boolean;
-	trialUsed: boolean;
-	trialStartDate: string | null;
-	trialEndDate: string | null;
-	trialTier: TrialTier | null;
-	daysRemaining: number;
-	source: TrialSource | null;
+/**
+ * トライアル状態。
+ *
+ * #4628: 「トライアル中なら期間・ティアは必ず具体値」という実装上の不変条件を型が持つ。
+ * 旧実装は `isTrialActive: boolean` + `trialEndDate: string | null` の直積で、
+ * `isTrialActive:true` かつ `trialEndDate:null` という不正な組み合わせが型として構成でき、
+ * 画面に日付の無い「 まで」を出しうる状態だった (#4622 の `max: null` と同一 class)。
+ */
+export type TrialStatus =
+	| {
+			isTrialActive: true;
+			trialUsed: boolean;
+			trialStartDate: string;
+			trialEndDate: string;
+			trialTier: TrialTier;
+			daysRemaining: number;
+			source: TrialSource;
+	  }
+	| {
+			isTrialActive: false;
+			trialUsed: boolean;
+			trialStartDate: string | null;
+			trialEndDate: string | null;
+			trialTier: TrialTier | null;
+			daysRemaining: number;
+			source: TrialSource | null;
+	  };
+
+/**
+ * client (page data) に配る表示用の部分集合。
+ *
+ * #4628: route で `{ isTrialActive: s.isTrialActive, trialEndDate: s.trialEndDate }` と
+ * **手で組み直すと相関が消える** (推論は `{ isTrialActive: boolean; trialEndDate: string | null }`)。
+ * 射影をこの 1 関数に集約し、UI 側でも `isTrialActive` で narrowing が効く状態を保つ。
+ */
+export type TrialStatusView =
+	| {
+			isTrialActive: true;
+			trialUsed: boolean;
+			daysRemaining: number;
+			trialEndDate: string;
+			trialTier: TrialTier;
+	  }
+	| {
+			isTrialActive: false;
+			trialUsed: boolean;
+			daysRemaining: number;
+			trialEndDate: string | null;
+			trialTier: TrialTier | null;
+	  };
+
+/** `TrialStatus` を相関を保ったまま client 配布用に射影する (#4628)。 */
+export function toTrialStatusView(status: TrialStatus): TrialStatusView {
+	if (status.isTrialActive) {
+		return {
+			isTrialActive: true,
+			trialUsed: status.trialUsed,
+			daysRemaining: status.daysRemaining,
+			trialEndDate: status.trialEndDate,
+			trialTier: status.trialTier,
+		};
+	}
+	return {
+		isTrialActive: false,
+		trialUsed: status.trialUsed,
+		daysRemaining: status.daysRemaining,
+		trialEndDate: status.trialEndDate,
+		trialTier: status.trialTier,
+	};
 }
 
 export type UpgradeReason = 'auto' | 'manual' | 'email_cta';
@@ -110,17 +171,27 @@ async function computeTrialStatus(tenantId: string): Promise<TrialStatus> {
 	const todayDate = new Date(`${todayStr}T00:00:00Z`);
 	const endDate = new Date(`${latest.endDate}T00:00:00Z`);
 	const isActive = endDate >= todayDate;
-	const daysRemaining = isActive
-		? Math.round((endDate.getTime() - todayDate.getTime()) / (1000 * 60 * 60 * 24))
-		: 0;
+
+	// #4628: active / inactive で戻り値の型が変わる (active は期間・ティアが必ず具体値)。
+	if (isActive) {
+		return {
+			isTrialActive: true,
+			trialUsed: true,
+			trialStartDate: latest.startDate,
+			trialEndDate: latest.endDate,
+			trialTier: latest.tier as TrialTier,
+			daysRemaining: Math.round((endDate.getTime() - todayDate.getTime()) / (1000 * 60 * 60 * 24)),
+			source: latest.source as TrialSource,
+		};
+	}
 
 	return {
-		isTrialActive: isActive,
+		isTrialActive: false,
 		trialUsed: true,
 		trialStartDate: latest.startDate,
 		trialEndDate: latest.endDate,
 		trialTier: latest.tier as TrialTier,
-		daysRemaining,
+		daysRemaining: 0,
 		source: latest.source as TrialSource,
 	};
 }

--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -200,11 +200,13 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
 		planTier,
 		tutorialStarted,
 		userRole,
+		// #4628: 本 layout の UI (header pill / TrialBanner / TrialEndedDialog) は
+		// 残日数と 2 つの flag しか読まない。`trialEndDate` は誰も描画しないまま
+		// client まで運ばれ、「flag と値が別々に届く = 相関の消えた形」を増やしていたので落とす。
 		trialStatus: {
 			isTrialActive: trialStatus.isTrialActive,
 			daysRemaining: trialStatus.daysRemaining,
 			trialUsed: trialStatus.trialUsed,
-			trialEndDate: trialStatus.trialEndDate,
 		},
 		trialJustExpired,
 		archivedSummary,

--- a/src/routes/(parent)/admin/+layout.svelte
+++ b/src/routes/(parent)/admin/+layout.svelte
@@ -21,7 +21,6 @@ interface Props {
 			isTrialActive: boolean;
 			daysRemaining: number;
 			trialUsed: boolean;
-			trialEndDate: string | null;
 		};
 		archivedSummary?: {
 			archivedChildCount: number;

--- a/src/routes/(parent)/admin/activities/+page.server.ts
+++ b/src/routes/(parent)/admin/activities/+page.server.ts
@@ -5,6 +5,7 @@ import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asActivityId, asCategoryId, asChildId, type ChildId } from '$lib/domain/ids';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import {
 	CATEGORY_DEFS,
 	getCategoryById,
@@ -180,7 +181,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(activityLimitCheck.max),
 				),
 			});
 		}
@@ -292,7 +293,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${importPackLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(importPackLimitCheck.max),
 				),
 			});
 		}
@@ -433,7 +434,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${activityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(activityLimitCheck.max),
 				),
 			});
 		}
@@ -543,7 +544,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${copyLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(copyLimitCheck.max),
 				),
 			});
 		}
@@ -609,7 +610,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`カスタム活動は最大${bulkActivityLimitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.activityLimitReached(bulkActivityLimitCheck.max),
 				),
 			});
 		}

--- a/src/routes/(parent)/admin/checklists/+page.server.ts
+++ b/src/routes/(parent)/admin/checklists/+page.server.ts
@@ -174,7 +174,7 @@ const importMarketplaceChecklistAction: Action = async ({ request, locals }) => 
 			error: createPlanLimitError(
 				tier,
 				'standard',
-				`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+				PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(limit.max),
 			),
 			upgradeRequired: true,
 		});
@@ -324,7 +324,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+					PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(limit.max),
 				),
 				upgradeRequired: true,
 			});
@@ -490,7 +490,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。`,
+					PLAN_GATE_LABELS.checklistTemplateLimitReached(limit.max),
 				),
 			});
 		}
@@ -563,7 +563,7 @@ export const actions: Actions = {
 					error: createPlanLimitError(
 						tier,
 						'standard',
-						`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+						PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(limit.max),
 					),
 					upgradeRequired: true,
 				});
@@ -753,7 +753,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`フリープランではお子さま1人あたり ${limit.max} 個までです。スタンダード以上にアップグレードすると無制限に作成できます。`,
+					PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(limit.max),
 				),
 				upgradeRequired: true,
 			});

--- a/src/routes/(parent)/admin/children/+page.server.ts
+++ b/src/routes/(parent)/admin/children/+page.server.ts
@@ -4,7 +4,7 @@ import { calculateAgeFromBirthDate } from '$lib/domain/date-utils';
 import { createPlanLimitError } from '$lib/domain/errors';
 import { formIdString } from '$lib/domain/form-value';
 import { asCategoryId, asChildId } from '$lib/domain/ids';
-import { ADMIN_CHILDREN_PAGE_LABELS } from '$lib/domain/labels';
+import { ADMIN_CHILDREN_PAGE_LABELS, PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { CATEGORY_DEFS } from '$lib/domain/validation/activity';
 import { requireTenantId } from '$lib/server/auth/factory';
 import { logger } from '$lib/server/logger';
@@ -181,7 +181,7 @@ export const actions: Actions = {
 				error: createPlanLimitError(
 					tier,
 					'standard',
-					`子供は最大${childLimitCheck.max}人まで登録できます。プランをアップグレードしてください。`,
+					PLAN_GATE_LABELS.childLimitReached(childLimitCheck.max),
 				),
 			});
 		}

--- a/src/routes/(parent)/admin/subscription/+page.server.ts
+++ b/src/routes/(parent)/admin/subscription/+page.server.ts
@@ -31,7 +31,7 @@ import {
 	getCancellationState,
 	reconcileCheckoutSession,
 } from '$lib/server/services/stripe-service';
-import { getTrialStatus, startTrial } from '$lib/server/services/trial-service';
+import { getTrialStatus, startTrial, toTrialStatusView } from '$lib/server/services/trial-service';
 import { isStripeEnabled } from '$lib/server/stripe/client';
 import type { Actions, PageServerLoad } from './$types';
 
@@ -124,13 +124,10 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 			const raw = url.searchParams.get(PORTAL_FALLBACK_REASON_PARAM);
 			return isPortalFallbackReason(raw) ? raw : PORTAL_FALLBACK_REASON.FLOW_REJECTED;
 		})(),
-		trialStatus: {
-			isTrialActive: trialStatus.isTrialActive,
-			trialUsed: trialStatus.trialUsed,
-			daysRemaining: trialStatus.daysRemaining,
-			trialEndDate: trialStatus.trialEndDate,
-			trialTier: trialStatus.trialTier,
-		},
+		// #4628: 手で組み直すと `isTrialActive` と `trialEndDate` の相関が推論から消え、
+		// 画面側の `{#if trialStatus.isTrialActive}` で narrowing が効かなくなる。射影は
+		// `toTrialStatusView` に集約する (route での再インライン化は fitness test が止める)。
+		trialStatus: toTrialStatusView(trialStatus),
 		// #3991: 期末解約の予約状態 (null = 契約なし / Stripe 未設定 / 取得失敗)
 		cancellation,
 		// EPIC #2327 / #2328: runtimeMode は +layout.server.ts (admin layout) で

--- a/src/routes/api/v1/activities/+server.ts
+++ b/src/routes/api/v1/activities/+server.ts
@@ -3,6 +3,7 @@ import * as v from 'valibot';
 // #3740: client-facing 経路の wire source は信頼せず正準 'custom' を強制する (trust 境界分離)
 import { PARENT_CREATED_SOURCE } from '$lib/domain/activity-source';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { activitiesQuerySchema, createActivitySchema } from '$lib/domain/validation/activity';
 import { findChildById } from '$lib/server/db/activity-repo';
 import { apiError, validationError } from '$lib/server/errors';
@@ -53,11 +54,10 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 	const licenseStatus = context.licenseStatus ?? AUTH_LICENSE_STATUS.NONE;
 	const limitCheck = await checkActivityLimit(tenantId, licenseStatus);
 	if (!limitCheck.allowed) {
-		return apiError(
-			'PLAN_LIMIT_EXCEEDED',
-			`カスタム活動は最大${limitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
-			{ current: limitCheck.current, max: limitCheck.max },
-		);
+		return apiError('PLAN_LIMIT_EXCEEDED', PLAN_GATE_LABELS.activityLimitReached(limitCheck.max), {
+			current: limitCheck.current,
+			max: limitCheck.max,
+		});
 	}
 
 	// #3740: wire `source` ('seed'/'curriculum' 含む) を信頼すると quota 集計対象外の値を

--- a/src/routes/api/v1/activities/import/+server.ts
+++ b/src/routes/api/v1/activities/import/+server.ts
@@ -1,6 +1,7 @@
 import { error, json } from '@sveltejs/kit';
 import type { ActivityPackItem } from '$lib/domain/activity-pack';
 import { AUTH_LICENSE_STATUS } from '$lib/domain/constants/auth-license-status';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import { CATEGORY_CODES } from '$lib/domain/validation/activity';
 // #2365 (ADR-0052): 新 Strategy + dispatchImport 経由
 import { dispatchImport, marketplaceRegistry } from '$lib/marketplace';
@@ -104,7 +105,7 @@ export const POST: RequestHandler = async ({ request, url, locals }) => {
 		if (!limitCheck.allowed) {
 			return apiError(
 				'PLAN_LIMIT_EXCEEDED',
-				`カスタム活動は最大${limitCheck.max}個まで作成できます。プランをアップグレードしてください。`,
+				PLAN_GATE_LABELS.activityLimitReached(limitCheck.max),
 				{ current: limitCheck.current, max: limitCheck.max },
 			);
 		}

--- a/src/routes/api/v1/admin/invites/+server.ts
+++ b/src/routes/api/v1/admin/invites/+server.ts
@@ -56,7 +56,9 @@ export const POST: RequestHandler = async ({ request, locals }) => {
 		return json(
 			{
 				error: 'MEMBER_LIMIT_REACHED',
-				message: PLAN_GATE_LABELS.memberLimitReached(memberLimit.max ?? 0),
+				// #4622: PlanLimitCheck が discriminated union になり、!allowed 側で max は number に確定する。
+				// 旧 `?? 0` fallback は「メンバー上限（0人）」という別の嘘を出しうるため撤去した。
+				message: PLAN_GATE_LABELS.memberLimitReached(memberLimit.max),
 				current: memberLimit.current,
 				max: memberLimit.max,
 			},

--- a/tests/unit/components/plan-status-card-upgrade-cta.test.ts
+++ b/tests/unit/components/plan-status-card-upgrade-cta.test.ts
@@ -55,11 +55,12 @@ describe('PlanStatusCard アップグレード CTA (#4139)', () => {
 			const { container } = render(PlanStatusCard, {
 				planTier: 'free',
 				onUpgrade,
+				// #4628: 旧 fixture は `isTrialActive: true` + `trialEndDate: null` という
+				// 実際には起こらない組み合わせを構成していた (型が許していたため誰も気づけなかった)。
 				trialStatus: {
 					isTrialActive: true,
 					trialUsed: false,
 					daysRemaining: 3,
-					trialEndDate: null,
 					trialTier: 'standard',
 				},
 			});

--- a/tests/unit/routes/admin-subscription-reconciliation.test.ts
+++ b/tests/unit/routes/admin-subscription-reconciliation.test.ts
@@ -48,13 +48,18 @@ vi.mock('$lib/server/services/child-service', () => ({
 	getAllChildren: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock('$lib/server/services/trial-service', () => ({
+vi.mock('$lib/server/services/trial-service', async (importOriginal) => ({
+	// #4628: client への射影 (toTrialStatusView) は本物を使う。mock で置き換えると
+	// 「route が正しい射影を通しているか」を検証できなくなる。
+	...(await importOriginal<typeof import('$lib/server/services/trial-service')>()),
 	getTrialStatus: vi.fn().mockResolvedValue({
 		isTrialActive: false,
 		trialUsed: false,
-		daysRemaining: 0,
+		trialStartDate: null,
 		trialEndDate: null,
 		trialTier: null,
+		daysRemaining: 0,
+		source: null,
 	}),
 	startTrial: vi.fn(),
 }));

--- a/tests/unit/services/plan-limit-check-null-type-hole.test.ts
+++ b/tests/unit/services/plan-limit-check-null-type-hole.test.ts
@@ -16,9 +16,13 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { PLAN_GATE_LABELS } from '$lib/domain/labels';
 import type { PlanLimitCheck } from '$lib/server/services/plan-limit-service';
+
+// #4085: 本 file は src/routes ツリーを walk する repo 走査 test (registry に scope:'repo' で宣言済)。
+// unit lane の並列実行では既定 5s を超えうるため明示 timeout を置く。
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPO_ROOT = path.resolve(__dirname, '../../..');
 const ROUTES_DIR = path.join(REPO_ROOT, 'src', 'routes');

--- a/tests/unit/services/plan-limit-check-null-type-hole.test.ts
+++ b/tests/unit/services/plan-limit-check-null-type-hole.test.ts
@@ -1,0 +1,120 @@
+// #4622: プラン上限メッセージに null が出うる型の穴の回帰ロック。
+//
+// 旧実装は上限チェック 4 関数が `{ allowed: boolean; current: number; max: number | null }` を
+// 返しており、「allowed:false なら max は必ず具体値」という不変条件を型が持っていなかった。
+// そのため `if (!check.allowed)` の内側でも max は `number | null` のままで、
+// `カスタム活動は最大${check.max}個まで作成できます` が型検査を通り、
+// 顧客の画面に「最大 null 個」と出しうる状態だった (routes 13 箇所)。
+//
+// 本 test が守るのは以下の 3 点:
+//   1. PlanLimitCheck が discriminated union で、allowed:false + max:null が**型として作れない**
+//   2. 上限メッセージのラベル関数が `max: number` を要求し、null を渡すと型エラーになる
+//   3. メッセージ本文が routes に再び直書きされない (SSOT = labels.ts、ADR-0045)
+//
+// 1 と 2 は `@ts-expect-error` で固定しているため、型が緩められると
+// 「未使用の @ts-expect-error」として svelte-check (pre-ready Step 2 / CI) が落ちる。
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { PLAN_GATE_LABELS } from '$lib/domain/labels';
+import type { PlanLimitCheck } from '$lib/server/services/plan-limit-service';
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const ROUTES_DIR = path.join(REPO_ROOT, 'src', 'routes');
+
+function collectTsFiles(dir: string, acc: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		const full = path.join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			collectTsFiles(full, acc);
+		} else if (full.endsWith('.ts') || full.endsWith('.svelte')) {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+describe('#4622 PlanLimitCheck — 不正な状態 (allowed:false + max:null) を型で表現不能にする', () => {
+	it('allowed:false のとき max は number しか代入できない', () => {
+		const reached: PlanLimitCheck = { allowed: false, current: 3, max: 3 };
+		expect(reached.allowed).toBe(false);
+
+		// 上限到達なのに「上限は無制限」という矛盾した状態は型として作れない。
+		// この @ts-expect-error が不要になる = 型が緩んだ、ということなので tsc が落ちる。
+		// @ts-expect-error allowed:false のとき max:null は不正な状態 (#4622)
+		const broken: PlanLimitCheck = { allowed: false, current: 3, max: null };
+		expect(broken).toBeDefined();
+	});
+
+	it('allowed:true のときだけ max:null (= 無制限) を表現できる', () => {
+		const unlimited: PlanLimitCheck = { allowed: true, current: 0, max: null };
+		expect(unlimited.max).toBeNull();
+	});
+
+	it('!allowed で narrowing すると max が number に確定する', () => {
+		const check: PlanLimitCheck = { allowed: false, current: 3, max: 3 };
+		if (!check.allowed) {
+			// narrowing 後は null 許容ではないので、number を要求する関数にそのまま渡せる。
+			const message: string = PLAN_GATE_LABELS.activityLimitReached(check.max);
+			expect(message).not.toContain('null');
+		}
+	});
+});
+
+describe('#4622 上限メッセージのラベル関数は null を受け取れない', () => {
+	it('null を渡すと型エラーになる', () => {
+		// @ts-expect-error 上限到達メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.activityLimitReached(null)).toBeTypeOf('string');
+		// @ts-expect-error 上限到達メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.childLimitReached(null)).toBeTypeOf('string');
+		// @ts-expect-error 上限到達メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.checklistTemplateLimitReached(null)).toBeTypeOf('string');
+		// @ts-expect-error 上限到達メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(null)).toBeTypeOf('string');
+		// @ts-expect-error メンバー上限メッセージに null は渡せない (#4622)
+		expect(PLAN_GATE_LABELS.memberLimitReached(null)).toBeTypeOf('string');
+	});
+
+	it('文言は移設前とバイト一致で不変', () => {
+		expect(PLAN_GATE_LABELS.activityLimitReached(3)).toBe(
+			'カスタム活動は最大3個まで作成できます。プランをアップグレードしてください。',
+		);
+		expect(PLAN_GATE_LABELS.childLimitReached(2)).toBe(
+			'子供は最大2人まで登録できます。プランをアップグレードしてください。',
+		);
+		expect(PLAN_GATE_LABELS.checklistTemplateLimitReached(3)).toBe(
+			'フリープランではお子さま1人あたり 3 個までです。',
+		);
+		expect(PLAN_GATE_LABELS.checklistTemplateLimitReachedWithUpgrade(3)).toBe(
+			'フリープランではお子さま1人あたり 3 個までです。スタンダード以上にアップグレードすると無制限に作成できます。',
+		);
+		expect(PLAN_GATE_LABELS.memberLimitReached(4)).toBe(
+			'メンバー上限（4人）に達しています。プランをアップグレードしてください。',
+		);
+	});
+});
+
+describe('#4622 fitness — 上限メッセージ本文を routes に直書きし戻さない', () => {
+	// labels.ts を経由しない直書きに戻すと `max: number` の関門が消え、
+	// 再び `${check.max}` に null を埋められるようになる。文面の断片で検出する。
+	const FORBIDDEN_FRAGMENTS = [
+		'個まで作成できます',
+		'人まで登録できます',
+		'個までです。',
+		'人）に達しています',
+	];
+
+	it('src/routes 配下に上限メッセージの直書きが無い', () => {
+		const offenders: string[] = [];
+		for (const file of collectTsFiles(ROUTES_DIR)) {
+			const source = readFileSync(file, 'utf8');
+			for (const fragment of FORBIDDEN_FRAGMENTS) {
+				if (source.includes(fragment)) {
+					offenders.push(`${path.relative(REPO_ROOT, file)}: "${fragment}"`);
+				}
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});

--- a/tests/unit/services/trial-status-null-type-hole.test.ts
+++ b/tests/unit/services/trial-status-null-type-hole.test.ts
@@ -1,0 +1,190 @@
+// #4628: トライアル期限表示に null が出うる型の穴の回帰ロック (#4622 と同一 class)。
+//
+// 旧実装の `TrialStatus` は `{ isTrialActive: boolean; trialEndDate: string | null; ... }` で、
+// 「トライアル中なら期限は必ず具体値」という不変条件を型が持っていなかった。そのため
+// `{#if trialStatus.isTrialActive}` の内側でも trialEndDate は `string | null` のままで、
+// 期限表示ラベルが `${date ?? ''} まで` という band-aid を抱え、null のときは日付の無い
+// 「 まで」だけを顧客に出しうる状態だった。
+//
+// 本 test が守るのは以下の 4 点:
+//   1. TrialStatus が discriminated union で、isTrialActive:true + trialEndDate:null が**作れない**
+//   2. 期限表示ラベルが `date: string` を要求し、null を渡すと型エラーになる
+//   3. client への射影 (toTrialStatusView) が相関を保つ = UI 側で narrowing が効く
+//   4. route が射影を手で組み直さない (組み直すと相関が推論から消え、穴が復活する)
+//
+// 1〜3 は `@ts-expect-error` / 代入で固定しているため、型が緩められると
+// 「未使用の @ts-expect-error」として svelte-check (pre-ready Step 2 / CI) が落ちる。
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { SUBSCRIPTION_PAGE_LABELS } from '$lib/domain/labels';
+import {
+	type TrialStatus,
+	type TrialStatusView,
+	toTrialStatusView,
+} from '$lib/server/services/trial-service';
+
+// #4085: 本 file は src/routes ツリーを walk する repo 走査 test (registry に scope:'repo' で宣言済)。
+// unit lane の並列実行では既定 5s を超えうるため明示 timeout を置く。
+vi.setConfig({ testTimeout: 60_000 });
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const ROUTES_DIR = path.join(REPO_ROOT, 'src', 'routes');
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+	for (const entry of readdirSync(dir)) {
+		const full = path.join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			collectSourceFiles(full, acc);
+		} else if (full.endsWith('.ts') || full.endsWith('.svelte')) {
+			acc.push(full);
+		}
+	}
+	return acc;
+}
+
+const ACTIVE: TrialStatus = {
+	isTrialActive: true,
+	trialUsed: true,
+	trialStartDate: '2026-08-01',
+	trialEndDate: '2026-08-08',
+	trialTier: 'standard',
+	daysRemaining: 3,
+	source: 'user_initiated',
+};
+
+describe('#4628 TrialStatus — 不正な状態 (isTrialActive:true + trialEndDate:null) を型で表現不能にする', () => {
+	it('トライアル中は期限・ティアが具体値でしか構成できない', () => {
+		// エラー位置が整形 (biome) で動かないよう、literal は素の const に取り、
+		// TrialStatus への代入行に @ts-expect-error を置く。
+		// この @ts-expect-error が不要になる = 型が緩んだ、ということなので tsc が落ちる。
+		const endMissing = {
+			isTrialActive: true,
+			trialUsed: true,
+			trialStartDate: '2026-08-01',
+			trialEndDate: null,
+			trialTier: 'standard',
+			daysRemaining: 3,
+			source: 'user_initiated',
+		} as const;
+		const tierMissing = {
+			isTrialActive: true,
+			trialUsed: true,
+			trialStartDate: '2026-08-01',
+			trialEndDate: '2026-08-08',
+			trialTier: null,
+			daysRemaining: 3,
+			source: 'user_initiated',
+		} as const;
+
+		// @ts-expect-error isTrialActive:true のとき trialEndDate:null は不正な状態 (#4628)
+		const brokenEnd: TrialStatus = endMissing;
+		// @ts-expect-error isTrialActive:true のとき trialTier:null は不正な状態 (#4628)
+		const brokenTier: TrialStatus = tierMissing;
+		expect(brokenEnd).toBeDefined();
+		expect(brokenTier).toBeDefined();
+	});
+
+	it('トライアル中でないときだけ期限 null (= 未開始 / 終了済) を表現できる', () => {
+		const notStarted: TrialStatus = {
+			isTrialActive: false,
+			trialUsed: false,
+			trialStartDate: null,
+			trialEndDate: null,
+			trialTier: null,
+			daysRemaining: 0,
+			source: null,
+		};
+		expect(notStarted.trialEndDate).toBeNull();
+	});
+
+	it('isTrialActive で narrowing すると trialEndDate / trialTier が確定する', () => {
+		const status: TrialStatus = ACTIVE;
+		if (status.isTrialActive) {
+			// narrowing 後は null 許容ではないので、string を要求する関数にそのまま渡せる。
+			const message: string = SUBSCRIPTION_PAGE_LABELS.trialActiveUntil(status.trialEndDate);
+			const tier: 'standard' | 'family' = status.trialTier;
+			expect(message).not.toContain('null');
+			expect(tier).toBe('standard');
+		} else {
+			throw new Error('narrowing 前提が崩れている');
+		}
+	});
+});
+
+describe('#4628 期限表示ラベルは null を受け取れない', () => {
+	it('null を渡すと型エラーになる', () => {
+		// @ts-expect-error トライアル期限表示に null は渡せない (#4628)
+		expect(SUBSCRIPTION_PAGE_LABELS.trialActiveUntil(null)).toBeTypeOf('string');
+	});
+
+	it('文言は band-aid 撤去前とバイト一致で不変', () => {
+		expect(SUBSCRIPTION_PAGE_LABELS.trialActiveUntil('2026-08-08')).toBe('2026-08-08 まで');
+	});
+});
+
+describe('#4628 client への射影は相関を保つ', () => {
+	it('toTrialStatusView 経由なら UI 側で narrowing が効く', () => {
+		const view: TrialStatusView = toTrialStatusView(ACTIVE);
+		if (view.isTrialActive) {
+			const message: string = SUBSCRIPTION_PAGE_LABELS.trialActiveUntil(view.trialEndDate);
+			expect(message).toBe('2026-08-08 まで');
+		} else {
+			throw new Error('射影が active 状態を落としている');
+		}
+	});
+
+	it('非 active はそのまま非 active として射影される', () => {
+		const view = toTrialStatusView({
+			isTrialActive: false,
+			trialUsed: true,
+			trialStartDate: '2026-07-01',
+			trialEndDate: '2026-07-08',
+			trialTier: 'family',
+			daysRemaining: 0,
+			source: 'campaign',
+		});
+		expect(view).toEqual({
+			isTrialActive: false,
+			trialUsed: true,
+			daysRemaining: 0,
+			trialEndDate: '2026-07-08',
+			trialTier: 'family',
+		});
+	});
+
+	it('view には UI が読まない値 (trialStartDate / source) を含めない', () => {
+		expect(Object.keys(toTrialStatusView(ACTIVE)).sort()).toEqual([
+			'daysRemaining',
+			'isTrialActive',
+			'trialEndDate',
+			'trialTier',
+			'trialUsed',
+		]);
+	});
+});
+
+describe('#4628 fitness — route で trial 状態を手で組み直さない', () => {
+	// `{ isTrialActive: s.isTrialActive, trialEndDate: s.trialEndDate }` と手で組み直すと
+	// 推論が `{ isTrialActive: boolean; trialEndDate: string | null }` に落ち、
+	// 画面側の narrowing が消えて穴が復活する。射影は toTrialStatusView に集約する。
+	//
+	// 検出するのは「flag (isTrialActive) と nullable な値 (trialEndDate / trialTier) を
+	// 同一 object literal に手で並べ直す」形。flag だけ / 値だけの参照は相関を壊さないので許す
+	// (admin +layout は残日数と flag しか配らない)。
+	const FLAG_PROJECTION = /isTrialActive\s*:\s*\w+\.isTrialActive/;
+	const VALUE_PROJECTION = /(trialEndDate|trialTier)\s*:\s*\w+\.(trialEndDate|trialTier)/;
+
+	it('src/routes 配下に trial 状態の手組み射影が無い', () => {
+		const offenders: string[] = [];
+		for (const file of collectSourceFiles(ROUTES_DIR)) {
+			const source = readFileSync(file, 'utf8');
+			const value = source.match(VALUE_PROJECTION);
+			if (FLAG_PROJECTION.test(source) && value) {
+				offenders.push(`${path.relative(REPO_ROOT, file)}: "${value[0]}"`);
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+});


### PR DESCRIPTION
## 顧客価値・目的

トライアル中の期限表示に内部値 (null) が混ざり、日付の無い「 まで」だけが出うる型の穴を塞ぐ。顧客が読む文面から内部値が漏れる経路を、型で成立しないようにする。

**merge 順: #4625 → 本 PR**（本 PR は #4625 (`fix/4622-null-in-limit-message`) の上に積んでいる。base は develop だが、#4625 が先に merge されること）

## 関連 Issue

Closes #4628

## 変更内容

### 1. 不正な状態を型で表現不能にする（根本）

`TrialStatus` を discriminated union にした。

```ts
export type TrialStatus =
	| { isTrialActive: true;  trialStartDate: string; trialEndDate: string; trialTier: TrialTier; trialUsed: boolean; daysRemaining: number; source: TrialSource }
	| { isTrialActive: false; trialStartDate: string | null; trialEndDate: string | null; trialTier: TrialTier | null; trialUsed: boolean; daysRemaining: number; source: TrialSource | null };
```

「トライアル中なら期間・ティアは必ず具体値」という実装上の不変条件を型が持つようにした。ランタイム挙動は不変（`computeTrialStatus` が返す値は前と同じ、分岐の書き方だけが変わる）。

### 2. 射影を 1 関数に集約（機械停止点）

union だけでは塞がらない。**route が戻り値を手で object literal に組み直しており、組み直した時点で相関が推論から消える**（`{ isTrialActive: s.isTrialActive, trialEndDate: s.trialEndDate }` は `{ isTrialActive: boolean; trialEndDate: string | null }` に落ちる）ため、client component に narrowing が届かない。#4625 が label 境界を作ったのと同じ位置づけで、**射影の関門** `toTrialStatusView()` を置き、subscription page をそこに通した。

`SUBSCRIPTION_PAGE_LABELS.trialActiveUntil` の引数を `string | null` → `string` に狭め、`?? ''` を撤去した（`?? ''` は null の代わりに「 まで」という日付の無い文を出す band-aid で、#4622 の `?? 0`（「メンバー上限（0人）」）と同型）。

**表示文言はバイト一致で不変**（`2026-08-08 まで`）。

### 3. 同じ形の残り（読まない値は持たない / 一段下の同型）

- `admin/+layout.server.ts` は `trialEndDate` を client に配っていたが **どの UI も描画していない**（header pill / TrialBanner / TrialEndedDialog は残日数と flag しか読まない）。読まない値を運ぶのは「相関の消えた形」を増やすだけなので落とした（`+layout.svelte` の inline 型も同様）
- `PlanStatusCard.svelte` の prop 型も描画しない `trialEndDate` を宣言しており、**実際に repo 内の test fixture が `isTrialActive: true` + `trialEndDate: null` を構成していた**（型が許すので誰も気づけなかった）。dead field を落とし、fixture を是正した
- `debug-plan.ts` の `DebugTrialOverride` も `{ endDate: string | null; tier: TrialTier | null }` の直積で同じ穴を持ち、union 化しないと呼び出し側が `?? 'standard'` の band-aid を要求してしまうため、あわせて union にした（active = 期限もティアもある / それ以外 = どちらも無い の 2 状態しかない）
- `trial-notification-service.ts` の `if (!status.isTrialActive || !status.trialEndDate || !status.trialTier)` は、型が保証しない分を実行時に手で埋め合わせていたもの。narrowing で不要になったので `!status.isTrialActive` だけにした

### 4. 回帰ロック

`tests/unit/services/trial-status-null-type-hole.test.ts`:

- `@ts-expect-error` で「`isTrialActive:true` + `trialEndDate:null` / `trialTier:null` が作れない」「期限ラベルに null を渡せない」を固定。型を緩めると **未使用の `@ts-expect-error`** として svelte-check（pre-ready Step 2 / CI）が落ちる
- fitness function: `src/routes/**` で flag（`isTrialActive`）と nullable な値（`trialEndDate` / `trialTier`）を同一 literal に手で並べ直していないことを assert（手組みに戻すと相関が消えて穴が復活するため）。flag だけ / 値だけの参照は相関を壊さないので許す
- 文言のバイト一致 assert / 射影が相関を保つこと / view に UI が読まない値を含めないこと

## 検証

### 到達可能性の実測（先に確かめたこと）

`isTrialActive: true` かつ `trialEndDate: null` は **現状のランタイムでは到達不能**。生成側 3 分岐すべてを読んだ結果:

| 生成側 | active になる条件 | trialEndDate |
|---|---|---|
| `computeTrialStatus` debug override | `if (debugOverride.endDate)` の内側でのみ active | 非 null（分岐条件そのもの） |
| `computeTrialStatus` DB 最新レコードあり | `endDate >= today` | `TrialHistoryRow.endDate` は **非 null 型**（`db/interfaces/trial-history-repo.interface.ts`）。仮に null が入っても `new Date('null...')` は Invalid Date で比較が false → active にならない |
| `computeTrialStatus` レコード無し | 常に非 active | null |

**それでも塞ぐ**のは、(a) 型が許すため**実際に repo 内で不正インスタンスが作られていた**（`plan-status-card-upgrade-cta.test.ts` が `isTrialActive: true` + `trialEndDate: null`）、(b) 表示側が `?? ''` の band-aid を抱えており「null が来たら何が出るか」が既に設計に織り込まれていた、(c) 生成側が 1 箇所増えるだけで到達可能になる、ため。

### 顧客に `null` が見える経路

`${trialEndDate}` の直接埋め込みは無い（唯一の表示経路は `SUBSCRIPTION_PAGE_LABELS.trialActiveUntil` 経由）。ただしそのラベルが `${date ?? ''} まで` で、**null なら「 まで」だけが出る**（`node -e` 実測: `" まで"`）。「最大 null 個」ほど露骨ではないが、日付の無い文が出る点で #4622 と同じ実害の形。

### failing-test-first

実装前に、現行型が不正な状態を許すことを svelte-check で確認した（probe を置き、`@ts-expect-error` が「未使用」になる = 穴の存在証明）:

```
$ npx svelte-check --tsconfig ./tsconfig.json --threshold error   # 実装前
ERROR "src\lib\server\services\zz-trial-type-hole-probe.ts" 6:1 "Unused '@ts-expect-error' directive."    # union の穴
ERROR "src\lib\server\services\zz-trial-type-hole-probe.ts" 17:1 "Unused '@ts-expect-error' directive."   # ラベルの穴
COMPLETED 8214 FILES 2 ERRORS

$ node -e "const d=null; console.log(JSON.stringify(\`\${d ?? ''} まで\`))"
" まで"
```

### mutation 検証（実装を commit した後、mutation は手で入れて手で戻した / `git stash` 不使用）

| # | 入れた mutation | 結果 |
|---|---|---|
| M1 | `TrialStatus` active 側の `trialEndDate` を `string \| null` に戻す | svelte-check **4 ERRORS**（`toTrialStatusView` の戻り / `trial-notification-service` / test の `Unused '@ts-expect-error'` + 引数型）→ 検出 |
| M2 | `trialActiveUntil` を `(date: string \| null) => ${date ?? ''} まで` に戻す | svelte-check **1 ERROR** `Unused '@ts-expect-error' directive.` → 検出 |
| M3 | subscription route の射影を手組みに戻す | vitest fitness **1 failed**（`src\routes\(parent)\admin\subscription\+page.server.ts: "trialEndDate: trialStatus.trialEndDate"`）→ 検出。**svelte-check は 0 ERRORS で素通り**（後述） |
| M4 | `TrialStatusView` active 側の `trialEndDate` を `string \| null` に戻す | svelte-check **2 ERRORS**、うち 1 件は**表示位置そのもの** `SaasLicensePanel.svelte 707:50` → 検出 |

**M3 で気づいたこと（設計に反映済み）**: `SaasLicensePanel` の `let { data } = $props()` に型注釈が無く `data` が `any` のため、**union を作っても画面側の narrowing が一度も効いていなかった**。当初の実装では M3（手組み射影）を型検査が素通りした。`trialStatus` derived に `TrialStatusView` を付けて初めて表示位置で型が働く（M4 の 707:50 がその証拠）。route 側は fitness function、表示側は型、の 2 層になった。

### コマンドと結果

```
npx biome check --write src tests scripts        → Checked 2271 files, Fixed 2 files (整形のみ)
npx svelte-check --threshold warning             → 8214 FILES 0 ERRORS 0 WARNINGS
npm run lint:svelte                              → エラーなし
npm run cspell                                   → Issues found: 0 in 0 files
node scripts/check-no-plan-literals.mjs          → OK — リテラル直書きなし
node scripts/check-repo-scan-test-declaration.mjs → OK — repo 走査 test 60 件すべて区分宣言済
npx vitest run src/lib/domain/ src/lib/server/services/ src/routes/ tests/unit/
                                                 → Test Files 724 passed (724) / Tests 10902 passed | 1 skipped
```

初回実行は **4 failed**（`admin-subscription-reconciliation.test.ts`）。trial-service を丸ごと mock している test に
`toTrialStatusView` が無かったため。mock を `importOriginal` 併用に直して解消した（射影は本物を通す — mock で
置き換えると「route が正しい射影を通しているか」を検証できなくなるため）。

CI (HEAD `fcf3e4cba`): **fail 0 / pending 0 で全 settle**。`lint-and-test` / `unit-test (1)` / `unit-test (2)` /
`unit-test-merge` / `dependency-cruiser` / `schema-change-tests-check` / `PR body 検証` すべて pass。

### lead 検収

**UI 変更なし** — `.svelte` 3 本の diff は **型注釈の追加と、描画しない dead field の宣言撤去のみ**です。テンプレート（描画される要素・文字列）に差分はありません。lead が diff を抽出して確認しました:

- `SaasLicensePanel.svelte`: `const trialStatus = $derived(data.trialStatus)` → **型注釈 `TrialStatusView | null` を付けただけ**
- `PlanStatusCard.svelte` / `admin/+layout.svelte`: **`trialEndDate: string | null` の型宣言を撤去**（どちらも描画していない dead field）

`trialActiveUntil` の `?? ''` を外した点は、**null が到達しないことを実測済み**（生成側 3 分岐を実読）なので、**表示は不変**です。

- `npm run pre-ready -- --pr 4630` **PASS** / CI fail 0 / pending 0
- **merge 順: #4625 → 本 PR**

### mutation が「当初実装の穴」を見つけています（本 PR の核心）

**M3（route の射影を手組みに戻す）で fitness function は落ちたのに、svelte-check は 0 ERRORS で素通り**しました。

原因は `SaasLicensePanel.svelte` の `let { data } = $props()` に型注釈が無く **`data` が `any`** だったこと — **union を作っても画面側の narrowing が一度も働いていませんでした**。型で塞いだつもりが、**画面まで届いていなかった**わけです。

`trialStatus` derived に `TrialStatusView` を付けて修正し、M4（view を緩める）で**表示位置そのもの**（`SaasLicensePanel.svelte 707:50`）がエラーになることを確認しています。結果、**route = fitness function / 表示位置 = 型**の 2 層になりました。

### 到達不能でも塞いだ根拠

`isTrialActive: true` + `trialEndDate: null` は**現行ランタイムでは到達不能**です（生成側 3 分岐を実読して確認）。それでも塞いだのは:

1. **型が許すため、repo 内に不正インスタンスが実在した** — `plan-status-card-upgrade-cta.test.ts:59-63` がその組み合わせを構成していた
2. 表示側が `?? ''` の band-aid を持ち、**「null が来たら何を出すか」が設計に織り込まれていた**（実測: `" まで"` だけが出る）
3. `trial-notification-service.ts:60` が**型の代わりに実行時 guard で埋め合わせていた**

## 影響範囲

顧客に見える変化: **なし**（表示文言はバイト一致で不変、ランタイム挙動も不変）。型と、trial 状態の射影の置き場所だけが変わる。

触ったファイル:

- `src/lib/server/services/trial-service.ts`（型 + `toTrialStatusView` 追加 + 分岐の書き方）
- `src/lib/server/services/trial-notification-service.ts`（冗長な実行時 guard の撤去）
- `src/lib/server/debug-plan.ts`（`DebugTrialOverride` の union 化）
- `src/lib/domain/labels.ts`（`trialActiveUntil` の引数を狭める / `?? ''` 撤去）
- `src/routes/(parent)/admin/subscription/+page.server.ts` / `src/routes/(parent)/admin/+layout.server.ts` / `+layout.svelte`
- `src/lib/features/admin/components/PlanStatusCard.svelte`（描画しない dead field の撤去）
- `tests/unit/services/trial-status-null-type-hole.test.ts`（新規）/ `tests/unit/components/plan-status-card-upgrade-cta.test.ts`（不正 fixture 是正）/ `scripts/lib/ci/repo-scan-test-registry.mjs`（#4085 区分宣言）

並行実装ペア: UI ラベルの SSOT は `labels.ts`。今回触ったのは admin 画面の期限表示のみで、LP (`site/shared-labels.js`) には配信されない。破壊的変更なし（DB / API の形は不変）。

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->



<!-- UI 変更なし — .svelte の diff は型注釈の追加と dead field 宣言の撤去のみで、テンプレートに差分なし (lead が diff 抽出で確認) -->

UI 変更なし（`.svelte` の変更は型注釈と dead field 宣言の撤去のみ。描画される要素・文字列に差分はありません）
