### PR TITLE
fix(auth): #4633 猶予期間の世帯からの招待受諾を通し、受諾拒否の無音フォールバックを塞ぐ

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -20,3 +20,213 @@ if command -v graphify >/dev/null 2>&1; then
     echo "Updating Graphify knowledge graph..."
     graphify update . || true
 fi
+
+# graphify-hook-start
+# Auto-rebuilds the knowledge graph after each commit (code files only, no LLM needed).
+# Installed by: graphify hook install
+
+# Deterministic clustering: networkx louvain iterates string-keyed sets whose
+# order is randomized per-process by PYTHONHASHSEED, so community assignments
+# churn run-to-run. Pinning it makes graphify-out reproducible.
+export PYTHONHASHSEED=0
+
+# Git for Windows/MSYS hooks can inherit fragile pipe handles from GUI clients
+# and agent shells. Keep hook-triggered rebuilds sequential by default there;
+# explicit GRAPHIFY_MAX_WORKERS still wins for users who want parallelism.
+if [ -n "${WINDIR:-}" ] || [ -n "${MSYSTEM:-}" ]; then
+    export GRAPHIFY_MAX_WORKERS="${GRAPHIFY_MAX_WORKERS:-1}"
+fi
+
+# Skip during rebase/merge/cherry-pick to avoid blocking --continue with unstaged changes
+# git exports GIT_DIR to hooks; the rev-parse fallback only runs when invoked by
+# hand (each git exec costs 1s+ on AV-scanned Windows machines).
+GIT_DIR=${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}
+[ -d "$GIT_DIR/rebase-merge" ] && exit 0
+[ -d "$GIT_DIR/rebase-apply" ] && exit 0
+[ -f "$GIT_DIR/MERGE_HEAD" ] && exit 0
+[ -f "$GIT_DIR/CHERRY_PICK_HEAD" ] && exit 0
+
+[ "${GRAPHIFY_SKIP_HOOK:-0}" = "1" ] && exit 0
+
+_GFY_GITDIR=$(cd "$(git rev-parse --git-dir 2>/dev/null)" 2>/dev/null && pwd)
+_GFY_COMMONDIR=$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)
+if [ -n "$_GFY_COMMONDIR" ] && [ "$_GFY_GITDIR" != "$_GFY_COMMONDIR" ]; then
+    exit 0
+fi
+
+CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git diff --name-only HEAD 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+    exit 0
+fi
+
+# Skip when only graphify-out/ artifacts changed (avoids rebuild loop when graph outputs are tracked in git)
+_NON_GRAPH=$(echo "$CHANGED" | grep -v '^graphify-out/' || true)
+if [ -z "$_NON_GRAPH" ]; then
+    exit 0
+fi
+
+# Detect the correct Python interpreter (handles uv tool, pipx, venv, system installs).
+# _PINNED was recorded at hook-install time; tried first so the hook works even
+# when the graphify launcher is not on PATH (common in GUI clients and CI).
+#
+# Probes check availability with importlib.util.find_spec instead of importing
+# the package: a probe that imports graphify wholesale executes the full package
+# import (10s+ cold on machines with AV-scanned or large site-packages) and used
+# to run up to FOUR times synchronously, stalling every commit before the
+# detached launch even started. find_spec locates the package without executing
+# it, so each probe costs interpreter startup only. The detached rebuild still
+# fails loudly in the log if the package is broken under that interpreter.
+_GFY_PROBE="import importlib.util, sys; sys.exit(0 if importlib.util.find_spec('graphify') else 1)"
+GRAPHIFY_PYTHON=""
+_PINNED='C:\Users\kokor\AppData\Roaming\uv\tools\graphifyy\Scripts\python.exe'
+if [ -n "$_PINNED" ] && [ -x "$_PINNED" ] && "$_PINNED" -c "$_GFY_PROBE" 2>/dev/null; then
+    GRAPHIFY_PYTHON="$_PINNED"
+fi
+# Second probe: read graphify-out/.graphify_python (written by the skill and
+# CLI; survives uv-tool reinstalls and is the same source the README documents).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    _GFY_PYTHON_FILE="graphify-out/.graphify_python"
+    if [ -f "$_GFY_PYTHON_FILE" ]; then
+        _FROM_FILE=$(cat "$_GFY_PYTHON_FILE" 2>/dev/null | tr -d '[:space:]')
+        case "$_FROM_FILE" in
+            *[!a-zA-Z0-9/_.@:\\-]*) _FROM_FILE="" ;;  # allowlist (covers Windows paths)
+        esac
+        if [ -n "$_FROM_FILE" ] && [ -x "$_FROM_FILE" ] && "$_FROM_FILE" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_FROM_FILE"
+        fi
+    fi
+fi
+# Third probe: resolve via the graphify launcher on PATH.
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    GRAPHIFY_BIN=$(command -v graphify 2>/dev/null)
+    if [ -n "$GRAPHIFY_BIN" ]; then
+        # Windows pip layout: Scripts/graphify(.exe) sits beside ..\python.exe
+        # (or .\python.exe inside a venv's Scripts dir). NOTE: command -v may
+        # return the launcher path WITHOUT the .exe suffix, so this cannot key
+        # on the extension.
+        _GFY_BINDIR=$(dirname "$GRAPHIFY_BIN")
+        if [ -x "$_GFY_BINDIR/../python.exe" ] && "$_GFY_BINDIR/../python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/../python.exe"
+        elif [ -x "$_GFY_BINDIR/python.exe" ] && "$_GFY_BINDIR/python.exe" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON="$_GFY_BINDIR/python.exe"
+        fi
+    fi
+    if [ -z "$GRAPHIFY_PYTHON" ] && [ -n "$GRAPHIFY_BIN" ]; then
+        # POSIX launcher: parse the shebang. head -c + tr strip NUL bytes first —
+        # when the launcher is a Windows binary reached without its .exe suffix,
+        # a raw `head -1` reads binary into the command substitution and the
+        # shell warns about ignored null bytes on every commit.
+        case "$GRAPHIFY_BIN" in
+            *.exe) _SHEBANG="" ;;
+            *)     _SHEBANG=$(head -c 256 "$GRAPHIFY_BIN" 2>/dev/null | tr -d '\000' | head -n 1 | sed 's/^#![[:space:]]*//') ;;
+        esac
+        case "$_SHEBANG" in
+            */env\ *) GRAPHIFY_PYTHON="${_SHEBANG#*/env }" ;;
+            *)         GRAPHIFY_PYTHON="$_SHEBANG" ;;
+        esac
+        # Allowlist: only keep characters valid in a filesystem path to prevent
+        # injection if the shebang contains shell metacharacters.
+        case "$GRAPHIFY_PYTHON" in
+            *[!a-zA-Z0-9/_.@:\\-]*) GRAPHIFY_PYTHON="" ;;
+        esac
+        if [ -n "$GRAPHIFY_PYTHON" ] && ! "$GRAPHIFY_PYTHON" -c "$_GFY_PROBE" 2>/dev/null; then
+            GRAPHIFY_PYTHON=""
+        fi
+    fi
+fi
+# Last resort: try python3 / python (works for system/venv installs on PATH).
+if [ -z "$GRAPHIFY_PYTHON" ]; then
+    if command -v python3 >/dev/null 2>&1 && python3 -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python3"
+    elif command -v python >/dev/null 2>&1 && python -c "$_GFY_PROBE" 2>/dev/null; then
+        GRAPHIFY_PYTHON="python"
+    else
+        echo "[graphify hook] could not locate a Python with graphify installed. Add the graphify bin dir to PATH or re-run 'graphify hook install' from the env where graphify lives." >&2
+        exit 0
+    fi
+fi
+
+export GRAPHIFY_CHANGED="$CHANGED"
+
+# Run the rebuild detached so git commit returns immediately. Full-repo rebuilds
+# can take hours; blocking the post-commit hook stalls the shell. The Python
+# launcher below detaches the child cross-platform, so it works on Git for
+# Windows' shell too (which lacks the coreutils backgrounding tools) (#1161).
+_GRAPHIFY_LOG="${HOME}/.cache/graphify-rebuild.log"
+mkdir -p "$(dirname "$_GRAPHIFY_LOG")"
+export GRAPHIFY_REBUILD_LOG="$_GRAPHIFY_LOG"
+echo "[graphify hook] launching background rebuild (log: $_GRAPHIFY_LOG)"
+"$GRAPHIFY_PYTHON" -c "import os, subprocess, sys
+_src = '''
+import os, signal, sys, threading
+from pathlib import Path
+
+changed_raw = os.environ.get('GRAPHIFY_CHANGED', '')
+changed = [Path(f.strip()) for f in changed_raw.strip().splitlines() if f.strip()]
+
+if not changed:
+    sys.exit(0)
+
+print(f'[graphify hook] {len(changed)} file(s) changed - rebuilding graph...')
+
+try:
+    from graphify.watch import _rebuild_code, _apply_resource_limits
+    _apply_resource_limits()
+    _timeout = int(os.environ.get('GRAPHIFY_REBUILD_TIMEOUT', '600'))
+    if _timeout > 0:
+        if hasattr(signal, 'SIGALRM'):
+            signal.signal(signal.SIGALRM, lambda *_: (_ for _ in ()).throw(TimeoutError(f'graphify rebuild exceeded {_timeout}s')))
+            signal.alarm(_timeout)
+        else:
+            def _bail():
+                print(f'[graphify hook] graphify rebuild exceeded {_timeout}s', flush=True)
+                os._exit(1)
+            _watchdog = threading.Timer(_timeout, _bail)
+            _watchdog.daemon = True
+            _watchdog.start()
+    _force = os.environ.get('GRAPHIFY_FORCE', '').lower() in ('1', 'true', 'yes')
+    _root = Path('.')
+    _out = os.environ.get('GRAPHIFY_OUT', 'graphify-out')
+    _saved = Path(_out) / '.graphify_root'
+    if _saved.exists():
+        _txt = _saved.read_text(encoding='utf-8').strip()
+        if _txt:
+            _root = Path(_txt)
+    _rebuild_code(_root, changed_paths=changed, force=_force)
+    # Refresh the work-memory lessons doc when saved Q&A outcomes exist
+    # (best-effort; never fails the hook).
+    try:
+        _md = (_root / _out) / 'memory'
+        if _md.is_dir() and any(_md.glob('*.md')):
+            from graphify.reflect import reflect as _reflect
+            _gj = (_root / _out) / 'graph.json'
+            _reflect(memory_dir=_md, out_path=(_root / _out) / 'reflections' / 'LESSONS.md',
+                     graph_path=_gj if _gj.exists() else None)
+    except Exception:
+        pass
+except TimeoutError as exc:
+    print(f'[graphify hook] {exc}')
+    sys.exit(1)
+except Exception as exc:
+    print(f'[graphify hook] Rebuild failed: {exc}')
+    sys.exit(1)
+
+'''
+_log = os.environ.get('GRAPHIFY_REBUILD_LOG') or os.path.join(os.path.expanduser('~'), '.cache', 'graphify-rebuild.log')
+try:
+    os.makedirs(os.path.dirname(_log), exist_ok=True)
+    _out = open(_log, 'a', buffering=1, encoding='utf-8', errors='replace')
+except OSError:
+    _out = subprocess.DEVNULL
+_kw = dict(stdout=_out, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, cwd=os.getcwd(), close_fds=True)
+_cmd = [sys.executable, '-c', _src]
+if os.name == 'nt':
+    _flags = 0x08000000 | 0x00000200  # CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP
+    try:
+        subprocess.Popen(_cmd, creationflags=_flags | 0x01000000, **_kw)  # + CREATE_BREAKAWAY_FROM_JOB
+    except OSError:
+        subprocess.Popen(_cmd, creationflags=_flags, **_kw)
+else:
+    subprocess.Popen(_cmd, start_new_session=True, **_kw)
+"
+# graphify-hook-end

--- a/scripts/capture-specs/flows/invite-accept-error-banner-4633.mjs
+++ b/scripts/capture-specs/flows/invite-accept-error-banner-4633.mjs
@@ -54,7 +54,13 @@ export default async (page, capture) => {
 		// バナーは SSR 出力に含まれる (server load の戻り値)。修正前 build では出ないため
 		// 存在待ちはせず、レイアウトが描画され切ったところで撮る。
 		await page.locator('main, [data-testid="admin-resource-header"], body').first().waitFor();
-		await page.waitForTimeout(300);
+		// 描画の落ち着きは固定時間ではなく 2 フレーム待ちで取る (#1208: scripts/ で waitForTimeout 禁止)
+		await page.evaluate(
+			() =>
+				new Promise((resolve) =>
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))),
+				),
+		);
 		await capture(`${PHASE}-invite-accept-error-${reason.toLowerCase().replace(/_/g, '-')}`);
 	}
 };

--- a/scripts/capture-specs/flows/invite-accept-error-banner-4633.mjs
+++ b/scripts/capture-specs/flows/invite-accept-error-banner-4633.mjs
@@ -1,0 +1,60 @@
+/**
+ * scripts/capture-specs/flows/invite-accept-error-banner-4633.mjs
+ *
+ * Issue #4633 AC-A: 招待受諾が拒否されたとき、admin に「なぜ参加できなかったか + 次アクション」の
+ * 案内バナーが出ることの before / after SS。
+ *
+ * 受諾拒否は理由を通知 cookie (`invite_accept_error`) に積み、admin +layout.server.ts が
+ * 読み取って即消費する。ここでは cookie を直接積むことで、招待受諾の実フロー
+ * (cognito + DSQL が要る、local backend では原理的に検証不能 #3732) を通さずに
+ * 「拒否理由 → 画面に何が出るか」だけを決定的に撮る。
+ *
+ * 撮影する 2 コマ (どちらの build でも同じ操作列):
+ *   1. TENANT_NOT_FOUND (猶予期間の世帯からの招待が落ちたときの理由)
+ *      - 修正前 (origin/main, SS_PHASE=before-*): 許可リストが email 束縛 2 理由限定のため
+ *        バナーは出ず、無説明の空 admin に着地する
+ *      - 修正後 (本 PR, SS_PHASE=after-*): 理由 + 次アクションのバナーが出る
+ *   2. ALREADY_IN_TENANT (既に別グループに所属していて受諾できなかったとき)
+ *      - 修正前: 同上 (無音)
+ *      - 修正後: バナーが出る
+ *
+ * 使用例 (dev server = AUTH_MODE=local を別途起動):
+ *   SS_PHASE=after BASE_URL=http://localhost:5173 \
+ *     node scripts/capture.mjs \
+ *     --flow invite-accept-error-banner-4633 \
+ *     --url /admin \
+ *     --actions scripts/capture-specs/flows/invite-accept-error-banner-4633.mjs \
+ *     --presets desktop --pr 4634
+ */
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
+const PHASE = process.env.SS_PHASE || 'after';
+
+/** 通知 cookie は admin +layout.server.ts が 1 回読んだら消すため、コマごとに積み直す。 */
+async function seedReasonCookie(page, reason) {
+	const url = new URL(BASE_URL);
+	await page.context().addCookies([
+		{
+			name: 'invite_accept_error',
+			value: reason,
+			domain: url.hostname,
+			path: '/',
+		},
+	]);
+}
+
+/**
+ * @param {import('playwright').Page} page
+ * @param {(label: string) => Promise<string>} capture
+ */
+export default async (page, capture) => {
+	for (const reason of ['TENANT_NOT_FOUND', 'ALREADY_IN_TENANT']) {
+		await seedReasonCookie(page, reason);
+		await page.goto(`${BASE_URL}/admin`, { waitUntil: 'domcontentloaded' });
+		// バナーは SSR 出力に含まれる (server load の戻り値)。修正前 build では出ないため
+		// 存在待ちはせず、レイアウトが描画され切ったところで撮る。
+		await page.locator('main, [data-testid="admin-resource-header"], body').first().waitFor();
+		await page.waitForTimeout(300);
+		await capture(`${PHASE}-invite-accept-error-${reason.toLowerCase().replace(/_/g, '-')}`);
+	}
+};

--- a/src/lib/domain/labels.ts
+++ b/src/lib/domain/labels.ts
@@ -6018,7 +6018,43 @@ export const AUTH_INVITE_LABELS = {
 		'招待は別のメールアドレス宛だったため参加できず、新しい家族グループが作成されました。招待で参加するには、招待した方にあなたのメールアドレス宛の招待を発行し直してもらってください。',
 	acceptErrorUnverifiedBanner:
 		'メールアドレスの確認が完了していないため招待を受諾できず、新しい家族グループが作成されました。メールアドレスの確認後、招待した方に新しい招待を発行してもらってください。',
+	// #4633 AC-A: email 束縛以外の受諾拒否も、同じく無音で「新しい家族グループの owner」に
+	// 化ける。理由ごとに「なぜ参加できなかったか + 次アクション」を必ず添える。
+	acceptErrorExpiredBanner:
+		'招待の有効期限が切れていたため参加できず、新しい家族グループが作成されました。招待した方に、新しい招待リンクを発行してもらってください。',
+	acceptErrorTenantNotFoundBanner:
+		'招待元の家族グループが現在ご利用できない状態のため参加できず、新しい家族グループが作成されました。招待した方に、お支払い状況をご確認のうえ改めて招待を発行してもらってください。',
+	acceptErrorAlreadyInTenantBanner:
+		'すでに別の家族グループに参加しているため招待を受けられず、新しい家族グループが作成されました。招待で参加するには、一度ログアウトして別のアカウントで招待リンクを開いてください。',
+	acceptErrorSelfInviteBanner:
+		'ご自身が発行した招待は受け取れないため参加できず、新しい家族グループが作成されました。参加する方ご本人のアカウントで招待リンクを開いてください。',
+	acceptErrorOwnerDowngradeBanner:
+		'すでにこの家族グループの管理者のため招待を受けられず、新しい家族グループが作成されました。管理者のまま参加を続ける場合、この招待は受け取る必要はありません。',
+	acceptErrorGenericBanner:
+		'招待を受け取れなかったため、新しい家族グループが作成されました。招待した方に、招待リンクを発行し直してもらってください。',
 } as const;
+
+/**
+ * #4633 AC-A: 受諾拒否理由 → 案内バナー文言の対応表 (SSOT)。
+ * 理由の一覧は `INVITE_ACCEPT_ERROR_REASONS` (`$lib/domain/validation/auth`) 側が持つ。
+ */
+export const INVITE_ACCEPT_ERROR_BANNERS = {
+	INVITE_EMAIL_MISMATCH: AUTH_INVITE_LABELS.acceptErrorMismatchBanner,
+	INVITE_EMAIL_UNVERIFIED: AUTH_INVITE_LABELS.acceptErrorUnverifiedBanner,
+	INVALID_OR_EXPIRED: AUTH_INVITE_LABELS.acceptErrorExpiredBanner,
+	TENANT_NOT_FOUND: AUTH_INVITE_LABELS.acceptErrorTenantNotFoundBanner,
+	ALREADY_IN_TENANT: AUTH_INVITE_LABELS.acceptErrorAlreadyInTenantBanner,
+	SELF_INVITE_NOT_ALLOWED: AUTH_INVITE_LABELS.acceptErrorSelfInviteBanner,
+	OWNER_CANNOT_BE_DOWNGRADED: AUTH_INVITE_LABELS.acceptErrorOwnerDowngradeBanner,
+} as const;
+
+/** 未知の理由 (古い cookie / 想定外) は汎用文言にフォールバックする。 */
+export function getInviteAcceptErrorBanner(reason: string): string {
+	return (
+		(INVITE_ACCEPT_ERROR_BANNERS as Record<string, string>)[reason] ??
+		AUTH_INVITE_LABELS.acceptErrorGenericBanner
+	);
+}
 
 // DEMO_ACHIEVEMENTS_LABELS: 実績機能廃止 (#1782 / #1816) で参照ゼロのため namespace 削除 (#1833)
 

--- a/src/lib/domain/validation/auth.ts
+++ b/src/lib/domain/validation/auth.ts
@@ -99,10 +99,10 @@ export type InviteAcceptErrorReason = (typeof INVITE_ACCEPT_ERROR_REASONS)[numbe
  * cookie 値が既知の拒否理由かを判定する。未知の値 (古い cookie / 改竄) は
  * 呼び出し側で汎用文言にフォールバックさせる。
  */
-export function isInviteAcceptErrorReason(value: string | undefined): value is InviteAcceptErrorReason {
-	return (
-		value !== undefined && (INVITE_ACCEPT_ERROR_REASONS as readonly string[]).includes(value)
-	);
+export function isInviteAcceptErrorReason(
+	value: string | undefined,
+): value is InviteAcceptErrorReason {
+	return value !== undefined && (INVITE_ACCEPT_ERROR_REASONS as readonly string[]).includes(value);
 }
 
 export const createInviteSchema = z.object({

--- a/src/lib/domain/validation/auth.ts
+++ b/src/lib/domain/validation/auth.ts
@@ -68,12 +68,42 @@ export const REFRESH_COOKIE_NAME = 'gq_refresh';
 export const INVITE_COOKIE_NAME = 'invite_code';
 export const INVITE_EXPIRY_DAYS = 7;
 /**
- * #3555 ①: 招待受諾が email 束縛で拒否されたことを受諾後の画面 (admin layout) に伝える
- * 1 回限りの通知 cookie。値は 'INVITE_EMAIL_MISMATCH' | 'INVITE_EMAIL_UNVERIFIED'。
+ * #3555 ①: 招待受諾が拒否されたことを受諾後の画面 (admin layout) に伝える 1 回限りの通知 cookie。
  * 受諾失敗 → 新規テナント自動作成で顧客が理由不明の dead-end になるのを防ぐ。
+ *
+ * #4633 AC-A: 通知対象は email 束縛の 2 理由だけではない。受諾拒否は **すべて**
+ * 「無音で新しい家族グループの owner になる」に化けるため、`acceptInvite` が返しうる
+ * 全 error 理由を本 cookie に載せる (未知の値も汎用文言でバナー表示する)。
  */
 export const INVITE_ACCEPT_ERROR_COOKIE_NAME = 'invite_accept_error';
 export const INVITE_ACCEPT_ERROR_MAX_AGE_SECONDS = 10 * 60;
+
+/**
+ * #4633 AC-A: 通知 cookie に載る受諾拒否理由の SSOT。
+ * `acceptInvite` (invite-service.ts) が返す error 文字列と 1:1 で対応する。
+ * 新しい拒否理由を追加したら、本配列と `INVITE_ACCEPT_ERROR_BANNERS` (labels.ts) を同時に足す。
+ */
+export const INVITE_ACCEPT_ERROR_REASONS = [
+	'INVITE_EMAIL_MISMATCH',
+	'INVITE_EMAIL_UNVERIFIED',
+	'INVALID_OR_EXPIRED',
+	'TENANT_NOT_FOUND',
+	'ALREADY_IN_TENANT',
+	'SELF_INVITE_NOT_ALLOWED',
+	'OWNER_CANNOT_BE_DOWNGRADED',
+] as const;
+
+export type InviteAcceptErrorReason = (typeof INVITE_ACCEPT_ERROR_REASONS)[number];
+
+/**
+ * cookie 値が既知の拒否理由かを判定する。未知の値 (古い cookie / 改竄) は
+ * 呼び出し側で汎用文言にフォールバックさせる。
+ */
+export function isInviteAcceptErrorReason(value: string | undefined): value is InviteAcceptErrorReason {
+	return (
+		value !== undefined && (INVITE_ACCEPT_ERROR_REASONS as readonly string[]).includes(value)
+	);
+}
 
 export const createInviteSchema = z.object({
 	role: z.enum(['parent', 'child']),

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -221,6 +221,8 @@ export class CognitoAuthProvider implements AuthProvider {
 				logger.warn('[AUTH] Invite not found or expired', {
 					context: { inviteCode },
 				});
+				// #4633 AC-A: ここも「無音で新規家族グループ作成」に化ける経路。理由を通知する。
+				this.setInviteAcceptErrorCookie(event, 'INVALID_OR_EXPIRED');
 				this.clearInviteCookie(event);
 				return null;
 			}
@@ -251,21 +253,13 @@ export class CognitoAuthProvider implements AuthProvider {
 				logger.warn('[AUTH] Invite acceptance failed', {
 					context: { inviteCode, error: result.error, userId: effectiveUserId },
 				});
-				// #3555 ①: email 束縛による拒否は受諾者に理由を伝えないと dead-end になる
+				// #3555 ① / #4633 AC-A: 受諾拒否は理由を伝えないと dead-end になる
 				// (この後 fallback の新規テナント自動作成が走り、無説明の空 admin に着地する)。
 				// 1 回限りの通知 cookie を積み、admin +layout が読み取って案内バナーを表示する。
-				if (
-					result.error === 'INVITE_EMAIL_MISMATCH' ||
-					result.error === 'INVITE_EMAIL_UNVERIFIED'
-				) {
-					event.cookies.set(INVITE_ACCEPT_ERROR_COOKIE_NAME, result.error, {
-						path: '/',
-						httpOnly: true,
-						sameSite: 'lax',
-						secure: true,
-						maxAge: INVITE_ACCEPT_ERROR_MAX_AGE_SECONDS,
-					});
-				}
+				// #4633: 旧実装は email 束縛の 2 理由限定だったため、それ以外の拒否
+				// (TENANT_NOT_FOUND / ALREADY_IN_TENANT / SELF_INVITE_NOT_ALLOWED /
+				// OWNER_CANNOT_BE_DOWNGRADED …) が無音のまま残っていた。理由を問わず通知する。
+				this.setInviteAcceptErrorCookie(event, result.error);
 				return null;
 			}
 
@@ -283,9 +277,29 @@ export class CognitoAuthProvider implements AuthProvider {
 			logger.error('[AUTH] Failed to accept invite', {
 				error: e instanceof Error ? e.message : String(e),
 			});
+			// #4633 AC-A: 例外経路も無音の新規家族グループ作成に化けるため通知する
+			// (内部例外は露出せず汎用文言のバナーに落とす、ADR-0062)。
+			this.setInviteAcceptErrorCookie(event, 'UNEXPECTED');
 			this.clearInviteCookie(event);
 			return null;
 		}
+	}
+
+	/**
+	 * #4633 AC-A: 招待受諾が拒否されたことを受諾後の admin 画面に伝える 1 回限りの通知 cookie。
+	 *
+	 * 拒否は例外なくこの後の `provisionNewUser` (新規家族グループ自動作成) にフォールバックする。
+	 * 通知を積まないと「招待されたはずの人が、別世帯の owner として空の管理画面に着地する」
+     * 失敗が成功に見える経路になる。理由の一覧 SSOT は `INVITE_ACCEPT_ERROR_REASONS`。
+	 */
+	private setInviteAcceptErrorCookie(event: RequestEvent, reason: string): void {
+		event.cookies.set(INVITE_ACCEPT_ERROR_COOKIE_NAME, reason, {
+			path: '/',
+			httpOnly: true,
+			sameSite: 'lax',
+			secure: true,
+			maxAge: INVITE_ACCEPT_ERROR_MAX_AGE_SECONDS,
+		});
 	}
 
 	/**

--- a/src/lib/server/auth/providers/cognito.ts
+++ b/src/lib/server/auth/providers/cognito.ts
@@ -290,7 +290,7 @@ export class CognitoAuthProvider implements AuthProvider {
 	 *
 	 * 拒否は例外なくこの後の `provisionNewUser` (新規家族グループ自動作成) にフォールバックする。
 	 * 通知を積まないと「招待されたはずの人が、別世帯の owner として空の管理画面に着地する」
-     * 失敗が成功に見える経路になる。理由の一覧 SSOT は `INVITE_ACCEPT_ERROR_REASONS`。
+	 * 失敗が成功に見える経路になる。理由の一覧 SSOT は `INVITE_ACCEPT_ERROR_REASONS`。
 	 */
 	private setInviteAcceptErrorCookie(event: RequestEvent, reason: string): void {
 		event.cookies.set(INVITE_ACCEPT_ERROR_COOKIE_NAME, reason, {

--- a/src/lib/server/services/invite-service.ts
+++ b/src/lib/server/services/invite-service.ts
@@ -2,7 +2,7 @@ import type { ChildId } from '$lib/domain/ids';
 // src/lib/server/services/invite-service.ts
 // 招待リンクサービス (#0129)
 
-import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
+import { isEntitledStatus } from '$lib/domain/constants/subscription-status';
 import type { Invite, Membership } from '$lib/server/auth/entities';
 import { checkInviteEmailBinding } from '$lib/server/auth/invite-email-binding';
 import type { Role } from '$lib/server/auth/types';
@@ -83,9 +83,13 @@ async function preflightAcceptInvite(
 		return existing?.role === 'owner' ? 'OWNER_CANNOT_BE_DOWNGRADED' : 'ALREADY_IN_TENANT';
 	}
 
-	// テナントの存在確認
+	// テナントの存在確認。
+	// #4633: 判定は「機能が利用可能な status か」= isEntitledStatus (active + grace_period)。
+	// active 厳密一致だと、支払いが 1 回失敗して猶予期間に入っただけの有料世帯からの招待が
+	// すべて TENANT_NOT_FOUND で拒否される (機能自体は使えている世帯なのに受諾だけ落ちる)。
+	// suspended / terminated は従来どおり拒否のまま。
 	const tenant = await repos().auth.findTenantById(invite.tenantId);
-	if (!tenant || tenant.status !== SUBSCRIPTION_STATUS.ACTIVE) return 'TENANT_NOT_FOUND';
+	if (!tenant || !isEntitledStatus(tenant.status)) return 'TENANT_NOT_FOUND';
 
 	return null;
 }

--- a/src/routes/(parent)/admin/+layout.server.ts
+++ b/src/routes/(parent)/admin/+layout.server.ts
@@ -174,15 +174,13 @@ export const load: LayoutServerLoad = async ({ locals, cookies, url }) => {
 		}
 	}
 
-	// #3555 ①: 招待受諾が email 束縛で拒否された直後の案内 (1 回限りの通知 cookie を
+	// #3555 ① / #4633 AC-A: 招待受諾が拒否された直後の案内 (1 回限りの通知 cookie を
 	// 読み取り即消費)。受諾失敗 → 新規テナント自動作成で無説明の空 admin に着地した
 	// 顧客に「なぜ招待で参加できなかったか + 次アクション」をバナーで伝える。
+	// #4633: 拒否理由は email 束縛の 2 種に限らない。未知の値も握り潰さず汎用文言で出す
+	// (握り潰すと「失敗が成功に見える」性質がそのまま残るため)。
 	const rawInviteAcceptError = cookies.get(INVITE_ACCEPT_ERROR_COOKIE_NAME);
-	const inviteAcceptError =
-		rawInviteAcceptError === 'INVITE_EMAIL_MISMATCH' ||
-		rawInviteAcceptError === 'INVITE_EMAIL_UNVERIFIED'
-			? rawInviteAcceptError
-			: null;
+	const inviteAcceptError = rawInviteAcceptError ? rawInviteAcceptError : null;
 	if (rawInviteAcceptError) {
 		cookies.delete(INVITE_ACCEPT_ERROR_COOKIE_NAME, { path: '/' });
 	}

--- a/src/routes/(parent)/admin/+layout.svelte
+++ b/src/routes/(parent)/admin/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { Snippet } from 'svelte';
-import { AUTH_INVITE_LABELS } from '$lib/domain/labels';
+import { getInviteAcceptErrorBanner } from '$lib/domain/labels';
 import AdminLayout from '$lib/features/admin/components/AdminLayout.svelte';
 import SetupResumeBanner from '$lib/features/admin/components/SetupResumeBanner.svelte';
 import TrialBanner from '$lib/features/admin/components/TrialBanner.svelte';
@@ -38,7 +38,9 @@ interface Props {
 		// AdminLayout へ橋渡しし、Stripe 無効時に requiredStripe='enabled' ガイド手順を除外する。
 		stripeEnabled?: boolean;
 		// #3555 ①: 招待受諾が email 束縛で拒否された直後の 1 回限り案内 (通知 cookie 由来)
-		inviteAcceptError?: 'INVITE_EMAIL_MISMATCH' | 'INVITE_EMAIL_UNVERIFIED' | null;
+		// #4633 AC-A: 拒否理由は email 束縛の 2 種に限らない (文言解決は
+		// getInviteAcceptErrorBanner が担い、未知の理由は汎用文言に落ちる)。
+		inviteAcceptError?: string | null;
 	};
 	children: Snippet;
 }
@@ -92,9 +94,7 @@ $effect(() => {
 			<Alert
 				variant="warning"
 				data-testid="invite-accept-error-banner"
-				message={data.inviteAcceptError === 'INVITE_EMAIL_UNVERIFIED'
-					? AUTH_INVITE_LABELS.acceptErrorUnverifiedBanner
-					: AUTH_INVITE_LABELS.acceptErrorMismatchBanner}
+				message={getInviteAcceptErrorBanner(data.inviteAcceptError)}
 			/>
 		</div>
 	{/if}

--- a/tests/unit/services/invite-service.test.ts
+++ b/tests/unit/services/invite-service.test.ts
@@ -317,21 +317,21 @@ describe('acceptInvite', () => {
 
 	// #4633: 緩和は grace_period までで、機能停止・退会済からの受諾は従来どおり拒否する
 	// (entitled 判定を「常に true」に緩めた瞬間に落ちる)。
-	it.each([SUBSCRIPTION_STATUS.SUSPENDED, SUBSCRIPTION_STATUS.TERMINATED])(
-		'entitled でないテナント (%s) からの招待は受諾できない (#4633)',
-		async (status) => {
-			inviteStore.set(`acc-${status}`, makePendingInvite({ inviteCode: `acc-${status}` }));
-			tenantStore.set('t-test', {
-				tenantId: 't-test',
-				status,
-				createdAt: new Date().toISOString(),
-			} as Tenant);
+	it.each([
+		SUBSCRIPTION_STATUS.SUSPENDED,
+		SUBSCRIPTION_STATUS.TERMINATED,
+	])('entitled でないテナント (%s) からの招待は受諾できない (#4633)', async (status) => {
+		inviteStore.set(`acc-${status}`, makePendingInvite({ inviteCode: `acc-${status}` }));
+		tenantStore.set('t-test', {
+			tenantId: 't-test',
+			status,
+			createdAt: new Date().toISOString(),
+		} as Tenant);
 
-			const result = assertError(await acceptInvite(`acc-${status}`, `user-${status}`));
-			expect(result.error).toBe('TENANT_NOT_FOUND');
-			expect(membershipStore).toHaveLength(0);
-		},
-	);
+		const result = assertError(await acceptInvite(`acc-${status}`, `user-${status}`));
+		expect(result.error).toBe('TENANT_NOT_FOUND');
+		expect(membershipStore).toHaveLength(0);
+	});
 
 	it('自分で作成した招待は受諾できない (#0203)', async () => {
 		inviteStore.set(

--- a/tests/unit/services/invite-service.test.ts
+++ b/tests/unit/services/invite-service.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SUBSCRIPTION_STATUS } from '$lib/domain/constants/subscription-status';
 import { asChildId } from '$lib/domain/ids';
+import { INVITE_ACCEPT_ERROR_BANNERS } from '$lib/domain/labels';
+import {
+	INVITE_ACCEPT_ERROR_REASONS,
+	type InviteAcceptErrorReason,
+	isInviteAcceptErrorReason,
+} from '$lib/domain/validation/auth';
 import type { Invite, Membership, Tenant } from '../../../src/lib/server/auth/entities';
 import type { IAuthRepo } from '../../../src/lib/server/db/interfaces/auth-repo.interface';
 import { assertError, assertSuccess } from '../helpers/assert-result';
@@ -290,6 +297,42 @@ describe('acceptInvite', () => {
 		expect(result.error).toBe('TENANT_NOT_FOUND');
 	});
 
+	// #4633: 支払いが 1 回失敗して猶予期間 (grace_period) に入っただけの有料世帯は、機能自体は
+	// 利用できている (isEntitledStatus=true)。ここを 'active' 厳密一致で判定していたため、
+	// 招待の作成は通るのに受諾だけが TENANT_NOT_FOUND で落ち、しかもその失敗が無音で
+	// 「新しい家族グループの作成」に化けていた。判定は entitled 集合で行う。
+	it('猶予期間 (grace_period) のテナントからの招待は受諾できる (#4633)', async () => {
+		inviteStore.set('acc-grace', makePendingInvite({ inviteCode: 'acc-grace' }));
+		tenantStore.set('t-test', {
+			tenantId: 't-test',
+			status: SUBSCRIPTION_STATUS.GRACE_PERIOD,
+			createdAt: new Date().toISOString(),
+		} as Tenant);
+
+		const result = assertSuccess(await acceptInvite('acc-grace', 'grace-user'));
+		expect(result.membership.tenantId).toBe('t-test');
+		expect(result.membership.role).toBe('parent');
+		expect(inviteStore.get('acc-grace')?.status).toBe('accepted');
+	});
+
+	// #4633: 緩和は grace_period までで、機能停止・退会済からの受諾は従来どおり拒否する
+	// (entitled 判定を「常に true」に緩めた瞬間に落ちる)。
+	it.each([SUBSCRIPTION_STATUS.SUSPENDED, SUBSCRIPTION_STATUS.TERMINATED])(
+		'entitled でないテナント (%s) からの招待は受諾できない (#4633)',
+		async (status) => {
+			inviteStore.set(`acc-${status}`, makePendingInvite({ inviteCode: `acc-${status}` }));
+			tenantStore.set('t-test', {
+				tenantId: 't-test',
+				status,
+				createdAt: new Date().toISOString(),
+			} as Tenant);
+
+			const result = assertError(await acceptInvite(`acc-${status}`, `user-${status}`));
+			expect(result.error).toBe('TENANT_NOT_FOUND');
+			expect(membershipStore).toHaveLength(0);
+		},
+	);
+
 	it('自分で作成した招待は受諾できない (#0203)', async () => {
 		inviteStore.set(
 			'self-inv',
@@ -316,6 +359,71 @@ describe('acceptInvite', () => {
 
 		const result = assertError(await acceptInvite('downgrade', 'owner-user'));
 		expect(result.error).toBe('OWNER_CANNOT_BE_DOWNGRADED');
+	});
+
+	// #4633 AC-A (no-silent-gap): 受諾拒否は例外なく「新規家族グループの自動作成」に
+	// フォールバックするため、通知バナーに載らない理由が 1 つでもあると「失敗が成功に見える」
+	// 経路が残る。acceptInvite が実際に返す全 error 理由が、通知理由 SSOT
+	// (INVITE_ACCEPT_ERROR_REASONS) と文言表 (INVITE_ACCEPT_ERROR_BANNERS) の両方に
+	// 登録されていることを固定する。新しい拒否理由を無登録で足した瞬間に落ちる。
+	it('受諾拒否の全理由が通知バナーの SSOT に登録されている (#4633 AC-A)', async () => {
+		const observed = new Set<string>();
+
+		// 無効 / 期限切れ
+		observed.add(assertError(await acceptInvite('no-such-code', 'u1')).error);
+
+		// 自己招待
+		inviteStore.set('g-self', makePendingInvite({ inviteCode: 'g-self', invitedBy: 'u-self' }));
+		observed.add(assertError(await acceptInvite('g-self', 'u-self')).error);
+
+		// email 束縛 (未検証 / 不一致)
+		inviteStore.set(
+			'g-unverified',
+			makePendingInvite({ inviteCode: 'g-unverified', email: 'invited@example.com' }),
+		);
+		observed.add(
+			assertError(
+				await acceptInvite('g-unverified', 'u2', 'invited@example.com', {
+					emailVerified: false,
+				}),
+			).error,
+		);
+		inviteStore.set(
+			'g-mismatch',
+			makePendingInvite({ inviteCode: 'g-mismatch', email: 'invited@example.com' }),
+		);
+		observed.add(
+			assertError(
+				await acceptInvite('g-mismatch', 'u3', 'other@example.com', { emailVerified: true }),
+			).error,
+		);
+
+		// 既に別グループ所属 / owner ダウングレード
+		inviteStore.set('g-already', makePendingInvite({ inviteCode: 'g-already' }));
+		userTenantStore.set('u4', [
+			{ userId: 'u4', tenantId: 't-other', role: 'parent', joinedAt: new Date().toISOString() },
+		]);
+		observed.add(assertError(await acceptInvite('g-already', 'u4')).error);
+		inviteStore.set('g-owner', makePendingInvite({ inviteCode: 'g-owner' }));
+		userTenantStore.set('u5', [
+			{ userId: 'u5', tenantId: 't-test', role: 'owner', joinedAt: new Date().toISOString() },
+		]);
+		observed.add(assertError(await acceptInvite('g-owner', 'u5')).error);
+
+		// テナントが entitled でない
+		inviteStore.set('g-tenant', makePendingInvite({ inviteCode: 'g-tenant' }));
+		observed.add(assertError(await acceptInvite('g-tenant', 'u6')).error);
+
+		// 観測した理由が 1 つも欠けずに通知 SSOT に載っていること
+		for (const reason of observed) {
+			expect(
+				isInviteAcceptErrorReason(reason),
+				`受諾拒否理由 ${reason} が INVITE_ACCEPT_ERROR_REASONS に未登録 (無音の新規家族グループ作成に化ける)`,
+			).toBe(true);
+			expect(INVITE_ACCEPT_ERROR_BANNERS[reason as InviteAcceptErrorReason]).toBeTruthy();
+		}
+		// 逆向き: SSOT にあるのに本 test が踏んでいない理由 (= 観測漏れ) も検出する
+		expect([...observed].sort()).toEqual([...INVITE_ACCEPT_ERROR_REASONS].sort());
 	});
 });
 


### PR DESCRIPTION
## 顧客価値・目的

支払いが 1 回失敗して猶予期間に入っただけの有料世帯でも、家族の招待を正しく受け取れるようになります。あわせて、招待の受諾に失敗したときに無言で「別の家族グループの owner」に着地する経路を塞ぎ、なぜ参加できなかったか + 次にどうすればよいかを画面で伝えます。

## 関連 Issue

Closes #4633

## 変更内容

**① 猶予期間の世帯からの受諾を通す（issue AC1 / AC2）**

- `invite-service.ts` `preflightAcceptInvite`: テナント検証を `tenant.status !== SUBSCRIPTION_STATUS.ACTIVE` から `!isEntitledStatus(tenant.status)` に置換。`active` + `grace_period` を通し、`suspended` / `terminated` は従来どおり拒否。

**② 受諾拒否の無音フォールバックを塞ぐ（AC-A、本丸）**

拒否は例外なく `provisionNewUser`（新規家族グループ自動作成）にフォールバックするため、通知に載らない理由が 1 つでも残ると「失敗が成功に見える」性質はそのまま残る。旧実装は通知 cookie が `INVITE_EMAIL_MISMATCH` / `INVITE_EMAIL_UNVERIFIED` の 2 理由限定だった。

- `validation/auth.ts`: 通知理由の SSOT `INVITE_ACCEPT_ERROR_REASONS`（7 理由）+ 型ガード `isInviteAcceptErrorReason` を追加
- `labels.ts`: 理由 → バナー文言の対応表 `INVITE_ACCEPT_ERROR_BANNERS` + 未知理由の汎用フォールバック `getInviteAcceptErrorBanner()` を追加（文言はすべて labels.ts 経由、DESIGN.md §6）
- `cognito.ts`: cookie 設定を `setInviteAcceptErrorCookie()` に集約し、**理由を問わず**通知する。依頼の 4 理由（`TENANT_NOT_FOUND` / `ALREADY_IN_TENANT` / `SELF_INVITE_NOT_ALLOWED` / `OWNER_CANNOT_BE_DOWNGRADED`）に加え、**同じく無音だった 2 経路も塞いだ**:
  - `getInvite()` が null（招待が無効 / 期限切れ）で早期 return する経路 → `INVALID_OR_EXPIRED`
  - 例外 catch 経路 → 汎用文言（内部例外は露出しない、ADR-0062）
  - ※AC-A が「無音の経路を 0 にする」ことなので、4 理由だけでは目的を満たさないと判断して含めました。除外が望ましければ戻します。
- `admin/+layout.server.ts` / `+layout.svelte`: 2 理由の許可リストを撤廃し、未知の値も握り潰さず汎用文言で表示

## 検証

すべて worktree `hotfix/4633-invite-accept-guard`（base = `origin/main` 2667a8d4b）で実行。

| 検査 | コマンド | 結果 |
|---|---|---|
| 単体（本体） | `vitest run tests/unit/services/invite-service.test.ts` | **35 passed** |
| 単体（周辺 auth） | `vitest run tests/unit/services/invite-service.test.ts tests/unit/auth/` | **8 files / 149 passed** |
| lint | `biome check <変更 6 ファイル>` | **pass**（`--write` で整形適用済） |
| 型 | `svelte-check --tsconfig ./tsconfig.json`（pre-ready Step 2） | **8163 files / 0 errors / 0 warnings** |
| E2E（招待通し） | — | **未実行**。招待 / メンバーの通しは local backend では原理的に検証不能（#3732）。cloud staging 手順は `docs/runbooks/staging-live-verification.md` |
| 5 年齢モード検証 | — | **実施せず**（PO が範囲外と明示。子供画面を通らないサーバ側の認可ガードのため） |

**追加した回帰テスト**

1. `猶予期間 (grace_period) のテナントからの招待は受諾できる (#4633)` — issue AC3
2. `entitled でないテナント (suspended / terminated) からの招待は受諾できない (#4633)` — issue AC2（緩めすぎの検出）
3. `受諾拒否の全理由が通知バナーの SSOT に登録されている (#4633 AC-A)` — no-silent-gap ガード。`acceptInvite` の全拒否経路を実際に踏み、観測した理由集合と `INVITE_ACCEPT_ERROR_REASONS` の**双方向一致**を assert する。新しい拒否理由を無登録で足した瞬間に落ちる

**mutation 検証（テストが実際に落ちることを確認）** — いずれも commit 後に適用し `git stash` で復元:

| 戻した内容 | 結果 |
|---|---|
| `isEntitledStatus(...)` → `status !== 'active'` | `猶予期間…受諾できる` が **FAIL**（1 failed / 34 passed） |
| `INVITE_ACCEPT_ERROR_REASONS` から `TENANT_NOT_FOUND` を削除 | `全理由が通知バナーの SSOT に登録されている` が **FAIL**（1 failed / 34 passed） |

**直近 30 日の重複変更チェック（ADR-0002）**

`git log --since=2026-07-16 -- invite-service.ts cognito.ts` の結果、同一箇所を触った直近は **#4068 / `73b911ce`（2026-07-29、18 日前）**。当該コミットは受諾を単一 txn（`acceptInviteTransactional`）に結線した変更で、`preflightAcceptInvite` の status ガード自体はそこで入った read ガードです。本 PR はその述語だけを entitled 判定に差し替えるもので、txn 結線には触れていません（`受諾は単一 txn の acceptInviteTransactional 経由で行う` テストが通過し続けることで担保）。

**なお issue 本文の「8/13 リリースのデグレ」という原因記述は不正確です。** 当該ガードは 7/29 の #4068 で入っており、8/13 の改修は `grace_period` が実際に割り当たるようにした側（顕在化の契機）です。

## スクリーンショット

`/admin` に受諾拒否の通知 cookie を積んだ状態（撮影フロー: `scripts/capture-specs/flows/invite-accept-error-banner-4633.mjs`、dev server = AUTH_MODE=local、desktop）。before = `origin/main` (2667a8d4b) を別 worktree で起動して同一操作列で撮影。

### ① TENANT_NOT_FOUND（今回の不具合で実際に出ていた拒否理由）

| Before（main: 無音） | After（本 PR: 理由 + 次アクション） |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4635/before-invite-accept-error-tenant-not-found.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4635/after-invite-accept-error-tenant-not-found.png) |

### ② ALREADY_IN_TENANT（既に別グループに所属していて受諾できなかった場合）

| Before（main: 無音） | After（本 PR: 理由 + 次アクション） |
|---|---|
| ![before](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4635/before-invite-accept-error-already-in-tenant.png) | ![after](https://raw.githubusercontent.com/Takenori-Kusaka/ganbari-quest/screenshots/pr-4635/after-invite-accept-error-already-in-tenant.png) |

before はバナーが一切出ず、招待されたはずの人が理由不明のまま「新しい家族グループの管理ダッシュボード」に着地しているのが分かります。

## 影響範囲

- **顧客に見える変化**: ① 猶予期間の世帯からの招待が受諾できるようになる ② 受諾に失敗した場合、admin 画面に理由 + 次アクションのバナーが出る（従来は email 束縛 2 理由のみ表示、それ以外は無表示）
- **本番データの書き換えなし**（PO 確認済み）。マイグレーションなし
- **並行実装ペア**: UI 文言は `labels.ts` 経由に統一済み。LP / デモ側への波及なし
- **破壊的変更**: なし。通知 cookie の値域が広がるのみ（未知の値は汎用文言にフォールバックするため、旧 cookie が残っていても壊れない）
- **AC-B（コード変更なし、報告のみ）**: #4633 にコメント済み。**該当者は実在します**（PO 報告: 2 アカウント）。修正後も 1 ユーザー = 1 テナント制約（`invite-service.ts:79-84`）で `ALREADY_IN_TENANT` に落ち自力復帰できないため、復帰手順の案内要否は PO 判断。本 PR に自動救済は含めていません

## 配布済み env / secret (ADR-0006)

- [x] N/A — 新規 env / secret の追加なし

## QM レビュー結果

<!-- QM が記入 -->

## PO 決裁ブリーフ (po-decision:required)

```mermaid
flowchart TB
  classDef danger fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
  classDef warn fill:#fef3c7,stroke:#b45309,color:#78350f
  classDef ok fill:#dcfce7,stroke:#15803d,color:#14532d
  classDef ask fill:#dbeafe,stroke:#1d4ed8,color:#1e3a8a

  subgraph RISK["① リスク・可逆性"]
    R1["可逆性: 🟢可逆 revert のみで戻る"]
    R2["顧客面: 招待受諾 + 親画面バナー 課金判定は不変"]
    R3["データ: 🟢書き換えなし migration なし"]
  end
  subgraph TRADE["② trade-off"]
    T1["得る: 猶予期間世帯の招待が通る 失敗が見える"]
    T2["捨てる: 受諾失敗時の新規世帯自動作成は残置 #4636"]
  end
  subgraph OBJ["③ 反対理由"]
    O1["business: 根治ではない 別世帯作成は起き続ける"]
    O2["UX: バナーは着地後 参加できた体験には戻らない"]
    O3["security: 受諾可能な status を 1 つ広げる suspended は拒否維持"]
  end
  subgraph CUST["④ 顧客面の変化"]
    C1["🟢猶予期間世帯の家族が招待で参加できる 実機SSは上記"]
  end
  subgraph ASK["⑤ PO 判断依頼"]
    Q1["Q1: main 直入れで進めてよいか 決裁済と理解"]
    Q2["Q2: 既に誤作成された2件の復帰手段はどれか AC-B"]
  end

  RISK --> ASK
  TRADE --> ASK
  OBJ --> ASK
  CUST --> ASK

  class R2 warn
  class R1,R3 ok
  class T2,O1,O2,O3 warn
  class T1,C1 ok
  class Q1,Q2 ask
```

補足: ③ の反対理由は本 PR の限界そのものです。フォールバック廃止は設計検討が要るため #4636 に分離しました。
